### PR TITLE
Refactor some validation tests in createBindGroupLayout

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -75,11 +75,17 @@ g.test('bindingTypeSpecific_optional_members')
     params()
       .combine(poptions('type', kBindingTypes))
       .combine([
-        ...poptions('minBufferBindingSize', [undefined, 0, 4]),
-        ...poptions('textureComponentType', [undefined, ...kTextureComponentTypes]),
-        ...poptions('multisampled', [undefined, false, true]),
-        ...poptions('viewDimension', [undefined, ...kTextureViewDimensions]),
-        ...poptions('storageTextureFormat', [undefined, ...kTextureFormats]),
+        // Case with every member set to `undefined`.
+        {
+          // Workaround for TS inferring the type of [ {}, ...x ] overly conservatively, as {}[].
+          _: 0,
+        },
+        // Cases with one member set.
+        ...poptions('minBufferBindingSize', [0, 4]),
+        ...poptions('textureComponentType', kTextureComponentTypes),
+        ...pbool('multisampled'),
+        ...poptions('viewDimension', kTextureViewDimensions),
+        ...poptions('storageTextureFormat', kTextureFormats),
       ])
   )
   .fn(t => {

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -70,7 +70,7 @@ g.test('visibility_and_dynamic_offsets')
     }, !success);
   });
 
-g.test('non_required_parameter_combined_with_type_separately')
+g.test('bindingTypeSpecific_optional_members')
   .params(
     params()
       .combine(poptions('type', kBindingTypes))
@@ -92,26 +92,24 @@ g.test('non_required_parameter_combined_with_type_separately')
       storageTextureFormat,
     } = t.params;
 
-    const minBufferBindingSizeValid =
-      minBufferBindingSize === undefined ||
-      minBufferBindingSize === 0 ||
-      type in kBufferBindingTypeInfo;
-    const textureComponentTypeValid =
-      textureComponentType === undefined || kBindingTypeInfo[type].resource === 'sampledTex';
-    const multisampledValid =
-      multisampled === false || kBindingTypeInfo[type].resource === 'sampledTex';
-    const viewDimensionValid = viewDimension === undefined || type in kTextureBindingTypeInfo;
-    const storageTextureFormatValid =
-      storageTextureFormat === undefined ||
-      (kBindingTypeInfo[type].resource === 'storageTex' &&
-        kTextureFormatInfo[storageTextureFormat].storage);
-
-    const success =
-      minBufferBindingSizeValid &&
-      textureComponentTypeValid &&
-      multisampledValid &&
-      viewDimensionValid &&
-      storageTextureFormatValid;
+    let success = true;
+    if (!(type in kBufferBindingTypeInfo)) {
+      if (minBufferBindingSize !== undefined) success = false;
+    }
+    if (!(type in kTextureBindingTypeInfo)) {
+      if (viewDimension !== undefined) success = false;
+    }
+    if (kBindingTypeInfo[type].resource !== 'sampledTex') {
+      if (textureComponentType !== undefined) success = false;
+      if (multisampled === true) success = false;
+    }
+    if (kBindingTypeInfo[type].resource !== 'storageTex') {
+      if (storageTextureFormat !== undefined) success = false;
+    } else {
+      if (storageTextureFormat !== undefined && !kTextureFormatInfo[storageTextureFormat].storage) {
+        success = false;
+      }
+    }
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout({

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -92,20 +92,26 @@ g.test('non_required_parameter_combined_with_type_separately')
       storageTextureFormat,
     } = t.params;
 
-    let success = false;
-    if (
-      (minBufferBindingSize === undefined ||
-        minBufferBindingSize === 0 ||
-        type in kBufferBindingTypeInfo) &&
-      (textureComponentType === undefined || kBindingTypeInfo[type].resource === 'sampledTex') &&
-      (multisampled === false || kBindingTypeInfo[type].resource === 'sampledTex') &&
-      (viewDimension === undefined || type in kTextureBindingTypeInfo) &&
-      (storageTextureFormat === undefined ||
-        (kBindingTypeInfo[type].resource === 'storageTex' &&
-          kTextureFormatInfo[storageTextureFormat].storage))
-    ) {
-      success = true;
-    }
+    const minBufferBindingSizeValid =
+      minBufferBindingSize === undefined ||
+      minBufferBindingSize === 0 ||
+      type in kBufferBindingTypeInfo;
+    const textureComponentTypeValid =
+      textureComponentType === undefined || kBindingTypeInfo[type].resource === 'sampledTex';
+    const multisampledValid =
+      multisampled === false || kBindingTypeInfo[type].resource === 'sampledTex';
+    const viewDimensionValid = viewDimension === undefined || type in kTextureBindingTypeInfo;
+    const storageTextureFormatValid =
+      storageTextureFormat === undefined ||
+      (kBindingTypeInfo[type].resource === 'storageTex' &&
+        kTextureFormatInfo[storageTextureFormat].storage);
+
+    const success =
+      minBufferBindingSizeValid &&
+      textureComponentTypeValid &&
+      multisampledValid &&
+      viewDimensionValid &&
+      storageTextureFormatValid;
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout({
@@ -125,7 +131,7 @@ g.test('non_required_parameter_combined_with_type_separately')
     }, !success);
   });
 
-g.test('multisample_requirs_2d_view_dimension')
+g.test('multisample_requires_2d_view_dimension')
   .params(
     params()
       .combine(poptions('multisampled', [undefined, false, true]))


### PR DESCRIPTION
This change refactors non-required parameters in BindGroupLayout.
It also adds 2 tests: format requirement of storageTextureFormats,
and multisample requirement for viewDimension.