### PR TITLE
Allow overriding of the path to glslang

### DIFF
--- a/src/framework/glslang.ts
+++ b/src/framework/glslang.ts
@@ -1,0 +1,44 @@
+import { getGlslangPath } from './glslang_path.js';
+import { SkipTestCase } from './index.js';
+import { assert } from './util/index.js';
+
+type glslang = typeof import('@webgpu/glslang/dist/web-devel/glslang');
+type Glslang = import('@webgpu/glslang/dist/web-devel/glslang').Glslang;
+type ShaderStage = import('@webgpu/glslang/dist/web-devel/glslang').ShaderStage;
+type SpirvVersion = import('@webgpu/glslang/dist/web-devel/glslang').SpirvVersion;
+
+let glslangAttempted: boolean = false;
+let glslangInstance: Glslang | undefined;
+
+export async function initGLSL(): Promise<void> {
+  if (glslangAttempted) {
+    if (!glslangInstance) {
+      throw new SkipTestCase('glslang is not available');
+    }
+  } else {
+    glslangAttempted = true;
+    const glslangPath = getGlslangPath() || '../glslang.js';
+    let glslangModule: () => Promise<Glslang>;
+    try {
+      glslangModule = ((await import(glslangPath)) as glslang).default;
+    } catch (ex) {
+      throw new SkipTestCase('glslang is not available');
+    }
+
+    const glslang = await glslangModule();
+    glslangInstance = glslang;
+  }
+}
+
+export function compileGLSL(
+  glsl: string,
+  shaderType: ShaderStage,
+  genDebug: boolean,
+  spirvVersion?: SpirvVersion
+): Uint32Array {
+  assert(
+    glslangInstance !== undefined,
+    'GLSL compiler is not instantiated. Run `await initGLSL()` first'
+  );
+  return glslangInstance.compileGLSL(glsl, shaderType, genDebug, spirvVersion);
+}

--- a/src/framework/glslang_path.ts
+++ b/src/framework/glslang_path.ts
@@ -1,0 +1,12 @@
+import { assert } from './util/index.js';
+
+let glslangPath: string | undefined;
+
+export function getGlslangPath(): string | undefined {
+  return glslangPath;
+}
+
+export function setGlslangPath(path: string): void {
+  assert(path.startsWith('/'), 'glslang path must be absolute');
+  glslangPath = path;
+}

--- a/src/suites/cts/glslang_available.spec.ts
+++ b/src/suites/cts/glslang_available.spec.ts
@@ -1,0 +1,17 @@
+export const description = `
+Checks that glslang is available. If glslang is not supposed to be available, suppress this test.
+`;
+
+import { initGLSL } from '../../framework/glslang.js';
+import { Fixture, TestGroup, unreachable } from '../../framework/index.js';
+
+export const g = new TestGroup(Fixture);
+
+g.test('check', async t => {
+  // try{} to prevent the SkipTestCase exception from propagating.
+  try {
+    await initGLSL();
+  } catch (ex) {
+    unreachable(String(ex));
+  }
+});

--- a/src/suites/cts/validation/createRenderPipeline.spec.ts
+++ b/src/suites/cts/validation/createRenderPipeline.spec.ts
@@ -2,6 +2,7 @@ export const description = `
 createRenderPipeline validation tests.
 `;
 
+import { initGLSL } from '../../../framework/glslang.js';
 import { TestGroup, poptions } from '../../../framework/index.js';
 import GLSL from '../../../tools/glsl.macro.js';
 import { kTextureFormatInfo, kTextureFormats } from '../capability_info.js';
@@ -11,7 +12,7 @@ import { ValidationTest } from './validation_test.js';
 class F extends ValidationTest {
   async init(): Promise<void> {
     await super.init();
-    await this.initGLSL();
+    await initGLSL();
   }
 
   getDescriptor(

--- a/src/suites/cts/validation/setVertexBuffer.spec.ts
+++ b/src/suites/cts/validation/setVertexBuffer.spec.ts
@@ -2,6 +2,7 @@ export const description = `
 setVertexBuffer validation tests.
 `;
 
+import { initGLSL } from '../../../framework/glslang.js';
 import { TestGroup, range } from '../../../framework/index.js';
 
 import { ValidationTest } from './validation_test.js';
@@ -9,7 +10,7 @@ import { ValidationTest } from './validation_test.js';
 class F extends ValidationTest {
   async init(): Promise<void> {
     await super.init();
-    await this.initGLSL();
+    await initGLSL();
   }
 
   getVertexBuffer(): GPUBuffer {

--- a/src/suites/cts/validation/vertex_state.spec.ts
+++ b/src/suites/cts/validation/vertex_state.spec.ts
@@ -2,6 +2,7 @@ export const description = `
 vertexState validation tests.
 `;
 
+import { initGLSL } from '../../../framework/glslang.js';
 import { C, TestGroup } from '../../../framework/index.js';
 
 import { ValidationTest } from './validation_test.js';
@@ -27,7 +28,7 @@ function clone<T extends GPUVertexStateDescriptor>(descriptor: T): T {
 class F extends ValidationTest {
   async init(): Promise<void> {
     await super.init();
-    await this.initGLSL();
+    await initGLSL();
   }
 
   getDescriptor(

--- a/templates/cts.html
+++ b/templates/cts.html
@@ -45,4 +45,10 @@
 </style>
 
 <textarea id=results></textarea>
-<script type=module src=/webgpu/runtime/wpt.js></script>
+<script type=module>
+  import { setGlslangPath } from '/webgpu/framework/glslang_path.js';
+  // To override the glslang.js path:
+  //   setGlslangPath('/path/to/glslang.js);
+
+  import '/webgpu/runtime/wpt.js';
+</script>


### PR DESCRIPTION
This potential change allows browsers to specify a path to a file outside WPT (which can
e.g. be downloaded as a dependency instead of checked into Git). This
would allow testing of runtime-generated shaders through WPT.