### PR TITLE
Fix imagebitmap test title

### DIFF
--- a/src/suites/cts/copyImageBitmapToTexture.spec.ts
+++ b/src/suites/cts/copyImageBitmapToTexture.spec.ts
@@ -91,7 +91,7 @@ class F extends GPUTest {
 
 export const g = new TestGroup(F);
 
-g.test('from image element', async t => {
+g.test('from ImageData', async t => {
   const { width, height } = t.params;
 
   // The texture format is rgba8uint, so the bytes per pixel is 4.


### PR DESCRIPTION
Test was changed from image element to ImageData, but the fix for the title got lost.