### PR TITLE
Remove NONE usage in tests

### DIFF
--- a/src/suites/cts/validation/createBindGroup.spec.ts
+++ b/src/suites/cts/validation/createBindGroup.spec.ts
@@ -243,7 +243,6 @@ g.test('texture binding must have correct usage', async t => {
   });
 
   function* mismatchedTextureUsages(): Iterable<GPUTextureUsage> {
-    yield GPUTextureUsage.NONE;
     yield GPUTextureUsage.COPY_SRC;
     yield GPUTextureUsage.COPY_DST;
     if (type !== 'sampled-texture') {

--- a/src/suites/cts/validation/createBindGroupLayout.spec.ts
+++ b/src/suites/cts/validation/createBindGroupLayout.spec.ts
@@ -63,27 +63,18 @@ g.test('negative binding index', async t => {
   });
 });
 
-g.test('Visibility of bindings cannot be 0', async t => {
-  const goodDescriptor: GPUBindGroupLayoutDescriptor = {
+g.test('Visibility of bindings can be 0', async t => {
+  const descriptor: GPUBindGroupLayoutDescriptor = {
     bindings: [
       {
         binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
+        visibility: 0,
         type: 'storage-buffer',
       },
     ],
   };
 
-  // Control case
-  t.device.createBindGroupLayout(goodDescriptor);
-
-  // Binding visibility set to 0 can't be specified.
-  const badDescriptor = clone(goodDescriptor);
-  badDescriptor.bindings![0].visibility = 0;
-
-  await t.expectValidationError(() => {
-    t.device.createBindGroupLayout(badDescriptor);
-  });
+  t.device.createBindGroupLayout(descriptor);
 });
 
 g.test('number of dynamic buffers exceeds the maximum value', async t => {

--- a/src/suites/cts/validation/createBindGroupLayout.spec.ts
+++ b/src/suites/cts/validation/createBindGroupLayout.spec.ts
@@ -63,6 +63,29 @@ g.test('negative binding index', async t => {
   });
 });
 
+g.test('Visibility of bindings cannot be 0', async t => {
+  const goodDescriptor: GPUBindGroupLayoutDescriptor = {
+    bindings: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.COMPUTE,
+        type: 'storage-buffer',
+      },
+    ],
+  };
+
+  // Control case
+  t.device.createBindGroupLayout(goodDescriptor);
+
+  // Binding visibility set to 0 can't be specified.
+  const badDescriptor = clone(goodDescriptor);
+  badDescriptor.bindings![0].visibility = 0;
+
+  await t.expectValidationError(() => {
+    t.device.createBindGroupLayout(badDescriptor);
+  });
+});
+
 g.test('number of dynamic buffers exceeds the maximum value', async t => {
   const { type, maxDynamicBufferCount } = t.params;
 

--- a/src/suites/cts/validation/createBindGroupLayout.spec.ts
+++ b/src/suites/cts/validation/createBindGroupLayout.spec.ts
@@ -63,30 +63,6 @@ g.test('negative binding index', async t => {
   });
 });
 
-// TODO: Update once https://github.com/gpuweb/gpuweb/issues/405 is decided.
-g.test('Visibility of bindings cannot be None', async t => {
-  const goodDescriptor: GPUBindGroupLayoutDescriptor = {
-    bindings: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        type: 'storage-buffer',
-      },
-    ],
-  };
-
-  // Control case
-  t.device.createBindGroupLayout(goodDescriptor);
-
-  // Binding visibility set to None can't be specified.
-  const badDescriptor = clone(goodDescriptor);
-  badDescriptor.bindings![0].visibility = GPUShaderStage.NONE;
-
-  await t.expectValidationError(() => {
-    t.device.createBindGroupLayout(badDescriptor);
-  });
-});
-
 g.test('number of dynamic buffers exceeds the maximum value', async t => {
   const { type, maxDynamicBufferCount } = t.params;
 


### PR DESCRIPTION
Following WebGPU spec change at https://github.com/gpuweb/gpuweb/pull/461/files, this PR removes NONE usage in CTS tests.