### PR TITLE
only checkForDuplicateCases during crawl(); slightly speed up comparePublicParamsPaths

### DIFF
--- a/src/common/framework/params_utils.ts
+++ b/src/common/framework/params_utils.ts
@@ -1,5 +1,5 @@
 import { comparePublicParamsPaths, Ordering } from './query/compare.js';
-import { kWildcard, kParamSeparator } from './query/separators.js';
+import { kWildcard, kParamSeparator, kParamKVSeparator } from './query/separators.js';
 
 // Consider adding more types here if needed
 export type ParamArgument = void | undefined | number | string | boolean | number[];
@@ -25,7 +25,9 @@ export function extractPublicParams(params: CaseParams): CaseParams {
   return publicParams;
 }
 
-export const badParamValueChars = new RegExp('[=' + kParamSeparator + kWildcard + ']');
+export const badParamValueChars = new RegExp(
+  '[' + kParamKVSeparator + kParamSeparator + kWildcard + ']'
+);
 
 export function publicParamsEquals(x: CaseParams, y: CaseParams): boolean {
   return comparePublicParamsPaths(x, y) === Ordering.Equal;

--- a/src/common/framework/query/compare.ts
+++ b/src/common/framework/query/compare.ts
@@ -1,4 +1,4 @@
-import { CaseParams, extractPublicParams } from '../params_utils.js';
+import { CaseParams, paramKeyIsPublic } from '../params_utils.js';
 import { assert, objectEquals } from '../util/util.js';
 
 import { TestQuery } from './query.js';
@@ -68,10 +68,8 @@ function comparePaths(a: readonly string[], b: readonly string[]): Ordering {
   }
 }
 
