### PR TITLE
Roll @webgpu/types to latest, and update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^13.1.2",
     "@types/offscreencanvas": "^2019.6.1",
     "@webgpu/glslang": "^0.0.15",
-    "@webgpu/types": "0.0.21",
+    "@webgpu/types": "0.0.22",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^0.0.5",
     "babel-plugin-macros": "^2.8.0",

--- a/src/suites/cts/capability_info.ts
+++ b/src/suites/cts/capability_info.ts
@@ -80,8 +80,8 @@ export const kPerStageBindingLimits: {
   'storage-texture': 4,
 };
 
-const kStagesVFC = C.ShaderStage.Vertex | C.ShaderStage.Fragment | C.ShaderStage.Compute;
-const kStagesC = C.ShaderStage.Compute;
+const kStagesAll = C.ShaderStage.Vertex | C.ShaderStage.Fragment | C.ShaderStage.Compute;
+const kStagesCompute = C.ShaderStage.Compute;
 export const kBindingTypeInfo: {
   [k in GPUBindingType]: {
     type: 'buffer' | 'texture' | 'sampler';
@@ -92,14 +92,14 @@ export const kBindingTypeInfo: {
   };
   // TODO: maxDynamicCount should be kPerPipelineLayoutBindingLimits instead
 } = /* prettier-ignore */ {
-  'uniform-buffer':            { type: 'buffer',  validStages: kStagesVFC, perStageLimitType: 'uniform-buffer',  maxDynamicCount: 8 },
-  'storage-buffer':            { type: 'buffer',  validStages: kStagesC,   perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
-  'readonly-storage-buffer':   { type: 'buffer',  validStages: kStagesVFC, perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
-  'sampler':                   { type: 'sampler', validStages: kStagesVFC, perStageLimitType: 'sampler',         maxDynamicCount: 0 },
-  'comparison-sampler':        { type: 'sampler', validStages: kStagesVFC, perStageLimitType: 'sampler',         maxDynamicCount: 0 },
-  'sampled-texture':           { type: 'texture', validStages: kStagesVFC, perStageLimitType: 'sampled-texture', maxDynamicCount: 0 },
-  'writeonly-storage-texture': { type: 'texture', validStages: kStagesC,   perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
-  'readonly-storage-texture':  { type: 'texture', validStages: kStagesVFC, perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
+  'uniform-buffer':            { type: 'buffer',  validStages: kStagesAll,     perStageLimitType: 'uniform-buffer',  maxDynamicCount: 8 },
+  'storage-buffer':            { type: 'buffer',  validStages: kStagesCompute, perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
+  'readonly-storage-buffer':   { type: 'buffer',  validStages: kStagesAll,     perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
+  'sampler':                   { type: 'sampler', validStages: kStagesAll,     perStageLimitType: 'sampler',         maxDynamicCount: 0 },
+  'comparison-sampler':        { type: 'sampler', validStages: kStagesAll,     perStageLimitType: 'sampler',         maxDynamicCount: 0 },
+  'sampled-texture':           { type: 'texture', validStages: kStagesAll,     perStageLimitType: 'sampled-texture', maxDynamicCount: 0 },
+  'writeonly-storage-texture': { type: 'texture', validStages: kStagesCompute, perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
+  'readonly-storage-texture':  { type: 'texture', validStages: kStagesAll,     perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
 };
 export const kBindingTypes = Object.keys(kBindingTypeInfo) as GPUBindingType[];
 

--- a/src/suites/cts/capability_info.ts
+++ b/src/suites/cts/capability_info.ts
@@ -80,8 +80,8 @@ export const kPerStageBindingLimits: {
   'storage-texture': 4,
 };
 
-const kStagesAll = C.ShaderStage.Vertex | C.ShaderStage.Fragment | C.ShaderStage.Compute;
-const kStagesNonVertex = C.ShaderStage.Fragment | C.ShaderStage.Compute;
+const kStagesVFC = C.ShaderStage.Vertex | C.ShaderStage.Fragment | C.ShaderStage.Compute;
+const kStagesC = C.ShaderStage.Compute;
 export const kBindingTypeInfo: {
   [k in GPUBindingType]: {
     type: 'buffer' | 'texture' | 'sampler';
@@ -90,13 +90,16 @@ export const kBindingTypeInfo: {
     maxDynamicCount: number;
     // Add fields as needed
   };
+  // TODO: maxDynamicCount should be kPerPipelineLayoutBindingLimits instead
 } = /* prettier-ignore */ {
-  'uniform-buffer':          { type: 'buffer',  validStages: kStagesAll, perStageLimitType: 'uniform-buffer',  maxDynamicCount: 8 },
-  'storage-buffer':          { type: 'buffer',  validStages: kStagesNonVertex, perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
-  'readonly-storage-buffer': { type: 'buffer',  validStages: kStagesAll, perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
-  'sampler':                 { type: 'sampler', validStages: kStagesAll, perStageLimitType: 'sampler',         maxDynamicCount: 0 },
-  'sampled-texture':         { type: 'texture', validStages: kStagesAll, perStageLimitType: 'sampled-texture', maxDynamicCount: 0 },
-  'storage-texture':         { type: 'texture', validStages: kStagesAll, perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
+  'uniform-buffer':            { type: 'buffer',  validStages: kStagesVFC, perStageLimitType: 'uniform-buffer',  maxDynamicCount: 8 },
+  'storage-buffer':            { type: 'buffer',  validStages: kStagesC,   perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
+  'readonly-storage-buffer':   { type: 'buffer',  validStages: kStagesVFC, perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
+  'sampler':                   { type: 'sampler', validStages: kStagesVFC, perStageLimitType: 'sampler',         maxDynamicCount: 0 },
+  'comparison-sampler':        { type: 'sampler', validStages: kStagesVFC, perStageLimitType: 'sampler',         maxDynamicCount: 0 },
+  'sampled-texture':           { type: 'texture', validStages: kStagesVFC, perStageLimitType: 'sampled-texture', maxDynamicCount: 0 },
+  'writeonly-storage-texture': { type: 'texture', validStages: kStagesC,   perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
+  'readonly-storage-texture':  { type: 'texture', validStages: kStagesVFC, perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
 };
 export const kBindingTypes = Object.keys(kBindingTypeInfo) as GPUBindingType[];
 

--- a/src/suites/cts/command_buffer/compute/basic.spec.ts
+++ b/src/suites/cts/command_buffer/compute/basic.spec.ts
@@ -21,13 +21,13 @@ g.test('memcpy', async t => {
   src.setSubData(0, data);
 
   const bgl = t.device.createBindGroupLayout({
-    bindings: [
+    entries: [
       { binding: 0, visibility: 4, type: 'storage-buffer' },
       { binding: 1, visibility: 4, type: 'storage-buffer' },
     ],
   });
   const bg = t.device.createBindGroup({
-    bindings: [
+    entries: [
       { binding: 0, resource: { buffer: src, offset: 0, size: 4 } },
       { binding: 1, resource: { buffer: dst, offset: 0, size: 4 } },
     ],

--- a/src/suites/cts/command_buffer/copies.spec.ts
+++ b/src/suites/cts/command_buffer/copies.spec.ts
@@ -52,13 +52,13 @@ g.test('b2t2b', async t => {
 
   const encoder = t.device.createCommandEncoder();
   encoder.copyBufferToTexture(
-    { buffer: src, rowPitch: 256, imageHeight: 1 },
+    { buffer: src, bytesPerRow: 256 },
     { texture: mid, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
     { width: 1, height: 1, depth: 1 }
   );
   encoder.copyTextureToBuffer(
     { texture: mid, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
-    { buffer: dst, rowPitch: 256, imageHeight: 1 },
+    { buffer: dst, bytesPerRow: 256 },
     { width: 1, height: 1, depth: 1 }
   );
   t.device.defaultQueue.submit([encoder.finish()]);
@@ -91,7 +91,7 @@ g.test('b2t2t2b', async t => {
 
   const encoder = t.device.createCommandEncoder();
   encoder.copyBufferToTexture(
-    { buffer: src, rowPitch: 256, imageHeight: 1 },
+    { buffer: src, bytesPerRow: 256 },
     { texture: mid1, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
     { width: 1, height: 1, depth: 1 }
   );
@@ -102,7 +102,7 @@ g.test('b2t2t2b', async t => {
   );
   encoder.copyTextureToBuffer(
     { texture: mid2, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
-    { buffer: dst, rowPitch: 256, imageHeight: 1 },
+    { buffer: dst, bytesPerRow: 256 },
     { width: 1, height: 1, depth: 1 }
   );
   t.device.defaultQueue.submit([encoder.finish()]);

--- a/src/suites/cts/command_buffer/render/basic.spec.ts
+++ b/src/suites/cts/command_buffer/render/basic.spec.ts
@@ -33,7 +33,7 @@ g.test('clear', async t => {
   pass.endPass();
   encoder.copyTextureToBuffer(
     { texture: colorAttachment, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
-    { buffer: dst, rowPitch: 256, imageHeight: 1 },
+    { buffer: dst, bytesPerRow: 256 },
     { width: 1, height: 1, depth: 1 }
   );
   t.device.defaultQueue.submit([encoder.finish()]);

--- a/src/suites/cts/command_buffer/render/rendering.spec.ts
+++ b/src/suites/cts/command_buffer/render/rendering.spec.ts
@@ -74,7 +74,7 @@ g.test('fullscreen quad', async t => {
   pass.endPass();
   encoder.copyTextureToBuffer(
     { texture: colorAttachment, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
-    { buffer: dst, rowPitch: 256, imageHeight: 1 },
+    { buffer: dst, bytesPerRow: 256 },
     { width: 1, height: 1, depth: 1 }
   );
   t.device.defaultQueue.submit([encoder.finish()]);

--- a/src/suites/cts/command_buffer/render/storeop.spec.ts
+++ b/src/suites/cts/command_buffer/render/storeop.spec.ts
@@ -68,7 +68,7 @@ g.test('storeOp controls whether 1x1 drawn quad is stored', async t => {
   });
   encoder.copyTextureToBuffer(
     { texture: renderTexture },
-    { buffer: dstBuffer, rowPitch: 256, imageHeight: 1 },
+    { buffer: dstBuffer, bytesPerRow: 256 },
     { width: 1, height: 1, depth: 1 }
   );
   t.device.defaultQueue.submit([encoder.finish()]);

--- a/src/suites/cts/copyImageBitmapToTexture.spec.ts
+++ b/src/suites/cts/copyImageBitmapToTexture.spec.ts
@@ -89,9 +89,9 @@ class F extends GPUTest {
     const imageBitmap = imageBitmapCopyView.imageBitmap;
     const dstTexture = dstTextureCopyView.texture;
 
-    const rowPitchValue = calculateRowPitch(imageBitmap.width, bytesPerPixel);
+    const bytesPerRow = calculateRowPitch(imageBitmap.width, bytesPerPixel);
     const testBuffer = this.device.createBuffer({
-      size: rowPitchValue * imageBitmap.height,
+      size: bytesPerRow * imageBitmap.height,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
 
@@ -99,7 +99,7 @@ class F extends GPUTest {
 
     encoder.copyTextureToBuffer(
       { texture: dstTexture, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
-      { buffer: testBuffer, rowPitch: rowPitchValue, imageHeight: 0 },
+      { buffer: testBuffer, bytesPerRow },
       { width: imageBitmap.width, height: imageBitmap.height, depth: 1 }
     );
     this.device.defaultQueue.submit([encoder.finish()]);

--- a/src/suites/cts/resource_init/sampled_texture_clear.spec.ts
+++ b/src/suites/cts/resource_init/sampled_texture_clear.spec.ts
@@ -22,7 +22,7 @@ g.test('compute pass test that sampled texture is cleared', async t => {
   const sampler = t.device.createSampler();
 
   const bindGroupLayout = t.device.createBindGroupLayout({
-    bindings: [
+    entries: [
       { binding: 0, visibility: GPUShaderStage.COMPUTE, type: 'sampled-texture' },
       { binding: 1, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' },
       { binding: 2, visibility: GPUShaderStage.COMPUTE, type: 'sampler' },
@@ -54,7 +54,7 @@ g.test('compute pass test that sampled texture is cleared', async t => {
   // create bindgroup
   const bindGroup = t.device.createBindGroup({
     layout: bindGroupLayout,
-    bindings: [
+    entries: [
       { binding: 0, resource: texture.createView() },
       { binding: 1, resource: { buffer: bufferTex, offset: 0, size: 4 * 256 * 256 } },
       { binding: 2, resource: sampler },

--- a/src/suites/cts/validation/createBindGroup.spec.ts
+++ b/src/suites/cts/validation/createBindGroup.spec.ts
@@ -212,7 +212,7 @@ g.test('texture must have correct dimension', async t => {
         binding: 0,
         visibility: GPUShaderStage.FRAGMENT,
         type: 'sampled-texture',
-        textureDimension: '2d',
+        viewDimension: '2d',
       },
     ],
   });

--- a/src/suites/cts/validation/createBindGroup.spec.ts
+++ b/src/suites/cts/validation/createBindGroup.spec.ts
@@ -7,7 +7,7 @@ import { kBindingTypes } from '../capability_info.js';
 
 import { BindingResourceType, ValidationTest, resourceBindingMatches } from './validation_test.js';
 
-function clone(descriptor: GPUTextureDescriptor): GPUTextureDescriptor {
+function clone<T extends GPUTextureDescriptor>(descriptor: T): T {
   return JSON.parse(JSON.stringify(descriptor));
 }
 
@@ -15,11 +15,11 @@ export const g = new TestGroup(ValidationTest);
 
 g.test('binding count mismatch', async t => {
   const bindGroupLayout = t.device.createBindGroupLayout({
-    bindings: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' }],
+    entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' }],
   });
 
   const goodDescriptor = {
-    bindings: [{ binding: 0, resource: { buffer: t.getStorageBuffer() } }],
+    entries: [{ binding: 0, resource: { buffer: t.getStorageBuffer() } }],
     layout: bindGroupLayout,
   };
 
@@ -28,7 +28,7 @@ g.test('binding count mismatch', async t => {
 
   // Another binding is not expected.
   const badDescriptor = {
-    bindings: [
+    entries: [
       { binding: 0, resource: { buffer: t.getStorageBuffer() } },
       // Another binding is added.
       { binding: 1, resource: { buffer: t.getStorageBuffer() } },
@@ -43,11 +43,11 @@ g.test('binding count mismatch', async t => {
 
 g.test('binding must be present in layout', async t => {
   const bindGroupLayout = t.device.createBindGroupLayout({
-    bindings: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' }],
+    entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' }],
   });
 
   const goodDescriptor = {
-    bindings: [{ binding: 0, resource: { buffer: t.getStorageBuffer() } }],
+    entries: [{ binding: 0, resource: { buffer: t.getStorageBuffer() } }],
     layout: bindGroupLayout,
   };
 
@@ -56,7 +56,7 @@ g.test('binding must be present in layout', async t => {
 
   // Binding index 0 must be present.
   const badDescriptor = {
-    bindings: [{ binding: 1, resource: { buffer: t.getStorageBuffer() } }],
+    entries: [{ binding: 1, resource: { buffer: t.getStorageBuffer() } }],
     layout: bindGroupLayout,
   };
 
@@ -70,14 +70,14 @@ g.test('buffer binding must contain exactly one buffer of its type', t => {
   const resourceType: BindingResourceType = t.params.resourceType;
 
   const layout = t.device.createBindGroupLayout({
-    bindings: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type: bindingType }],
+    entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type: bindingType }],
   });
 
   const resource = t.getBindingResource(resourceType);
 
   const shouldError = !resourceBindingMatches(bindingType, resourceType);
   t.expectValidationError(() => {
-    t.device.createBindGroup({ layout, bindings: [{ binding: 0, resource }] });
+    t.device.createBindGroup({ layout, entries: [{ binding: 0, resource }] });
   }, shouldError);
 }).params(
   pcombine(
@@ -91,7 +91,7 @@ g.test('texture binding must have correct usage', async t => {
   const usage: GPUTextureUsageFlags = t.params._usage;
 
   const bindGroupLayout = t.device.createBindGroupLayout({
-    bindings: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, type }],
+    entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, type }],
   });
 
   const goodDescriptor = {
@@ -102,7 +102,7 @@ g.test('texture binding must have correct usage', async t => {
 
   // Control case
   t.device.createBindGroup({
-    bindings: [{ binding: 0, resource: t.device.createTexture(goodDescriptor).createView() }],
+    entries: [{ binding: 0, resource: t.device.createTexture(goodDescriptor).createView() }],
     layout: bindGroupLayout,
   });
 
@@ -112,7 +112,7 @@ g.test('texture binding must have correct usage', async t => {
     if (type !== 'sampled-texture') {
       yield GPUTextureUsage.SAMPLED;
     }
-    if (type !== 'storage-texture') {
+    if (type !== 'readonly-storage-texture' && type !== 'writeonly-storage-texture') {
       yield GPUTextureUsage.STORAGE;
     }
     yield GPUTextureUsage.OUTPUT_ATTACHMENT;
@@ -125,7 +125,7 @@ g.test('texture binding must have correct usage', async t => {
 
     t.expectValidationError(() => {
       t.device.createBindGroup({
-        bindings: [{ binding: 0, resource: t.device.createTexture(badDescriptor).createView() }],
+        entries: [{ binding: 0, resource: t.device.createTexture(badDescriptor).createView() }],
         layout: bindGroupLayout,
       });
     });
@@ -139,7 +139,7 @@ g.test('texture must have correct component type', async t => {
   const { textureComponentType } = t.params;
 
   const bindGroupLayout = t.device.createBindGroupLayout({
-    bindings: [
+    entries: [
       {
         binding: 0,
         visibility: GPUShaderStage.FRAGMENT,
@@ -169,7 +169,7 @@ g.test('texture must have correct component type', async t => {
 
   // Control case
   t.device.createBindGroup({
-    bindings: [
+    entries: [
       {
         binding: 0,
         resource: t.device.createTexture(goodDescriptor).createView(),
@@ -192,12 +192,12 @@ g.test('texture must have correct component type', async t => {
 
   // Mismatched texture binding formats are not valid.
   for (const mismatchedTextureFormat of mismatchedTextureFormats()) {
-    const badDescriptor = clone(goodDescriptor);
+    const badDescriptor: GPUTextureDescriptor = clone(goodDescriptor);
     badDescriptor.format = mismatchedTextureFormat;
 
     t.expectValidationError(() => {
       t.device.createBindGroup({
-        bindings: [{ binding: 0, resource: t.device.createTexture(badDescriptor).createView() }],
+        entries: [{ binding: 0, resource: t.device.createTexture(badDescriptor).createView() }],
         layout: bindGroupLayout,
       });
     });
@@ -207,7 +207,7 @@ g.test('texture must have correct component type', async t => {
 // TODO: Write test for all dimensions.
 g.test('texture must have correct dimension', async t => {
   const bindGroupLayout = t.device.createBindGroupLayout({
-    bindings: [
+    entries: [
       {
         binding: 0,
         visibility: GPUShaderStage.FRAGMENT,
@@ -219,24 +219,23 @@ g.test('texture must have correct dimension', async t => {
 
   const goodDescriptor = {
     size: { width: 16, height: 16, depth: 1 },
-    arrayLayerCount: 1,
     format: C.TextureFormat.RGBA8Unorm,
     usage: GPUTextureUsage.SAMPLED,
   };
 
   // Control case
   t.device.createBindGroup({
-    bindings: [{ binding: 0, resource: t.device.createTexture(goodDescriptor).createView() }],
+    entries: [{ binding: 0, resource: t.device.createTexture(goodDescriptor).createView() }],
     layout: bindGroupLayout,
   });
 
   // Mismatched texture binding formats are not valid.
   const badDescriptor = clone(goodDescriptor);
-  badDescriptor.arrayLayerCount = 2;
+  badDescriptor.size.depth = 2;
 
   t.expectValidationError(() => {
     t.device.createBindGroup({
-      bindings: [{ binding: 0, resource: t.device.createTexture(badDescriptor).createView() }],
+      entries: [{ binding: 0, resource: t.device.createTexture(badDescriptor).createView() }],
       layout: bindGroupLayout,
     });
   });
@@ -246,7 +245,7 @@ g.test('buffer offset and size for bind groups match', async t => {
   const { offset, size, _success } = t.params;
 
   const bindGroupLayout = t.device.createBindGroupLayout({
-    bindings: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' }],
+    entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' }],
   });
 
   const buffer = t.device.createBuffer({
@@ -255,7 +254,7 @@ g.test('buffer offset and size for bind groups match', async t => {
   });
 
   const descriptor = {
-    bindings: [
+    entries: [
       {
         binding: 0,
         resource: { buffer, offset, size },

--- a/src/suites/cts/validation/createBindGroupLayout.spec.ts
+++ b/src/suites/cts/validation/createBindGroupLayout.spec.ts
@@ -22,7 +22,7 @@ export const g = new TestGroup(ValidationTest);
 
 g.test('some binding index was specified more than once', async t => {
   const goodDescriptor = {
-    bindings: [
+    entries: [
       { binding: 0, visibility: GPUShaderStage.COMPUTE, type: C.BindingType.StorageBuffer },
       { binding: 1, visibility: GPUShaderStage.COMPUTE, type: C.BindingType.StorageBuffer },
     ],
@@ -32,7 +32,7 @@ g.test('some binding index was specified more than once', async t => {
   t.device.createBindGroupLayout(goodDescriptor);
 
   const badDescriptor = clone(goodDescriptor);
-  badDescriptor.bindings[1].binding = 0;
+  badDescriptor.entries[1].binding = 0;
 
   // Binding index 0 can't be specified twice.
   t.expectValidationError(() => {
@@ -42,14 +42,14 @@ g.test('some binding index was specified more than once', async t => {
 
 g.test('Visibility of bindings can be 0', async t => {
   t.device.createBindGroupLayout({
-    bindings: [{ binding: 0, visibility: 0, type: 'storage-buffer' }],
+    entries: [{ binding: 0, visibility: 0, type: 'storage-buffer' }],
   });
 });
 
 g.test('number of dynamic buffers exceeds the maximum value', async t => {
   const { type, maxDynamicBufferCount } = t.params;
 
-  const maxDynamicBufferBindings: GPUBindGroupLayoutBinding[] = [];
+  const maxDynamicBufferBindings: GPUBindGroupLayoutEntry[] = [];
   for (let i = 0; i < maxDynamicBufferCount; i++) {
     maxDynamicBufferBindings.push({
       binding: i,
@@ -60,7 +60,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
   }
 
   const goodDescriptor = {
-    bindings: [
+    entries: [
       ...maxDynamicBufferBindings,
       {
         binding: maxDynamicBufferBindings.length,
@@ -76,7 +76,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
 
   // Dynamic buffers exceed maximum in a bind group layout.
   const badDescriptor = clone(goodDescriptor);
-  badDescriptor.bindings[maxDynamicBufferCount].hasDynamicOffset = true;
+  badDescriptor.entries[maxDynamicBufferCount].hasDynamicOffset = true;
 
   t.expectValidationError(() => {
     t.device.createBindGroupLayout(badDescriptor);
@@ -91,7 +91,7 @@ g.test('dynamic set to true is allowed only for buffers', async t => {
   const success = kBindingTypeInfo[type].type === 'buffer';
 
   const descriptor = {
-    bindings: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, type, hasDynamicOffset: true }],
+    entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, type, hasDynamicOffset: true }],
   };
 
   t.expectValidationError(() => {
@@ -155,7 +155,7 @@ g.test('max resources per stage/in bind group layout', async t => {
   const { maxedVisibility, extraVisibility } = t.params;
   const maxedCount = kPerStageBindingLimits[kBindingTypeInfo[maxedType].perStageLimitType];
 
-  const maxResourceBindings: GPUBindGroupLayoutBinding[] = [];
+  const maxResourceBindings: GPUBindGroupLayoutEntry[] = [];
   for (let i = 0; i < maxedCount; i++) {
     maxResourceBindings.push({
       binding: i,
@@ -164,13 +164,13 @@ g.test('max resources per stage/in bind group layout', async t => {
     });
   }
 
-  const goodDescriptor = { bindings: maxResourceBindings };
+  const goodDescriptor = { entries: maxResourceBindings };
 
   // Control
   t.device.createBindGroupLayout(goodDescriptor);
 
   const newDescriptor = clone(goodDescriptor);
-  newDescriptor.bindings.push({
+  newDescriptor.entries.push({
     binding: maxedCount,
     visibility: extraVisibility,
     type: extraType,
@@ -192,7 +192,7 @@ g.test('max resources per stage/in pipeline layout', async t => {
   const { maxedVisibility, extraVisibility } = t.params;
   const maxedCount = kPerStageBindingLimits[kBindingTypeInfo[maxedType].perStageLimitType];
 
-  const maxResourceBindings: GPUBindGroupLayoutBinding[] = [];
+  const maxResourceBindings: GPUBindGroupLayoutEntry[] = [];
   for (let i = 0; i < maxedCount; i++) {
     maxResourceBindings.push({
       binding: i,
@@ -201,13 +201,13 @@ g.test('max resources per stage/in pipeline layout', async t => {
     });
   }
 
-  const goodLayout = t.device.createBindGroupLayout({ bindings: maxResourceBindings });
+  const goodLayout = t.device.createBindGroupLayout({ entries: maxResourceBindings });
 
   // Control
   t.device.createPipelineLayout({ bindGroupLayouts: [goodLayout] });
 
   const extraLayout = t.device.createBindGroupLayout({
-    bindings: [{ binding: 0, visibility: extraVisibility, type: extraType }],
+    entries: [{ binding: 0, visibility: extraVisibility, type: extraType }],
   });
 
   // Some binding types use the same limit, e.g. 'storage-buffer' and 'readonly-storage-buffer'.

--- a/src/suites/cts/validation/createPipelineLayout.spec.ts
+++ b/src/suites/cts/validation/createPipelineLayout.spec.ts
@@ -17,17 +17,17 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
   const { type, visibility } = t.params;
   const maxDynamicCount = kBindingTypeInfo[type as GPUBindingType].maxDynamicCount;
 
-  const maxDynamicBufferBindings: GPUBindGroupLayoutBinding[] = [];
+  const maxDynamicBufferBindings: GPUBindGroupLayoutEntry[] = [];
   for (let binding = 0; binding < maxDynamicCount; binding++) {
     maxDynamicBufferBindings.push({ binding, visibility, type, hasDynamicOffset: true });
   }
 
   const maxDynamicBufferBindGroupLayout = t.device.createBindGroupLayout({
-    bindings: maxDynamicBufferBindings,
+    entries: maxDynamicBufferBindings,
   });
 
   const goodDescriptor = {
-    bindings: [{ binding: 0, visibility, type, hasDynamicOffset: false }],
+    entries: [{ binding: 0, visibility, type, hasDynamicOffset: false }],
   };
 
   const goodPipelineLayoutDescriptor = {
@@ -42,7 +42,7 @@ g.test('number of dynamic buffers exceeds the maximum value', async t => {
 
   // Check dynamic buffers exceed maximum in pipeline layout.
   const badDescriptor = clone(goodDescriptor);
-  badDescriptor.bindings[0].hasDynamicOffset = true;
+  badDescriptor.entries[0].hasDynamicOffset = true;
 
   const badPipelineLayoutDescriptor = {
     bindGroupLayouts: [
@@ -68,7 +68,7 @@ g.test('visibility and dynamic offsets', t => {
   const info = kBindingTypeInfo[type as GPUBindingType];
 
   const descriptor = {
-    bindings: [{ binding: 0, visibility, type, hasDynamicOffset }],
+    entries: [{ binding: 0, visibility, type, hasDynamicOffset }],
   };
 
   let success = true;
@@ -90,7 +90,7 @@ g.test('visibility and dynamic offsets', t => {
 
 g.test('number of bind group layouts exceeds the maximum value', async t => {
   const bindGroupLayoutDescriptor: GPUBindGroupLayoutDescriptor = {
-    bindings: [],
+    entries: [],
   };
 
   // 4 is the maximum number of bind group layouts.

--- a/src/suites/cts/validation/createTexture.spec.ts
+++ b/src/suites/cts/validation/createTexture.spec.ts
@@ -27,8 +27,7 @@ class F extends ValidationTest {
       format = 'rgba8unorm',
     } = options;
     return {
-      size: { width, height, depth: 1 },
-      arrayLayerCount,
+      size: { width, height, depth: arrayLayerCount },
       mipLevelCount,
       sampleCount,
       dimension: '2d',

--- a/src/suites/cts/validation/createView.spec.ts
+++ b/src/suites/cts/validation/createView.spec.ts
@@ -29,8 +29,7 @@ class F extends ValidationTest {
     } = options;
 
     return this.device.createTexture({
-      size: { width, height, depth: 1 },
-      arrayLayerCount,
+      size: { width, height, depth: arrayLayerCount },
       mipLevelCount,
       sampleCount,
       dimension: '2d',

--- a/src/suites/cts/validation/render_pass.spec.ts
+++ b/src/suites/cts/validation/render_pass.spec.ts
@@ -81,7 +81,7 @@ g.test('it is invalid to draw in a render pass with missing bind groups', async 
   const uniformBuffer = t.getUniformBuffer();
 
   const bindGroupLayout1 = t.device.createBindGroupLayout({
-    bindings: [
+    entries: [
       {
         binding: 0,
         visibility: GPUShaderStage.VERTEX,
@@ -91,7 +91,7 @@ g.test('it is invalid to draw in a render pass with missing bind groups', async 
   });
 
   const bindGroup1 = t.device.createBindGroup({
-    bindings: [
+    entries: [
       {
         binding: 0,
         resource: {
@@ -103,7 +103,7 @@ g.test('it is invalid to draw in a render pass with missing bind groups', async 
   });
 
   const bindGroupLayout2 = t.device.createBindGroupLayout({
-    bindings: [
+    entries: [
       {
         binding: 0,
         visibility: GPUShaderStage.FRAGMENT,
@@ -113,7 +113,7 @@ g.test('it is invalid to draw in a render pass with missing bind groups', async 
   });
 
   const bindGroup2 = t.device.createBindGroup({
-    bindings: [
+    entries: [
       {
         binding: 0,
         resource: {

--- a/src/suites/cts/validation/render_pass_descriptor.spec.ts
+++ b/src/suites/cts/validation/render_pass_descriptor.spec.ts
@@ -29,9 +29,8 @@ class F extends ValidationTest {
     } = options;
 
     return this.device.createTexture({
-      size: { width, height, depth: 1 },
+      size: { width, height, depth: arrayLayerCount },
       format,
-      arrayLayerCount,
       mipLevelCount,
       sampleCount,
       usage,

--- a/src/suites/cts/validation/setBindGroup.spec.ts
+++ b/src/suites/cts/validation/setBindGroup.spec.ts
@@ -50,8 +50,8 @@ class F extends ValidationTest {
 export const g = new TestGroup(F);
 
 g.test('dynamic offsets passed but not expected/compute pass', async t => {
-  const bindGroupLayout = t.device.createBindGroupLayout({ bindings: [] });
-  const bindGroup = t.device.createBindGroup({ layout: bindGroupLayout, bindings: [] });
+  const bindGroupLayout = t.device.createBindGroupLayout({ entries: [] });
+  const bindGroup = t.device.createBindGroup({ layout: bindGroupLayout, entries: [] });
 
   const { type } = t.params;
   const dynamicOffsets = [0];
@@ -94,7 +94,7 @@ g.test('dynamic offsets match expectations in pass encoder', async t => {
   const BINDING_SIZE = 9;
 
   const bindGroupLayout = t.device.createBindGroupLayout({
-    bindings: [
+    entries: [
       {
         binding: 0,
         visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
@@ -122,7 +122,7 @@ g.test('dynamic offsets match expectations in pass encoder', async t => {
 
   const bindGroup = t.device.createBindGroup({
     layout: bindGroupLayout,
-    bindings: [
+    entries: [
       {
         binding: 0,
         resource: {

--- a/src/suites/cts/validation/validation_test.ts
+++ b/src/suites/cts/validation/validation_test.ts
@@ -21,7 +21,8 @@ export function resourceBindingMatches(b: GPUBindingType, r: BindingResourceType
       return r === 'sampled-textureview';
     case 'sampler':
       return r === 'sampler';
-    case 'storage-texture':
+    case 'readonly-storage-texture':
+    case 'writeonly-storage-texture':
       return r === 'storage-textureview';
     case 'uniform-buffer':
       return r === 'uniform-buffer';

--- a/src/suites/cts/validation/vertex_state.spec.ts
+++ b/src/suites/cts/validation/vertex_state.spec.ts
@@ -427,11 +427,11 @@ g.test('check out of bounds on number of vertex attributes on a single vertex bu
 });
 
 g.test('check out of bounds on number of vertex attributes across vertex buffers', async t => {
-  const vertexBuffers: GPUVertexBufferLayoutDescriptor[] = [];
+  const vertexBuffers = [];
   for (let i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
     vertexBuffers.push({
       arrayStride: 0,
-      attributes: [{ format: 'float', offset: 0, shaderLocation: i }],
+      attributes: [{ format: C.VertexFormat.Float, offset: 0, shaderLocation: i }],
     });
   }
 
@@ -444,7 +444,7 @@ g.test('check out of bounds on number of vertex attributes across vertex buffers
   {
     // Test vertex attribute number exceed the limit
     vertexBuffers[MAX_VERTEX_ATTRIBUTES - 1].attributes.push({
-      format: 'float',
+      format: C.VertexFormat.Float,
       offset: 0,
       shaderLocation: MAX_VERTEX_ATTRIBUTES,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,10 +305,10 @@
   resolved "https://registry.yarnpkg.com/@webgpu/glslang/-/glslang-0.0.15.tgz#f5ccaf6015241e6175f4b90906b053f88483d1f2"
   integrity sha512-niT+Prh3Aff8Uf1MVBVUsaNjFj9rJAKDXuoHIKiQbB+6IUP/3J3JIhBNyZ7lDhytvXxw6ppgnwKZdDJ08UMj4Q==
 
-"@webgpu/types@0.0.21":
-  version "0.0.21"
-  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.0.21.tgz#ada3f2a984a10ffb8579564aef079928005f44ee"
-  integrity sha512-fqIYQ9PybboEFUFV3iup7TRWkuPBZXzBCWbTbowyMfZb8Pt6zlg4T58tm4/WQgtN3KwuQoAuM64M7SUfW8+3ng==
+"@webgpu/types@0.0.22":
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.0.22.tgz#320ccd7a8560061b5a6a2db7d5965b861bded004"
+  integrity sha512-qT2NUglkiWcnqmgyrqDU79F7FdQXQX4h1TEALWIY7od2gI+1FcbKnAPvb6qW9XfGEqGaxOFVliotY5U/ewdQAA==
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
Also update the capability tables to include the new binding types and the correct restrictions on writable storage buffers and textures.

Haven't run these tests yet because we have yet to implement these changes. But soon.