### PR TITLE
Add dynamic state validation tests

### DIFF
--- a/src/suites/cts/validation/setBlendColor.spec.ts
+++ b/src/suites/cts/validation/setBlendColor.spec.ts
@@ -1,0 +1,45 @@
+export const description = `
+setBlendColor validation tests.
+`;
+
+import { TestGroup } from '../../../framework/index.js';
+
+import { ValidationTest } from './validation_test.js';
+
+// TODO: Move beginRenderPass to a Fixture class.
+export class F extends ValidationTest {
+  beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
+    const attachmentTexture = this.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 16, height: 16, depth: 1 },
+      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+    });
+
+    return commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          attachment: attachmentTexture.createView(),
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        },
+      ],
+    });
+  }
+}
+
+export const g = new TestGroup(F);
+
+g.test('basic use of setBlendColor', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  renderPass.setBlendColor({ r: 0, g: 0, b: 0, a: 0 });
+  renderPass.endPass();
+  commandEncoder.finish();
+});
+
+g.test('setBlendColor allows any number value', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  renderPass.setBlendColor({ r: -1, g: 42, b: -0, a: 0 });
+  renderPass.endPass();
+  commandEncoder.finish();
+});

--- a/src/suites/cts/validation/setBlendColor.spec.ts
+++ b/src/suites/cts/validation/setBlendColor.spec.ts
@@ -7,7 +7,7 @@ import { TestGroup } from '../../../framework/index.js';
 import { ValidationTest } from './validation_test.js';
 
 // TODO: Move beginRenderPass to a Fixture class.
