### PR TITLE
Add a fence test with time limit

### DIFF
--- a/src/framework/util/index.ts
+++ b/src/framework/util/index.ts
@@ -18,6 +18,10 @@ export function rejectOnTimeout(ms: number, msg: string): Promise<never> {
   });
 }
 
+export function raceWithRejectOnTimeout<T>(p: Promise<T>, ms: number, msg: string): Promise<T> {
+  return Promise.race([p, rejectOnTimeout(ms, msg)]);
+}
+
 export function objectEquals(x: unknown, y: unknown): boolean {
   if (typeof x !== 'object' || typeof y !== 'object') return x === y;
   if (x === null || y === null) return x === y;

--- a/src/suites/cts/fences.spec.ts
+++ b/src/suites/cts/fences.spec.ts
@@ -111,15 +111,15 @@ g.test('wait/many/parallel', async t => {
 g.test('wait/timed promise', async t => {
   return new Promise<void>((resolve, reject) => {
     const fence = t.queue.createFence();
-    timeout(() => t.queue.signal(fence, 2), 10)
+    timeout(() => t.queue.signal(fence, 2), 10);
 
     fence.onCompletion(2).then(() => {
       t.expect(fence.getCompletedValue() === 2);
-      resolve()
-    })
+      resolve();
+    });
 
-    rejectOnTimeout(100, 'The fence has not been resolved within time limit.').catch(reject)
-  })
+    rejectOnTimeout(100, 'The fence has not been resolved within time limit.').catch(reject);
+  });
 });
 
 // Test dropping references to the fence and onCompletion promise does not crash.

--- a/src/suites/cts/fences.spec.ts
+++ b/src/suites/cts/fences.spec.ts
@@ -118,7 +118,7 @@ g.test('wait/timed promise', async t => {
       resolve()
     })
 
-    rejectOnTimeout(100, 'The fence has not been resolved in a time limit').catch(reject)
+    rejectOnTimeout(100, 'The fence has not been resolved within time limit.').catch(reject)
   })
 });
 

--- a/src/suites/cts/fences.spec.ts
+++ b/src/suites/cts/fences.spec.ts
@@ -106,6 +106,19 @@ g.test('wait/many/parallel', async t => {
   t.expect(fence.getCompletedValue() === 20);
 });
 
+// Test promise resolving with a time limit
+g.test('wait/timed promise', async t => {
+  return new Promise<void>((resolve, reject) => {
+    const fence = t.queue.createFence();
+    setTimeout(() => t.queue.signal(fence, 2), 100)
+    fence.onCompletion(2).then(() => {
+      t.expect(fence.getCompletedValue() == 2);
+      resolve()
+    })
+    setTimeout(() => reject(), 1000)
+  })
+});
+
 // Test dropping references to the fence and onCompletion promise does not crash.
 g.test('drop/fence and promise', t => {
   {

--- a/src/suites/cts/fences.spec.ts
+++ b/src/suites/cts/fences.spec.ts
@@ -111,12 +111,12 @@ g.test('wait/many/parallel', async t => {
 g.test('wait/timed promise', async t => {
   return new Promise<void>((resolve, reject) => {
     const fence = t.queue.createFence();
-    timeout(() => t.queue.signal(fence, 2), 100)
+    timeout(() => t.queue.signal(fence, 2), 10)
     fence.onCompletion(2).then(() => {
       t.expect(fence.getCompletedValue() === 2);
       resolve()
     })
-    rejectOnTimeout(1000, '')
+    rejectOnTimeout(100, '')
   })
 });
 

--- a/src/suites/cts/fences.spec.ts
+++ b/src/suites/cts/fences.spec.ts
@@ -112,11 +112,13 @@ g.test('wait/timed promise', async t => {
   return new Promise<void>((resolve, reject) => {
     const fence = t.queue.createFence();
     timeout(() => t.queue.signal(fence, 2), 10)
+
     fence.onCompletion(2).then(() => {
       t.expect(fence.getCompletedValue() === 2);
       resolve()
     })
-    rejectOnTimeout(100, '')
+
+    rejectOnTimeout(100, 'The fence has not been resolved in a time limit').catch(reject)
   })
 });
 

--- a/src/suites/cts/fences.spec.ts
+++ b/src/suites/cts/fences.spec.ts
@@ -1,7 +1,8 @@
 export const description = ``;
 
 import { attemptGarbageCollection } from '../../framework/collect_garbage.js';
-import { TestGroup } from '../../framework/index.js';
+import { TestGroup, rejectOnTimeout } from '../../framework/index.js';
+import { timeout } from '../../framework/util/timeout.js';
 
 import { GPUTest } from './gpu_test.js';
 
@@ -106,16 +107,16 @@ g.test('wait/many/parallel', async t => {
   t.expect(fence.getCompletedValue() === 20);
 });
 
-// Test promise resolving with a time limit
+// Test promise resolving with a time limit.
 g.test('wait/timed promise', async t => {
   return new Promise<void>((resolve, reject) => {
     const fence = t.queue.createFence();
-    setTimeout(() => t.queue.signal(fence, 2), 100)
+    timeout(() => t.queue.signal(fence, 2), 100)
     fence.onCompletion(2).then(() => {
       t.expect(fence.getCompletedValue() == 2);
       resolve()
     })
-    setTimeout(() => reject(), 1000)
+    rejectOnTimeout(1000, '')
   })
 });
 

--- a/src/suites/cts/fences.spec.ts
+++ b/src/suites/cts/fences.spec.ts
@@ -113,7 +113,7 @@ g.test('wait/timed promise', async t => {
     const fence = t.queue.createFence();
     timeout(() => t.queue.signal(fence, 2), 100)
     fence.onCompletion(2).then(() => {
-      t.expect(fence.getCompletedValue() == 2);
+      t.expect(fence.getCompletedValue() === 2);
       resolve()
     })
     rejectOnTimeout(1000, '')

--- a/src/suites/cts/validation/error_scope.spec.ts
+++ b/src/suites/cts/validation/error_scope.spec.ts
@@ -3,7 +3,7 @@ error scope validation tests.
 `;
 
 import { getGPU } from '../../../framework/gpu/implementation.js';
-import { Fixture, TestGroup, rejectOnTimeout } from '../../../framework/index.js';
+import { Fixture, TestGroup, raceWithRejectOnTimeout } from '../../../framework/index.js';
 
 class F extends Fixture {
   device: GPUDevice = undefined!;
@@ -42,10 +42,11 @@ class F extends Fixture {
 
       fn();
 
-      return Promise.race([
+      return raceWithRejectOnTimeout(
         promise,
-        rejectOnTimeout(TIMEOUT_IN_MS, 'Timeout occurred waiting for uncaptured error'),
-      ]);
+        TIMEOUT_IN_MS,
+        'Timeout occurred waiting for uncaptured error'
+      );
     });
   }
 }


### PR DESCRIPTION
Hi,

I implemented fences today and I discovered that empty `onCompletion` could pass the CTS.

I added a new test case which catches that problem.

Regards