### PR TITLE
Replace optional chaining operator with equivalent syntax

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -235,7 +235,11 @@ got [${failedByteActualValues.join(', ')}]`;
 
     const commandEncoder = this.device.createCommandEncoder();
     commandEncoder.copyTextureToBuffer(
-      { texture: src, mipLevel: layout?.mipLevel, arrayLayer: slice },
+      {
+        texture: src,
+        mipLevel: layout === null || layout === undefined ? undefined : layout.mipLevel,
+        arrayLayer: slice,
+      },
       { buffer, bytesPerRow, rowsPerImage },
       mipSize
     );


### PR DESCRIPTION
Optional chaining has recently been introduced and not all browsers support it yet. It would be good if we could avoid using that. I am working on implementing WebGPU in [Servo](https://github.com/servo/servo), which doesn't support optional chaining yet.