### PR TITLE
Added range validation tests for GPUQueue.writeBuffer

### DIFF
--- a/src/webgpu/api/operation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/operation/queue/writeBuffer.spec.ts
@@ -8,3 +8,89 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
+
+g.test('writeBuffer,Ranges')
+  .params([
+    {},
+  ])
+  .fn(async t => {
+    const queue = t.device.defaultQueue;
+
+    function runTest(arrayType : any, testBuffer : boolean) {
+      const elementSize = arrayType.BYTES_PER_ELEMENT;
+      const buffer = t.device.createBuffer({ size: 16 * elementSize, usage: GPUBufferUsage.COPY_DST });
+      let arraySm : any = new arrayType(8);
+      let arrayMd : any = new arrayType(16);
+      let arrayLg : any = new arrayType(32);
+
+      if (testBuffer) {
+        arraySm = arraySm.buffer;
+        arrayMd = arrayMd.buffer;
+        arrayLg = arrayLg.buffer;
+
+        const array15 = new Uint8Array(15).buffer;
+
+        // Writing the full buffer that isn't 4-byte aligned.
+        t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, array15));
+
+        // Writing from an offset that causes source to be 4-byte aligned.
+        t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, array15, 3), false);
+      }
+
+      if (elementSize < 4) {
+        // Writing from an offset that causes the source to not be 4-byte aligned.
+        t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arrayMd, 3));
+
+        // Writing with a size that is not 4-byte aligned.
+        t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 0, 7));
+      }
+
+      // Writing the full buffer without offsets.
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arraySm), false);
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayMd), false);
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayLg), true);
+
+      // Writing the full buffer with a 4-byte aligned offset.
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 8, arraySm), false);
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 8, arrayMd), true);
+
+      // Writing the full buffer with a unaligned offset.
+      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 3, arraySm));
+
+      // Writing remainder of buffer from offset.
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arraySm, 4), false);
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayMd, 4), false);
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayLg, 4), true);
+
+      // Writing a larger buffer from an offset that allows it to fit in the destination.
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayLg, 16), false);
+
+      // Writing with both an offset and size.
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arraySm, 4, 4), false);
+
+      // Writing with a size that extends past the source buffer length.
+      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 0, 16));
+      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 4, 8));
+
+      // Writing with a size that is 4-byte aligned but an offset that is not.
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arraySm, 3, 4), false);
+    }
+
+    const arrayTypes = [
+      Uint8Array,
+      Uint8Array,
+      Int8Array,
+      Uint16Array,
+      Int16Array,
+      Uint32Array,
+      Int32Array,
+      Float32Array,
+      Float64Array,
+    ];
+
+    runTest(Uint8Array, true);
+
+    for (const arrayType of arrayTypes) {
+      runTest(arrayType, false);
+    }
+  });

