### PR TITLE
Minor Improvements To Setup Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,18 @@ npx grunt test
 
 ### Run
 
-To test in a browser under the standalone harness, run `grunt serve`, then
+To test in a browser under the standalone harness, run `npx grunt serve`, then
 open:
 
-- http://localhost:8080/standalone/ (defaults to ?runnow=0&worker=0&debug=0&q=webgpu:)
-- http://localhost:8080/standalone/?runnow=1&q=unittests:
-- http://localhost:8080/standalone/?runnow=1&q=unittests:basic:&q=unittests:params:
+- http://localhost:8080/standalone/index.html (defaults to ?runnow=0&worker=0&debug=0&q=webgpu:)
+- http://localhost:8080/standalone/index.html?runnow=1&q=unittests:
+- http://localhost:8080/standalone/index.html?runnow=1&q=unittests:basic:&q=unittests:params:
 
 ### Debug
 
 To see debug logs in a browser, use the `debug=1` query string:
 
-- http://localhost:8080/standalone/?q=webgpu:validation&debug=1
+- http://localhost:8080/standalone/index.html?q=webgpu:validation&debug=1
 
 ### Making Changes
 


### PR DESCRIPTION
Adds /index.html to the CTS links when running locally. On Chrome/Windows I was seeing infinite redirects when index.html was not present.