### PR TITLE
[Framework] Add debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,15 @@ npx grunt build
 To test in a browser under the standalone harness, run `grunt serve`, then
 open:
 
-* http://localhost:8080/ (defaults to ?runnow=0&q=cts)
-* http://localhost:8080/?runnow=1&q=unittests:
-* http://localhost:8080/?runnow=1&q=unittests:basic:&q=unittests:params:
+- http://localhost:8080/ (defaults to ?runnow=0&q=cts)
+- http://localhost:8080/?runnow=1&q=unittests:
+- http://localhost:8080/?runnow=1&q=unittests:basic:&q=unittests:params:
+
+### Debug
+
+To see debug logs in a browser, use the `debug=1` query string:
+
+- http://localhost:8080/?q=cts:validation&debug=1
 
 ### Making Changes
 

--- a/src/framework/fixture.ts
+++ b/src/framework/fixture.ts
@@ -18,6 +18,10 @@ export class Fixture {
   // we need to be able to ergonomically override it in subclasses.
   async init(): Promise<void> {}
 
+  debug(msg: string): void {
+    this.rec.debug(msg);
+  }
+
   log(msg: string): void {
     this.rec.log(msg);
   }

--- a/src/framework/logger.ts
+++ b/src/framework/logger.ts
@@ -54,16 +54,18 @@ export class TestCaseRecorder {
   private warned = false;
   private startTime = -1;
   private logs: string[] = [];
+  private debugging = false;
 
   constructor(result: LiveTestCaseResult) {
     this.result = result;
   }
 
-  start(): void {
+  start(debug: boolean = false): void {
     this.startTime = now();
     this.logs = [];
     this.failed = false;
     this.warned = false;
+    this.debugging = debug;
   }
 
   finish(): void {
@@ -76,6 +78,14 @@ export class TestCaseRecorder {
     this.result.status = this.failed ? 'fail' : this.warned ? 'warn' : 'pass';
 
     this.result.logs = this.logs;
+    this.debugging = false;
+  }
+
+  debug(msg: string): void {
+    if (!this.debugging) {
+      return;
+    }
+    this.log('DEBUG: ' + msg);
   }
 
   log(msg: string): void {

--- a/src/framework/test_group.ts
+++ b/src/framework/test_group.ts
@@ -6,7 +6,7 @@ import { ParamSpecIterable, ParamsAny, paramsEquals } from './params/index.js';
 
 export interface RunCase {
   readonly id: TestCaseID;
-  run(): Promise<LiveTestCaseResult>;
+  run(debug?: boolean): Promise<LiveTestCaseResult>;
 }
 
 export interface RunCaseIterable {
@@ -108,9 +108,9 @@ class RunCaseSpecific<F extends Fixture> implements RunCase {
     this.fn = fn;
   }
 
-  async run(): Promise<LiveTestCaseResult> {
+  async run(debug: boolean): Promise<LiveTestCaseResult> {
     const [rec, res] = this.recorder.record(this.id.test, this.id.params);
-    rec.start();
+    rec.start(debug);
     try {
       const inst = new this.fixture(rec, this.id.params || {});
       await inst.init();

--- a/src/runtime/standalone.ts
+++ b/src/runtime/standalone.ts
@@ -48,7 +48,12 @@ function makeTest(spec: TestSpecID, description: string): HTMLElement {
   return testcases[0];
 }
 
-function mkCase(testcasesVis: HTMLElement, query: string, t: RunCase): () => Promise<void> {
+function mkCase(
+  testcasesVis: HTMLElement,
+  query: string,
+  t: RunCase,
+  debug: boolean
+): () => Promise<void> {
   const testcase = $('<div>')
     .addClass('testcase')
     .appendTo(testcasesVis);
@@ -71,7 +76,7 @@ function mkCase(testcasesVis: HTMLElement, query: string, t: RunCase): () => Pro
   const caselogs = $('<div>', { class: 'caselogs' }).appendTo(testcase);
 
   const runCase = async () => {
-    const res = await t.run();
+    const res = await t.run(debug);
 
     casetime.text(res.timems.toFixed(4) + ' ms');
 
@@ -100,6 +105,7 @@ function mkCase(testcasesVis: HTMLElement, query: string, t: RunCase): () => Pro
 (async () => {
   const url = new URL(window.location.toString());
   const runnow = url.searchParams.get('runnow') === '1';
+  const debug = url.searchParams.get('debug') === '1';
 
   const loader = new TestLoader();
 
@@ -119,7 +125,7 @@ function mkCase(testcasesVis: HTMLElement, query: string, t: RunCase): () => Pro
     const [tRec] = log.record(f.id);
     for (const t of f.spec.g.iterate(tRec)) {
       const query = makeQueryString(f.id, t.id);
-      const runCase = mkCase(testcasesVis, query, t);
+      const runCase = mkCase(testcasesVis, query, t, debug);
       runCaseList.push(runCase);
     }
   }

--- a/src/suites/cts/validation/validation_test.ts
+++ b/src/suites/cts/validation/validation_test.ts
@@ -25,6 +25,8 @@ export class ValidationTest extends GPUTest {
       const gpuValidationError = await this.device.popErrorScope();
       if (!gpuValidationError) {
         this.fail('Validation error was expected.');
+      } else if (gpuValidationError instanceof GPUValidationError) {
+        this.debug(`Captured validation error - ${gpuValidationError.message}`);
       }
     });
   }

--- a/src/suites/unittests/logger.spec.ts
+++ b/src/suites/unittests/logger.spec.ts
@@ -84,3 +84,21 @@ g.test('fail', t => {
   t.expect(res.status === 'fail');
   t.expect(res.timems >= 0);
 });
+
+g.test('debug', t => {
+  const { debug, logsCount } = t.params;
+
+  const mylog = new Logger();
+  const [testrec] = mylog.record({ suite: '', path: '' });
+  const [rec, res] = testrec.record('baz', null);
+
+  rec.start(debug);
+  rec.debug('hello');
+  rec.finish();
+  t.expect(res.status === 'pass');
+  t.expect(res.timems >= 0);
+  t.expect(res.logs!.length === logsCount);
+}).params([
+  { debug: true, logsCount: 1 }, // ()
+  { debug: false, logsCount: 0 },
+]);


### PR DESCRIPTION
When writing validation tests, I was always logging the validation error captured. Since I don't want to pollute test case results with those all the time, a debug mode easily accessible seems like a good idea to me.

This PR adds a debug mode, available with `debug=1`. It uses it when an expected validation error is captured.

![image](https://user-images.githubusercontent.com/634478/65329615-1f2d3580-dbb9-11e9-8f54-a65eb44ad0e0.png)


FYI @Kangz  @austinEng 