### PR TITLE
[wgsl] Add runtime array validation tests

### DIFF
--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
@@ -1,0 +1,13 @@
+# v-0031: in 'y = x', x is a runtime array and it's used as an expression.
+
+type RTArr = [[stride (16)]] array<i32>;
+struct S{
+  [[offset(0)]] data : RTArr;
+};
+
+[[stage(vertex)]]
+fn main() -> void {
+  var <storage> x : S;
+  var y : array<i32,2>;
+  y = x;
+}

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
@@ -1,0 +1,9 @@
+# v-0030 - This fails because 'RTArr' is a runtime array alias and it is used as store type. 
+
+type RTArr = [[stride(4)]] array<f32>;
+[[set(0), binding(1)]] var<storage> x : RTArr;
+
+[[stage(vertex)]]
+fn main() -> void {
+  return;
+}

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
@@ -1,12 +1,12 @@
-# v-0031 - This fails because the runtime array must not be the store type of variable 'buf'.
+# v-0015: variable 's' store type is struct 'SArr' that has a runtime-sized member but its storage class is not 'storage'.
 
+type RTArr = [[stride (16)]] array<vec4<f32>>;
 [[block]]
-struct Foo {
-  [[offset (0)]] a : [[stride (4)]] array<f32>;
+struct SArr{
+  [[offset(0)]] data : RTArr;
 };
-[[set(0), binding(1)]] var<storage> buf: Foo;
 
 [[stage(vertex)]]
 fn main() -> void {
-  return;
+  var s : SArr;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
@@ -1,0 +1,12 @@
+# v-0031 - This fails because the runtime array must not be the store type of variable 'buf'.
+
+[[block]]
+struct Foo {
+  [[offset (0)]] a : [[stride (4)]] array<f32>;
+};
+[[set(0), binding(1)]] var<storage> buf: Foo;
+
+[[stage(vertex)]]
+fn main() -> void {
+  return;
+}

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
@@ -7,4 +7,5 @@ struct S{
 
 [[stage(vertex)]]
 fn main() -> void {
+  var <storage> x : S;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
@@ -1,0 +1,10 @@
+# v-0031: struct 'S' has runtime-sized member but it's storage class is not 'storage'.
+
+type RTArr = [[stride (16)]] array<vec4<f32>>;
+struct S{
+  [[offset(0)]] data : RTArr;
+};
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
@@ -1,12 +1,12 @@
 # v-0015 - This fails because of the runtime array is not last member of the struct.
 
-[[block]]
-struct Foo {
-  [[offset (0)]] a : [[stride (16)]] array<f32>;
-  [[offset (8)]] b : f32;
+type RTArr = [[stride (16)]] array<vec4<f32>>;
+[[block]] 
+struct S {
+  [[offset(0)]] data : RTArr;
+  [[offset(4)]] b : f32;
 };
 
 [[stage(vertex)]]
 fn main() -> void {
-  return;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0015 - This fails because of the runtime array is not last member of the struct.
+# v-0015 - This fails because of the aliased runtime array is not last member of the struct.
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
 [[block]] 

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0015 - This fails because of the runtime array is not last member of a [[block]] struct.
+
+type RTArr = [[stride (16)]] array<vec4<f32>>;
+
+[[stage(vertex)]]
+fn main() -> void {
+  var rt : RTArr;
+}

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
@@ -1,8 +1,8 @@
-# v-0015 - This fails because of the runtime array is not last member of a [[block]] struct.
+# v-0030 - This fails because the runtime array must not be used as a store type.
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
 
 [[stage(vertex)]]
 fn main() -> void {
-  var rt : RTArr;
+  var<storage> rt : RTArr;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
@@ -1,0 +1,11 @@
+# v-0032 - This fails because the runtime array does not have a stride attribute.
+
+[[block]]
+struct Foo {
+  [[offset (0)]] a : array<f32>;
+};
+
+[[stage(vertex)]]
+fn main() -> void {
+  return;
+}


### PR DESCRIPTION
Adding runtime array validation tests for following rules:
v-0015: The last member of the structure type defining the "store type" for variable in the storage storage class may be a runtime-sized array.
v-0030: A runtime-sized array must not be used as the store type or contained within a store type except as allowed by v-0015
v-0031: The type of an expression must not be a runtime-sized array type.
v-0032: A runtime-sized array must have a stride attribute.