### PR TITLE
standalone: use <pre> for descriptions

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -184,9 +184,9 @@ function makeTreeNodeHeaderHTML(
     .val(n.query.toString())
     .appendTo(nodetitle);
   if ('description' in n && n.description) {
-    $('<div>')
+    $('<pre>') //
       .addClass('nodedescription')
-      .html(n.description.replace(/\n\n/g, '<br><br>'))
+      .text(n.description)
       .appendTo(nodetitle);
   }
   return div[0];

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -114,6 +114,7 @@
       .nodedescription {
         margin: 0;
         color: gray;
+        white-space: pre-wrap;
       }
 
       /* tree nodes which are subtrees */


### PR DESCRIPTION
Now that we put test plans in descriptions, the contents are not just
trivial paragraph-style text blocks. So we have to preserve the original
formatting for descriptions to render properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gpuweb/cts/259)
<!-- Reviewable:end -->
