### PR TITLE
Fix nits

### DIFF
--- a/src/suites/cts/command_buffer/basic.spec.ts
+++ b/src/suites/cts/command_buffer/basic.spec.ts
@@ -8,7 +8,7 @@ import { GPUTest } from '../gpu_test.js';
 export const g = new TestGroup(GPUTest);
 
 g.test('empty', async t => {
-  const encoder = t.device.createCommandEncoder({});
+  const encoder = t.device.createCommandEncoder();
   const cmd = encoder.finish();
   t.device.getQueue().submit([cmd]);
 

--- a/src/suites/cts/command_buffer/compute/basic.spec.ts
+++ b/src/suites/cts/command_buffer/compute/basic.spec.ts
@@ -57,7 +57,7 @@ g.test('memcpy', async t => {
     layout: pl,
   });
 
-  const encoder = t.device.createCommandEncoder({});
+  const encoder = t.device.createCommandEncoder();
   const pass = encoder.beginComputePass();
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, bg);

--- a/src/suites/cts/command_buffer/copies.spec.ts
+++ b/src/suites/cts/command_buffer/copies.spec.ts
@@ -22,7 +22,7 @@ g.test('b2b', async t => {
     usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
   });
 
-  const encoder = t.device.createCommandEncoder({});
+  const encoder = t.device.createCommandEncoder();
   encoder.copyBufferToBuffer(src, 0, dst, 0, 4);
   t.device.getQueue().submit([encoder.finish()]);
 
@@ -50,7 +50,7 @@ g.test('b2t2b', async t => {
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
   });
 
-  const encoder = t.device.createCommandEncoder({});
+  const encoder = t.device.createCommandEncoder();
   encoder.copyBufferToTexture(
     { buffer: src, rowPitch: 256, imageHeight: 1 },
     { texture: mid, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
@@ -89,7 +89,7 @@ g.test('b2t2t2b', async t => {
   const mid1 = t.device.createTexture(midDesc);
   const mid2 = t.device.createTexture(midDesc);
 
-  const encoder = t.device.createCommandEncoder({});
+  const encoder = t.device.createCommandEncoder();
   encoder.copyBufferToTexture(
     { buffer: src, rowPitch: 256, imageHeight: 1 },
     { texture: mid1, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },

--- a/src/suites/cts/command_buffer/render/basic.spec.ts
+++ b/src/suites/cts/command_buffer/render/basic.spec.ts
@@ -20,7 +20,7 @@ g.test('clear', async t => {
   });
   const colorAttachmentView = colorAttachment.createView();
 
-  const encoder = t.device.createCommandEncoder({});
+  const encoder = t.device.createCommandEncoder();
   const pass = encoder.beginRenderPass({
     colorAttachments: [
       {

--- a/src/suites/cts/command_buffer/render/rendering.spec.ts
+++ b/src/suites/cts/command_buffer/render/rendering.spec.ts
@@ -59,7 +59,7 @@ g.test('fullscreen quad', async t => {
     },
   });
 
-  const encoder = t.device.createCommandEncoder({});
+  const encoder = t.device.createCommandEncoder();
   const pass = encoder.beginRenderPass({
     colorAttachments: [
       {

--- a/src/suites/cts/gpu_test.ts
+++ b/src/suites/cts/gpu_test.ts
@@ -10,7 +10,7 @@ export class GPUTest extends Fixture {
     super.init();
     const gpu = getGPU();
     const adapter = await gpu.requestAdapter();
-    this.device = await adapter.requestDevice({});
+    this.device = await adapter.requestDevice();
     this.queue = this.device.getQueue();
 
     this.device.pushErrorScope('out-of-memory');
@@ -28,8 +28,8 @@ export class GPUTest extends Fixture {
 
     const gpuOutOfMemoryError = await this.device.popErrorScope();
     if (gpuOutOfMemoryError !== null) {
-      if (!(gpuOutOfMemoryError instanceof GPUValidationError)) throw new Error();
-      this.fail(`Unexpected out-of-memory error occurred: ${gpuOutOfMemoryError.message}`);
+      if (!(gpuOutOfMemoryError instanceof GPUOutOfMemoryError)) throw new Error();
+      this.fail('Unexpected out-of-memory error occurred');
     }
   }
 
@@ -45,7 +45,7 @@ export class GPUTest extends Fixture {
         usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
       });
 
-      const c = this.device.createCommandEncoder({});
+      const c = this.device.createCommandEncoder();
       c.copyBufferToBuffer(src, 0, dst, 0, size);
 
       this.queue.submit([c.finish()]);


### PR DESCRIPTION
Few nits:
- GPUOutOfMemoryError doesn't have any message according to https://gpuweb.github.io/gpuweb/#gpuoutofmemoryerror
- Remove unnecessary `{}` in `requestDevice` and `createCommandEncoder`