### PR TITLE
s/dynamic/hasDynamicOffset/g

### DIFF
--- a/src/suites/cts/validation/createBindGroupLayout.spec.ts
+++ b/src/suites/cts/validation/createBindGroupLayout.spec.ts
@@ -96,7 +96,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
       binding: i,
       visibility: GPUShaderStage.COMPUTE,
       type,
-      dynamic: true,
+      hasDynamicOffset: true,
     });
   }
 
@@ -107,7 +107,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
         binding: maxDynamicBufferBindings.length,
         visibility: GPUShaderStage.COMPUTE,
         type,
-        dynamic: false,
+        hasDynamicOffset: false,
       },
     ],
   };
@@ -117,7 +117,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
 
   // Dynamic buffers exceed maximum in a bind group layout.
   const badDescriptor = clone(goodDescriptor);
-  badDescriptor.bindings![maxDynamicBufferCount].dynamic = true;
+  badDescriptor.bindings![maxDynamicBufferCount].hasDynamicOffset = true;
 
   await t.expectValidationError(() => {
     t.device.createBindGroupLayout(badDescriptor);
@@ -136,7 +136,7 @@ g.test('dynamic set to true is allowed only for buffers', async t => {
         binding: 0,
         visibility: GPUShaderStage.FRAGMENT,
         type,
-        dynamic: true,
+        hasDynamicOffset: true,
       },
     ],
   };

--- a/src/suites/cts/validation/createPipelineLayout.spec.ts
+++ b/src/suites/cts/validation/createPipelineLayout.spec.ts
@@ -21,7 +21,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
       binding: i,
       visibility: GPUShaderStage.COMPUTE,
       type,
-      dynamic: true,
+      hasDynamicOffset: true,
     });
   }
 
@@ -35,7 +35,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
         binding: 0,
         visibility: GPUShaderStage.COMPUTE,
         type,
-        dynamic: false,
+        hasDynamicOffset: false,
       },
     ],
   };
@@ -52,7 +52,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
 
   // Check dynamic buffers exceed maximum in pipeline layout.
   const badDescriptor = clone(goodDescriptor);
-  badDescriptor.bindings![0].dynamic = true;
+  badDescriptor.bindings![0].hasDynamicOffset = true;
 
   const badPipelineLayoutDescriptor = {
     bindGroupLayouts: [

--- a/src/suites/cts/validation/setBindGroup.spec.ts
+++ b/src/suites/cts/validation/setBindGroup.spec.ts
@@ -99,13 +99,13 @@ g.test('dynamic offsets match expectations in pass encoder', async t => {
         binding: 0,
         visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
         type: 'uniform-buffer',
-        dynamic: true,
+        hasDynamicOffset: true,
       },
       {
         binding: 1,
         visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
         type: 'storage-buffer',
-        dynamic: true,
+        hasDynamicOffset: true,
       },
     ],
   });


### PR DESCRIPTION
This PR simply renames all occurrences of GPUBindGroupLayoutBinding `dynamic` to `hasDynamicOffset`.

It depends on https://github.com/kainino0x/-webgpu-types/pull/3.
I'll update package.json version of -webgpu-types then.

FYI @Kangz @austinEng 