### PR TITLE
Add indirect validation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/jquery": "^3.3.30",
     "@types/node": "^12.0.8",
     "@webgpu/glslang": "^0.0.6",
-    "@webgpu/types": "0.0.10",
+    "@webgpu/types": "0.0.12",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-macros": "^2.6.1",
     "clang-format": "^1.2.4",

--- a/src/suites/cts/validation/dispatchIndirect.spec.ts
+++ b/src/suites/cts/validation/dispatchIndirect.spec.ts
@@ -3,61 +3,55 @@ dispatchIndirect validation tests.
 `;
 
 import { TestGroup } from '../../../framework/index.js';
-
-import { ValidationTest } from './validation_test.js';
 import GLSL from '../../../tools/glsl.macro.js';
 
-export class F extends ValidationTest {
-  async testIndirectOffset(data: number[], offset: number, success: boolean): Promise<void> {
-    const module = this.device.createShaderModule({
-      code: GLSL(
-        'compute',
-        `#version 450
-          void main() {
-          }
-        `
-      ),
-    });
+import { ValidationTest } from './validation_test.js';
 
-    const pipelineLayout = this.device.createPipelineLayout({
-      bindGroupLayouts: [],
-    });
-
-    const pipeline = this.device.createComputePipeline({
-      computeStage: { module, entryPoint: 'main' },
-      layout: pipelineLayout,
-    });
-
-    const [indirectBuffer, arrayBuffer] = await this.device.createBufferMappedAsync({
-      size: data.length * Uint32Array.BYTES_PER_ELEMENT,
-      usage: GPUBufferUsage.INDIRECT,
-    });
-    new Uint32Array(arrayBuffer).set(data);
-
-    const commandEncoder = this.device.createCommandEncoder();
-    const computePass = commandEncoder.beginComputePass();
-    computePass.setPipeline(pipeline);
-    computePass.dispatchIndirect(indirectBuffer, offset * Uint32Array.BYTES_PER_ELEMENT);
-    computePass.endPass();
-
-    if (success) {
-      // Control case
-      commandEncoder.finish();
-    } else {
-      // Out of bounds indirect calls are caught
-      await this.expectValidationError(() => {
-        commandEncoder.finish();
-      });
-    }
-  }
-}
-
-export const g = new TestGroup(F);
+export const g = new TestGroup(ValidationTest);
 
 g.test('out of bounds indirect dispatch calls are caught early', async t => {
   const { data, offset, success } = t.params;
 
-  await t.testIndirectOffset(data, offset, success);
+  const module = t.device.createShaderModule({
+    code: GLSL(
+      'compute',
+      `#version 450
+        void main() {
+        }
+      `
+    ),
+  });
+
+  const pipelineLayout = t.device.createPipelineLayout({
+    bindGroupLayouts: [],
+  });
+
+  const pipeline = t.device.createComputePipeline({
+    computeStage: { module, entryPoint: 'main' },
+    layout: pipelineLayout,
+  });
+
+  const [indirectBuffer, arrayBuffer] = await t.device.createBufferMappedAsync({
+    size: data.length * Uint32Array.BYTES_PER_ELEMENT,
+    usage: GPUBufferUsage.INDIRECT,
+  });
+  new Uint32Array(arrayBuffer).set(data);
+
+  const commandEncoder = t.device.createCommandEncoder();
+  const computePass = commandEncoder.beginComputePass();
+  computePass.setPipeline(pipeline);
+  computePass.dispatchIndirect(indirectBuffer, offset * Uint32Array.BYTES_PER_ELEMENT);
+  computePass.endPass();
+
+  if (success) {
+    // Control case
+    commandEncoder.finish();
+  } else {
+    // Out of bounds indirect calls are caught
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
 }).params([
   { data: [1, 2, 3], offset: 0, success: true }, // In bounds
   { data: [1, 2, 3, 4, 5, 6], offset: 0, success: true }, // In bounds, bigger buffer
@@ -65,5 +59,5 @@ g.test('out of bounds indirect dispatch calls are caught early', async t => {
   { data: [1, 2], offset: 0, success: false }, //Out of bounds, buffer too small
   { data: [1, 2, 3], offset: 1, success: false }, //Out of bounds, index too big
   { data: [1, 2, 3], offset: 4, success: false }, //Out of bounds, index past buffer
-  { data: [1, 2, 3, 4, 5, 6], offset: Number.MAX_SAFE_INTEGER, success: false }, // In bounds,index + size of command overflows
+  { data: [1, 2, 3, 4, 5, 6], offset: Number.MAX_SAFE_INTEGER, success: false }, // Out of bounds, offset is very large
 ]);

--- a/src/suites/cts/validation/dispatchIndirect.spec.ts
+++ b/src/suites/cts/validation/dispatchIndirect.spec.ts
@@ -1,0 +1,69 @@
+export const description = `
+dispatchIndirect validation tests.
+`;
+
+import { TestGroup } from '../../../framework/index.js';
+
+import { ValidationTest } from './validation_test.js';
+import GLSL from '../../../tools/glsl.macro.js';
+
+export class F extends ValidationTest {
+  async testIndirectOffset(data: number[], offset: number, success: boolean): Promise<void> {
+    const module = this.device.createShaderModule({
+      code: GLSL(
+        'compute',
+        `#version 450
+          void main() {
+          }
+        `
+      ),
+    });
+
+    const pipelineLayout = this.device.createPipelineLayout({
+      bindGroupLayouts: [],
+    });
+
+    const pipeline = this.device.createComputePipeline({
+      computeStage: { module, entryPoint: 'main' },
+      layout: pipelineLayout,
+    });
+
+    const [indirectBuffer, arrayBuffer] = await this.device.createBufferMappedAsync({
+      size: data.length * Uint32Array.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.INDIRECT,
+    });
+    new Uint32Array(arrayBuffer).set(data);
+
+    const commandEncoder = this.device.createCommandEncoder();
+    const computePass = commandEncoder.beginComputePass();
+    computePass.setPipeline(pipeline);
+    computePass.dispatchIndirect(indirectBuffer, offset * Uint32Array.BYTES_PER_ELEMENT);
+    computePass.endPass();
+
+    if (success) {
+      // Control case
+      commandEncoder.finish();
+    } else {
+      // Out of bounds indirect calls are caught
+      await this.expectValidationError(() => {
+        commandEncoder.finish();
+      });
+    }
+  }
+}
+
+export const g = new TestGroup(F);
+
+g.test('out of bounds indirect dispatch calls are caught early', async t => {
+  const { data, offset, success } = t.params;
+
+  await t.testIndirectOffset(data, offset, success);
+}).params([
+  { data: [1, 2, 3], offset: 0, success: true }, // In bounds
+  { data: [1, 2, 3, 4, 5, 6], offset: 0, success: true }, // In bounds, bigger buffer
+  { data: [1, 2, 3, 4, 5, 6], offset: 3, success: true }, // In bounds, bigger buffer, positive offset
+  { data: [1, 2], offset: 0, success: false }, //Out of bounds, buffer too small
+  { data: [1, 2, 3], offset: 1, success: false }, //Out of bounds, index too big
+  { data: [1, 2, 3], offset: 4, success: false }, //Out of bounds, index past buffer
+  { data: [1, 2, 3, 4, 5, 6], offset: Number.MAX_SAFE_INTEGER, success: false }, // In bounds,index + size of command overflows
+]);

--- a/src/suites/cts/validation/drawIndirect.spec.ts
+++ b/src/suites/cts/validation/drawIndirect.spec.ts
@@ -1,0 +1,128 @@
+export const description = `
+drawIndirect and drawIndexedIndirect validation tests.
+`;
+
+import { TestGroup } from '../../../framework/index.js';
+
+import { ValidationTest } from './validation_test.js';
+import GLSL from '../../../tools/glsl.macro.js';
+
+export class F extends ValidationTest {
+  async testIndirectOffset(
+    data: number[],
+    offset: number,
+    indexed: boolean,
+    success: boolean
+  ): Promise<void> {
+    const vertexModule = this.device.createShaderModule({
+      code: GLSL(
+        'vertex',
+        `#version 450
+          void main() {
+            gl_Position = vec4(0);
+          }
+        `
+      ),
+    });
+
+    const fragmentModule = this.device.createShaderModule({
+      code: GLSL(
+        'fragment',
+        `#version 450
+          layout(location = 0) out vec4 fragColor;
+          void main() {
+            fragColor = vec4(0.0);
+          }
+        `
+      ),
+    });
+
+    const pipelineLayout = this.device.createPipelineLayout({
+      bindGroupLayouts: [],
+    });
+
+    const pipeline = this.device.createRenderPipeline({
+      vertexStage: { module: vertexModule, entryPoint: 'main' },
+      fragmentStage: { module: fragmentModule, entryPoint: 'main' },
+      layout: pipelineLayout,
+      primitiveTopology: 'triangle-list',
+      colorStates: [{ format: 'rgba8unorm' }],
+    });
+
+    const [indirectBuffer, arrayBuffer] = await this.device.createBufferMappedAsync({
+      size: data.length * Uint32Array.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.INDIRECT,
+    });
+    new Uint32Array(arrayBuffer).set(data);
+
+    const attachmentTexture = this.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 16, height: 16, depth: 1 },
+      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+    });
+
+    const commandEncoder = this.device.createCommandEncoder();
+    const renderPass = commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          attachment: attachmentTexture.createView(),
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        },
+      ],
+    });
+    renderPass.setPipeline(pipeline);
+
+    const indirectOffset = offset * Uint32Array.BYTES_PER_ELEMENT;
+    if (indexed) {
+      const indexBuffer = this.device.createBuffer({
+        size: 100,
+        usage: GPUBufferUsage.INDEX,
+      });
+      renderPass.setIndexBuffer(indexBuffer, 0);
+      renderPass.drawIndexedIndirect(indirectBuffer, indirectOffset);
+    } else {
+      renderPass.drawIndirect(indirectBuffer, indirectOffset);
+    }
+    renderPass.endPass();
+
+    if (success) {
+      // Control case
+      commandEncoder.finish();
+    } else {
+      // Out of bounds indirect calls are caught
+      await this.expectValidationError(() => {
+        commandEncoder.finish();
+      });
+    }
+  }
+}
+
+export const g = new TestGroup(F);
+
+g.test('out of bounds indirect draw calls are caught early', async t => {
+  const { data, offset, success } = t.params;
+
+  await t.testIndirectOffset(data, offset, false /* indexed */, success);
+}).params([
+  { data: [1, 2, 3, 4], offset: 0, success: true }, // In bounds
+  { data: [1, 2, 3, 4, 5, 6, 7], offset: 0, success: true }, // In bounds, bigger buffer
+  { data: [1, 2, 3, 4, 5, 6, 7, 8], offset: 4, success: true }, // In bounds, bigger buffer, positive offset
+  { data: [1, 2, 3], offset: 0, success: false }, // Out of bounds, buffer too small
+  { data: [1, 2, 3, 4], offset: 1, success: false }, // Out of bounds, index too big
+  { data: [1, 2, 3, 4], offset: 5, success: false }, // Out of bounds, past buffer
+  { data: [1, 2, 3, 4, 5, 6, 7], offset: Number.MAX_SAFE_INTEGER, success: false }, // In bounds,index + size of command overflows
+]);
+
+g.test('out of bounds indirect draw indexed calls are caught early', async t => {
+  const { data, offset, success } = t.params;
+
+  await t.testIndirectOffset(data, offset, true /* indexed */, success);
+}).params([
+  { data: [1, 2, 3, 4, 5], offset: 0, success: true }, // In bounds
+  { data: [1, 2, 3, 4, 5, 6, 7, 8, 9], offset: 0, success: true }, // In bounds, bigger buffer
+  { data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offset: 5, success: true }, // In bounds, bigger buffer, positive offset
+  { data: [1, 2, 3, 4], offset: 0, success: false }, // Out of bounds, buffer too small
+  { data: [1, 2, 3, 4, 5], offset: 1, success: false }, // Out of bounds, index too big
+  { data: [1, 2, 3, 4, 5], offset: 5, success: false }, // Out of bounds, past buffer
+  { data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offset: Number.MAX_SAFE_INTEGER, success: false }, // In bounds,index + size of command overflows
+]);

--- a/src/suites/cts/validation/drawIndirect.spec.ts
+++ b/src/suites/cts/validation/drawIndirect.spec.ts
@@ -2,127 +2,119 @@ export const description = `
 drawIndirect and drawIndexedIndirect validation tests.
 `;
 
-import { TestGroup } from '../../../framework/index.js';
-
-import { ValidationTest } from './validation_test.js';
+import { TestGroup, pcombine } from '../../../framework/index.js';
 import GLSL from '../../../tools/glsl.macro.js';
 
-export class F extends ValidationTest {
-  async testIndirectOffset(
-    data: number[],
-    offset: number,
-    indexed: boolean,
-    success: boolean
-  ): Promise<void> {
-    const vertexModule = this.device.createShaderModule({
-      code: GLSL(
-        'vertex',
-        `#version 450
-          void main() {
-            gl_Position = vec4(0);
-          }
-        `
-      ),
-    });
+import { ValidationTest } from './validation_test.js';
 
-    const fragmentModule = this.device.createShaderModule({
-      code: GLSL(
-        'fragment',
-        `#version 450
-          layout(location = 0) out vec4 fragColor;
-          void main() {
-            fragColor = vec4(0.0);
-          }
-        `
-      ),
-    });
-
-    const pipelineLayout = this.device.createPipelineLayout({
-      bindGroupLayouts: [],
-    });
-
-    const pipeline = this.device.createRenderPipeline({
-      vertexStage: { module: vertexModule, entryPoint: 'main' },
-      fragmentStage: { module: fragmentModule, entryPoint: 'main' },
-      layout: pipelineLayout,
-      primitiveTopology: 'triangle-list',
-      colorStates: [{ format: 'rgba8unorm' }],
-    });
-
-    const [indirectBuffer, arrayBuffer] = await this.device.createBufferMappedAsync({
-      size: data.length * Uint32Array.BYTES_PER_ELEMENT,
-      usage: GPUBufferUsage.INDIRECT,
-    });
-    new Uint32Array(arrayBuffer).set(data);
-
-    const attachmentTexture = this.device.createTexture({
-      format: 'rgba8unorm',
-      size: { width: 16, height: 16, depth: 1 },
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
-    });
-
-    const commandEncoder = this.device.createCommandEncoder();
-    const renderPass = commandEncoder.beginRenderPass({
-      colorAttachments: [
-        {
-          attachment: attachmentTexture.createView(),
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
-        },
-      ],
-    });
-    renderPass.setPipeline(pipeline);
-
-    const indirectOffset = offset * Uint32Array.BYTES_PER_ELEMENT;
-    if (indexed) {
-      const indexBuffer = this.device.createBuffer({
-        size: 100,
-        usage: GPUBufferUsage.INDEX,
-      });
-      renderPass.setIndexBuffer(indexBuffer, 0);
-      renderPass.drawIndexedIndirect(indirectBuffer, indirectOffset);
-    } else {
-      renderPass.drawIndirect(indirectBuffer, indirectOffset);
-    }
-    renderPass.endPass();
-
-    if (success) {
-      // Control case
-      commandEncoder.finish();
-    } else {
-      // Out of bounds indirect calls are caught
-      await this.expectValidationError(() => {
-        commandEncoder.finish();
-      });
-    }
-  }
-}
-
-export const g = new TestGroup(F);
+export const g = new TestGroup(ValidationTest);
 
 g.test('out of bounds indirect draw calls are caught early', async t => {
-  const { data, offset, success } = t.params;
+  const { data, offset, indexed, success } = t.params;
 
-  await t.testIndirectOffset(data, offset, false /* indexed */, success);
+  const vertexModule = t.device.createShaderModule({
+    code: GLSL(
+      'vertex',
+      `#version 450
+        void main() {
+          gl_Position = vec4(0);
+        }
+      `
+    ),
+  });
+
+  const fragmentModule = t.device.createShaderModule({
+    code: GLSL(
+      'fragment',
+      `#version 450
+        layout(location = 0) out vec4 fragColor;
+        void main() {
+          fragColor = vec4(0.0);
+        }
+      `
+    ),
+  });
+
+  const pipelineLayout = t.device.createPipelineLayout({
+    bindGroupLayouts: [],
+  });
+
+  const pipeline = t.device.createRenderPipeline({
+    vertexStage: { module: vertexModule, entryPoint: 'main' },
+    fragmentStage: { module: fragmentModule, entryPoint: 'main' },
+    layout: pipelineLayout,
+    primitiveTopology: 'triangle-list',
+    colorStates: [{ format: 'rgba8unorm' }],
+  });
+
+  const [indirectBuffer, arrayBuffer] = await t.device.createBufferMappedAsync({
+    size: data.length * Uint32Array.BYTES_PER_ELEMENT,
+    usage: GPUBufferUsage.INDIRECT,
+  });
+  new Uint32Array(arrayBuffer).set(data);
+
+  const attachmentTexture = t.device.createTexture({
+    format: 'rgba8unorm',
+    size: { width: 16, height: 16, depth: 1 },
+    usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+  });
+
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = commandEncoder.beginRenderPass({
+    colorAttachments: [
+      {
+        attachment: attachmentTexture.createView(),
+        loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+      },
+    ],
+  });
+  renderPass.setPipeline(pipeline);
+
+  const indirectOffset = offset * Uint32Array.BYTES_PER_ELEMENT;
+  if (indexed) {
+    const indexBuffer = t.device.createBuffer({
+      size: 100,
+      usage: GPUBufferUsage.INDEX,
+    });
+    renderPass.setIndexBuffer(indexBuffer, 0);
+    renderPass.drawIndexedIndirect(indirectBuffer, indirectOffset);
+  } else {
+    renderPass.drawIndirect(indirectBuffer, indirectOffset);
+  }
+  renderPass.endPass();
+
+  if (success) {
+    // Control case
+    commandEncoder.finish();
+  } else {
+    // Out of bounds indirect calls are caught
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
 }).params([
-  { data: [1, 2, 3, 4], offset: 0, success: true }, // In bounds
-  { data: [1, 2, 3, 4, 5, 6, 7], offset: 0, success: true }, // In bounds, bigger buffer
-  { data: [1, 2, 3, 4, 5, 6, 7, 8], offset: 4, success: true }, // In bounds, bigger buffer, positive offset
-  { data: [1, 2, 3], offset: 0, success: false }, // Out of bounds, buffer too small
-  { data: [1, 2, 3, 4], offset: 1, success: false }, // Out of bounds, index too big
-  { data: [1, 2, 3, 4], offset: 5, success: false }, // Out of bounds, past buffer
-  { data: [1, 2, 3, 4, 5, 6, 7], offset: Number.MAX_SAFE_INTEGER, success: false }, // In bounds,index + size of command overflows
-]);
-
-g.test('out of bounds indirect draw indexed calls are caught early', async t => {
-  const { data, offset, success } = t.params;
-
-  await t.testIndirectOffset(data, offset, true /* indexed */, success);
-}).params([
-  { data: [1, 2, 3, 4, 5], offset: 0, success: true }, // In bounds
-  { data: [1, 2, 3, 4, 5, 6, 7, 8, 9], offset: 0, success: true }, // In bounds, bigger buffer
-  { data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offset: 5, success: true }, // In bounds, bigger buffer, positive offset
-  { data: [1, 2, 3, 4], offset: 0, success: false }, // Out of bounds, buffer too small
-  { data: [1, 2, 3, 4, 5], offset: 1, success: false }, // Out of bounds, index too big
-  { data: [1, 2, 3, 4, 5], offset: 5, success: false }, // Out of bounds, past buffer
-  { data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offset: Number.MAX_SAFE_INTEGER, success: false }, // In bounds,index + size of command overflows
+  ...pcombine([
+    [{ indexed: false }],
+    [
+      { data: [1, 2, 3, 4], offset: 0, success: true }, // In bounds
+      { data: [1, 2, 3, 4, 5, 6, 7], offset: 0, success: true }, // In bounds, bigger buffer
+      { data: [1, 2, 3, 4, 5, 6, 7, 8], offset: 4, success: true }, // In bounds, bigger buffer, positive offset
+      { data: [1, 2, 3], offset: 0, success: false }, // Out of bounds, buffer too small
+      { data: [1, 2, 3, 4], offset: 1, success: false }, // Out of bounds, index too big
+      { data: [1, 2, 3, 4], offset: 5, success: false }, // Out of bounds, past buffer
+      { data: [1, 2, 3, 4, 5, 6, 7], offset: Number.MAX_SAFE_INTEGER, success: false }, // Out of bounds, offset is very large
+    ],
+  ]),
+  ...pcombine([
+    [{ indexed: true }],
+    [
+      { data: [1, 2, 3, 4, 5], offset: 0, success: true }, // In bounds
+      { data: [1, 2, 3, 4, 5, 6, 7, 8, 9], offset: 0, success: true }, // In bounds, bigger buffer
+      { data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offset: 5, success: true }, // In bounds, bigger buffer, positive offset
+      { data: [1, 2, 3, 4], offset: 0, success: false }, // Out of bounds, buffer too small
+      { data: [1, 2, 3, 4, 5], offset: 1, success: false }, // Out of bounds, index too big
+      { data: [1, 2, 3, 4, 5], offset: 5, success: false }, // Out of bounds, past buffer
+      { data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], offset: Number.MAX_SAFE_INTEGER, success: false }, // Out of bounds, offset is very large
+    ],
+  ]),
 ]);


### PR DESCRIPTION
This PR is about adding some compute/render indirect validation tests.
It is based on https://github.com/gpuweb/cts/pull/25/

Note that it requires https://github.com/kainino0x/-webgpu-types/issues/2 to be fixed. I'll update package.json file when it's done.

FYI @Kangz @austinEng 