### PR TITLE
Update vertex_idx to vertex_index in WGSL.

### DIFF
--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -53,7 +53,7 @@ g.test('render_pass_resolve')
         module: t.device.createShaderModule({
           code: `
             [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[builtin(vertex_idx)]] var<in> VertexIndex : i32;
+            [[builtin(vertex_index)]] var<in> VertexIndex : i32;
 
             [[stage(vertex)]] fn main() -> void {
               const pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -27,7 +27,7 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
         module: t.device.createShaderModule({
           code: `
             [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[builtin(vertex_idx)]] var<in> VertexIndex : i32;
+            [[builtin(vertex_index)]] var<in> VertexIndex : i32;
 
             [[stage(vertex)]] fn main() -> void {
               const pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -102,7 +102,7 @@ g.test('culling')
           module: t.device.createShaderModule({
             code: `
               [[builtin(position)]] var<out> Position : vec4<f32>;
-              [[builtin(vertex_idx)]] var<in> VertexIndex : i32;
+              [[builtin(vertex_index)]] var<in> VertexIndex : i32;
 
               [[stage(vertex)]] fn main() -> void {
                 const pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -59,7 +59,7 @@ g.test('fullscreen_quad').fn(async t => {
       module: t.device.createShaderModule({
         code: `
           [[builtin(position)]] var<out> Position : vec4<f32>;
-          [[builtin(vertex_idx)]] var<in> VertexIndex : i32;
+          [[builtin(vertex_index)]] var<in> VertexIndex : i32;
 
           [[stage(vertex)]] fn main() -> void {
             const pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -7,7 +7,7 @@ function makeFullscreenVertexModule(device: GPUDevice) {
   return device.createShaderModule({
     code: `
     [[builtin(position)]] var<out> Position : vec4<f32>;
-    [[builtin(vertex_idx)]] var<in> VertexIndex : i32;
+    [[builtin(vertex_index)]] var<in> VertexIndex : i32;
 
     [[stage(vertex)]]
     fn main() -> void {

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -65,7 +65,7 @@ class IndexFormatTest extends GPUTest {
           vec2<f32>(0.01, -0.98));
 
         [[builtin(position)]] var<out> Position : vec4<f32>;
-        [[builtin(vertex_idx)]] var<in> VertexIndex : u32;
+        [[builtin(vertex_index)]] var<in> VertexIndex : u32;
 
         [[stage(vertex)]]
         fn main() -> void {

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -35,7 +35,7 @@ class F extends ValidationTest {
             [[set(0), binding(0)]] var<uniform> uniforms : VertexUniforms;
 
             [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[builtin(vertex_idx)]] var<in> VertexIndex : i32;
+            [[builtin(vertex_index)]] var<in> VertexIndex : i32;
             [[stage(vertex)]] fn main() -> void {
               var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                 vec2<f32>(-1.0, -1.0),

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -355,7 +355,7 @@ g.test('vertexAccess')
         module: t.device.createShaderModule({
           code: `
             [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[builtin(vertex_idx)]] var<in> VertexIndex : u32;
+            [[builtin(vertex_index)]] var<in> VertexIndex : u32;
             ${layoutStr}
 
             fn valid(f : f32) -> bool {


### PR DESCRIPTION
This CL updates the WGSL tests to use the new `vertex_index` decoration
instead of the deprecated `vertex_idx`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
