### PR TITLE
CTS of CopyImageBitmap to cover canvas path

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/preset-typescript": "^7.7.7",
     "@types/jquery": "^3.3.30",
     "@types/node": "^13.1.2",
+    "@types/offscreencanvas": "^2019.6.1",
     "@webgpu/glslang": "^0.0.15",
     "@webgpu/types": "0.0.21",
     "babel-plugin-add-header-comment": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,6 +278,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.5.tgz#4d5efc52a1d3e45d13e5ec9f911cbc5b089ccaec"
   integrity sha512-wupvfmtbqRJzjCm1H2diy7wo31Gn1OzvqoxCfQuKM9eSecogzP0WTlrjdq7cf7jgSO2ZX6hxwgRPR8Wt7FA22g==
 
+"@types/offscreencanvas@^2019.6.1":
+  version "2019.6.1"
+  resolved "https://registry.yarnpkg.com/@types/offscreencanvas/-/offscreencanvas-2019.6.1.tgz#3ec0b0cbf3d9c484b0628931e097f6ce8fccdadd"
+  integrity sha512-V3uCxw0phT4+Mgy/gVWm5xinN7xhIb2d1JwQXBJh7FRt9GvuNUzgQUlKakO+4utgv+XaWMwy3Ok8Mz9ix3BJEw==
+  dependencies:
+    "@types/webgl2" "*"
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -287,6 +294,11 @@
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
+
+"@types/webgl2@*":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.5.tgz#dd925e20ab8ace80eb4b1e46fda5b109c508fb0d"
+  integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
 
 "@webgpu/glslang@^0.0.15":
   version "0.0.15"


### PR DESCRIPTION
This patch added a test path to cover CopyImageBitmap from canvas source which is mainly the GPU copy path.