### PR TITLE
Expect GPUOutOfMemoryError in map_oom tests

### DIFF
--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -3,27 +3,31 @@ export const description = '';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
-function getBufferDesc(): GPUBufferDescriptor {
+function getBufferDesc(usage: GPUBufferUsageFlags): GPUBufferDescriptor {
   return {
     size: Number.MAX_SAFE_INTEGER,
-    usage: GPUBufferUsage.MAP_WRITE,
+    usage,
   };
 }
 
 export const g = makeTestGroup(GPUTest);
 
 g.test('mapWriteAsync').fn(async t => {
-  const buffer = t.device.createBuffer(getBufferDesc());
+  const buffer = t.expectError('out-of-memory', () => {
+    return t.device.createBuffer(getBufferDesc(GPUBufferUsage.MAP_WRITE));
+  });
   t.shouldReject('RangeError', buffer.mapWriteAsync());
 });
 
 g.test('mapReadAsync').fn(async t => {
-  const buffer = t.device.createBuffer(getBufferDesc());
+  const buffer = t.expectError('out-of-memory', () => {
+    return t.device.createBuffer(getBufferDesc(GPUBufferUsage.MAP_READ));
+  });
   t.shouldReject('RangeError', buffer.mapReadAsync());
 });
 
 g.test('createBufferMapped').fn(async t => {
   t.shouldThrow('RangeError', () => {
-    t.device.createBufferMapped(getBufferDesc());
+    t.device.createBufferMapped(getBufferDesc(GPUBufferUsage.COPY_SRC));
   });
 });

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -13,17 +13,17 @@ function getBufferDesc(usage: GPUBufferUsageFlags): GPUBufferDescriptor {
 export const g = makeTestGroup(GPUTest);
 
 g.test('mapWriteAsync').fn(async t => {
-  const buffer = t.expectError('out-of-memory', () => {
+  const buffer = t.expectGPUError('out-of-memory', () => {
     return t.device.createBuffer(getBufferDesc(GPUBufferUsage.MAP_WRITE));
   });
-  t.shouldReject('RangeError', buffer.mapWriteAsync());
+  t.shouldReject('OperationError', buffer.mapWriteAsync());
 });
 
 g.test('mapReadAsync').fn(async t => {
-  const buffer = t.expectError('out-of-memory', () => {
+  const buffer = t.expectGPUError('out-of-memory', () => {
     return t.device.createBuffer(getBufferDesc(GPUBufferUsage.MAP_READ));
   });
-  t.shouldReject('RangeError', buffer.mapReadAsync());
+  t.shouldReject('OperationError', buffer.mapReadAsync());
 });
 
 g.test('createBufferMapped').fn(async t => {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -226,4 +226,40 @@ got [${failedByteActualValues.join(', ')}]`;
     fillTextureDataWithTexelValue(expectedTexelData, format, dimension, arrayBuffer, size, layout);
     this.expectContents(buffer, new Uint8Array(arrayBuffer));
   }
+
+  expectError<R>(filter: GPUErrorFilter, fn: () => R): R {
+    this.device.pushErrorScope(filter);
+    const returnValue = fn();
+    const promise = this.device.popErrorScope();
+
+    this.eventualAsyncExpectation(async niceStack => {
+      const error = await promise;
+
+      let failed = false;
+      switch (filter) {
+        case 'none':
+          failed = error !== null;
+          break;
+        case 'out-of-memory':
+          failed = !(error instanceof GPUOutOfMemoryError);
+          break;
+        case 'validation':
+          failed = !(error instanceof GPUValidationError);
+          break;
+      }
+
+      if (failed) {
+        niceStack.message = `Expected ${filter} error`;
+        this.rec.expectationFailed(niceStack);
+      } else {
+        niceStack.message = `Captured ${filter} error`;
+        if (error instanceof GPUValidationError) {
+          niceStack.message += ` - ${error.message}`;
+        }
+        this.rec.debug(niceStack);
+      }
+    });
+
+    return returnValue;
+  }
 }

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -227,7 +227,7 @@ got [${failedByteActualValues.join(', ')}]`;
     this.expectContents(buffer, new Uint8Array(arrayBuffer));
   }
 
-  expectError<R>(filter: GPUErrorFilter, fn: () => R): R {
+  expectGPUError<R>(filter: GPUErrorFilter, fn: () => R): R {
     this.device.pushErrorScope(filter);
     const returnValue = fn();
     const promise = this.device.popErrorScope();


### PR DESCRIPTION
Fixes #199. Also adds a helper to asynchronously expect errors.