### PR TITLE
[wgsl] add validation test - v-0035: The access decoration is required for variables in the storage storage class.

### DIFF
--- a/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
@@ -5,7 +5,7 @@ struct Particles {
   [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;  
 };                                                              
                                                                 
-[[binding(1), set(0)]] var<storage> particles : Particles;
+[[group(0), binding(1)]] var<storage> particles : Particles;
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
@@ -1,0 +1,12 @@
+# v-0035: The access decoration is required for 'particles'.
+
+[[block]]
+struct Particles {
+  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;  
+};                                                              
+                                                                
+[[binding(1), set(0)]] var<storage> particles : Particles;
+
+[[stage(vertex)]]
+fn main() -> void {
+}


### PR DESCRIPTION

-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
