### PR TITLE
[wgsl] Add validation test - v-0037: Module scope variables must be declared with an explicit storage class decoration.

### DIFF
--- a/src/webgpu/shader/validation/wgsl/module-scope-variable-no-explicit-storage-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/module-scope-variable-no-explicit-storage-decoration.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0037: 'f' is a module scope variable so it must be declared with an explicit storage class 
+# decoration.
+
+var f : vec2<f32>;
+
+[[stage(vertex)]]
+fn main() -> void {
+}


### PR DESCRIPTION
A module scope variable in the in, out, private, workgroup, uniform, or storage storage classes, must be declared with an explicit storage class decoration.
-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
