### PR TITLE
Loosen precision in multisample resolve operation test

### DIFF
--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -187,21 +187,15 @@ g.test('render_pass_resolve')
       );
 
       // Test top right pixel, which should be {127, 127, 127, 127} due to the multisampled resolve.
-      {
-        const buffer = t.makeBufferFromTextureSinglePixel(
-          resolveTarget,
-          kFormat,
-          { x: kSize - 1, y: 0 },
-          {
-            slice: t.params.resolveTargetBaseArrayLayer,
-            layout: { mipLevel: t.params.resolveTargetBaseMipLevel },
-          }
-        );
-        t.expectContentsTwoValidValues(
-          buffer,
-          new Uint8Array([0x7f, 0x7f, 0x7f, 0x7f]),
-          new Uint8Array([0x80, 0x80, 0x80, 0x80])
-        );
-      }
+      t.expectSinglePixelBetweenTwoValuesIn2DTexture(
+        resolveTarget,
+        kFormat,
+        { x: kSize - 1, y: 0 },
+        {
+          exp: [new Uint8Array([0x7f, 0x7f, 0x7f, 0x7f]), new Uint8Array([0x80, 0x80, 0x80, 0x80])],
+          slice: t.params.resolveTargetBaseArrayLayer,
+          layout: { mipLevel: t.params.resolveTargetBaseMipLevel },
+        }
+      );
     }
   });

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -31,9 +31,9 @@ export const g = makeTestGroup(GPUTest);
 g.test('render_pass_resolve')
   .params(
     params()
+      .combine(poptions('storeOperation', ['clear', 'store'] as const))
       .combine(poptions('numColorAttachments', [2, 4] as const))
       .combine(poptions('slotsToResolve', kSlotsToResolve))
-      .combine(poptions('storeOperation', ['clear', 'store'] as const))
       .combine(poptions('resolveTargetBaseMipLevel', [0, 1] as const))
       .combine(poptions('resolveTargetBaseArrayLayer', [0, 1] as const))
   )
@@ -161,10 +161,10 @@ g.test('render_pass_resolve')
     t.device.queue.submit([encoder.finish()]);
 
     // Verify the resolve targets contain the correct values.
-    for (let i = 0; i < resolveTargets.length; i++) {
+    for (const resolveTarget of resolveTargets) {
       // Test top left pixel, which should be {255, 255, 255, 255}.
       t.expectSinglePixelIn2DTexture(
-        resolveTargets[i],
+        resolveTarget,
         kFormat,
         { x: 0, y: 0 },
         {
@@ -176,7 +176,7 @@ g.test('render_pass_resolve')
 
       // Test bottom right pixel, which should be {0, 0, 0, 0}.
       t.expectSinglePixelIn2DTexture(
-        resolveTargets[i],
+        resolveTarget,
         kFormat,
         { x: kSize - 1, y: kSize - 1 },
         {
@@ -187,15 +187,21 @@ g.test('render_pass_resolve')
       );
 
       // Test top right pixel, which should be {127, 127, 127, 127} due to the multisampled resolve.
-      t.expectSinglePixelIn2DTexture(
-        resolveTargets[i],
-        kFormat,
-        { x: kSize - 1, y: 0 },
-        {
-          exp: new Uint8Array([0x7f, 0x7f, 0x7f, 0x7f]),
-          slice: t.params.resolveTargetBaseArrayLayer,
-          layout: { mipLevel: t.params.resolveTargetBaseMipLevel },
-        }
-      );
+      {
+        const buffer = t.makeBufferFromTextureSinglePixel(
+          resolveTarget,
+          kFormat,
+          { x: kSize - 1, y: 0 },
+          {
+            slice: t.params.resolveTargetBaseArrayLayer,
+            layout: { mipLevel: t.params.resolveTargetBaseMipLevel },
+          }
+        );
+        t.expectContentsTwoValidValues(
+          buffer,
+          new Uint8Array([0x7f, 0x7f, 0x7f, 0x7f]),
+          new Uint8Array([0x80, 0x80, 0x80, 0x80])
+        );
+      }
     }
   });

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -444,8 +444,7 @@ got [${failedByteActualValues.join(', ')}]`;
     src: GPUTexture,
     format: SizedTextureFormat,
     { x, y }: { x: number; y: number },
-    slice = 0,
-    layout?: TextureLayoutOptions
+    { slice = 0, layout }: { slice?: number; layout?: TextureLayoutOptions }
   ): GPUBuffer {
     const { byteLength, bytesPerRow, rowsPerImage, mipSize } = getTextureCopyLayout(
       format,
@@ -487,7 +486,7 @@ got [${failedByteActualValues.join(', ')}]`;
       generateWarningOnly?: boolean;
     }
   ): void {
-    const buffer = this.readSinglePixelFrom2DTexture(src, format, { x, y }, slice, layout);
+    const buffer = this.readSinglePixelFrom2DTexture(src, format, { x, y }, { slice, layout });
     this.expectContents(buffer, exp, 0, { generateWarningOnly });
   }
 
@@ -507,7 +506,7 @@ got [${failedByteActualValues.join(', ')}]`;
       generateWarningOnly?: boolean;
     }
   ): void {
-    const buffer = this.readSinglePixelFrom2DTexture(src, format, { x, y }, slice, layout);
+    const buffer = this.readSinglePixelFrom2DTexture(src, format, { x, y }, { slice, layout });
     this.expectContentsBetweenTwoValues(buffer, exp, 0, { generateWarningOnly });
   }
 


### PR DESCRIPTION
Some platforms produce 0x7f and others 0x80 when a pixel is
half-covered.

I'd like to do this with #388 but that's a bigger project, so here's a more targeted fix.

-----

<!-- Leave this section in the PR description. -->

- [ ] New helpers, if any, are documented in `helper_index.md`. **Left undocumented because none of the siblings are documented and I expect this to go away with #388 anyway.**
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
