### PR TITLE
Improve exception logging

### DIFF
--- a/src/framework/logger.ts
+++ b/src/framework/logger.ts
@@ -104,8 +104,6 @@ export class TestCaseRecorder {
 
   threw(e: Error): void {
     this.failed = true;
-    let m = 'EXCEPTION';
-    m += ' ' + e.name + ' ' + e.message + ' ' + getStackTrace(e);
-    this.log(m);
+    this.log('EXCEPTION: ' + e.name + ': ' + e.message + '\n' + getStackTrace(e));
   }
 }

--- a/src/framework/logger.ts
+++ b/src/framework/logger.ts
@@ -105,7 +105,7 @@ export class TestCaseRecorder {
   threw(e: Error): void {
     this.failed = true;
     let m = 'EXCEPTION';
-    m += ' ' + getStackTrace(e);
+    m += ' ' + e.name + ' ' + e.message + ' ' + getStackTrace(e);
     this.log(m);
   }
 }


### PR DESCRIPTION
This nit allows us to learn more when an exception is thrown. For info, I've used this when running CTS in Safari.

![image](https://user-images.githubusercontent.com/634478/64862833-c64b2380-d633-11e9-96b6-e92d6f12653d.png)
