### PR TITLE
Change setVertexBuffers to setVertexBuffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/jquery": "^3.3.30",
     "@types/node": "^12.0.8",
     "@webgpu/glslang": "^0.0.8",
-    "@webgpu/types": "0.0.14",
+    "@webgpu/types": "0.0.15",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-macros": "^2.6.1",
     "clang-format": "^1.2.4",

--- a/src/suites/cts/validation/setVertexBuffer.spec.ts
+++ b/src/suites/cts/validation/setVertexBuffer.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-setVertexBuffers validation tests.
+setVertexBuffer validation tests.
 `;
 
 import { TestGroup, range } from '../../../framework/index.js';
@@ -48,6 +48,7 @@ class F extends ValidationTest {
         gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
        }
     `;
+    console.log(code);
     return {
       module: this.makeShaderModule('vertex', code),
       entryPoint: 'main',
@@ -96,8 +97,8 @@ g.test('vertex buffers inherit from previous pipeline', async t => {
   const pipeline1 = t.createRenderPipeline(1);
   const pipeline2 = t.createRenderPipeline(2);
 
-  const vertexBuffers = [t.getVertexBuffer(), t.getVertexBuffer()];
-  const offsets = [0, 0];
+  const vertexBuffer1 = t.getVertexBuffer();
+  const vertexBuffer2 = t.getVertexBuffer();
 
   {
     // Check failure when vertex buffer is not set
@@ -116,7 +117,8 @@ g.test('vertex buffers inherit from previous pipeline', async t => {
     const commandEncoder = t.device.createCommandEncoder();
     const renderPass = t.beginRenderPass(commandEncoder);
     renderPass.setPipeline(pipeline2);
-    renderPass.setVertexBuffers(0, vertexBuffers, offsets);
+    renderPass.setVertexBuffer(0, vertexBuffer1);
+    renderPass.setVertexBuffer(1, vertexBuffer2);
     renderPass.draw(3, 1, 0, 0);
     renderPass.setPipeline(pipeline1);
     renderPass.draw(3, 1, 0, 0);
@@ -130,8 +132,8 @@ g.test('vertex buffers do not inherit between render passes', async t => {
   const pipeline1 = t.createRenderPipeline(1);
   const pipeline2 = t.createRenderPipeline(2);
 
-  const vertexBuffers = [t.getVertexBuffer(), t.getVertexBuffer()];
-  const offsets = [0, 0];
+  const vertexBuffer1 = t.getVertexBuffer();
+  const vertexBuffer2 = t.getVertexBuffer();
 
   {
     // Check success when vertex buffer is set for each render pass
@@ -139,14 +141,15 @@ g.test('vertex buffers do not inherit between render passes', async t => {
     {
       const renderPass = t.beginRenderPass(commandEncoder);
       renderPass.setPipeline(pipeline2);
-      renderPass.setVertexBuffers(0, vertexBuffers, offsets);
+      renderPass.setVertexBuffer(0, vertexBuffer1);
+      renderPass.setVertexBuffer(1, vertexBuffer2);
       renderPass.draw(3, 1, 0, 0);
       renderPass.endPass();
     }
     {
       const renderPass = t.beginRenderPass(commandEncoder);
       renderPass.setPipeline(pipeline1);
-      renderPass.setVertexBuffers(0, [vertexBuffers[0]], [offsets[0]]);
+      renderPass.setVertexBuffer(0, vertexBuffer1);
       renderPass.draw(3, 1, 0, 0);
       renderPass.endPass();
     }
@@ -158,7 +161,8 @@ g.test('vertex buffers do not inherit between render passes', async t => {
     {
       const renderPass = t.beginRenderPass(commandEncoder);
       renderPass.setPipeline(pipeline2);
-      renderPass.setVertexBuffers(0, vertexBuffers, offsets);
+      renderPass.setVertexBuffer(0, vertexBuffer1);
+      renderPass.setVertexBuffer(1, vertexBuffer2);
       renderPass.draw(3, 1, 0, 0);
       renderPass.endPass();
     }

--- a/src/suites/cts/validation/setVertexBuffer.spec.ts
+++ b/src/suites/cts/validation/setVertexBuffer.spec.ts
@@ -48,7 +48,6 @@ class F extends ValidationTest {
         gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
        }
     `;
-    console.log(code);
     return {
       module: this.makeShaderModule('vertex', code),
       entryPoint: 'main',

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,10 +278,10 @@
   resolved "https://registry.yarnpkg.com/@webgpu/glslang/-/glslang-0.0.8.tgz#174d803a0eb4c6e121a590d1d98d98446512c782"
   integrity sha512-HqGv36jd87zwv6q5v5+GnzQe2pNT3eML8Ln1RG6NfS0OGN1cmNrt2FamiNin+bXChcGCjDTjSyOc1tEpi07jRg==
 
-"@webgpu/types@0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.0.14.tgz#557b4693ea6839d77fac876ded9b9fd2d4a442c3"
-  integrity sha512-bSVjZbeT4p8EDm2YKeLIOrIXtThW42aErC3tx2lqKo9eHmXTwTz/kUY0Hxot/WTCD5qwShicHuZiPuQrXpjkPA==
+"@webgpu/types@0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.0.15.tgz#56838d826476afc9801adbe72fe48d2e380e342e"
+  integrity sha512-bYQf0cL/aX8JZjKSj8pmuAIoJhRKwV1Trtv/u2nfCgcrPazF9g7dxJ4vG0K/tCO6xrnj4mzOkFwqLE6X+WESiA==
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
Following WebGPU spec change at https://github.com/gpuweb/gpuweb/pull/468, this PR updates tests using `setVertexBuffer`.

Note that this requires https://github.com/gpuweb/types/pull/4