### PR TITLE
standalone runtime: make tree structure, fix selections, add links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
     <title></title>
     <script src="third_party/jquery/jquery-3.3.1.min.js"></script>
     <style>
+      * {
+        box-sizing: border-box;
+      }
       #info {
         font-family: monospace;
       }
@@ -11,50 +14,59 @@
         width: 100%;
         height: 15em;
       }
-      .test {
-        border-width: 1px 1px 0 1px;
+
+      #resultsVis {
+        border-right: 1px solid gray;
+      }
+
+      /* tree nodes */
+
+      .nodeheader {
+        display: flex;
+        width: 100%;
+        padding: 1px 2px 1px 1px;
+      }
+      .noderun {
+        font-size: 10pt;
+        padding: 0 3pt 0 3pt;
+        margin: 0 2px;
+      }
+      .nodetitle {
+        flex-grow: 1;
+      }
+      .nodename {
+        user-select: all;
+      }
+      .nodelink {
+        margin: 0 2px;
+      }
+
+      /* tree nodes which are subtrees */
+
+      .subtree {
+        margin: 0px;
+        border-width: 1px 0 0 1px;
         border-style: solid;
         border-color: gray;
       }
-      .testrun {
-        display: inline-block;
-        font-size: 10pt;
-        padding: 0 3pt 0 3pt;
-      }
-      .testname {
-        display: inline-block;
-        margin-left: 2pt;
-      }
-      .testdesc {
-        margin-left: 1.8em;
-      }
-      .testcases {
+      .subtreechildren {
         margin-left: 8pt;
       }
+
+      /* tree nodes which are test cases */
+
       .testcase {
         border-width: 1px 0 0 1px;
         border-style: solid;
         border-color: gray;
         background: white;
       }
-      .casehead {
-        overflow: auto;
+      .testcasetime {
+        text-align: right;
+        min-width: 8em;
+        max-width: 8em;
       }
-      .caserun {
-        display: inline-block;
-        font-size: 10pt;
-        padding: 0 3pt 0 3pt;
-      }
-      .casename {
-        display: inline-block;
-        margin-left: 2pt;
-        width: 65%;
-      }
-      .casetime {
-        width: 20%;
-        float: right;
-      }
-      .caselogs {
+      .testcaselogs {
         margin-left: 8pt;
         width: calc(100% - 8pt - 1px);
         border-width: 0 1px 0 1px;
@@ -62,13 +74,12 @@
         border-color: gray;
         background: white;
       }
-      .caselog {
+      .testcaselog {
         margin-left: 2pt;
         border-width: 0 0 1px 0;
         border-style: solid;
         border-color: #eee;
       }
-
       .fail {
         background: #fcc;
       }
@@ -87,6 +98,7 @@
   </head>
   <body>
     <h1>WebGPU Conformance Test Suite</h1>
+
     <div id="info"></div>
     <div id="resultsVis"></div>
     <textarea id="resultsJSON"></textarea>

--- a/src/framework/tree.ts
+++ b/src/framework/tree.ts
@@ -1,0 +1,64 @@
+import { Logger } from './logger.js';
+import { TestFilterResult } from './test_filter/index.js';
+import { RunCase } from './test_group.js';
+import { makeQueryString } from './url_query.js';
+
+export interface FilterResultTreeNode {
+  //description?: string;
+  runCase?: RunCase;
+  children?: Map<string, FilterResultTreeNode>;
+}
+
+// e.g. iteratePath('a/b/c/d', ':') yields ['a/', 'a/b/', 'a/b/c/', 'a/b/c/d:']
+function* iteratePath(path: string, terminator: string): IterableIterator<string> {
+  const parts = path.split('/');
+  if (parts.length > 1) {
+    let partial = parts[0] + '/';
+    yield partial;
+    for (let i = 1; i < parts.length - 1; ++i) {
+      partial += parts[i] + '/';
+      yield partial;
+    }
+  }
+  yield path + terminator;
+}
+
+export function treeFromFilterResults(
+  log: Logger,
+  listing: IterableIterator<TestFilterResult>
+): FilterResultTreeNode {
+  function insertOrNew(n: FilterResultTreeNode, k: string): FilterResultTreeNode {
+    const children = n.children!;
+    if (children.has(k)) {
+      return children.get(k) as FilterResultTreeNode;
+    }
+    const v = { children: new Map() };
+    children.set(k, v);
+    return v;
+  }
+
+  const tree = { children: new Map() };
+  for (const f of listing) {
+    const files = insertOrNew(tree, f.id.suite + ':');
+    let tests = files;
+    for (const path of iteratePath(f.id.path, ':')) {
+      tests = insertOrNew(tests, f.id.suite + ':' + path);
+    }
+
+    if (!('g' in f.spec)) continue;
+
+    const [tRec] = log.record(f.id);
+    for (const t of f.spec.g.iterate(tRec)) {
+      let cases = tests;
+      for (const path of iteratePath(t.id.test, '~')) {
+        cases = insertOrNew(cases, makeQueryString(f.id) + path);
+      }
+
+      const p = t.id.params ? JSON.stringify(t.id.params) : '';
+      cases.children!.set(makeQueryString(f.id) + t.id.test + '=' + p, {
+        runCase: t,
+      });
+    }
+  }
+  return tree;
+}


### PR DESCRIPTION
- selecting test names no longer also selects the black triangle
- on chrome/firefox, clicking the name of a test/case selects it
- added links to test and case lines to open just that test/case
- convert flat structure into tree structure, splitting on slashes
  - make run buttons work recursively
  - make link buttons work for any subtree
  - do css to make tree structure nice
- prevent page reload if there are any test results