### PR TITLE
Fix vscode workspace, add src/webgpu as a separate folder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -185,24 +185,25 @@ module.exports = function (grunt) {
     'run:unittest',
     'run:lint',
   ]);
-  registerTaskAndAddToHelp('test', 'Quick development build: standalone+typecheck+unittest', [
+  registerTaskAndAddToHelp('standalone', 'Build standalone and typecheck', [
     'set-quiet-mode',
     'build-standalone',
     'build-done-message',
     'ts:check',
-    'run:unittest',
   ]);
-  registerTaskAndAddToHelp('wpt', 'Build for WPT: wpt+typecheck+unittest', [
+  registerTaskAndAddToHelp('wpt', 'Build for WPT and typecheck', [
     'set-quiet-mode',
     'build-wpt',
     'build-done-message',
     'ts:check',
+  ]);
+  registerTaskAndAddToHelp('unittest', 'Build standalone, typecheck, and unittest', [
+    'standalone',
     'run:unittest',
   ]);
-  registerTaskAndAddToHelp('check', 'Typecheck and lint', [
+  registerTaskAndAddToHelp('check', 'Just typecheck', [
     'set-quiet-mode',
     'ts:check',
-    'run:lint',
   ]);
 
   registerTaskAndAddToHelp('dev', 'Start the dev server, and watch for changes', [

--- a/cts.code-workspace
+++ b/cts.code-workspace
@@ -28,25 +28,54 @@
   "tasks": {
     "version": "2.0.0",
     "tasks": [
+      // Only supports "shell" and "process" tasks.
+      // https://code.visualstudio.com/docs/editor/multi-root-workspaces#_workspace-task-configuration
       {
-        "type": "grunt",
-        "task": "test",
-        "problemMatcher": [],
-        "group": {
-          "kind": "build",
-          "isDefault": true
-        }
-      },
-      {
-        "type": "grunt",
-        "task": "pre",
+        // Use "group": "build" instead of "test" so it's easy to access from cmd-shift-B.
+        "group": "build",
+        "label": "npm: test",
+        "detail": "Run all presubmit checks",
+
+        "type": "shell",
+        "command": "npm run test",
         "problemMatcher": []
       },
       {
-        "type": "grunt",
-        "task": "check",
+        "group": "build",
+        "label": "npm: check",
+        "detail": "Just typecheck",
+
+        "type": "shell",
+        "command": "npm run check",
         "problemMatcher": ["$tsc"]
-      }
+      },
+      {
+        "group": "build",
+        "label": "npm: standalone",
+        "detail": "Build standalone and typecheck",
+
+        "type": "shell",
+        "command": "npm run standalone",
+        "problemMatcher": []
+      },
+      {
+        "group": "build",
+        "label": "npm: wpt",
+        "detail": "Build for WPT and typecheck",
+
+        "type": "shell",
+        "command": "npm run wpt",
+        "problemMatcher": []
+      },
+      {
+        "group": "build",
+        "label": "npm: unittest",
+        "detail": "Build standalone, typecheck, and unittest",
+
+        "type": "shell",
+        "command": "npm run unittest",
+        "problemMatcher": []
+      },
     ]
   }
 }

--- a/cts.code-workspace
+++ b/cts.code-workspace
@@ -1,6 +1,15 @@
 // Note: VS Code's setting precedence is `.vscode/` > `cts.code-workspace` > global user settings.
 {
-  "folders": [{ "path": "." }],
+  "folders": [
+    {
+      "name": "cts",
+      "path": "."
+    },
+    {
+      "name": "webgpu",
+      "path": "src/webgpu"
+    }
+  ],
   "settings": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.detectIndentation": false,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@webgpu/cts",
   "version": "0.1.0",
-  "description": "",
+  "description": "WebGPU Conformance Test Suite",
   "scripts": {
     "test": "grunt pre",
+    "check": "grunt check",
+    "standalone": "grunt standalone",
+    "wpt": "grunt wpt",
+    "unittest": "grunt unittest",
     "gen_wpt_cts_html": "tools/gen_wpt_cts_html"
   },
   "engines": {


### PR DESCRIPTION
Only `"shell"` and `"process"` tasks are allowed in `.code-workspace` files. Replace all the `"grunt"` tasks with `"shell"` tasks.
Configure `package.json`'s `"scripts"` to expose the relevant build commands from Grunt.

Also adds `src/webgpu` as a separate folder in the vscode workspace, so the test file hierarchy is clearly visible without getting mixed in with everything else.