### PR TITLE
Adding a TODO for copy between linear data and texture tests

### DIFF
--- a/src/webgpu/api/validation/copy_between_linear_data_and_texture/README.txt
+++ b/src/webgpu/api/validation/copy_between_linear_data_and_texture/README.txt
@@ -3,12 +3,17 @@ writeTexture + copyBufferToTexture + copyTextureToBuffer validation tests.
 Test coverage:
 * resource usages:
 	- texture_usage_must_be_valid: for GPUTextureUsage::COPY_SRC, GPUTextureUsage::COPY_DST flags.
+	- TODO: buffer_usage_must_be_valid
 
 * textureCopyView:
 	- texture_must_be_valid: for valid, destroyed, error textures.
 	- sample_count_must_be_1: for sample count 1 and 4.
 	- mip_level_must_be_in_range: for various combinations of mipLevel and mipLevelCount.
 	- texel_block_alignment_on_origin: for all formats and coordinates.
+
+* bufferCopyView:
+	- TODO: buffer_must_be_valid
+	- TODO: bytes_per_row_alignment
 
 * linear texture data:
 	- bound_on_rows_per_image: for various combinations of copyDepth (1, >1), copyHeight, rowsPerImage.
@@ -25,4 +30,3 @@ Test coverage:
 	- texture_range_conditons: for all coordinate and various combinations of origin, copyExtent, textureSize and mipLevel.
 
 TODO: more test coverage for 1D and 3D textures.
-TODO: add tests for buffer usage and bufferCopyView

--- a/src/webgpu/api/validation/copy_between_linear_data_and_texture/README.txt
+++ b/src/webgpu/api/validation/copy_between_linear_data_and_texture/README.txt
@@ -25,3 +25,4 @@ Test coverage:
 	- texture_range_conditons: for all coordinate and various combinations of origin, copyExtent, textureSize and mipLevel.
 
 TODO: more test coverage for 1D and 3D textures.
+TODO: add tests for buffer usage and bufferCopyView


### PR DESCRIPTION
That should be covered by something like copyBetweenLinearDataAndTexture_bufferRelated.spec.ts.