### PR TITLE
[glsl-dependent] Allow overriding of the path to glslang

### DIFF
--- a/src/common/glslang.ts
+++ b/src/common/glslang.ts
@@ -1,0 +1,44 @@
+import { SkipTestCase } from './framework/fixture.js';
+import { assert } from './framework/util/util.js';
+import { getGlslangPath } from './glslang_path.js';
+
+type glslang = typeof import('@webgpu/glslang/dist/web-devel/glslang');
+type Glslang = import('@webgpu/glslang/dist/web-devel/glslang').Glslang;
+type ShaderStage = import('@webgpu/glslang/dist/web-devel/glslang').ShaderStage;
+type SpirvVersion = import('@webgpu/glslang/dist/web-devel/glslang').SpirvVersion;
+
+let glslangAttempted: boolean = false;
+let glslangInstance: Glslang | undefined;
+
+export async function initGLSL(): Promise<void> {
+  if (glslangAttempted) {
+    if (!glslangInstance) {
+      throw new SkipTestCase('glslang is not available');
+    }
+  } else {
+    glslangAttempted = true;
+    const glslangPath = getGlslangPath() || '../glslang.js';
+    let glslangModule: () => Promise<Glslang>;
+    try {
+      glslangModule = ((await import(glslangPath)) as glslang).default;
+    } catch (ex) {
+      throw new SkipTestCase('glslang is not available');
+    }
+
+    const glslang = await glslangModule();
+    glslangInstance = glslang;
+  }
+}
+
+export function compileGLSL(
+  glsl: string,
+  shaderType: ShaderStage,
+  genDebug: boolean,
+  spirvVersion?: SpirvVersion
+): Uint32Array {
+  assert(
+    glslangInstance !== undefined,
+    'GLSL compiler is not instantiated. Run `await initGLSL()` first'
+  );
+  return glslangInstance.compileGLSL(glsl, shaderType, genDebug, spirvVersion);
+}

--- a/src/common/glslang_path.ts
+++ b/src/common/glslang_path.ts
@@ -1,0 +1,12 @@
+import { assert } from './framework/util/util.js';
+
+let glslangPath: string | undefined;
+
+export function getGlslangPath(): string | undefined {
+  return glslangPath;
+}
+
+export function setGlslangPath(path: string): void {
+  assert(path.startsWith('/'), 'glslang path must be absolute');
+  glslangPath = path;
+}

--- a/src/common/templates/cts.html
+++ b/src/common/templates/cts.html
@@ -45,4 +45,10 @@
 </style>
 
 <textarea id=results></textarea>
-<script type=module src=/webgpu/common/runtime/wpt.js></script>
+<script type=module>
+  import { setGlslangPath } from '/webgpu/common/glslang_path.js';
+  // To override the glslang.js path:
+  //   setGlslangPath('/path/to/glslang.js);
+
+  import '/webgpu/common/runtime/wpt.js';
+</script>

--- a/src/suites/cts/glslang_available.spec.ts
+++ b/src/suites/cts/glslang_available.spec.ts
@@ -1,0 +1,19 @@
+export const description = `
+Checks that glslang is available. If glslang is not supposed to be available, suppress this test.
+`;
+
+import { Fixture } from '../../common/framework/fixture.js';
+import { TestGroup } from '../../common/framework/test_group.js';
+import { unreachable } from '../../common/framework/util/util.js';
+import { initGLSL } from '../../common/glslang.js';
+
+export const g = new TestGroup(Fixture);
+
+g.test('check', async t => {
+  // try{} to prevent the SkipTestCase exception from propagating.
+  try {
+    await initGLSL();
+  } catch (ex) {
+    unreachable(String(ex));
+  }
+});

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -4,6 +4,7 @@ createRenderPipeline validation tests.
 
 import { poptions } from '../../../common/framework/params.js';
 import { TestGroup } from '../../../common/framework/test_group.js';
