### PR TITLE
Add texture usage validation scope test

### DIFF
--- a/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInRender.spec.ts
@@ -851,8 +851,8 @@ g.test('validation_scope')
     const view = t
       .createTexture({ usage: GPUTextureUsage.STORAGE | GPUTextureUsage.SAMPLED })
       .createView();
-    const bindGroup0 = t.createBindGroup(0, view, 'sampled-texture', undefined);
-    const bindGroup1 = t.createBindGroup(0, view, 'writeonly-storage-texture', 'rgba8unorm');
+    const bindGroup0 = t.createBindGroup(0, view, 'sampled-texture', '2d', undefined);
+    const bindGroup1 = t.createBindGroup(0, view, 'writeonly-storage-texture', '2d', 'rgba8unorm');
 
     const encoder = t.device.createCommandEncoder();
     const pass = t.beginSimpleRenderPass(encoder, t.createTexture().createView());

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -95,6 +95,40 @@ export class ValidationTest extends GPUTest {
     }
   }
 
+  createNoOpRenderPipeline(): GPURenderPipeline {
+    const wgslVertex = `
+      fn main() -> void {
+        return;
+      }
+
+      entry_point vertex = main;
+    `;
+    const wgslFragment = `
+      fn main() -> void {
+        return;
+      }
+
+      entry_point fragment = main;
+    `;
+
+    return this.device.createRenderPipeline({
+      vertexStage: {
+        module: this.device.createShaderModule({
+          code: wgslVertex,
+        }),
+        entryPoint: 'main',
+      },
+      fragmentStage: {
+        module: this.device.createShaderModule({
+          code: wgslFragment,
+        }),
+        entryPoint: 'main',
+      },
+      primitiveTopology: 'triangle-list',
+      colorStates: [{ format: 'rgba8unorm' }],
+    });
+  }
+
   expectValidationError(fn: Function, shouldError: boolean = true): void {
     // If no error is expected, we let the scope surrounding the test catch it.
     if (shouldError === false) {


### PR DESCRIPTION
Resource usages validation should be done per each render pass.
Inside a pass, resource usage conflict should always validated.
But resource usage conflict between passes is not a problem.