### PR TITLE
Represent undefined with a magic value in JSON

### DIFF
--- a/src/common/framework/query/encode_selectively.ts
+++ b/src/common/framework/query/encode_selectively.ts
@@ -16,5 +16,6 @@ export function encodeURIComponentSelectively(s: string): string {
   ret = ret.replace(/%3D/g, '='); // for params (k=v)
   ret = ret.replace(/%5B/g, '['); // for JSON arrays
   ret = ret.replace(/%5D/g, ']'); // for JSON arrays
+  ret = ret.replace(/%E2%9C%97/g, '✗'); // for jsUndefinedMagicValue
   return ret;
 }

--- a/src/common/framework/query/json_param_value.ts
+++ b/src/common/framework/query/json_param_value.ts
@@ -1,0 +1,18 @@
+import { ParamArgument } from '../params_utils.js';
+import { assert } from '../util/util.js';
+
+// JSON can't represent `undefined` and by default stores it as `null`.
+// Instead, store `undefined` as this magic string value in JSON.
+const jsUndefinedMagicValue = '✗undefined';
+
+export function stringifyParamValue(value: ParamArgument): string {
+  return JSON.stringify(value, (k, v) => {
+    assert(v !== jsUndefinedMagicValue);
+
+    return v === undefined ? jsUndefinedMagicValue : v;
+  });
+}
+
+export function parseParamValue(s: string): ParamArgument {
+  return JSON.parse(s, (k, v) => (v === jsUndefinedMagicValue ? undefined : v));
+}

--- a/src/common/framework/query/parseQuery.ts
+++ b/src/common/framework/query/parseQuery.ts
@@ -15,6 +15,7 @@ import {
 } from './query.js';
 import { kBigSeparator, kWildcard, kPathSeparator, kParamSeparator } from './separators.js';
 import { validQueryPart } from './validQueryPart.js';
+import { parseParamValue } from './json_param_value.js';
 
 export function parseQuery(s: string): TestQuery {
   try {
@@ -128,5 +129,5 @@ function parseSingleParamValue(s: string): ParamArgument {
     !badParamValueChars.test(s),
     `param value must not match ${badParamValueChars} - was ${s}`
   );
-  return s === 'undefined' ? undefined : JSON.parse(s);
+  return parseParamValue(s);
 }

--- a/src/common/framework/query/parseQuery.ts
+++ b/src/common/framework/query/parseQuery.ts
@@ -6,6 +6,7 @@ import {
 } from '../params_utils.js';
 import { assert } from '../util/util.js';
 
+import { parseParamValue } from './json_param_value.js';
 import {
   TestQuery,
   TestQueryMultiFile,
@@ -15,7 +16,6 @@ import {
 } from './query.js';
 import { kBigSeparator, kWildcard, kPathSeparator, kParamSeparator } from './separators.js';
 import { validQueryPart } from './validQueryPart.js';
-import { parseParamValue } from './json_param_value.js';
 
 export function parseQuery(s: string): TestQuery {
   try {

--- a/src/common/framework/query/stringify_params.ts
+++ b/src/common/framework/query/stringify_params.ts
@@ -6,8 +6,8 @@ import {
 } from '../params_utils.js';
 import { assert } from '../util/util.js';
 
-import { kParamKVSeparator } from './separators.js';
 import { stringifyParamValue } from './json_param_value.js';
+import { kParamKVSeparator } from './separators.js';
 
 export function stringifyPublicParams(p: CaseParams): string[] {
   return Object.keys(p)

--- a/src/common/framework/query/stringify_params.ts
+++ b/src/common/framework/query/stringify_params.ts
@@ -7,6 +7,7 @@ import {
 import { assert } from '../util/util.js';
 
 import { kParamKVSeparator } from './separators.js';
+import { stringifyParamValue } from './json_param_value.js';
 
 export function stringifyPublicParams(p: CaseParams): string[] {
   return Object.keys(p)
@@ -19,7 +20,7 @@ export function stringifySingleParam(k: string, v: ParamArgument) {
 }
 
 function stringifySingleParamValue(v: ParamArgument): string {
-  const s = v === undefined ? 'undefined' : JSON.stringify(v);
+  const s = stringifyParamValue(v);
   assert(
     !badParamValueChars.test(s),
     `JSON.stringified param value must not match ${badParamValueChars} - was ${s}`


### PR DESCRIPTION
Needed for testing in #245.

Allows representing `null` and `undefined` separately inside param values. Previously did this only for the toplevel value (which was needed for parameterized testing of a bunch of apis that take undefined), but this is more robust.