### PR TITLE
Add more texture usage validation tests: unused bindings

### DIFF
--- a/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
@@ -588,7 +588,9 @@ g.test('unused_bindings_in_pipeline')
 
     const wgslVertex = `
       fn main() -> void {
+      return;
       }
+
       entry_point vertex = main;
     `;
     const binding0: string = useBindGroup0 ? '[[set 0, binding 0]] var<image> image0' : '';
@@ -598,7 +600,9 @@ g.test('unused_bindings_in_pipeline')
       binding1 +
       `
       fn main() -> void {
+        return;
       }
+
       entry_point fragment = main;
     `;
     const pipeline = t.device.createRenderPipeline({

--- a/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
@@ -583,11 +583,12 @@ g.test('unused_bindings_in_pipeline')
     params()
       .combine(pbool('useBindGroup0'))
       .combine(pbool('useBindGroup1'))
-      .combine(pbool('callSetPipeline'))
+      .combine(poptions('setBindGroupsOrder', ['common', 'reversed'] as const))
+      .combine(poptions('setPipeline', ['before', 'middle', 'after', 'none'] as const))
       .combine(pbool('callDraw'))
   )
   .fn(async t => {
-    const { useBindGroup0, useBindGroup1, callSetPipeline, callDraw } = t.params;
+    const { useBindGroup0, useBindGroup1, setBindGroupsOrder, setPipeline, callDraw } = t.params;
     const view = t.createTexture({ usage: GPUTextureUsage.STORAGE }).createView();
     const bindGroup0 = t.createBindGroup(0, view, 'readonly-storage-texture', 'rgba8unorm');
     const bindGroup1 = t.createBindGroup(0, view, 'writeonly-storage-texture', 'rgba8unorm');
@@ -636,9 +637,13 @@ g.test('unused_bindings_in_pipeline')
         },
       ],
     });
-    pass.setBindGroup(0, bindGroup0);
-    pass.setBindGroup(1, bindGroup1);
-    if (callSetPipeline) pass.setPipeline(pipeline);
+    const index0 = setBindGroupsOrder === 'common' ? 0 : 1;
+    const index1 = setBindGroupsOrder === 'common' ? 1 : 0;
+    if (setPipeline === 'before') pass.setPipeline(pipeline);
+    pass.setBindGroup(index0, bindGroup0);
+    if (setPipeline === 'middle') pass.setPipeline(pipeline);
+    pass.setBindGroup(index1, bindGroup1);
+    if (setPipeline === 'after') pass.setPipeline(pipeline);
     if (callDraw) pass.draw(3, 1, 0, 0);
     pass.endPass();
 


### PR DESCRIPTION
The tests have a simple no-op wgsl shader, but it leads to device lost when I verify the tests in Chromium (I pulled the code and built it a few days ago, not very old). Either the wgsl is incorrect, or the wgsl code snippet I wrote can't be supported by Chromium so far. I guess the wgsl code itself is incorrect. For example, the bindings definition in wgsl. I am not familiar with wgsl and I can't find a good example about wgsl for render. Can you take a look?@kainino0x , @Kangz , @austinEng ? 