### PR TITLE
Adding subcases() to TestGroupBuilder

### DIFF
--- a/src/common/framework/params_builder.ts
+++ b/src/common/framework/params_builder.ts
@@ -1,36 +1,18 @@
-import { CaseParams, CaseParamsIterable, publicParamsEquals } from './params_utils.js';
+import {
+  CaseParams,
+  CaseParamsIterable,
+  FlattenUnionOfInterfaces,
+  Merged,
+  mergeParams,
+  publicParamsEquals,
+} from './params_utils.js';
 import { ResolveType, UnionToIntersection } from './util/types.js';
-import { assert } from './util/util.js';
 
 /** Conditionally chooses between two types depending on whether T is a union. */
 type CheckForUnion<T, TErr, TOk> = [T] extends [UnionToIntersection<T>] ? TOk : TErr;
 
 /** Conditionally chooses a type (or void) depending on whether T is a string. */
 type CheckForStringLiteralType<T, TOk> = string extends T ? void : CheckForUnion<T, void, TOk>;
-
-type KeyOfNeverable<T> = T extends never ? never : keyof T;
-type AllKeysFromUnion<T> = keyof T | KeyOfNeverable<UnionToIntersection<T>>;
-type KeyOfOr<T, K, Default> = K extends keyof T ? T[K] : Default;
-
-/**
- * Flatten a union of interfaces into a single interface encoding the same type.
- *
- * Flattens a union in such a way that:
- * `{ a: number, b?: undefined } | { b: string, a?: undefined }`
- * (which is the value type of `[{ a: 1 }, { b: 1 }]`)
- * becomes `{ a: number | undefined, b: string | undefined }`.
- *
- * And also works for `{ a: number } | { b: string }` which maps to the same.
- */
-type FlattenUnionOfInterfaces<T> = {
-  [K in AllKeysFromUnion<T>]: KeyOfOr<
-    T,
-    // If T always has K, just take T[K] (union of C[K] for each component C of T):
-    K,
-    // Otherwise, take the union of C[K] for each component C of T, PLUS undefined:
-    undefined | KeyOfOr<UnionToIntersection<T>, K, void>
-  >;
-};
 
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 function typeAssert<T extends 'pass'>() {}
@@ -169,28 +151,4 @@ export class ParamsBuilder<A extends {}> implements CaseParamsIterable {
 // one use. This just wraps a generator function in an object so it be iterated multiple times.
 function makeReusableIterable<P>(generatorFn: () => Generator<P>): Iterable<P> {
   return { [Symbol.iterator]: generatorFn };
-}
-
-type ValueTypeForKeyOfMergedType<A, B, Key extends keyof A | keyof B> = Key extends keyof A
-  ? Key extends keyof B
-    ? void // Key is in both types
-    : A[Key] // Key is only in A
-  : Key extends keyof B
-  ? B[Key] // Key is only in B
-  : void; // Key is in neither type (not possible)
-
-type Merged<A, B> = MergedFromFlat<A, FlattenUnionOfInterfaces<B>>;
-type MergedFromFlat<A, B> = keyof A & keyof B extends never
-  ? string extends keyof A | keyof B
-    ? never // (keyof A | keyof B) == string, which is too broad
-    : {
-        [Key in keyof A | keyof B]: ValueTypeForKeyOfMergedType<A, B, Key>;
-      }
-  : never; // (keyof A & keyof B) is not empty, so they overlapped
-
-function mergeParams<A extends {}, B extends {}>(a: A, b: B): Merged<A, B> {
-  for (const key of Object.keys(a)) {
-    assert(!(key in b), 'Duplicate key: ' + key);
-  }
-  return { ...a, ...b } as Merged<A, B>;
 }

--- a/src/common/framework/params_utils.ts
+++ b/src/common/framework/params_utils.ts
@@ -1,5 +1,7 @@
 import { comparePublicParamsPaths, Ordering } from './query/compare.js';
 import { kWildcard, kParamSeparator, kParamKVSeparator } from './query/separators.js';
+import { UnionToIntersection } from './util/types.js';
+import { assert } from './util/util.js';
 
 // Consider adding more types here if needed
 //
@@ -41,4 +43,52 @@ export const badParamValueChars = new RegExp(
 
 export function publicParamsEquals(x: CaseParams, y: CaseParams): boolean {
   return comparePublicParamsPaths(x, y) === Ordering.Equal;
+}
+
+export type KeyOfNeverable<T> = T extends never ? never : keyof T;
+export type AllKeysFromUnion<T> = keyof T | KeyOfNeverable<UnionToIntersection<T>>;
+export type KeyOfOr<T, K, Default> = K extends keyof T ? T[K] : Default;
+
+/**
+ * Flatten a union of interfaces into a single interface encoding the same type.
+ *
+ * Flattens a union in such a way that:
+ * `{ a: number, b?: undefined } | { b: string, a?: undefined }`
+ * (which is the value type of `[{ a: 1 }, { b: 1 }]`)
+ * becomes `{ a: number | undefined, b: string | undefined }`.
+ *
+ * And also works for `{ a: number } | { b: string }` which maps to the same.
+ */
+export type FlattenUnionOfInterfaces<T> = {
+  [K in AllKeysFromUnion<T>]: KeyOfOr<
+    T,
+    // If T always has K, just take T[K] (union of C[K] for each component C of T):
+    K,
+    // Otherwise, take the union of C[K] for each component C of T, PLUS undefined:
+    undefined | KeyOfOr<UnionToIntersection<T>, K, void>
+  >;
+};
+
+export type ValueTypeForKeyOfMergedType<A, B, Key extends keyof A | keyof B> = Key extends keyof A
+  ? Key extends keyof B
+    ? void // Key is in both types
+    : A[Key] // Key is only in A
+  : Key extends keyof B
+  ? B[Key] // Key is only in B
+  : void; // Key is in neither type (not possible)
+
+export type Merged<A, B> = MergedFromFlat<A, FlattenUnionOfInterfaces<B>>;
+export type MergedFromFlat<A, B> = keyof A & keyof B extends never
+  ? string extends keyof A | keyof B
+    ? never // (keyof A | keyof B) == string, which is too broad
+    : {
+        [Key in keyof A | keyof B]: ValueTypeForKeyOfMergedType<A, B, Key>;
+      }
+  : never; // (keyof A & keyof B) is not empty, so they overlapped
+
+export function mergeParams<A extends {}, B extends {}>(a: A, b: B): Merged<A, B> {
+  for (const key of Object.keys(a)) {
+    assert(!(key in b), 'Duplicate key: ' + key);
+  }
+  return { ...a, ...b } as Merged<A, B>;
 }

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -1,6 +1,6 @@
 import { Fixture, SkipTestCase } from './fixture.js';
 import { TestCaseRecorder } from './logging/test_case_recorder.js';
-import { CaseParams, CaseParamsIterable, extractPublicParams } from './params_utils.js';
+import { CaseParams, extractPublicParams, Merged, mergeParams } from './params_utils.js';
 import { kPathSeparator } from './query/separators.js';
 import { stringifyPublicParams, stringifyPublicParamsUniquely } from './query/stringify_params.js';
 import { validQueryPart } from './query/validQueryPart.js';
@@ -20,7 +20,7 @@ export interface RunCase {
 
 // Interface for defining tests
 export interface TestGroupBuilder<F extends Fixture> {
-  test(name: string): TestBuilderWithName<F, never>;
+  test(name: string): TestBuilderWithName<F>;
 }
 export function makeTestGroup<F extends Fixture>(fixture: FixtureClass<F>): TestGroupBuilder<F> {
   return new TestGroup(fixture);
@@ -43,13 +43,15 @@ export function makeTestGroupForUnitTesting<F extends Fixture>(
   return new TestGroup(fixture);
 }
 
-type FixtureClass<F extends Fixture> = new (log: TestCaseRecorder, params: CaseParams) => F;
-type TestFn<F extends Fixture, P extends {}> = (t: F & { params: P }) => Promise<void> | void;
+type FixtureClass<F extends Fixture> = new <P extends {}>(log: TestCaseRecorder, params: P) => F;
+type TestFn<F extends Fixture, P extends {}, SubP extends {}> = (
+  t: F & { params: Merged<P, SubP> }
+) => Promise<void> | void;
 
 class TestGroup<F extends Fixture> implements TestGroupBuilder<F> {
   private fixture: FixtureClass<F>;
   private seen: Set<string> = new Set();
-  private tests: Array<TestBuilder<F, never>> = [];
+  private tests: Array<TestBuilder<F, {}, {}>> = [];
 
   constructor(fixture: FixtureClass<F>) {
     this.fixture = fixture;
@@ -72,7 +74,7 @@ class TestGroup<F extends Fixture> implements TestGroupBuilder<F> {
   }
 
   // TODO: This could take a fixture, too, to override the one for the group.
-  test(name: string): TestBuilderWithName<F, never> {
+  test(name: string): TestBuilderWithName<F> {
     const testCreationStack = new Error(`Test created: ${name}`);
 
     this.checkName(name);
@@ -82,7 +84,7 @@ class TestGroup<F extends Fixture> implements TestGroupBuilder<F> {
       assert(validQueryPart.test(p), `Invalid test name part ${p}; must match ${validQueryPart}`);
     }
 
-    const test = new TestBuilder<F, never>(parts, this.fixture, testCreationStack);
+    const test = new TestBuilder<F, {}, {}>(parts, this.fixture, testCreationStack);
     this.tests.push(test);
     return test;
   }
@@ -94,23 +96,44 @@ class TestGroup<F extends Fixture> implements TestGroupBuilder<F> {
   }
 }
 
-interface TestBuilderWithName<F extends Fixture, P extends {}> extends TestBuilderWithParams<F, P> {
+interface TestBuilderWithName<F extends Fixture>
+  extends TestBuilderWithParamsAndSubParams<F, {}, {}> {
   desc(description: string): this;
+  /** @deprecated use cases() and subcases() instead */
   params<NewP extends {}>(specs: Iterable<NewP>): TestBuilderWithParams<F, NewP>;
+  cases<NewP extends {}>(specs: Iterable<NewP>): TestBuilderWithParams<F, NewP>;
+  subcases<NewSubP extends {}>(
+    specs: (_: {}) => Iterable<NewSubP>
+  ): TestBuilderWithSubParams<F, NewSubP>;
 }
 
-interface TestBuilderWithParams<F extends Fixture, P extends {}> {
-  fn(fn: TestFn<F, P>): void;
+interface TestBuilderWithSubParams<F extends Fixture, SubP extends {}>
+  extends TestBuilderWithParamsAndSubParams<F, {}, SubP> {
+  /** @deprecated use cases() and subcases() instead */
+  params<NewP extends {}>(specs: Iterable<NewP>): TestBuilderWithParamsAndSubParams<F, NewP, SubP>;
+  cases<NewP extends {}>(specs: Iterable<NewP>): TestBuilderWithParamsAndSubParams<F, NewP, SubP>;
+}
+
+interface TestBuilderWithParams<F extends Fixture, P extends {}>
+  extends TestBuilderWithParamsAndSubParams<F, P, {}> {
+  subcases<NewSubP extends {}>(
+    specs: (_: P) => Iterable<NewSubP>
+  ): TestBuilderWithParamsAndSubParams<F, P, NewSubP>;
+}
+
+interface TestBuilderWithParamsAndSubParams<F extends Fixture, P extends {}, SubP extends {}> {
+  fn(fn: TestFn<F, P, SubP>): void;
   unimplemented(): void;
 }
 
-class TestBuilder<F extends Fixture, P extends {}> {
+class TestBuilder<F extends Fixture, P extends {}, SubP extends {}> {
   readonly testPath: string[];
   description: string | undefined;
 
   private readonly fixture: FixtureClass<F>;
-  private testFn: TestFn<F, P> | undefined;
-  private cases?: CaseParamsIterable = undefined;
+  private testFn: TestFn<F, P, SubP> | undefined;
+  private caseParams?: Iterable<P> = undefined;
+  private subcaseParams?: (_: P) => Iterable<SubP> = undefined;
   private testCreationStack: Error;
 
   constructor(testPath: string[], fixture: FixtureClass<F>, testCreationStack: Error) {
@@ -124,7 +147,7 @@ class TestBuilder<F extends Fixture, P extends {}> {
     return this;
   }
 
-  fn(fn: TestFn<F, P>): void {
+  fn(fn: TestFn<F, P, SubP>): void {
     // TODO: add TODO if there's no description? (and make sure it only ends up on actual tests,
     // not on test parents in the tree, which is what happens if you do it here, not sure why)
     assert(this.testFn === undefined);
@@ -152,12 +175,12 @@ class TestBuilder<F extends Fixture, P extends {}> {
       return s;
     });
 
-    if (this.cases === undefined) {
+    if (this.caseParams === undefined) {
       return;
     }
 
     const seen = new Set<string>();
-    for (const testcase of this.cases) {
+    for (const testcase of this.caseParams) {
       // stringifyPublicParams also checks for invalid params values
       const testcaseString = stringifyPublicParams(testcase);
 
@@ -171,44 +194,74 @@ class TestBuilder<F extends Fixture, P extends {}> {
     }
   }
 
-  params<NewP extends {}>(casesIterable: Iterable<NewP>): TestBuilderWithParams<F, NewP> {
-    assert(this.cases === undefined, 'test case is already parameterized');
-    this.cases = Array.from(casesIterable);
+  params<NewP extends {}>(casesIterable: Iterable<NewP>): TestBuilder<F, NewP, SubP> {
+    return this.cases(casesIterable);
+  }
 
-    return (this as unknown) as TestBuilderWithParams<F, NewP>;
+  cases<NewP extends {}>(casesIterable: Iterable<NewP>): TestBuilder<F, NewP, SubP> {
+    assert(this.caseParams === undefined, 'test case is already parameterized');
+    const newSelf = (this as unknown) as TestBuilder<F, NewP, SubP>;
+    newSelf.caseParams = Array.from(casesIterable);
+
+    return newSelf;
+  }
+
+  subcases<NewSubP extends {}>(specs: (_: P) => Iterable<NewSubP>): TestBuilder<F, P, NewSubP> {
+    assert(this.subcaseParams === undefined, 'test subcases are already parameterized');
+    const newSelf = (this as unknown) as TestBuilder<F, P, NewSubP>;
+    newSelf.subcaseParams = specs;
+
+    return newSelf;
   }
 
   *iterate(): IterableIterator<RunCase> {
     assert(this.testFn !== undefined, 'No test function (.fn()) for test');
-    for (const params of this.cases || [{}]) {
-      yield new RunCaseSpecific(this.testPath, params, this.fixture, this.testFn);
+    for (const params of this.caseParams || [<P>{}]) {
+      yield new RunCaseSpecific(
+        this.testPath,
+        params,
+        this.subcaseParams,
+        this.fixture,
+        this.testFn
+      );
     }
   }
 }
 
-class RunCaseSpecific<F extends Fixture> implements RunCase {
+class RunCaseSpecific<
+  F extends Fixture,
+  P extends CaseParams,
+  SubP extends CaseParams,
+  FN extends TestFn<F, P, SubP>
+> implements RunCase {
   readonly id: TestCaseID;
 
-  private readonly params: CaseParams | null;
+  private readonly params: P;
+  private readonly subParamGen?: (_: P) => Iterable<SubP>;
   private readonly fixture: FixtureClass<F>;
-  private readonly fn: TestFn<F, never>;
+  private readonly fn: FN;
 
   constructor(
     testPath: string[],
-    params: CaseParams,
+    params: P,
+    subParamGen: ((_: P) => Iterable<SubP>) | undefined,
     fixture: FixtureClass<F>,
-    fn: TestFn<F, never>
+    fn: FN
   ) {
     this.id = { test: testPath, params: extractPublicParams(params) };
     this.params = params;
+    this.subParamGen = subParamGen;
     this.fixture = fixture;
     this.fn = fn;
   }
 
-  async run(rec: TestCaseRecorder): Promise<void> {
-    rec.start();
+  async runTest(
+    rec: TestCaseRecorder,
+    params: P | Merged<P, SubP>,
+    throwSkip: boolean
+  ): Promise<void> {
     try {
-      const inst = new this.fixture(rec, this.params || {});
+      const inst = new this.fixture(rec, params);
 
       try {
         await inst.init();
@@ -223,7 +276,40 @@ class RunCaseSpecific<F extends Fixture> implements RunCase {
       // An error from init or test may have been a SkipTestCase.
       // An error from finalize may have been an eventualAsyncExpectation failure
       // or unexpected validation/OOM error from the GPUDevice.
+      if (throwSkip && ex instanceof SkipTestCase) {
+        throw ex;
+      }
       rec.threw(ex);
+    }
+  }
+
+  async run(rec: TestCaseRecorder): Promise<void> {
+    rec.start();
+    if (this.subParamGen) {
+      let totalCount = 0;
+      let skipCount = 0;
+      for (const subParams of this.subParamGen(this.params)) {
+        rec.debug(new Error('subcase: ' + stringifyPublicParamsUniquely(subParams)));
+        try {
+          await this.runTest(rec, mergeParams(this.params, subParams), true);
+        } catch (ex) {
+          if (ex instanceof SkipTestCase) {
+            // Convert SkipTestCase to debug messages
+            ex.message = 'subcase skipped: ' + ex.message;
+            rec.debug(ex);
+            ++skipCount;
+          } else {
+            // Since we are catching all error inside runTest(), this should never happen
+            rec.threw(ex);
+          }
+        }
+        ++totalCount;
+      }
+      if (skipCount === totalCount) {
+        rec.skipped(new SkipTestCase('all subcases were skipped'));
+      }
+    } else {
+      await this.runTest(rec, this.params, false);
     }
     rec.finish();
   }

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -79,10 +79,11 @@ g.test('basic,async').fn(async t => {
 // They can also be private by starting with an underscore (_result), which passes
 // them into the test but does not make them part of the case name:
 //
-// - webgpu:examples:basic/params={"x":2,"y":4}    runs with t.params = {x: 2, y: 5, _result: 6}.
-// - webgpu:examples:basic/params={"x":-10,"y":18} runs with t.params = {x: -10, y: 18, _result: 8}.
-g.test('basic,params')
-  .params([
+// - webgpu:examples:basic/cases={"x":2,"y":4}    runs with t.params = {x: 2, y: 5, _result: 6}.
+// - webgpu:examples:basic/cases={"x":-10,"y":18} runs with t.params = {x: -10, y: 18, _result: 8}.
+
+g.test('basic,cases')
+  .cases([
     { x: 2, y: 4, _result: 6 }, //
     { x: -10, y: 18, _result: 8 },
   ])
@@ -91,13 +92,23 @@ g.test('basic,params')
   });
 // (note the blank comment above to enforce newlines on autoformat)
 
+g.test('basic,subcases')
+  .cases([{ x: 1 }, { x: 2 }])
+  .subcases(p => [{ a: p.x + 1 }, { b: 2 }])
+  .fn(t => {
+    t.expect(
+      ((t.params.a === 2 || t.params.a === 3) && t.params.b === undefined) ||
+        (t.params.a === undefined && t.params.b === 2)
+    );
+  });
+
 // Runs the following cases:
 // { x: 2, y: 2 }
 // { x: 2, z: 3 }
 // { x: 3, y: 2 }
 // { x: 3, z: 3 }
 g.test('basic,params_builder')
-  .params(
+  .cases(
     params()
       .combine(poptions('x', [2, 3]))
       .combine([{ y: 2 }, { z: 3 }])
@@ -133,7 +144,7 @@ g.test('gpu,with_texture_compression,bc')
     `Example of a test using a device descriptor.
 Tests that a BC format passes validation iff the feature is enabled.`
   )
-  .params(pbool('textureCompressionBC'))
+  .cases(pbool('textureCompressionBC'))
   .fn(async t => {
     const { textureCompressionBC } = t.params;
 
@@ -161,7 +172,7 @@ g.test('gpu,with_texture_compression,etc')
 
 TODO: Test that an ETC format passes validation iff the feature is enabled.`
   )
-  .params(pbool('textureCompressionETC'))
+  .cases(pbool('textureCompressionETC'))
   .fn(async t => {
     const { textureCompressionETC } = t.params;
 


### PR DESCRIPTION
First pass at issue #305.

We are still missing to the ability to drill down into subcases. It shouldn't be too hard to add, but there is no reason for new test to have to wait for it.

Since we moved to `.cases()` instead of `.params()`. I have tagged `.params()` with `@deprecated` as well as updated `example.spec.ts` and `test_group.spec.ts`,

-----

<!-- Leave this section in the PR description. -->

- [ ] New helpers, if any, are documented in `helper_index.md`.
- [ ] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
