### PR TITLE
in gen_wpt_cts_html, filter out readmes from the variant list

### DIFF
--- a/src/tools/gen_wpt_cts_html.ts
+++ b/src/tools/gen_wpt_cts_html.ts
@@ -14,6 +14,10 @@ import { listing } from '../suites/cts/index.js';
 
   const ls = (await listing) as TestSuiteListingEntry[];
   for (const l of ls) {
+    if (l.path.length === 0 || l.path.endsWith('/')) {
+      // This is a readme.
+      continue;
+    }
     result += `<meta name=variant content='?q=cts:${l.path}:'>\n`;
   }
 


### PR DESCRIPTION
Bug caused by recently adding readmes into the listing files.