### PR TITLE
Use an async-mutex to run one test at a time in WPT runtime

### DIFF
--- a/src/framework/util/async_mutex.ts
+++ b/src/framework/util/async_mutex.ts
@@ -1,0 +1,21 @@
+export class AsyncMutex {
+  private lastToRun: Promise<unknown> | undefined;
+
+  // Run an async function with a lock on this mutex.
+  // Waits until the mutex is available, locks it, runs the function, then releases it.
+  async with<T>(fn: () => Promise<T>): Promise<T> {
+    const p = (async () => {
+      // If the mutex is locked, wait for the last thing in the queue before running.
+      // (Everything in the queue runs in order, so this is after everything currently enqueued.)
+      if (this.lastToRun) {
+        await this.lastToRun;
+      }
+      return fn();
+    })();
+
+    // Push the newly-created Promise onto the queue.
+    this.lastToRun = p;
+    // And return so the caller can wait on the result.
+    return p;
+  }
+}

--- a/src/framework/util/async_mutex.ts
+++ b/src/framework/util/async_mutex.ts
@@ -1,5 +1,7 @@
 export class AsyncMutex {
-  private lastToRun: Promise<unknown> | undefined;
+  // The newest item currently waiting for the mutex. This promise is chained so
+  // that it implicitly defines a FIFO queue where this is the "last-in" item.
+  private newestQueueItem: Promise<unknown> | undefined;
 
   // Run an async function with a lock on this mutex.
   // Waits until the mutex is available, locks it, runs the function, then releases it.
@@ -7,14 +9,14 @@ export class AsyncMutex {
     const p = (async () => {
       // If the mutex is locked, wait for the last thing in the queue before running.
       // (Everything in the queue runs in order, so this is after everything currently enqueued.)
-      if (this.lastToRun) {
-        await this.lastToRun;
+      if (this.newestQueueItem) {
+        await this.newestQueueItem;
       }
       return fn();
     })();
 
-    // Push the newly-created Promise onto the queue.
-    this.lastToRun = p;
+    // Push the newly-created Promise onto the queue by replacing the old "newest" item.
+    this.newestQueueItem = p;
     // And return so the caller can wait on the result.
     return p;
   }

--- a/src/suites/unittests/async_mutex.spec.ts
+++ b/src/suites/unittests/async_mutex.spec.ts
@@ -1,0 +1,61 @@
+export const description = `
+Tests for AsyncMutex.
+`;
+
+import { TestGroup, objectEquals } from '../../framework/index.js';
+import { AsyncMutex } from '../../framework/util/async_mutex.js';
+
+import { UnitTest } from './unit_test.js';
+
+export const g = new TestGroup(UnitTest);
+
+g.test('basic', async t => {
+  const mutex = new AsyncMutex();
+  await mutex.with(async () => {});
+});
+
+g.test('serial', async t => {
+  const mutex = new AsyncMutex();
+  await mutex.with(async () => {});
+  await mutex.with(async () => {});
+  await mutex.with(async () => {});
+});
+
+g.test('parallel', async t => {
+  const mutex = new AsyncMutex();
+  await Promise.all([
+    mutex.with(async () => {}),
+    mutex.with(async () => {}),
+    mutex.with(async () => {}),
+  ]);
+});
+
+g.test('parallel/many', async t => {
+  const mutex = new AsyncMutex();
+  const actual: number[] = [];
+  const expected = [];
+  for (let i = 0; i < 1000; ++i) {
+    expected.push(i);
+    mutex.with(async () => {
+      actual.push(i);
+    });
+  }
+  await mutex.with(async () => {});
+  t.expect(objectEquals(actual, expected));
+});
+
+g.test('return', async t => {
+  const mutex = new AsyncMutex();
+  const ret = await mutex.with(async () => 123);
+  t.expect(ret === 123);
+});
+
+g.test('return/parallel', async t => {
+  const mutex = new AsyncMutex();
+  const ret = await Promise.all([
+    mutex.with(async () => 1),
+    mutex.with(async () => 2),
+    mutex.with(async () => 3),
+  ]);
+  t.expect(objectEquals(ret, [1, 2, 3]));
+});


### PR DESCRIPTION
This is technically a workaround for a Chrome bug (in which I think every device is actually the same device).

However, this is an old TODO anyway - I never really wanted to run all the tests in parallel.

In the future I think we'll want to extend this to do something like "run up to 10 in parallel".