### PR TITLE
Catch exceptions in expectValidationError

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -42,10 +42,12 @@ export class Fixture {
 
     // Loop to exhaust the eventualExpectations in case they chain off each other.
     while (this.eventualExpectations.length) {
-      const previousExpectations = this.eventualExpectations;
-      this.eventualExpectations = [];
-
-      await Promise.all(previousExpectations);
+      const p = this.eventualExpectations.shift()!;
+      try {
+        await p;
+      } catch (ex) {
+        this.rec.threw(ex);
+      }
     }
   }
 

--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -44,15 +44,16 @@ class F extends ValidationTest {
       const p = buffer.mapAsync(mode, offset, size);
       await p;
     } else {
-      await this.expectValidationErrorImmediate(async () => {
-        const p = buffer.mapAsync(mode, offset, size);
-        try {
-          await p;
-          assert(rejectName === null, 'mapAsync unexpectedly passed');
-        } catch (ex) {
-          assert(rejectName === ex.name, `mapAsync rejected unexpectedly with: ${ex}`);
-        }
+      let p: Promise<void>;
+      this.expectValidationError(() => {
+        p = buffer.mapAsync(mode, offset, size);
       });
+      try {
+        await p!;
+        assert(rejectName === null, 'mapAsync unexpectedly passed');
+      } catch (ex) {
+        assert(rejectName === ex.name, `mapAsync rejected unexpectedly with: ${ex}`);
+      }
     }
   }
 

--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -26,7 +26,7 @@ TODO: review existing tests and merge with this plan:
 
 import { pbool, poptions, params } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { unreachable } from '../../../../common/framework/util/util.js';
+import { assert, unreachable } from '../../../../common/framework/util/util.js';
 import { kBufferUsages } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import { ValidationTest } from '../validation_test.js';
@@ -43,12 +43,15 @@ class F extends ValidationTest {
     if (success) {
       const p = buffer.mapAsync(mode, offset, size);
       await p;
-      this.shouldResolve(p);
     } else {
-      this.expectValidationError(async () => {
+      await this.expectValidationErrorImmediate(async () => {
         const p = buffer.mapAsync(mode, offset, size);
-        await p;
-        this.shouldReject(rejectName!, p);
+        try {
+          await p;
+          assert(rejectName === null, 'mapAsync unexpectedly passed');
+        } catch (ex) {
+          assert(rejectName === ex.name, `mapAsync rejected unexpectedly with: ${ex}`);
+        }
       });
     }
   }


### PR DESCRIPTION
And fix unhandled rejection in testMapAsyncCall.

Was previously caught in WPT (due to window.onunhandledrejection) but
not in standalone.



-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Reviews](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are outstanding for:**

- [x] WebGPU readability
- [x] TypeScript readability
