### PR TITLE
Fix storage-texture and comparison-sampler tests

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -80,9 +80,13 @@ g.test('buffer binding must contain exactly one buffer of its type')
   )
   .fn(t => {
     const { bindingType, resourceType } = t.params;
+    const info = kBindingTypeInfo[bindingType];
 
+    const storageTextureFormat = info.kind === 'storage-texture' ? 'rgba8unorm' : undefined;
     const layout = t.device.createBindGroupLayout({
-      entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type: bindingType }],
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.COMPUTE, type: bindingType, storageTextureFormat },
+      ],
     });
 
     const resource = t.getBindingResource(resourceType);
@@ -101,14 +105,16 @@ g.test('texture binding must have correct usage')
   ])
   .fn(async t => {
     const { type, _usage: usage } = t.params;
+    const info = kBindingTypeInfo[type];
 
+    const storageTextureFormat = info.kind === 'storage-texture' ? 'rgba8unorm' : undefined;
     const bindGroupLayout = t.device.createBindGroupLayout({
-      entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, type }],
+      entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, type, storageTextureFormat }],
     });
 
     const goodDescriptor = {
       size: { width: 16, height: 16, depth: 1 },
-      format: C.TextureFormat.R8Unorm,
+      format: C.TextureFormat.RGBA8Unorm,
       usage,
     };
 
@@ -118,7 +124,6 @@ g.test('texture binding must have correct usage')
       layout: bindGroupLayout,
     });
 
-    const info = kBindingTypeInfo[type];
     function* mismatchedTextureUsages(): Iterable<GPUTextureUsageFlags> {
       yield GPUTextureUsage.COPY_SRC;
       yield GPUTextureUsage.COPY_DST;

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -145,7 +145,9 @@ g.test('max resources per stage/in bind group layout')
   .params(kCasesForMaxResourcesPerStageTests)
   .fn(async t => {
     const { maxedType, extraType, maxedVisibility, extraVisibility } = t.params;
-    const maxedCount = kPerStageBindingLimits[kBindingTypeInfo[maxedType].perStageLimitType];
+    const maxedTypeInfo = kBindingTypeInfo[maxedType];
+    const maxedCount = kPerStageBindingLimits[maxedTypeInfo.perStageLimitType];
+    const extraTypeInfo = kBindingTypeInfo[extraType];
 
     const maxResourceBindings: GPUBindGroupLayoutEntry[] = [];
     for (let i = 0; i < maxedCount; i++) {
@@ -153,6 +155,7 @@ g.test('max resources per stage/in bind group layout')
         binding: i,
         visibility: maxedVisibility,
         type: maxedType,
+        storageTextureFormat: maxedTypeInfo.kind === 'storage-texture' ? 'rgba8unorm' : undefined,
       });
     }
 
@@ -166,6 +169,7 @@ g.test('max resources per stage/in bind group layout')
       binding: maxedCount,
       visibility: extraVisibility,
       type: extraType,
+      storageTextureFormat: extraTypeInfo.kind === 'storage-texture' ? 'rgba8unorm' : undefined,
     });
 
     const shouldError = maxedCount >= kMaxBindingsPerBindGroup;
@@ -182,7 +186,9 @@ g.test('max resources per stage/in pipeline layout')
   .params(kCasesForMaxResourcesPerStageTests)
   .fn(async t => {
     const { maxedType, extraType, maxedVisibility, extraVisibility } = t.params;
-    const maxedCount = kPerStageBindingLimits[kBindingTypeInfo[maxedType].perStageLimitType];
+    const maxedTypeInfo = kBindingTypeInfo[maxedType];
+    const maxedCount = kPerStageBindingLimits[maxedTypeInfo.perStageLimitType];
+    const extraTypeInfo = kBindingTypeInfo[extraType];
 
     const maxResourceBindings: GPUBindGroupLayoutEntry[] = [];
     for (let i = 0; i < maxedCount; i++) {
@@ -190,6 +196,7 @@ g.test('max resources per stage/in pipeline layout')
         binding: i,
         visibility: maxedVisibility,
         type: maxedType,
+        storageTextureFormat: maxedTypeInfo.kind === 'storage-texture' ? 'rgba8unorm' : undefined,
       });
     }
 
@@ -199,7 +206,14 @@ g.test('max resources per stage/in pipeline layout')
     t.device.createPipelineLayout({ bindGroupLayouts: [goodLayout] });
 
     const extraLayout = t.device.createBindGroupLayout({
-      entries: [{ binding: 0, visibility: extraVisibility, type: extraType }],
+      entries: [
+        {
+          binding: 0,
+          visibility: extraVisibility,
+          type: extraType,
+          storageTextureFormat: extraTypeInfo.kind === 'storage-texture' ? 'rgba8unorm' : undefined,
+        },
+      ],
     });
 
     // Some binding types use the same limit, e.g. 'storage-buffer' and 'readonly-storage-buffer'.

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -8,6 +8,7 @@ export enum BindingResourceType {
   'uniform-buffer' = 'uniform-buffer',
   'storage-buffer' = 'storage-buffer',
   'sampler' = 'sampler',
+  'comparison-sampler' = 'comparison-sampler',
   'sampled-textureview' = 'sampled-textureview',
   'storage-textureview' = 'storage-textureview',
 }