-export function comparePublicParamsPaths(a0: CaseParams, b0: CaseParams): Ordering {
-  const a = extractPublicParams(a0);
-  const b = extractPublicParams(b0);
-  const aKeys = Object.keys(a);
+export function comparePublicParamsPaths(a: CaseParams, b: CaseParams): Ordering {
+  const aKeys = Object.keys(a).filter(k => paramKeyIsPublic(k));
   const commonKeys = new Set(aKeys.filter(k => k in b));
 
   for (const k of commonKeys) {
@@ -79,7 +77,7 @@ export function comparePublicParamsPaths(a0: CaseParams, b0: CaseParams): Orderi
       return Ordering.Unordered;
     }
   }
-  const bKeys = Object.keys(b);
+  const bKeys = Object.keys(b).filter(k => paramKeyIsPublic(k));
   const aRemainingKeys = aKeys.length - commonKeys.size;
   const bRemainingKeys = bKeys.length - commonKeys.size;
   if (aRemainingKeys === 0 && bRemainingKeys === 0) return Ordering.Equal;

--- a/src/common/framework/query/stringify_params.ts
+++ b/src/common/framework/query/stringify_params.ts
@@ -1,16 +1,17 @@
 import {
   CaseParams,
-  extractPublicParams,
   ParamArgument,
   badParamValueChars,
+  paramKeyIsPublic,
 } from '../params_utils.js';
 import { assert } from '../util/util.js';
 
 import { kParamKVSeparator } from './separators.js';
 
 export function stringifyPublicParams(p: CaseParams): string[] {
-  const pub = extractPublicParams(p);
-  return Object.entries(pub).map(([k, v]) => stringifySingleParam(k, v));
+  return Object.keys(p)
+    .filter(k => paramKeyIsPublic(k))
+    .map(k => stringifySingleParam(k, p[k]));
 }
 
 export function stringifySingleParam(k: string, v: ParamArgument) {

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -34,7 +34,7 @@ export function makeTestGroup<F extends Fixture>(fixture: FixtureClass<F>): Test
 // Interface for running tests
 export interface RunCaseIterable {
   iterate(): Iterable<RunCase>;
-  checkForDuplicateCases(): void;
+  checkCaseNamesAndDuplicates(): void;
 }
 export function makeTestGroupForUnitTesting<F extends Fixture>(
   fixture: FixtureClass<F>
@@ -86,9 +86,9 @@ class TestGroup<F extends Fixture> implements RunCaseIterable, TestGroupBuilder<
     return test;
   }
 
-  checkForDuplicateCases(): void {
+  checkCaseNamesAndDuplicates(): void {
     for (const test of this.tests) {
-      test.checkForDuplicateCases();
+      test.checkCaseNamesAndDuplicates();
     }
   }
 }
@@ -116,7 +116,7 @@ class TestBuilder<F extends Fixture, P extends {}> {
     this.testFn = fn;
   }
 
-  checkForDuplicateCases(): void {
+  checkCaseNamesAndDuplicates(): void {
     if (this.cases === undefined) {
       return;
     }

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -120,7 +120,7 @@ class TestBuilder<F extends Fixture, P extends {}> {
     for (const testcase of this.cases) {
       // stringifyPublicParams also checks for invalid params values
       const testcaseString = stringifyPublicParams(testcase).join(kParamSeparator);
-      assert(!seen.has(testcaseString));
+      assert(!seen.has(testcaseString), `Duplicate public test case params: ${testcaseString}`);
       seen.add(testcaseString);
     }
   }

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -1,14 +1,8 @@
 import { Fixture } from './fixture.js';
 import { TestCaseRecorder } from './logging/test_case_recorder.js';
-import {
-  CaseParams,
-  CaseParamsIterable,
-  extractPublicParams,
-  publicParamsEquals,
-  paramKeyIsPublic,
-} from './params_utils.js';
-import { kPathSeparator } from './query/separators.js';
-import { stringifySingleParam } from './query/stringify_params.js';
+import { CaseParams, CaseParamsIterable, extractPublicParams } from './params_utils.js';
+import { kPathSeparator, kParamSeparator } from './query/separators.js';
+import { stringifyPublicParams } from './query/stringify_params.js';
 import { validQueryPart } from './query/validQueryPart.js';
 import { assert } from './util/util.js';
 
@@ -122,20 +116,12 @@ class TestBuilder<F extends Fixture, P extends {}> {
       return;
     }
 
-    // This is n^2.
-    const seen: CaseParams[] = [];
+    const seen = new Set<string>();
     for (const testcase of this.cases) {
-      for (const [k, v] of Object.entries(testcase as CaseParams)) {
-        if (paramKeyIsPublic(k)) {
-          stringifySingleParam(k, v); // To check for invalid params values
-        }
-      }
-
-      assert(
-        !seen.some(x => publicParamsEquals(x, testcase)),
-        () => 'Duplicate public test case params: ' + JSON.stringify(testcase)
-      );
-      seen.push(testcase);
+      // stringifyPublicParams also checks for invalid params values
+      const testcaseString = stringifyPublicParams(testcase).join(kParamSeparator);
+      assert(!seen.has(testcaseString));
+      seen.add(testcaseString);
     }
   }
 

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -1,7 +1,12 @@
 import { Fixture } from './fixture.js';
 import { TestCaseRecorder } from './logging/test_case_recorder.js';
-import { CaseParams, CaseParamsIterable, extractPublicParams } from './params_utils.js';
-import { kPathSeparator, kParamSeparator } from './query/separators.js';
+import {
+  CaseParams,
+  CaseParamsIterable,
+  extractPublicParams,
+  publicParamsEquals,
+} from './params_utils.js';
+import { kPathSeparator } from './query/separators.js';
 import { stringifyPublicParams } from './query/stringify_params.js';
 import { validQueryPart } from './query/validQueryPart.js';
 import { assert } from './util/util.js';
@@ -116,12 +121,16 @@ class TestBuilder<F extends Fixture, P extends {}> {
       return;
     }
 
-    const seen = new Set<string>();
+    // This is n^2.
+    const seen: CaseParams[] = [];
     for (const testcase of this.cases) {
       // stringifyPublicParams also checks for invalid params values
-      const testcaseString = stringifyPublicParams(testcase).join(kParamSeparator);
-      assert(!seen.has(testcaseString), `Duplicate public test case params: ${testcaseString}`);
-      seen.add(testcaseString);
+      const testcaseString = stringifyPublicParams(testcase);
+      assert(
+        !seen.some(x => publicParamsEquals(x, testcase)),
+        `Duplicate public test case params: ${testcaseString}`
+      );
+      seen.push(testcase);
     }
   }
 

--- a/src/common/framework/util/util.ts
+++ b/src/common/framework/util/util.ts
@@ -1,8 +1,8 @@
 import { timeout } from './timeout.js';
 
-export function assert(condition: boolean, msg?: string): asserts condition {
+export function assert(condition: boolean, msg?: string | (() => string)): asserts condition {
   if (!condition) {
-    throw new Error(msg);
+    throw new Error(msg && (typeof msg === 'string' ? msg : msg()));
   }
 }
 

--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -21,10 +21,7 @@ declare function async_test(f: (this: WptTestObject) => Promise<void>, name: str
   assert(qs.length === 1, 'currently, there must be exactly one ?q=');
   const testcases = await loader.loadTests(qs[0]);
 
-  const log = await addWPTTests(testcases);
-
-  const resultsElem = document.getElementById('results') as HTMLElement;
-  resultsElem.textContent = log.asJSON(2);
+  await addWPTTests(testcases);
 })();
 
 // Note: async_tests must ALL be added within the same task. This function *must not* be async.

--- a/src/common/templates/cts.html
+++ b/src/common/templates/cts.html
@@ -25,24 +25,4 @@
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
-<style>
-#results {
-    font-family: monospace;
-    width: 100%;
-    height: 15em;
-}
-
-/* Test Name column */
-#results > tbody > tr > td:nth-child(2) {
-    word-break: break-word;
-}
-
-/* Message column */
-#results > tbody > tr > td:nth-child(3) {
-    white-space: pre-wrap;
-    word-break: break-word;
-}
-</style>
-
-<textarea id=results></textarea>
 <script type=module src=/webgpu/common/runtime/wpt.js></script>

