### PR TITLE
Update WGSL tests to use // comments.

### DIFF
--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -375,10 +375,10 @@ g.test('vertexAccess')
                    VertexIndex < ${vertexIndexOffset + numVertices}u);
 
               if (attributesInBounds && (${!p.indexed} || indexInBounds)) {
-                # Success case, move the vertex out of the viewport
+                // Success case, move the vertex out of the viewport
                 Position = vec4<f32>(-1.0, 0.0, 0.0, 1.0);
               } else {
-                # Failure case, move the vertex inside the viewport
+                // Failure case, move the vertex inside the viewport
                 Position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
               }
             }`,

--- a/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
@@ -1,10 +1,10 @@
-# v-0035: The access decoration is required for 'particles'.
+// v-0035: The access decoration is required for 'particles'.
 
 [[block]]
 struct Particles {
-  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;  
-};                                                              
-                                                                
+  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;
+};
+
 [[group(0), binding(1)]] var<storage> particles : Particles;
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
@@ -1,11 +1,11 @@
-# pass v-0034: The access decoration appears on a type used as the store type of variable
-# 'particles', which is in 'storage' storage class.
+// pass v-0034: The access decoration appears on a type used as the store type of variable
+// 'particles', which is in 'storage' storage class.
 
 [[block]]
 struct Particles {
-  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;  
-};                                                              
-                                                                
+  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;
+};
+
 [[group(1), binding(0)]] var<storage> particles : [[access(read_write)]] Particles;
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
@@ -1,11 +1,11 @@
-# v-0034: The access decoration appears on a type used as the store type of variable
-# 'particles', which is in the 'uniform' storage class.
+// v-0034: The access decoration appears on a type used as the store type of variable
+// 'particles', which is in the 'uniform' storage class.
 
 [[block]]
 struct Particles {
-  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;  
-};                                                              
-                                                                
+  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;
+};
+
 [[group(0), binding(0)]] var<uniform> particles : [[access(read_write)]] Particles;
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/break-outside-for-or-switch.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/break-outside-for-or-switch.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0009 - This fails because the break is used outside a for or switch block.
+// v-0009 - This fails because the break is used outside a for or switch block.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/continue-outside-for.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/continue-outside-for.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0010 - This fails because the continue is used outside of a for block.
+// v-0010 - This fails because the continue is used outside of a for block.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/duplicate-entry-point.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-entry-point.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0020 - Duplicate entry point 
+// v-0020 - Duplicate entry point
 
 [[stage(vertex)]]
 [[stage(fragment)]]

--- a/src/webgpu/shader/validation/wgsl/duplicate-func-name.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-func-name.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0016 - This fails because of the duplicate function `my_func`.
+// v-0016 - This fails because of the duplicate function `my_func`.
 
 fn my_func() -> void {
   return;
@@ -6,7 +6,7 @@ fn my_func() -> void {
 
 fn my_func() -> void {
   return;
-} 
+}
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/duplicate-name-between-global-and-func-vars.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-name-between-global-and-func-vars.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0013 - This fails because of the duplicated `a` variable.
+// v-0013 - This fails because of the duplicated `a` variable.
 
 const a : vec2<f32> = vec2<f32>(0.1, 1.0);
 

--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0012 - This fails because |struct Foo|, |fn Foo| and |var Foo| have
-# the same name |Foo|.
+// v-0012 - This fails because |struct Foo|, |fn Foo| and |var Foo| have
+// the same name |Foo|.
 
 struct Foo {
   b : f32;

--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0012 - This fails because of the duplicated `foo` structure.
+// v-0012 - This fails because of the duplicated `foo` structure.
 
 struct foo {
   [[offset (0)]] a : i32;

--- a/src/webgpu/shader/validation/wgsl/duplicate-var-name-sibling.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-name-sibling.pass.wgsl
@@ -1,4 +1,4 @@
-# v-0014 - This passes because variable `a` is redeclared in a sibling scope.
+// v-0014 - This passes because variable `a` is redeclared in a sibling scope.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/duplicate-var-name-within-func.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-name-within-func.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0014 - This fails because variable `a` is redeclared.
+// v-0014 - This fails because variable `a` is redeclared.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/fn-use-before-def.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/fn-use-before-def.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0006 - Fails because `a` calls `c` but `c` has not been defined.
+// v-0006 - Fails because `a` calls `c` but `c` has not been defined.
 
 fn a() -> i32 {
   return c();

--- a/src/webgpu/shader/validation/wgsl/function-return-missing-return-empty-body.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/function-return-missing-return-empty-body.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0002 - This program fails due to the missing return at the end of the
-# function.
+// v-0002 - This program fails due to the missing return at the end of the
+// function.
 
 fn func() -> i32 {
 }

--- a/src/webgpu/shader/validation/wgsl/function-return-missing-return.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/function-return-missing-return.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0002 - This program fails due to the missing return at the end of the
-# function.
+// v-0002 - This program fails due to the missing return at the end of the
+// function.
 
 fn func() -> i32 {
   var a : i32 = 0;

--- a/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v2.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0011 - This fails because of the duplicate name `a`.
+// v-0011 - This fails because of the duplicate name `a`.
 
 const a : vec2<f32> = vec2<f32>(0.1, 1.0);
 

--- a/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v3.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0011 - This fails because of the duplicated `a` variable.
+// v-0011 - This fails because of the duplicated `a` variable.
 
 const a : vec2<f32> = vec2<f32>(0.1, 1.0);
 

--- a/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0011 - This fails because of the duplicated `a` variable.
+// v-0011 - This fails because of the duplicated `a` variable.
 
 const a : vec2<f32> = vec2<f32>(0.1, 1.0);
 [[location (0)]] var<in> a : vec4<f32>;

--- a/src/webgpu/shader/validation/wgsl/module-scope-variable-function-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/module-scope-variable-function-storage-class.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0036: 'f' is a module scope variable however its storage class is 'function'.
+// v-0036: 'f' is a module scope variable however its storage class is 'function'.
 
 var<function> f : vec2<f32>;
 

--- a/src/webgpu/shader/validation/wgsl/module-scope-variable-no-explicit-storage-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/module-scope-variable-no-explicit-storage-decoration.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0037: 'f' is a module scope variable so it must be declared with an explicit storage class 
-# decoration.
+// v-0037: 'f' is a module scope variable so it must be declared with an explicit storage class
+// decoration.
 
 var f : vec2<f32>;
 

--- a/src/webgpu/shader/validation/wgsl/no-enty-point-declared.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/no-enty-point-declared.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0003 - This fails because there must be at least one function with a vertex,
-# fragment or compute decoration.
+// v-0003 - This fails because there must be at least one function with a vertex,
+// fragment or compute decoration.
 
 fn main() -> void {
   return;

--- a/src/webgpu/shader/validation/wgsl/reassign-const.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/reassign-const.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0021 - Fails because `c` is a const and can not be re-assigned.
+// v-0021 - Fails because `c` is a const and can not be re-assigned.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0031: in 'y = x', x is a runtime array and it's used as an expression.
+// v-0031: in 'y = x', x is a runtime array and it's used as an expression.
 
 type RTArr = [[stride (16)]] array<i32>;
 struct S{

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0030 - This fails because 'RTArr' is a runtime array alias and it is used as store type. 
+// v-0030 - This fails because 'RTArr' is a runtime array alias and it is used as store type.
 
 type RTArr = [[stride(4)]] array<f32>;
 [[set(0), binding(1)]] var<storage> x : RTArr;

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0015: variable 's' store type is struct 'SArr' that has a runtime-sized member but its storage class is not 'storage'.
+// v-0015: variable 's' store type is struct 'SArr' that has a runtime-sized member but its storage class is not 'storage'.
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
 [[block]]

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0031: struct 'S' has runtime-sized member but it's storage class is not 'storage'.
+// v-0031: struct 'S' has runtime-sized member but it's storage class is not 'storage'.
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
 struct S{

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
@@ -1,7 +1,7 @@
-# v-0015 - This fails because of the aliased runtime array is not last member of the struct.
+// v-0015 - This fails because of the aliased runtime array is not last member of the struct.
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
-[[block]] 
+[[block]]
 struct S {
   [[offset(0)]] data : RTArr;
   [[offset(4)]] b : f32;

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0030 - This fails because the runtime array must not be used as a store type.
+// v-0030 - This fails because the runtime array must not be used as a store type.
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
 

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0015 - This fails because of the runtime array is not last member of the struct.
+// v-0015 - This fails because of the runtime array is not last member of the struct.
 
 [[block]]
 struct Foo {

--- a/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0032 - This fails because the runtime array does not have a stride attribute.
+// v-0032 - This fails because the runtime array does not have a stride attribute.
 
 [[block]]
 struct Foo {

--- a/src/webgpu/shader/validation/wgsl/self-recursion-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/self-recursion-v2.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0004 - Self recursion is dis-allowed and `c` calls itself.
+// v-0004 - Self recursion is dis-allowed and `c` calls itself.
 
 fn d() -> i32 {
   return 2;

--- a/src/webgpu/shader/validation/wgsl/self-recursion.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/self-recursion.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0004 - Self recursion is dis-allowed and `other` calls itself.
+// v-0004 - Self recursion is dis-allowed and `other` calls itself.
 
 [[stage(vertex)]]
 fn other() -> i32 {

--- a/src/webgpu/shader/validation/wgsl/struct-def-before-use.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-def-before-use.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0007 - fails because 'f' is not a struct.
+// v-0007 - fails because 'f' is not a struct.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0007 - Fails because struct 'boo' does not have a member 't'.
+// v-0007 - Fails because struct 'boo' does not have a member 't'.
 
 struct boo {
   z : f32;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0007 -  This fails because `fn Foo()` returns `struct goo`, which does not
-# have a member `s.z`.
+// v-0007 -  This fails because `fn Foo()` returns `struct goo`, which does not
+// have a member `s.z`.
 
 struct goo {
   s : vec2<i32>;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0007 - Fails because struct `foo` does not have a member `c`however `f.c`
-# is used.
+// v-0007 - Fails because struct `foo` does not have a member `c`however `f.c`
+// is used.
 
 struct foo {
   [[offset (0)]] b : f32;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0007 - Fails because struct `foo` does not have a member `b`however `f.b` is
-# used.
+// v-0007 - Fails because struct `foo` does not have a member `b`however `f.b` is
+// used.
 
 struct goo {
   b : f32;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0007 - Fails because 'f' is not a struct.
+// v-0007 - Fails because 'f' is not a struct.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0007 - This fails because the structure is used before definition.
+// v-0007 - This fails because the structure is used before definition.
 
 const a : Foo;
 

--- a/src/webgpu/shader/validation/wgsl/switch-case-selector-must-have-the-same-type-as-the-selector-expression-2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-case-selector-must-have-the-same-type-as-the-selector-expression-2.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0026: line 7: the case selector values must have the same type as the selector expression
+// v-0026: line 7: the case selector values must have the same type as the selector expression
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/switch-case-selector-must-have-the-same-type-as-the-selector-expression.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-case-selector-must-have-the-same-type-as-the-selector-expression.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0026: line 7: the case selector values must have the same type as the selector expression
+// v-0026: line 7: the case selector values must have the same type as the selector expression
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/switch-case-selector-value-must-be-unique.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-case-selector-value-must-be-unique.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0027: line 9: a literal value must not appear more than once in the case selectors for a
-# switch statement: '0'
+// v-0027: line 9: a literal value must not appear more than once in the case selectors for a
+// switch statement: '0'
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/switch-case.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-case.pass.wgsl
@@ -1,4 +1,4 @@
-# correct use of switch statement  
+// correct use of switch statement
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/switch-fallthrough-must-not-be-last-stmt-of-last-clause.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-fallthrough-must-not-be-last-stmt-of-last-clause.fail.wgsl
@@ -1,5 +1,5 @@
-# v-0028: line 9: a fallthrough statement must not appear as the last statement in last clause
-# of a switch
+// v-0028: line 9: a fallthrough statement must not appear as the last statement in last clause
+// of a switch
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/switch-must-have-exactly-one-default-clause-2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-must-have-exactly-one-default-clause-2.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0008: line 6: switch statement must have exactly one default clause
+// v-0008: line 6: switch statement must have exactly one default clause
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/switch-must-have-exactly-one-default-clause.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-must-have-exactly-one-default-clause.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0008: line 6: switch statement must have exactly one default clause
+// v-0008: line 6: switch statement must have exactly one default clause
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/switch-selector-expression-must-be-scalar-integer-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-selector-expression-must-be-scalar-integer-type.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0025: line 6: switch statement selector expression must be of a scalar integer type
+// v-0025: line 6: switch statement selector expression must be of a scalar integer type
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/var-def-before-use.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/var-def-before-use.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0006 - Fails because 'a' is not defined.
+// v-0006 - Fails because 'a' is not defined.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-f32.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'flag' store type is 'bool' however the initializer type is 'f32'.
+// v-0033: variable 'flag' store type is 'bool' however the initializer type is 'f32'.
 
 var<out> flag : bool  = 0.0;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-i32.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'flag' store type is 'bool' however the initializer type is 'i32'.
+// v-0033: variable 'flag' store type is 'bool' however the initializer type is 'i32'.
 
 var<out> flag : bool  = 0;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-u32.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'flag' store type is 'bool' however the initializer type is 'u32'.
+// v-0033: variable 'flag' store type is 'bool' however the initializer type is 'u32'.
 
 var<out> flag : bool  = 1u;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool.pass.wgsl
@@ -1,4 +1,4 @@
-# pass v-0033: variable 'a' and its initilizer have the same store type, 'bool'.
+// pass v-0033: variable 'a' and its initilizer have the same store type, 'bool'.
 
 var<out> flag : bool  = true;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-bool.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'f' store type is 'f32' however the initializer type is 'bool'.
+// v-0033: variable 'f' store type is 'f32' however the initializer type is 'bool'.
 
 var<out> f : f32  = true;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-i32.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'f' store type is 'f32' however the initializer type is 'i32'.
+// v-0033: variable 'f' store type is 'f32' however the initializer type is 'i32'.
 
 var<out> f : f32  = 0;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-u32.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'f' store type is 'f32' however the initializer type is 'i32'.
+// v-0033: variable 'f' store type is 'f32' however the initializer type is 'i32'.
 
 var<out> f : f32  = 0u;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32.pass.wgsl
@@ -1,4 +1,4 @@
-# pass v-0033: variable 'a' and its initializer have the same storetype, 'f32'.
+// pass v-0033: variable 'a' and its initializer have the same storetype, 'f32'.
 
 var<out> a : f32  = 0.0;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-function.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-function.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'a' store type is 'f32', however its initializer type is 'i32'.
+// v-0033: variable 'a' store type is 'f32', however its initializer type is 'i32'.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-bool.fail.wgsl
@@ -1,6 +1,6 @@
-# v-0033: variable 'a' store type is 'i32' however the initializer type is 'bool'.
+// v-0033: variable 'a' store type is 'i32' however the initializer type is 'bool'.
 
-var<out> a : i32  = true; 
+var<out> a : i32  = true;
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-f32.fail.wgsl
@@ -1,6 +1,6 @@
-# v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
+// v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
 
-var<out> a : i32  = 123.0; 
+var<out> a : i32  = 123.0;
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-u32.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'a' store type is 'i32' however the initializer type is 'u32'.
+// v-0033: variable 'a' store type is 'i32' however the initializer type is 'u32'.
 
 var<out> a : i32  = 1u;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32.pass.wgsl
@@ -1,4 +1,4 @@
-# pass v-0033: variable 'a' and its initializer have the same storetype, 'i32'.
+// pass v-0033: variable 'a' and its initializer have the same storetype, 'i32'.
 
 var<out> a : i32  = 0;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-out.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-out.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
+// v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
 
 var<out> a : i32  = 1.0;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-private.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-private.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
+// v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
 
 var<private> a : i32  = 1.0;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-bool.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'u' store type is 'u32' however the initializer type is 'bool'.
+// v-0033: variable 'u' store type is 'u32' however the initializer type is 'bool'.
 
 var<out> u : u32  = true;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-f32.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'u' store type is 'u32' however the initializer type is 'f32'.
+// v-0033: variable 'u' store type is 'u32' however the initializer type is 'f32'.
 
 var<out> f : u32  = 0.0;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-i32.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0033: variable 'u' store type is 'u32' however the initializer type is 'i32'.
+// v-0033: variable 'u' store type is 'u32' however the initializer type is 'i32'.
 
 var<out> f : u32  = 0;
 

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32.pass.wgsl
@@ -1,4 +1,4 @@
-# pass v-0033: variable 'a' and its initializer have the same storetype, 'u32'.
+// pass v-0033: variable 'a' and its initializer have the same storetype, 'u32'.
 
 var<out> a : u32  = 0u;
 

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-function.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-function.pass.wgsl
@@ -1,4 +1,4 @@
-# pass v-0032: variable 'a' has an initializer and its storage class is 'function'.
+// pass v-0032: variable 'a' has an initializer and its storage class is 'function'.
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-in.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-in.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0032: variable 'a' has an initializer, however its storage class is 'in'. 
+// v-0032: variable 'a' has an initializer, however its storage class is 'in'.
 
 var<in> a : i32  = 1;
 

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-out.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-out.pass.wgsl
@@ -1,4 +1,4 @@
-# pass v-0032: variable 'a' has an initializer and its storage class is 'out'.
+// pass v-0032: variable 'a' has an initializer and its storage class is 'out'.
 
 var<out> a : i32  = 1;
 

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-private.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-private.pass.wgsl
@@ -1,4 +1,4 @@
-# pass v-0032: variable 'a' has an initializer and its storage class is 'private'.
+// pass v-0032: variable 'a' has an initializer and its storage class is 'private'.
 
 var<private> a : i32  = 1;
 

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
@@ -1,8 +1,8 @@
-# v-0032: variable 'u' has an initializer, however its storage class is 'storage'.
+// v-0032: variable 'u' has an initializer, however its storage class is 'storage'.
 
 [[block]]
 struct PositionBuffer {
-  [[offset(0)]] pos: vec2<f32>; 
+  [[offset(0)]] pos: vec2<f32>;
 };
 
 [[group(0), binding(0)]]

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0032: variable 'u' has an initializer, however its storage class is 'uniform'.
+// v-0032: variable 'u' has an initializer, however its storage class is 'uniform'.
 
 [[block]]
 struct Params {

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup-array.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup-array.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0032: variable 'w' has an initializer, however its storage class is 'workgroup'.
+// v-0032: variable 'w' has an initializer, however its storage class is 'workgroup'.
 
 var<workgroup> w : array<i32, 4> = array<i32, 4>(0, 1, 0, 1);
 

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup.fail.wgsl
@@ -1,4 +1,4 @@
-# v-0032: variable 'w' has an initializer, however its storage class is 'workgroup'.
+// v-0032: variable 'w' has an initializer, however its storage class is 'workgroup'.
 
 var<workgroup> w : vec3<i32> = vec3<i32>(0, 1, 0);
 


### PR DESCRIPTION
This CL updates the CTS tests to match the new // comment character and
stop using #.


**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
