### PR TITLE
standalone: Show only the full query string for a test, and aligned

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -200,13 +200,6 @@ function makeTreeNodeHeaderHTML(
     .attr('title', 'Open')
     .appendTo(div);
   const nodetitle = $('<div>').addClass('nodetitle').appendTo(div);
-  const nodename = $('<span>')
-    .addClass('nodename')
-    .text(n.readableRelativeName)
-    .appendTo(nodetitle);
-  if ('run' in n) {
-    nodename.addClass('leafname');
-  }
   $('<input>')
     .attr('type', 'text')
     .prop('readonly', true)
@@ -214,6 +207,7 @@ function makeTreeNodeHeaderHTML(
     .val(n.query.toString())
     .appendTo(nodetitle);
   if ('description' in n && n.description) {
+    nodetitle.append('&nbsp;');
     $('<pre>') //
       .addClass('nodedescription')
       .text(n.description)

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -11,9 +11,6 @@
     <link rel="stylesheet" href="third_party/normalize.min.css" />
     <script src="third_party/jquery/jquery-3.3.1.min.js"></script>
     <style>
-      html {
-        overflow-x: hidden;
-      }
       body {
         font-family: monospace;
         min-width: 400px;
@@ -94,27 +91,21 @@
       .nodetitle {
         flex: 10 0 4em;
       }
-      .nodename {
-        margin: 0 0.5em;
-        padding: 2px;
-      }
-      .leafname {
-        background: black;
-        color: white;
-      }
       .nodequery {
+        position: absolute;
+        left: 220px;
+
         background: transparent;
         border: none;
         padding: 2px;
         margin: 0 0.5em;
-        color: #999;
-        width: 50%;
-        max-width: 50%;
+        width: calc(100vw - 360px);
       }
       .nodedescription {
         margin: 0;
         color: gray;
         white-space: pre-wrap;
+        font-size: 80%;
       }
 
       /* tree nodes which are subtrees */
@@ -148,7 +139,7 @@
         border-width: 1px 0 0 1px;
         border-style: solid;
         border-color: gray;
-        background: white;
+        background: #bbb;
       }
       .testcase[data-status='fail'] {
         background: #fdd;
@@ -206,6 +197,11 @@
         .testcaselogs {
           margin-left: 2px;
           width: calc(100% - 2px);
+        }
+        .nodequery {
+          position: relative;
+          left: 0;
+          width: 100%;
         }
       }
     </style>


### PR DESCRIPTION
Remove the "relative" paths in the test tree and promote the full query
string. With the "relative" paths I find that it's way too hard to see
"where" you are in the tree when browsing.

Aligns all of the full query strings with one another (unless the screen
is too small), so the tree structure is easy to see.