### PR TITLE
Add "private" params, prefixed with underscore

### DIFF
--- a/src/framework/logger.ts
+++ b/src/framework/logger.ts
@@ -1,6 +1,7 @@
 import { TestSpecID } from './id.js';
 import { ParamsSpec } from './params/index.js';
 import { makeQueryString } from './url_query.js';
+import { extractPublicParams } from './url_query.js';
 import { getStackTrace, now } from './util/index.js';
 import { version } from './version.js';
 
@@ -42,7 +43,12 @@ export class TestSpecRecorder {
   }
 
   record(test: string, params: ParamsSpec | null): [TestCaseRecorder, LiveTestCaseResult] {
-    const result: LiveTestCaseResult = { test, params, status: 'running', timems: -1 };
+    const result: LiveTestCaseResult = {
+      test,
+      params: params ? extractPublicParams(params) : null,
+      status: 'running',
+      timems: -1,
+    };
     this.result.cases.push(result);
     return [new TestCaseRecorder(result), result];
   }

--- a/src/framework/test_group.ts
+++ b/src/framework/test_group.ts
@@ -3,6 +3,7 @@ import { Fixture } from './fixture.js';
 import { TestCaseID } from './id.js';
 import { LiveTestCaseResult, TestCaseRecorder, TestSpecRecorder } from './logger.js';
 import { ParamSpecIterable, ParamsAny, paramsEquals } from './params/index.js';
