### PR TITLE
Fix comment in copyImageBitmapToTexture cts

### DIFF
--- a/src/suites/cts/copyImageBitmapToTexture.spec.ts
+++ b/src/suites/cts/copyImageBitmapToTexture.spec.ts
@@ -119,7 +119,7 @@ export const g = new TestGroup(F);
 g.test('from ImageData', async t => {
   const { width, height } = t.params;
 
-  // The texture format is rgba8uint, so the bytes per pixel is 4.
+  // The texture format is rgba8unorm, so the bytes per pixel is 4.
   const bytesPerPixel = 4;
 
   const imagePixels = new Uint8ClampedArray(bytesPerPixel * width * height);
@@ -179,7 +179,7 @@ g.test('from canvas', async t => {
     return;
   }
 
-  // The texture format is rgba8uint, so the bytes per pixel is 4.
+  // The texture format is rgba8unorm, so the bytes per pixel is 4.
   const bytesPerPixel = 4;
 
   // Generate original data.


### PR DESCRIPTION
Sry, caught some out-dated comments. Fix them.