### PR TITLE
Usability improvements for tree in standalone

### DIFF
--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -38,6 +38,8 @@ export class TestQueryMultiFile {
     this.filePathParts = [...file];
   }
 
+  get depthInLevel() { return this.filePathParts.length; }
+
   toString(): string {
     return encodeURIComponentSelectively(this.toStringHelper().join(kBigSeparator));
   }
@@ -63,6 +65,8 @@ export class TestQueryMultiTest extends TestQueryMultiFile {
     assert(file.length > 0, 'multi-test (or finer) query must have file-path');
     this.testPathParts = [...test];
   }
+
+  get depthInLevel() { return this.testPathParts.length; }
 
   protected toStringHelper(): string[] {
     return [
@@ -91,6 +95,8 @@ export class TestQueryMultiCase extends TestQueryMultiTest {
     this.params = { ...params };
   }
 
+  get depthInLevel() { return Object.keys(this.params).length; }
+
   protected toStringHelper(): string[] {
     const paramsParts = stringifyPublicParams(this.params);
     return [
@@ -110,6 +116,8 @@ export class TestQueryMultiCase extends TestQueryMultiTest {
 export class TestQuerySingleCase extends TestQueryMultiCase {
   readonly level: TestQueryLevel = 4;
   readonly isMultiCase: false = false;
+
+  get depthInLevel() { return 0; }
 
   protected toStringHelper(): string[] {
     const paramsParts = stringifyPublicParams(this.params);

--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -38,7 +38,9 @@ export class TestQueryMultiFile {
     this.filePathParts = [...file];
   }
 
-  get depthInLevel() { return this.filePathParts.length; }
+  get depthInLevel() {
+    return this.filePathParts.length;
+  }
 
   toString(): string {
     return encodeURIComponentSelectively(this.toStringHelper().join(kBigSeparator));
@@ -66,7 +68,9 @@ export class TestQueryMultiTest extends TestQueryMultiFile {
     this.testPathParts = [...test];
   }
 
-  get depthInLevel() { return this.testPathParts.length; }
+  get depthInLevel() {
+    return this.testPathParts.length;
+  }
 
   protected toStringHelper(): string[] {
     return [
@@ -95,7 +99,9 @@ export class TestQueryMultiCase extends TestQueryMultiTest {
     this.params = { ...params };
   }
 
-  get depthInLevel() { return Object.keys(this.params).length; }
+  get depthInLevel() {
+    return Object.keys(this.params).length;
+  }
 
   protected toStringHelper(): string[] {
     const paramsParts = stringifyPublicParams(this.params);
@@ -117,7 +123,9 @@ export class TestQuerySingleCase extends TestQueryMultiCase {
   readonly level: TestQueryLevel = 4;
   readonly isMultiCase: false = false;
 
-  get depthInLevel() { return 0; }
+  get depthInLevel() {
+    return 0;
+  }
 
   protected toStringHelper(): string[] {
     const paramsParts = stringifyPublicParams(this.params);


### PR DESCRIPTION
- Put the test description on `s:f:t:*` instead of `s:f:t,*`.
- Dissolve single child trees that aren't the first in their level,
  instead of dissolving just boundaries between `,*` and `:*` .
  Better reduction of the total number of useless nodes.

-----

<!-- Reminders to the PR author:

* Ensure any new helpers are documented in `helpers.md`.
* Ensure TODOs (or `.unimplemented()`) are present for any incomplete areas.

Leave the following in the pull request description:
-->

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