-export class F extends ValidationTest {
+class F extends ValidationTest {
   beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
     const attachmentTexture = this.device.createTexture({
       format: 'rgba8unorm',
@@ -37,9 +37,12 @@ g.test('basic use of setBlendColor', t => {
 });
 
 g.test('setBlendColor allows any number value', t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  renderPass.setBlendColor({ r: -1, g: 42, b: -0, a: 0 });
-  renderPass.endPass();
-  commandEncoder.finish();
+  const values = [Number.MIN_SAFE_INTEGER, Number.MAX_SAFE_INTEGER];
+  for (const value of values) {
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    renderPass.setBlendColor({ r: value, g: value, b: value, a: value });
+    renderPass.endPass();
+    commandEncoder.finish();
+  }
 });

--- a/src/suites/cts/validation/setScissorRect.spec.ts
+++ b/src/suites/cts/validation/setScissorRect.spec.ts
@@ -1,0 +1,90 @@
+export const description = `
+setScissorRect validation tests.
+`;
+
+import { TestGroup } from '../../../framework/index.js';
+
+import { ValidationTest } from './validation_test.js';
+
+// TODO: Move beginRenderPass to a Fixture class.
+export class F extends ValidationTest {
+  textureWidth: number = 16;
+  textureHeight: number = 16;
+
+  beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
+    const attachmentTexture = this.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: this.textureWidth, height: this.textureHeight, depth: 1 },
+      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+    });
+
+    return commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          attachment: attachmentTexture.createView(),
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        },
+      ],
+    });
+  }
+}
+
+export const g = new TestGroup(F);
+
+g.test('basic use of setScissorRect', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  renderPass.setScissorRect(0, 0, 1, 1);
+  renderPass.endPass();
+  commandEncoder.finish();
+});
+
+g.test('an empty scissor is not allowed', async t => {
+  {
+    // Width of scissor rect is zero
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const width = 0;
+    renderPass.setScissorRect(0, 0, width, 1);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+  {
+    // Height of scissor rect is zero
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const height = 0;
+    renderPass.setScissorRect(0, 0, 0, height);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+  {
+    // Both width and height of scissor rect are zero
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const width = 0;
+    const height = 0;
+    renderPass.setScissorRect(0, 0, width, height);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+});
+
+g.test('scissor larger than the framebuffer is allowed', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const width = t.textureWidth + 1;
+  const height = t.textureHeight + 1;
+  renderPass.setScissorRect(0, 0, width, height);
+  renderPass.endPass();
+  commandEncoder.finish();
+});

--- a/src/suites/cts/validation/setScissorRect.spec.ts
+++ b/src/suites/cts/validation/setScissorRect.spec.ts
@@ -6,7 +6,7 @@ import { TestGroup } from '../../../framework/index.js';
 
 import { ValidationTest } from './validation_test.js';
 
-// TODO: Move beginRenderPass to a Fixture class.
+// TODO: Move this fixture class to a common file.
 export class F extends ValidationTest {
   textureWidth: number = 16;
   textureHeight: number = 16;
@@ -39,44 +39,41 @@ g.test('basic use of setScissorRect', t => {
   commandEncoder.finish();
 });
 
-g.test('an empty scissor is not allowed', async t => {
-  {
-    // Width of scissor rect is zero
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const width = 0;
-    renderPass.setScissorRect(0, 0, width, 1);
-    renderPass.endPass();
+g.test('a scissor rect width of zero is not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const width = 0;
+  renderPass.setScissorRect(0, 0, width, 1);
+  renderPass.endPass();
 
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
-  {
-    // Height of scissor rect is zero
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const height = 0;
-    renderPass.setScissorRect(0, 0, 0, height);
-    renderPass.endPass();
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
+});
 
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
-  {
-    // Both width and height of scissor rect are zero
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const width = 0;
-    const height = 0;
-    renderPass.setScissorRect(0, 0, width, height);
-    renderPass.endPass();
+g.test('a scissor rect height of zero is not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const height = 0;
+  renderPass.setScissorRect(0, 0, 0, height);
+  renderPass.endPass();
 
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
+});
+
+g.test('both scissor rect width and height of zero are not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const width = 0;
+  const height = 0;
+  renderPass.setScissorRect(0, 0, width, height);
+  renderPass.endPass();
+
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
 });
 
 g.test('scissor larger than the framebuffer is allowed', t => {

--- a/src/suites/cts/validation/setStencilReference.spec.ts
+++ b/src/suites/cts/validation/setStencilReference.spec.ts
@@ -1,0 +1,45 @@
+export const description = `
+setStencilReference validation tests.
+`;
+
+import { TestGroup } from '../../../framework/index.js';
+
+import { ValidationTest } from './validation_test.js';
+
+// TODO: Move beginRenderPass to a Fixture class.
+export class F extends ValidationTest {
+  beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
+    const attachmentTexture = this.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 16, height: 16, depth: 1 },
+      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+    });
+
+    return commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          attachment: attachmentTexture.createView(),
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        },
+      ],
+    });
+  }
+}
+
+export const g = new TestGroup(F);
+
+g.test('basic use of setStencilReference', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  renderPass.setStencilReference(0);
+  renderPass.endPass();
+  commandEncoder.finish();
+});
+
+g.test('setStencilReference allows any bit to be set', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  renderPass.setStencilReference(0xffffffff);
+  renderPass.endPass();
+  commandEncoder.finish();
+});

--- a/src/suites/cts/validation/setStencilReference.spec.ts
+++ b/src/suites/cts/validation/setStencilReference.spec.ts
@@ -6,7 +6,7 @@ import { TestGroup } from '../../../framework/index.js';
 
 import { ValidationTest } from './validation_test.js';
 