+import { extractPublicParams } from './url_query.js';
 
 export interface RunCase {
   readonly id: TestCaseID;
@@ -80,16 +81,18 @@ class Test<F extends Fixture> {
     const seen: ParamsAny[] = [];
     // This is n^2.
     for (const spec of cases) {
-      if (seen.some(x => paramsEquals(x, spec))) {
+      const publicParams = extractPublicParams(spec);
+      if (seen.some(x => paramsEquals(x, publicParams))) {
         throw new Error('Duplicate test case params');
       }
-      seen.push(spec);
+      seen.push(publicParams);
     }
     this.cases = cases;
   }
 
   *iterate(rec: TestSpecRecorder): IterableIterator<RunCase> {
-    for (const params of this.cases || [null]) {
+    for (const p of this.cases || [null]) {
+      const params = p ? extractPublicParams(p) : null;
       yield new RunCaseSpecific(rec, { test: this.name, params }, this.fixture, this.fn);
     }
   }

--- a/src/framework/url_query.ts
+++ b/src/framework/url_query.ts
@@ -1,4 +1,5 @@
 import { TestCaseID, TestSpecID } from './id.js';
+import { ParamsSpec } from './params/index.js';
 
 export function encodeSelectively(s: string): string {
   let ret = encodeURIComponent(s);
@@ -15,13 +16,23 @@ export function encodeSelectively(s: string): string {
   return ret;
 }
 
+export function extractPublicParams(params: ParamsSpec): ParamsSpec {
+  const publicParams: ParamsSpec = {};
+  for (const k of Object.keys(params)) {
+    if (!k.startsWith('_')) {
+      publicParams[k] = params[k];
+    }
+  }
+  return publicParams;
+}
+
 export function makeQueryString(spec: TestSpecID, testcase?: TestCaseID): string {
   let s = spec.suite + ':';
   s += spec.path + ':';
   if (testcase !== undefined) {
     s += testcase.test + '=';
     if (testcase.params) {
-      s += JSON.stringify(testcase.params);
+      s += JSON.stringify(extractPublicParams(testcase.params));
     }
   }
   return encodeSelectively(s);

--- a/src/suites/cts/examples.spec.ts
+++ b/src/suites/cts/examples.spec.ts
@@ -55,13 +55,21 @@ g.test('basic/async', async t => {
   );
 });
 
+// A test can be parameterized with a simple array of objects.
+//
+// Parameters can be public (x, y) which means they're part of the case name.
+// They can also be private by starting with an underscore (_result), which passes
+// them into the test but does not make them part of the case name:
+//
+// - cts:examples:basic/params={"x":2,"y":4}    runs with t.params = {x: 2, y: 5, _result: 6}.
+// - cts:examples:basic/params={"x":-10,"y":18} runs with t.params = {x: -10, y: 18, _result: 8}.
 g.test('basic/params', t => {
-  t.expect(t.params.x + t.params.y === t.params.result);
+  t.expect(t.params.x + t.params.y === t.params._result);
 }).params([
-  { x: 2, y: 4, result: 6 }, //
-  { x: -10, y: 18, result: 8 },
+  { x: 2, y: 4, _result: 6 }, //
+  { x: -10, y: 18, _result: 8 },
 ]);
-// (note blank comment above to enforce newlines on autoformat)
+// (note the blank comment above to enforce newlines on autoformat)
 
 g.test('gpu/async', async t => {
   const fence = t.queue.createFence();

--- a/src/suites/cts/validation/createBindGroup.spec.ts
+++ b/src/suites/cts/validation/createBindGroup.spec.ts
@@ -396,7 +396,7 @@ g.test('texture must have correct dimension', async t => {
 });
 
 g.test('buffer offset and size for bind groups match', async t => {
-  const { offset, size, success } = t.params;
+  const { offset, size, _success } = t.params;
 
   const bindGroupLayout = t.device.createBindGroupLayout({
     bindings: [
@@ -423,7 +423,7 @@ g.test('buffer offset and size for bind groups match', async t => {
     layout: bindGroupLayout,
   };
 
-  if (success) {
+  if (_success) {
     // Control case
     t.device.createBindGroup(descriptor);
   } else {
@@ -433,22 +433,22 @@ g.test('buffer offset and size for bind groups match', async t => {
     });
   }
 }).params([
-  { offset: 0, size: 512, success: true }, // offset 0 is valid
-  { offset: 256, size: 256, success: true }, // offset 256 (aligned) is valid
+  { offset: 0, size: 512, _success: true }, // offset 0 is valid
+  { offset: 256, size: 256, _success: true }, // offset 256 (aligned) is valid
 
   // unaligned buffer offset is invalid
-  { offset: 1, size: 256, success: false },
-  { offset: 1, size: undefined, success: false },
-  { offset: 128, size: 256, success: false },
-  { offset: 255, size: 256, success: false },
+  { offset: 1, size: 256, _success: false },
+  { offset: 1, size: undefined, _success: false },
+  { offset: 128, size: 256, _success: false },
+  { offset: 255, size: 256, _success: false },
 
-  { offset: 0, size: 256, success: true }, // touching the start of the buffer works
-  { offset: 256 * 3, size: 256, success: true }, // touching the end of the buffer works
-  { offset: 1024, size: 0, success: true }, // touching the end of the buffer works
-  { offset: 0, size: 1024, success: true }, // touching the full buffer works
-  { offset: 0, size: undefined, success: true }, // touching the full buffer works
-  { offset: 256 * 5, size: 0, success: false }, // offset is OOB
-  { offset: 0, size: 256 * 5, success: false }, // size is OOB
-  { offset: 1024, size: 1, success: false }, // offset+size is OOB
-  { offset: 256, size: -256, success: false }, // offset+size overflows to be 0
+  { offset: 0, size: 256, _success: true }, // touching the start of the buffer works
+  { offset: 256 * 3, size: 256, _success: true }, // touching the end of the buffer works
+  { offset: 1024, size: 0, _success: true }, // touching the end of the buffer works
+  { offset: 0, size: 1024, _success: true }, // touching the full buffer works
+  { offset: 0, size: undefined, _success: true }, // touching the full buffer works
+  { offset: 256 * 5, size: 0, _success: false }, // offset is OOB
+  { offset: 0, size: 256 * 5, _success: false }, // size is OOB
+  { offset: 1024, size: 1, _success: false }, // offset+size is OOB
+  { offset: 256, size: -256, _success: false }, // offset+size overflows to be 0
 ]);

--- a/src/suites/cts/validation/createBindGroupLayout.spec.ts
+++ b/src/suites/cts/validation/createBindGroupLayout.spec.ts
@@ -118,7 +118,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
 ]);
 
 g.test('dynamic set to true is allowed only for buffers', async t => {
-  const { type, success } = t.params;
+  const { type, _success } = t.params;
 
   const descriptor = {
     bindings: [
@@ -131,7 +131,7 @@ g.test('dynamic set to true is allowed only for buffers', async t => {
     ],
   };
 
-  if (success) {
+  if (_success) {
     // Control case
     t.device.createBindGroupLayout(descriptor);
   } else {
@@ -141,10 +141,10 @@ g.test('dynamic set to true is allowed only for buffers', async t => {
     });
   }
 }).params([
-  { type: 'uniform-buffer', success: true },
-  { type: 'storage-buffer', success: true },
-  { type: 'readonly-storage-buffer', success: true },
-  { type: 'sampler', success: false },
-  { type: 'sampled-texture', success: false },
-  { type: 'storage-texture', success: false },
+  { type: 'uniform-buffer', _success: true },
+  { type: 'storage-buffer', _success: true },
+  { type: 'readonly-storage-buffer', _success: true },
+  { type: 'sampler', _success: false },
+  { type: 'sampled-texture', _success: false },
+  { type: 'storage-texture', _success: false },
 ]);

--- a/src/suites/cts/validation/createPipelineLayout.spec.ts
+++ b/src/suites/cts/validation/createPipelineLayout.spec.ts
@@ -13,10 +13,10 @@ function clone(descriptor: GPUBindGroupLayoutDescriptor): GPUBindGroupLayoutDesc
 export const g = new TestGroup(ValidationTest);
 
 g.test('number of dynamic buffers exceeds the maximum value', async t => {
-  const { type, maxDynamicBufferCount } = t.params;
+  const { type, _expectedMaxDynamicBufferCount } = t.params;
 
   const maxDynamicBufferBindings: GPUBindGroupLayoutBinding[] = [];
-  for (let i = 0; i < maxDynamicBufferCount; i++) {
+  for (let i = 0; i < _expectedMaxDynamicBufferCount; i++) {
     maxDynamicBufferBindings.push({
       binding: i,
       visibility: GPUShaderStage.COMPUTE,
@@ -65,8 +65,8 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
     t.device.createPipelineLayout(badPipelineLayoutDescriptor);
   });
 }).params([
-  { type: 'storage-buffer', maxDynamicBufferCount: 4 },
-  { type: 'uniform-buffer', maxDynamicBufferCount: 8 },
+  { type: 'storage-buffer', _expectedMaxDynamicBufferCount: 4 },
+  { type: 'uniform-buffer', _expectedMaxDynamicBufferCount: 8 },
 ]);
 
 g.test('number of bind group layouts exceeds the maximum value', async t => {

--- a/src/suites/cts/validation/createRenderPipeline.spec.ts
+++ b/src/suites/cts/validation/createRenderPipeline.spec.ts
@@ -124,11 +124,11 @@ g.test('at least one color state is required', async t => {
 });
 
 g.test('color formats must be renderable', async t => {
-  const { format, success } = t.params;
+  const { format, _success } = t.params;
 
   const descriptor = t.getDescriptor({ colorStates: [{ format }] });
 
-  if (success) {
+  if (_success) {
     // Succeeds when format is renderable
     t.device.createRenderPipeline(descriptor);
   } else {
@@ -139,54 +139,54 @@ g.test('color formats must be renderable', async t => {
   }
 }).params([
   // 8-bit formats
-  { format: 'r8unorm', success: true },
-  { format: 'r8snorm', success: false },
-  { format: 'r8uint', success: true },
-  { format: 'r8sint', success: true },
+  { format: 'r8unorm', _success: true },
+  { format: 'r8snorm', _success: false },
+  { format: 'r8uint', _success: true },
+  { format: 'r8sint', _success: true },
   // 16-bit formats
-  { format: 'r16uint', success: true },
-  { format: 'r16sint', success: true },
-  { format: 'r16float', success: true },
-  { format: 'rg8unorm', success: true },
-  { format: 'rg8snorm', success: false },
-  { format: 'rg8uint', success: true },
-  { format: 'rg8sint', success: true },
+  { format: 'r16uint', _success: true },
+  { format: 'r16sint', _success: true },
+  { format: 'r16float', _success: true },
+  { format: 'rg8unorm', _success: true },
+  { format: 'rg8snorm', _success: false },
+  { format: 'rg8uint', _success: true },
+  { format: 'rg8sint', _success: true },
   // 32-bit formats
-  { format: 'r32uint', success: true },
-  { format: 'r32sint', success: true },
-  { format: 'r32float', success: true },
-  { format: 'rg16uint', success: true },
-  { format: 'rg16sint', success: true },
-  { format: 'rg16float', success: true },
-  { format: 'rgba8unorm', success: true },
-  { format: 'rgba8unorm-srgb', success: true },
-  { format: 'rgba8snorm', success: false },
-  { format: 'rgba8uint', success: true },
-  { format: 'rgba8sint', success: true },
-  { format: 'bgra8unorm', success: true },
-  { format: 'bgra8unorm-srgb', success: true },
+  { format: 'r32uint', _success: true },
+  { format: 'r32sint', _success: true },
+  { format: 'r32float', _success: true },
+  { format: 'rg16uint', _success: true },
+  { format: 'rg16sint', _success: true },
+  { format: 'rg16float', _success: true },
+  { format: 'rgba8unorm', _success: true },
+  { format: 'rgba8unorm-srgb', _success: true },
+  { format: 'rgba8snorm', _success: false },
+  { format: 'rgba8uint', _success: true },
+  { format: 'rgba8sint', _success: true },
+  { format: 'bgra8unorm', _success: true },
+  { format: 'bgra8unorm-srgb', _success: true },
   // Packed 32-bit formats
-  { format: 'rgb10a2unorm', success: true },
-  { format: 'rg11b10float', success: false },
+  { format: 'rgb10a2unorm', _success: true },
+  { format: 'rg11b10float', _success: false },
   // 64-bit formats
-  { format: 'rg32uint', success: true },
-  { format: 'rg32sint', success: true },
-  { format: 'rg32float', success: true },
-  { format: 'rgba16uint', success: true },
-  { format: 'rgba16sint', success: true },
-  { format: 'rgba16float', success: true },
+  { format: 'rg32uint', _success: true },
+  { format: 'rg32sint', _success: true },
+  { format: 'rg32float', _success: true },
+  { format: 'rgba16uint', _success: true },
+  { format: 'rgba16sint', _success: true },
+  { format: 'rgba16float', _success: true },
   // 128-bit formats
-  { format: 'rgba32uint', success: true },
-  { format: 'rgba32sint', success: true },
-  { format: 'rgba32float', success: true },
+  { format: 'rgba32uint', _success: true },
+  { format: 'rgba32sint', _success: true },
+  { format: 'rgba32float', _success: true },
 ]);
 
 g.test('sample count must be valid', async t => {
-  const { sampleCount, success } = t.params;
+  const { sampleCount, _success } = t.params;
 
   const descriptor = t.getDescriptor({ sampleCount });
 
-  if (success) {
+  if (_success) {
     // Succeeds when sample count is valid
     t.device.createRenderPipeline(descriptor);
   } else {
@@ -196,17 +196,17 @@ g.test('sample count must be valid', async t => {
     });
   }
 }).params([
-  { sampleCount: 0, success: false },
-  { sampleCount: 1, success: true },
-  { sampleCount: 2, success: false },
-  { sampleCount: 3, success: false },
-  { sampleCount: 4, success: true },
-  { sampleCount: 8, success: false },
-  { sampleCount: 16, success: false },
+  { sampleCount: 0, _success: false },
+  { sampleCount: 1, _success: true },
+  { sampleCount: 2, _success: false },
+  { sampleCount: 3, _success: false },
+  { sampleCount: 4, _success: true },
+  { sampleCount: 8, _success: false },
+  { sampleCount: 16, _success: false },
 ]);
 
 g.test('sample count must be equal to the one of every attachment in the render pass', async t => {
-  const { attachmentSamples, pipelineSamples, success } = t.params;
+  const { attachmentSamples, pipelineSamples, _success } = t.params;
 
   const colorTexture = t.createTexture({
     format: 'rgba8unorm',
@@ -265,10 +265,10 @@ g.test('sample count must be equal to the one of every attachment in the render 
 
     await t.expectValidationError(() => {
       commandEncoder.finish();
-    }, !success);
+    }, !_success);
   }
 }).params([
-  { attachmentSamples: 4, pipelineSamples: 4, success: true }, // It is allowed to use multisampled render pass and multisampled render pipeline.
-  { attachmentSamples: 4, pipelineSamples: 1, success: false }, // It is not allowed to use multisampled render pass and non-multisampled render pipeline.
-  { attachmentSamples: 1, pipelineSamples: 4, success: false }, // It is not allowed to use non-multisampled render pass and multisampled render pipeline.
+  { attachmentSamples: 4, pipelineSamples: 4, _success: true }, // It is allowed to use multisampled render pass and multisampled render pipeline.
+  { attachmentSamples: 4, pipelineSamples: 1, _success: false }, // It is not allowed to use multisampled render pass and non-multisampled render pipeline.
+  { attachmentSamples: 1, pipelineSamples: 4, _success: false }, // It is not allowed to use non-multisampled render pass and multisampled render pipeline.
 ]);

--- a/src/suites/cts/validation/createTexture.spec.ts
+++ b/src/suites/cts/validation/createTexture.spec.ts
@@ -40,41 +40,41 @@ class F extends ValidationTest {
 export const g = new TestGroup(F);
 
 g.test('validation of sampleCount', async t => {
-  const { sampleCount, mipLevelCount, arrayLayerCount, success } = t.params;
+  const { sampleCount, mipLevelCount, arrayLayerCount, _success } = t.params;
 
   const descriptor = t.getDescriptor({ sampleCount, mipLevelCount, arrayLayerCount });
 
   await t.expectValidationError(() => {
     t.device.createTexture(descriptor);
-  }, !success);
+  }, !_success);
 }).params([
-  { sampleCount: 0, success: false }, // sampleCount of 0 is not allowed
-  { sampleCount: 1, success: true }, // sampleCount of 1 is allowed
-  { sampleCount: 2, success: false }, // sampleCount of 2 is not allowed
-  { sampleCount: 3, success: false }, // sampleCount of 3 is not allowed
-  { sampleCount: 4, success: true }, // sampleCount of 4 is allowed
-  { sampleCount: 8, success: false }, // sampleCount of 8 is not allowed
-  { sampleCount: 16, success: false }, // sampleCount of 16 is not allowed
-  { sampleCount: 4, mipLevelCount: 2, success: false }, // it is an error to create a multisampled texture with mipLevelCount > 1
-  { sampleCount: 4, arrayLayerCount: 2, success: true }, // multisampled 2D array texture is supported
+  { sampleCount: 0, _success: false }, // sampleCount of 0 is not allowed
+  { sampleCount: 1, _success: true }, // sampleCount of 1 is allowed
+  { sampleCount: 2, _success: false }, // sampleCount of 2 is not allowed
+  { sampleCount: 3, _success: false }, // sampleCount of 3 is not allowed
+  { sampleCount: 4, _success: true }, // sampleCount of 4 is allowed
+  { sampleCount: 8, _success: false }, // sampleCount of 8 is not allowed
+  { sampleCount: 16, _success: false }, // sampleCount of 16 is not allowed
+  { sampleCount: 4, mipLevelCount: 2, _success: false }, // it is an error to create a multisampled texture with mipLevelCount > 1
+  { sampleCount: 4, arrayLayerCount: 2, _success: true }, // multisampled 2D array texture is supported
 ]);
 
 g.test('validation of mipLevelCount', async t => {
-  const { width, height, mipLevelCount, success } = t.params;
+  const { width, height, mipLevelCount, _success } = t.params;
 
   const descriptor = t.getDescriptor({ width, height, mipLevelCount });
 
   await t.expectValidationError(() => {
     t.device.createTexture(descriptor);
-  }, !success);
+  }, !_success);
 }).params([
-  { width: 32, height: 32, mipLevelCount: 1, success: true }, // mipLevelCount of 1 is allowed
-  { width: 32, height: 32, mipLevelCount: 0, success: false }, // mipLevelCount of 0 is not allowed
-  { width: 32, height: 32, mipLevelCount: 6, success: true }, // full mip chains are allowed (Mip level sizes: 32, 16, 8, 4, 2, 1)
-  { width: 31, height: 32, mipLevelCount: 7, success: false }, // too big mip chains on width are disallowed (Mip level width: 31, 15, 7, 3, 1, 1)
-  { width: 32, height: 31, mipLevelCount: 7, success: false }, // too big mip chains on height are disallowed (Mip level width: 31, 15, 7, 3, 1, 1)
-  { width: 32, height: 32, mipLevelCount: 100, success: false }, // undefined shift check if miplevel is bigger than the integer bit width
-  { width: 32, height: 8, mipLevelCount: 6, success: true }, // non square mip map halves the resolution until a 1x1 dimension. (Mip maps: 32 * 8, 16 * 4, 8 * 2, 4 * 1, 2 * 1, 1 * 1)
+  { width: 32, height: 32, mipLevelCount: 1, _success: true }, // mipLevelCount of 1 is allowed
+  { width: 32, height: 32, mipLevelCount: 0, _success: false }, // mipLevelCount of 0 is not allowed
+  { width: 32, height: 32, mipLevelCount: 6, _success: true }, // full mip chains are allowed (Mip level sizes: 32, 16, 8, 4, 2, 1)
+  { width: 31, height: 32, mipLevelCount: 7, _success: false }, // too big mip chains on width are disallowed (Mip level width: 31, 15, 7, 3, 1, 1)
+  { width: 32, height: 31, mipLevelCount: 7, _success: false }, // too big mip chains on height are disallowed (Mip level width: 31, 15, 7, 3, 1, 1)
+  { width: 32, height: 32, mipLevelCount: 100, _success: false }, // undefined shift check if miplevel is bigger than the integer bit width
+  { width: 32, height: 8, mipLevelCount: 6, _success: true }, // non square mip map halves the resolution until a 1x1 dimension. (Mip maps: 32 * 8, 16 * 4, 8 * 2, 4 * 1, 2 * 1, 1 * 1)
 ]);
 
 g.test('it is valid to destroy a texture', t => {
@@ -91,7 +91,7 @@ g.test('it is valid to destroy a destroyed texture', t => {
 });
 
 g.test('it is invalid to submit a destroyed texture before and after encode', async t => {
-  const { destroyBeforeEncode, destroyAfterEncode, success } = t.params;
+  const { destroyBeforeEncode, destroyAfterEncode, _success } = t.params;
 
   const descriptor = t.getDescriptor();
   const texture = t.device.createTexture(descriptor);
@@ -119,63 +119,63 @@ g.test('it is invalid to submit a destroyed texture before and after encode', as
 
   await t.expectValidationError(() => {
     t.queue.submit([commandBuffer]);
-  }, !success);
+  }, !_success);
 }).params([
-  { destroyBeforeEncode: false, destroyAfterEncode: false, success: true },
-  { destroyBeforeEncode: true, destroyAfterEncode: false, success: false },
-  { destroyBeforeEncode: false, destroyAfterEncode: true, success: false },
+  { destroyBeforeEncode: false, destroyAfterEncode: false, _success: true },
+  { destroyBeforeEncode: true, destroyAfterEncode: false, _success: false },
+  { destroyBeforeEncode: false, destroyAfterEncode: true, _success: false },
 ]);
 
 g.test('it is invalid to have an output attachment texture with non renderable format', async t => {
-  const { format, success } = t.params;
+  const { format, _success } = t.params;
 
   const descriptor = t.getDescriptor({ width: 1, height: 1, format });
 
   await t.expectValidationError(() => {
     t.device.createTexture(descriptor);
-  }, !success);
+  }, !_success);
 }).params([
   // 8-bit formats
-  { format: 'r8unorm', success: true },
-  { format: 'r8snorm', success: false },
-  { format: 'r8uint', success: true },
-  { format: 'r8sint', success: true },
+  { format: 'r8unorm', _success: true },
+  { format: 'r8snorm', _success: false },
+  { format: 'r8uint', _success: true },
+  { format: 'r8sint', _success: true },
   // 16-bit formats
-  { format: 'r16uint', success: true },
-  { format: 'r16sint', success: true },
-  { format: 'r16float', success: true },
-  { format: 'rg8unorm', success: true },
-  { format: 'rg8snorm', success: false },
-  { format: 'rg8uint', success: true },
-  { format: 'rg8sint', success: true },
+  { format: 'r16uint', _success: true },
+  { format: 'r16sint', _success: true },
+  { format: 'r16float', _success: true },
+  { format: 'rg8unorm', _success: true },
+  { format: 'rg8snorm', _success: false },
+  { format: 'rg8uint', _success: true },
+  { format: 'rg8sint', _success: true },
   // 32-bit formats
-  { format: 'r32uint', success: true },
-  { format: 'r32sint', success: true },
-  { format: 'r32float', success: true },
-  { format: 'rg16uint', success: true },
-  { format: 'rg16sint', success: true },
-  { format: 'rg16float', success: true },
-  { format: 'rgba8unorm', success: true },
-  { format: 'rgba8unorm-srgb', success: true },
-  { format: 'rgba8snorm', success: false },
-  { format: 'rgba8uint', success: true },
-  { format: 'rgba8sint', success: true },
-  { format: 'bgra8unorm', success: true },
-  { format: 'bgra8unorm-srgb', success: true },
+  { format: 'r32uint', _success: true },
+  { format: 'r32sint', _success: true },
+  { format: 'r32float', _success: true },
+  { format: 'rg16uint', _success: true },
+  { format: 'rg16sint', _success: true },
+  { format: 'rg16float', _success: true },
+  { format: 'rgba8unorm', _success: true },
+  { format: 'rgba8unorm-srgb', _success: true },
+  { format: 'rgba8snorm', _success: false },
+  { format: 'rgba8uint', _success: true },
+  { format: 'rgba8sint', _success: true },
+  { format: 'bgra8unorm', _success: true },
+  { format: 'bgra8unorm-srgb', _success: true },
   // Packed 32-bit formats
-  { format: 'rgb10a2unorm', success: true },
-  { format: 'rg11b10float', success: false },
+  { format: 'rgb10a2unorm', _success: true },
+  { format: 'rg11b10float', _success: false },
   // 64-bit formats
-  { format: 'rg32uint', success: true },
-  { format: 'rg32sint', success: true },
-  { format: 'rg32float', success: true },
-  { format: 'rgba16uint', success: true },
-  { format: 'rgba16sint', success: true },
-  { format: 'rgba16float', success: true },
+  { format: 'rg32uint', _success: true },
+  { format: 'rg32sint', _success: true },
+  { format: 'rg32float', _success: true },
+  { format: 'rgba16uint', _success: true },
+  { format: 'rgba16sint', _success: true },
+  { format: 'rgba16float', _success: true },
   // 128-bit formats
-  { format: 'rgba32uint', success: true },
-  { format: 'rgba32sint', success: true },
-  { format: 'rgba32float', success: true },
+  { format: 'rgba32uint', _success: true },
+  { format: 'rgba32sint', _success: true },
+  { format: 'rgba32float', _success: true },
 ]);
 
 // TODO: Add tests for compressed texture formats

--- a/src/suites/cts/validation/createView.spec.ts
+++ b/src/suites/cts/validation/createView.spec.ts
@@ -71,7 +71,7 @@ class F extends ValidationTest {
 export const g = new TestGroup(F);
 
 g.test('creating texture view on a 2D non array texture', async t => {
-  const { dimension = '2d', arrayLayerCount, mipLevelCount, baseMipLevel, success } = t.params;
+  const { dimension = '2d', arrayLayerCount, mipLevelCount, baseMipLevel, _success } = t.params;
 
   const texture = t.createTexture({ arrayLayerCount: 1 });
 
@@ -84,29 +84,29 @@ g.test('creating texture view on a 2D non array texture', async t => {
 
   await t.expectValidationError(() => {
     texture.createView(descriptor);
-  }, !success);
+  }, !_success);
 }).params([
-  { success: true }, // default view works
-  { arrayLayerCount: 1, success: true }, // it is OK to create a 2D texture view on a 2D texture
-  { arrayLayerCount: 2, success: false }, // it is an error to view a layer past the end of the texture
-  { dimension: '2d-array', arrayLayerCount: 1, success: true }, // it is OK to create a 1-layer 2D array texture view on a 2D texture
+  { _success: true }, // default view works
+  { arrayLayerCount: 1, _success: true }, // it is OK to create a 2D texture view on a 2D texture
+  { arrayLayerCount: 2, _success: false }, // it is an error to view a layer past the end of the texture
+  { dimension: '2d-array', arrayLayerCount: 1, _success: true }, // it is OK to create a 1-layer 2D array texture view on a 2D texture
   // mip level is in range
-  { mipLevelCount: 1, baseMipLevel: MIP_LEVEL_COUNT - 1, success: true },
-  { mipLevelCount: 2, baseMipLevel: MIP_LEVEL_COUNT - 2, success: true },
+  { mipLevelCount: 1, baseMipLevel: MIP_LEVEL_COUNT - 1, _success: true },
+  { mipLevelCount: 2, baseMipLevel: MIP_LEVEL_COUNT - 2, _success: true },
   // baseMipLevel == k && mipLevelCount == 0 means to use levels k..end
-  { mipLevelCount: 0, baseMipLevel: 0, success: true },
-  { mipLevelCount: 0, baseMipLevel: 1, success: true },
-  { mipLevelCount: 0, baseMipLevel: MIP_LEVEL_COUNT - 1, success: true },
-  { mipLevelCount: 0, baseMipLevel: MIP_LEVEL_COUNT, success: false },
+  { mipLevelCount: 0, baseMipLevel: 0, _success: true },
+  { mipLevelCount: 0, baseMipLevel: 1, _success: true },
+  { mipLevelCount: 0, baseMipLevel: MIP_LEVEL_COUNT - 1, _success: true },
+  { mipLevelCount: 0, baseMipLevel: MIP_LEVEL_COUNT, _success: false },
   // it is an error to make the mip level out of range
-  { mipLevelCount: MIP_LEVEL_COUNT + 1, baseMipLevel: 0, success: false },
-  { mipLevelCount: MIP_LEVEL_COUNT, baseMipLevel: 1, success: false },
-  { mipLevelCount: 2, baseMipLevel: MIP_LEVEL_COUNT - 1, success: false },
-  { mipLevelCount: 1, baseMipLevel: MIP_LEVEL_COUNT, success: false },
+  { mipLevelCount: MIP_LEVEL_COUNT + 1, baseMipLevel: 0, _success: false },
+  { mipLevelCount: MIP_LEVEL_COUNT, baseMipLevel: 1, _success: false },
+  { mipLevelCount: 2, baseMipLevel: MIP_LEVEL_COUNT - 1, _success: false },
+  { mipLevelCount: 1, baseMipLevel: MIP_LEVEL_COUNT, _success: false },
 ]);
 
 g.test('creating texture view on a 2D array texture', async t => {
-  const { dimension = '2d-array', arrayLayerCount, baseArrayLayer, success } = t.params;
+  const { dimension = '2d-array', arrayLayerCount, baseArrayLayer, _success } = t.params;
 
   const texture = t.createTexture({ arrayLayerCount: ARRAY_LAYER_COUNT_2D });
 
@@ -118,27 +118,27 @@ g.test('creating texture view on a 2D array texture', async t => {
 
   await t.expectValidationError(() => {
     texture.createView(descriptor);
-  }, !success);
+  }, !_success);
 }).params([
-  { success: true }, // default view works
-  { dimension: '2d', arrayLayerCount: 1, success: true }, // it is OK to create a 2D texture view on a 2D array texture
-  { arrayLayerCount: ARRAY_LAYER_COUNT_2D, success: true }, // it is OK to create a 2D array texture view on a 2D array texture
+  { _success: true }, // default view works
+  { dimension: '2d', arrayLayerCount: 1, _success: true }, // it is OK to create a 2D texture view on a 2D array texture
+  { arrayLayerCount: ARRAY_LAYER_COUNT_2D, _success: true }, // it is OK to create a 2D array texture view on a 2D array texture
   // baseArrayLayer == k && arrayLayerCount == 0 means to use layers k..end.
-  { arrayLayerCount: 0, baseArrayLayer: 0, success: true },
-  { arrayLayerCount: 0, baseArrayLayer: 1, success: true },
-  { arrayLayerCount: 0, baseArrayLayer: ARRAY_LAYER_COUNT_2D - 1, success: true },
-  { arrayLayerCount: 0, baseArrayLayer: ARRAY_LAYER_COUNT_2D, success: false },
+  { arrayLayerCount: 0, baseArrayLayer: 0, _success: true },
+  { arrayLayerCount: 0, baseArrayLayer: 1, _success: true },
+  { arrayLayerCount: 0, baseArrayLayer: ARRAY_LAYER_COUNT_2D - 1, _success: true },
+  { arrayLayerCount: 0, baseArrayLayer: ARRAY_LAYER_COUNT_2D, _success: false },
   // It is an error for the array layer range of the view to exceed that of the texture
-  { arrayLayerCount: ARRAY_LAYER_COUNT_2D + 1, baseArrayLayer: 0, success: false },
-  { arrayLayerCount: ARRAY_LAYER_COUNT_2D, baseArrayLayer: 1, success: false },
-  { arrayLayerCount: 2, baseArrayLayer: ARRAY_LAYER_COUNT_2D - 1, success: false },
-  { arrayLayerCount: 1, baseArrayLayer: ARRAY_LAYER_COUNT_2D, success: false },
+  { arrayLayerCount: ARRAY_LAYER_COUNT_2D + 1, baseArrayLayer: 0, _success: false },
+  { arrayLayerCount: ARRAY_LAYER_COUNT_2D, baseArrayLayer: 1, _success: false },
+  { arrayLayerCount: 2, baseArrayLayer: ARRAY_LAYER_COUNT_2D - 1, _success: false },
+  { arrayLayerCount: 1, baseArrayLayer: ARRAY_LAYER_COUNT_2D, _success: false },
 ]);
 
 g.test(
   'Using defaults validates the same as setting values for more than 1 array layer',
   async t => {
-    const { format, dimension, arrayLayerCount, mipLevelCount, success } = t.params;
+    const { format, dimension, arrayLayerCount, mipLevelCount, _success } = t.params;
 
     const texture = t.createTexture({ arrayLayerCount: ARRAY_LAYER_COUNT_2D });
 
@@ -146,26 +146,26 @@ g.test(
 
     await t.expectValidationError(() => {
       texture.createView(descriptor);
-    }, !success);
+    }, !_success);
   }
 ).params([
-  { success: true },
-  { format: 'rgba8unorm', success: true },
-  { format: 'r8unorm', success: false },
-  { dimension: '2d-array', success: true },
-  { dimension: '2d', success: false },
-  { arrayLayerCount: ARRAY_LAYER_COUNT_2D, success: false }, // setting array layers to non-0 means the dimensionality will default to 2D so by itself it causes an error.
-  { arrayLayerCount: ARRAY_LAYER_COUNT_2D, dimension: '2d-array', success: true },
+  { _success: true },
+  { format: 'rgba8unorm', _success: true },
+  { format: 'r8unorm', _success: false },
+  { dimension: '2d-array', _success: true },
+  { dimension: '2d', _success: false },
+  { arrayLayerCount: ARRAY_LAYER_COUNT_2D, _success: false }, // setting array layers to non-0 means the dimensionality will default to 2D so by itself it causes an error.
+  { arrayLayerCount: ARRAY_LAYER_COUNT_2D, dimension: '2d-array', _success: true },
   {
     arrayLayerCount: ARRAY_LAYER_COUNT_2D,
     dimension: '2d-array',
     mipLevelCount: MIP_LEVEL_COUNT,
-    success: true,
+    _success: true,
   },
 ]);
 
 g.test('Using defaults validates the same as setting values for only 1 array layer', async t => {
-  const { format, dimension, arrayLayerCount, mipLevelCount, success } = t.params;
+  const { format, dimension, arrayLayerCount, mipLevelCount, _success } = t.params;
 
   const texture = t.createTexture({ arrayLayerCount: 1 });
 
@@ -173,22 +173,22 @@ g.test('Using defaults validates the same as setting values for only 1 array lay
 
   await t.expectValidationError(() => {
     texture.createView(descriptor);
-  }, !success);
+  }, !_success);
 }).params([
-  { success: true },
-  { format: 'rgba8unorm', success: true },
-  { format: 'r8unorm', success: false },
-  { dimension: '2d-array', success: true },
-  { dimension: '2d', success: true },
-  { arrayLayerCount: 0, success: true },
-  { arrayLayerCount: 1, success: true },
-  { arrayLayerCount: 2, success: false },
-  { mipLevelCount: MIP_LEVEL_COUNT, success: true },
-  { mipLevelCount: 1, success: true },
+  { _success: true },
+  { format: 'rgba8unorm', _success: true },
+  { format: 'r8unorm', _success: false },
+  { dimension: '2d-array', _success: true },
+  { dimension: '2d', _success: true },
+  { arrayLayerCount: 0, _success: true },
+  { arrayLayerCount: 1, _success: true },
+  { arrayLayerCount: 2, _success: false },
+  { mipLevelCount: MIP_LEVEL_COUNT, _success: true },
+  { mipLevelCount: 1, _success: true },
 ]);
 
 g.test('creating cube map texture view', async t => {
-  const { dimension = '2d-array', arrayLayerCount, success } = t.params;
+  const { dimension = '2d-array', arrayLayerCount, _success } = t.params;
 
   const texture = t.createTexture({ arrayLayerCount: 16 });
 
@@ -199,18 +199,18 @@ g.test('creating cube map texture view', async t => {
 
   await t.expectValidationError(() => {
     texture.createView(descriptor);
-  }, !success);
+  }, !_success);
 }).params([
-  { dimension: 'cube', arrayLayerCount: 6, success: true }, // it is OK to create a cube map texture view with arrayLayerCount == 6
+  { dimension: 'cube', arrayLayerCount: 6, _success: true }, // it is OK to create a cube map texture view with arrayLayerCount == 6
   // it is an error to create a cube map texture view with arrayLayerCount != 6
-  { dimension: 'cube', arrayLayerCount: 3, success: false },
-  { dimension: 'cube', arrayLayerCount: 7, success: false },
-  { dimension: 'cube', arrayLayerCount: 12, success: false },
-  { dimension: 'cube', success: false },
-  { dimension: 'cube-array', arrayLayerCount: 12, success: true }, // it is OK to create a cube map array texture view with arrayLayerCount % 6 == 0
+  { dimension: 'cube', arrayLayerCount: 3, _success: false },
+  { dimension: 'cube', arrayLayerCount: 7, _success: false },
+  { dimension: 'cube', arrayLayerCount: 12, _success: false },
+  { dimension: 'cube', _success: false },
+  { dimension: 'cube-array', arrayLayerCount: 12, _success: true }, // it is OK to create a cube map array texture view with arrayLayerCount % 6 == 0
   // it is an error to create a cube map array texture view with arrayLayerCount % 6 != 0
-  { dimension: 'cube-array', arrayLayerCount: 11, success: false },
-  { dimension: 'cube-array', arrayLayerCount: 13, success: false },
+  { dimension: 'cube-array', arrayLayerCount: 11, _success: false },
+  { dimension: 'cube-array', arrayLayerCount: 13, _success: false },
 ]);
 
 g.test('creating cube map texture view with a non square texture', async t => {

--- a/src/suites/cts/validation/render_pass.spec.ts
+++ b/src/suites/cts/validation/render_pass.spec.ts
@@ -76,7 +76,7 @@ class F extends ValidationTest {
 export const g = new TestGroup(F);
 
 g.test('it is invalid to draw in a render pass with missing bind groups', async t => {
-  const { setBindGroup1, setBindGroup2, success } = t.params;
+  const { setBindGroup1, setBindGroup2, _success } = t.params;
 
   const uniformBuffer = t.getUniformBuffer();
 
@@ -143,10 +143,10 @@ g.test('it is invalid to draw in a render pass with missing bind groups', async 
   renderPass.endPass();
   await t.expectValidationError(() => {
     commandEncoder.finish();
-  }, !success);
+  }, !_success);
 }).params([
-  { setBindGroup1: true, setBindGroup2: true, success: true },
-  { setBindGroup1: true, setBindGroup2: false, success: false },
-  { setBindGroup1: false, setBindGroup2: true, success: false },
-  { setBindGroup1: false, setBindGroup2: false, success: false },
+  { setBindGroup1: true, setBindGroup2: true, _success: true },
+  { setBindGroup1: true, setBindGroup2: false, _success: false },
+  { setBindGroup1: false, setBindGroup2: true, _success: false },
+  { setBindGroup1: false, setBindGroup2: false, _success: false },
 ]);

--- a/src/suites/cts/validation/render_pass_descriptor.spec.ts
+++ b/src/suites/cts/validation/render_pass_descriptor.spec.ts
@@ -98,7 +98,7 @@ g.test('a render pass with only one depth attachment is ok', t => {
 });
 
 g.test('OOB color attachment indices are handled', async t => {
-  const { colorAttachmentsCount, success } = t.params;
+  const { colorAttachmentsCount, _success } = t.params;
 
   const colorAttachments = [];
   for (let i = 0; i < colorAttachmentsCount; i++) {
@@ -106,10 +106,10 @@ g.test('OOB color attachment indices are handled', async t => {
     colorAttachments.push(t.getColorAttachment(colorTexture));
   }
 
-  await t.tryRenderPass(success, { colorAttachments });
+  await t.tryRenderPass(_success, { colorAttachments });
 }).params([
-  { colorAttachmentsCount: 4, success: true }, // Control case
-  { colorAttachmentsCount: 5, success: false }, // Out of bounds
+  { colorAttachmentsCount: 4, _success: true }, // Control case
+  { colorAttachmentsCount: 5, _success: false }, // Out of bounds
 ]);
 
 g.test('attachments must have the same size', async t => {
@@ -188,7 +188,7 @@ g.test('attachments must match whether they are used for color or depth stencil'
 });
 
 g.test('check layer count for color or depth stencil', async t => {
-  const { arrayLayerCount, baseArrayLayer, success } = t.params;
+  const { arrayLayerCount, baseArrayLayer, _success } = t.params;
 
   const ARRAY_LAYER_COUNT = 10;
   const MIP_LEVEL_COUNT = 1;
@@ -229,7 +229,7 @@ g.test('check layer count for color or depth stencil', async t => {
       colorAttachments: [t.getColorAttachment(colorTexture, textureViewDescriptor)],
     };
 
-    await t.tryRenderPass(success, descriptor);
+    await t.tryRenderPass(_success, descriptor);
   }
   {
     // Check 2D array texture view for depth stencil
@@ -246,16 +246,16 @@ g.test('check layer count for color or depth stencil', async t => {
       ),
     };
 
-    await t.tryRenderPass(success, descriptor);
+    await t.tryRenderPass(_success, descriptor);
   }
 }).params([
-  { arrayLayerCount: 5, baseArrayLayer: 0, success: false }, // using 2D array texture view with arrayLayerCount > 1 is not allowed
-  { arrayLayerCount: 1, baseArrayLayer: 0, success: true }, // using 2D array texture view that covers the first layer of the texture is OK
-  { arrayLayerCount: 1, baseArrayLayer: 9, success: true }, // using 2D array texture view that covers the last layer is OK for depth stencil
+  { arrayLayerCount: 5, baseArrayLayer: 0, _success: false }, // using 2D array texture view with arrayLayerCount > 1 is not allowed
+  { arrayLayerCount: 1, baseArrayLayer: 0, _success: true }, // using 2D array texture view that covers the first layer of the texture is OK
+  { arrayLayerCount: 1, baseArrayLayer: 9, _success: true }, // using 2D array texture view that covers the last layer is OK for depth stencil
 ]);
 
 g.test('check mip level count for color or depth stencil', async t => {
-  const { mipLevelCount, baseMipLevel, success } = t.params;
+  const { mipLevelCount, baseMipLevel, _success } = t.params;
 
   const ARRAY_LAYER_COUNT = 1;
   const MIP_LEVEL_COUNT = 4;
@@ -296,7 +296,7 @@ g.test('check mip level count for color or depth stencil', async t => {
       colorAttachments: [t.getColorAttachment(colorTexture, textureViewDescriptor)],
     };
 
-    await t.tryRenderPass(success, descriptor);
+    await t.tryRenderPass(_success, descriptor);
   }
   {
     // Check 2D texture view for depth stencil
@@ -313,12 +313,12 @@ g.test('check mip level count for color or depth stencil', async t => {
       ),
     };
 
-    await t.tryRenderPass(success, descriptor);
+    await t.tryRenderPass(_success, descriptor);
   }
 }).params([
-  { mipLevelCount: 2, baseMipLevel: 0, success: false }, // using 2D texture view with mipLevelCount > 1 is not allowed
-  { mipLevelCount: 1, baseMipLevel: 0, success: true }, // using 2D texture view that covers the first level of the texture is OK
-  { mipLevelCount: 1, baseMipLevel: 3, success: true }, // using 2D texture view that covers the last level of the texture is OK
+  { mipLevelCount: 2, baseMipLevel: 0, _success: false }, // using 2D texture view with mipLevelCount > 1 is not allowed
+  { mipLevelCount: 1, baseMipLevel: 0, _success: true }, // using 2D texture view that covers the first level of the texture is OK
+  { mipLevelCount: 1, baseMipLevel: 3, _success: true }, // using 2D texture view that covers the last level of the texture is OK
 ]);
 
 g.test('it is invalid to set resolve target if color attachment is non multisampled', async t => {

--- a/src/suites/cts/validation/setBindGroup.spec.ts
+++ b/src/suites/cts/validation/setBindGroup.spec.ts
@@ -140,7 +140,7 @@ g.test('dynamic offsets match expectations in pass encoder', async t => {
     ],
   });
 
-  const { type, dynamicOffsets, success } = t.params;
+  const { type, dynamicOffsets, _success } = t.params;
 
   await t.expectValidationError(() => {
     if (type === 'compute') {
@@ -153,28 +153,28 @@ g.test('dynamic offsets match expectations in pass encoder', async t => {
       t.fail();
     }
     t.testComputePass(bindGroup, dynamicOffsets);
-  }, !success);
+  }, !_success);
 }).params(
   pcombine([
     poptions('type', ['compute', 'renderpass', 'renderbundle']),
     [
-      { dynamicOffsets: [256, 0], success: true }, // Dynamic offsets aligned
-      { dynamicOffsets: [1, 2], success: false }, // Dynamic offsets not aligned
+      { dynamicOffsets: [256, 0], _success: true }, // Dynamic offsets aligned
+      { dynamicOffsets: [1, 2], _success: false }, // Dynamic offsets not aligned
 
       // Wrong number of dynamic offsets
-      { dynamicOffsets: [256, 0, 0], success: false },
-      { dynamicOffsets: [256], success: false },
-      { dynamicOffsets: [], success: false },
+      { dynamicOffsets: [256, 0, 0], _success: false },
+      { dynamicOffsets: [256], _success: false },
+      { dynamicOffsets: [], _success: false },
 
       // Dynamic uniform buffer out of bounds because of binding size
-      { dynamicOffsets: [512, 0], success: false },
-      { dynamicOffsets: [1024, 0], success: false },
-      { dynamicOffsets: [Number.MAX_SAFE_INTEGER, 0], success: false },
+      { dynamicOffsets: [512, 0], _success: false },
+      { dynamicOffsets: [1024, 0], _success: false },
+      { dynamicOffsets: [Number.MAX_SAFE_INTEGER, 0], _success: false },
 
       // Dynamic storage buffer out of bounds because of binding size
-      { dynamicOffsets: [0, 512], success: false },
-      { dynamicOffsets: [0, 1024], success: false },
-      { dynamicOffsets: [0, Number.MAX_SAFE_INTEGER], success: false },
+      { dynamicOffsets: [0, 512], _success: false },
+      { dynamicOffsets: [0, 1024], _success: false },
+      { dynamicOffsets: [0, Number.MAX_SAFE_INTEGER], _success: false },
     ],
   ])
 );

--- a/src/suites/cts/validation/setScissorRect.spec.ts
+++ b/src/suites/cts/validation/setScissorRect.spec.ts
@@ -32,7 +32,7 @@ class F extends ValidationTest {
 export const g = new TestGroup(F);
 
 g.test('use of setScissorRect', async t => {
-  const { x, y, width, height, success } = t.params;
+  const { x, y, width, height, _success } = t.params;
 
   const commandEncoder = t.device.createCommandEncoder();
   const renderPass = t.beginRenderPass(commandEncoder);
@@ -41,11 +41,11 @@ g.test('use of setScissorRect', async t => {
 
   await t.expectValidationError(() => {
     commandEncoder.finish();
-  }, !success);
+  }, !_success);
 }).params([
-  { x: 0, y: 0, width: 1, height: 1, success: true }, // Basic use
-  { x: 0, y: 0, width: 0, height: 1, success: false }, // Width of zero is not allowed
-  { x: 0, y: 0, width: 1, height: 0, success: false }, // Height of zero is not allowed
-  { x: 0, y: 0, width: 0, height: 0, success: false }, // Both width and height of zero are not allowed
-  { x: 0, y: 0, width: TEXTURE_WIDTH + 1, height: TEXTURE_HEIGHT + 1, success: true }, // Scissor larger than the framebuffer is allowed
+  { x: 0, y: 0, width: 1, height: 1, _success: true }, // Basic use
+  { x: 0, y: 0, width: 0, height: 1, _success: false }, // Width of zero is not allowed
+  { x: 0, y: 0, width: 1, height: 0, _success: false }, // Height of zero is not allowed
+  { x: 0, y: 0, width: 0, height: 0, _success: false }, // Both width and height of zero are not allowed
+  { x: 0, y: 0, width: TEXTURE_WIDTH + 1, height: TEXTURE_HEIGHT + 1, _success: true }, // Scissor larger than the framebuffer is allowed
 ]);

--- a/src/suites/cts/validation/setViewport.spec.ts
+++ b/src/suites/cts/validation/setViewport.spec.ts
@@ -32,7 +32,7 @@ class F extends ValidationTest {
 export const g = new TestGroup(F);
 
 g.test('use of setViewport', async t => {
-  const { x, y, width, height, minDepth, maxDepth, success } = t.params;
+  const { x, y, width, height, minDepth, maxDepth, _success } = t.params;
 
   const commandEncoder = t.device.createCommandEncoder();
   const renderPass = t.beginRenderPass(commandEncoder);
@@ -41,22 +41,22 @@ g.test('use of setViewport', async t => {
 
   await t.expectValidationError(() => {
     commandEncoder.finish();
-  }, !success);
+  }, !_success);
 }).params([
-  { x: 0, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: 1, success: true }, // Basic use
-  { x: 0, y: 0, width: 0, height: 1, minDepth: 0, maxDepth: 1, success: false }, // Width of zero is not allowed
-  { x: 0, y: 0, width: 1, height: 0, minDepth: 0, maxDepth: 1, success: false }, // Height of zero is not allowed
-  { x: 0, y: 0, width: 0, height: 0, minDepth: 0, maxDepth: 1, success: false }, // Both width and height of zero are not allowed
-  { x: -1, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: 1, success: true }, // Negative x is allowed
-  { x: 0, y: -1, width: 1, height: 1, minDepth: 0, maxDepth: 1, success: true }, // Negative y is allowed
-  { x: 0, y: 0, width: -1, height: 1, minDepth: 0, maxDepth: 1, success: false }, // Negative width is not allowed
-  { x: 0, y: 0, width: 1, height: -1, minDepth: 0, maxDepth: 1, success: false }, // Negative height is not allowed
-  { x: 0, y: 0, width: 1, height: 1, minDepth: -1, maxDepth: 1, success: false }, // Negative minDepth is not allowed
-  { x: 0, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: -1, success: false }, // Negative maxDepth is not allowed
-  { x: 0, y: 0, width: 1, height: 1, minDepth: 10, maxDepth: 1, success: false }, // minDepth greater than 1 is not allowed
-  { x: 0, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: 10, success: false }, // maxDepth greater than 1 is not allowed
-  { x: 0, y: 0, width: 1, height: 1, minDepth: 0.5, maxDepth: 0.5, success: true }, // minDepth equal to maxDepth is allowed
-  { x: 0, y: 0, width: 1, height: 1, minDepth: 0.8, maxDepth: 0.5, success: true }, // minDepth greater than maxDepth is allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: 1, _success: true }, // Basic use
+  { x: 0, y: 0, width: 0, height: 1, minDepth: 0, maxDepth: 1, _success: false }, // Width of zero is not allowed
+  { x: 0, y: 0, width: 1, height: 0, minDepth: 0, maxDepth: 1, _success: false }, // Height of zero is not allowed
+  { x: 0, y: 0, width: 0, height: 0, minDepth: 0, maxDepth: 1, _success: false }, // Both width and height of zero are not allowed
+  { x: -1, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: 1, _success: true }, // Negative x is allowed
+  { x: 0, y: -1, width: 1, height: 1, minDepth: 0, maxDepth: 1, _success: true }, // Negative y is allowed
+  { x: 0, y: 0, width: -1, height: 1, minDepth: 0, maxDepth: 1, _success: false }, // Negative width is not allowed
+  { x: 0, y: 0, width: 1, height: -1, minDepth: 0, maxDepth: 1, _success: false }, // Negative height is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: -1, maxDepth: 1, _success: false }, // Negative minDepth is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: -1, _success: false }, // Negative maxDepth is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 10, maxDepth: 1, _success: false }, // minDepth greater than 1 is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0, maxDepth: 10, _success: false }, // maxDepth greater than 1 is not allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0.5, maxDepth: 0.5, _success: true }, // minDepth equal to maxDepth is allowed
+  { x: 0, y: 0, width: 1, height: 1, minDepth: 0.8, maxDepth: 0.5, _success: true }, // minDepth greater than maxDepth is allowed
   {
     x: 0,
     y: 0,
@@ -64,6 +64,6 @@ g.test('use of setViewport', async t => {
     height: TEXTURE_HEIGHT + 1,
     minDepth: 0,
     maxDepth: 1,
-    success: true,
+    _success: true,
   }, // Viewport larger than the framebuffer is allowed
 ]);

--- a/src/suites/unittests/loading.spec.ts
+++ b/src/suites/unittests/loading.spec.ts
@@ -49,8 +49,8 @@ const specsData: { [k: string]: TestSpecOrReadme } = {
     g: (() => {
       const g = new TestGroup(UnitTest);
       g.test('zed', () => {}).params([
-        { a: 1, b: 2 }, //
-        { a: 1, b: 3 },
+        { a: 1, b: 2, _c: 0 }, //
+        { a: 1, b: 3, _c: 0 },
       ]);
       return g;
     })(),
@@ -155,6 +155,8 @@ g.test('partial test/exact', async t => {
   t.expect((await t.singleGroup('suite1:baz:zed=')).length === 0);
   t.expect((await t.singleGroup('suite1:baz:zed={}')).length === 0);
   t.expect((await t.singleGroup('suite1:baz:zed={"a":1,"b":2}')).length === 1);
+  t.expect((await t.singleGroup('suite1:baz:zed={"b":2,"a":1}')).length === 1);
+  t.expect((await t.singleGroup('suite1:baz:zed={"a":1,"b":2,"_c":0}')).length === 0);
 });
 
 g.test('partial test/makeQueryString', async t => {
@@ -173,7 +175,8 @@ g.test('partial test/match', async t => {
   t.expect((await t.singleGroup('suite1:baz:zed~{"b":2,"a":1}')).length === 1);
   t.expect((await t.singleGroup('suite1:baz:zed~{"b":2}')).length === 1);
   t.expect((await t.singleGroup('suite1:baz:zed~{"a":2}')).length === 0);
-  t.expect((await t.singleGroup('suite1:baz:zed~{"c":3}')).length === 0);
+  t.expect((await t.singleGroup('suite1:baz:zed~{"c":0}')).length === 0);
+  t.expect((await t.singleGroup('suite1:baz:zed~{"_c":0}')).length === 0);
 });
 
 g.test('end2end', async t => {

--- a/src/suites/unittests/logger.spec.ts
+++ b/src/suites/unittests/logger.spec.ts
@@ -4,7 +4,7 @@ Unit tests for namespaced logging system.
 Also serves as a larger test of async test functions, and of the logging system.
 `;
 
-import { TestGroup } from '../../framework/index.js';
+import { TestGroup, paramsEquals } from '../../framework/index.js';
 import { Logger } from '../../framework/logger.js';
 
 import { UnitTest } from './unit_test.js';
@@ -28,10 +28,18 @@ g.test('construct', t => {
   t.expect(res1.status === 'running');
   t.expect(res1.timems < 0);
   t.expect(res2.test === 'qux');
-  t.expect(res2.params === params2);
+  t.expect(paramsEquals(res2.params, params2));
   t.expect(res2.logs === undefined);
   t.expect(res2.status === 'running');
   t.expect(res2.timems < 0);
+});
+
+g.test('private params', t => {
+  const mylog = new Logger();
+  const [testrec] = mylog.record({ suite: 'a', path: 'foo/bar' });
+  const [, res] = testrec.record('baz', { a: 1, _b: 2 });
+
+  t.expect(paramsEquals(res.params, { a: 1 }));
 });
 
 g.test('empty', t => {

--- a/src/suites/unittests/test_group.spec.ts
+++ b/src/suites/unittests/test_group.spec.ts
@@ -86,6 +86,32 @@ g.test('duplicate test name', t => {
   });
 });
 
+g.test('duplicate test params', t => {
+  const g = new TestGroup(UnitTest);
+
+  t.shouldThrow('Error', () => {
+    g.test('abc', () => {
+      //
+    }).params([
+      { a: 1 }, //
+      { a: 1 },
+    ]);
+  });
+});
+
+g.test('duplicate test params/with different private params', t => {
+  const g = new TestGroup(UnitTest);
+
+  t.shouldThrow('Error', () => {
+    g.test('abc', () => {
+      //
+    }).params([
+      { a: 1, _b: 1 }, //
+      { a: 1, _b: 2 },
+    ]);
+  });
+});
+
 const badChars = Array.from('"`~@#$+=\\|!^&*[]<>{}-\'.,');
 g.test('invalid test name', t => {
   const g = new TestGroup(UnitTest);

--- a/src/suites/unittests/url_query.spec.ts
+++ b/src/suites/unittests/url_query.spec.ts
@@ -13,3 +13,8 @@ g.test('makeQueryString', async t => {
   const s = makeQueryString({ suite: 'a', path: 'b/c' }, { test: 'd/e', params: { f: 'g', h: 3 } });
   t.expect(s === 'a:b/c:d/e={"f":"g","h":3}');
 });
+
+g.test('makeQueryString/private', async t => {
+  const s = makeQueryString({ suite: 'a', path: 'b' }, { test: 'c', params: { pub: 2, _pri: 3 } });
+  t.expect(s === 'a:b:c={"pub":2}');
+});


### PR DESCRIPTION
This cleans up the test case IDs because they no longer have non-identifying "success"/"result" keys in them.