### PR TITLE
make pcombine take variadic args instead of an array

### DIFF
--- a/src/framework/params/combine.ts
+++ b/src/framework/params/combine.ts
@@ -1,6 +1,6 @@
 import { ParamSpec, ParamSpecIterable, ParamSpecIterator } from './index.js';
 
-export function pcombine(params: ParamSpecIterable[]): PCombine {
+export function pcombine(...params: ParamSpecIterable[]): ParamSpecIterable {
   return new PCombine(params);
 }
 

--- a/src/framework/params/index.ts
+++ b/src/framework/params/index.ts
@@ -1,7 +1,7 @@
 export * from './combine.js';
+export * from './exclude.js';
 export * from './filter.js';
 export * from './options.js';
-export * from './exclude.js';
 
 // tslint:disable-next-line: no-any
 export type ParamArgument = any;

--- a/src/suites/cts/buffers/create_mapped.spec.ts
+++ b/src/suites/cts/buffers/create_mapped.spec.ts
@@ -14,10 +14,10 @@ g.test('createBufferMapped', async t => {
   });
   await t.checkMapWrite(buffer, arrayBuffer, size);
 }).params(
-  pcombine([
+  pcombine(
     poptions('size', [12, 512 * 1024]), //
-    pbool('mappable'),
-  ])
+    pbool('mappable')
+  )
 );
 
 g.test('createBufferMappedAsync', async t => {
@@ -28,8 +28,8 @@ g.test('createBufferMappedAsync', async t => {
   });
   await t.checkMapWrite(buffer, arrayBuffer, size);
 }).params(
-  pcombine([
+  pcombine(
     poptions('size', [12, 512 * 1024]), //
-    pbool('mappable'),
-  ])
+    pbool('mappable')
+  )
 );

--- a/src/suites/cts/buffers/map.spec.ts
+++ b/src/suites/cts/buffers/map.spec.ts
@@ -44,10 +44,10 @@ g.test('createBufferMapped', async t => {
   });
   await t.checkMapWrite(buffer, arrayBuffer, size);
 }).params(
-  pcombine([
+  pcombine(
     poptions('size', [12, 512 * 1024]), //
-    pbool('mappable'),
-  ])
+    pbool('mappable')
+  )
 );
 
 g.test('createBufferMappedAsync', async t => {
@@ -58,8 +58,8 @@ g.test('createBufferMappedAsync', async t => {
   });
   await t.checkMapWrite(buffer, arrayBuffer, size);
 }).params(
-  pcombine([
+  pcombine(
     poptions('size', [12, 512 * 1024]), //
-    pbool('mappable'),
-  ])
+    pbool('mappable')
+  )
 );

--- a/src/suites/cts/buffers/map_detach.spec.ts
+++ b/src/suites/cts/buffers/map_detach.spec.ts
@@ -57,12 +57,12 @@ g.test('create mapped', async t => {
   t.expect(arrayBuffer.byteLength === 0, 'ArrayBuffer should be detached');
   t.expect(view.byteLength === 0, 'ArrayBufferView should be detached');
 }).params(
-  pcombine([
+  pcombine(
     pbool('async'), //
     [
       { unmap: true, destroy: false },
       { unmap: false, destroy: true },
       { unmap: true, destroy: true },
-    ],
-  ])
+    ]
+  )
 );

