### PR TITLE
Add pp.join([...]), which joins an array of strings, preserving vertical alignment

### DIFF
--- a/src/unittests/preprocessor.spec.ts
+++ b/src/unittests/preprocessor.spec.ts
@@ -58,6 +58,35 @@ b`;
   t.test(act, exp);
 });
 
+g.test('join,0').fn(t => {
+  const act = pp`a ${pp.join([])} b`;
+  const exp = 'a  b';
+  t.test(act, exp);
+});
+
+g.test('join,1').fn(t => {
+  const act = pp`a ${pp.join(['3'])} b`;
+  const exp = 'a 3 b';
+  t.test(act, exp);
+});
+
+g.test('join,2').fn(t => {
+  const act = pp`a ${pp.join(['3', '4'])} b`;
+  const exp = `\
+a 3
+  4 b`;
+  t.test(act, exp);
+});
+
+g.test('join,22').fn(t => {
+  const act = pp`a ${pp.join(['33333', '4'])} b ${pp.join(['5', '66'])} d`;
+  const exp = `\
+a 33333
+  4 b 5
+      66 d`;
+  t.test(act, exp);
+});
+
 g.test('if,true').fn(t => {
   const act = pp`
 a

--- a/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/textureUsageInPassEncoder.spec.ts
@@ -39,6 +39,7 @@ Test Coverage:
 `;
 
 import { pbool, poptions, params } from '../../../../common/framework/params_builder.js';
+import { pp } from '../../../../common/framework/preprocessor.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert } from '../../../../common/framework/util/util.js';
 import {
@@ -925,9 +926,9 @@ g.test('unused_bindings_in_pipeline')
       entry_point vertex = main;
     `;
     // TODO: revisit the shader code once 'image' can be supported in wgsl.
-    const wgslFragment = `
-      ${useBindGroup0 ? '[[set 0, binding 0]] var<image> image0;' : ''}
-      ${useBindGroup1 ? '[[set 1, binding 0]] var<image> image1;' : ''}
+    const wgslFragment = pp`
+      ${pp._if(useBindGroup0)}[[set 0, binding 0]] var<image> image0;${pp._endif}
+      ${pp._if(useBindGroup1)}[[set 1, binding 0]] var<image> image1;${pp._endif}
       fn main() -> void {
         return;
       }
@@ -937,8 +938,8 @@ g.test('unused_bindings_in_pipeline')
 
     // TODO: revisit the shader code once 'image' can be supported in wgsl.
     const wgslCompute = `
-      ${useBindGroup0 ? '[[set 0, binding 0]] var<image> image0;' : ''}
-      ${useBindGroup1 ? '[[set 1, binding 0]] var<image> image1;' : ''}
+      ${pp._if(useBindGroup0)}[[set 0, binding 0]] var<image> image0;${pp._endif}
+      ${pp._if(useBindGroup1)}[[set 1, binding 0]] var<image> image1;${pp._endif}
       fn main() -> void {
         return;
       }

--- a/src/webgpu/util/texture/texelData.spec.ts
+++ b/src/webgpu/util/texture/texelData.spec.ts
@@ -1,6 +1,7 @@
 export const description = 'Test helpers for texel data produce the expected data in the shader';
 
 import { params, poptions } from '../../../common/framework/params_builder.js';
+import { pp } from '../../../common/framework/preprocessor.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { unreachable, assert } from '../../../common/framework/util/util.js';
 import {
@@ -68,20 +69,18 @@ function doTest(
       unreachable();
   }
 
-  const shader = `
+  const shader = pp`
   [[set(0), binding(0)]] var<uniform_constant> tex : texture_2d<${shaderType}>;
 
   [[block]] struct Output {
-    ${rep.componentOrder
-      .map((C, i) => `[[offset(${i * 4})]] result${C} : ${shaderType};`)
-      .join('\n')}
+    ${pp.join(rep.componentOrder.map((C, i) => `[[offset(${i * 4})]] result${C} : ${shaderType};`))}
   };
   [[set(0), binding(1)]] var<storage_buffer> output : Output;
 
   [[stage(compute)]]
   fn main() -> void {
       var texel : vec4<${shaderType}> = textureLoad(tex, vec2<i32>(0, 0), 0);
-      ${rep.componentOrder.map(C => `output.result${C} = texel.${C.toLowerCase()};`).join('\n')}
+      ${pp.join(rep.componentOrder.map(C => `output.result${C} = texel.${C.toLowerCase()};`))}
       return;
   }`;
 


### PR DESCRIPTION
And use `pp` in a few places.

Fixes #356