### PR TITLE
wpt export: use single quotes and absolute path for runtime

### DIFF
--- a/src/tools/gen_wpt_cts_html.ts
+++ b/src/tools/gen_wpt_cts_html.ts
@@ -14,7 +14,7 @@ import { listing } from '../suites/cts/index.js';
 
   const ls = (await listing) as TestSuiteListingEntry[];
   for (const l of ls) {
-    result += `<meta name="variant" content="?q=cts:${l.path}:">\n`;
+    result += `<meta name=variant content='?q=cts:${l.path}:'>\n`;
   }
 
   return fs.writeFile('./out-wpt/cts.html', result);

--- a/templates/cts.html
+++ b/templates/cts.html
@@ -23,7 +23,7 @@
 <!doctype html>
 <title>WebGPU CTS</title>
 <meta charset=utf-8>
-<link rel="help" href="https://gpuweb.github.io/gpuweb/">
+<link rel=help href='https://gpuweb.github.io/gpuweb/'>
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
@@ -36,4 +36,4 @@
 </style>
 
 <textarea id=results></textarea>
-<script type=module src="runtime/wpt.js"></script>
+<script type=module src=/webgpu/runtime/wpt.js></script>


### PR DESCRIPTION
- use single quotes in variant list: so that when using a variant string
  containing JSON, the double quotes are contained properly by the
  single quotes.
- use absolute path to wpt runtime: so that if copied to an external
  directory like Chromium's `wpt_internal`, it can still find the
  runtime file.