### PR TITLE
Fix log printing on Safari/Firefox, fix a typo in a timems check

### DIFF
--- a/src/common/framework/logging/log_message.ts
+++ b/src/common/framework/logging/log_message.ts
@@ -22,12 +22,10 @@ export class LogMessageWithStack extends Error {
   }
 
   toJSON(): string {
-    let m = this.name + ': ';
+    let m = this.name;
+    if (this.message) m += ': ' + this.message;
     if (!this.stackHidden && this.stack) {
-      // this.message is already included in this.stack
-      m += extractImportantStackTrace(this);
-    } else {
-      m += this.message;
+      m += '\n' + extractImportantStackTrace(this);
     }
     if (this.timesSeen > 1) {
       m += `\n(seen ${this.timesSeen} times with identical stack)`;

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -91,7 +91,7 @@ const specsData: { [k: string]: SpecFile } = {
           t.debug('OK');
         });
       g.test('bluh,a').fn(t => {
-        t.fail('bye');
+        t.fail('goodbye');
       });
       return g;
     })(),
@@ -223,7 +223,7 @@ g.test('end2end').fn(async t => {
 
     t.expect(log.results.get(name) === res);
     t.expect(res.status === status);
-    t.expect(res.timems > 0);
+    t.expect(res.timems >= 0);
     assert(res.logs !== undefined); // only undefined while pending
     t.expect(logs(res.logs.map(l => JSON.stringify(l))));
   };
@@ -240,7 +240,7 @@ g.test('end2end').fn(async t => {
     'fail',
     logs =>
       logs.length === 1 &&
-      logs[0].startsWith('"EXPECTATION FAILED: Error: bye\\n') &&
+      logs[0].startsWith('"EXPECTATION FAILED: goodbye\\n') &&
       logs[0].indexOf('loaders_and_trees.spec.') !== -1
   );
 });


### PR DESCRIPTION
Thought I had tested the log printing, but error.stack does not contain the error
message on Safari and Firefox. So include it explicitly when printing.