### PR TITLE
Significantly speed up build by optimizing n^2 code

### DIFF
--- a/src/common/framework/query/json_param_value.ts
+++ b/src/common/framework/query/json_param_value.ts
@@ -1,16 +1,31 @@
 import { ParamArgument } from '../params_utils.js';
-import { assert } from '../util/util.js';
+import { assert, sortObjectByKey } from '../util/util.js';
 
 // JSON can't represent `undefined` and by default stores it as `null`.
 // Instead, store `undefined` as this magic string value in JSON.
 const jsUndefinedMagicValue = '_undef_';
 
-export function stringifyParamValue(value: ParamArgument): string {
-  return JSON.stringify(value, (k, v) => {
-    // Make sure no one actually uses the magic value as a parameter.
-    assert(v !== jsUndefinedMagicValue);
+function stringifyFilter(k: string, v: unknown): unknown {
+  // Make sure no one actually uses the magic value as a parameter.
+  assert(v !== jsUndefinedMagicValue);
 
-    return v === undefined ? jsUndefinedMagicValue : v;
+  return v === undefined ? jsUndefinedMagicValue : v;
+}
+
+export function stringifyParamValue(value: ParamArgument): string {
+  return JSON.stringify(value, stringifyFilter);
+}
+
+/**
+ * Like stringifyParamValue but sorts dictionaries by key, for hashing.
+ */
+export function stringifyParamValueUniquely(value: ParamArgument): string {
+  return JSON.stringify(value, (k, v) => {
+    if (typeof v === 'object' && v !== null) {
+      return sortObjectByKey(v);
+    }
+
+    return stringifyFilter(k, v);
   });
 }
 

--- a/src/common/framework/query/stringify_params.ts
+++ b/src/common/framework/query/stringify_params.ts
@@ -6,8 +6,8 @@ import {
 } from '../params_utils.js';
 import { assert } from '../util/util.js';
 
-import { stringifyParamValue } from './json_param_value.js';
-import { kParamKVSeparator } from './separators.js';
+import { stringifyParamValue, stringifyParamValueUniquely } from './json_param_value.js';
+import { kBigSeparator, kParamKVSeparator } from './separators.js';
 
 export function stringifyPublicParams(p: CaseParams): string[] {
   return Object.keys(p)
@@ -15,8 +15,23 @@ export function stringifyPublicParams(p: CaseParams): string[] {
     .map(k => stringifySingleParam(k, p[k]));
 }
 
+/**
+ * An _approximately_ unique string representing a CaseParams value.
+ */
+export function stringifyPublicParamsUniquely(p: CaseParams): string {
+  const keys = Object.keys(p).sort();
+  return keys
+    .filter(k => paramKeyIsPublic(k))
+    .map(k => stringifySingleParamUniquely(k, p[k]))
+    .join(kBigSeparator);
+}
+
 export function stringifySingleParam(k: string, v: ParamArgument) {
   return `${k}${kParamKVSeparator}${stringifySingleParamValue(v)}`;
+}
+
+function stringifySingleParamUniquely(k: string, v: ParamArgument) {
+  return `${k}${kParamKVSeparator}${stringifyParamValueUniquely(v)}`;
 }
 
 function stringifySingleParamValue(v: ParamArgument): string {

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -1,13 +1,8 @@
 import { Fixture } from './fixture.js';
 import { TestCaseRecorder } from './logging/test_case_recorder.js';
-import {
-  CaseParams,
-  CaseParamsIterable,
-  extractPublicParams,
-  publicParamsEquals,
-} from './params_utils.js';
+import { CaseParams, CaseParamsIterable, extractPublicParams } from './params_utils.js';
 import { kPathSeparator } from './query/separators.js';
-import { stringifyPublicParams } from './query/stringify_params.js';
+import { stringifyPublicParams, stringifyPublicParamsUniquely } from './query/stringify_params.js';
 import { validQueryPart } from './query/validQueryPart.js';
 import { assert } from './util/util.js';
 
@@ -121,16 +116,18 @@ class TestBuilder<F extends Fixture, P extends {}> {
       return;
     }
 
-    // This is n^2.
-    const seen: CaseParams[] = [];
+    const seen = new Set<string>();
     for (const testcase of this.cases) {
       // stringifyPublicParams also checks for invalid params values
       const testcaseString = stringifyPublicParams(testcase);
+
+      // A (hopefully) unique representation of a params value.
+      const testcaseStringUnique = stringifyPublicParamsUniquely(testcase);
       assert(
-        !seen.some(x => publicParamsEquals(x, testcase)),
+        !seen.has(testcaseStringUnique),
         `Duplicate public test case params: ${testcaseString}`
       );
-      seen.push(testcase);
+      seen.add(testcaseStringUnique);
     }
   }
 

--- a/src/common/framework/util/util.ts
+++ b/src/common/framework/util/util.ts
@@ -48,6 +48,14 @@ export function raceWithRejectOnTimeout<T>(p: Promise<T>, ms: number, msg: strin
   return Promise.race([p, rejectOnTimeout(ms, msg)]);
 }
 
+export function sortObjectByKey(v: { [k: string]: unknown }): object {
+  const sortedObject: { [k: string]: unknown } = {};
+  for (const k of Object.keys(v).sort()) {
+    sortedObject[k] = v[k];
+  }
+  return sortedObject;
+}
+
 export function objectEquals(x: unknown, y: unknown): boolean {
   if (typeof x !== 'object' || typeof y !== 'object') return x === y;
   if (x === null || y === null) return x === y;

--- a/src/common/framework/util/util.ts
+++ b/src/common/framework/util/util.ts
@@ -48,7 +48,7 @@ export function raceWithRejectOnTimeout<T>(p: Promise<T>, ms: number, msg: strin
   return Promise.race([p, rejectOnTimeout(ms, msg)]);
 }
 
-export function sortObjectByKey(v: { [k: string]: unknown }): object {
+export function sortObjectByKey(v: { [k: string]: unknown }): { [k: string]: unknown } {
   const sortedObject: { [k: string]: unknown } = {};
   for (const k of Object.keys(v).sort()) {
     sortedObject[k] = v[k];


### PR DESCRIPTION
Replaces n^2 comparisons with a `Set<string>`.