### PR TITLE
Fix an error in 'use a texture view created from a destroyed texture'

### DIFF
--- a/src/suites/cts/validation/createView.spec.ts
+++ b/src/suites/cts/validation/createView.spec.ts
@@ -253,8 +253,6 @@ g.test('test the format compatibility rules when creating a texture view', async
 g.test('it is invalid to use a texture view created from a destroyed texture', async t => {
   const texture = t.createTexture({ arrayLayerCount: 1 });
 
-  texture.destroy();
-
   const commandEncoder = t.device.createCommandEncoder();
   const renderPass = commandEncoder.beginRenderPass({
     colorAttachments: [
@@ -265,6 +263,8 @@ g.test('it is invalid to use a texture view created from a destroyed texture', a
     ],
   });
   renderPass.endPass();
+
+  texture.destroy();
 
   t.expectValidationError(() => {
     commandEncoder.finish();


### PR DESCRIPTION
This patch intends to fix an error in 'use a texture view created
from a destroyed texture' test. In this test texture.createView()
should be called before texture.destroy() or the validation error
will occur on texture.createView() instead of commandEncoder.finish().