### PR TITLE
Add missing storageTextureFormat to BGL descriptor

### DIFF
--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -85,8 +85,12 @@ g.test('visibility_and_dynamic_offsets')
     const { type, hasDynamicOffset, visibility } = t.params;
     const info = kBindingTypeInfo[type as GPUBindingType];
 
+    const storageTextureFormat =
+      type === 'readonly-storage-texture' || type === 'writeonly-storage-texture'
+        ? ('r32uint' as const)
+        : undefined;
     const descriptor = {
-      entries: [{ binding: 0, visibility, type, hasDynamicOffset }],
+      entries: [{ binding: 0, visibility, type, hasDynamicOffset, storageTextureFormat }],
     };
 
     const supportsDynamicOffset = kBindingTypeInfo[type].perPipelineLimitClass.maxDynamic > 0;

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -85,10 +85,7 @@ g.test('visibility_and_dynamic_offsets')
     const { type, hasDynamicOffset, visibility } = t.params;
     const info = kBindingTypeInfo[type as GPUBindingType];
 
-    const storageTextureFormat =
-      type === 'readonly-storage-texture' || type === 'writeonly-storage-texture'
-        ? ('r32uint' as const)
-        : undefined;
+    const storageTextureFormat = info.resource === 'storageTex' ? ('r32uint' as const) : undefined;
     const descriptor = {
       entries: [{ binding: 0, visibility, type, hasDynamicOffset, storageTextureFormat }],
     };


### PR DESCRIPTION
Fixes #200. createPipelineLayout:visibility_and_dynamic_offsets
tests were incorrectly missing the storageTextureFormat for storage
texture binding types.