--- a/src/common/tools/crawl.ts
+++ b/src/common/tools/crawl.ts
@@ -35,6 +35,8 @@ export async function crawl(suite: string): Promise<TestSuiteListingEntry[]> {
       assert(mod.description !== undefined, 'Test spec file missing description: ' + filename);
       assert(mod.g !== undefined, 'Test spec file missing TestGroup definition: ' + filename);
 
+      mod.g.checkForDuplicateCases();
+
       const path = filepathWithoutExtension.split('/');
       entries.push({ file: path, description: mod.description.trim() });
     } else if (path.basename(file) === 'README.txt') {

--- a/src/common/tools/crawl.ts
+++ b/src/common/tools/crawl.ts
@@ -35,7 +35,7 @@ export async function crawl(suite: string): Promise<TestSuiteListingEntry[]> {
       assert(mod.description !== undefined, 'Test spec file missing description: ' + filename);
       assert(mod.g !== undefined, 'Test spec file missing TestGroup definition: ' + filename);
 
-      mod.g.checkForDuplicateCases();
+      mod.g.checkCaseNamesAndDuplicates();
 
       const path = filepathWithoutExtension.split('/');
       entries.push({ file: path, description: mod.description.trim() });

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -96,30 +96,32 @@ g.test('duplicate_test_name').fn(t => {
 g.test('duplicate_test_params').fn(t => {
   const g = makeTestGroupForUnitTesting(UnitTest);
 
+  g.test('abc')
+    .params([
+      { a: 1 }, //
+      { a: 1 },
+    ])
+    .fn(() => {
+      //
+    });
   t.shouldThrow('Error', () => {
-    g.test('abc')
-      .params([
-        { a: 1 }, //
-        { a: 1 },
-      ])
-      .fn(() => {
-        //
-      });
+    g.checkForDuplicateCases();
   });
 });
 
 g.test('duplicate_test_params,with_different_private_params').fn(t => {
   const g = makeTestGroupForUnitTesting(UnitTest);
 
+  g.test('abc')
+    .params([
+      { a: 1, _b: 1 }, //
+      { a: 1, _b: 2 },
+    ])
+    .fn(() => {
+      //
+    });
   t.shouldThrow('Error', () => {
-    g.test('abc')
-      .params([
-        { a: 1, _b: 1 }, //
-        { a: 1, _b: 2 },
-      ])
-      .fn(() => {
-        //
-      });
+    g.checkForDuplicateCases();
   });
 });
 

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -93,33 +93,67 @@ g.test('duplicate_test_name').fn(t => {
   });
 });
 
-g.test('duplicate_test_params').fn(t => {
-  const g = makeTestGroupForUnitTesting(UnitTest);
-
-  g.test('abc')
-    .params([
-      { a: 1 }, //
-      { a: 1 },
-    ])
-    .fn(() => {
-      //
-    });
-  t.shouldThrow('Error', () => {
+g.test('duplicate_test_params,none').fn(t => {
+  {
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('abc')
+      .params([])
+      .fn(() => {});
     g.checkForDuplicateCases();
-  });
+  }
+
+  {
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('abc').fn(() => {});
+    g.checkForDuplicateCases();
+  }
+
+  {
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('abc')
+      .params([
+        { a: 1 }, //
+      ])
+      .fn(() => {});
+    g.checkForDuplicateCases();
+  }
+});
+
+g.test('duplicate_test_params,basic').fn(t => {
+  {
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('abc')
+      .params([
+        { a: 1 }, //
+        { a: 1 },
+      ])
+      .fn(() => {});
+    t.shouldThrow('Error', () => {
+      g.checkForDuplicateCases();
+    });
+  }
+  {
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('abc')
+      .params([
+        { a: 1, b: 3 }, //
+        { b: 3, a: 1 },
+      ])
+      .fn(() => {});
+    t.shouldThrow('Error', () => {
+      g.checkForDuplicateCases();
+    });
+  }
 });
 
 g.test('duplicate_test_params,with_different_private_params').fn(t => {
   const g = makeTestGroupForUnitTesting(UnitTest);
-
   g.test('abc')
     .params([
       { a: 1, _b: 1 }, //
       { a: 1, _b: 2 },
     ])
-    .fn(() => {
-      //
-    });
+    .fn(() => {});
   t.shouldThrow('Error', () => {
     g.checkForDuplicateCases();
   });

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -99,13 +99,13 @@ g.test('duplicate_test_params,none').fn(t => {
     g.test('abc')
       .params([])
       .fn(() => {});
-    g.checkForDuplicateCases();
+    g.checkCaseNamesAndDuplicates();
   }
 
   {
     const g = makeTestGroupForUnitTesting(UnitTest);
     g.test('abc').fn(() => {});
-    g.checkForDuplicateCases();
+    g.checkCaseNamesAndDuplicates();
   }
 
   {
@@ -115,7 +115,7 @@ g.test('duplicate_test_params,none').fn(t => {
         { a: 1 }, //
       ])
       .fn(() => {});
-    g.checkForDuplicateCases();
+    g.checkCaseNamesAndDuplicates();
   }
 });
 
@@ -129,7 +129,7 @@ g.test('duplicate_test_params,basic').fn(t => {
       ])
       .fn(() => {});
     t.shouldThrow('Error', () => {
-      g.checkForDuplicateCases();
+      g.checkCaseNamesAndDuplicates();
     });
   }
   {
@@ -141,7 +141,7 @@ g.test('duplicate_test_params,basic').fn(t => {
       ])
       .fn(() => {});
     t.shouldThrow('Error', () => {
-      g.checkForDuplicateCases();
+      g.checkCaseNamesAndDuplicates();
     });
   }
 });
@@ -155,7 +155,7 @@ g.test('duplicate_test_params,with_different_private_params').fn(t => {
     ])
     .fn(() => {});
   t.shouldThrow('Error', () => {
-    g.checkForDuplicateCases();
+    g.checkCaseNamesAndDuplicates();
   });
 });
 
@@ -175,9 +175,19 @@ g.test('invalid_test_name').fn(t => {
   }
 });
 
-g.test('valid_param_value').fn(() => {
+g.test('param_value,valid').fn(() => {
   const g = makeTestGroup(UnitTest);
   g.test('a').params([{ x: JSON.stringify({ a: 1, b: 2 }) }]);
+});
+
+g.test('param_value,invalid').fn(t => {
+  for (const badChar of ';=*') {
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('a').params([{ badChar }]);
+    t.shouldThrow('Error', () => {
+      g.checkCaseNamesAndDuplicates();
+    });
+  }
 });
 
 g.test('throws').fn(async t0 => {


### PR DESCRIPTION
Avoids doing checkForDuplicateCases when just importing a `.spec.js` file.

Significantly speeds up page load time for standalone and wpt.