### PR TITLE
Simplify how debug=1 affects log messages, fixes

### DIFF
--- a/src/common/framework/logging/log_message.ts
+++ b/src/common/framework/logging/log_message.ts
@@ -28,7 +28,7 @@ export class LogMessageWithStack extends Error {
       m += '\n' + extractImportantStackTrace(this);
     }
     if (this.timesSeen > 1) {
-      m += `\n(seen ${this.timesSeen} times with identical stack)`;
+      m += `\n(seen ${this.timesSeen} times with identical stack, not necessarily in a row)`;
     }
     return m;
   }

--- a/src/common/framework/logging/test_case_recorder.ts
+++ b/src/common/framework/logging/test_case_recorder.ts
@@ -110,7 +110,7 @@ export class TestCaseRecorder {
     // Final case status should be the "worst" of all log entries.
     if (level > this.finalCaseStatus) this.finalCaseStatus = level;
 
-    // setStackHidden for all logs except 2 at the highest severity
+    // setStackHidden for all logs except `kMaxLogStacks` stacks at the highest severity
     if (level > this.hideStacksBelowSeverity) {
       this.logLinesAtCurrentSeverity = 0;
       this.hideStacksBelowSeverity = level;

--- a/src/common/framework/logging/test_case_recorder.ts
+++ b/src/common/framework/logging/test_case_recorder.ts
@@ -18,7 +18,8 @@ const kMaxLogStacks = 2;
 /** Holds onto a LiveTestCaseResult owned by the Logger, and writes the results into it. */
 export class TestCaseRecorder {
   private result: LiveTestCaseResult;
-  private maxLogSeverity = LogSeverity.Pass;
+  private finalCaseStatus = LogSeverity.Pass;
+  private hideStacksBelowSeverity = LogSeverity.Warn;
   private startTime = -1;
   private logs: LogMessageWithStack[] = [];
   private logLinesAtCurrentSeverity = 0;
@@ -45,11 +46,11 @@ export class TestCaseRecorder {
 
     // Convert numeric enum back to string (but expose 'exception' as 'fail')
     this.result.status =
-      this.maxLogSeverity === LogSeverity.Pass
+      this.finalCaseStatus === LogSeverity.Pass
         ? 'pass'
-        : this.maxLogSeverity === LogSeverity.Skip
+        : this.finalCaseStatus === LogSeverity.Skip
         ? 'skip'
-        : this.maxLogSeverity === LogSeverity.Warn
+        : this.finalCaseStatus === LogSeverity.Warn
         ? 'warn'
         : 'fail'; // Everything else is an error
 
@@ -61,38 +62,28 @@ export class TestCaseRecorder {
   }
 
   debug(ex: Error): void {
-    if (!this.debugging) {
-      return;
-    }
-    const logMessage = new LogMessageWithStack('DEBUG', ex);
-    logMessage.setStackHidden();
-    this.logImpl(LogSeverity.Pass, logMessage);
+    if (!this.debugging) return;
+    this.logImpl(LogSeverity.Pass, 'DEBUG', ex);
   }
 
   info(ex: Error): void {
-    const logMessage = new LogMessageWithStack('INFO', ex);
-    logMessage.setStackHidden();
-    this.logImpl(LogSeverity.Pass, logMessage);
+    this.logImpl(LogSeverity.Pass, 'INFO', ex);
   }
 
   skipped(ex: SkipTestCase): void {
-    const message = new LogMessageWithStack('SKIP', ex);
-    if (!this.debugging) {
-      message.setStackHidden();
-    }
-    this.logImpl(LogSeverity.Skip, message);
+    this.logImpl(LogSeverity.Skip, 'SKIP', ex);
   }
 
   warn(ex: Error): void {
-    this.logImpl(LogSeverity.Warn, new LogMessageWithStack('WARN', ex));
+    this.logImpl(LogSeverity.Warn, 'WARN', ex);
   }
 
   expectationFailed(ex: Error): void {
-    this.logImpl(LogSeverity.ExpectFailed, new LogMessageWithStack('EXPECTATION FAILED', ex));
+    this.logImpl(LogSeverity.ExpectFailed, 'EXPECTATION FAILED', ex);
   }
 
   validationFailed(ex: Error): void {
-    this.logImpl(LogSeverity.ValidationFailed, new LogMessageWithStack('VALIDATION FAILED', ex));
+    this.logImpl(LogSeverity.ValidationFailed, 'VALIDATION FAILED', ex);
   }
 
   threw(ex: Error): void {
@@ -100,10 +91,12 @@ export class TestCaseRecorder {
       this.skipped(ex);
       return;
     }
-    this.logImpl(LogSeverity.ThrewException, new LogMessageWithStack('EXCEPTION', ex));
+    this.logImpl(LogSeverity.ThrewException, 'EXCEPTION', ex);
   }
 
-  private logImpl(level: LogSeverity, logMessage: LogMessageWithStack): void {
+  private logImpl(level: LogSeverity, name: string, baseException: Error): void {
+    const logMessage = new LogMessageWithStack(name, baseException);
+
     // Deduplicate errors with the exact same stack
     if (logMessage.stack) {
       const seen = this.messagesForPreviouslySeenStacks.get(logMessage.stack);
@@ -114,23 +107,26 @@ export class TestCaseRecorder {
       this.messagesForPreviouslySeenStacks.set(logMessage.stack, logMessage);
     }
 
-    // Mark printStack=false for all logs except 2 at the highest severity
-    if (level > this.maxLogSeverity) {
+    // Final case status should be the "worst" of all log entries.
+    if (level > this.finalCaseStatus) this.finalCaseStatus = level;
+
+    // setStackHidden for all logs except 2 at the highest severity
+    if (level > this.hideStacksBelowSeverity) {
       this.logLinesAtCurrentSeverity = 0;
-      this.maxLogSeverity = level;
-      if (!this.debugging) {
-        // Go back and turn off printStack for everything of a lower log level
-        for (const log of this.logs) {
-          log.setStackHidden();
-        }
+      this.hideStacksBelowSeverity = level;
+
+      // Go back and setStackHidden for everything of a lower log level
+      for (const log of this.logs) {
+        log.setStackHidden();
       }
     }
-    if (level < this.maxLogSeverity || this.logLinesAtCurrentSeverity >= kMaxLogStacks) {
-      if (!this.debugging) {
-        logMessage.setStackHidden();
-      }
+    if (level === this.hideStacksBelowSeverity) {
+      this.logLinesAtCurrentSeverity++;
     }
+    if (level < this.hideStacksBelowSeverity || this.logLinesAtCurrentSeverity > kMaxLogStacks) {
+      logMessage.setStackHidden();
+    }
+
     this.logs.push(logMessage);
-    this.logLinesAtCurrentSeverity++;
   }
 }

--- a/src/demo/a/b/c.spec.ts
+++ b/src/demo/a/b/c.spec.ts
@@ -43,3 +43,29 @@ g.test('statuses,fail').fn(t => {
 g.test('statuses,throw').fn(() => {
   unreachable('unreachable');
 });
+
+g.test('multiple_same_stack').fn(t => {
+  for (let i = 0; i < 3; ++i) {
+    t.fail(
+      i === 2
+        ? 'this should appear after deduplicated line'
+        : 'this should be "seen 2 times with identical stack"'
+    );
+  }
+});
+
+g.test('multiple_same_level').fn(t => {
+  t.fail('this should print a stack');
+  t.fail('this should print a stack');
+  t.fail('this should not print a stack');
+});
+
+g.test('lower_levels_hidden,before').fn(t => {
+  t.warn('warn - this should not print a stack');
+  t.fail('fail');
+});
+
+g.test('lower_levels_hidden,after').fn(t => {
+  t.fail('fail');
+  t.warn('warn - this should not print a stack');
+});


### PR DESCRIPTION

-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
