### PR TITLE
Memory sync test for buffer: write after write in the same pass

### DIFF
--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -256,11 +256,11 @@ export class BufferSyncTest extends GPUTest {
     this.expectContents(buffer, bufferData);
   }
 
-  verifyAlternativeData(buffer: GPUBuffer, expectedValue1: number, expectedValue2: number) {
+  verifyDataMultipleValidValues(buffer: GPUBuffer, expectedValue1: number, expectedValue2: number) {
     const bufferData1 = new Uint32Array(1);
     bufferData1[0] = expectedValue1;
     const bufferData2 = new Uint32Array(1);
     bufferData2[0] = expectedValue2;
-    this.expectAlternativeContents(buffer, bufferData1, bufferData2);
+    this.expectContentsMultipleValidValues(buffer, bufferData1, bufferData2);
   }
 }

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -255,4 +255,12 @@ export class BufferSyncTest extends GPUTest {
     bufferData[0] = expectedValue;
     this.expectContents(buffer, bufferData);
   }
+
+  verifyAlternativeData(buffer: GPUBuffer, expectedValue1: number, expectedValue2: number) {
+    const bufferData1 = new Uint32Array(1);
+    bufferData1[0] = expectedValue1;
+    const bufferData2 = new Uint32Array(1);
+    bufferData2[0] = expectedValue2;
+    this.expectAlternativeContents(buffer, bufferData1, bufferData2);
+  }
 }

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -256,11 +256,11 @@ export class BufferSyncTest extends GPUTest {
     this.expectContents(buffer, bufferData);
   }
 
-  verifyDataMultipleValidValues(buffer: GPUBuffer, expectedValue1: number, expectedValue2: number) {
+  verifyDataTwoValidValues(buffer: GPUBuffer, expectedValue1: number, expectedValue2: number) {
     const bufferData1 = new Uint32Array(1);
     bufferData1[0] = expectedValue1;
     const bufferData2 = new Uint32Array(1);
     bufferData2[0] = expectedValue2;
-    this.expectContentsMultipleValidValues(buffer, bufferData1, bufferData2);
+    this.expectContentsTwoValidValues(buffer, bufferData1, bufferData2);
   }
 }

--- a/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
@@ -133,7 +133,7 @@ g.test('two_draws_in_the_same_render_bundle')
       renderEncoder.draw(1, 1, 0, 0);
     }
 
-    passEncoder.executeBundles([(renderEncoder as GPURenderBundleEncoder).finish()]);
+    passEncoder.executeBundles([renderEncoder.finish()]);
     passEncoder.endPass();
     t.device.defaultQueue.submit([encoder.finish()]);
     t.verifyDataTwoValidValues(buffer, 1, 2);

--- a/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
@@ -108,7 +108,7 @@ g.test('two_draws_in_the_same_render_pass')
 
     passEncoder.endPass();
     t.device.defaultQueue.submit([encoder.finish()]);
-    t.verifyDataMultipleValidValues(buffer, 1, 2);
+    t.verifyDataTwoValidValues(buffer, 1, 2);
   });
 
 g.test('two_draws_in_the_same_render_bundle')
@@ -136,7 +136,7 @@ g.test('two_draws_in_the_same_render_bundle')
     passEncoder.executeBundles([(renderEncoder as GPURenderBundleEncoder).finish()]);
     passEncoder.endPass();
     t.device.defaultQueue.submit([encoder.finish()]);
-    t.verifyDataMultipleValidValues(buffer, 1, 2);
+    t.verifyDataTwoValidValues(buffer, 1, 2);
   });
 
 g.test('two_dispatches_in_the_same_compute_pass')

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -167,7 +167,7 @@ export class GPUTest extends Fixture {
     });
   }
 
-  expectAlternativeContents(
+  expectContentsMultipleValidValues(
     src: GPUBuffer,
     expected1: TypedArrayBufferView,
     expected2: TypedArrayBufferView,
@@ -187,7 +187,9 @@ export class GPUTest extends Fixture {
       const check1 = this.checkBuffer(actual.subarray(begin, end), expected1);
       const check2 = this.checkBuffer(actual.subarray(begin, end), expected2);
       if (check1 !== undefined && check2 !== undefined) {
-        niceStack.message = check1 + check2;
+        niceStack.message = `Expected one of the following two checks to succeed:
+  - ${check1}
+  - ${check2}`;
         this.rec.expectationFailed(niceStack);
       }
       dst.destroy();

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -167,7 +167,9 @@ export class GPUTest extends Fixture {
     });
   }
 
-  expectContentsMultipleValidValues(
+  // We can expand this function in order to support multiple valid values or two mixed vectors
+  // if needed. See the discussion at https://github.com/gpuweb/cts/pull/384#discussion_r533101429
+  expectContentsTwoValidValues(
     src: GPUBuffer,
     expected1: TypedArrayBufferView,
     expected2: TypedArrayBufferView,

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -167,6 +167,33 @@ export class GPUTest extends Fixture {
     });
   }
 
+  expectAlternativeContents(
+    src: GPUBuffer,
+    expected1: TypedArrayBufferView,
+    expected2: TypedArrayBufferView,
+    srcOffset: number = 0
+  ): void {
+    assert(expected1.byteLength === expected2.byteLength);
+    const { dst, begin, end } = this.createAlignedCopyForMapRead(
+      src,
+      expected1.byteLength,
+      srcOffset
+    );
+
+    this.eventualAsyncExpectation(async niceStack => {
+      const constructor = expected1.constructor as TypedArrayBufferViewConstructor;
+      await dst.mapAsync(GPUMapMode.READ);
+      const actual = new constructor(dst.getMappedRange());
+      const check1 = this.checkBuffer(actual.subarray(begin, end), expected1);
+      const check2 = this.checkBuffer(actual.subarray(begin, end), expected2);
+      if (check1 !== undefined && check2 !== undefined) {
+        niceStack.message = check1 + check2;
+        this.rec.expectationFailed(niceStack);
+      }
+      dst.destroy();
+    });
+  }
+
   expectBuffer(actual: Uint8Array, exp: Uint8Array): void {
     const check = this.checkBuffer(actual, exp);
     if (check !== undefined) {


### PR DESCRIPTION
PTAL. Thanks. The naming like verifyAlternativeData and expectAlternativeContents might not be very good, though. But I can't think of a better one. 