### PR TITLE
At the end of a GPUTest, release the device back into the pool

### DIFF
--- a/src/suites/cts/gpu_test.ts
+++ b/src/suites/cts/gpu_test.ts
@@ -87,6 +87,8 @@ export class GPUTest extends Fixture {
         this.fail('Unexpected out-of-memory error occurred');
       }
     }
+
+    devicePool.release(this.device);
   }
 
   async initGLSL(): Promise<void> {


### PR DESCRIPTION
Oops. Fix for #122 which I didn't test sufficiently.

cc @Jiawei-Shao