### PR TITLE
standalone runner: implement collapsing, show relative names

### DIFF
--- a/src/common/framework/file_loader.ts
+++ b/src/common/framework/file_loader.ts
@@ -1,4 +1,5 @@
 import { parseQuery } from './query/parseQuery.js';
+import { TestQuery } from './query/query.js';
 import { RunCaseIterable } from './test_group.js';
 import { TestSuiteListing } from './test_suite_listing.js';
 import { loadTreeForQuery, TestTree, TestTreeLeaf } from './tree.js';
@@ -25,15 +26,15 @@ export abstract class TestFileLoader {
     return this.import(`${suite}/${path.join('/')}.spec.js`);
   }
 
-  async loadTree(query: string, subqueriesToExpand: string[] = []): Promise<TestTree> {
+  async loadTree(query: TestQuery, subqueriesToExpand: string[] = []): Promise<TestTree> {
     return loadTreeForQuery(
       this,
-      parseQuery(query),
+      query,
       subqueriesToExpand.map(q => parseQuery(q))
     );
   }
 
-  async loadTests(query: string): Promise<IterableIterator<TestTreeLeaf>> {
+  async loadCases(query: TestQuery): Promise<IterableIterator<TestTreeLeaf>> {
     const tree = await this.loadTree(query);
     return tree.iterateLeaves();
   }

--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -11,7 +11,14 @@ export type TestQuery =
   | TestQueryMultiTest
   | TestQueryMultiFile;
 
+export type TestQueryLevel =
+  | 1 // MultiFile
+  | 2 // MultiTest
+  | 3 // MultiCase
+  | 4; // SingleCase
+
 export class TestQueryMultiFile {
+  readonly level: TestQueryLevel = 1;
   readonly isMultiFile: boolean = true;
   readonly suite: string;
   readonly filePathParts: readonly string[];
@@ -25,16 +32,13 @@ export class TestQueryMultiFile {
     return encodeURIComponentSelectively(this.toStringHelper().join(kBigSeparator));
   }
 
-  toHTML(): string {
-    return this.toStringHelper().join(kBigSeparator + '<wbr>');
-  }
-
   protected toStringHelper(): string[] {
     return [this.suite, [...this.filePathParts, kWildcard].join(kPathSeparator)];
   }
 }
 
 export class TestQueryMultiTest extends TestQueryMultiFile {
+  readonly level: TestQueryLevel = 2;
   readonly isMultiFile: false = false;
   readonly isMultiTest: boolean = true;
   readonly testPathParts: readonly string[];
@@ -55,6 +59,7 @@ export class TestQueryMultiTest extends TestQueryMultiFile {
 }
 
 export class TestQueryMultiCase extends TestQueryMultiTest {
+  readonly level: TestQueryLevel = 3;
   readonly isMultiTest: false = false;
   readonly isMultiCase: boolean = true;
   readonly params: CaseParams;
@@ -77,6 +82,7 @@ export class TestQueryMultiCase extends TestQueryMultiTest {
 }
 
 export class TestQuerySingleCase extends TestQueryMultiCase {
+  readonly level: TestQueryLevel = 4;
   readonly isMultiCase: false = false;
 
   protected toStringHelper(): string[] {

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -142,7 +142,7 @@ class TestBuilder<F extends Fixture, P extends {}> {
   }
 
   *iterate(): IterableIterator<RunCase> {
-    assert(this.testFn !== undefined, 'internal error');
+    assert(this.testFn !== undefined, 'No test function (.fn()) for test');
     for (const params of this.cases || [{}]) {
       yield new RunCaseSpecific(this.testPath, params, this.fixture, this.testFn);
     }

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -260,6 +260,7 @@ function addSubtreeForFilePath(
   // This goes from that -> suite:a,b:*
   const subtree = getOrInsertSubtree('', tree, () => {
     const query = new TestQueryMultiTest(tree.query.suite, tree.query.filePathParts, []);
+    assert(file.length > 0, 'file path is empty');
     return {
       relativeName: file[file.length - 1] + kBigSeparator + kWildcard,
       query,
@@ -301,6 +302,7 @@ function addSubtreeForTestPath(
       subqueryTest,
       {}
     );
+    assert(subqueryTest.length > 0, 'subqueryTest is empty');
     return {
       relativeName: subqueryTest[subqueryTest.length - 1] + kBigSeparator + kWildcard,
       kWildcard,

--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -7,6 +7,7 @@ import * as process from 'process';
 import { DefaultTestFileLoader } from '../framework/file_loader.js';
 import { Logger } from '../framework/logging/logger.js';
 import { LiveTestCaseResult } from '../framework/logging/result.js';
+import { parseQuery } from '../framework/query/parseQuery.js';
 import { assert, unreachable } from '../framework/util/util.js';
 
 function usage(rc: number): never {
@@ -28,7 +29,7 @@ if (!fs.existsSync('src/common/runtime/cmdline.ts')) {
 let verbose = false;
 let debug = false;
 let printJSON = false;
-const filterArgs: string[] = [];
+const queries: string[] = [];
 for (const a of process.argv.slice(2)) {
   if (a.startsWith('-')) {
     if (a === '--verbose') {
@@ -41,19 +42,19 @@ for (const a of process.argv.slice(2)) {
       usage(1);
     }
   } else {
-    filterArgs.push(a);
+    queries.push(a);
   }
 }
 
-if (filterArgs.length === 0) {
+if (queries.length === 0) {
   usage(0);
 }
 
 (async () => {
   try {
     const loader = new DefaultTestFileLoader();
-    assert(filterArgs.length === 1, 'currently, there must be exactly one query on the cmd line');
-    const testcases = await loader.loadTests(filterArgs[0]);
+    assert(queries.length === 1, 'currently, there must be exactly one query on the cmd line');
+    const testcases = await loader.loadCases(parseQuery(queries[0]));
 
     const log = new Logger(debug);
 

--- a/src/common/runtime/helper/test_worker-worker.ts
+++ b/src/common/runtime/helper/test_worker-worker.ts
@@ -1,5 +1,6 @@
 import { DefaultTestFileLoader } from '../../framework/file_loader.js';
 import { Logger } from '../../framework/logging/logger.js';
+import { parseQuery } from '../../framework/query/parseQuery.js';
 import { assert } from '../../framework/util/util.js';
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -13,7 +14,7 @@ self.onmessage = async (ev: MessageEvent) => {
 
   const log = new Logger(debug);
 
-  const testcases = Array.from(await loader.loadTests(query));
+  const testcases = Array.from(await loader.loadCases(parseQuery(query)));
   assert(testcases.length === 1, 'worker query resulted in != 1 cases');
 
   const testcase = testcases[0];

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -2,7 +2,8 @@
 
 import { DefaultTestFileLoader } from '../framework/file_loader.js';
 import { Logger } from '../framework/logging/logger.js';
-import { TestQuery } from '../framework/query/query.js';
+import { parseQuery } from '../framework/query/parseQuery.js';
+import { TestQueryLevel } from '../framework/query/query.js';
 import { TestTreeNode, TestSubtree, TestTreeLeaf } from '../framework/tree.js';
 import { assert } from '../framework/util/util.js';
 
@@ -30,9 +31,12 @@ type RunSubtree = () => Promise<void>;
 
 // DOM generation
 
-function makeTreeNodeHTML(tree: TestTreeNode): [HTMLElement, RunSubtree] {
+function makeTreeNodeHTML(
+  tree: TestTreeNode,
+  parentLevel: TestQueryLevel
+): [HTMLElement, RunSubtree] {
   if ('children' in tree) {
-    return makeSubtreeHTML(tree);
+    return makeSubtreeHTML(tree, parentLevel);
   } else {
     return makeCaseHTML(tree);
   }
@@ -73,30 +77,43 @@ function makeCaseHTML(t: TestTreeLeaf): [HTMLElement, RunSubtree] {
     }
   };
 
-  const casehead = makeTreeNodeHeaderHTML(t.query, undefined, runSubtree, true);
+  const caselogs = $('<div>').addClass('testcaselogs');
+  const casehead = makeTreeNodeHeaderHTML(t, runSubtree, 2, checked => {
+    checked ? caselogs.show() : caselogs.hide();
+  });
   div.append(casehead);
   const casetime = $('<div>').addClass('testcasetime').html('ms').appendTo(casehead);
-  const caselogs = $('<div>').addClass('testcaselogs').appendTo(div);
+  caselogs.appendTo(div);
 
   return [div[0], runSubtree];
 }
 
-function makeSubtreeHTML(t: TestSubtree): [HTMLElement, RunSubtree] {
+function makeSubtreeHTML(n: TestSubtree, parentLevel: TestQueryLevel): [HTMLElement, RunSubtree] {
   const div = $('<div>').addClass('subtree');
 
-  const header = makeTreeNodeHeaderHTML(t.query, t.description, () => runSubtree(), false);
-  div.append(header);
+  const subtreeHTML = $('<div>').addClass('subtreechildren');
+  const runSubtree = makeSubtreeChildrenHTML(subtreeHTML[0], n.children.values(), n.query.level);
 
-  const subtreeHTML = $('<div>').addClass('subtreechildren').appendTo(div);
-  const runSubtree = makeSubtreeChildrenHTML(subtreeHTML[0], t.children.values());
+  const header = makeTreeNodeHeaderHTML(n, runSubtree, parentLevel, checked => {
+    checked ? subtreeHTML.show() : subtreeHTML.hide();
+  });
+
+  div.append(header);
+  div.append(subtreeHTML);
+
+  div[0].classList.add(['', 'multifile', 'multitest', 'multicase'][n.query.level]);
 
   return [div[0], runSubtree];
 }
 
-function makeSubtreeChildrenHTML(div: HTMLElement, children: Iterable<TestTreeNode>): RunSubtree {
+function makeSubtreeChildrenHTML(
+  div: HTMLElement,
+  children: Iterable<TestTreeNode>,
+  parentLevel: TestQueryLevel
+): RunSubtree {
   const runSubtreeFns: RunSubtree[] = [];
   for (const subtree of children) {
-    const [subtreeHTML, runSubtree] = makeTreeNodeHTML(subtree);
+    const [subtreeHTML, runSubtree] = makeTreeNodeHTML(subtree, parentLevel);
     div.append(subtreeHTML);
     runSubtreeFns.push(runSubtree);
   }
@@ -109,18 +126,38 @@ function makeSubtreeChildrenHTML(div: HTMLElement, children: Iterable<TestTreeNo
 }
 
 function makeTreeNodeHeaderHTML(
-  query: TestQuery,
-  description: string | undefined,
+  n: TestTreeNode,
   runSubtree: RunSubtree,
-  isLeaf: boolean
+  parentLevel: TestQueryLevel,
+  onChange: (checked: boolean) => void
 ): HTMLElement {
+  const isLeaf = 'run' in n;
   const div = $('<div>').addClass('nodeheader');
 
-  const href = `?${worker ? 'worker&' : ''}${debug ? 'debug&' : ''}q=${query.toString()}`;
+  const href = `?${worker ? 'worker&' : ''}${debug ? 'debug&' : ''}q=${n.query.toString()}`;
+  if (onChange) {
+    const checkbox = $('<input>')
+      .attr('type', 'checkbox')
+      .addClass('collapsebtn')
+      .change(function (this) {
+        onChange((this as HTMLInputElement).checked);
+      })
+      .attr('alt', 'Expand')
+      .attr('title', 'Expand')
+      .appendTo(div);
+
+    // Collapse s:f:* or s:f:t:* or s:f:t:c by default.
+    if (n.query.level > rootQueryLevel && n.query.level > parentLevel) {
+      onChange(false);
+    } else {
+      checkbox.prop('checked', true); // (does not fire onChange)
+    }
+  }
+  const runtext = isLeaf ? 'Run case' : 'Run subtree';
   $('<button>')
     .addClass(isLeaf ? 'leafrun' : 'subtreerun')
-    .attr('alt', 'Run subtree')
-    .attr('title', 'Run subtree')
+    .attr('alt', runtext)
+    .attr('title', runtext)
     .on('click', async () => {
       await runSubtree();
       updateJSON();
@@ -133,11 +170,19 @@ function makeTreeNodeHeaderHTML(
     .attr('title', 'Open')
     .appendTo(div);
   const nodetitle = $('<div>').addClass('nodetitle').appendTo(div);
-  $('<span>').addClass('nodename').html(query.toHTML()).appendTo(nodetitle);
-  if (description) {
+  if ('relativeName' in n) {
+    $('<span>').addClass('nodename').text(n.relativeName).appendTo(nodetitle);
+  }
+  $('<input>')
+    .attr('type', 'text')
+    .prop('readonly', true)
+    .addClass('nodequery')
+    .val(n.query.toString())
+    .appendTo(nodetitle);
+  if ('description' in n && n.description) {
     $('<div>')
       .addClass('nodedescription')
-      .html(description.replace(/\n/g, '<br>'))
+      .html(n.description.replace(/\n\n/g, '<br><br>'))
       .appendTo(nodetitle);
   }
   return div[0];
@@ -146,6 +191,8 @@ function makeTreeNodeHeaderHTML(
 function updateJSON(): void {
   resultsJSON.textContent = logger.asJSON(2);
 }
+
+let rootQueryLevel: TestQueryLevel = 1;
 
 (async () => {
   const loader = new DefaultTestFileLoader();
@@ -172,10 +219,17 @@ function updateJSON(): void {
   }
 
   assert(qs.length === 1, 'currently, there must be exactly one ?q=');
-  const tree = await loader.loadTree(qs[0]);
+  const rootQuery = parseQuery(qs[0]);
+  rootQueryLevel = rootQuery.level;
+  const tree = await loader.loadTree(rootQuery);
 
-  const [el, runSubtree] = makeSubtreeHTML(tree.root);
+  const [el, runSubtree] = makeSubtreeHTML(tree.root, 1);
   resultsVis.append(el);
+
+  $('#expandall').change(function (this) {
+    const checked = (this as HTMLInputElement).checked;
+    $('.collapsebtn').prop('checked', checked).trigger('change');
+  });
 
   if (runnow) {
     runSubtree();

--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -1,5 +1,6 @@
 import { DefaultTestFileLoader } from '../framework/file_loader.js';
 import { Logger } from '../framework/logging/logger.js';
+import { parseQuery } from '../framework/query/parseQuery.js';
 import { TestTreeLeaf } from '../framework/tree.js';
 import { AsyncMutex } from '../framework/util/async_mutex.js';
 import { assert } from '../framework/util/util.js';
@@ -19,7 +20,7 @@ declare function async_test(f: (this: WptTestObject) => Promise<void>, name: str
   const loader = new DefaultTestFileLoader();
   const qs = new URLSearchParams(window.location.search).getAll('q');
   assert(qs.length === 1, 'currently, there must be exactly one ?q=');
-  const testcases = await loader.loadTests(qs[0]);
+  const testcases = await loader.loadCases(parseQuery(qs[0]));
 
   await addWPTTests(testcases);
 })();

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -2,8 +2,7 @@ import { promises as fs } from 'fs';
 
 import { listing } from '../../webgpu/listing.js';
 import { DefaultTestFileLoader } from '../framework/file_loader.js';
-import { TestQueryMultiTest } from '../framework/query/query.js';
-import { kBigSeparator, kWildcard } from '../framework/query/separators.js';
+import { TestQueryMultiTest, TestQueryMultiFile } from '../framework/query/query.js';
 import { TestSuiteListingEntry } from '../framework/test_suite_listing.js';
 import { assert } from '../framework/util/util.js';
 
@@ -84,10 +83,8 @@ const [
     const loader = new DefaultTestFileLoader();
     const lines: Array<string | undefined> = [];
     for (const prefix of argsPrefixes) {
-      const tree = await loader.loadTree(
-        suite + kBigSeparator + kWildcard,
-        expectations.get(prefix)!
-      );
+      const rootQuery = new TestQueryMultiFile(suite, []);
+      const tree = await loader.loadTree(rootQuery, expectations.get(prefix)!);
 
       lines.push(undefined); // output blank line between prefixes
       for (const q of tree.iterateCollapsedQueries()) {

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -39,11 +39,15 @@
       .nodeheader {
         display: flex;
         width: 100%;
-        padding: 1px 2px 1px 1px;
+        padding: 0px 2px 0px 1px;
+      }
+      .nodeheader:hover {
+        background: #eee;
       }
       .subtreerun,
       .leafrun,
       .nodelink,
+      .collapsebtn,
       .testcaselogbtn {
         display: inline-block;
         flex-shrink: 0;
@@ -58,17 +62,19 @@
         .subtreerun,
         .leafrun,
         .nodelink,
+        .collapsebtn,
         .testcaselogbtn {
           flex-basis: 24px;
           border-radius: 4px;
           width: 24px;
-          height: 24px;
+          height: 18px;
         }
       }
       @media (pointer: coarse) {
         .subtreerun,
         .leafrun,
         .nodelink,
+        .collapsebtn,
         .testcaselogbtn {
           flex-basis: 36px;
           border-radius: 6px;
@@ -89,11 +95,17 @@
         flex: 10 0 4em;
       }
       .nodename {
-        word-break: break-word;
+        background: transparent;
+        border: none;
+        margin: 0 0.5em;
       }
-      @media only screen and (max-width: 600px) {
-        /* TODO: make the uninteresting part of the name be really small or something, such that it gets
-         * auto selected but doesn't take space. */
+      .nodequery {
+        background: transparent;
+        border: none;
+        margin: 0 0.5em;
+        color: #ccc;
+        width: 50%;
+        max-width: 50%;
       }
       .nodedescription {
         margin: 0;
@@ -106,7 +118,20 @@
         margin: 0px;
         border-width: 1px 0 0 1px;
         border-style: solid;
-        border-color: gray;
+        border-color: #ddd;
+      }
+      .subtree:hover {
+        border-left-color: #000;
+      }
+      .subtree.multifile > .subtreechildren > .subtree.multitest,
+      .subtree.multifile > .subtreechildren > .subtree.multicase {
+        border-width: 2px 0 0 1px;
+        border-color: #55f;
+      }
+      .subtree.multitest > .subtreechildren > .subtree.multicase,
+      .subtree.multitest > .subtreechildren > .testcase {
+        border-width: 2px 0 0 1px;
+        border-color: #bbf;
       }
       .subtreechildren {
         margin-left: 6px;
@@ -182,10 +207,11 @@
   </head>
   <body>
     <h1>WebGPU Conformance Test Suite</h1>
+    <input type="checkbox" id="expandall" /><label for="expandall">Expand All</label>
 
     <div id="info"></div>
     <div id="resultsVis"></div>
-    <textarea id="resultsJSON"></textarea>
+    <textarea id="resultsJSON" spellcheck="false"></textarea>
 
     <script type="module" src="../out/common/runtime/standalone.js"></script>
   </body>


### PR DESCRIPTION
DOM is not lazy-loaded, but at least every case is not displayed by default.

The default state is everything expanded, except for:
- top level of a file (`s:f:*`)
- top level of a test (`s:f:t:*`)

Followup: should collapse logs for each case, as well.