### PR TITLE
standalone: Don't generate DOM when test finishes

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -179,10 +179,9 @@ function makeSubtreeChildrenHTML(
     }
   };
   const generateMyHTML = (div: HTMLElement) => {
-    const setChildrenChecked: SetCheckedRecursively[] = [];
-    for (const { generateSubtreeHTML } of childFns) {
-      setChildrenChecked.push(generateSubtreeHTML(div));
-    }
+    const setChildrenChecked = Array.from(childFns, ({ generateSubtreeHTML }) =>
+      generateSubtreeHTML(div)
+    );
 
     return () => {
       for (const setChildChecked of setChildrenChecked) {

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -89,7 +89,7 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
   const generateSubtreeHTML = (div: HTMLElement) => {
     div.classList.add('testcase');
 
-    const caselogs = $('<div>').addClass('testcaselogs');
+    const caselogs = $('<div>').addClass('testcaselogs').hide();
     const [casehead, setChecked] = makeTreeNodeHeaderHTML(t, runSubtree, 2, checked => {
       checked ? caselogs.show() : caselogs.hide();
     });

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -212,7 +212,9 @@
   </head>
   <body>
     <h1>WebGPU Conformance Test Suite</h1>
-    <input type="checkbox" id="expandall" /><label for="expandall">Expand All</label>
+    <p>
+      <input type=button id=expandall value="Expand All (slow!)">
+    </p>
 
     <div id="info"></div>
     <div id="resultsVis"></div>


### PR DESCRIPTION
Previously the test status and logs would get inserted into the DOM immediately when run. This just stores off the result so that it can be rendered into the DOM on-demand.

Also fixes "expand all" button. Previously this just searched the entire page for checkboxes and checked all of them. With lazy DOM generation, this didn't work anymore. Now returns a function from GenerateSubtreeHTML which sets the subtree as "checked", recursively.

Fixes #304 