### PR TITLE
[glsl-dependent] Replace some usages of constants.ts with `as const`

### DIFF
--- a/src/webgpu/api/operation/command_buffer/render/storeop.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/render/storeop.spec.ts
@@ -1,7 +1,6 @@
 export const description = `
 renderPass store op test that drawn quad is either stored or cleared based on storeop`;
 
-import * as C from '../../../../../common/constants.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 
@@ -9,9 +8,9 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
   .params([
-    { storeOp: C.StoreOp.Store, _expected: 1 }, //
-    { storeOp: C.StoreOp.Clear, _expected: 0 },
-  ])
+    { storeOp: 'store', _expected: 1 }, //
+    { storeOp: 'clear', _expected: 0 },
+  ] as const)
   .fn(async t => {
     const renderTexture = t.device.createTexture({
       size: { width: 1, height: 1, depth: 1 },

--- a/src/webgpu/api/operation/resource_init/depth_stencil_attachment_clear.spec.ts
+++ b/src/webgpu/api/operation/resource_init/depth_stencil_attachment_clear.spec.ts
@@ -1,7 +1,6 @@
 export const description =
   'Test uninitialized textures are initialized to zero when used as a depth/stencil attachment.';
 
-import * as C from '../../../../common/constants.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { unreachable } from '../../../../common/framework/util/util.js';
 import { SubresourceRange } from '../../../util/texture/subresource.js';
@@ -138,7 +137,7 @@ class DepthStencilAttachmentClearTest extends TextureZeroInitTest {
       const renderTexture = this.device.createTexture({
         size: [width, height, 1],
         format: 'r8unorm',
-        usage: C.TextureUsage.OutputAttachment | C.TextureUsage.CopySrc,
+        usage: GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.COPY_SRC,
         sampleCount: this.params.sampleCount,
       });
 
@@ -148,7 +147,7 @@ class DepthStencilAttachmentClearTest extends TextureZeroInitTest {
         resolveTexture = this.device.createTexture({
           size: [width, height, 1],
           format: 'r8unorm',
-          usage: C.TextureUsage.OutputAttachment | C.TextureUsage.CopySrc,
+          usage: GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.COPY_SRC,
         });
         resolveTarget = resolveTexture.createView();
       }

--- a/src/webgpu/api/operation/resource_init/sampled_texture_clear.spec.ts
+++ b/src/webgpu/api/operation/resource_init/sampled_texture_clear.spec.ts
@@ -1,6 +1,5 @@
 export const description = 'Test uninitialized textures are initialized to zero when sampled.';
 
-import * as C from '../../../../common/constants.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert } from '../../../../common/framework/util/util.js';
 import { SubresourceRange } from '../../../util/texture/subresource.js';
@@ -120,7 +119,7 @@ class SampledTextureClearTest extends TextureZeroInitTest {
       for (const slice of slices) {
         const [ubo, uboMapping] = this.device.createBufferMapped({
           size: 4,
-          usage: C.BufferUsage.Uniform | C.BufferUsage.CopyDst,
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
         });
         new Int32Array(uboMapping, 0, 1)[0] = level;
         ubo.unmap();
@@ -132,7 +131,7 @@ class SampledTextureClearTest extends TextureZeroInitTest {
           getTexelDataRepresentation(this.params.format).componentOrder.length;
         const resultBuffer = this.device.createBuffer({
           size: byteLength,
-          usage: C.BufferUsage.Storage | C.BufferUsage.CopySrc,
+          usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
         });
 
         const bindGroup = this.device.createBindGroup({

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -5,7 +5,6 @@ vertexState validation tests.
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 import { ValidationTest } from './validation_test.js';
-import { VertexFormat } from '../../../common/constants.js';
 
 const MAX_VERTEX_ATTRIBUTES: number = 16;
 const MAX_VERTEX_BUFFER_END: number = 2048;
@@ -234,12 +233,12 @@ g.test('offset_should_be_within_vertex_buffer_arrayStride_if_arrayStride_is_not_
           arrayStride: 2 * SIZEOF_FLOAT,
           attributes: [
             {
-              format: VertexFormat.Float,
+              format: 'float' as GPUVertexFormat,
               offset: 0,
               shaderLocation: 0,
             },
             {
-              format: VertexFormat.Float,
+              format: 'float' as GPUVertexFormat,
               offset: SIZEOF_FLOAT,
               shaderLocation: 1,
             },
@@ -255,7 +254,7 @@ g.test('offset_should_be_within_vertex_buffer_arrayStride_if_arrayStride_is_not_
     {
       // Test vertex attribute offset exceed vertex buffer arrayStride range
       const badVertexState = clone(vertexState);
-      badVertexState.vertexBuffers[0].attributes[1].format = VertexFormat.Float2;
+      badVertexState.vertexBuffers[0].attributes[1].format = 'float2';
       const descriptor = t.getDescriptor(badVertexState, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
       t.expectValidationError(() => {
@@ -289,12 +288,12 @@ g.test('check_two_attributes_overlapping').fn(async t => {
         arrayStride: 2 * SIZEOF_FLOAT,
         attributes: [
           {
-            format: VertexFormat.Float,
+            format: 'float' as GPUVertexFormat,
             offset: 0,
             shaderLocation: 0,
           },
           {
-            format: VertexFormat.Float,
+            format: 'float' as GPUVertexFormat,
             offset: SIZEOF_FLOAT,
             shaderLocation: 1,
           },
@@ -310,7 +309,7 @@ g.test('check_two_attributes_overlapping').fn(async t => {
   {
     // Test two attributes overlapping
     const badVertexState = clone(vertexState);
-    badVertexState.vertexBuffers[0].attributes[0].format = VertexFormat.Int2;
+    badVertexState.vertexBuffers[0].attributes[0].format = 'int2';
     const descriptor = t.getDescriptor(badVertexState, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
     t.expectValidationError(() => {
@@ -651,7 +650,9 @@ g.test('check_multiple_of_4_bytes_constraint_on_offset').fn(async t => {
     vertexBuffers: [
       {
         arrayStride: 0,
-        attributes: [{ format: VertexFormat.Float, offset: SIZEOF_FLOAT, shaderLocation: 0 }],
+        attributes: [
+          { format: 'float' as GPUVertexFormat, offset: SIZEOF_FLOAT, shaderLocation: 0 },
+        ],
       },
     ],
   };
@@ -663,7 +664,7 @@ g.test('check_multiple_of_4_bytes_constraint_on_offset').fn(async t => {
   {
     // Test offset of 2 bytes with uchar2 format
     vertexState.vertexBuffers[0].attributes[0].offset = 2;
-    vertexState.vertexBuffers[0].attributes[0].format = VertexFormat.Uchar2;
+    vertexState.vertexBuffers[0].attributes[0].format = 'uchar2';
     const descriptor = t.getDescriptor(vertexState, VERTEX_SHADER_CODE_WITH_NO_INPUT);
     t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
@@ -672,7 +673,7 @@ g.test('check_multiple_of_4_bytes_constraint_on_offset').fn(async t => {
   {
     // Test offset of 2 bytes with float format
     vertexState.vertexBuffers[0].attributes[0].offset = 2;
-    vertexState.vertexBuffers[0].attributes[0].format = VertexFormat.Float;
+    vertexState.vertexBuffers[0].attributes[0].format = 'float';
     const descriptor = t.getDescriptor(vertexState, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
     t.expectValidationError(() => {

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -2,10 +2,10 @@ export const description = `
 vertexState validation tests.
 `;
 
-import * as C from '../../../common/constants.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 import { ValidationTest } from './validation_test.js';
+import { VertexFormat } from '../../../common/constants.js';
 
 const MAX_VERTEX_ATTRIBUTES: number = 16;
 const MAX_VERTEX_BUFFER_END: number = 2048;
@@ -205,7 +205,7 @@ g.test('an_arrayStride_of_0_is_valid').fn(t => {
         arrayStride: 0,
         attributes: [
           {
-            format: C.VertexFormat.Float,
+            format: 'float' as const,
             offset: 0,
             shaderLocation: 0,
           },
@@ -234,12 +234,12 @@ g.test('offset_should_be_within_vertex_buffer_arrayStride_if_arrayStride_is_not_
           arrayStride: 2 * SIZEOF_FLOAT,
           attributes: [
             {
-              format: C.VertexFormat.Float,
+              format: VertexFormat.Float,
               offset: 0,
               shaderLocation: 0,
             },
             {
-              format: C.VertexFormat.Float,
+              format: VertexFormat.Float,
               offset: SIZEOF_FLOAT,
               shaderLocation: 1,
             },
@@ -255,7 +255,7 @@ g.test('offset_should_be_within_vertex_buffer_arrayStride_if_arrayStride_is_not_
     {
       // Test vertex attribute offset exceed vertex buffer arrayStride range
       const badVertexState = clone(vertexState);
-      badVertexState.vertexBuffers[0].attributes[1].format = C.VertexFormat.Float2;
+      badVertexState.vertexBuffers[0].attributes[1].format = VertexFormat.Float2;
       const descriptor = t.getDescriptor(badVertexState, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
       t.expectValidationError(() => {
@@ -289,12 +289,12 @@ g.test('check_two_attributes_overlapping').fn(async t => {
         arrayStride: 2 * SIZEOF_FLOAT,
         attributes: [
           {
-            format: C.VertexFormat.Float,
+            format: VertexFormat.Float,
             offset: 0,
             shaderLocation: 0,
           },
           {
-            format: C.VertexFormat.Float,
+            format: VertexFormat.Float,
             offset: SIZEOF_FLOAT,
             shaderLocation: 1,
           },
@@ -310,7 +310,7 @@ g.test('check_two_attributes_overlapping').fn(async t => {
   {
     // Test two attributes overlapping
     const badVertexState = clone(vertexState);
-    badVertexState.vertexBuffers[0].attributes[0].format = C.VertexFormat.Int2;
+    badVertexState.vertexBuffers[0].attributes[0].format = VertexFormat.Int2;
     const descriptor = t.getDescriptor(badVertexState, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
     t.expectValidationError(() => {
@@ -420,7 +420,7 @@ g.test('check_out_of_bounds_on_number_of_vertex_attributes_across_vertex_buffers
   for (let i = 0; i < MAX_VERTEX_ATTRIBUTES; i++) {
     vertexBuffers.push({
       arrayStride: 0,
-      attributes: [{ format: C.VertexFormat.Float, offset: 0, shaderLocation: i }],
+      attributes: [{ format: 'float' as const, offset: 0, shaderLocation: i }],
     });
   }
 
@@ -433,7 +433,7 @@ g.test('check_out_of_bounds_on_number_of_vertex_attributes_across_vertex_buffers
   {
     // Test vertex attribute number exceed the limit
     vertexBuffers[MAX_VERTEX_ATTRIBUTES - 1].attributes.push({
-      format: C.VertexFormat.Float,
+      format: 'float' as const,
       offset: 0,
       shaderLocation: MAX_VERTEX_ATTRIBUTES,
     });
@@ -471,7 +471,7 @@ g.test('check_multiple_of_4_bytes_constraint_on_input_arrayStride').fn(async t =
     vertexBuffers: [
       {
         arrayStride: 4,
-        attributes: [{ format: C.VertexFormat.Uchar2, offset: 0, shaderLocation: 0 }],
+        attributes: [{ format: 'uchar2' as const, offset: 0, shaderLocation: 0 }],
       },
     ],
   };
@@ -496,7 +496,7 @@ g.test('identical_duplicate_attributes_are_invalid').fn(async t => {
     vertexBuffers: [
       {
         arrayStride: 0,
-        attributes: [{ format: C.VertexFormat.Float, offset: 0, shaderLocation: 0 }],
+        attributes: [{ format: 'float' as const, offset: 0, shaderLocation: 0 }],
       },
     ],
   };
@@ -508,7 +508,7 @@ g.test('identical_duplicate_attributes_are_invalid').fn(async t => {
   {
     // Oh no, attribute 0 is set twice
     vertexState.vertexBuffers[0].attributes.push({
-      format: C.VertexFormat.Float,
+      format: 'float' as const,
       offset: 0,
       shaderLocation: 0,
     });
@@ -527,8 +527,8 @@ g.test('we_cannot_set_same_shader_location').fn(async t => {
         {
           arrayStride: 0,
           attributes: [
-            { format: C.VertexFormat.Float, offset: 0, shaderLocation: 0 },
-            { format: C.VertexFormat.Float, offset: SIZEOF_FLOAT, shaderLocation: 1 },
+            { format: 'float' as const, offset: 0, shaderLocation: 0 },
+            { format: 'float' as const, offset: SIZEOF_FLOAT, shaderLocation: 1 },
           ],
         },
       ],
@@ -588,7 +588,7 @@ g.test('check_out_of_bounds_condition_on_attribute_shader_location').fn(async t 
       {
         arrayStride: 0,
         attributes: [
-          { format: C.VertexFormat.Float, offset: 0, shaderLocation: MAX_VERTEX_ATTRIBUTES - 1 },
+          { format: 'float' as const, offset: 0, shaderLocation: MAX_VERTEX_ATTRIBUTES - 1 },
         ],
       },
     ],
@@ -616,7 +616,7 @@ g.test('check_attribute_offset_out_of_bounds').fn(async t => {
         arrayStride: 0,
         attributes: [
           {
-            format: C.VertexFormat.Float2,
+            format: 'float2' as const,
             offset: MAX_VERTEX_BUFFER_END - 2 * SIZEOF_FLOAT,
             shaderLocation: 0,
           },
@@ -651,7 +651,7 @@ g.test('check_multiple_of_4_bytes_constraint_on_offset').fn(async t => {
     vertexBuffers: [
       {
         arrayStride: 0,
-        attributes: [{ format: C.VertexFormat.Float, offset: SIZEOF_FLOAT, shaderLocation: 0 }],
+        attributes: [{ format: VertexFormat.Float, offset: SIZEOF_FLOAT, shaderLocation: 0 }],
       },
     ],
   };
@@ -663,7 +663,7 @@ g.test('check_multiple_of_4_bytes_constraint_on_offset').fn(async t => {
   {
     // Test offset of 2 bytes with uchar2 format
     vertexState.vertexBuffers[0].attributes[0].offset = 2;
-    vertexState.vertexBuffers[0].attributes[0].format = C.VertexFormat.Uchar2;
+    vertexState.vertexBuffers[0].attributes[0].format = VertexFormat.Uchar2;
     const descriptor = t.getDescriptor(vertexState, VERTEX_SHADER_CODE_WITH_NO_INPUT);
     t.expectValidationError(() => {
       t.device.createRenderPipeline(descriptor);
@@ -672,7 +672,7 @@ g.test('check_multiple_of_4_bytes_constraint_on_offset').fn(async t => {
   {
     // Test offset of 2 bytes with float format
     vertexState.vertexBuffers[0].attributes[0].offset = 2;
-    vertexState.vertexBuffers[0].attributes[0].format = C.VertexFormat.Float;
+    vertexState.vertexBuffers[0].attributes[0].format = VertexFormat.Float;
     const descriptor = t.getDescriptor(vertexState, VERTEX_SHADER_CODE_WITH_NO_INPUT);
 
     t.expectValidationError(() => {


### PR DESCRIPTION
I had to fix up some of the remaining usages with e.g. `'float' as GPUTextureFormat` (edit: needed if the field gets reassigned later). I previously avoided that as it's not typo safe, so I am sort of considering add a helper function to safely assert the type `is<GPUTextureFormat>('float')`. Unfortunately TS doesn't have a way to do it without creating a function call (https://github.com/microsoft/TypeScript/issues/7481).

Removes more runtime dependence on constants.ts.