### PR TITLE
Use expectSingleColor helper in glsl-dependent tests

### DIFF
--- a/src/webgpu/api/operation/command_buffer/render/storeop.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/render/storeop.spec.ts
@@ -9,7 +9,7 @@ export const g = new TestGroup(GPUTest);
 
 g.test('storeOp controls whether 1x1 drawn quad is stored')
   .params([
-    { storeOp: C.StoreOp.Store, _expected: 255 }, //
+    { storeOp: C.StoreOp.Store, _expected: 1 }, //
     { storeOp: C.StoreOp.Clear, _expected: 0 },
   ])
   .fn(async t => {
@@ -65,18 +65,11 @@ g.test('storeOp controls whether 1x1 drawn quad is stored')
     pass.setPipeline(renderPipeline);
     pass.draw(3, 1, 0, 0);
     pass.endPass();
-    const dstBuffer = t.device.createBuffer({
-      size: 4,
-      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
-    });
-    encoder.copyTextureToBuffer(
-      { texture: renderTexture },
-      { buffer: dstBuffer, bytesPerRow: 256 },
-      { width: 1, height: 1, depth: 1 }
-    );
     t.device.defaultQueue.submit([encoder.finish()]);
 
     // expect the buffer to be clear
-    const expectedContent = new Uint32Array([t.params._expected]);
-    t.expectContents(dstBuffer, expectedContent);
+    t.expectSingleColor(renderTexture, 'r8unorm', {
+      size: [1, 1, 1],
+      exp: { R: t.params._expected },
+    });
   });

--- a/src/webgpu/api/operation/resource_init/depth_stencil_attachment_clear.spec.ts
+++ b/src/webgpu/api/operation/resource_init/depth_stencil_attachment_clear.spec.ts
@@ -4,12 +4,7 @@ export const description =
 import * as C from '../../../../common/constants.js';
 import { TestGroup } from '../../../../common/framework/test_group.js';
 import { unreachable } from '../../../../common/framework/util/util.js';
-import {
-  fillTextureDataWithTexelValue,
-  getTextureCopyLayout,
-} from '../../../util/texture/layout.js';
 import { SubresourceRange } from '../../../util/texture/subresource.js';
-import { getTexelDataRepresentation } from '../../../util/texture/texelData.js';
 
 import {
   InitializedState,
@@ -200,37 +195,12 @@ class DepthStencilAttachmentClearTest extends TextureZeroInitTest {
       pass.draw(3, 1, 0, 0);
       pass.endPass();
 
-      const { bytesPerRow, byteLength, rowsPerImage } = getTextureCopyLayout('r8unorm', '2d', [
-        width,
-        height,
-        1,
-      ]);
-      const expectedTexelData = getTexelDataRepresentation('r8unorm').getBytes({ R: 1 });
-
-      const buffer = this.device.createBuffer({
-        size: byteLength,
-        usage: C.BufferUsage.CopySrc | C.BufferUsage.CopyDst,
-      });
-
-      commandEncoder.copyTextureToBuffer(
-        { texture: resolveTexture || renderTexture },
-        {
-          buffer,
-          bytesPerRow,
-          rowsPerImage,
-        },
-        [width, height, 1]
-      );
-
       this.queue.submit([commandEncoder.finish()]);
 
-      const arrayBuffer = new ArrayBuffer(byteLength);
-      fillTextureDataWithTexelValue(expectedTexelData, 'r8unorm', '2d', arrayBuffer, [
-        width,
-        height,
-        1,
-      ]);
-      this.expectContents(buffer, new Uint8Array(arrayBuffer));
+      this.expectSingleColor(resolveTexture || renderTexture, 'r8unorm', {
+        size: [width, height, 1],
+        exp: { R: 1 },
+      });
     }
   }
 }


### PR DESCRIPTION
This function checks that the entire subresource region of some texture is entirely filled by a single color.
For #173 