### PR TITLE
[wgsl] Update tests to match spec update: Relaxing void return requirement

### DIFF
--- a/src/webgpu/shader/validation/wgsl/fn-use-before-def.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/fn-use-before-def.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0005 - Fails because `a` calls `c` but `c` has not been defined.
+# v-0006 - Fails because `a` calls `c` but `c` has not been defined.
 
 fn a() -> i32 {
   return c();

--- a/src/webgpu/shader/validation/wgsl/function-return-missing-return-empty-body.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/function-return-missing-return-empty-body.fail.wgsl
@@ -2,10 +2,8 @@
 # function.
 
 fn func() -> i32 {
-  var a : i32 = 0;
 }
 
 [[stage(vertex)]]
 fn main() -> void {
-  func();
 }

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0006 - Fails because struct 'boo' does not have a member 't'.
+# v-0007 - Fails because struct 'boo' does not have a member 't'.
 
 struct boo {
   z : f32;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0006 -  This fails because `fn Foo()` returns `struct goo`, which does not
+# v-0007 -  This fails because `fn Foo()` returns `struct goo`, which does not
 # have a member `s.z`.
 
 struct goo {

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0006 - Fails because struct `foo` does not have a member `c`however `f.c`
+# v-0007 - Fails because struct `foo` does not have a member `c`however `f.c`
 # is used.
 
 struct foo {

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0006 - Fails because struct `foo` does not have a member `b`however `f.b` is
+# v-0007 - Fails because struct `foo` does not have a member `b`however `f.b` is
 # used.
 
 struct goo {
@@ -9,10 +9,10 @@ struct foo {
   a : f32;
 };
 
+[[stage(vertex)]]
 fn main() -> void {
   var f : foo;
   f.a = 2.0;
   f.b = 5.0;
   return;
 }
-entry_point vertex = main;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0006 - Fails because 'f' is not a struct.
+# v-0007 - Fails because 'f' is not a struct.
 
 [[stage(vertex)]]
 fn main() -> void {


### PR DESCRIPTION
Update wgsl validation tests to match this spec update:
https://github.com/gpuweb/gpuweb/pull/1179