### PR TITLE
[wgsl] Add validation test - v-0038: A module scope variable in the in or out storage class must be IO-shareable.

### DIFF
--- a/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-boolean-array.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-boolean-array.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0038: A module scope variable in 'out' storage class must be IO-sharable.
+# An array type with boolean elements is not IO-shareable.
+
+var<out> particle : array<bool, 4>;
+
+[[stage(vertex)]]
+fn main() -> void{
+}

--- a/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-boolean-vector.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-boolean-vector.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0038: A module scope variable in 'out' storage class must be IO-sharable.
+# A vector type with boolean components is not IO-shareable.
+
+var<out> particle : vec2<bool>;
+
+[[stage(vertex)]]
+fn main() -> void{
+}

--- a/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-boolean.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-boolean.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0038: A module scope variable in 'in' storage class must be IO-sharable.
+# Boolean type is not IO-shareable.
+
+var<in> particle : bool;
+
+[[stage(vertex)]]
+fn main() -> void{
+}

--- a/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-struct-with-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-struct-with-bool.fail.wgsl
@@ -1,0 +1,13 @@
+# v-0038: A module scope variable in 'out' storage class must be IO-sharable.
+# A struct type with a boolean element is not IO-shareable.
+
+[[block]] 
+struct S {
+  [[offset(0)]] b : bool;
+};
+
+var<out> arr : S;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-struct-with-runtime-array.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/in-storage-class-not-IO-shareable-struct-with-runtime-array.fail.wgsl
@@ -1,0 +1,15 @@
+# v-0038: A module scope variable in 'in' storage class must be IO-sharable.
+# A struct type with a runtime array element is not IO-shareable.
+
+type RTArr = [[stride (16)]] array<vec4<f32>>;
+[[block]] 
+struct S {
+  [[offset(0)]] b : f32;
+  [[offset(4)]] data : RTArr;
+};
+
+var<in> arr : S;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-boolean-array.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-boolean-array.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0038: A module scope variable in 'out' storage class must be IO-sharable.
+# An array type with boolean elements is not IO-shareable.
+
+var<out> particle : array<bool, 4>;
+
+[[stage(vertex)]]
+fn main() -> void{
+}

--- a/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-boolean-vector.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-boolean-vector.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0038: A module scope variable in 'out' storage class must be IO-sharable.
+# A vector type with boolean components is not IO-shareable.
+
+var<out> particle : vec2<bool>;
+
+[[stage(vertex)]]
+fn main() -> void{
+}

--- a/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-boolean.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-boolean.fail.wgsl
@@ -1,0 +1,8 @@
+# v-0038: A module scope variable in 'out' storage class must be IO-sharable.
+# Boolean type is not IO-shareable.
+
+var<out> particle : bool;
+
+[[stage(vertex)]]
+fn main() -> void{
+}

--- a/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-struct-with-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-struct-with-bool.fail.wgsl
@@ -1,0 +1,13 @@
+# v-0038: A module scope variable in 'out' storage class must be IO-sharable.
+# A struct type with a boolean element is not IO-shareable.
+
+[[block]] 
+struct S {
+  [[offset(0)]] b : bool;
+};
+
+var<out> arr : S;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-struct-with-runtime-array.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/out-storage-class-not-IO-shareable-struct-with-runtime-array.fail.wgsl
@@ -1,0 +1,15 @@
+# v-0038: A module scope variable in 'out' storage class must be IO-sharable.
+# A struct type with a runtime array element is not IO-shareable.
+
+type RTArr = [[stride (16)]] array<vec4<f32>>;
+[[block]] 
+struct S {
+  [[offset(0)]] b : f32;
+  [[offset(4)]] data : RTArr;
+};
+
+var<out> arr : S;
+
+[[stage(vertex)]]
+fn main() -> void {
+}


### PR DESCRIPTION
A variable in the in or out storage classes:
Must use a store type as described in § [3.4.5 Storage Classes.](https://gpuweb.github.io/gpuweb/wgsl.html#storage-class).
ie. it must be IO shareable.

The following types are IO-shareable:

- numeric scalar types
- numeric vector types
- § 3.3.6 Matrix Types
- § 3.3.7 Array Types if its element type is IO-shareable, and the array is not runtime-sized
- § 3.3.8 Structure Types if all its members are IO-shareable

As a result these are not IO-shareable:

- boolean
- vector of bools
- array of bools
- array runtime sized -> cannot be used outside of a struct, so no cts for this
- struct with bool component
- struct with runtime array


-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
