### PR TITLE
Add eventualAsyncExpectations, and use it for most async expectations

### DIFF
--- a/src/framework/test_group.ts
+++ b/src/framework/test_group.ts
@@ -135,6 +135,7 @@ class RunCaseSpecific<F extends Fixture> implements RunCase {
       await inst.finalize();
     } catch (ex) {
       // There was an exception from constructor, init, or finalize.
+      // (An error from finalize may have been an eventualAsyncExpectation failure.)
       rec.threw(ex);
     }
 

--- a/src/suites/cts/buffers/map_oom.spec.ts
+++ b/src/suites/cts/buffers/map_oom.spec.ts
@@ -14,20 +14,20 @@ export const g = new TestGroup(GPUTest);
 
 g.test('mapWriteAsync', async t => {
   const buffer = t.device.createBuffer(getBufferDesc());
-  await t.shouldReject('RangeError', buffer.mapWriteAsync());
+  t.shouldReject('RangeError', buffer.mapWriteAsync());
 });
 
 g.test('mapReadAsync', async t => {
   const buffer = t.device.createBuffer(getBufferDesc());
-  await t.shouldReject('RangeError', buffer.mapReadAsync());
+  t.shouldReject('RangeError', buffer.mapReadAsync());
 });
 
 g.test('createBufferMapped', async t => {
-  await t.shouldThrow('RangeError', () => {
+  t.shouldThrow('RangeError', () => {
     t.device.createBufferMapped(getBufferDesc());
   });
 });
 
 g.test('createBufferAsync', async t => {
-  await t.shouldReject('RangeError', t.device.createBufferMappedAsync(getBufferDesc()));
+  t.shouldReject('RangeError', t.device.createBufferMappedAsync(getBufferDesc()));
 });

--- a/src/suites/cts/buffers/mapping_test.ts
+++ b/src/suites/cts/buffers/mapping_test.ts
@@ -1,7 +1,7 @@
 import { GPUTest } from '../gpu_test.js';
 
 export class MappingTest extends GPUTest {
-  checkMapWrite(buffer: GPUBuffer, mappedContents: ArrayBuffer, size: number): Promise<void> {
+  checkMapWrite(buffer: GPUBuffer, mappedContents: ArrayBuffer, size: number): void {
     this.checkMapWriteZeroed(mappedContents, size);
 
     const mappedView = new Uint32Array(mappedContents);
@@ -12,7 +12,7 @@ export class MappingTest extends GPUTest {
     }
     buffer.unmap();
 
-    return this.expectContents(buffer, expected);
+    this.expectContents(buffer, expected);
   }
 
   checkMapWriteZeroed(arrayBuffer: ArrayBuffer, expectedSize: number): void {

--- a/src/suites/cts/command_buffer/compute/basic.spec.ts
+++ b/src/suites/cts/command_buffer/compute/basic.spec.ts
@@ -65,5 +65,5 @@ g.test('memcpy', async t => {
   pass.endPass();
   t.device.getQueue().submit([encoder.finish()]);
 
-  await t.expectContents(dst, data);
+  t.expectContents(dst, data);
 });

--- a/src/suites/cts/command_buffer/copies.spec.ts
+++ b/src/suites/cts/command_buffer/copies.spec.ts
@@ -26,7 +26,7 @@ g.test('b2b', async t => {
   encoder.copyBufferToBuffer(src, 0, dst, 0, 4);
   t.device.getQueue().submit([encoder.finish()]);
 
-  await t.expectContents(dst, data);
+  t.expectContents(dst, data);
 });
 
 g.test('b2t2b', async t => {
@@ -63,7 +63,7 @@ g.test('b2t2b', async t => {
   );
   t.device.getQueue().submit([encoder.finish()]);
 
-  await t.expectContents(dst, data);
+  t.expectContents(dst, data);
 });
 
 g.test('b2t2t2b', async t => {
@@ -107,5 +107,5 @@ g.test('b2t2t2b', async t => {
   );
   t.device.getQueue().submit([encoder.finish()]);
 
-  await t.expectContents(dst, data);
+  t.expectContents(dst, data);
 });

--- a/src/suites/cts/command_buffer/render/basic.spec.ts
+++ b/src/suites/cts/command_buffer/render/basic.spec.ts
@@ -38,5 +38,5 @@ g.test('clear', async t => {
   );
   t.device.getQueue().submit([encoder.finish()]);
 
-  await t.expectContents(dst, new Uint8Array([0x00, 0xff, 0x00, 0xff]));
+  t.expectContents(dst, new Uint8Array([0x00, 0xff, 0x00, 0xff]));
 });

--- a/src/suites/cts/command_buffer/render/rendering.spec.ts
+++ b/src/suites/cts/command_buffer/render/rendering.spec.ts
@@ -79,5 +79,5 @@ g.test('fullscreen quad', async t => {
   );
   t.device.getQueue().submit([encoder.finish()]);
 
-  await t.expectContents(dst, new Uint8Array([0x00, 0xff, 0x00, 0xff]));
+  t.expectContents(dst, new Uint8Array([0x00, 0xff, 0x00, 0xff]));
 });

--- a/src/suites/cts/command_buffer/render/storeop.spec.ts
+++ b/src/suites/cts/command_buffer/render/storeop.spec.ts
@@ -74,9 +74,9 @@ g.test('storeOp controls whether 1x1 drawn quad is stored', async t => {
   t.device.getQueue().submit([encoder.finish()]);
 
   // expect the buffer to be clear
-  const expectedContent = new Uint32Array([t.params.expected]);
+  const expectedContent = new Uint32Array([t.params._expected]);
   t.expectContents(dstBuffer, expectedContent);
 }).params([
-  { storeOp: 'store', expected: 255 }, //
-  { storeOp: 'clear', expected: 0 },
+  { storeOp: 'store', _expected: 255 }, //
+  { storeOp: 'clear', _expected: 0 },
 ]);

--- a/src/suites/cts/command_buffer/render/storeop.spec.ts
+++ b/src/suites/cts/command_buffer/render/storeop.spec.ts
@@ -75,7 +75,7 @@ g.test('storeOp controls whether 1x1 drawn quad is stored', async t => {
 
   // expect the buffer to be clear
   const expectedContent = new Uint32Array([t.params.expected]);
-  await t.expectContents(dstBuffer, expectedContent);
+  t.expectContents(dstBuffer, expectedContent);
 }).params([
   { storeOp: 'store', expected: 255 }, //
   { storeOp: 'clear', expected: 0 },

--- a/src/suites/cts/examples.spec.ts
+++ b/src/suites/cts/examples.spec.ts
@@ -36,7 +36,7 @@ g.test('basic', t => {
 
 g.test('basic/async', async t => {
   // shouldReject must be awaited to ensure it can wait for the promise before the test ends.
-  await t.shouldReject(
+  t.shouldReject(
     // The expected '.name' of the thrown error.
     'TypeError',
     // Promise expected to reject.
@@ -46,7 +46,7 @@ g.test('basic/async', async t => {
   );
 
   // Promise can also be an IIFE.
-  await t.shouldReject(
+  t.shouldReject(
     'TypeError',
     (async () => {
       throw new TypeError();
@@ -89,5 +89,5 @@ g.test('gpu/buffers', async t => {
 
   // Use the expectContents helper to check the actual contents of a GPUBuffer.
   // Like shouldReject, it must be awaited.
-  await t.expectContents(src, data);
+  t.expectContents(src, data);
 });

--- a/src/suites/cts/gpu_test.ts
+++ b/src/suites/cts/gpu_test.ts
@@ -62,23 +62,24 @@ export class GPUTest extends Fixture {
 
   // TODO: add an expectContents for textures, which logs data: uris on failure
 
-  expectContents(src: GPUBuffer, expected: ArrayBufferView): Promise<void> {
-    return this.asyncExpectation(async () => {
-      const exp = new Uint8Array(expected.buffer, expected.byteOffset, expected.byteLength);
+  expectContents(src: GPUBuffer, expected: ArrayBufferView): void {
+    const exp = new Uint8Array(expected.buffer, expected.byteOffset, expected.byteLength);
 
-      const size = expected.buffer.byteLength;
-      const dst = this.device.createBuffer({
-        size: expected.buffer.byteLength,
-        usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
-      });
+    const size = expected.buffer.byteLength;
+    const dst = this.device.createBuffer({
+      size: expected.buffer.byteLength,
+      usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    });
 
-      const c = this.device.createCommandEncoder();
-      c.copyBufferToBuffer(src, 0, dst, 0, size);
+    const c = this.device.createCommandEncoder();
+    c.copyBufferToBuffer(src, 0, dst, 0, size);
 
-      this.queue.submit([c.finish()]);
+    this.queue.submit([c.finish()]);
 
+    this.eventualAsyncExpectation(async () => {
       const actual = new Uint8Array(await dst.mapReadAsync());
       this.expectBuffer(actual, exp);
+      dst.destroy();
     });
   }
 

--- a/src/suites/cts/validation/createBindGroup.spec.ts
+++ b/src/suites/cts/validation/createBindGroup.spec.ts
@@ -94,7 +94,7 @@ g.test('binding count mismatch', async t => {
     layout: bindGroupLayout,
   };
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createBindGroup(badDescriptor);
   });
 });
@@ -138,7 +138,7 @@ g.test('binding must be present in layout', async t => {
     layout: bindGroupLayout,
   };
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createBindGroup(badDescriptor);
   });
 });
@@ -176,7 +176,7 @@ g.test('buffer binding must contain exactly one buffer of its type', async t => 
     shouldError = false;
   }
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createBindGroup({
       bindings: [{ binding: 0, resource }],
       layout: bindGroupLayout,
@@ -259,7 +259,7 @@ g.test('texture binding must have correct usage', async t => {
     const badDescriptor = clone(goodDescriptor);
     badDescriptor.usage = mismatchedTextureUsage;
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createBindGroup({
         bindings: [
           {
@@ -333,7 +333,7 @@ g.test('texture must have correct component type', async t => {
     const badDescriptor = clone(goodDescriptor);
     badDescriptor.format = mismatchedTextureFormat;
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createBindGroup({
         bindings: [
           {
@@ -382,7 +382,7 @@ g.test('texture must have correct dimension', async t => {
   const badDescriptor = clone(goodDescriptor);
   badDescriptor.arrayLayerCount = 2;
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createBindGroup({
       bindings: [
         {
@@ -428,7 +428,7 @@ g.test('buffer offset and size for bind groups match', async t => {
     t.device.createBindGroup(descriptor);
   } else {
     // Buffer offset and/or size don't match in bind groups.
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createBindGroup(descriptor);
     });
   }

--- a/src/suites/cts/validation/createBindGroupLayout.spec.ts
+++ b/src/suites/cts/validation/createBindGroupLayout.spec.ts
@@ -35,7 +35,7 @@ g.test('some binding index was specified more than once', async t => {
   badDescriptor.bindings![1].binding = 0;
 
   // Binding index 0 can't be specified twice.
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createBindGroupLayout(badDescriptor);
   });
 });
@@ -58,7 +58,7 @@ g.test('negative binding index', async t => {
   const badDescriptor = clone(goodDescriptor);
   badDescriptor.bindings![0].binding = -1;
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createBindGroupLayout(badDescriptor);
   });
 });
@@ -109,7 +109,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
   const badDescriptor = clone(goodDescriptor);
   badDescriptor.bindings![maxDynamicBufferCount].hasDynamicOffset = true;
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createBindGroupLayout(badDescriptor);
   });
 }).params([
@@ -136,7 +136,7 @@ g.test('dynamic set to true is allowed only for buffers', async t => {
     t.device.createBindGroupLayout(descriptor);
   } else {
     // Dynamic set to true is not allowed in some cases.
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createBindGroupLayout(descriptor);
     });
   }

--- a/src/suites/cts/validation/createPipelineLayout.spec.ts
+++ b/src/suites/cts/validation/createPipelineLayout.spec.ts
@@ -61,7 +61,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
     ],
   };
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createPipelineLayout(badPipelineLayoutDescriptor);
   });
 }).params([
@@ -102,7 +102,7 @@ g.test('number of bind group layouts exceeds the maximum value', async t => {
     ],
   };
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createPipelineLayout(badPipelineLayoutDescriptor);
   });
 }).params(poptions('type', ['storage-buffer', 'uniform-buffer']));

--- a/src/suites/cts/validation/createRenderPipeline.spec.ts
+++ b/src/suites/cts/validation/createRenderPipeline.spec.ts
@@ -119,7 +119,7 @@ g.test('at least one color state is required', async t => {
     colorStates: [],
   });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createRenderPipeline(badDescriptor);
   });
 });
@@ -135,7 +135,7 @@ g.test('color formats must be renderable', async t => {
     t.device.createRenderPipeline(descriptor);
   } else {
     // Fails because when format is non-renderable
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -151,7 +151,7 @@ g.test('sample count must be valid', async t => {
     t.device.createRenderPipeline(descriptor);
   } else {
     // Fails when sample count is not 4 or 1
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -223,7 +223,7 @@ g.test('sample count must be equal to the one of every attachment in the render 
     renderPass.setPipeline(pipeline);
     renderPass.endPass();
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       commandEncoder.finish();
     }, !_success);
   }

--- a/src/suites/cts/validation/createTexture.spec.ts
+++ b/src/suites/cts/validation/createTexture.spec.ts
@@ -45,7 +45,7 @@ g.test('validation of sampleCount', async t => {
 
   const descriptor = t.getDescriptor({ sampleCount, mipLevelCount, arrayLayerCount });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createTexture(descriptor);
   }, !_success);
 }).params([
@@ -65,7 +65,7 @@ g.test('validation of mipLevelCount', async t => {
 
   const descriptor = t.getDescriptor({ width, height, mipLevelCount });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createTexture(descriptor);
   }, !_success);
 }).params([
@@ -118,7 +118,7 @@ g.test('it is invalid to submit a destroyed texture before and after encode', as
     texture.destroy();
   }
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.queue.submit([commandBuffer]);
   }, !_success);
 }).params([
@@ -133,7 +133,7 @@ g.test('it is invalid to have an output attachment texture with non renderable f
 
   const descriptor = t.getDescriptor({ width: 1, height: 1, format });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createTexture(descriptor);
   }, !info.renderable);
 }).params(textureFormatParams);

--- a/src/suites/cts/validation/createView.spec.ts
+++ b/src/suites/cts/validation/createView.spec.ts
@@ -82,7 +82,7 @@ g.test('creating texture view on a 2D non array texture', async t => {
     baseMipLevel,
   });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     texture.createView(descriptor);
   }, !_success);
 }).params([
@@ -116,7 +116,7 @@ g.test('creating texture view on a 2D array texture', async t => {
     baseArrayLayer,
   });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     texture.createView(descriptor);
   }, !_success);
 }).params([
@@ -144,7 +144,7 @@ g.test(
 
     const descriptor = { format, dimension, arrayLayerCount, mipLevelCount };
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       texture.createView(descriptor);
     }, !_success);
   }
@@ -171,7 +171,7 @@ g.test('Using defaults validates the same as setting values for only 1 array lay
 
   const descriptor = { format, dimension, arrayLayerCount, mipLevelCount };
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     texture.createView(descriptor);
   }, !_success);
 }).params([
@@ -197,7 +197,7 @@ g.test('creating cube map texture view', async t => {
     arrayLayerCount,
   });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     texture.createView(descriptor);
   }, !_success);
 }).params([
@@ -228,7 +228,7 @@ g.test('creating cube map texture view with a non square texture', async t => {
     arrayLayerCount,
   });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     nonSquareTexture.createView(descriptor);
   });
 }).params([
@@ -245,7 +245,7 @@ g.test('test the format compatibility rules when creating a texture view', async
   });
 
   // it is invalid to create a view in depth-stencil format on a RGBA texture
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     texture.createView(descriptor);
   });
 });
