### PR TITLE
Replace usages of constants.ts with `as const`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
       },
       lint: {
         cmd: 'node',
-        args: ['node_modules/eslint/bin/eslint', 'src/**/*.ts'],
+        args: ['node_modules/eslint/bin/eslint', 'src/**/*.ts', '--max-warnings=0'],
       },
       fix: {
         cmd: 'node',

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -93,7 +93,7 @@ g.test('duplicate_test_name').fn(t => {
   });
 });
 
-g.test('duplicate_test_params,none').fn(t => {
+g.test('duplicate_test_params,none').fn(() => {
   {
     const g = makeTestGroupForUnitTesting(UnitTest);
     g.test('abc')

--- a/src/webgpu/api/operation/resource_init/copied_texture_clear.spec.ts
+++ b/src/webgpu/api/operation/resource_init/copied_texture_clear.spec.ts
@@ -1,6 +1,5 @@
 export const description = 'Test uninitialized textures are initialized to zero when copied.';
 
-import * as C from '../../../../common/constants.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, unreachable } from '../../../../common/framework/util/util.js';
 import { SubresourceRange } from '../../../util/texture/subresource.js';
@@ -40,7 +39,7 @@ class CopiedTextureClearTest extends TextureZeroInitTest {
       const dst = this.device.createTexture({
         size: [width, height, 1],
         format: this.params.format,
-        usage: C.TextureUsage.CopyDst | C.TextureUsage.CopySrc,
+        usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
       });
 
       const commandEncoder = this.device.createCommandEncoder();

--- a/src/webgpu/api/operation/resource_init/texture_zero_init_test.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero_init_test.ts
@@ -1,4 +1,4 @@
-import * as C from '../../../../common/constants.js';
+import { TextureUsage } from '../../../../common/constants.js';
 import { TestCaseRecorder } from '../../../../common/framework/logging/test_case_recorder.js';
 import { params, poptions, pbool } from '../../../../common/framework/params_builder.js';
 import { CaseParams } from '../../../../common/framework/params_utils.js';
@@ -163,13 +163,13 @@ function getRequiredTextureUsage(
   uninitializeMethod: UninitializeMethod,
   readMethod: ReadMethod
 ): GPUTextureUsageFlags {
-  let usage: GPUTextureUsageFlags = C.TextureUsage.CopyDst;
+  let usage: GPUTextureUsageFlags = TextureUsage.CopyDst;
 
   switch (uninitializeMethod) {
     case UninitializeMethod.Creation:
       break;
     case UninitializeMethod.StoreOpClear:
-      usage |= C.TextureUsage.OutputAttachment;
+      usage |= TextureUsage.OutputAttachment;
       break;
     default:
       unreachable();
@@ -178,18 +178,18 @@ function getRequiredTextureUsage(
   switch (readMethod) {
     case ReadMethod.CopyToBuffer:
     case ReadMethod.CopyToTexture:
-      usage |= C.TextureUsage.CopySrc;
+      usage |= TextureUsage.CopySrc;
       break;
     case ReadMethod.Sample:
-      usage |= C.TextureUsage.Sampled;
+      usage |= TextureUsage.Sampled;
       break;
     case ReadMethod.Storage:
-      usage |= C.TextureUsage.Storage;
+      usage |= TextureUsage.Storage;
       break;
     case ReadMethod.DepthTest:
     case ReadMethod.StencilTest:
     case ReadMethod.ColorBlending:
-      usage |= C.TextureUsage.OutputAttachment;
+      usage |= TextureUsage.OutputAttachment;
       break;
     default:
       unreachable();
@@ -198,14 +198,14 @@ function getRequiredTextureUsage(
   if (sampleCount > 1) {
     // Copies to multisampled textures are not allowed. We need OutputAttachment to initialize
     // canary data in multisampled textures.
-    usage |= C.TextureUsage.OutputAttachment;
+    usage |= TextureUsage.OutputAttachment;
   }
 
   if (!kTextureFormatInfo[format].copyable) {
     // Copies are not possible. We need OutputAttachment to initialize
     // canary data.
     assert(kTextureFormatInfo[format].renderable);
-    usage |= C.TextureUsage.OutputAttachment;
+    usage |= TextureUsage.OutputAttachment;
   }
 
   return usage;
@@ -510,11 +510,11 @@ export abstract class TextureZeroInitTest extends GPUTest {
             readMethod
           );
 
-          if (usage & C.TextureUsage.OutputAttachment && !kTextureFormatInfo[format].renderable) {
+          if (usage & TextureUsage.OutputAttachment && !kTextureFormatInfo[format].renderable) {
             return false;
           }
 
-          if (usage & C.TextureUsage.Storage && !kTextureFormatInfo[format].storage) {
+          if (usage & TextureUsage.Storage && !kTextureFormatInfo[format].storage) {
             return false;
           }
 

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 createBindGroup validation tests.
 `;
 
-import * as C from '../../../common/constants.js';
 import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { unreachable } from '../../../common/framework/util/util.js';
@@ -117,7 +116,7 @@ g.test('texture_binding_must_have_correct_usage')
 
     const descriptor = {
       size: { width: 16, height: 16, depth: 1 },
-      format: C.TextureFormat.RGBA8Unorm,
+      format: 'rgba8unorm' as const,
       usage,
     };
 
@@ -131,13 +130,7 @@ g.test('texture_binding_must_have_correct_usage')
   });
 
 g.test('texture_must_have_correct_component_type')
-  .params(
-    poptions('textureComponentType', [
-      C.TextureComponentType.Float,
-      C.TextureComponentType.Sint,
-      C.TextureComponentType.Uint,
-    ])
-  )
+  .params(poptions('textureComponentType', ['float', 'sint', 'uint'] as const))
   .fn(async t => {
     const { textureComponentType } = t.params;
 
@@ -222,7 +215,7 @@ g.test('texture_must_have_correct_dimension').fn(async t => {
 
   const goodDescriptor = {
     size: { width: 16, height: 16, depth: 1 },
-    format: C.TextureFormat.RGBA8Unorm,
+    format: 'rgba8unorm' as const,
     usage: GPUTextureUsage.SAMPLED,
   };
 

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 createBindGroupLayout validation tests.
 `;
 
-import * as C from '../../../common/constants.js';
 import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
@@ -23,8 +22,8 @@ export const g = makeTestGroup(ValidationTest);
 g.test('some_binding_index_was_specified_more_than_once').fn(async t => {
   const goodDescriptor = {
     entries: [
-      { binding: 0, visibility: GPUShaderStage.COMPUTE, type: C.BindingType.StorageBuffer },
-      { binding: 1, visibility: GPUShaderStage.COMPUTE, type: C.BindingType.StorageBuffer },
+      { binding: 0, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' as const },
+      { binding: 1, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' as const },
     ],
   };
 
@@ -48,8 +47,8 @@ g.test('visibility_of_bindings_can_be_0').fn(async t => {
 
 g.test('number_of_dynamic_buffers_exceeds_the_maximum_value')
   .params([
-    { type: C.BindingType.StorageBuffer, maxDynamicBufferCount: 4 },
-    { type: C.BindingType.UniformBuffer, maxDynamicBufferCount: 8 },
+    { type: 'storage-buffer' as const, maxDynamicBufferCount: 4 },
+    { type: 'uniform-buffer' as const, maxDynamicBufferCount: 8 },
   ])
   .fn(async t => {
     const { type, maxDynamicBufferCount } = t.params;

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 createPipelineLayout validation tests.
 `;
 
-import * as C from '../../../common/constants.js';
 import { pbool, poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
@@ -24,11 +23,7 @@ g.test('number_of_dynamic_buffers_exceeds_the_maximum_value')
     params()
       .combine(poptions('visibility', [0, 2, 4, 6]))
       .combine(
-        poptions('type', [
-          C.BindingType.UniformBuffer,
-          C.BindingType.StorageBuffer,
-          C.BindingType.ReadonlyStorageBuffer,
-        ])
+        poptions('type', ['uniform-buffer', 'storage-buffer', 'readonly-storage-buffer'] as const)
       )
   )
   .fn(async t => {

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 createView validation tests.
 `;
 
-import * as C from '../../../common/constants.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 import { ValidationTest } from './validation_test.js';
@@ -75,7 +74,7 @@ g.test('creating_texture_view_on_a_2D_non_array_texture')
     { _success: true }, // default view works
     { arrayLayerCount: 1, _success: true }, // it is OK to create a 2D texture view on a 2D texture
     { arrayLayerCount: 2, _success: false }, // it is an error to view a layer past the end of the texture
-    { dimension: C.TextureViewDimension.E2dArray, arrayLayerCount: 1, _success: true }, // it is OK to create a 1-layer 2D array texture view on a 2D texture
+    { dimension: '2d-array' as const, arrayLayerCount: 1, _success: true }, // it is OK to create a 1-layer 2D array texture view on a 2D texture
     // mip level is in range
     { mipLevelCount: 1, baseMipLevel: MIP_LEVEL_COUNT - 1, _success: true },
     { mipLevelCount: 2, baseMipLevel: MIP_LEVEL_COUNT - 2, _success: true },
@@ -110,7 +109,7 @@ g.test('creating_texture_view_on_a_2D_non_array_texture')
 g.test('creating_texture_view_on_a_2D_array_texture')
   .params([
     { _success: true }, // default view works
-    { dimension: C.TextureViewDimension.E2d, arrayLayerCount: 1, _success: true }, // it is OK to create a 2D texture view on a 2D array texture
+    { dimension: '2d' as const, arrayLayerCount: 1, _success: true }, // it is OK to create a 2D texture view on a 2D array texture
     { arrayLayerCount: ARRAY_LAYER_COUNT_2D, _success: true }, // it is OK to create a 2D array texture view on a 2D array texture
     // baseArrayLayer == k && arrayLayerCount == 0 means to use layers k..end.
     { arrayLayerCount: 0, baseArrayLayer: 0, _success: true },
@@ -142,23 +141,19 @@ g.test('creating_texture_view_on_a_2D_array_texture')
 g.test('Using_defaults_validates_the_same_as_setting_values_for_more_than_1_array_layer')
   .params([
     { _success: true },
-    { format: C.TextureFormat.RGBA8Unorm, _success: true },
-    { format: C.TextureFormat.R8Unorm, _success: false },
-    { dimension: C.TextureViewDimension.E2dArray, _success: true },
-    { dimension: C.TextureViewDimension.E2d, _success: false },
+    { format: 'rgba8unorm', _success: true },
+    { format: 'r8unorm', _success: false },
+    { dimension: '2d-array', _success: true },
+    { dimension: '2d', _success: false },
     { arrayLayerCount: ARRAY_LAYER_COUNT_2D, _success: false }, // setting array layers to non-0 means the dimensionality will default to 2D so by itself it causes an error.
+    { arrayLayerCount: ARRAY_LAYER_COUNT_2D, dimension: '2d-array', _success: true },
     {
       arrayLayerCount: ARRAY_LAYER_COUNT_2D,
-      dimension: C.TextureViewDimension.E2dArray,
-      _success: true,
-    },
-    {
-      arrayLayerCount: ARRAY_LAYER_COUNT_2D,
-      dimension: C.TextureViewDimension.E2dArray,
+      dimension: '2d-array',
       mipLevelCount: MIP_LEVEL_COUNT,
       _success: true,
     },
-  ])
+  ] as const)
   .fn(async t => {
     const { format, dimension, arrayLayerCount, mipLevelCount, _success } = t.params;
 
@@ -174,16 +169,16 @@ g.test('Using_defaults_validates_the_same_as_setting_values_for_more_than_1_arra
 g.test('Using_defaults_validates_the_same_as_setting_values_for_only_1_array_layer')
   .params([
     { _success: true },
-    { format: C.TextureFormat.RGBA8Unorm, _success: true },
-    { format: C.TextureFormat.R8Unorm, _success: false },
-    { dimension: C.TextureViewDimension.E2dArray, _success: true },
-    { dimension: C.TextureViewDimension.E2d, _success: true },
+    { format: 'rgba8unorm', _success: true },
+    { format: 'r8unorm', _success: false },
+    { dimension: '2d-array', _success: true },
+    { dimension: '2d', _success: true },
     { arrayLayerCount: 0, _success: true },
     { arrayLayerCount: 1, _success: true },
     { arrayLayerCount: 2, _success: false },
     { mipLevelCount: MIP_LEVEL_COUNT, _success: true },
     { mipLevelCount: 1, _success: true },
-  ])
+  ] as const)
   .fn(async t => {
     const { format, dimension, arrayLayerCount, mipLevelCount, _success } = t.params;
 
@@ -198,17 +193,17 @@ g.test('Using_defaults_validates_the_same_as_setting_values_for_only_1_array_lay
 
 g.test('creating_cube_map_texture_view')
   .params([
-    { dimension: C.TextureViewDimension.Cube, arrayLayerCount: 6, _success: true }, // it is OK to create a cube map texture view with arrayLayerCount == 6
+    { dimension: 'cube', arrayLayerCount: 6, _success: true }, // it is OK to create a cube map texture view with arrayLayerCount == 6
     // it is an error to create a cube map texture view with arrayLayerCount != 6
-    { dimension: C.TextureViewDimension.Cube, arrayLayerCount: 3, _success: false },
-    { dimension: C.TextureViewDimension.Cube, arrayLayerCount: 7, _success: false },
-    { dimension: C.TextureViewDimension.Cube, arrayLayerCount: 12, _success: false },
-    { dimension: C.TextureViewDimension.Cube, _success: false },
-    { dimension: C.TextureViewDimension.CubeArray, arrayLayerCount: 12, _success: true }, // it is OK to create a cube map array texture view with arrayLayerCount % 6 == 0
+    { dimension: 'cube', arrayLayerCount: 3, _success: false },
+    { dimension: 'cube', arrayLayerCount: 7, _success: false },
+    { dimension: 'cube', arrayLayerCount: 12, _success: false },
+    { dimension: 'cube', _success: false },
+    { dimension: 'cube-array', arrayLayerCount: 12, _success: true }, // it is OK to create a cube map array texture view with arrayLayerCount % 6 == 0
     // it is an error to create a cube map array texture view with arrayLayerCount % 6 != 0
-    { dimension: C.TextureViewDimension.CubeArray, arrayLayerCount: 11, _success: false },
-    { dimension: C.TextureViewDimension.CubeArray, arrayLayerCount: 13, _success: false },
-  ])
+    { dimension: 'cube-array', arrayLayerCount: 11, _success: false },
+    { dimension: 'cube-array', arrayLayerCount: 13, _success: false },
+  ] as const)
   .fn(async t => {
     const { dimension = '2d-array', arrayLayerCount, _success } = t.params;
 
@@ -226,9 +221,9 @@ g.test('creating_cube_map_texture_view')
 
 g.test('creating_cube_map_texture_view_with_a_non_square_texture')
   .params([
-    { dimension: C.TextureViewDimension.Cube, arrayLayerCount: 6 }, // it is an error to create a cube map texture view with width != height.
-    { dimension: C.TextureViewDimension.CubeArray, arrayLayerCount: 12 }, // it is an error to create a cube map array texture view with width != height.
-  ])
+    { dimension: 'cube', arrayLayerCount: 6 }, // it is an error to create a cube map texture view with width != height.
+    { dimension: 'cube-array', arrayLayerCount: 12 }, // it is an error to create a cube map array texture view with width != height.
+  ] as const)
   .fn(async t => {
     const { dimension, arrayLayerCount } = t.params;
 

--- a/src/webgpu/util/texture/layout.ts
+++ b/src/webgpu/util/texture/layout.ts
@@ -1,4 +1,3 @@
-import * as C from '../../../common/constants.js';
 import { assert, unreachable } from '../../../common/framework/util/util.js';
 import { kTextureFormatInfo } from '../../capability_info.js';
 import { align, isAligned } from '../math.js';
@@ -143,7 +142,7 @@ export function createTextureUploadBuffer(
 
   const [buffer, mapping] = device.createBufferMapped({
     size: byteLength,
-    usage: C.BufferUsage.CopySrc,
+    usage: GPUBufferUsage.COPY_SRC,
   });
 
   assert(texelValue.byteLength === bytesPerBlock);

--- a/src/webgpu/web-platform/copyImageBitmapToTexture.spec.ts
+++ b/src/webgpu/web-platform/copyImageBitmapToTexture.spec.ts
@@ -151,6 +151,7 @@ g.test('from_ImageData')
     }
 
     const imageData = new ImageData(imagePixels, width, height);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const imageBitmap = await (createImageBitmap as any)(imageData, {
       premultiplyAlpha: alpha,
       imageOrientation: orientation,


### PR DESCRIPTION
I discovered `as const` today. It's really useful.

- [ ] Probably needs more work on `glsl-dependent` after landing