### PR TITLE
Add validation test for createSampler with different maxAnisotropy values

### DIFF
--- a/src/webgpu/api/validation/createSampler.spec.ts
+++ b/src/webgpu/api/validation/createSampler.spec.ts
@@ -52,5 +52,5 @@ g.test('maxAnisotropy')
         mipmapFilter,
         maxAnisotropy,
       });
-    }, typeof maxAnisotropy !== 'number' || maxAnisotropy < 1 || (maxAnisotropy > 1 && !(minFilter === 'linear' && magFilter === 'linear' && mipmapFilter === 'linear')));
+    }, maxAnisotropy < 1 || (maxAnisotropy > 1 && !(minFilter === 'linear' && magFilter === 'linear' && mipmapFilter === 'linear')));
   });

--- a/src/webgpu/api/validation/createSampler.spec.ts
+++ b/src/webgpu/api/validation/createSampler.spec.ts
@@ -42,5 +42,5 @@ g.test('maxAnisotropy')
         mipmapFilter: t.params.mipmapFilter as GPUFilterMode,
         maxAnisotropy: t.params.maxAnisotropy,
       });
-    }, t.params.maxAnisotropy < 1 || (t.params.maxAnisotropy > 1 && !(t.params.minFilter == 'linear' && t.params.magFilter == 'linear' && t.params.mipmapFilter == 'linear') ));
+    }, t.params.maxAnisotropy < 1 || (t.params.maxAnisotropy > 1 && !(t.params.minFilter === 'linear' && t.params.magFilter === 'linear' && t.params.mipmapFilter === 'linear') ));
   });

--- a/src/webgpu/api/validation/createSampler.spec.ts
+++ b/src/webgpu/api/validation/createSampler.spec.ts
@@ -37,9 +37,9 @@ g.test('maxAnisotropy')
   .fn(async t => {
     t.expectValidationError(() => {
       t.device.createSampler({
-        minFilter: t.params.minFilter,
-        magFilter: t.params.magFilter,
-        mipmapFilter: t.params.mipmapFilter,
+        minFilter: t.params.minFilter as GPUFilterMode,
+        magFilter: t.params.magFilter as GPUFilterMode,
+        mipmapFilter: t.params.mipmapFilter as GPUFilterMode,
         maxAnisotropy: t.params.maxAnisotropy,
       });
     }, t.params.maxAnisotropy < 1 || (t.params.maxAnisotropy > 1 && !(t.params.minFilter == 'linear' && t.params.magFilter == 'linear' && t.params.mipmapFilter == 'linear') ));

--- a/src/webgpu/api/validation/createSampler.spec.ts
+++ b/src/webgpu/api/validation/createSampler.spec.ts
@@ -27,20 +27,30 @@ g.test('lodMinAndMaxClamp')
 
 g.test('maxAnisotropy')
   .desc('test different maxAnisotropy values and combinations with min/mag/mipmapFilter')
-  .params(
-    params()
-      .combine(poptions('maxAnisotropy', [0, 1, 2, 4, 16, 32, 1024]))
-      .combine(poptions('minFilter', ['nearest', 'linear']))
-      .combine(poptions('magFilter', ['nearest', 'linear']))
-      .combine(poptions('mipmapFilter', ['nearest', 'linear']))
-  )
+  .params([
+    ...poptions('maxAnisotropy', [-1, undefined, 0, 1, 2, 4, 7, 16, 32, 33, 1024]),
+    { minFilter: 'nearest' as const },
+    { magFilter: 'nearest' as const },
+    { mipmapFilter: 'nearest' as const },
+  ])
   .fn(async t => {
+    const {
+      maxAnisotropy = 1,
+      minFilter = 'linear',
+      magFilter = 'linear',
+      mipmapFilter = 'linear',
+    } = t.params as {
+      maxAnisotropy?: number;
+      minFilter?: GPUFilterMode;
+      magFilter?: GPUFilterMode;
+      mipmapFilter?: GPUFilterMode;
+    };
     t.expectValidationError(() => {
       t.device.createSampler({
-        minFilter: t.params.minFilter as GPUFilterMode,
-        magFilter: t.params.magFilter as GPUFilterMode,
-        mipmapFilter: t.params.mipmapFilter as GPUFilterMode,
-        maxAnisotropy: t.params.maxAnisotropy,
+        minFilter,
+        magFilter,
+        mipmapFilter,
+        maxAnisotropy,
       });
-    }, t.params.maxAnisotropy < 1 || (t.params.maxAnisotropy > 1 && !(t.params.minFilter === 'linear' && t.params.magFilter === 'linear' && t.params.mipmapFilter === 'linear')));
+    }, typeof maxAnisotropy !== 'number' || maxAnisotropy < 1 || (maxAnisotropy > 1 && !(minFilter === 'linear' && magFilter === 'linear' && mipmapFilter === 'linear')));
   });

--- a/src/webgpu/api/validation/createSampler.spec.ts
+++ b/src/webgpu/api/validation/createSampler.spec.ts
@@ -42,5 +42,5 @@ g.test('maxAnisotropy')
         mipmapFilter: t.params.mipmapFilter as GPUFilterMode,
         maxAnisotropy: t.params.maxAnisotropy,
       });
-    }, t.params.maxAnisotropy < 1 || (t.params.maxAnisotropy > 1 && !(t.params.minFilter === 'linear' && t.params.magFilter === 'linear' && t.params.mipmapFilter === 'linear') ));
+    }, t.params.maxAnisotropy < 1 || (t.params.maxAnisotropy > 1 && !(t.params.minFilter === 'linear' && t.params.magFilter === 'linear' && t.params.mipmapFilter === 'linear')));
   });

--- a/src/webgpu/api/validation/createSampler.spec.ts
+++ b/src/webgpu/api/validation/createSampler.spec.ts
@@ -24,3 +24,23 @@ g.test('lodMinAndMaxClamp')
       });
     }, t.params.lodMinClamp > t.params.lodMaxClamp || t.params.lodMinClamp < 0 || t.params.lodMaxClamp < 0);
   });
+
+g.test('maxAnisotropy')
+  .desc('test different maxAnisotropy values and combinations with min/mag/mipmapFilter')
+  .params(
+    params()
+      .combine(poptions('maxAnisotropy', [0, 1, 2, 4, 16, 32, 1024]))
+      .combine(poptions('minFilter', ['nearest', 'linear']))
+      .combine(poptions('magFilter', ['nearest', 'linear']))
+      .combine(poptions('mipmapFilter', ['nearest', 'linear']))
+  )
+  .fn(async t => {
+    t.expectValidationError(() => {
+      t.device.createSampler({
+        minFilter: t.params.minFilter,
+        magFilter: t.params.magFilter,
+        mipmapFilter: t.params.mipmapFilter,
+        maxAnisotropy: t.params.maxAnisotropy,
+      });
+    }, t.params.maxAnisotropy < 1 || (t.params.maxAnisotropy > 1 && !(t.params.minFilter == 'linear' && t.params.magFilter == 'linear' && t.params.mipmapFilter == 'linear') ));
+  });


### PR DESCRIPTION
Related to spec update at: https://github.com/gpuweb/gpuweb/pull/1323

~~I'm using Visual Code and seeing intelligence warning for assigning 'nearest' 'linear' to enum type `GPUFilterMode`. But the code builds and runs fine. Wondering if there needs any extra coding pattern for typescript.
(Well seems it doesn't build)~~

-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
