### PR TITLE
Autoformat out-wpt/

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,6 +64,10 @@ module.exports = function (grunt) {
         cmd: 'node',
         args: ['node_modules/eslint/bin/eslint', 'src/**/*.ts', '--fix'],
       },
+      'autoformat-out-wpt': {
+        cmd: 'node',
+        args: ['node_modules/.bin/prettier', '--write', 'out-wpt/**/*.js'],
+      }
     },
 
     watch: {
@@ -160,6 +164,7 @@ module.exports = function (grunt) {
   ]);
   grunt.registerTask('build-wpt', 'Build out/ (no checks)', [
     'run:build-out-wpt',
+    'run:autoformat-out-wpt',
     'run:generate-version',
     'run:generate-listings',
     'copy:out-wpt-generated',

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,10 @@ module.exports = function (api) {
       ],
     ],
     compact: false,
-    retainLines: true, // Keeps code *and comments* on ~the same line as in the source
+    // Keeps comments from getting hoisted to the end of the previous line of code.
+    // (Also keeps lines close to their original line numbers - but for WPT we
+    // reformat with prettier anyway.)
+    retainLines: true,
     shouldPrintComment: val => !/eslint|prettier-ignore/.test(val),
   };
 };


### PR DESCRIPTION
Since I decided not to include inline source maps in `out-wpt/` (filesize too large), we can do the next best thing: just autoformat `out-wpt/` so it's more readable.