@@ -266,7 +266,7 @@ g.test('it is invalid to use a texture view created from a destroyed texture', a
   });
   renderPass.endPass();
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     commandEncoder.finish();
   });
 });

--- a/src/suites/cts/validation/error_scope.spec.ts
+++ b/src/suites/cts/validation/error_scope.spec.ts
@@ -24,8 +24,10 @@ class F extends Fixture {
     this.device.getQueue().submit([]);
   }
 
+  // Expect an uncapturederror event to occur. Note: this MUST be awaited, because
+  // otherwise it could erroneously pass by capturing an error from later in the test.
   async expectUncapturedError(fn: Function): Promise<GPUUncapturedErrorEvent> {
-    return this.asyncExpectation(() => {
+    return this.immediateAsyncExpectation(() => {
       // TODO: Make arbitrary timeout value a test runner variable
       const TIMEOUT_IN_MS = 1000;
 
@@ -106,7 +108,7 @@ g.test('if no error scope handles an error it fires an uncapturederror event', a
 g.test('push/popping sibling error scopes must be balanced', async t => {
   {
     const promise = t.device.popErrorScope();
-    await t.shouldReject('OperationError', promise);
+    t.shouldReject('OperationError', promise);
   }
 
   const promises = [];
@@ -119,14 +121,14 @@ g.test('push/popping sibling error scopes must be balanced', async t => {
 
   {
     const promise = t.device.popErrorScope();
-    await t.shouldReject('OperationError', promise);
+    t.shouldReject('OperationError', promise);
   }
 });
 
 g.test('push/popping nested error scopes must be balanced', async t => {
   {
     const promise = t.device.popErrorScope();
-    await t.shouldReject('OperationError', promise);
+    t.shouldReject('OperationError', promise);
   }
 
   const promises = [];
@@ -141,6 +143,6 @@ g.test('push/popping nested error scopes must be balanced', async t => {
 
   {
     const promise = t.device.popErrorScope();
-    await t.shouldReject('OperationError', promise);
+    t.shouldReject('OperationError', promise);
   }
 });

--- a/src/suites/cts/validation/fences.spec.ts
+++ b/src/suites/cts/validation/fences.spec.ts
@@ -12,8 +12,9 @@ export const g = new TestGroup(ValidationTest);
 g.test('wait on a fence without signaling the value is invalid', async t => {
   const fence = t.queue.createFence();
 
-  await t.expectValidationError(() => {
-    t.shouldReject('OperationError', fence.onCompletion(2));
+  t.expectValidationError(() => {
+    const promise = fence.onCompletion(2);
+    t.shouldReject('OperationError', promise);
   });
 });
 
@@ -22,15 +23,16 @@ g.test('wait on a fence with a value greater than signaled value is invalid', as
   const fence = t.queue.createFence();
   t.queue.signal(fence, 2);
 
-  await t.expectValidationError(() => {
-    t.shouldReject('OperationError', fence.onCompletion(3));
+  t.expectValidationError(() => {
+    const promise = fence.onCompletion(3);
+    t.shouldReject('OperationError', promise);
   });
 });
 
 g.test('signal a value lower than signaled value is invalid', async t => {
   const fence = t.queue.createFence({ initialValue: 1 });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.queue.signal(fence, 0);
   });
 });
@@ -38,7 +40,7 @@ g.test('signal a value lower than signaled value is invalid', async t => {
 g.test('signal a value equal to signaled value is invalid', async t => {
   const fence = t.queue.createFence({ initialValue: 1 });
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.queue.signal(fence, 1);
   });
 });
@@ -59,7 +61,7 @@ g.test('signal a fence on a different device than it was created on is invalid',
   const anotherDevice = await t.device.adapter.requestDevice();
   const anotherQueue = anotherDevice.getQueue();
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     anotherQueue.signal(fence, 2);
   });
 });
@@ -70,7 +72,7 @@ g.test('signal a fence on a different device does not update fence signaled valu
   const anotherDevice = await t.device.adapter.requestDevice();
   const anotherQueue = anotherDevice.getQueue();
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     anotherQueue.signal(fence, 2);
   });
 

--- a/src/suites/cts/validation/queue_submit.spec.ts
+++ b/src/suites/cts/validation/queue_submit.spec.ts
@@ -32,7 +32,7 @@ g.test('submitting with a mapped buffer is disallowed', async t => {
   await buffer.mapWriteAsync();
   t.queue.submit([]);
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.queue.submit([getCommandBuffer()]);
   });
 

--- a/src/suites/cts/validation/render_pass.spec.ts
+++ b/src/suites/cts/validation/render_pass.spec.ts
@@ -141,7 +141,7 @@ g.test('it is invalid to draw in a render pass with missing bind groups', async 
   }
   renderPass.draw(3, 1, 0, 0);
   renderPass.endPass();
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     commandEncoder.finish();
   }, !_success);
 }).params([

--- a/src/suites/cts/validation/render_pass_descriptor.spec.ts
+++ b/src/suites/cts/validation/render_pass_descriptor.spec.ts
@@ -70,7 +70,7 @@ class F extends ValidationTest {
     const renderPass = commandEncoder.beginRenderPass(descriptor);
     renderPass.endPass();
 
-    await this.expectValidationError(() => {
+    this.expectValidationError(() => {
       commandEncoder.finish();
     }, !success);
   }
@@ -427,7 +427,7 @@ g.test('it is invalid to use a resolve target in error state', async t => {
   const resolveTargetTexture = t.createTexture({ arrayLayerCount: ARRAY_LAYER_COUNT });
 
   const colorAttachment = t.getColorAttachment(multisampledColorTexture);
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     colorAttachment.resolveTarget = resolveTargetTexture.createView({
       dimension: '2d',
       format: 'rgba8unorm',

--- a/src/suites/cts/validation/setBindGroup.spec.ts
+++ b/src/suites/cts/validation/setBindGroup.spec.ts
@@ -56,7 +56,7 @@ g.test('dynamic offsets passed but not expected/compute pass', async t => {
   const { type } = t.params;
   const dynamicOffsets = [0];
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     if (type === 'compute') {
       const encoder = t.device.createCommandEncoder();
       const computePass = encoder.beginComputePass();
@@ -142,7 +142,7 @@ g.test('dynamic offsets match expectations in pass encoder', async t => {
 
   const { type, dynamicOffsets, _success } = t.params;
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     if (type === 'compute') {
       t.testComputePass(bindGroup, dynamicOffsets);
     } else if (type === 'renderpass') {

--- a/src/suites/cts/validation/setScissorRect.spec.ts
+++ b/src/suites/cts/validation/setScissorRect.spec.ts
@@ -39,7 +39,7 @@ g.test('use of setScissorRect', async t => {
   renderPass.setScissorRect(x, y, width, height);
   renderPass.endPass();
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     commandEncoder.finish();
   }, !_success);
 }).params([

--- a/src/suites/cts/validation/setVertexBuffer.spec.ts
+++ b/src/suites/cts/validation/setVertexBuffer.spec.ts
@@ -107,7 +107,7 @@ g.test('vertex buffers inherit from previous pipeline', async t => {
     renderPass.draw(3, 1, 0, 0);
     renderPass.endPass();
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       commandEncoder.finish();
     });
   }
@@ -172,7 +172,7 @@ g.test('vertex buffers do not inherit between render passes', async t => {
       renderPass.endPass();
     }
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       commandEncoder.finish();
     });
   }

--- a/src/suites/cts/validation/setViewport.spec.ts
+++ b/src/suites/cts/validation/setViewport.spec.ts
@@ -39,7 +39,7 @@ g.test('use of setViewport', async t => {
   renderPass.setViewport(x, y, width, height, minDepth, maxDepth);
   renderPass.endPass();
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     commandEncoder.finish();
   }, !_success);
 }).params([

--- a/src/suites/cts/validation/validation_test.ts
+++ b/src/suites/cts/validation/validation_test.ts
@@ -11,18 +11,19 @@ export class ValidationTest extends GPUTest {
     return errorBuffer;
   }
 
-  async expectValidationError(fn: Function, shouldError: boolean = true): Promise<void> {
+  expectValidationError(fn: Function, shouldError: boolean = true): void {
     // If no error is expected, we let the scope surrounding the test catch it.
     if (shouldError === false) {
       fn();
       return;
     }
-    return this.asyncExpectation(async () => {
-      this.device.pushErrorScope('validation');
 
-      fn();
+    this.device.pushErrorScope('validation');
+    fn();
+    const promise = this.device.popErrorScope();
 
-      const gpuValidationError = await this.device.popErrorScope();
+    this.eventualAsyncExpectation(async () => {
+      const gpuValidationError = await promise;
       if (!gpuValidationError) {
         this.fail('Validation error was expected.');
       } else if (gpuValidationError instanceof GPUValidationError) {

--- a/src/suites/cts/validation/vertex_input.spec.ts
+++ b/src/suites/cts/validation/vertex_input.spec.ts
@@ -199,7 +199,7 @@ g.test('pipeline vertex buffers are backed by attributes in vertex input', async
     `;
     const descriptor = t.getDescriptor(vertexInput, code);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -262,7 +262,7 @@ g.test('offset should be within vertex buffer stride if stride is not zero', asy
     badVertexInput.vertexBuffers![0].attributeSet[1].format = 'float2';
     const descriptor = t.getDescriptor(badVertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -272,7 +272,7 @@ g.test('offset should be within vertex buffer stride if stride is not zero', asy
     badVertexInput.vertexBuffers![0].stride = Float32Array.BYTES_PER_ELEMENT;
     const descriptor = t.getDescriptor(badVertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -315,7 +315,7 @@ g.test('check two attributes overlapping', async t => {
     badVertexInput.vertexBuffers![0].attributeSet[0].format = 'int2';
     const descriptor = t.getDescriptor(badVertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -359,7 +359,7 @@ g.test('check out of bounds condition on total number of vertex buffers', async 
     };
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -405,7 +405,7 @@ g.test('check out of bounds on number of vertex attributes on a single vertex bu
     };
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -440,7 +440,7 @@ g.test('check out of bounds on number of vertex attributes across vertex buffers
     const vertexInput: GPUVertexInputDescriptor = { vertexBuffers };
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -465,7 +465,7 @@ g.test('check out of bounds condition on input strides', async t => {
     vertexInput.vertexBuffers![0].stride = MAX_VERTEX_BUFFER_STRIDE + 4;
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -495,7 +495,7 @@ g.test('check multiple of 4 bytes constraint on input stride', async t => {
     vertexInput.vertexBuffers![0].stride = 2;
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -528,7 +528,7 @@ g.test('identical duplicate attributes are invalid', async t => {
     });
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -564,7 +564,7 @@ g.test('we cannot set same shader location', async t => {
       vertexInput.vertexBuffers![0].attributeSet![1].shaderLocation = 0;
       const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-      await t.expectValidationError(() => {
+      t.expectValidationError(() => {
         t.device.createRenderPipeline(descriptor);
       });
     }
@@ -595,7 +595,7 @@ g.test('we cannot set same shader location', async t => {
     // Test same shader location in two attributes in different buffers
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -625,7 +625,7 @@ g.test('check out of bounds condition on attribute shader location', async t => 
     vertexInput.vertexBuffers![0].attributeSet![0].shaderLocation = MAX_VERTEX_ATTRIBUTES;
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -662,7 +662,7 @@ g.test('check attribute offset out of bounds', async t => {
     vertexInput.vertexBuffers![0].attributeSet![0].offset = MAX_VERTEX_BUFFER_END - 4;
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -693,7 +693,7 @@ g.test('check multiple of 4 bytes constraint on offset', async t => {
     vertexInput.vertexBuffers![0].attributeSet![0].offset = 2;
     vertexInput.vertexBuffers![0].attributeSet![0].format = 'uchar2';
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -703,7 +703,7 @@ g.test('check multiple of 4 bytes constraint on offset', async t => {
     vertexInput.vertexBuffers![0].attributeSet![0].format = 'float';
     const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-    await t.expectValidationError(() => {
+    t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
     });
   }
@@ -726,7 +726,7 @@ g.test('check attribute offset overflow', async t => {
   };
   const descriptor = t.getDescriptor(vertexInput, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
-  await t.expectValidationError(() => {
+  t.expectValidationError(() => {
     t.device.createRenderPipeline(descriptor);
   });
 });

--- a/src/suites/unittests/loading.spec.ts
+++ b/src/suites/unittests/loading.spec.ts
@@ -124,9 +124,9 @@ g.test('partial suite', async t => {
 });
 
 g.test('whole group', async t => {
-  await t.shouldReject('Error', t.load(['suite1::']));
-  await t.shouldReject('Error', t.load(['suite1:bar:']));
-  await t.shouldReject('Error', t.load(['suite1:bar/:']));
+  t.shouldReject('Error', t.load(['suite1::']));
+  t.shouldReject('Error', t.load(['suite1:bar:']));
+  t.shouldReject('Error', t.load(['suite1:bar/:']));
   t.expect((await t.singleGroup('suite1:bar/buzz:')).length === 1);
   t.expect((await t.singleGroup('suite1:baz:')).length === 2);
 

--- a/src/suites/unittests/test_group.spec.ts
+++ b/src/suites/unittests/test_group.spec.ts
@@ -150,7 +150,7 @@ g.test('shouldThrow', async t0 => {
 });
 
 g.test('shouldReject', async t0 => {
-  await t0.shouldReject(
+  t0.shouldReject(
     'TypeError',
     (async () => {
       throw new TypeError();
@@ -160,7 +160,7 @@ g.test('shouldReject', async t0 => {
   const g = new TestGroup(UnitTest);
 
   g.test('a', async t => {
-    await t.shouldReject(
+    t.shouldReject(
       'Error',
       (async () => {
         throw new TypeError();
@@ -169,23 +169,6 @@ g.test('shouldReject', async t0 => {
   });
 
   const result = await t0.run(g);
-  t0.expect(result.cases[0].status === 'fail');
-});
-
-g.test('shouldReject/unawaited', async t0 => {
-  const g = new TestGroup(UnitTest);
-
-  g.test('a', async t => {
-    // This test passes...
-    t.shouldReject(
-      'Error',
-      (async () => {
-        throw new Error();
-      })()
-    );
-  });
-
-  const result = await t0.run(g);
-  // ... but the test fails, because there were outstanding expectations at the end of the test.
+  // Fails even though shouldReject doesn't fail until after the test function ends
   t0.expect(result.cases[0].status === 'fail');
 });


### PR DESCRIPTION
eventualAsyncExpectations are awaited during finalize, but don't need to
block the rest of the test. More importantly, you don't have to remember
to use "await" every single time in every test.

The old thing, now called immediateAsyncExpectation, still exists but is
only needed in one place: expectUncapturedError.