--- a/src/webgpu/api/operation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/operation/queue/writeBuffer.spec.ts
@@ -1,96 +1,11 @@
 export const description = `
 TODO:
 - source.origin is unaligned
-- ?
+- data given as ArrayBuffer
+- data given as each TypedArray variant
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
-
-g.test('writeBuffer,Ranges')
-  .params([
-    {},
-  ])
-  .fn(async t => {
-    const queue = t.device.defaultQueue;
-
-    function runTest(arrayType : any, testBuffer : boolean) {
-      const elementSize = arrayType.BYTES_PER_ELEMENT;
-      const buffer = t.device.createBuffer({ size: 16 * elementSize, usage: GPUBufferUsage.COPY_DST });
-      let arraySm : any = new arrayType(8);
-      let arrayMd : any = new arrayType(16);
-      let arrayLg : any = new arrayType(32);
-
-      if (testBuffer) {
-        arraySm = arraySm.buffer;
-        arrayMd = arrayMd.buffer;
-        arrayLg = arrayLg.buffer;
-
-        const array15 = new Uint8Array(15).buffer;
-
-        // Writing the full buffer that isn't 4-byte aligned.
-        t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, array15));
-
-        // Writing from an offset that causes source to be 4-byte aligned.
-        t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, array15, 3), false);
-      }
-
-      if (elementSize < 4) {
-        // Writing from an offset that causes the source to not be 4-byte aligned.
-        t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arrayMd, 3));
-
-        // Writing with a size that is not 4-byte aligned.
-        t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 0, 7));
-      }
-
-      // Writing the full buffer without offsets.
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arraySm), false);
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayMd), false);
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayLg), true);
-
-      // Writing the full buffer with a 4-byte aligned offset.
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 8, arraySm), false);
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 8, arrayMd), true);
-
-      // Writing the full buffer with a unaligned offset.
-      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 3, arraySm));
-
-      // Writing remainder of buffer from offset.
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arraySm, 4), false);
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayMd, 4), false);
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayLg, 4), true);
-
-      // Writing a larger buffer from an offset that allows it to fit in the destination.
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayLg, 16), false);
-
-      // Writing with both an offset and size.
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arraySm, 4, 4), false);
-
-      // Writing with a size that extends past the source buffer length.
-      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 0, 16));
-      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 4, 8));
-
-      // Writing with a size that is 4-byte aligned but an offset that is not.
-      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arraySm, 3, 4), false);
-    }
-
-    const arrayTypes = [
-      Uint8Array,
-      Uint8Array,
-      Int8Array,
-      Uint16Array,
-      Int16Array,
-      Uint32Array,
-      Int32Array,
-      Float32Array,
-      Float64Array,
-    ];
-
-    runTest(Uint8Array, true);
-
-    for (const arrayType of arrayTypes) {
-      runTest(arrayType, false);
-    }
-  });

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -42,8 +42,9 @@ Also verifies that the specified data range:
 
     function runTest(arrayType: TypedArrayBufferViewConstructor, testBuffer: boolean) {
       const elementSize = arrayType.BYTES_PER_ELEMENT;
+      const bufferSize = 16 * elementSize;
       const buffer = t.device.createBuffer({
-        size: 16 * elementSize,
+        size: bufferSize,
         usage: GPUBufferUsage.COPY_DST,
       });
       const arraySm: TypedArrayBufferView | ArrayBuffer = testBuffer
@@ -103,6 +104,12 @@ Also verifies that the specified data range:
 
       // Writing with a size that is 4-byte aligned but an offset that is not.
       queue.writeBuffer(buffer, 0, arraySm, 3, 4);
+
+      // Writing zero bytes at the end of the buffer
+      queue.writeBuffer(buffer, bufferSize, arraySm, 0, 0);
+
+      // Writing zero bytes from the end of the data
+      queue.writeBuffer(buffer, 0, arraySm, 8, 0);
     }
 
     const arrayTypes = [

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -11,10 +11,115 @@ Tests writeBuffer validation.
 
 Note: destroyed buffer is tested in destroyed/.
 
-TODO: implement.
+TODO: implement usage flag validation.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { TypedArrayBufferView, TypedArrayBufferViewConstructor } from '../../../gpu_test.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
+
+g.test('ranges')
+  .desc(
+    `
+Tests that the data ranges given to GPUQueue.writeBuffer() are properly validated. Tests calling
+writeBuffer with both TypedArrays and ArrayBuffers and checks that the data offset and size is
+interpreted correctly for both.
+
+  - When passing a TypedArray the data offset and size is given in elements.
+  - When passing an ArrayBuffer the data offset and size is given in bytes.
+
+Also verifies that the specified data range:
+
+  - Describes a valid range of the source buffer.
+  - Fits fully within the destination buffer.
+  - Is 4-byte aligned.
+`
+  )
+  .fn(async t => {
+    const queue = t.device.defaultQueue;
+
+    function runTest(arrayType: TypedArrayBufferViewConstructor, testBuffer: boolean) {
+      const elementSize = arrayType.BYTES_PER_ELEMENT;
+      const buffer = t.device.createBuffer({
+        size: 16 * elementSize,
+        usage: GPUBufferUsage.COPY_DST,
+      });
+      const arraySm: TypedArrayBufferView | ArrayBuffer = testBuffer
+        ? new arrayType(8).buffer
+        : new arrayType(8);
+      const arrayMd: TypedArrayBufferView | ArrayBuffer = testBuffer
+        ? new arrayType(16).buffer
+        : new arrayType(16);
+      const arrayLg: TypedArrayBufferView | ArrayBuffer = testBuffer
+        ? new arrayType(32).buffer
+        : new arrayType(32);
+
+      if (testBuffer) {
+        const array15 = new Uint8Array(15).buffer;
+
+        // Writing the full buffer that isn't 4-byte aligned.
+        t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, array15));
+
+        // Writing from an offset that causes source to be 4-byte aligned.
+        queue.writeBuffer(buffer, 0, array15, 3);
+      }
+
+      if (testBuffer || elementSize < 4) {
+        // Writing from an offset that causes the source to not be 4-byte aligned.
+        t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arrayMd, 3));
+
+        // Writing with a size that is not 4-byte aligned.
+        t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 0, 7));
+      }
+
+      // Writing the full buffer without offsets.
+      queue.writeBuffer(buffer, 0, arraySm);
+      queue.writeBuffer(buffer, 0, arrayMd);
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayLg));
+
+      // Writing the full buffer with a 4-byte aligned offset.
+      queue.writeBuffer(buffer, 8, arraySm);
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 8, arrayMd));
+
+      // Writing the full buffer with a unaligned offset.
+      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 3, arraySm));
+
+      // Writing remainder of buffer from offset.
+      queue.writeBuffer(buffer, 0, arraySm, 4);
+      queue.writeBuffer(buffer, 0, arrayMd, 4);
+      t.expectGPUError('validation', () => queue.writeBuffer(buffer, 0, arrayLg, 4));
+
+      // Writing a larger buffer from an offset that allows it to fit in the destination.
+      queue.writeBuffer(buffer, 0, arrayLg, 16);
+
+      // Writing with both an offset and size.
+      queue.writeBuffer(buffer, 0, arraySm, 4, 4);
+
+      // Writing with a size that extends past the source buffer length.
+      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 0, 16));
+      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 4, 8));
+
+      // Writing with a size that is 4-byte aligned but an offset that is not.
+      queue.writeBuffer(buffer, 0, arraySm, 3, 4);
+    }
+
+    const arrayTypes = [
+      Uint8Array,
+      Uint8Array,
+      Int8Array,
+      Uint16Array,
+      Int16Array,
+      Uint32Array,
+      Int32Array,
+      Float32Array,
+      Float64Array,
+    ];
+
+    runTest(Uint8Array, true);
+
+    for (const arrayType of arrayTypes) {
+      runTest(arrayType, false);
+    }
+  });

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -12,7 +12,7 @@ import {
 } from './util/texture/layout.js';
 import { PerTexelComponent, kTexelRepresentationInfo } from './util/texture/texel_data.js';
 
-type TypedArrayBufferView =
+export type TypedArrayBufferView =
   | Uint8Array
   | Uint16Array
   | Uint32Array
@@ -22,7 +22,7 @@ type TypedArrayBufferView =
   | Float32Array
   | Float64Array;
 
-type TypedArrayBufferViewConstructor =
+export type TypedArrayBufferViewConstructor =
   | Uint8ArrayConstructor
   | Uint16ArrayConstructor
   | Uint32ArrayConstructor


### PR DESCRIPTION
Adds tests that check various validation edge cases for the offset and size ranges provided to `GPUQueue.writeBuffer`.

I would have liked each TypedArray variant to be a different `params` for the test, but couldn't figure out how to make TypeScript happy with that. Suggestions welcome!

-----

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [ ] TypeScript readability
