### PR TITLE
[wgsl] Add validation test - v-0038: A module scope variable in the in or out storage class must be IO-shareable.

### DIFF
--- a/src/webgpu/shader/validation/variable_and_const.spec.ts
+++ b/src/webgpu/shader/validation/variable_and_const.spec.ts
@@ -108,43 +108,42 @@ g.test('v_0038')
   .desc(
     `Tests for validation rule v-0038:
   The following types are IO-shareable:
-  numeric scalar types
-  numeric vector types
-  Matrix Types
-  Array Types if its element type is IO-shareable, and the array is not runtime-sized
-  Structure Types if all its members are IO-shareable
+  - numeric scalar types
+  - numeric vector types
+  - Matrix Types
+  - Array Types if its element type is IO-shareable, and the array is not runtime-sized
+  - Structure Types if all its members are IO-shareable
 
   As a result these are not IO-shareable:
-  boolean
-  vector of booleans
-  array of booleans
-  matrix of booleans
-  array runtime sized -> cannot be used outside of a struct, so no cts for this
-  struct with bool component
-  struct with runtime array
-  TODO: add test for structs`
+  - boolean
+  - vector of booleans
+  - array of booleans
+  - matrix of booleans
+  - array runtime sized -> cannot be used outside of a struct, so no cts for this
+  - struct with bool component
+  - struct with runtime array
+
+  Control case: 'private' is used to make sure when only the storage class changes, the shader
+  becomes invalid and nothing else is wrong.
+  TODO: add test for: struct - struct with bool component - struct with runtime array`
   )
   .params(
     params()
-      .combine([
-        { variableOrConstant: 'var', inputOrOutput: 'in' },
-        { variableOrConstant: 'var', inputOrOutput: 'out' },
-        { variableOrConstant: 'const', inputOrOutput: 'out' },
-      ])
+      .combine(poptions('storageClass', ['in', 'out', 'private']))
       .combine(poptions('containerType', kContainerTypes))
       .combine(poptions('scalarType', kScalarType))
   )
   .fn(t => {
-    const { variableOrConstant, inputOrOutput, containerType, scalarType } = t.params;
+    const { storageClass, containerType, scalarType } = t.params;
     const type = containerType ? `${containerType}<${scalarType}>` : scalarType;
 
     const code = `
-      [[location(0)]] ${variableOrConstant}<${inputOrOutput}> a : ${type} = ${type}();
+      [[location(0)]] var<${storageClass}> a : ${type} = ${type}();
         [[stage(vertex)]]
         fn main() -> void {
         }
       `;
 
-    const expectation = scalarType !== 'bool' || 'v-0038';
+    const expectation = storageClass === 'private' || scalarType !== 'bool' || 'v-0038';
     t.expectCompileResult(expectation, code);
   });

--- a/src/webgpu/shader/validation/variable_and_const.spec.ts
+++ b/src/webgpu/shader/validation/variable_and_const.spec.ts
@@ -69,7 +69,7 @@ g.test('v_0033')
     `Tests for validation rule v-0033:
   If present, the initializer's type must match the store type of the variable.
   Testing scalars, vectors, and matrices of every dimension and type.
-  TODO: add test for: structs - arrays bf vectors and matrices - arrays of different length
+  TODO: add test for: structs - arrays of vectors and matrices - arrays of different length
 `
   )
   .params(
@@ -101,5 +101,50 @@ g.test('v_0033')
 
     const expectation =
       (lhsScalarType === rhsScalarType && lhsContainerType === rhsContainerType) || 'v-0033';
+    t.expectCompileResult(expectation, code);
+  });
+
+g.test('v_0038')
+  .desc(
+    `Tests for validation rule v-0038:
+  The following types are IO-shareable:
+  numeric scalar types
+  numeric vector types
+  Matrix Types
+  Array Types if its element type is IO-shareable, and the array is not runtime-sized
+  Structure Types if all its members are IO-shareable
+
+  As a result these are not IO-shareable:
+  boolean
+  vector of booleans
+  array of booleans
+  matrix of booleans
+  array runtime sized -> cannot be used outside of a struct, so no cts for this
+  struct with bool component
+  struct with runtime array
+  TODO: add test for structs`
+  )
+  .params(
+    params()
+      .combine([
+        { variableOrConstant: 'var', inputOrOutput: 'in' },
+        { variableOrConstant: 'var', inputOrOutput: 'out' },
+        { variableOrConstant: 'const', inputOrOutput: 'out' },
+      ])
+      .combine(poptions('containerType', kContainerTypes))
+      .combine(poptions('scalarType', kScalarType))
+  )
+  .fn(t => {
+    const { variableOrConstant, inputOrOutput, containerType, scalarType } = t.params;
+    const type = containerType ? `${containerType}<${scalarType}>` : scalarType;
+
+    const code = `
+      [[location(0)]] ${variableOrConstant}<${inputOrOutput}> a : ${type} = ${type}();
+        [[stage(vertex)]]
+        fn main() -> void {
+        }
+      `;
+
+    const expectation = scalarType !== 'bool' || 'v-0038';
     t.expectCompileResult(expectation, code);
   });


### PR DESCRIPTION
Tests for validation rule v-0038:
  The following types are IO-shareable:
  - numeric scalar types
  - numeric vector types
  - Matrix Types
  - Array Types if its element type is IO-shareable, and the array is not runtime-sized
  - Structure Types if all its members are IO-shareable

  As a result these are not IO-shareable:
  - boolean
  - vector of booleans
  - array of booleans
  - matrix of booleans
  - array runtime sized -> cannot be used outside of a struct, so no cts for this
  - struct with bool component
  - struct with runtime array
 
  TODO: add test for: struct - struct with bool component - struct with runtime array

-----

<!-- Leave this section in the PR description. -->

- [ ] New helpers, if any, are documented in `helper_index.md`.
- [ ] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
