### PR TITLE
Fixes about hasDynamicOffset and multisampled in BGL

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -16,6 +16,7 @@ import {
   kTextureFormats,
   kTextureFormatInfo,
   kTextureViewDimensions,
+  kTextureViewDimensionInfo,
 } from '../../capability_info.js';
 
 import { ValidationTest } from './validation_test.js';
@@ -101,12 +102,6 @@ g.test('bindingTypeSpecific_optional_members')
     }
     if (!(type in kTextureBindingTypeInfo)) {
       if (viewDimension !== undefined) success = false;
-      if (
-        kBindingTypeInfo[type].resource === 'storageTex' &&
-        (viewDimension === 'cube' || viewDimension === 'cube-array')
-      ) {
-        success = false;
-      }
     }
     if (kBindingTypeInfo[type].resource !== 'sampledTex') {
       if (textureComponentType !== undefined) success = false;
@@ -115,6 +110,9 @@ g.test('bindingTypeSpecific_optional_members')
     if (kBindingTypeInfo[type].resource !== 'storageTex') {
       if (storageTextureFormat !== undefined) success = false;
     } else {
+      if (viewDimension !== undefined && !kTextureViewDimensionInfo[viewDimension].storage) {
+        success = false;
+      }
       if (storageTextureFormat !== undefined && !kTextureFormatInfo[storageTextureFormat].storage) {
         success = false;
       }

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -125,15 +125,16 @@ export const kTextureComponentTypes = keysOf(kTextureComponentTypeInfo);
 
 export const kTextureViewDimensionInfo: {
   readonly [k in GPUTextureViewDimension]: {
+    readonly storage: boolean;
     // Add fields as needed
   };
 } = /* prettier-ignore */ {
-  '1d': {},
-  '2d': {},
-  '2d-array': {},
-  'cube': {},
-  'cube-array': {},
-  '3d': {},
+  '1d':         { storage: true  },
+  '2d':         { storage: true  },
+  '2d-array':   { storage: true  },
+  'cube':       { storage: false },
+  'cube-array': { storage: false },
+  '3d':         { storage: true  },
 };
 export const kTextureViewDimensions = keysOf(kTextureViewDimensionInfo);
 


### PR DESCRIPTION
https://github.com/gpuweb/gpuweb/pull/949

hasDynamicOffset and multisampled should be undefined in BGL if the
binding types are incorrect. Previously we allow them to be false.

This change moves hasDynamicOffset tests out of visiblity test
and combine it with other optional parameters in BGL.

It also added a validation rule that if the binding type is storage
texture, the viewDimension can't be 'cube' or 'cube-array'.