### PR TITLE
[wgsl] validation v-0040: uniform and storage buffer are declared with group and binding decorations.

### DIFF
--- a/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
@@ -6,7 +6,7 @@ struct PositionBuffer {
   [[offset(0)]] pos: vec2<f32>; 
 };
 
-var<storage_buffer> s : PositionBuffer;
+var<storage> s : PositionBuffer;
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
@@ -1,0 +1,13 @@
+# v-0039: variable 's' is in storage storage class so it must be declared with group and binding
+# decoration.
+
+[[block]]
+struct PositionBuffer {
+  [[offset(0)]] pos: vec2<f32>; 
+};
+
+var<storage_buffer> s : PositionBuffer;
+
+[[stage(vertex)]]
+fn main() -> void {
+}

--- a/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
@@ -1,0 +1,13 @@
+# v-0040: variable 'u' is in uniform storage class so it must be declared with group and binding
+# decoration. 
+
+[[block]]
+struct Params {
+  [[offset(0)]] count: i32;
+};
+
+var<uniform> u : Params;
+
+[[stage(vertex)]]
+fn main() -> void {
+}


### PR DESCRIPTION
As described in [§ 8.3.2 Resource interface](https://gpuweb.github.io/gpuweb/wgsl.html#resource-interface), uniform buffers, storage buffers, textures, and samplers form the resource interface of a shader. Such variables are declared with group and binding decorations.
[Link](https://gpuweb.github.io/gpuweb/wgsl.html#module-scope-variables) to WGSL spec.

-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
