### PR TITLE
Split IDL flags tests into one case per member; add QUERY_RESOLVE

### DIFF
--- a/src/webgpu/idl/constants/flags.spec.ts
+++ b/src/webgpu/idl/constants/flags.spec.ts
@@ -2,53 +2,79 @@ export const description = `
 Test the values of flags interfaces (e.g. GPUTextureUsage).
 `;
 
+import { poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { IDLTest } from '../idl_test.js';
 
 export const g = makeTestGroup(IDLTest);
 
-g.test('BufferUsage').fn(t => {
-  const expected = {
-    MAP_READ: 0x0001,
-    MAP_WRITE: 0x0002,
-    COPY_SRC: 0x0004,
-    COPY_DST: 0x0008,
-    INDEX: 0x0010,
-    VERTEX: 0x0020,
-    UNIFORM: 0x0040,
-    STORAGE: 0x0080,
-    INDIRECT: 0x0100,
-  };
-  t.assertMembers(GPUBufferUsage, expected);
+const kBufferUsageExp = {
+  MAP_READ: 0x0001,
+  MAP_WRITE: 0x0002,
+  COPY_SRC: 0x0004,
+  COPY_DST: 0x0008,
+  INDEX: 0x0010,
+  VERTEX: 0x0020,
+  UNIFORM: 0x0040,
+  STORAGE: 0x0080,
+  INDIRECT: 0x0100,
+  QUERY_RESOLVE: 0x0200,
+};
+g.test('BufferUsage,count').fn(t => {
+  t.assertMemberCount(GPUBufferUsage, kBufferUsageExp);
 });
+g.test('BufferUsage,values')
+  .params(poptions('key', Object.keys(kBufferUsageExp)))
+  .fn(t => {
+    const { key } = t.params;
+    t.assertMember(GPUBufferUsage, kBufferUsageExp, key);
+  });
 
-g.test('TextureUsage').fn(t => {
-  const expected = {
-    COPY_SRC: 0x01,
-    COPY_DST: 0x02,
-    SAMPLED: 0x04,
-    STORAGE: 0x08,
-    OUTPUT_ATTACHMENT: 0x10,
-  };
-  t.assertMembers(GPUTextureUsage, expected);
+const kTextureUsageExp = {
+  COPY_SRC: 0x01,
+  COPY_DST: 0x02,
+  SAMPLED: 0x04,
+  STORAGE: 0x08,
+  OUTPUT_ATTACHMENT: 0x10,
+};
+g.test('TextureUsage,count').fn(t => {
+  t.assertMemberCount(GPUTextureUsage, kTextureUsageExp);
 });
+g.test('TextureUsage,values')
+  .params(poptions('key', Object.keys(kTextureUsageExp)))
+  .fn(t => {
+    const { key } = t.params;
+    t.assertMember(GPUTextureUsage, kTextureUsageExp, key);
+  });
 
-g.test('ColorWrite').fn(t => {
-  const expected = {
-    RED: 0x1,
-    GREEN: 0x2,
-    BLUE: 0x4,
-    ALPHA: 0x8,
-    ALL: 0xf,
-  };
-  t.assertMembers(GPUColorWrite, expected);
+const kColorWriteExp = {
+  RED: 0x1,
+  GREEN: 0x2,
+  BLUE: 0x4,
+  ALPHA: 0x8,
+  ALL: 0xf,
+};
+g.test('ColorWrite,count').fn(t => {
+  t.assertMemberCount(GPUColorWrite, kColorWriteExp);
 });
+g.test('ColorWrite,values')
+  .params(poptions('key', Object.keys(kColorWriteExp)))
+  .fn(t => {
+    const { key } = t.params;
+    t.assertMember(GPUColorWrite, kColorWriteExp, key);
+  });
 
-g.test('ShaderStage').fn(t => {
-  const expected = {
-    VERTEX: 0x1,
-    FRAGMENT: 0x2,
-    COMPUTE: 0x4,
-  };
-  t.assertMembers(GPUShaderStage, expected);
+const kShaderStageExp = {
+  VERTEX: 0x1,
+  FRAGMENT: 0x2,
+  COMPUTE: 0x4,
+};
+g.test('ShaderStage,count').fn(t => {
+  t.assertMemberCount(GPUShaderStage, kShaderStageExp);
 });
+g.test('ShaderStage,values')
+  .params(poptions('key', Object.keys(kShaderStageExp)))
+  .fn(t => {
+    const { key } = t.params;
+    t.assertMember(GPUShaderStage, kShaderStageExp, key);
+  });

--- a/src/webgpu/idl/idl_test.ts
+++ b/src/webgpu/idl/idl_test.ts
@@ -6,18 +6,24 @@ interface UnknownObject {
 }
 
 export class IDLTest extends Fixture {
+  // TODO: add a helper to check prototype chains
+
   /**
-   * Asserts that an IDL interface has the expected members.
+   * Asserts that a member of an IDL interface has the expected value.
    */
-  // TODO: exp should allow sentinel markers for unnameable values, such as methods and attributes
-  // TODO: handle extensions
-  // TODO: check prototype chains (maybe as separate method)
-  assertMembers(act: UnknownObject, exp: UnknownObject) {
+  assertMember(act: UnknownObject, exp: UnknownObject, key: string) {
+    assert(key in act, () => `Expected key ${key} missing`);
+    assert(act[key] === exp[key], () => `Value of [${key}] was ${act[key]}, expected ${exp[key]}`);
+  }
+
+  /**
+   * Asserts that an IDL interface has the same number of keys as the
+   *
+   * TODO: add a way to check for the types of keys with unknown values, like methods and attributes
+   * TODO: handle extensions
+   */
+  assertMemberCount(act: UnknownObject, exp: UnknownObject) {
     const expKeys = Object.keys(exp);
-    for (const k of expKeys) {
-      assert(k in act, () => `Expected key ${k} missing`);
-      assert(act[k] === exp[k], () => `Value of [${k}] was ${act[k]}, expected ${exp[k]}`);
-    }
     const actKeys = Object.keys(act);
     assert(
       actKeys.length === expKeys.length,


### PR DESCRIPTION
Prevents the whole test from failing just because there's an extra or missing member.