### PR TITLE
Fix deployment of newly-added files

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,8 +17,7 @@ jobs:
       - run: npm ci
       - run: |
           npm test
-          sed -i '/out\//d' .gitignore
-          sed -i '/out-wpt\//d' .gitignore
+          git add -f out/ out-wpt/
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I think deployment wasn't adding new files, only changes to existing
files. Seems like editing the .gitignore in place didn't quite work.
Replace that with `git add -f`. Hopefully that works.

Bug: #398