### PR TITLE
Use 8 float buffer instead of 4 for mat2

### DIFF
--- a/src/webgpu/api/validation/render_pass.spec.ts
+++ b/src/webgpu/api/validation/render_pass.spec.ts
@@ -9,7 +9,7 @@ import { ValidationTest } from './validation_test.js';
 class F extends ValidationTest {
   getUniformBuffer(): GPUBuffer {
     return this.device.createBuffer({
-      size: 4 * Float32Array.BYTES_PER_ELEMENT,
+      size: 8 * Float32Array.BYTES_PER_ELEMENT,
       usage: GPUBufferUsage.UNIFORM,
     });
   }


### PR DESCRIPTION
According to [https://www.khronos.org/opengl/wiki/Talk:Uniform_Buffer_Object](https://www.khronos.org/opengl/wiki/Talk:Uniform_Buffer_Object), mat2 uses a vec4 for each column internally, meaning it needs 8 floats instead of 4 floats for a bound buffer.