### PR TITLE
wpt: Don't return promise from async_test

### DIFF
--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -54,7 +54,6 @@ function addWPTTests(testcases: IterableIterator<TestTreeLeaf>): Promise<Logger>
       });
 
       running.push(p);
-      return p;
     };
 
     async_test(wpt_fn, name);


### PR DESCRIPTION
async_test now asserts that its test function doesn't return anything,
to detect whether you actually intended to use promise_test.
We don't need to use promise_test, so we just don't return the promise.