### PR TITLE
Fix setScissorRect() validation

### DIFF
--- a/src/webgpu/api/validation/setScissorRect.spec.ts
+++ b/src/webgpu/api/validation/setScissorRect.spec.ts
@@ -37,7 +37,7 @@ g.test('use_of_setScissorRect')
     { x: 0, y: 0, width: 0, height: 1, _success: false }, // Width of zero is not allowed
     { x: 0, y: 0, width: 1, height: 0, _success: false }, // Height of zero is not allowed
     { x: 0, y: 0, width: 0, height: 0, _success: false }, // Both width and height of zero are not allowed
-    { x: 0, y: 0, width: TEXTURE_WIDTH + 1, height: TEXTURE_HEIGHT + 1, _success: true }, // Scissor larger than the framebuffer is allowed
+    { x: 0, y: 0, width: TEXTURE_WIDTH + 1, height: TEXTURE_HEIGHT + 1, _success: false }, // Scissor larger than the framebuffer is not allowed
   ])
   .fn(async t => {
     const { x, y, width, height, _success } = t.params;


### PR DESCRIPTION
According to the spec-
- x+width is less than or equal to this.[[attachment_size]].width.
- y+height is less than or equal to this.[[attachment_size]].height.