### PR TITLE
Add tests for bindGroupLayout's variables

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -11,6 +11,9 @@ import {
   kMaxBindingsPerBindGroup,
   kShaderStages,
   kShaderStageCombinations,
+  kTextureBindingTypeInfo,
+  kTextureComponentTypes,
+  kTextureViewDimensions,
 } from '../../capability_info.js';
 
 import { ValidationTest } from './validation_test.js';
@@ -65,7 +68,7 @@ g.test('visibility_and_dynamic_offsets')
     }, !success);
   });
 
-g.test('mininum_buffer_binding_size')
+g.test('min_buffer_binding_size')
   .params(
     params()
       .combine(poptions('type', kBindingTypes))
@@ -75,15 +78,91 @@ g.test('mininum_buffer_binding_size')
     const { type, minBufferBindingSize } = t.params;
 
     let success = false;
-    if (minBufferBindingSize !== undefined && minBufferBindingSize !== 0) {
-      if (type in kBufferBindingTypeInfo) {
-        success = true;
-      }
+    if (
+      minBufferBindingSize === undefined ||
+      minBufferBindingSize === 0 ||
+      type in kBufferBindingTypeInfo
+    ) {
+      success = true;
     }
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout({
         entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type, minBufferBindingSize }],
+      });
+    }, !success);
+  });
+
+g.test('view_dimension')
+  .params(
+    params()
+      .combine(poptions('type', kBindingTypes))
+      .combine(poptions('viewDimension', [undefined, ...kTextureViewDimensions]))
+  )
+  .fn(async t => {
+    const { type, viewDimension } = t.params;
+
+    const success = viewDimension === undefined || type in kTextureBindingTypeInfo;
+
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type, viewDimension }],
+      });
+    }, !success);
+  });
+
+g.test('texture_component_type')
+  .params(
+    params()
+      .combine(poptions('type', kBindingTypes))
+      .combine(poptions('textureComponentType', [undefined, ...kTextureComponentTypes]))
+  )
+  .fn(async t => {
+    const { type, textureComponentType } = t.params;
+
+    const success =
+      textureComponentType === undefined || kBindingTypeInfo[type].resource === 'sampledTex';
+
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type, textureComponentType }],
+      });
+    }, !success);
+  });
+
+g.test('multisampled')
+  .params(
+    params()
+      .combine(poptions('type', kBindingTypes))
+      .combine(poptions('multisampled', [undefined, false, true]))
+  )
+  .fn(async t => {
+    const { type, multisampled } = t.params;
+
+    const success = multisampled === false || kBindingTypeInfo[type].resource === 'sampledTex';
+
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type, multisampled }],
+      });
+    }, !success);
+  });
+
+g.test('storage_texture_format')
+  .params(
+    params()
+      .combine(poptions('type', kBindingTypes))
+      .combine(poptions('storageTextureFormat', [undefined, 'rgba8unorm'] as const))
+  )
+  .fn(async t => {
+    const { type, storageTextureFormat } = t.params;
+
+    const success =
+      storageTextureFormat === undefined || kBindingTypeInfo[type].resource === 'storageTex';
+
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, type, storageTextureFormat }],
       });
     }, !success);
   });

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -110,6 +110,33 @@ export const kTextureUsageInfo: {
 };
 export const kTextureUsages = numericKeysOf<GPUTextureUsage>(kTextureUsageInfo);
 
+export const kTextureComponentTypeInfo: {
+  readonly [k in GPUTextureComponentType]: {
+    // Add fields as needed
+  };
+} = /* prettier-ignore */ {
+  'float': {},
+  'sint': {},
+  'uint': {},
+};
+export const kTextureComponentTypes = keysOf(kTextureComponentTypeInfo);
+
+// Texture View
+
+export const kTextureViewDimensionInfo: {
+  readonly [k in GPUTextureViewDimension]: {
+    // Add fields as needed
+  };
+} = /* prettier-ignore */ {
+  '1d': {},
+  '2d': {},
+  '2d-array': {},
+  'cube': {},
+  'cube-array': {},
+  '3d': {},
+};
+export const kTextureViewDimensions = keysOf(kTextureViewDimensionInfo);
+
 // Typedefs for bindings
 
 export type PerStageBindingLimitClass =


### PR DESCRIPTION
This change adds tests for 'viewDimension', 'textureComponentType',
'multisampled', and 'storageTextureFormat' in bindGroupLayout.
