### PR TITLE
[wgsl] Add validation test - v-0033: If  the initializer is present, it's store type must match the store type of the variable.

### DIFF
--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-f32.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'flag' store type is 'bool' however the initializer type is 'f32'.
+
+var<out> flag : bool  = 0.0;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-i32.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'flag' store type is 'bool' however the initializer type is 'i32'.
+
+var<out> flag : bool  = 0;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-u32.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'flag' store type is 'bool' however the initializer type is 'u32'.
+
+var<out> flag : bool  = 1u;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool.pass.wgsl
@@ -1,0 +1,7 @@
+# pass v-0033: variable 'a' and its initilizer have the same store type, 'bool'.
+
+var<out> flag : bool  = true;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-bool.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'f' store type is 'f32' however the initializer type is 'bool'.
+
+var<out> f : f32  = true;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-i32.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'f' store type is 'f32' however the initializer type is 'i32'.
+
+var<out> f : f32  = 0;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-u32.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'f' store type is 'f32' however the initializer type is 'i32'.
+
+var<out> f : f32  = 0u;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32.pass.wgsl
@@ -1,0 +1,7 @@
+# pass v-0033: variable 'a' and its initializer have the same storetype, 'f32'.
+
+var<out> a : f32  = 0.0;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-function.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-function.wgsl
@@ -1,0 +1,6 @@
+# v-0033: variable 'a' store type is 'f32', however its initializer type is 'i32'.
+
+[[stage(vertex)]]
+fn main() -> void {
+  var<function> a : f32  = 1;
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-bool.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'a' store type is 'i32' however the initializer type is 'bool'.
+
+var<out> a : i32  = true; 
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-f32.fail.wgsl
@@ -1,6 +1,6 @@
 # v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
 
-var<private> a : i32  = 1.0;
+var<out> a : i32  = 123.0; 
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-u32.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'a' store type is 'i32' however the initializer type is 'u32'.
+
+var<out> a : i32  = 1u;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32.pass.wgsl
@@ -1,0 +1,7 @@
+# pass v-0033: variable 'a' and its initializer have the same storetype, 'i32'.
+
+var<out> a : i32  = 0;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-out.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-out.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
+
+var<out> a : i32  = 1.0;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-private.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-private.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
+
+var<out> a : i32  = 1.0;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-bool.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'u' store type is 'u32' however the initializer type is 'bool'.
+
+var<out> u : u32  = true;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-f32.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'u' store type is 'u32' however the initializer type is 'f32'.
+
+var<out> f : u32  = 0.0;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-i32.fail.wgsl
@@ -1,0 +1,7 @@
+# v-0033: variable 'u' store type is 'u32' however the initializer type is 'i32'.
+
+var<out> f : u32  = 0;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32.pass.wgsl
@@ -1,0 +1,7 @@
+# pass v-0033: variable 'a' and its initializer have the same storetype, 'u32'.
+
+var<out> a : u32  = 0u;
+
+[[stage(vertex)]]
+fn main() -> void {
+}


### PR DESCRIPTION
A variable declaration can optionally have an initializer expression, if it is in the private, function, or out storage classes. If present, the initializer’s type must match the store type of the variable.
[Link](https://gpuweb.github.io/gpuweb/wgsl.html#variables) to spec.


-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [ ] TypeScript readability
