### PR TITLE
Add CI on Actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,61 @@
+name: Pull Request CI
+
+on:
+  pull_request_target:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - run: |
+          git fetch
+          git checkout ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: "15.x"
+      - run: npm ci
+      - run: |
+          npm test
+          sed -i '/out\//d' .gitignore
+          sed -i '/out-wpt\//d' .gitignore
+      - run: |
+          cat << EOF >> firebase.json
+          {
+            "hosting": {
+              "public": ".",
+              "ignore": [
+                "firebase.json",
+                "**/.*",
+                "**/node_modules/**"
+              ]
+            }
+          }
+          EOF
+          cat << EOF >> .firebaserc
+          {
+            "projects": {
+              "default": "gpuweb-prs"
+            }
+          }
+          EOF
+      - id: deployment
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          expires: 30d
+          channelId: cts-prs-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+      - uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Previews, as seen at the time of posting this comment:
+            [**Run this PR's tests live**](${{ steps.deployment.outputs.details_url }}/standalone/)
+            <sub>${{ github.event.pull_request.head.sha }}</sub>
+            <!--
+            pr;label;sha
+            ${{ github.event.pull_request.number }};${{ github.event.pull_request.head.label }};${{ github.event.pull_request.head.sha }}
+            -->

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,27 @@
+name: Push CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v2-beta
+        with:
+          node-version: "15.x"
+      - run: npm ci
+      - run: |
+          npm test
+          sed -i '/out\//d' .gitignore
+          sed -i '/out-wpt\//d' .gitignore
+      - uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: .
+          CLEAN: true


### PR DESCRIPTION
Changes in this pull request enable GitHub Actions to act for CI on the push and pull request (target) events. Instead of having less conditional steps, there are two actions: better readability and taking advantage of pull request target events better.