### PR TITLE
Allow marking tests as explicitly unimplemented

### DIFF
--- a/src/common/framework/logging/test_case_recorder.ts
+++ b/src/common/framework/logging/test_case_recorder.ts
@@ -70,7 +70,11 @@ export class TestCaseRecorder {
   }
 
   skipped(ex: SkipTestCase): void {
-    this.logImpl(LogSeverity.Skip, new LogMessageWithStack('SKIP', ex));
+    const message = new LogMessageWithStack('SKIP', ex);
+    if (!this.debugging) {
+      message.setStackHidden();
+    }
+    this.logImpl(LogSeverity.Skip, message);
   }
 
   warn(ex: Error): void {

--- a/src/common/tools/crawl.ts
+++ b/src/common/tools/crawl.ts
@@ -35,7 +35,7 @@ export async function crawl(suite: string): Promise<TestSuiteListingEntry[]> {
       assert(mod.description !== undefined, 'Test spec file missing description: ' + filename);
       assert(mod.g !== undefined, 'Test spec file missing TestGroup definition: ' + filename);
 
-      mod.g.checkCaseNamesAndDuplicates();
+      mod.g.validate();
 
       const path = filepathWithoutExtension.split('/');
       entries.push({ file: path, description: mod.description.trim() });

--- a/src/demo/a.spec.ts
+++ b/src/demo/a.spec.ts
@@ -4,3 +4,5 @@ import { makeTestGroup } from '../common/framework/test_group.js';
 import { UnitTest } from '../unittests/unit_test.js';
 
 export const g = makeTestGroup(UnitTest);
+
+g.test('not_implemented_yet').unimplemented();

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -84,6 +84,16 @@ g.test('stack').fn(async t0 => {
   }
 });
 
+g.test('no_fn').fn(t => {
+  const g = makeTestGroupForUnitTesting(UnitTest);
+
+  g.test('missing');
+
+  t.shouldThrow('Error', () => {
+    g.validate();
+  });
+});
+
 g.test('duplicate_test_name').fn(t => {
   const g = makeTestGroupForUnitTesting(UnitTest);
   g.test('abc').fn(() => {});
@@ -99,13 +109,13 @@ g.test('duplicate_test_params,none').fn(() => {
     g.test('abc')
       .params([])
       .fn(() => {});
-    g.checkCaseNamesAndDuplicates();
+    g.validate();
   }
 
   {
     const g = makeTestGroupForUnitTesting(UnitTest);
     g.test('abc').fn(() => {});
-    g.checkCaseNamesAndDuplicates();
+    g.validate();
   }
 
   {
@@ -115,7 +125,7 @@ g.test('duplicate_test_params,none').fn(() => {
         { a: 1 }, //
       ])
       .fn(() => {});
-    g.checkCaseNamesAndDuplicates();
+    g.validate();
   }
 });
 
@@ -129,7 +139,7 @@ g.test('duplicate_test_params,basic').fn(t => {
       ])
       .fn(() => {});
     t.shouldThrow('Error', () => {
-      g.checkCaseNamesAndDuplicates();
+      g.validate();
     });
   }
   {
@@ -141,7 +151,7 @@ g.test('duplicate_test_params,basic').fn(t => {
       ])
       .fn(() => {});
     t.shouldThrow('Error', () => {
-      g.checkCaseNamesAndDuplicates();
+      g.validate();
     });
   }
 });
@@ -155,7 +165,7 @@ g.test('duplicate_test_params,with_different_private_params').fn(t => {
     ])
     .fn(() => {});
   t.shouldThrow('Error', () => {
-    g.checkCaseNamesAndDuplicates();
+    g.validate();
   });
 });
 
@@ -185,7 +195,7 @@ g.test('param_value,invalid').fn(t => {
     const g = makeTestGroupForUnitTesting(UnitTest);
     g.test('a').params([{ badChar }]);
     t.shouldThrow('Error', () => {
-      g.checkCaseNamesAndDuplicates();
+      g.validate();
     });
   }
 });

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -25,6 +25,17 @@ export const g = makeTestGroup(GPUTest);
 /* eslint-disable-next-line  @typescript-eslint/no-unused-vars */
 g.test('test_name').fn(t => {});
 
+g.test('not_implemented_yet,without_plan').unimplemented();
+g.test('not_implemented_yet,with_plan')
+  .desc(
+    `
+Plan for this test. What it tests. Summary of how it tests that functionality.
+- Description of cases, by describing parameters {a, b, c}
+- x= more parameters {x, y, z}
+`
+  )
+  .unimplemented();
+
 g.test('basic').fn(t => {
   t.expect(true);
   t.expect(true, 'true should be true');


### PR DESCRIPTION
This allows for test structure to be committed into the CTS before the
tests themselves are implemented.

Also hide SKIP error messages when not in "debugging" mode.