### PR TITLE
Introduce expectSingleColor helper function

### DIFF
--- a/src/webgpu/api/operation/resource_init/copied_texture_clear.spec.ts
+++ b/src/webgpu/api/operation/resource_init/copied_texture_clear.spec.ts
@@ -3,76 +3,26 @@ export const description = 'Test uninitialized textures are initialized to zero 
 import * as C from '../../../../common/constants.js';
 import { TestGroup } from '../../../../common/framework/test_group.js';
 import { assert, unreachable } from '../../../../common/framework/util/util.js';
-import {
-  fillTextureDataWithTexelValue,
-  getTextureCopyLayout,
-} from '../../../util/texture/layout.js';
 import { SubresourceRange } from '../../../util/texture/subresource.js';
-import { getTexelDataRepresentation } from '../../../util/texture/texelData.js';
 
 import { InitializedState, ReadMethod, TextureZeroInitTest } from './texture_zero_init_test.js';
 
 class CopiedTextureClearTest extends TextureZeroInitTest {
-  private checkTextureSliceByBufferCopy(
-    texture: GPUTexture,
-    state: InitializedState,
-    width: number,
-    height: number,
-    level: number,
-    layer: number
-  ): void {
-    const { byteLength, bytesPerRow, bytesPerBlock, rowsPerImage } = getTextureCopyLayout(
-      this.params.format,
-      this.params.dimension,
-      [width, height, 1]
-    );
-
-    const buffer = this.device.createBuffer({
-      size: byteLength,
-      usage: C.BufferUsage.CopySrc | C.BufferUsage.CopyDst,
-    });
-
-    const commandEncoder = this.device.createCommandEncoder();
-    commandEncoder.copyTextureToBuffer(
-      { texture, mipLevel: level, arrayLayer: layer },
-      {
-        buffer,
-        bytesPerRow,
-        rowsPerImage,
-      },
-      [width, height, 1]
-    );
-    this.queue.submit([commandEncoder.finish()]);
-
-    const expectedTexelData = new Uint8Array(
-      getTexelDataRepresentation(this.params.format).getBytes(this.stateToTexelComponents[state])
-    );
-    assert(expectedTexelData.byteLength === bytesPerBlock);
-
-    const arrayBuffer = new ArrayBuffer(byteLength);
-    fillTextureDataWithTexelValue(
-      expectedTexelData,
-      this.params.format,
-      this.params.dimension,
-      arrayBuffer,
-      [width, height, 1]
-    );
-
-    this.expectContents(buffer, new Uint8Array(arrayBuffer));
-  }
-
   private checkContentsByBufferCopy(
     texture: GPUTexture,
     state: InitializedState,
     subresourceRange: SubresourceRange
   ): void {
-    for (const { level, slice } of subresourceRange.each()) {
+    for (const { level: mipLevel, slice } of subresourceRange.each()) {
       assert(this.params.dimension === '2d');
 
-      const width = this.textureWidth >> level;
-      const height = this.textureHeight >> level;
-
-      this.checkTextureSliceByBufferCopy(texture, state, width, height, level, slice);
+      this.expectSingleColor(texture, this.params.format, {
+        size: [this.textureWidth, this.textureHeight, 1],
+        dimension: this.params.dimension,
+        slice,
+        layout: { mipLevel },
+        exp: this.stateToTexelComponents[state],
+      });
     }
   }
 
@@ -101,7 +51,10 @@ class CopiedTextureClearTest extends TextureZeroInitTest {
       );
       this.queue.submit([commandEncoder.finish()]);
 
-      this.checkTextureSliceByBufferCopy(dst, state, width, height, 0, 0);
+      this.expectSingleColor(dst, this.params.format, {
+        size: [width, height, 1],
+        exp: this.stateToTexelComponents[state],
+      });
     }
   }
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -2,6 +2,13 @@ import { Fixture } from '../common/framework/fixture.js';
 import { getGPU } from '../common/framework/gpu/implementation.js';
 import { assert, unreachable } from '../common/framework/util/util.js';
 
+import {
+  fillTextureDataWithTexelValue,
+  getTextureCopyLayout,
+  LayoutOptions as TextureLayoutOptions,
+} from './util/texture/layout.js';
+import { PerTexelComponent, getTexelDataRepresentation } from './util/texture/texelData.js';
+
 type TypedArrayBufferView =
   | Uint8Array
   | Uint16Array
@@ -210,5 +217,47 @@ export class GPUTest extends Fixture {
       return lines.join('\n');
     }
     return undefined;
+  }
+
+  expectSingleColor(
+    src: GPUTexture,
+    format: GPUTextureFormat,
+    {
+      size,
+      exp,
+      dimension = '2d',
+      slice = 0,
+      layout,
+    }: {
+      size: [number, number, number];
+      exp: PerTexelComponent<number>;
+      dimension?: GPUTextureDimension;
+      slice?: number;
+      layout?: TextureLayoutOptions;
+    }
+  ): void {
+    const { byteLength, bytesPerRow, rowsPerImage } = getTextureCopyLayout(
+      format,
+      dimension,
+      size,
+      layout
+    );
+    const expectedTexelData = getTexelDataRepresentation(format).getBytes(exp);
+
+    const buffer = this.device.createBuffer({
+      size: byteLength,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+
+    const commandEncoder = this.device.createCommandEncoder();
+    commandEncoder.copyTextureToBuffer(
+      { texture: src, mipLevel: layout?.mipLevel, arrayLayer: slice },
+      { buffer, bytesPerRow, rowsPerImage },
+      size
+    );
+    this.queue.submit([commandEncoder.finish()]);
+    const arrayBuffer = new ArrayBuffer(byteLength);
+    fillTextureDataWithTexelValue(expectedTexelData, format, dimension, arrayBuffer, size, layout);
+    this.expectContents(buffer, new Uint8Array(arrayBuffer));
   }
 }

--- a/src/webgpu/util/texture/layout.ts
+++ b/src/webgpu/util/texture/layout.ts
@@ -6,7 +6,7 @@ import { align, isAligned } from '../math.js';
 export const kBytesPerRowAlignment = 256;
 export const kBufferCopyAlignment = 4;
 
-interface LayoutOptions {
+export interface LayoutOptions {
   mipLevel: number;
   bytesPerRow?: number;
   rowsPerImage?: number;


### PR DESCRIPTION
This function checks that the entire subresource region of some texture is entirely filled by a single color.