### PR TITLE
Reduce logging verbosity

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -43,7 +43,7 @@ export class Fixture {
   }
 
   fail(msg?: string): void {
-    this.rec.fail(new Error(msg));
+    this.rec.expectationFailed(new Error(msg));
   }
 
   protected async immediateAsyncExpectation<T>(fn: () => Promise<T>): Promise<T> {
@@ -62,13 +62,13 @@ export class Fixture {
   private expectErrorValue(expectedName: string, ex: unknown, niceStack: Error): void {
     if (!(ex instanceof Error)) {
       niceStack.message = `THREW non-error value, of type ${typeof ex}: ${ex}`;
-      this.rec.fail(niceStack);
+      this.rec.expectationFailed(niceStack);
       return;
     }
     const actualName = ex.name;
     if (actualName !== expectedName) {
       niceStack.message = `THREW ${actualName}, instead of ${expectedName}: ${ex}`;
-      this.rec.fail(niceStack);
+      this.rec.expectationFailed(niceStack);
     } else {
       niceStack.message = `OK: threw ${actualName}${ex.message}`;
       this.rec.debug(niceStack);
@@ -81,7 +81,7 @@ export class Fixture {
       try {
         await p;
         niceStack.message = 'DID NOT REJECT' + m;
-        this.rec.fail(niceStack);
+        this.rec.expectationFailed(niceStack);
       } catch (ex) {
         niceStack.message = m;
         this.expectErrorValue(expectedName, ex, niceStack);
@@ -93,7 +93,7 @@ export class Fixture {
     const m = msg ? ': ' + msg : '';
     try {
       fn();
-      this.rec.fail(new Error('DID NOT THROW' + m));
+      this.rec.expectationFailed(new Error('DID NOT THROW' + m));
     } catch (ex) {
       this.expectErrorValue(expectedName, ex, new Error(m));
     }
@@ -104,7 +104,7 @@ export class Fixture {
       const m = msg ? ': ' + msg : '';
       this.rec.debug(new Error('expect OK' + m));
     } else {
-      this.rec.fail(new Error(msg));
+      this.rec.expectationFailed(new Error(msg));
     }
     return cond;
   }

--- a/src/common/framework/logging/log_message.ts
+++ b/src/common/framework/logging/log_message.ts
@@ -1,8 +1,8 @@
 import { extractImportantStackTrace } from '../util/stack.js';
 
 export class LogMessageWithStack extends Error {
-  printStack: boolean = true;
-  timesSeen: number = 1;
+  private stackHidden: boolean = false;
+  private timesSeen: number = 1;
 
   constructor(name: string, ex: Error) {
     super(ex.message);
@@ -11,9 +11,19 @@ export class LogMessageWithStack extends Error {
     this.stack = ex.stack;
   }
 
+  /** Set a flag so the stack is not printed in toJSON(). */
+  setStackHidden() {
+    this.stackHidden = false;
+  }
+
+  /** Increment the "seen x times" counter. */
+  incrementTimesSeen() {
+    this.timesSeen++;
+  }
+
   toJSON(): string {
     let m = this.name + ': ';
-    if (this.printStack && this.stack) {
+    if (this.stackHidden && this.stack) {
       // this.message is already included in this.stack
       m += extractImportantStackTrace(this);
     } else {

--- a/src/common/framework/logging/log_message.ts
+++ b/src/common/framework/logging/log_message.ts
@@ -2,6 +2,7 @@ import { extractImportantStackTrace } from '../util/stack.js';
 
 export class LogMessageWithStack extends Error {
   printStack: boolean = true;
+  timesSeen: number = 1;
 
   constructor(name: string, ex: Error) {
     super(ex.message);
@@ -17,6 +18,9 @@ export class LogMessageWithStack extends Error {
       m += extractImportantStackTrace(this);
     } else {
       m += this.message;
+    }
+    if (this.timesSeen > 1) {
+      m += `\n(seen ${this.timesSeen} times with identical stack)`;
     }
     return m;
   }

--- a/src/common/framework/logging/log_message.ts
+++ b/src/common/framework/logging/log_message.ts
@@ -13,7 +13,7 @@ export class LogMessageWithStack extends Error {
 
   /** Set a flag so the stack is not printed in toJSON(). */
   setStackHidden() {
-    this.stackHidden = false;
+    this.stackHidden = true;
   }
 
   /** Increment the "seen x times" counter. */
@@ -23,7 +23,7 @@ export class LogMessageWithStack extends Error {
 
   toJSON(): string {
     let m = this.name + ': ';
-    if (this.stackHidden && this.stack) {
+    if (!this.stackHidden && this.stack) {
       // this.message is already included in this.stack
       m += extractImportantStackTrace(this);
     } else {

--- a/src/common/framework/logging/log_message.ts
+++ b/src/common/framework/logging/log_message.ts
@@ -1,16 +1,18 @@
 import { extractImportantStackTrace } from '../util/stack.js';
 
 export class LogMessageWithStack extends Error {
-  constructor(name: string, ex: Error, includeStack: boolean = true) {
+  printStack: boolean = true;
+
+  constructor(name: string, ex: Error) {
     super(ex.message);
 
     this.name = name;
-    this.stack = includeStack ? ex.stack : undefined;
+    this.stack = ex.stack;
   }
 
   toJSON(): string {
     let m = this.name + ': ';
-    if (this.stack) {
+    if (this.printStack && this.stack) {
       // this.message is already included in this.stack
       m += extractImportantStackTrace(this);
     } else {

--- a/src/common/framework/logging/test_case_recorder.ts
+++ b/src/common/framework/logging/test_case_recorder.ts
@@ -2,21 +2,26 @@ import { SkipTestCase } from '../fixture.js';
 import { now, assert } from '../util/util.js';
 
 import { LogMessageWithStack } from './log_message.js';
-import { LiveTestCaseResult, Status } from './result.js';
+import { LiveTestCaseResult } from './result.js';
 
-enum PassState {
-  pass = 0,
-  skip = 1,
-  warn = 2,
-  fail = 3,
+enum LogSeverity {
+  Pass = 0,
+  Skip = 1,
+  Warn = 2,
+  ExpectFailed = 3,
+  ValidationFailed = 4,
+  ThrewException = 5,
 }
+
+const kMaxLogStacks = 2;
 
 // Holds onto a LiveTestCaseResult owned by the Logger, and writes the results into it.
 export class TestCaseRecorder {
   private result: LiveTestCaseResult;
-  private state = PassState.pass;
+  private maxLogSeverity = LogSeverity.Pass;
   private startTime = -1;
   private logs: LogMessageWithStack[] = [];
+  private logLinesAtCurrentSeverity = 0;
   private debugging = false;
 
   constructor(result: LiveTestCaseResult, debugging: boolean) {
@@ -35,7 +40,16 @@ export class TestCaseRecorder {
     const timeMilliseconds = now() - this.startTime;
     // Round to next microsecond to avoid storing useless .xxxx00000000000002 in results.
     this.result.timems = Math.ceil(timeMilliseconds * 1000) / 1000;
-    this.result.status = PassState[this.state] as Status; // Convert numeric enum back to string
+
+    // Convert numeric enum back to string (but expose 'exception' as 'fail')
+    this.result.status =
+      this.maxLogSeverity === LogSeverity.Pass
+        ? 'pass'
+        : this.maxLogSeverity === LogSeverity.Skip
+        ? 'skip'
+        : this.maxLogSeverity === LogSeverity.Warn
+        ? 'warn'
+        : 'fail'; // Everything else is an error
 
     this.result.logs = this.logs;
   }
@@ -48,22 +62,25 @@ export class TestCaseRecorder {
     if (!this.debugging) {
       return;
     }
-    this.logs.push(new LogMessageWithStack('DEBUG', ex, false));
-  }
-
-  warn(ex: Error): void {
-    this.setState(PassState.warn);
-    this.logs.push(new LogMessageWithStack('WARN', ex));
-  }
-
-  fail(ex: Error): void {
-    this.setState(PassState.fail);
-    this.logs.push(new LogMessageWithStack('FAIL', ex));
+    const logMessage = new LogMessageWithStack('DEBUG', ex);
+    logMessage.printStack = false;
+    this.logImpl(LogSeverity.Pass, logMessage);
   }
 
   skipped(ex: SkipTestCase): void {
-    this.setState(PassState.skip);
-    this.logs.push(new LogMessageWithStack('SKIP', ex));
+    this.logImpl(LogSeverity.Skip, new LogMessageWithStack('SKIP', ex));
+  }
+
+  warn(ex: Error): void {
+    this.logImpl(LogSeverity.Warn, new LogMessageWithStack('WARN', ex));
+  }
+
+  expectationFailed(ex: Error): void {
+    this.logImpl(LogSeverity.ExpectFailed, new LogMessageWithStack('EXPECTATION FAILED', ex));
+  }
+
+  validationFailed(ex: Error): void {
+    this.logImpl(LogSeverity.ValidationFailed, new LogMessageWithStack('VALIDATION FAILED', ex));
   }
 
   threw(ex: Error): void {
@@ -71,12 +88,26 @@ export class TestCaseRecorder {
       this.skipped(ex);
       return;
     }
-
-    this.setState(PassState.fail);
-    this.logs.push(new LogMessageWithStack('EXCEPTION', ex));
+    this.logImpl(LogSeverity.ThrewException, new LogMessageWithStack('EXCEPTION', ex));
   }
 
-  private setState(state: PassState): void {
-    this.state = Math.max(this.state, state);
+  private logImpl(level: LogSeverity, logMessage: LogMessageWithStack): void {
+    if (level > this.maxLogSeverity) {
+      this.logLinesAtCurrentSeverity = 0;
+      this.maxLogSeverity = level;
+      if (!this.debugging) {
+        // Go back and turn off printStack for everything of a lower log level
+        for (const log of this.logs) {
+          log.printStack = false;
+        }
+      }
+    }
+    if (level < this.maxLogSeverity || this.logLinesAtCurrentSeverity >= kMaxLogStacks) {
+      if (!this.debugging) {
+        logMessage.printStack = false;
+      }
+    }
+    this.logs.push(logMessage);
+    this.logLinesAtCurrentSeverity++;
   }
 }

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -239,7 +239,7 @@ g.test('end2end').fn(async t => {
     'fail',
     logs =>
       logs.length === 1 &&
-      logs[0].startsWith('"FAIL: Error: bye\\n') &&
+      logs[0].startsWith('"EXPECTATION FAILED: Error: bye\\n') &&
       logs[0].indexOf('loaders_and_trees.spec.') !== -1
   );
 });

--- a/src/unittests/logger.spec.ts
+++ b/src/unittests/logger.spec.ts
@@ -79,12 +79,40 @@ g.test('warn').fn(t => {
   t.expect(res.timems >= 0);
 });
 
-g.test('fail').fn(t => {
+g.test('fail,expectationFailed').fn(t => {
   const mylog = new Logger(true);
   const [rec, res] = mylog.record('one');
 
   rec.start();
-  rec.fail(new Error('bye'));
+  rec.expectationFailed(new Error('bye'));
+  rec.warn(new Error());
+  rec.skipped(new SkipTestCase());
+  rec.finish();
+
+  t.expect(res.status === 'fail');
+  t.expect(res.timems >= 0);
+});
+
+g.test('fail,validationFailed').fn(t => {
+  const mylog = new Logger(true);
+  const [rec, res] = mylog.record('one');
+
+  rec.start();
+  rec.validationFailed(new Error('bye'));
+  rec.warn(new Error());
+  rec.skipped(new SkipTestCase());
+  rec.finish();
+
+  t.expect(res.status === 'fail');
+  t.expect(res.timems >= 0);
+});
+
+g.test('fail,threw').fn(t => {
+  const mylog = new Logger(true);
+  const [rec, res] = mylog.record('one');
+
+  rec.start();
+  rec.threw(new Error('bye'));
   rec.warn(new Error());
   rec.skipped(new SkipTestCase());
   rec.finish();
@@ -106,7 +134,7 @@ g.test('debug')
 
     rec.start();
     rec.debug(new Error('hello'));
-    rec.fail(new Error('bye'));
+    rec.expectationFailed(new Error('bye'));
     rec.warn(new Error());
     rec.skipped(new SkipTestCase());
     rec.debug(new Error('foo'));

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -105,7 +105,7 @@ export class ValidationTest extends GPUTest {
       const gpuValidationError = await promise;
       if (!gpuValidationError) {
         niceStack.message = 'Validation error was expected.';
-        this.rec.fail(niceStack);
+        this.rec.validationFailed(niceStack);
       } else if (gpuValidationError instanceof GPUValidationError) {
         niceStack.message = `Captured validation error - ${gpuValidationError.message}`;
         this.rec.debug(niceStack);

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -106,7 +106,7 @@ export class GPUTest extends Fixture {
       const check = this.checkBuffer(actual, expected);
       if (check !== undefined) {
         niceStack.message = check;
-        this.rec.fail(niceStack);
+        this.rec.expectationFailed(niceStack);
       }
       dst.destroy();
     });
@@ -115,7 +115,7 @@ export class GPUTest extends Fixture {
   expectBuffer(actual: Uint8Array, exp: Uint8Array): void {
     const check = this.checkBuffer(actual, exp);
     if (check !== undefined) {
-      this.rec.fail(new Error(check));
+      this.rec.expectationFailed(new Error(check));
     }
   }
 
@@ -140,7 +140,7 @@ export class GPUTest extends Fixture {
           break;
         }
         failedPixels++;
-        lines.push(`at [${i}], expected ${exp[i]}, got ${actual[i]}`);
+        lines.push(`index [${i}]: expected ${exp[i]}, got ${actual[i]}`);
       }
     }
 

--- a/src/webgpu/web-platform/copyImageBitmapToTexture.spec.ts
+++ b/src/webgpu/web-platform/copyImageBitmapToTexture.spec.ts
@@ -36,7 +36,7 @@ class F extends GPUTest {
       );
       if (check !== undefined) {
         niceStack.message = check;
-        this.rec.fail(niceStack);
+        this.rec.expectationFailed(niceStack);
       }
       dst.destroy();
     });
@@ -62,7 +62,7 @@ class F extends GPUTest {
             break;
           }
           failedPixels++;
-          lines.push(`at [${indexExp}], expected ${exp[indexExp]}, got ${actual[indexActual]}`);
+          lines.push(`index [${indexExp}]: expected ${exp[indexExp]}, got ${actual[indexActual]}`);
         }
       }
       if (failedPixels > 4) {

--- a/src/webgpu/web-platform/copyImageBitmapToTexture.spec.ts
+++ b/src/webgpu/web-platform/copyImageBitmapToTexture.spec.ts
@@ -50,27 +50,33 @@ class F extends GPUTest {
     rowPitch: number,
     bytesPerPixel: number
   ): string | undefined {
-    const lines = [];
-    let failedPixels = 0;
-    for (let i = 0; i < height; ++i) {
+    const failedByteIndices: string[] = [];
+    const failedByteExpectedValues: string[] = [];
+    const failedByteActualValues: string[] = [];
+    iLoop: for (let i = 0; i < height; ++i) {
       const bytesPerRow = width * bytesPerPixel;
       for (let j = 0; j < bytesPerRow; ++j) {
         const indexExp = j + i * bytesPerRow;
         const indexActual = j + rowPitch * i;
         if (actual[indexActual] !== exp[indexExp]) {
-          if (failedPixels > 4) {
-            break;
+          if (failedByteIndices.length >= 4) {
+            failedByteIndices.push('...');
+            failedByteExpectedValues.push('...');
+            failedByteActualValues.push('...');
+            break iLoop;
           }
-          failedPixels++;
-          lines.push(`index [${indexExp}]: expected ${exp[indexExp]}, got ${actual[indexActual]}`);
+          failedByteIndices.push(`(${i},${j})`);
+          failedByteExpectedValues.push(exp[indexExp].toString());
+          failedByteActualValues.push(actual[indexActual].toString());
         }
       }
-      if (failedPixels > 4) {
-        lines.push('... and more');
-        break;
-      }
     }
-    return failedPixels > 0 ? lines.join('\n') : undefined;
+    if (failedByteIndices.length > 0) {
+      return `at [${failedByteIndices.join(', ')}], \
+expected [${failedByteExpectedValues.join(', ')}], \
+got [${failedByteActualValues.join(', ')}]`;
+    }
+    return undefined;
   }
 
   doTestAndCheckResult(


### PR DESCRIPTION
Excess verbosity was making it difficult to navigate both the standalone runner and the logs from our WPT bots.