### PR TITLE
Update texture storage syntax.

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -924,10 +924,10 @@ g.test('unused_bindings_in_pipeline')
     // TODO: revisit the shader code once 'image' can be supported in wgsl.
     const wgslFragment = pp`
       ${pp._if(useBindGroup0)}
-      [[set(0), binding(0)]] var<image> image0 : texture_storage_ro_2d<rgba8unorm>;
+      [[set(0), binding(0)]] var<image> image0 : [[access(read)]] texture_storage_2d<rgba8unorm>;
       ${pp._endif}
       ${pp._if(useBindGroup1)}
-      [[set(1), binding(0)]] var<image> image1 : texture_storage_ro_2d<rgba8unorm>;
+      [[set(1), binding(0)]] var<image> image1 : [[access(read)]] texture_storage_2d<rgba8unorm>;
       ${pp._endif}
       [[stage(fragment)]] fn main() -> void {}
     `;
@@ -935,10 +935,10 @@ g.test('unused_bindings_in_pipeline')
     // TODO: revisit the shader code once 'image' can be supported in wgsl.
     const wgslCompute = pp`
       ${pp._if(useBindGroup0)}
-      [[set(0), binding(0)]] var<image> image0 : texture_storage_ro_2d<rgba8unorm>;
+      [[set(0), binding(0)]] var<image> image0 : [[access(read)]] texture_storage_2d<rgba8unorm>;
       ${pp._endif}
       ${pp._if(useBindGroup1)}
-      [[set(1), binding(0)]] var<image> image1 : texture_storage_ro_2d<rgba8unorm>;
+      [[set(1), binding(0)]] var<image> image1 : [[access(read)]] texture_storage_2d<rgba8unorm>;
       ${pp._endif}
       [[stage(compute)]] fn main() -> void {}
     `;


### PR DESCRIPTION
This Cl updates the texture storage usage in the WGSL code to use the
new decorated format.


**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
