### PR TITLE
Add "print stack" button to standalone

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,13 +41,12 @@
         width: 100%;
         padding: 1px 2px 1px 1px;
       }
-      .nodebuttons {
-        flex-grow: 0;
-        flex-shrink: 0;
-      }
       .noderun,
-      .nodelink {
+      .nodelink,
+      .testcaselogbtn {
         display: inline-block;
+        flex-shrink: 0;
+        flex-grow: 0;
         vertical-align: top;
         background-color: #eee;
         background-repeat: no-repeat;
@@ -55,22 +54,20 @@
         border: 1px solid #888;
       }
       @media (pointer: fine) {
-        .nodebuttons {
-          flex-basis: 52px;
-        }
         .noderun,
-        .nodelink {
+        .nodelink,
+        .testcaselogbtn {
+          flex-basis: 24px;
           border-radius: 4px;
           width: 24px;
           height: 24px;
         }
       }
       @media (pointer: coarse) {
-        .nodebuttons {
-          flex-basis: 76px;
-        }
         .noderun,
-        .nodelink {
+        .nodelink,
+        .testcaselogbtn {
+          flex-basis: 36px;
           border-radius: 6px;
           width: 36px;
           height: 36px;
@@ -144,9 +141,7 @@
         background: white;
       }
       .testcaselog {
-        font-size: 10pt;
-        margin: 0 2px;
-        color: #666;
+        display: flex;
       }
       .testcaselog:nth-child(odd) {
         background: #fff;
@@ -154,7 +149,18 @@
       .testcaselog:nth-child(even) {
         background: #f8f8f8;
       }
-      .testcaselog::first-line {
+      .testcaselogbtn {
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMAQMAAABsu86kAAAABlBMVEUAAAAAAAClZ7nPAAAAAXRSTlMAQObYZgAAACRJREFUCNdjYGBg+H+AwUGBwV+BQUGAQX0CiNQQYFABk8ogLgBsYQUt2gNKPwAAAABJRU5ErkJggg==);
+      }
+      .testcaselogtext {
+        flex: 1 0;
+        font-size: 10pt;
+        white-space: pre-wrap;
+        word-break: break-word;
+        margin: 0;
+        color: #666;
+      }
+      .testcaselogtext::first-line {
         color: #000;
       }
 

--- a/src/runtime/cmdline.ts
+++ b/src/runtime/cmdline.ts
@@ -82,19 +82,26 @@ for (const a of process.argv.slice(2)) {
       console.log(log.asJSON(2));
     }
 
+    function printResults(results: Array<[TestSpecID, LiveTestCaseResult]>): void {
+      for (const [id, r] of results) {
+        console.log(makeQueryString(id, r), r.status, r.timems + 'ms');
+        if (r.logs) {
+          for (const l of r.logs) {
+            console.log('- ' + l.toJSON().replace(/\n/g, '\n  '));
+          }
+        }
+      }
+    }
+
     if (warned.length) {
       console.log('');
       console.log('** Warnings **');
-      for (const [id, r] of warned) {
-        console.log(makeQueryString(id), r);
-      }
+      printResults(warned);
     }
     if (failed.length) {
       console.log('');
       console.log('** Failures **');
-      for (const [id, r] of failed) {
-        console.log(makeQueryString(id), r);
-      }
+      printResults(failed);
     }
 
     const total = running.length;

--- a/src/runtime/standalone.ts
+++ b/src/runtime/standalone.ts
@@ -57,10 +57,22 @@ function makeCaseHTML(name: string, t: RunCase): [HTMLElement, RunSubtree] {
     if (res.logs) {
       caselogs.empty();
       for (const l of res.logs) {
-        $('<pre>')
+        const caselog = $('<div>')
           .addClass('testcaselog')
-          .appendTo(caselogs)
-          .text(l);
+          .appendTo(caselogs);
+        $('<button>')
+          .addClass('testcaselogbtn')
+          .attr('alt', 'Log stack to console')
+          .attr('title', 'Log stack to console')
+          .appendTo(caselog)
+          .on('click', () => {
+            // tslint:disable-next-line: no-console
+            console.log(l);
+          });
+        $('<pre>')
+          .addClass('testcaselogtext')
+          .appendTo(caselog)
+          .text(l.toJSON());
       }
     }
   };
@@ -129,26 +141,21 @@ function makeTreeNodeHeaderHTML(
   }
 
   const href = `?${worker ? 'worker&' : ''}${debug ? 'debug&' : ''}q=${nameEncoded}`;
-  $('<div>')
-    .addClass('nodebuttons')
-    .appendTo(div)
-    .append(
-      $('<button>')
-        .addClass('noderun')
-        .attr('alt', 'Run subtree')
-        .attr('title', 'Run subtree')
-        .on('click', async () => {
-          await runSubtree();
-          updateJSON();
-        })
-    )
-    .append(
-      $('<a>')
-        .addClass('nodelink')
-        .attr('href', href)
-        .attr('alt', 'Open')
-        .attr('title', 'Open')
-    );
+  $('<button>')
+    .addClass('noderun')
+    .attr('alt', 'Run subtree')
+    .attr('title', 'Run subtree')
+    .on('click', async () => {
+      await runSubtree();
+      updateJSON();
+    })
+    .appendTo(div);
+  $('<a>')
+    .addClass('nodelink')
+    .attr('href', href)
+    .attr('alt', 'Open')
+    .attr('title', 'Open')
+    .appendTo(div);
   const nodetitle = $('<div>')
     .addClass('nodetitle')
     .appendTo(div);

--- a/src/runtime/wpt.ts
+++ b/src/runtime/wpt.ts
@@ -47,7 +47,7 @@ declare function async_test(f: (this: WptTestObject) => Promise<void>, name: str
           this.step(() => {
             // Unfortunately, it seems not possible to surface any logs for warn/skip.
             if (r.status === 'fail') {
-              throw (r.logs || []).join('\n');
+              throw (r.logs || []).map(s => s.toJSON()).join('\n\n');
             }
           });
           this.done();

--- a/src/suites/cts/gpu_test.ts
+++ b/src/suites/cts/gpu_test.ts
@@ -103,28 +103,39 @@ export class GPUTest extends Fixture {
 
     this.queue.submit([c.finish()]);
 
-    this.eventualAsyncExpectation(async () => {
+    this.eventualAsyncExpectation(async niceStack => {
       const actual = new Uint8Array(await dst.mapReadAsync());
-      this.expectBuffer(actual, exp);
+      const check = this.checkBuffer(actual, exp);
+      if (check !== undefined) {
+        niceStack.message = check;
+        this.rec.fail(niceStack);
+      }
       dst.destroy();
     });
   }
 
   expectBuffer(actual: Uint8Array, exp: Uint8Array): void {
+    const check = this.checkBuffer(actual, exp);
+    if (check !== undefined) {
+      this.rec.fail(new Error(check));
+    }
+  }
+
+  checkBuffer(actual: Uint8Array, exp: Uint8Array): string | undefined {
     const size = exp.byteLength;
     if (actual.byteLength !== size) {
-      this.rec.fail('size mismatch');
-      return;
+      return 'size mismatch';
     }
+    const lines = [];
     let failedPixels = 0;
     for (let i = 0; i < size; ++i) {
       if (actual[i] !== exp[i]) {
         if (failedPixels > 4) {
-          this.rec.fail('... and more');
+          lines.push('... and more');
           break;
         }
         failedPixels++;
-        this.rec.fail(`at [${i}], expected ${exp[i]}, got ${actual[i]}`);
+        lines.push(`at [${i}], expected ${exp[i]}, got ${actual[i]}`);
       }
     }
     if (size <= 256 && failedPixels > 0) {
@@ -134,8 +145,12 @@ export class GPUTest extends Fixture {
       const actHex = Array.from(actual)
         .map(x => x.toString(16).padStart(2, '0'))
         .join('');
-      this.rec.log('EXPECT: ' + expHex);
-      this.rec.log('ACTUAL: ' + actHex);
+      lines.push('EXPECT: ' + expHex);
+      lines.push('ACTUAL: ' + actHex);
     }
+    if (failedPixels) {
+      return lines.join('\n');
+    }
+    return undefined;
   }
 }

--- a/src/suites/cts/validation/validation_test.ts
+++ b/src/suites/cts/validation/validation_test.ts
@@ -22,12 +22,14 @@ export class ValidationTest extends GPUTest {
     fn();
     const promise = this.device.popErrorScope();
 
-    this.eventualAsyncExpectation(async () => {
+    this.eventualAsyncExpectation(async niceStack => {
       const gpuValidationError = await promise;
       if (!gpuValidationError) {
-        this.fail('Validation error was expected.');
+        niceStack.message = 'Validation error was expected.';
+        this.rec.fail(niceStack);
       } else if (gpuValidationError instanceof GPUValidationError) {
-        this.debug(`Captured validation error - ${gpuValidationError.message}`);
+        niceStack.message = `Captured validation error - ${gpuValidationError.message}`;
+        this.rec.debug(niceStack);
       }
     });
   }

--- a/src/suites/unittests/basic.spec.ts
+++ b/src/suites/unittests/basic.spec.ts
@@ -13,11 +13,11 @@ g.test('test/sync', t => {});
 g.test('test/async', async t => {});
 
 g.test('testp/sync', t => {
-  t.log(JSON.stringify(t.params));
+  t.debug(JSON.stringify(t.params));
 }).params([{}]);
 
 g.test('testp/async', async t => {
-  t.log(JSON.stringify(t.params));
+  t.debug(JSON.stringify(t.params));
 }).params([{}]);
 
 g.test('testp/private', t => {

--- a/src/suites/unittests/logger.spec.ts
+++ b/src/suites/unittests/logger.spec.ts
@@ -60,7 +60,7 @@ g.test('pass', t => {
   const [rec, res] = testrec.record('baz', null);
 
   rec.start();
-  rec.log('hello');
+  rec.debug(new Error('hello'));
   t.expect(res.status === 'running');
   rec.finish();
   t.expect(res.status === 'pass');
@@ -76,7 +76,7 @@ g.test('skip', t => {
   t.expect(res.status === 'running');
 
   rec.skipped(new SkipTestCase());
-  rec.log('hello');
+  rec.debug(new Error('hello'));
 
   t.expect(res.status === 'running');
   rec.finish();
@@ -93,7 +93,7 @@ g.test('warn', t => {
   rec.start();
   t.expect(res.status === 'running');
 
-  rec.warn();
+  rec.warn(new Error());
   rec.skipped(new SkipTestCase());
 
   t.expect(res.status === 'running');
@@ -111,8 +111,8 @@ g.test('fail', t => {
   rec.start();
   t.expect(res.status === 'running');
 
-  rec.fail('bye');
-  rec.warn();
+  rec.fail(new Error('bye'));
+  rec.warn(new Error());
   rec.skipped(new SkipTestCase());
 
   t.expect(res.status === 'running');
@@ -130,7 +130,7 @@ g.test('debug', t => {
   const [rec, res] = testrec.record('baz', null);
 
   rec.start(debug);
-  rec.debug('hello');
+  rec.debug(new Error('hello'));
   rec.finish();
   t.expect(res.status === 'pass');
   t.expect(res.timems >= 0);

--- a/src/suites/unittests/test_group.spec.ts
+++ b/src/suites/unittests/test_group.spec.ts
@@ -71,8 +71,9 @@ g.test('stack', async t0 => {
     if (logs === undefined) {
       throw new Error('expected logs');
     }
-    t0.expect(search.test(logs[0]));
-    const st = logs[0].split('\n');
+    const l = logs[0].toJSON();
+    t0.expect(search.test(l));
+    const st = l.split('\n');
     t0.expect(search.test(st[st.length - 1]));
   }
 });


### PR DESCRIPTION
- Logs error objects instead of strings, and convert to strings in toJSON.
  - Refactor logger to only take error objects.
- Add a button to print that stack to the console so you can click source links.
- Capture stacks before async work so they're useful.
- Update uses of t.warn() et al to use t.rec.warn() et al.
- Remove t.log() and t.rec.log() in favor of t.debug().
- Improve logging of multi-line messages in cmdline runner.

chrome:
![screenshot chrome](https://user-images.githubusercontent.com/606355/68249627-098e9680-ffd4-11e9-8b73-1abf5774843c.png)
safari:
![screenshot safari](https://user-images.githubusercontent.com/606355/68249710-3478ea80-ffd4-11e9-8ffd-4cdd48825584.png)
