### PR TITLE
standalone: Replace results JSON textarea with copy button

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -28,10 +28,6 @@ const resultsVis = document.getElementById('resultsVis')!;
 
 type RunSubtree = () => Promise<void>;
 
-document.getElementById('copyResultsJSON')!.addEventListener('click', () => {
-  navigator.clipboard.writeText(logger.asJSON(2));
-});
-
 // DOM generation
 
 function memoize<T>(fn: () => T): () => T {
@@ -265,6 +261,10 @@ let lastQueryLevelToExpand: TestQueryLevel = 2;
   $('#expandall').change(function (this) {
     const checked = (this as HTMLInputElement).checked;
     $('.collapsebtn').prop('checked', checked).trigger('change');
+  });
+
+  document.getElementById('copyResultsJSON')!.addEventListener('click', () => {
+    navigator.clipboard.writeText(logger.asJSON(2));
   });
 
   if (runnow) {

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -25,9 +25,12 @@ const logger = new Logger(debug);
 const worker = optionEnabled('worker') ? new TestWorker(debug) : undefined;
 
 const resultsVis = document.getElementById('resultsVis')!;
-const resultsJSON = document.getElementById('resultsJSON')!;
 
 type RunSubtree = () => Promise<void>;
+
+document.getElementById('copyResultsJSON')!.addEventListener('click', () => {
+  navigator.clipboard.writeText(logger.asJSON(2));
+});
 
 // DOM generation
 
@@ -190,7 +193,6 @@ function makeTreeNodeHeaderHTML(
     .attr('title', runtext)
     .on('click', async () => {
       await runSubtree();
-      updateJSON();
     })
     .appendTo(div);
   $('<a>')
@@ -220,10 +222,6 @@ function makeTreeNodeHeaderHTML(
       .appendTo(nodetitle);
   }
   return div[0];
-}
-
-function updateJSON(): void {
-  resultsJSON.textContent = logger.asJSON(2);
 }
 
 // Collapse s:f:t:* or s:f:t:c by default.

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -212,9 +212,7 @@
   </head>
   <body>
     <h1>WebGPU Conformance Test Suite</h1>
-    <p>
-      <input type="checkbox" id="expandall" /><label for="expandall">Expand All (slow!)</label>
-    </p>
+    <input type="checkbox" id="expandall" /><label for="expandall">Expand All</label>
 
     <div id="info"></div>
     <div id="resultsVis"></div>

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -212,11 +212,16 @@
   </head>
   <body>
     <h1>WebGPU Conformance Test Suite</h1>
-    <input type="checkbox" id="expandall" /><label for="expandall">Expand All</label>
+    <p>
+      <input type="checkbox" id="expandall" /><label for="expandall">Expand All (slow!)</label>
+    </p>
 
     <div id="info"></div>
     <div id="resultsVis"></div>
-    <textarea id="resultsJSON" spellcheck="false"></textarea>
+
+    <p>
+      <input type=button id=copyResultsJSON value="Copy results as JSON">
+    </p>
 
     <script type="module" src="../out/common/runtime/standalone.js"></script>
   </body>

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -218,7 +218,7 @@
     <div id="resultsVis"></div>
 
     <p>
-      <input type=button id=copyResultsJSON value="Copy results as JSON">
+      <input type="button" id="copyResultsJSON" value="Copy results as JSON">
     </p>
 
     <script type="module" src="../out/common/runtime/standalone.js"></script>


### PR DESCRIPTION
In Chromium, this textarea causes a massive relayout whenever it gets
updated (e.g. 40s on my machine). Remove it, and replace it with a button
that copies the JSON to the clipboard (fast).