### PR TITLE
Replace spaces with underscores in test names for readability

### DIFF
--- a/src/framework/allowed_characters.ts
+++ b/src/framework/allowed_characters.ts
@@ -1,2 +1,2 @@
 // It may be OK to add more allowed characters here.
-export const allowedTestNameCharacters = 'a-zA-Z0-9/_ ';
+export const allowedTestNameCharacters = 'a-zA-Z0-9/_';

--- a/src/framework/loader.ts
+++ b/src/framework/loader.ts
@@ -54,9 +54,7 @@ export class TestLoader {
   // TODO: Test
   // TODO: Probably should actually not exist at all, just use queries on cmd line too.
   async loadTestsFromCmdLine(filters: string[]): Promise<TestFilterResultIterator> {
-    // In actual URL queries (?q=...), + represents a space. But decodeURIComponent doesn't do this,
-    // so do it manually. (+ is used over %20 for readability.) (See also encodeSelectively.)
-    return this.loadTests(filters.map(f => decodeURIComponent(f.replace(/\+/g, '%20'))));
+    return this.loadTests(filters);
   }
 
   private async loadTests(filters: string[]): Promise<TestFilterResultIterator> {

--- a/src/framework/test_group.ts
+++ b/src/framework/test_group.ts
@@ -52,6 +52,12 @@ export class TestGroup<F extends Fixture> implements RunCaseIterable {
 
   // TODO: This could take a fixture, too, to override the one for the group.
   test(name: string, fn: TestFn<F>): Test<F> {
+    // Replace spaces with underscores for readability.
+    if (name.indexOf('_') !== -1) {
+      throw new Error('Invalid test name ${name}: contains underscore (use space)');
+    }
+    name = name.replace(/ /g, '_');
+
     this.checkName(name);
 
     const test = new Test<F>(name, this.fixture, fn);

--- a/src/framework/url_query.ts
+++ b/src/framework/url_query.ts
@@ -3,7 +3,6 @@ import { ParamArgument, ParamSpec } from './params/index.js';
 
 export function encodeSelectively(s: string): string {
   let ret = encodeURIComponent(s);
-  ret = ret.replace(/%20/g, '+'); // Encode space with + (equivalent but more readable)
   ret = ret.replace(/%22/g, '"');
   ret = ret.replace(/%2C/g, ',');
   ret = ret.replace(/%2F/g, '/');

--- a/src/suites/cts/examples.spec.ts
+++ b/src/suites/cts/examples.spec.ts
@@ -18,6 +18,9 @@ import { GPUTest } from './gpu_test.js';
 
 export const g = new TestGroup(GPUTest);
 
+// Note: spaces in test names are replaced with underscores: cts:examples:test_name=
+g.test('test name', t => {});
+
 g.test('basic', t => {
   t.expect(true);
   t.expect(true, 'true should be true');


### PR DESCRIPTION
Since we started adding long test names with lots of spaces, the pluses got really annoying. Replace them with spaces.

e.g. cts:validation/createBindGroup:binding_must_be_present_in_layout=