### PR TITLE
Add test for different read write usages combinations

### DIFF
--- a/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
@@ -3,14 +3,20 @@ Texture Usages Validation Tests in Render Pass.
 
 Test Coverage:
 
-  - Test the combination of different pairs of usages upon the same texture subresource or different
-    subresources of the same texture. Different subresources of the same texture includes different
-    mip levels, different array layers, and different aspects.
-    - When read-write or write-write usages are binding to the same texture subresource, an error
-      should be generated. Otherwise, no error should be generated. One exception is race condition
-      upon two writeonly-storage-texture usages, which is valid.
+  - For each combination of two texture usages:
+    - For various subresource ranges (different mip levels or array layers) that overlap a given
+      subresources or not for color formats:
+      - Check that an error is generated when read-write or write-write usages are binding to the
+        same texture subresource. Otherwise, no error should be generated. One exception is race
+        condition upon two writeonly-storage-texture usages, which is valid.
 
-  - Test different shader stages.
+  - For each combination of two texture usages:
+    - For various aspects (all, depth-only, stencil-only) that overlap a given subresources or not
+      for depth/stencil formats:
+      - Check that an error is generated when read-write or write-write usages are binding to the
+        same aspect. Otherwise, no error should be generated.
+
+  - Test combinations of two shader stages:
     - Texture usages in bindings with invisible shader stages should be tracked. Invisible shader
       stages include shader stage with visibility none and compute shader stage in render pass.
 `;
@@ -312,10 +318,10 @@ g.test('subresources_and_binding_types_combination_for_aspect')
     pass.setBindGroup(0, bindGroup);
     pass.endPass();
 
-    const resourceSuccess =
+    const disjointAspects =
       (aspect0 === 'depth-only' && aspect1 === 'stencil-only') ||
       (aspect0 === 'stencil-only' && aspect1 === 'depth-only');
-    const success = resourceSuccess || _usageSuccess;
+    const success = disjointAspects || _usageSuccess;
 
     t.expectValidationError(() => {
       encoder.finish();

--- a/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
@@ -105,52 +105,52 @@ g.test('subresources_and_binding_types_combination_for_color')
       ])
       .combine([
         {
-          type0: 'sampled-texture' as const,
-          type1: 'sampled-texture' as const,
+          type0: 'sampled-texture',
+          type1: 'sampled-texture',
           _usageSuccess: true,
         },
         {
-          type0: 'sampled-texture' as const,
-          type1: 'readonly-storage-texture' as const,
+          type0: 'sampled-texture',
+          type1: 'readonly-storage-texture',
           _usageSuccess: true,
         },
         {
-          type0: 'sampled-texture' as const,
-          type1: 'writeonly-storage-texture' as const,
+          type0: 'sampled-texture',
+          type1: 'writeonly-storage-texture',
           _usageSuccess: false,
         },
         {
-          type0: 'sampled-texture' as const,
-          type1: 'render-target' as const,
+          type0: 'sampled-texture',
+          type1: 'render-target',
           _usageSuccess: false,
         },
         {
-          type0: 'readonly-storage-texture' as const,
-          type1: 'readonly-storage-texture' as const,
+          type0: 'readonly-storage-texture',
+          type1: 'readonly-storage-texture',
           _usageSuccess: true,
         },
         {
-          type0: 'readonly-storage-texture' as const,
-          type1: 'writeonly-storage-texture' as const,
+          type0: 'readonly-storage-texture',
+          type1: 'writeonly-storage-texture',
           _usageSuccess: false,
         },
         {
-          type0: 'readonly-storage-texture' as const,
-          type1: 'render-target' as const,
+          type0: 'readonly-storage-texture',
+          type1: 'render-target',
           _usageSuccess: false,
         },
         // Race condition upon multiple writable storage texture is valid.
         {
-          type0: 'writeonly-storage-texture' as const,
-          type1: 'writeonly-storage-texture' as const,
+          type0: 'writeonly-storage-texture',
+          type1: 'writeonly-storage-texture',
           _usageSuccess: true,
         },
         {
-          type0: 'writeonly-storage-texture' as const,
-          type1: 'render-target' as const,
+          type0: 'writeonly-storage-texture',
+          type1: 'render-target',
           _usageSuccess: false,
         },
-      ])
+      ] as const)
   )
   .fn(async t => {
     const {

--- a/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
@@ -288,6 +288,9 @@ g.test('binding_types_combination')
         binding: 0,
         visibility: GPUShaderStage.FRAGMENT,
         type: type0,
+        // Currently setting two 'render-target' usages in the same render pass is impossible.
+        // We don't need to test that. So type0 is either 'sampled-texture' or storage usages.
+        // It can't be 'render-target'.
         storageTextureFormat: type0 === 'sampled-texture' ? undefined : 'rgba8unorm',
       },
     ];

--- a/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
@@ -2,11 +2,17 @@ export const description = `
 Texture Usages Validation Tests in Render Pass.
 
 Test Coverage:
- - Tests that read and write usages upon the same texture subresource, or different subresources
-   of the same texture. Different subresources of the same texture includes different mip levels,
-   different array layers, and different aspects.
-   - When read and write usages are binding to the same texture subresource, an error should be
-     generated. Otherwise, no error should be generated.
+
+  - Test the combination of different pairs of usages upon the same texture subresource or different
+    subresources of the same texture. Different subresources of the same texture includes different
+    mip levels, different array layers, and different aspects.
+    - When read-write or write-write usages are binding to the same texture subresource, an error
+      should be generated. Otherwise, no error should be generated. One exception is race condition
+      upon two writeonly-storage-texture usages, which is valid.
+
+  - Test different shader stages.
+    - Texture usages in bindings with invisible shader stages should be tracked. Invisible shader
+      stages include shader stage with visibility none and compute shader stage in render pass.
 `;
 
 import { poptions, params } from '../../../../common/framework/params_builder.js';
@@ -230,7 +236,7 @@ g.test('subresources_and_binding_types_combination_for_color')
     }, !success);
   });
 
-g.test('readwrite_upon_aspects')
+g.test('subresources_and_binding_types_combination_for_aspect')
   .params(
     params()
       .combine(poptions('format', ['depth32float', 'depth24plus', 'depth24plus-stencil8'] as const))


### PR DESCRIPTION
Texture read usages include sampled-texture and readonly storage
texture. Texture write usages include writeonly storage texture
and render target. Different usages upon the same subresource
should follow this rule:
- multiple read usages upon the same subresource is valid.
- multiple write usages, or read/write usages upon the same
  subresource is invalid, with one exception that multiple
  writeonly storage texture usages are valid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gpuweb/cts/253)
<!-- Reviewable:end -->
