### PR TITLE
[wgsl] Add validation test - v-0032: constraints on module variables with an initializers

### DIFF
--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-function.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-function.pass.wgsl
@@ -1,0 +1,6 @@
+# pass v-0032: variable 'a' has an initializer and its storage class is 'function'.
+
+[[stage(vertex)]]
+fn main() -> void {
+  var<function> a : i32  = 1;
+}

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-in.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-in.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0032: variable 'a' has an initializer, however its storage class is 'in'. 
+
+var<in> a : i32  = 1;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-out.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-out.pass.wgsl
@@ -1,0 +1,7 @@
+# pass v-0032: variable 'a' has an initializer and its storage class is 'out'.
+
+var<out> a : i32  = 1;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-private.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-private.pass.wgsl
@@ -1,0 +1,7 @@
+# pass v-0032: variable 'a' has an initializer and its storage class is 'private'.
+
+var<private> a : i32  = 1;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
@@ -1,0 +1,13 @@
+# v-0032: variable 'u' has an initializer, however its storage class is 'storage'.
+
+[[block]]
+struct PositionBuffer {
+  [[offset(0)]] pos: vec2<f32>; 
+};
+
+[[group(0), binding(0)]]
+var<storage_buffer> s : PositionBuffer = PositionBuffer(vec2<f32>(0.0, 0.0));
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
@@ -6,7 +6,7 @@ struct PositionBuffer {
 };
 
 [[group(0), binding(0)]]
-var<storage_buffer> s : PositionBuffer = PositionBuffer(vec2<f32>(0.0, 0.0));
+var<storage> s : PositionBuffer = PositionBuffer(vec2<f32>(0.0, 0.0));
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
@@ -1,0 +1,13 @@
+# v-0032: variable 'u' has an initializer, however its storage class is 'uniform'.
+
+[[block]]
+struct Params {
+  [[offset(0)]] count: i32;
+};
+
+[[group(0), binding(0)]]
+var<uniform> u : Params = Params(1);
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup-array.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup-array.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0032: variable 'w' has an initializer, however its storage class is 'workgroup'.
+
+var<workgroup> w : array<i32, 4> = array<i32, 4>(0, 1, 0, 1);
+
+[[stage(vertex)]]
+fn main() -> void {
+}
+

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0032: variable 'w' has an initializer, however its storage class is 'workgroup'.
+
+var<workgroup> w : vec3<i32> = vec3<i32>(0, 1, 0);
+
+[[stage(vertex)]]
+fn main() -> void {
+}
+


### PR DESCRIPTION
If a variable has an initializer, then its storage class must be one of private, function, or out.
[Link](https://gpuweb.github.io/gpuweb/wgsl.html#variables) to WGSL spec section citing this rule.


-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Reviews requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [ ] TypeScript readability
