### PR TITLE
Fix GLSL tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -77,7 +77,7 @@ module.exports = function (grunt) {
       'out-wpt': {
         files: [
           { expand: true, cwd: '.', src: 'LICENSE.txt', dest: 'out-wpt/' },
-          { expand: true, cwd: 'out', src: 'common/*.js', dest: 'out-wpt/' },
+          { expand: true, cwd: 'out', src: 'common/constants.js', dest: 'out-wpt/' },
           { expand: true, cwd: 'out', src: 'common/framework/**/*.js', dest: 'out-wpt/' },
           { expand: true, cwd: 'out', src: 'webgpu/**/*.js', dest: 'out-wpt/' },
           { expand: true, cwd: 'out', src: 'common/runtime/wpt.js', dest: 'out-wpt/' },

--- a/src/common/framework/glsl.ts
+++ b/src/common/framework/glsl.ts
@@ -37,5 +37,5 @@ export function compileGLSL(
     glslangInstance !== undefined,
     'GLSL compiler is not instantiated. Run `await initGLSL()` first'
   );
-  return glslangInstance.compileGLSL(glsl, shaderType, genDebug, spirvVersion);
+  return glslangInstance.compileGLSL(glsl.trimLeft(), shaderType, genDebug, spirvVersion);
 }

--- a/src/common/framework/glsl.ts
+++ b/src/common/framework/glsl.ts
@@ -1,5 +1,5 @@
-import { assert, unreachable } from './framework/util/util.js';
 import { getGlslangPath } from './glslang_path.js';
+import { assert, unreachable } from './util/util.js';
 
 type glslang = typeof import('@webgpu/glslang/dist/web-devel/glslang');
 type Glslang = import('@webgpu/glslang/dist/web-devel/glslang').Glslang;

--- a/src/common/framework/glslang_path.ts
+++ b/src/common/framework/glslang_path.ts
@@ -1,4 +1,4 @@
-import { assert } from './framework/util/util.js';
+import { assert } from './util/util.js';
 
 let glslangPath: string | undefined;
 

--- a/src/common/templates/cts.html
+++ b/src/common/templates/cts.html
@@ -46,7 +46,7 @@
 
 <textarea id=results></textarea>
 <script type=module>
-  import { setGlslangPath } from '/webgpu/common/glslang_path.js';
+  import { setGlslangPath } from '/webgpu/common/framework/glslang_path.js';
   // To override the glslang.js path:
   //   setGlslangPath('/path/to/glslang.js);
 

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -2,9 +2,9 @@ export const description = `
 createRenderPipeline validation tests.
 `;
 
+import { initGLSL } from '../../../common/framework/glsl.js';
 import { poptions } from '../../../common/framework/params.js';
 import { TestGroup } from '../../../common/framework/test_group.js';
-import { initGLSL } from '../../../common/glslang.js';
 import { kTextureFormatInfo, kTextureFormats } from '../../capability_info.js';
 
 import { ValidationTest } from './validation_test.js';

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 createRenderPipeline validation tests.
 `;
 
-import { initGLSL } from '../../../common/framework/glsl.js';
 import { poptions } from '../../../common/framework/params.js';
 import { TestGroup } from '../../../common/framework/test_group.js';
 import { kTextureFormatInfo, kTextureFormats } from '../../capability_info.js';
@@ -10,11 +9,6 @@ import { kTextureFormatInfo, kTextureFormats } from '../../capability_info.js';
 import { ValidationTest } from './validation_test.js';
 
 class F extends ValidationTest {
-  async init(): Promise<void> {
-    await super.init();
-    await initGLSL();
-  }
-
   getDescriptor(
     options: {
       primitiveTopology?: GPUPrimitiveTopology;

--- a/src/webgpu/api/validation/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/setVertexBuffer.spec.ts
@@ -2,18 +2,12 @@ export const description = `
 setVertexBuffer validation tests.
 `;
 
-import { initGLSL } from '../../../common/framework/glsl.js';
 import { TestGroup } from '../../../common/framework/test_group.js';
 import { range } from '../../../common/framework/util/util.js';
 
 import { ValidationTest } from './validation_test.js';
 
 class F extends ValidationTest {
-  async init(): Promise<void> {
-    await super.init();
-    await initGLSL();
-  }
-
   getVertexBuffer(): GPUBuffer {
     return this.device.createBuffer({
       size: 256,

--- a/src/webgpu/api/validation/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/setVertexBuffer.spec.ts
@@ -2,9 +2,9 @@ export const description = `
 setVertexBuffer validation tests.
 `;
 
+import { initGLSL } from '../../../common/framework/glsl.js';
 import { TestGroup } from '../../../common/framework/test_group.js';
 import { range } from '../../../common/framework/util/util.js';
-import { initGLSL } from '../../../common/glslang.js';
 
 import { ValidationTest } from './validation_test.js';
 

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -3,8 +3,8 @@ vertexState validation tests.
 `;
 
 import * as C from '../../../common/constants.js';
+import { initGLSL } from '../../../common/framework/glsl.js';
 import { TestGroup } from '../../../common/framework/test_group.js';
-import { initGLSL } from '../../../common/glslang.js';
 
 import { ValidationTest } from './validation_test.js';
 

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -3,7 +3,6 @@ vertexState validation tests.
 `;
 
 import * as C from '../../../common/constants.js';
-import { initGLSL } from '../../../common/framework/glsl.js';
 import { TestGroup } from '../../../common/framework/test_group.js';
 
 import { ValidationTest } from './validation_test.js';
@@ -35,11 +34,6 @@ function clone<T extends GPUVertexStateDescriptor>(descriptor: T): T {
 }
 
 class F extends ValidationTest {
-  async init(): Promise<void> {
-    await super.init();
-    await initGLSL();
-  }
-
   getDescriptor(
     vertexState: GPUVertexStateDescriptor,
     vertexShaderCode: string

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1,5 +1,5 @@
 import { Fixture } from '../common/framework/fixture.js';
-import { compileGLSL } from '../common/framework/glsl.js';
+import { compileGLSL, initGLSL } from '../common/framework/glsl.js';
 import { getGPU } from '../common/framework/gpu/implementation.js';
 import { assert, unreachable } from '../common/framework/util/util.js';
 
@@ -59,6 +59,7 @@ export class GPUTest extends Fixture {
 
   async init(): Promise<void> {
     await super.init();
+    await initGLSL();
 
     const device = await devicePool.acquire();
     const queue = device.defaultQueue;

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1,7 +1,7 @@
 import { Fixture } from '../common/framework/fixture.js';
+import { compileGLSL } from '../common/framework/glsl.js';
 import { getGPU } from '../common/framework/gpu/implementation.js';
 import { assert, unreachable } from '../common/framework/util/util.js';
-import { compileGLSL } from '../common/glslang.js';
 
 type ShaderStage = import('@webgpu/glslang/dist/web-devel/glslang').ShaderStage;
 


### PR DESCRIPTION
Somehow these changes, which are necessary to actually run the GLSL tests, got lost after the point when I tested them.

Also, there was a conflict where the actual `glslang.js` was getting overwritten with the built version of src/common/glslang.ts.

Tested in standalone and WPT

Reverts #154