### PR TITLE
standalone: Lazily-generate DOM subtrees

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -144,7 +144,7 @@ function makeTreeNodeHeaderHTML(
     const checkbox = $('<input>')
       .attr('type', 'checkbox')
       .addClass('collapsebtn')
-      .change(function (this) {
+      .on('change', function (this) {
         onChange((this as HTMLInputElement).checked);
       })
       .attr('alt', 'Expand')

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -151,8 +151,8 @@ function makeTreeNodeHeaderHTML(
       .attr('title', 'Expand')
       .appendTo(div);
 
-    // Collapse s:f:* or s:f:t:* or s:f:t:c by default.
-    if (n.query.level > rootQueryLevel && n.query.level > parentLevel) {
+    // Collapse deeper parts of the tree at load.
+    if (n.query.level > lastQueryLevelToExpand && n.query.level > parentLevel) {
       onChange(false);
     } else {
       checkbox.prop('checked', true); // (does not fire onChange)
@@ -201,7 +201,8 @@ function updateJSON(): void {
   resultsJSON.textContent = logger.asJSON(2);
 }
 
-let rootQueryLevel: TestQueryLevel = 1;
+// Collapse s:f:t:* or s:f:t:c by default.
+let lastQueryLevelToExpand: TestQueryLevel = 2;
 
 (async () => {
   const loader = new DefaultTestFileLoader();
@@ -229,7 +230,9 @@ let rootQueryLevel: TestQueryLevel = 1;
 
   assert(qs.length === 1, 'currently, there must be exactly one ?q=');
   const rootQuery = parseQuery(qs[0]);
-  rootQueryLevel = rootQuery.level;
+  if (rootQuery.level > lastQueryLevelToExpand) {
+    lastQueryLevelToExpand = rootQuery.level;
+  }
   const tree = await loader.loadTree(rootQuery);
 
   tree.dissolveLevelBoundaries();


### PR DESCRIPTION
Significantly improves the performance of loading /standalone/. Code is still messy but at least it still seems to work :)

Before: ~110s
After: ~2s

Note that due to the way the code is currently written, actually running tests causes the DOM for those test cases to get generated, which means running the whole CTS in standalone is difficult (it was better before because once the page loaded, tests ran quickly).

Can be reviewed in separate commits.

Partially fixes #304