### PR TITLE
Make jsUndefinedMagicValue less magic

### DIFF
--- a/src/common/framework/query/json_param_value.ts
+++ b/src/common/framework/query/json_param_value.ts
@@ -3,10 +3,11 @@ import { assert } from '../util/util.js';
 
 // JSON can't represent `undefined` and by default stores it as `null`.
 // Instead, store `undefined` as this magic string value in JSON.
-const jsUndefinedMagicValue = '✗undefined';
+const jsUndefinedMagicValue = '_undef_';
 
 export function stringifyParamValue(value: ParamArgument): string {
   return JSON.stringify(value, (k, v) => {
+    // Make sure no one actually uses the magic value as a parameter.
     assert(v !== jsUndefinedMagicValue);
 
     return v === undefined ? jsUndefinedMagicValue : v;


### PR DESCRIPTION
Perhaps unsurprisingly, a lot of WPT-related tooling breaks when there's a
unicode character here.