### PR TITLE
Use babel plugin to prevent optional chaining in generated code

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,9 @@ module.exports = function (api) {
     presets: ['@babel/preset-typescript'],
     plugins: [
       '@babel/plugin-proposal-class-properties',
+      // Transforms optional chaining operator to equivalent ternary operator syntax.
+      // We need this to run tests on browsers that don't support optional chaining yet.
+      '@babel/plugin-proposal-optional-chaining',
       'const-enum',
       [
         'add-header-comment',

--- a/package-lock.json
+++ b/package-lock.json
@@ -240,6 +240,33 @@
         "@babel/helper-plugin-utils": "^7.10.1"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.10.3.tgz",
+      "integrity": "sha512-yyG3n9dJ1vZ6v5sfmIlMMZ8azQoqx/5/nZTSWX1td6L1H1bsjzA8TInDChpafCZiJkeOFzp/PtrfigAQXxI1Ng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz",
+          "integrity": "sha512-j/+j8NAWUTxOtx4LKHybpSClxHoq6I91DQ/mKgAXn5oNUPIUiGppjPIX3TDtJWPrdfP9Kfl7e4fgVMiQR9VE/g==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
     "@babel/plugin-syntax-typescript": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@babel/cli": "^7.10.1",
     "@babel/core": "^7.10.2",
     "@babel/plugin-proposal-class-properties": "^7.10.1",
+    "@babel/plugin-proposal-optional-chaining": "^7.10.3",
     "@babel/preset-typescript": "^7.10.1",
     "@types/jquery": "^3.3.38",
     "@types/node": "^14.0.12",


### PR DESCRIPTION
Follow up from #220 

Please do not merge this yet. I'll test this locally to make sure we don't need any more changes.
(Sorry! probably should have done this before opening this PR)