### PR TITLE
Remove out-of-bounds tests that will become part of the IDL tests

### DIFF
--- a/src/suites/cts/validation/createBindGroup.spec.ts
+++ b/src/suites/cts/validation/createBindGroup.spec.ts
@@ -291,5 +291,4 @@ g.test('buffer offset and size for bind groups match', async t => {
   { offset: 256 * 5, size: 0, _success: false }, // offset is OOB
   { offset: 0, size: 256 * 5, _success: false }, // size is OOB
   { offset: 1024, size: 1, _success: false }, // offset+size is OOB
-  { offset: 256, size: -256, _success: false }, // offset+size overflows to be 0
 ]);

--- a/src/suites/cts/validation/createBindGroupLayout.spec.ts
+++ b/src/suites/cts/validation/createBindGroupLayout.spec.ts
@@ -40,25 +40,6 @@ g.test('some binding index was specified more than once', async t => {
   });
 });
 
-g.test('negative binding index', async t => {
-  const goodDescriptor = {
-    bindings: [
-      { binding: 0, visibility: GPUShaderStage.COMPUTE, type: C.BindingType.StorageBuffer },
-    ],
-  };
-
-  // Control case
-  t.device.createBindGroupLayout(goodDescriptor);
-
-  // Negative binding index can't be specified.
-  const badDescriptor = clone(goodDescriptor);
-  badDescriptor.bindings[0].binding = -1;
-
-  t.expectValidationError(() => {
-    t.device.createBindGroupLayout(badDescriptor);
-  });
-});
-
 g.test('Visibility of bindings can be 0', async t => {
   t.device.createBindGroupLayout({
     bindings: [{ binding: 0, visibility: 0, type: 'storage-buffer' }],


### PR DESCRIPTION
Now that we've added `[EnforceRange]`, these throw exceptions, not validation errors.

They will be tested when we do IDL tests (which will verify all of the EnforceRange annotations).