--- a/src/suites/cts/validation/createBindGroup.spec.ts
+++ b/src/suites/cts/validation/createBindGroup.spec.ts
@@ -183,7 +183,7 @@ g.test('buffer binding must contain exactly one buffer of its type', async t => 
     });
   }, shouldError);
 }).params(
-  pcombine([
+  pcombine(
     poptions('bindingType', [
       'uniform-buffer',
       'storage-buffer',
@@ -199,8 +199,8 @@ g.test('buffer binding must contain exactly one buffer of its type', async t => 
       'sampler',
       'sampled-texture',
       'storage-texture',
-    ]),
-  ])
+    ])
+  )
 );
 
 g.test('texture binding must have correct usage', async t => {

--- a/src/suites/cts/validation/setBindGroup.spec.ts
+++ b/src/suites/cts/validation/setBindGroup.spec.ts
@@ -155,27 +155,24 @@ g.test('dynamic offsets match expectations in pass encoder', async t => {
     t.testComputePass(bindGroup, dynamicOffsets);
   }, !_success);
 }).params(
-  pcombine([
-    poptions('type', ['compute', 'renderpass', 'renderbundle']),
-    [
-      { dynamicOffsets: [256, 0], _success: true }, // Dynamic offsets aligned
-      { dynamicOffsets: [1, 2], _success: false }, // Dynamic offsets not aligned
+  pcombine(poptions('type', ['compute', 'renderpass', 'renderbundle']), [
+    { dynamicOffsets: [256, 0], _success: true }, // Dynamic offsets aligned
+    { dynamicOffsets: [1, 2], _success: false }, // Dynamic offsets not aligned
 
-      // Wrong number of dynamic offsets
-      { dynamicOffsets: [256, 0, 0], _success: false },
-      { dynamicOffsets: [256], _success: false },
-      { dynamicOffsets: [], _success: false },
+    // Wrong number of dynamic offsets
+    { dynamicOffsets: [256, 0, 0], _success: false },
+    { dynamicOffsets: [256], _success: false },
+    { dynamicOffsets: [], _success: false },
 
-      // Dynamic uniform buffer out of bounds because of binding size
-      { dynamicOffsets: [512, 0], _success: false },
-      { dynamicOffsets: [1024, 0], _success: false },
-      { dynamicOffsets: [Number.MAX_SAFE_INTEGER, 0], _success: false },
+    // Dynamic uniform buffer out of bounds because of binding size
+    { dynamicOffsets: [512, 0], _success: false },
+    { dynamicOffsets: [1024, 0], _success: false },
+    { dynamicOffsets: [Number.MAX_SAFE_INTEGER, 0], _success: false },
 
-      // Dynamic storage buffer out of bounds because of binding size
-      { dynamicOffsets: [0, 512], _success: false },
-      { dynamicOffsets: [0, 1024], _success: false },
-      { dynamicOffsets: [0, Number.MAX_SAFE_INTEGER], _success: false },
-    ],
+    // Dynamic storage buffer out of bounds because of binding size
+    { dynamicOffsets: [0, 512], _success: false },
+    { dynamicOffsets: [0, 1024], _success: false },
+    { dynamicOffsets: [0, Number.MAX_SAFE_INTEGER], _success: false },
   ])
 );
 

--- a/src/suites/unittests/param_helpers.spec.ts
+++ b/src/suites/unittests/param_helpers.spec.ts
@@ -29,28 +29,28 @@ g.test('options', t => {
 });
 
 g.test('combine/none', t => {
-  t.expectSpecEqual(pcombine([]), []);
+  t.expectSpecEqual(pcombine(), []);
 });
 
 g.test('combine/zeroes and ones', t => {
-  t.expectSpecEqual(pcombine([[], []]), []);
-  t.expectSpecEqual(pcombine([[], [{}]]), []);
-  t.expectSpecEqual(pcombine([[{}], []]), []);
-  t.expectSpecEqual(pcombine([[{}], [{}]]), [{}]);
+  t.expectSpecEqual(pcombine([], []), []);
+  t.expectSpecEqual(pcombine([], [{}]), []);
+  t.expectSpecEqual(pcombine([{}], []), []);
+  t.expectSpecEqual(pcombine([{}], [{}]), [{}]);
 });
 
 g.test('combine/mixed', t => {
   t.expectSpecEqual(
-    pcombine([poptions('x', [1, 2]), poptions('y', ['a', 'b']), [{ p: 4 }, { q: 5 }], [{}]]),
+    pcombine(poptions('x', [1, 2]), poptions('y', ['a', 'b']), [{ p: 4 }, { q: 5 }], [{}]),
     [
-      { p: 4, x: 1, y: 'a' },
-      { q: 5, x: 1, y: 'a' },
-      { p: 4, x: 1, y: 'b' },
-      { q: 5, x: 1, y: 'b' },
-      { p: 4, x: 2, y: 'a' },
-      { q: 5, x: 2, y: 'a' },
-      { p: 4, x: 2, y: 'b' },
-      { q: 5, x: 2, y: 'b' },
+      { x: 1, y: 'a', p: 4 },
+      { x: 1, y: 'a', q: 5 },
+      { x: 1, y: 'b', p: 4 },
+      { x: 1, y: 'b', q: 5 },
+      { x: 2, y: 'a', p: 4 },
+      { x: 2, y: 'a', q: 5 },
+      { x: 2, y: 'b', p: 4 },
+      { x: 2, y: 'b', q: 5 },
     ]
   );
 });


### PR DESCRIPTION
Just a tiny readability/writability improvement.