### PR TITLE
Revert "Fix deployment of newly-added files"

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,8 @@ jobs:
       - run: npm ci
       - run: |
           npm test
-          git add -f out/ out-wpt/
+          sed -i '/out\//d' .gitignore
+          sed -i '/out-wpt\//d' .gitignore
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts gpuweb/cts#402

It didn't work. It just deleted everything from the deployment instead (I guess because it's all `.gitignore`d).