### PR TITLE
[wgsl] Add validation test - v-0034: The access decoration must only appear on a type used as the store type for a variable in the storage storage class.

### DIFF
--- a/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
@@ -1,0 +1,13 @@
+# pass v-0034: The access decoration appears on a type used as the store type of variable
+# 'particles', which is in 'storage' storage class.
+
+[[block]]
+struct Particles {
+  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;  
+};                                                              
+                                                                
+[[binding(1), set(0)]] var<storage> particles : [[access(read_write)]] Particles;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
@@ -6,7 +6,7 @@ struct Particles {
   [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;  
 };                                                              
                                                                 
-[[binding(1), set(0)]] var<storage> particles : [[access(read_write)]] Particles;
+[[group(1), binding(0)]] var<storage> particles : [[access(read_write)]] Particles;
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
@@ -6,7 +6,7 @@ struct Particles {
   [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;  
 };                                                              
                                                                 
-[[binding(0), set(0)]] var<uniform> particles : [[access(read_write)]] Particles;
+[[group(0), binding(0)]] var<uniform> particles : [[access(read_write)]] Particles;
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
@@ -1,0 +1,13 @@
+# v-0034: The access decoration appears on a type used as the store type of variable
+# 'particles', which is in the 'uniform' storage class.
+
+[[block]]
+struct Particles {
+  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;  
+};                                                              
+                                                                
+[[binding(0), set(0)]] var<uniform> particles : [[access(read_write)]] Particles;
+
+[[stage(vertex)]]
+fn main() -> void {
+}


### PR DESCRIPTION
The access decoration ie. read or read write must only appear on a type used as the store type for a variable in the storage storage class.


-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
