### PR TITLE
Update WGSL to new struct syntax.

### DIFF
--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
@@ -1,7 +1,7 @@
-# v-0012 - This fails because |struct Foo|, |fn Foo| and |var Foo| have 
+# v-0012 - This fails because |struct Foo|, |fn Foo| and |var Foo| have
 # the same name |Foo|.
 
-type Foo = struct {
+struct Foo {
   b : f32;
 };
 

--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
@@ -1,10 +1,10 @@
 # v-0012 - This fails because of the duplicated `foo` structure.
 
-type foo = struct {
+struct foo {
   [[offset (0)]] a : i32;
 };
 
-type foo = struct {
+struct foo {
   [[offset (0)]] b : f32;
 };
 

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
@@ -1,6 +1,6 @@
 # v-0015 - This fails because of the runtime array is not last member of the struct.
 
-type Foo = struct {
+struct Foo {
   [[offset (0)]] a : array<f32>;
   [[offset (8)]] b : f32;
 };

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
@@ -1,14 +1,14 @@
 # v-0006 - Fails because struct 'boo' does not have a member 't'.
 
-type boo = struct {
+struct boo {
   z : f32;
 };
 
-type goo = struct {
+struct goo {
   y : boo;
 };
 
-type foo = struct {
+struct foo {
   x : goo;
 };
 

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
@@ -1,7 +1,7 @@
 # v-0006 -  This fails because `fn Foo()` returns `struct goo`, which does not
 # have a member `s.z`.
 
-type goo = struct {
+struct goo {
   s : vec2<i32>;
 };
 

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
@@ -1,7 +1,7 @@
 # v-0006 - Fails because struct `foo` does not have a member `c`however `f.c`
 # is used.
 
-type foo = struct {
+struct foo {
   [[offset (0)]] b : f32;
   [[offset (8)]] a : array<f32>;
 };

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
@@ -1,11 +1,11 @@
 # v-0006 - Fails because struct `foo` does not have a member `b`however `f.b` is
 # used.
 
-type goo = struct {
+struct goo {
   b : f32;
 };
 
-type foo = struct {
+struct foo {
   a : f32;
 };
 

--- a/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
@@ -2,7 +2,7 @@
 
 const a : Foo;
 
-type Foo = struct {
+struct Foo {
   [[offset 0]] a : i32;
 };
 


### PR DESCRIPTION
This CL updates the WGSL CTS tests to use the `struct IDENT` form
instead of the original `type IDENT = struct` form.