### PR TITLE
Test replaced bindings for texture usage validation in compute

### DIFF
--- a/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
@@ -185,6 +185,10 @@ class TextureUsageTracking extends ValidationTest {
       (pass as GPURenderPassEncoder).draw(3, 1, 0, 0);
     }
   }
+
+  isWritableBinding(bindingType: GPUBindingType | 'render-target'): boolean {
+    return bindingType === 'writeonly-storage-texture' ? true : false;
+  }
 }
 
 export const g = makeTestGroup(TextureUsageTracking);
@@ -789,7 +793,7 @@ g.test('replaced_binding')
     pass.setBindGroup(0, bindGroup1);
     pass.endPass();
 
-    let success = bindingType === 'writeonly-storage-texture' ? false : true;
+    let success = !t.isWritableBinding(bindingType);
     // Replaced bindings across dispatch calls should not be validated in compute pass.
     if (compute && callDrawOrDispatch) success = true;
 
@@ -871,9 +875,7 @@ g.test('bindings_in_bundle')
       success = true;
     }
 
-    if (type0 === 'writeonly-storage-texture' && type1 === 'writeonly-storage-texture') {
-      success = true;
-    }
+    if (t.isWritableBinding(type0) && t.isWritableBinding(type1)) success = true;
 
     // Resource usages in bundle should be validated.
     t.expectValidationError(() => {

--- a/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
@@ -789,6 +789,8 @@ g.test('replaced_binding')
     pass.setBindGroup(0, bindGroup1);
     pass.endPass();
 
+    // TODO: If the Compatible Usage List (https://gpuweb.github.io/gpuweb/#compatible-usage-list)
+    // gets programmatically defined in capability_info, use it here, instead of this logic, for clarity.
     let success = bindingType === 'writeonly-storage-texture' ? false : true;
     // Replaced bindings should not be validated in compute pass, because validation only occurs
     // inside dispatch() which only looks at the current resource usages.

--- a/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
@@ -185,10 +185,6 @@ class TextureUsageTracking extends ValidationTest {
       (pass as GPURenderPassEncoder).draw(3, 1, 0, 0);
     }
   }
-
-  isWritableBinding(bindingType: GPUBindingType | 'render-target'): boolean {
-    return bindingType === 'writeonly-storage-texture' ? true : false;
-  }
 }
 
 export const g = makeTestGroup(TextureUsageTracking);
@@ -793,7 +789,7 @@ g.test('replaced_binding')
     pass.setBindGroup(0, bindGroup1);
     pass.endPass();
 
-    let success = !t.isWritableBinding(bindingType);
+    let success = bindingType === 'writeonly-storage-texture' ? false : true;
     // Replaced bindings should not be validated in compute pass, because validation only occurs
     // inside dispatch() which only looks at the current resource usages.
     if (compute) success = true;
@@ -876,7 +872,9 @@ g.test('bindings_in_bundle')
       success = true;
     }
 
-    if (t.isWritableBinding(type0) && t.isWritableBinding(type1)) success = true;
+    if (type0 === 'writeonly-storage-texture' && type1 === 'writeonly-storage-texture') {
+      success = true;
+    }
 
     // Resource usages in bundle should be validated.
     t.expectValidationError(() => {

--- a/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
@@ -24,8 +24,8 @@ Test Coverage:
 
   - Tests replaced bindings:
     - Texture usages via bindings replaced by another setBindGroup() upon the same bindGroup index
-      in render pass should be validated. However, replaced bindings crorss dispatch calls should
-      not be validated.
+      in render pass should be validated. However, replaced bindings should not be validated in
+      compute pass.
 
   - Test texture usages in bundle:
     - Texture usages in bundle should be validated if that bundle is executed in the current scope.
@@ -735,8 +735,8 @@ g.test('shader_stages_and_visibility')
   });
 
 // We should validate the texture usages in bindings which are replaced by another setBindGroup()
-// call site upon the same index in the same render pass. However, replaced bindings across dispatch
-// calls should not be validated.
+// call site upon the same index in the same render pass. However, replaced bindings in compute
+// should not be validated.
 g.test('replaced_binding')
   .params(
     params()
@@ -794,8 +794,9 @@ g.test('replaced_binding')
     pass.endPass();
 
     let success = !t.isWritableBinding(bindingType);
-    // Replaced bindings across dispatch calls should not be validated in compute pass.
-    if (compute && callDrawOrDispatch) success = true;
+    // Replaced bindings should not be validated in compute pass, because validation only occurs
+    // inside dispatch() which only looks at the current resource usages.
+    if (compute) success = true;
 
     t.expectValidationError(() => {
       encoder.finish();


### PR DESCRIPTION
Replaced bindings are always validated in render pass because removing replaced bindings in Chromium/Dawn implementation is difficult (but it is doable, I think). 

This change added tests for `replaced bindings in compute pass`, I think the validation rule should be: 
  * replaced bindings within the same dispatch (or no dispatch call at all in a compute pass, which is only for test, but not useful in real world app) should be validated, just as what we did for replaced bindings in render. 
  * replaced bindings across dispatch calls (but within the same compute pass) should not be validated, because resource usages validation is done per each dispatch call for compute. So replaced bindings across dispatch calls should be ignored. 

I am not sure whether it is easy to add the validation code for replaced bindings across dispatch calls in Dawn. Per may understanding, bindings are inherited across dispatch calls, so it may require us to inherit and then remove replaced bindings, which might be difficult in current Dawn implementation. I mean, I am worried about the implementation in Dawn.

PTAL. Feel free to add Dzmitry to discuss and review if needed.  