### PR TITLE
Provide a way to run GLSL in standalone mode

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,16 @@ module.exports = function(grunt) {
       },
       'build-out': {
         cmd: 'node',
-        args: ['node_modules/@babel/cli/bin/babel', '--source-maps', 'true', '--extensions', '.ts', '--out-dir', 'out/', 'src/'],
+        args: [
+          'node_modules/@babel/cli/bin/babel',
+          '--source-maps',
+          'true',
+          '--extensions',
+          '.ts',
+          '--out-dir',
+          'out/',
+          'src/',
+        ],
       },
       'gts-check': {
         cmd: 'node',
@@ -41,6 +50,16 @@ module.exports = function(grunt) {
     },
 
     copy: {
+      glslang: {
+        files: [
+          {
+            expand: true,
+            cwd: 'node_modules/@webgpu/glslang/dist/web-devel',
+            src: 'glslang.{js,wasm}',
+            dest: 'out/',
+          },
+        ],
+      },
       'out-wpt': {
         files: [
           { expand: true, cwd: 'wpt', src: 'cts.html', dest: 'out-wpt/' },
@@ -91,6 +110,7 @@ module.exports = function(grunt) {
   registerTaskAndAddToHelp('build', 'Build out/ (without type checking)', [
     'clean',
     'mkdir:out',
+    'copy:glslang',
     'run:build-out',
     'run:generate-version',
     'run:generate-listings',

--- a/src/suites/cts/gpu_test.ts
+++ b/src/suites/cts/gpu_test.ts
@@ -5,7 +5,7 @@ type glslang = typeof import('@webgpu/glslang/dist/web-devel/glslang');
 type Glslang = import('@webgpu/glslang/dist/web-devel/glslang').Glslang;
 type ShaderStage = import('@webgpu/glslang/dist/web-devel/glslang').ShaderStage;
 
-let glslangInstance: Glslang = undefined!;
+let glslangInstance: Glslang | undefined;
 
 // TODO: Should this gain some functionality currently only in UnitTest?
 export class GPUTest extends Fixture {
@@ -54,14 +54,10 @@ export class GPUTest extends Fixture {
 
   makeShaderModule(stage: ShaderStage, source: string): GPUShaderModule {
     if (!glslangInstance) {
-      throw new Error('GLSL is not instanciated. Run `await initGLSL()` first');
+      throw new Error('GLSL is not instantiated. Run `await t.initGLSL()` first');
     }
-    return this.device.createShaderModule({ code: this.compile(stage, source) });
-  }
-
-  private compile(stage: ShaderStage, source: string): Uint32Array {
-    const data = glslangInstance.compileGLSL(source, stage, false);
-    return data;
+    const code = glslangInstance.compileGLSL(source, stage, false);
+    return this.device.createShaderModule({ code });
   }
 
   // TODO: add an expectContents for textures, which logs data: uris on failure


### PR DESCRIPTION
This PR is about providing a way to run GLSL in standalone mode so that we can compile GLSL code at runtime.

I was inspired heavily by https://github.com/kainino0x/cts/tree/glslang-in-standalone

It will be used by setVertexBuffers and vertex input validation tests.

FYI @Kangz @austinEng

