### PR TITLE
[Framework] Print duplicated test name

### DIFF
--- a/src/framework/test_group.ts
+++ b/src/framework/test_group.ts
@@ -44,7 +44,7 @@ export class TestGroup<F extends Fixture> implements RunCaseIterable {
     }
 
     if (this.seen.has(name)) {
-      throw new Error('Duplicate test name');
+      throw new Error(`Duplicate test name: ${name}`);
     }
     this.seen.add(name);
   }


### PR DESCRIPTION
This PR prints the name of the test that is found as duplicate. It helps with debugging.