### PR TITLE
Replace textureDimension with viewDimension

### DIFF
--- a/src/suites/cts/validation/createBindGroup.spec.ts
+++ b/src/suites/cts/validation/createBindGroup.spec.ts
@@ -212,7 +212,7 @@ g.test('texture must have correct dimension', async t => {
         binding: 0,
         visibility: GPUShaderStage.FRAGMENT,
         type: 'sampled-texture',
-        textureDimension: '2d',
+        viewDimension: '2d',
       },
     ],
   });


### PR DESCRIPTION
The member for the texture-view-dimension is of type
GPUTextureViewDimension, but the name is textureDimension, which is
confusing because there's also a type GPUTextureDimension[1][2].

[1] https://github.com/gpuweb/gpuweb/issues/587
[2] https://github.com/gpuweb/gpuweb/pull/589