### PR TITLE
Allow per-test descriptions

### DIFF
--- a/src/common/framework/file_loader.ts
+++ b/src/common/framework/file_loader.ts
@@ -1,6 +1,6 @@
 import { parseQuery } from './query/parseQuery.js';
 import { TestQuery } from './query/query.js';
-import { RunCaseIterable } from './test_group.js';
+import { IterableTestGroup } from './test_group.js';
 import { TestSuiteListing } from './test_suite_listing.js';
 import { loadTreeForQuery, TestTree, TestTreeLeaf } from './tree.js';
 
@@ -14,7 +14,7 @@ interface ListingFile {
 // A .spec.ts file, as imported.
 export interface SpecFile {
   readonly description: string;
-  readonly g: RunCaseIterable;
+  readonly g: IterableTestGroup;
 }
 
 // Base class for DefaultTestFileLoader and FakeTestFileLoader.

--- a/src/demo/a/b/c.spec.ts
+++ b/src/demo/a/b/c.spec.ts
@@ -6,7 +6,13 @@ import { UnitTest } from '../../../unittests/unit_test.js';
 
 export const g = makeTestGroup(UnitTest);
 
-g.test('f').fn(() => {});
+g.test('f')
+  .desc(
+    `Test plan for f
+    - Test stuff
+    - Test some more stuff`
+  )
+  .fn(() => {});
 
 g.test('f,g').fn(() => {});
 

--- a/src/unittests/test_group_test.ts
+++ b/src/unittests/test_group_test.ts
@@ -1,23 +1,28 @@
 import { Logger, LogResults } from '../common/framework/logging/logger.js';
 import { TestQuerySingleCase } from '../common/framework/query/query.js';
-import { RunCaseIterable, TestCaseID } from '../common/framework/test_group.js';
+import { IterableTestGroup, TestCaseID } from '../common/framework/test_group.js';
 import { objectEquals } from '../common/framework/util/util.js';
 
 import { UnitTest } from './unit_test.js';
 
 export class TestGroupTest extends UnitTest {
-  async run(g: RunCaseIterable): Promise<LogResults> {
+  async run(g: IterableTestGroup): Promise<LogResults> {
     const logger = new Logger(true);
-    for (const rc of await Promise.all(g.iterate())) {
-      const query = new TestQuerySingleCase('xx', ['yy'], rc.id.test, rc.id.params);
-      const [rec] = logger.record(query.toString());
-      await rc.run(rec);
+    for (const t of g.iterate()) {
+      for (const rc of t.iterate()) {
+        const query = new TestQuerySingleCase('xx', ['yy'], rc.id.test, rc.id.params);
+        const [rec] = logger.record(query.toString());
+        await rc.run(rec);
+      }
     }
     return logger.results;
   }
 
-  expectCases(g: RunCaseIterable, cases: TestCaseID[]): void {
-    const gcases = Array.from(g.iterate()).map(rc => rc.id);
+  expectCases(g: IterableTestGroup, cases: TestCaseID[]): void {
+    const gcases = [];
+    for (const t of g.iterate()) {
+      gcases.push(...Array.from(t.iterate(), c => c.id));
+    }
     this.expect(objectEquals(gcases, cases));
   }
 }


### PR DESCRIPTION
This should enable us to organize our test plans to parallel the test code more closely.