### PR TITLE
Update group to set in WGSL.

### DIFF
--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -31,8 +31,8 @@ g.test('memcpy').fn(async t => {
               [[offset(0)]] value : u32;
           };
 
-          [[set(0), binding(0)]] var<storage_buffer> src : Data;
-          [[set(0), binding(1)]] var<storage_buffer> dst : Data;
+          [[group(0), binding(0)]] var<storage_buffer> src : Data;
+          [[group(0), binding(1)]] var<storage_buffer> dst : Data;
 
           [[stage(compute)]] fn main() -> void {
             dst.value = src.value;

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -60,7 +60,7 @@ export class BufferSyncTest extends GPUTest {
         [[offset(0)]] a : i32;
       };
 
-      [[set(0), binding(0)]] var<storage_buffer> data : Data;
+      [[group(0), binding(0)]] var<storage_buffer> data : Data;
       [[stage(compute)]] fn main() -> void {
         data.a = ${value};
         return;
@@ -94,7 +94,7 @@ export class BufferSyncTest extends GPUTest {
         [[offset(0)]] a : i32;
       };
 
-      [[set(0), binding(0)]] var<storage_buffer> data : Data;
+      [[group(0), binding(0)]] var<storage_buffer> data : Data;
       [[stage(fragment)]] fn frag_main() -> void {
         data.a = ${value};
         outColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -52,13 +52,13 @@ export const checkContentsBySampling: CheckContents = (
               [[offset(0)]] level : i32;
             };
 
-            [[set(0), binding(0)]] var<uniform> constants : Constants;
-            [[set(0), binding(1)]] var<uniform_constant> myTexture : texture${_multisampled}${_xd}<${shaderType}>;
+            [[group(0), binding(0)]] var<uniform> constants : Constants;
+            [[group(0), binding(1)]] var<uniform_constant> myTexture : texture${_multisampled}${_xd}<${shaderType}>;
 
             [[block]] struct Result {
               [[offset(0)]] values : [[stride(4)]] array<${shaderType}>;
             };
-            [[set(0), binding(3)]] var<storage_buffer> result : Result;
+            [[group(0), binding(3)]] var<storage_buffer> result : Result;
 
             [[builtin(global_invocation_id)]] var<in> GlobalInvocationID : vec3<u32>;
 

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -32,7 +32,7 @@ class F extends ValidationTest {
             [[block]] struct VertexUniforms {
               [[offset(0)]] transform : mat2x2<f32> ;
             };
-            [[set(0), binding(0)]] var<uniform> uniforms : VertexUniforms;
+            [[group(0), binding(0)]] var<uniform> uniforms : VertexUniforms;
 
             [[builtin(position)]] var<out> Position : vec4<f32>;
             [[builtin(vertex_idx)]] var<in> VertexIndex : i32;
@@ -54,7 +54,7 @@ class F extends ValidationTest {
             [[block]] struct FragmentUniforms {
               [[offset(0)]] color : vec4<f32>;
             };
-            [[set(1), binding(0)]] var<uniform> uniforms : FragmentUniforms;
+            [[group(1), binding(0)]] var<uniform> uniforms : FragmentUniforms;
 
             [[location(0)]] var<out> fragColor : vec4<f32>;
             [[stage(fragment)]] fn main() -> void {

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -924,10 +924,10 @@ g.test('unused_bindings_in_pipeline')
     // TODO: revisit the shader code once 'image' can be supported in wgsl.
     const wgslFragment = pp`
       ${pp._if(useBindGroup0)}
-      [[set(0), binding(0)]] var<image> image0 : [[access(read)]] texture_storage_2d<rgba8unorm>;
+      [[group(0), binding(0)]] var<image> image0 : [[access(read)]] texture_storage_2d<rgba8unorm>;
       ${pp._endif}
       ${pp._if(useBindGroup1)}
-      [[set(1), binding(0)]] var<image> image1 : [[access(read)]] texture_storage_2d<rgba8unorm>;
+      [[group(1), binding(0)]] var<image> image1 : [[access(read)]] texture_storage_2d<rgba8unorm>;
       ${pp._endif}
       [[stage(fragment)]] fn main() -> void {}
     `;
@@ -935,10 +935,10 @@ g.test('unused_bindings_in_pipeline')
     // TODO: revisit the shader code once 'image' can be supported in wgsl.
     const wgslCompute = pp`
       ${pp._if(useBindGroup0)}
-      [[set(0), binding(0)]] var<image> image0 : [[access(read)]] texture_storage_2d<rgba8unorm>;
+      [[group(0), binding(0)]] var<image> image0 : [[access(read)]] texture_storage_2d<rgba8unorm>;
       ${pp._endif}
       ${pp._if(useBindGroup1)}
-      [[set(1), binding(0)]] var<image> image1 : [[access(read)]] texture_storage_2d<rgba8unorm>;
+      [[group(1), binding(0)]] var<image> image1 : [[access(read)]] texture_storage_2d<rgba8unorm>;
       ${pp._endif}
       [[stage(compute)]] fn main() -> void {}
     `;

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0030 - This fails because 'RTArr' is a runtime array alias and it is used as store type.
 
 type RTArr = [[stride(4)]] array<f32>;
-[[set(0), binding(1)]] var<storage> x : RTArr;
+[[group(0), binding(1)]] var<storage> x : RTArr;
 
 [[stage(vertex)]]
 fn main() -> void {

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -55,14 +55,14 @@ function doTest(
   const { ReadbackTypedArray, shaderType } = getComponentReadbackTraits(getSingleDataType(format));
 
   const shader = `
-  [[set(0), binding(0)]] var<uniform_constant> tex : texture_2d<${shaderType}>;
+  [[group(0), binding(0)]] var<uniform_constant> tex : texture_2d<${shaderType}>;
 
   [[block]] struct Output {
     ${rep.componentOrder
       .map((C, i) => `[[offset(${i * 4})]] result${C} : ${shaderType};`)
       .join('\n')}
   };
-  [[set(0), binding(1)]] var<storage_buffer> output : Output;
+  [[group(0), binding(1)]] var<storage_buffer> output : Output;
 
   [[stage(compute)]]
   fn main() -> void {


### PR DESCRIPTION
This CL updates the CTS to use the new `group` decoration instead of the
deprecated `set` decoration.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