-// TODO: Move beginRenderPass to a Fixture class.
+// TODO: Move this fixture class to a common file.
 export class F extends ValidationTest {
   beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
     const attachmentTexture = this.device.createTexture({

--- a/src/suites/cts/validation/setStencilReference.spec.ts
+++ b/src/suites/cts/validation/setStencilReference.spec.ts
@@ -2,12 +2,12 @@ export const description = `
 setStencilReference validation tests.
 `;
 
-import { TestGroup } from '../../../framework/index.js';
+import { TestGroup, poptions } from '../../../framework/index.js';
 
 import { ValidationTest } from './validation_test.js';
 
 // TODO: Move this fixture class to a common file.
-export class F extends ValidationTest {
+class F extends ValidationTest {
   beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
     const attachmentTexture = this.device.createTexture({
       format: 'rgba8unorm',
@@ -28,18 +28,12 @@ export class F extends ValidationTest {
 
 export const g = new TestGroup(F);
 
-g.test('basic use of setStencilReference', t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  renderPass.setStencilReference(0);
-  renderPass.endPass();
-  commandEncoder.finish();
-});
+g.test('use of setStencilReference', t => {
+  const { reference } = t.params;
 
-g.test('setStencilReference allows any bit to be set', t => {
   const commandEncoder = t.device.createCommandEncoder();
   const renderPass = t.beginRenderPass(commandEncoder);
-  renderPass.setStencilReference(0xffffffff);
+  renderPass.setStencilReference(reference);
   renderPass.endPass();
   commandEncoder.finish();
-});
+}).params(poptions('reference', [0, 0xffffffff]));

--- a/src/suites/cts/validation/setViewport.spec.ts
+++ b/src/suites/cts/validation/setViewport.spec.ts
@@ -1,0 +1,215 @@
+export const description = `
+setViewport validation tests.
+`;
+
+import { TestGroup } from '../../../framework/index.js';
+
+import { ValidationTest } from './validation_test.js';
+
+// TODO: Move beginRenderPass to a Fixture class.
+export class F extends ValidationTest {
+  textureWidth: number = 16;
+  textureHeight: number = 16;
+
+  beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
+    const attachmentTexture = this.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: this.textureWidth, height: this.textureHeight, depth: 1 },
+      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+    });
+
+    return commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          attachment: attachmentTexture.createView(),
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        },
+      ],
+    });
+  }
+}
+
+export const g = new TestGroup(F);
+
+g.test('basic use of setViewport', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  renderPass.setViewport(0, 0, 1, 1, 0, 1);
+  renderPass.endPass();
+  commandEncoder.finish();
+});
+
+g.test('an empty viewport is not allowed', async t => {
+  {
+    // Width of viewport is zero
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const width = 0;
+    renderPass.setViewport(0, 0, width, 1, 0, 1);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+  {
+    // Height of viewport is zero
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const height = 0;
+    renderPass.setViewport(0, 0, 0, height, 0, 1);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+  {
+    // Both width and height of viewport are zero
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const width = 0;
+    const height = 0;
+    renderPass.setViewport(0, 0, width, height, 0, 1);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+});
+
+g.test('viewport larger than the framebuffer is allowed', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const width = t.textureWidth + 1;
+  const height = t.textureHeight + 1;
+  renderPass.setViewport(0, 0, width, height, 0, 1);
+  renderPass.endPass();
+  commandEncoder.finish();
+});
+
+g.test('negative x and y in viewport are allowed', t => {
+  {
+    //  negative x in viewport is allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const x = -1;
+    renderPass.setViewport(x, 0, 1, 1, 0, 1);
+    renderPass.endPass();
+    commandEncoder.finish();
+  }
+  {
+    //  negative y in viewport is allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const y = -1;
+    renderPass.setViewport(0, y, 1, 1, 0, 1);
+    renderPass.endPass();
+    commandEncoder.finish();
+  }
+});
+
+g.test('negative width and height in viewport are not allowed', async t => {
+  {
+    //  negative width in viewport is not allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const width = -1;
+    renderPass.setViewport(0, 0, width, 1, 0, 1);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+  {
+    //  negative height in viewport is not allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const height = -1;
+    renderPass.setViewport(0, 0, 1, height, 0, 1);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+});
+
+g.test('minDepth between 0 and 1 is required', async t => {
+  {
+    //  negative minDepth in viewport is not allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const minDepth = -1;
+    renderPass.setViewport(0, 0, 1, 1, minDepth, 1);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+  {
+    //  minDepth > 1 in viewport is not allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const minDepth = 2;
+    renderPass.setViewport(0, 0, 1, 1, minDepth, 1);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+});
+
+g.test('maxDepth between 0 and 1 is required', async t => {
+  {
+    //  negative maxDepth in viewport is not allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const maxDepth = -1;
+    renderPass.setViewport(0, 0, 1, 1, 0, maxDepth);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+  {
+    //  maxDepth > 1 in viewport is not allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const maxDepth = 2;
+    renderPass.setViewport(0, 0, 1, 1, 0, maxDepth);
+    renderPass.endPass();
+
+    await t.expectValidationError(() => {
+      commandEncoder.finish();
+    });
+  }
+});
+
+g.test('minDepth equal or greater than maxDepth is allowed', t => {
+  {
+    //  minDepth equal to maxDepth is allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const minDepth = 0.5;
+    const maxDepth = 0.5;
+    renderPass.setViewport(0, 0, 1, 1, minDepth, maxDepth);
+    renderPass.endPass();
+    commandEncoder.finish();
+  }
+  {
+    // minDepth greater than maxDepth is allowed
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = t.beginRenderPass(commandEncoder);
+    const minDepth = 0.8;
+    const maxDepth = 0.5;
+    renderPass.setViewport(0, 0, 1, 1, minDepth, maxDepth);
+    renderPass.endPass();
+    commandEncoder.finish();
+  }
+});

--- a/src/suites/cts/validation/setViewport.spec.ts
+++ b/src/suites/cts/validation/setViewport.spec.ts
@@ -6,7 +6,7 @@ import { TestGroup } from '../../../framework/index.js';
 
 import { ValidationTest } from './validation_test.js';
 
-// TODO: Move beginRenderPass to a Fixture class.
+// TODO: Move this fixture class to a common file.
 export class F extends ValidationTest {
   textureWidth: number = 16;
   textureHeight: number = 16;
@@ -39,44 +39,41 @@ g.test('basic use of setViewport', t => {
   commandEncoder.finish();
 });
 
-g.test('an empty viewport is not allowed', async t => {
-  {
-    // Width of viewport is zero
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const width = 0;
-    renderPass.setViewport(0, 0, width, 1, 0, 1);
-    renderPass.endPass();
+g.test('a viewport width of zero is not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const width = 0;
+  renderPass.setViewport(0, 0, width, 1, 0, 1);
+  renderPass.endPass();
 
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
-  {
-    // Height of viewport is zero
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const height = 0;
-    renderPass.setViewport(0, 0, 0, height, 0, 1);
-    renderPass.endPass();
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
+});
 
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
-  {
-    // Both width and height of viewport are zero
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const width = 0;
-    const height = 0;
-    renderPass.setViewport(0, 0, width, height, 0, 1);
-    renderPass.endPass();
+g.test('a viewport height of zero is not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const height = 0;
+  renderPass.setViewport(0, 0, 0, height, 0, 1);
+  renderPass.endPass();
 
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
+});
+
+g.test('both viewport width and height of zero are not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const width = 0;
+  const height = 0;
+  renderPass.setViewport(0, 0, width, height, 0, 1);
+  renderPass.endPass();
+
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
 });
 
 g.test('viewport larger than the framebuffer is allowed', t => {
@@ -89,127 +86,112 @@ g.test('viewport larger than the framebuffer is allowed', t => {
   commandEncoder.finish();
 });
 
-g.test('negative x and y in viewport are allowed', t => {
-  {
-    //  negative x in viewport is allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const x = -1;
-    renderPass.setViewport(x, 0, 1, 1, 0, 1);
-    renderPass.endPass();
-    commandEncoder.finish();
-  }
-  {
-    //  negative y in viewport is allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const y = -1;
-    renderPass.setViewport(0, y, 1, 1, 0, 1);
-    renderPass.endPass();
-    commandEncoder.finish();
-  }
+g.test('negative x in viewport is not allowed', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const x = -1;
+  renderPass.setViewport(x, 0, 1, 1, 0, 1);
+  renderPass.endPass();
+  commandEncoder.finish();
 });
 
-g.test('negative width and height in viewport are not allowed', async t => {
-  {
-    //  negative width in viewport is not allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const width = -1;
-    renderPass.setViewport(0, 0, width, 1, 0, 1);
-    renderPass.endPass();
-
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
-  {
-    //  negative height in viewport is not allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const height = -1;
-    renderPass.setViewport(0, 0, 1, height, 0, 1);
-    renderPass.endPass();
-
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
+g.test('negative y in viewport is not allowed', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const y = -1;
+  renderPass.setViewport(0, y, 1, 1, 0, 1);
+  renderPass.endPass();
+  commandEncoder.finish();
 });
 
-g.test('minDepth between 0 and 1 is required', async t => {
-  {
-    //  negative minDepth in viewport is not allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const minDepth = -1;
-    renderPass.setViewport(0, 0, 1, 1, minDepth, 1);
-    renderPass.endPass();
+g.test('negative width in viewport is not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const width = -1;
+  renderPass.setViewport(0, 0, width, 1, 0, 1);
+  renderPass.endPass();
 
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
-  {
-    //  minDepth > 1 in viewport is not allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const minDepth = 2;
-    renderPass.setViewport(0, 0, 1, 1, minDepth, 1);
-    renderPass.endPass();
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
+});
 
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
+g.test('negative height in viewport is not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const height = -1;
+  renderPass.setViewport(0, 0, 1, height, 0, 1);
+  renderPass.endPass();
+
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
+});
+
+g.test('negative minDepth in viewport is not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const minDepth = -1;
+  renderPass.setViewport(0, 0, 1, 1, minDepth, 1);
+  renderPass.endPass();
+
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
+});
+
+g.test('minDepth greater than 1 in viewport is not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const minDepth = 2;
+  renderPass.setViewport(0, 0, 1, 1, minDepth, 1);
+  renderPass.endPass();
+
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
 });
 
 g.test('maxDepth between 0 and 1 is required', async t => {
-  {
-    //  negative maxDepth in viewport is not allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const maxDepth = -1;
-    renderPass.setViewport(0, 0, 1, 1, 0, maxDepth);
-    renderPass.endPass();
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const maxDepth = -1;
+  renderPass.setViewport(0, 0, 1, 1, 0, maxDepth);
+  renderPass.endPass();
 
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
-  {
-    //  maxDepth > 1 in viewport is not allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const maxDepth = 2;
-    renderPass.setViewport(0, 0, 1, 1, 0, maxDepth);
-    renderPass.endPass();
-
-    await t.expectValidationError(() => {
-      commandEncoder.finish();
-    });
-  }
+  await t.expectValidationError(() => {
+    commandEncoder.finish();
+  });
 });
 
-g.test('minDepth equal or greater than maxDepth is allowed', t => {
-  {
-    //  minDepth equal to maxDepth is allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const minDepth = 0.5;
-    const maxDepth = 0.5;
-    renderPass.setViewport(0, 0, 1, 1, minDepth, maxDepth);
-    renderPass.endPass();
+g.test('maxDepth greater than 1 in viewport is not allowed', async t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const maxDepth = 2;
+  renderPass.setViewport(0, 0, 1, 1, 0, maxDepth);
+  renderPass.endPass();
+
+  await t.expectValidationError(() => {
     commandEncoder.finish();
-  }
-  {
-    // minDepth greater than maxDepth is allowed
-    const commandEncoder = t.device.createCommandEncoder();
-    const renderPass = t.beginRenderPass(commandEncoder);
-    const minDepth = 0.8;
-    const maxDepth = 0.5;
-    renderPass.setViewport(0, 0, 1, 1, minDepth, maxDepth);
-    renderPass.endPass();
-    commandEncoder.finish();
-  }
+  });
+});
+
+g.test('minDepth equal to maxDepth is allowed', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const minDepth = 0.5;
+  const maxDepth = 0.5;
+  renderPass.setViewport(0, 0, 1, 1, minDepth, maxDepth);
+  renderPass.endPass();
+  commandEncoder.finish();
+});
+
+g.test('minDepth greater than maxDepth is allowed', t => {
+  const commandEncoder = t.device.createCommandEncoder();
+  const renderPass = t.beginRenderPass(commandEncoder);
+  const minDepth = 0.8;
+  const maxDepth = 0.5;
+  renderPass.setViewport(0, 0, 1, 1, minDepth, maxDepth);
+  renderPass.endPass();
+  commandEncoder.finish();
 });

--- a/src/suites/cts/validation/setViewport.spec.ts
+++ b/src/suites/cts/validation/setViewport.spec.ts
@@ -6,15 +6,15 @@ import { TestGroup } from '../../../framework/index.js';
 
 import { ValidationTest } from './validation_test.js';
 
-// TODO: Move this fixture class to a common file.
-export class F extends ValidationTest {
-  textureWidth: number = 16;
-  textureHeight: number = 16;
+const TEXTURE_WIDTH: number = 16;
+const TEXTURE_HEIGHT: number = 16;
 
+// TODO: Move this fixture class to a common file.
+class F extends ValidationTest {
   beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
     const attachmentTexture = this.device.createTexture({
       format: 'rgba8unorm',
-      size: { width: this.textureWidth, height: this.textureHeight, depth: 1 },
+      size: { width: TEXTURE_WIDTH, height: TEXTURE_HEIGHT, depth: 1 },
       usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
     });
 
@@ -31,167 +31,39 @@ export class F extends ValidationTest {
 
 export const g = new TestGroup(F);
 
-g.test('basic use of setViewport', t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  renderPass.setViewport(0, 0, 1, 1, 0, 1);
-  renderPass.endPass();
-  commandEncoder.finish();
-});
+g.test('use of setViewport', async t => {
+  const { x, y, width, height, minDepth, maxDepth, success } = t.params;
 
-g.test('a viewport width of zero is not allowed', async t => {
   const commandEncoder = t.device.createCommandEncoder();
   const renderPass = t.beginRenderPass(commandEncoder);
-  const width = 0;
-  renderPass.setViewport(0, 0, width, 1, 0, 1);
+  renderPass.setViewport(x, y, width, height, minDepth, maxDepth);
   renderPass.endPass();
 
   await t.expectValidationError(() => {
     commandEncoder.finish();
-  });
-});
-
-g.test('a viewport height of zero is not allowed', async t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const height = 0;
-  renderPass.setViewport(0, 0, 0, height, 0, 1);
-  renderPass.endPass();
-
-  await t.expectValidationError(() => {
-    commandEncoder.finish();
-  });
-});
-
-g.test('both viewport width and height of zero are not allowed', async t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const width = 0;
-  const height = 0;
-  renderPass.setViewport(0, 0, width, height, 0, 1);
-  renderPass.endPass();
-
-  await t.expectValidationError(() => {
-    commandEncoder.finish();
-  });
-});
-
-g.test('viewport larger than the framebuffer is allowed', t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const width = t.textureWidth + 1;
-  const height = t.textureHeight + 1;
-  renderPass.setViewport(0, 0, width, height, 0, 1);
-  renderPass.endPass();
-  commandEncoder.finish();
-});
-
-g.test('negative x in viewport is not allowed', t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const x = -1;
-  renderPass.setViewport(x, 0, 1, 1, 0, 1);
-  renderPass.endPass();
-  commandEncoder.finish();
-});
-
-g.test('negative y in viewport is not allowed', t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const y = -1;
-  renderPass.setViewport(0, y, 1, 1, 0, 1);
-  renderPass.endPass();
-  commandEncoder.finish();
-});
-
-g.test('negative width in viewport is not allowed', async t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const width = -1;
-  renderPass.setViewport(0, 0, width, 1, 0, 1);
-  renderPass.endPass();
-
-  await t.expectValidationError(() => {
-    commandEncoder.finish();
-  });
-});
-
-g.test('negative height in viewport is not allowed', async t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const height = -1;
-  renderPass.setViewport(0, 0, 1, height, 0, 1);
-  renderPass.endPass();
-
-  await t.expectValidationError(() => {
-    commandEncoder.finish();
-  });
-});
-
-g.test('negative minDepth in viewport is not allowed', async t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const minDepth = -1;
-  renderPass.setViewport(0, 0, 1, 1, minDepth, 1);
-  renderPass.endPass();
-
-  await t.expectValidationError(() => {
-    commandEncoder.finish();
-  });
-});
-
-g.test('minDepth greater than 1 in viewport is not allowed', async t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const minDepth = 2;
-  renderPass.setViewport(0, 0, 1, 1, minDepth, 1);
-  renderPass.endPass();
-
-  await t.expectValidationError(() => {
-    commandEncoder.finish();
-  });
-});
-
-g.test('maxDepth between 0 and 1 is required', async t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const maxDepth = -1;
-  renderPass.setViewport(0, 0, 1, 1, 0, maxDepth);
-  renderPass.endPass();
-
-  await t.expectValidationError(() => {
-    commandEncoder.finish();
-  });
-});
-
-g.test('maxDepth greater than 1 in viewport is not allowed', async t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const maxDepth = 2;
-  renderPass.setViewport(0, 0, 1, 1, 0, maxDepth);
-  renderPass.endPass();
-
-  await t.expectValidationError(() => {
-    commandEncoder.finish();
-  });
-});
-
-g.test('minDepth equal to maxDepth is allowed', t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const minDepth = 0.5;
-  const maxDepth = 0.5;
-  renderPass.setViewport(0, 0, 1, 1, minDepth, maxDepth);
-  renderPass.endPass();
-  commandEncoder.finish();
-});
-
-g.test('minDepth greater than maxDepth is allowed', t => {
-  const commandEncoder = t.device.createCommandEncoder();
-  const renderPass = t.beginRenderPass(commandEncoder);
-  const minDepth = 0.8;
-  const maxDepth = 0.5;
-  renderPass.setViewport(0, 0, 1, 1, minDepth, maxDepth);
-  renderPass.endPass();
-  commandEncoder.finish();
-});
+  }, !success);
+}).params([
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: 1, success: true }, // Basic use
+  { x: 0, y: 0, width: 0, height: 1, minDepth: 0, maxDepth: 1, success: false }, // Width of zero is not allowed
+  { x: 0, y: 0, width: 1, height: 0, minDepth: 0, maxDepth: 1, success: false }, // Height of zero is not allowed
+  { x: 0, y: 0, width: 0, height: 0, minDepth: 0, maxDepth: 1, success: false }, // Both width and height of zero are not allowed
+  { x: -1, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: 1, success: true }, // Negative x is allowed
+  { x: 0, y: -1, width: 1, height: 1, minDepth: 0, maxDepth: 1, success: true }, // Negative y is allowed
+  { x: 0, y: 0, width: -1, height: 1, minDepth: 0, maxDepth: 1, success: false }, // Negative width is not allowed
+  { x: 0, y: 0, width: 1, height: -1, minDepth: 0, maxDepth: 1, success: false }, // Negative height is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: -1, maxDepth: 1, success: false }, // Negative minDepth is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: -1, success: false }, // Negative maxDepth is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 10, maxDepth: 1, success: false }, // minDepth greater than 1 is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: 10, success: false }, // maxDepth greater than 1 is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0.5, maxDepth: 0.5, success: true }, // minDepth equal to maxDepth is allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0.8, maxDepth: 0.5, success: true }, // minDepth greater than maxDepth is allowed
+  {
+    x: 0,
+    y: 0,
+    width: TEXTURE_WIDTH + 1,
+    height: TEXTURE_HEIGHT + 1,
+    minDepth: 0,
+    maxDepth: 1,
+    success: true,
+  }, // Viewport larger than the framebuffer is allowed
+]);


### PR DESCRIPTION
This PR is about adding some dynamic state validation tests.
It is based on https://github.com/gpuweb/cts/pull/25/

I'm still not sure where to add this `BeginPass` fixture class I was mentioning in https://github.com/gpuweb/cts/pull/29 as I sometimes need the texture width and height.

FYI @Kangz @austinEng 