+import { initGLSL } from '../../../common/glslang.js';
 import GLSL from '../../../common/tools/glsl.macro.js';
 import { kTextureFormatInfo, kTextureFormats } from '../../capability_info.js';
 
@@ -12,7 +13,7 @@ import { ValidationTest } from './validation_test.js';
 class F extends ValidationTest {
   async init(): Promise<void> {
     await super.init();
-    await this.initGLSL();
+    await initGLSL();
   }
 
   getDescriptor(

--- a/src/webgpu/api/validation/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/setVertexBuffer.spec.ts
@@ -4,13 +4,14 @@ setVertexBuffer validation tests.
 
 import { TestGroup } from '../../../common/framework/test_group.js';
 import { range } from '../../../common/framework/util/util.js';
+import { initGLSL } from '../../../common/glslang.js';
 
 import { ValidationTest } from './validation_test.js';
 
 class F extends ValidationTest {
   async init(): Promise<void> {
     await super.init();
-    await this.initGLSL();
+    await initGLSL();
   }
 
   getVertexBuffer(): GPUBuffer {

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -4,6 +4,7 @@ vertexState validation tests.
 
 import * as C from '../../../common/constants.js';
 import { TestGroup } from '../../../common/framework/test_group.js';
+import { initGLSL } from '../../../common/glslang.js';
 
 import { ValidationTest } from './validation_test.js';
 
@@ -28,7 +29,7 @@ function clone<T extends GPUVertexStateDescriptor>(descriptor: T): T {
 class F extends ValidationTest {
   async init(): Promise<void> {
     await super.init();
-    await this.initGLSL();
+    await initGLSL();
   }
 
   getDescriptor(

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1,12 +1,9 @@
 import { Fixture } from '../common/framework/fixture.js';
 import { getGPU } from '../common/framework/gpu/implementation.js';
 import { assert, unreachable } from '../common/framework/util/util.js';
+import { compileGLSL } from '../common/glslang.js';
 
-type glslang = typeof import('@webgpu/glslang/dist/web-devel/glslang');
-type Glslang = import('@webgpu/glslang/dist/web-devel/glslang').Glslang;
 type ShaderStage = import('@webgpu/glslang/dist/web-devel/glslang').ShaderStage;
-
-let glslangInstance: Glslang | undefined;
 
 class DevicePool {
   device: GPUDevice | undefined = undefined;
@@ -107,38 +104,15 @@ export class GPUTest extends Fixture {
     }
   }
 
-  async initGLSL(): Promise<void> {
-    if (!glslangInstance) {
-      const glslangPath = '../common/glslang.js';
-      let glslangModule: () => Promise<Glslang>;
-      try {
-        glslangModule = ((await import(glslangPath)) as glslang).default;
-      } catch (ex) {
-        this.skip('glslang is not available');
-      }
-      await new Promise(resolve => {
-        glslangModule().then((glslang: Glslang) => {
-          glslangInstance = glslang;
-          resolve();
-        });
-      });
-    }
-  }
-
   createShaderModule(desc: GPUShaderModuleDescriptor): GPUShaderModule {
     if (!this.supportsSPIRV) {
-      this.skip('SPIR-V not available');
+      this.skip('SPIR-V not available in this browser');
     }
     return this.device.createShaderModule(desc);
   }
 
   makeShaderModuleFromGLSL(stage: ShaderStage, glsl: string): GPUShaderModule {
-    assert(
-      glslangInstance !== undefined,
-      'GLSL compiler is not instantiated. Run `await t.initGLSL()` first'
-    );
-
-    const code = glslangInstance.compileGLSL(glsl, stage, false);
+    const code = compileGLSL(glsl, stage, false);
     return this.device.createShaderModule({ code });
   }
 


### PR DESCRIPTION
This allows browsers to specify a path to a file outside WPT (which can
e.g. be downloaded as a dependency instead of checked into Git). This
will allow testing of runtime-generated shaders through WPT.