### PR TITLE
Add a test for storage buffer and readonly storage buffer

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -2,13 +2,14 @@ export const description = `
 createBindGroupLayout validation tests.
 `;
 
-import { poptions, params } from '../../../common/framework/params_builder.js';
+import { pbool, poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
   kBindingTypeInfo,
   kBindingTypes,
   kMaxBindingsPerBindGroup,
   kShaderStages,
+  kShaderStageCombinations,
 } from '../../capability_info.js';
 
 import { ValidationTest } from './validation_test.js';
@@ -39,11 +40,29 @@ g.test('some_binding_index_was_specified_more_than_once').fn(async t => {
   });
 });
 
-g.test('visibility_of_bindings_can_be_0').fn(async t => {
-  t.device.createBindGroupLayout({
-    entries: [{ binding: 0, visibility: 0, type: 'storage-buffer' }],
+g.test('visibility_and_dynamic_offsets')
+  .params(
+    params()
+      .combine(poptions('type', kBindingTypes))
+      .combine(pbool('hasDynamicOffset'))
+      .combine(poptions('visibility', kShaderStageCombinations))
+  )
+  .fn(async t => {
+    const { type, hasDynamicOffset, visibility } = t.params;
+    const info = kBindingTypeInfo[type as GPUBindingType];
+
+    const supportsDynamicOffset = kBindingTypeInfo[type].perPipelineLimitClass.maxDynamic > 0;
+    let success = true;
+    if (!supportsDynamicOffset && hasDynamicOffset) success = false;
+    if ((visibility & ~info.validStages) !== 0) success = false;
+
+    // When hasDynamicOffset is false, it actually tests visibility.
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility, type, hasDynamicOffset }],
+      });
+    }, !success);
   });
-});
 
 g.test('number_of_dynamic_buffers_exceeds_the_maximum_value')
   .params([

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -2,13 +2,9 @@ export const description = `
 createPipelineLayout validation tests.
 `;
 
-import { pbool, poptions, params } from '../../../common/framework/params_builder.js';
+import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import {
-  kBindingTypeInfo,
-  kBindingTypes,
-  kShaderStageCombinations,
-} from '../../capability_info.js';
+import { kBindingTypeInfo } from '../../capability_info.js';
 
 import { ValidationTest } from './validation_test.js';
 
@@ -67,33 +63,6 @@ g.test('number_of_dynamic_buffers_exceeds_the_maximum_value')
     t.expectValidationError(() => {
       t.device.createPipelineLayout(badPipelineLayoutDescriptor);
     });
-  });
-
-g.test('visibility_and_dynamic_offsets')
-  .params(
-    params()
-      .combine(poptions('type', kBindingTypes))
-      .combine(pbool('hasDynamicOffset'))
-      .combine(poptions('visibility', kShaderStageCombinations))
-  )
-  .fn(t => {
-    const { type, hasDynamicOffset, visibility } = t.params;
-    const info = kBindingTypeInfo[type as GPUBindingType];
-
-    const descriptor = {
-      entries: [{ binding: 0, visibility, type, hasDynamicOffset }],
-    };
-
-    const supportsDynamicOffset = kBindingTypeInfo[type].perPipelineLimitClass.maxDynamic > 0;
-    let success = true;
-    if (!supportsDynamicOffset && hasDynamicOffset) success = false;
-    if ((visibility & ~info.validStages) !== 0) success = false;
-
-    t.expectValidationError(() => {
-      t.device.createPipelineLayout({
-        bindGroupLayouts: [t.device.createBindGroupLayout(descriptor)],
-      });
-    }, !success);
   });
 
 g.test('number_of_bind_group_layouts_exceeds_the_maximum_value').fn(async t => {


### PR DESCRIPTION
The first patch to webgpu cts project. PTAL. Thank you!

We have already had a similar test in Dawn validation test.