@@ -22,6 +23,8 @@ export function resourceBindingMatches(b: GPUBindingType, r: BindingResourceType
       return r === 'sampled-textureview';
     case 'sampler':
       return r === 'sampler';
+    case 'comparison-sampler':
+      return r === 'comparison-sampler';
     case 'readonly-storage-texture':
     case 'writeonly-storage-texture':
       return r === 'storage-textureview';
@@ -53,6 +56,10 @@ export class ValidationTest extends GPUTest {
 
   getSampler(): GPUSampler {
     return this.device.createSampler();
+  }
+
+  getComparisonSampler(): GPUSampler {
+    return this.device.createSampler({ compare: 'never' });
   }
 
   getErrorSampler(): GPUSampler {
@@ -105,6 +112,8 @@ export class ValidationTest extends GPUTest {
         return { buffer: this.getStorageBuffer() };
       case 'sampler':
         return this.getSampler();
+      case 'comparison-sampler':
+        return this.getComparisonSampler();
       case 'sampled-textureview':
         return this.getSampledTexture().createView();
       case 'storage-textureview':

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -109,11 +109,20 @@ export const kPerStageBindingLimits: {
   'storage-texture': 4,
 };
 
+type BindingKind =
+  | 'uniform-buffer'
+  | 'storage-buffer'
+  | 'sampler'
+  | 'comparison-sampler'
+  | 'sampled-texture'
+  | 'storage-texture';
+
 const kStagesAll = C.ShaderStage.Vertex | C.ShaderStage.Fragment | C.ShaderStage.Compute;
 const kStagesCompute = C.ShaderStage.Compute;
 export const kBindingTypeInfo: {
   [k in GPUBindingType]: {
     type: 'buffer' | 'texture' | 'sampler';
+    kind: BindingKind;
     validStages: GPUShaderStageFlags;
     perStageLimitType: PerStageBindingLimitType;
     maxDynamicCount: number;
@@ -121,14 +130,14 @@ export const kBindingTypeInfo: {
   };
   // TODO: maxDynamicCount should be kPerPipelineLayoutBindingLimits instead
 } = /* prettier-ignore */ {
-  'uniform-buffer':            { type: 'buffer',  validStages: kStagesAll,     perStageLimitType: 'uniform-buffer',  maxDynamicCount: 8 },
-  'storage-buffer':            { type: 'buffer',  validStages: kStagesCompute, perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
-  'readonly-storage-buffer':   { type: 'buffer',  validStages: kStagesAll,     perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
-  'sampler':                   { type: 'sampler', validStages: kStagesAll,     perStageLimitType: 'sampler',         maxDynamicCount: 0 },
-  'comparison-sampler':        { type: 'sampler', validStages: kStagesAll,     perStageLimitType: 'sampler',         maxDynamicCount: 0 },
-  'sampled-texture':           { type: 'texture', validStages: kStagesAll,     perStageLimitType: 'sampled-texture', maxDynamicCount: 0 },
-  'writeonly-storage-texture': { type: 'texture', validStages: kStagesCompute, perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
-  'readonly-storage-texture':  { type: 'texture', validStages: kStagesAll,     perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
+  'uniform-buffer':            { type: 'buffer',  kind: 'uniform-buffer',     validStages: kStagesAll,     perStageLimitType: 'uniform-buffer',  maxDynamicCount: 8 },
+  'storage-buffer':            { type: 'buffer',  kind: 'storage-buffer',     validStages: kStagesCompute, perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
+  'readonly-storage-buffer':   { type: 'buffer',  kind: 'storage-buffer',     validStages: kStagesAll,     perStageLimitType: 'storage-buffer',  maxDynamicCount: 4 },
+  'sampler':                   { type: 'sampler', kind: 'sampler',            validStages: kStagesAll,     perStageLimitType: 'sampler',         maxDynamicCount: 0 },
+  'comparison-sampler':        { type: 'sampler', kind: 'comparison-sampler', validStages: kStagesAll,     perStageLimitType: 'sampler',         maxDynamicCount: 0 },
+  'sampled-texture':           { type: 'texture', kind: 'sampled-texture',    validStages: kStagesAll,     perStageLimitType: 'sampled-texture', maxDynamicCount: 0 },
+  'writeonly-storage-texture': { type: 'texture', kind: 'storage-texture',    validStages: kStagesCompute, perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
+  'readonly-storage-texture':  { type: 'texture', kind: 'storage-texture',    validStages: kStagesAll,     perStageLimitType: 'storage-texture', maxDynamicCount: 0 },
 };
 export const kBindingTypes = Object.keys(kBindingTypeInfo) as GPUBindingType[];
 


### PR DESCRIPTION
Handles:
- storageTextureFormat required for storage texture bindings in BGL
- comparison sampler objects not tested
- default sampler is not a valid comparison sampler
