### PR TITLE
iterateCollapsedQueries: don't yield files with no tests

### DIFF
--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -253,8 +253,8 @@ export async function loadTreeForQuery(
     const seen = seenSubqueriesToExpand[i];
     assert(
       seen,
-      `subqueriesToExpand entry did not match anything \
-(can happen due to overlap with another subquery): ${sq.toString()}`
+      `subqueriesToExpand entry did not match anything (can happen if the subquery was larger \
+than one file, or due to overlap with another subquery): ${sq.toString()}`
     );
   }
   assert(foundCase, 'Query does not match any cases');

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -96,9 +96,16 @@ export class TestTree {
 
   static *iterateSubtreeCollapsedQueries(subtree: TestSubtree): IterableIterator<TestQuery> {
     for (const [, child] of subtree.children) {
-      if ('children' in child && !child.collapsible) {
-        yield* TestTree.iterateSubtreeCollapsedQueries(child);
+      if ('children' in child) {
+        // Is a subtree
+        if (!child.collapsible) {
+          yield* TestTree.iterateSubtreeCollapsedQueries(child);
+        } else if (child.children.size) {
+          // Don't yield empty subtrees (e.g. files with no tests)
+          yield child.query;
+        }
       } else {
+        // Is a leaf
         yield child.query;
       }
     }

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -24,7 +24,8 @@ const listingData: { [k: string]: TestSuiteListingEntry[] } = {
   suite1: [
     { file: [], readme: 'desc 1a' },
     { file: ['foo'], description: 'desc 1b' },
-    { file: ['bar'], readme: 'desc 1c' },
+    { file: ['bar'], readme: 'desc 1h' },
+    { file: ['bar', 'biz'], description: 'desc 1f' },
     { file: ['bar', 'buzz', 'buzz'], description: 'desc 1d' },
     { file: ['baz'], description: 'desc 1e' },
   ],
@@ -47,10 +48,6 @@ const specsData: { [k: string]: SpecFile } = {
   },
   'suite1/bar/biz.spec.js': {
     description: 'desc 1f',
-    g: makeTestGroupForUnitTesting(UnitTest),
-  },
-  'suite1/bar/bez.spec.js': {
-    description: 'desc 1g',
     g: makeTestGroupForUnitTesting(UnitTest),
   },
   'suite1/bar/buzz/buzz.spec.js': {
@@ -349,12 +346,12 @@ g.test('iterateCollapsed').fn(async t => {
   await testIterateCollapsed(t, ['garbage*'], 'throws');
   await testIterateCollapsed(t, ['suite1*'], 'throws');
   await testIterateCollapsed(t, ['suite1:foo*'], 'throws');
-  await testIterateCollapsed(t, ['suite1:foo:ba*'], 'throws');
+  await testIterateCollapsed(t, ['suite1:foo:he*'], 'throws');
 
   // Valid expectation queries but they don't match anything
   await testIterateCollapsed(t, ['garbage:*'], 'throws');
   await testIterateCollapsed(t, ['suite1:doesntexist:*'], 'throws');
   await testIterateCollapsed(t, ['suite2:foo:*'], 'throws');
-  // Doesn't match anything because we collapse this unnecessary node into just 'suite1:foo:*'
-  await testIterateCollapsed(t, ['suite1:foo,*'], 'throws');
+  // Can't expand subqueries bigger than one suite.
+  await testIterateCollapsed(t, ['suite1:bar,*'], 'throws');
 });


### PR DESCRIPTION
This prevents gen_wpt_cts_html, which generates a list of test queries to cover the whole CTS, from generating "variant" entries for test files (groups) that don't have any tests in them (which throws an error when the browser tries to actually run those variants). I added several such files, as TODOs, in #368.