### PR TITLE
Update defaultQueue->queue, OUTPUT_ATTACHMENT->RENDER_ATTACHMENT to match latest spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1240,9 +1240,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.0.34.tgz",
-      "integrity": "sha512-PKaA151d75u76I33Kod6fOqL7xLXM1XXYcCE5UqoqAgPkecyW0cWqUflMACoR14iuDlhtGUaflu0iFxzAAAqSA==",
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.0.35.tgz",
+      "integrity": "sha512-nthA2EkBWNmu6mfSG8bWN8k3YxmdbHH4EKaN9v6oFIeEl1EIXVdTTBkXTrgIujxnY790JsNUtlnW6mp49QUUKA==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/morgan": "^1.9.2",
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
-    "@webgpu/types": "0.0.34",
+    "@webgpu/types": "0.0.35",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",
     "chokidar": "^3.4.3",

--- a/src/webgpu/api/operation/command_buffer/basic.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/basic.spec.ts
@@ -10,7 +10,7 @@ export const g = makeTestGroup(GPUTest);
 g.test('empty').fn(async t => {
   const encoder = t.device.createCommandEncoder();
   const cmd = encoder.finish();
-  t.device.defaultQueue.submit([cmd]);
+  t.device.queue.submit([cmd]);
 });
 
 g.test('b2t2b').fn(async t => {
@@ -46,7 +46,7 @@ g.test('b2t2b').fn(async t => {
     { buffer: dst, bytesPerRow: 256 },
     { width: 1, height: 1, depth: 1 }
   );
-  t.device.defaultQueue.submit([encoder.finish()]);
+  t.device.queue.submit([encoder.finish()]);
 
   t.expectContents(dst, data);
 });
@@ -91,7 +91,7 @@ g.test('b2t2t2b').fn(async t => {
     { buffer: dst, bytesPerRow: 256 },
     { width: 1, height: 1, depth: 1 }
   );
-  t.device.defaultQueue.submit([encoder.finish()]);
+  t.device.queue.submit([encoder.finish()]);
 
   t.expectContents(dst, data);
 });

--- a/src/webgpu/api/operation/command_buffer/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyBufferToBuffer.spec.ts
@@ -52,7 +52,7 @@ g.test('single')
 
     const encoder = t.device.createCommandEncoder();
     encoder.copyBufferToBuffer(src, srcOffset, dst, dstOffset, copySize);
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     const expectedDstData = new Uint8Array(dstBufferSize);
     for (let i = 0; i < copySize; ++i) {
@@ -90,7 +90,7 @@ g.test('state_transitions')
     const encoder = t.device.createCommandEncoder();
     encoder.copyBufferToBuffer(src, 0, dst, 4, 4);
     encoder.copyBufferToBuffer(dst, 0, src, 4, 4);
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     const expectedSrcData = new Uint8Array([1, 2, 3, 4, 10, 20, 30, 40]);
     const expectedDstData = new Uint8Array([10, 20, 30, 40, 1, 2, 3, 4]);
@@ -123,7 +123,7 @@ g.test('copy_order')
     const encoder = t.device.createCommandEncoder();
     encoder.copyBufferToBuffer(src, 0, dst, 0, 16);
     encoder.copyBufferToBuffer(src, 16, dst, 8, 16);
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     const expectedDstData = new Uint32Array([1, 2, 5, 6, 7, 8, 0, 0]);
     t.expectContents(dst, expectedDstData);

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -79,7 +79,7 @@ class F extends GPUTest {
     const blockHeight = kSizedTextureFormatInfo[format].blockHeight;
     const srcBlocksPerRow = srcTextureSizeAtLevel.width / blockWidth;
     const srcBlockRowsPerImage = srcTextureSizeAtLevel.height / blockHeight;
-    this.device.defaultQueue.writeTexture(
+    this.device.queue.writeTexture(
       { texture: srcTexture, mipLevel: srcCopyLevel },
       initialSrcData,
       {
@@ -154,7 +154,7 @@ class F extends GPUTest {
       },
       dstTextureSizeAtLevel
     );
-    this.device.defaultQueue.submit([encoder.finish()]);
+    this.device.queue.submit([encoder.finish()]);
 
     // Fill expectedDataWithPadding with the expected data of dstTexture. The other values in
     // expectedDataWithPadding are kept 0 to check if the texels untouched by the copy are 0

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -58,7 +58,7 @@ g.test('memcpy').fn(async t => {
   pass.setBindGroup(0, bg);
   pass.dispatch(1);
   pass.endPass();
-  t.device.defaultQueue.submit([encoder.finish()]);
+  t.device.queue.submit([encoder.finish()]);
 
   t.expectContents(dst, data);
 });

--- a/src/webgpu/api/operation/copyBetweenLinearDataAndTexture.spec.ts
+++ b/src/webgpu/api/operation/copyBetweenLinearDataAndTexture.spec.ts
@@ -281,7 +281,7 @@ class CopyBetweenLinearDataAndTextureTest extends GPUTest {
       { buffer, ...appliedDataLayout },
       appliedCheckSize
     );
-    this.device.defaultQueue.submit([encoder.finish()]);
+    this.device.queue.submit([encoder.finish()]);
   }
 
   /** Put data into a part of the texture with an appropriate method. */
@@ -316,7 +316,7 @@ class CopyBetweenLinearDataAndTextureTest extends GPUTest {
 
     switch (method) {
       case 'WriteTexture': {
-        this.device.defaultQueue.writeTexture(
+        this.device.queue.writeTexture(
           appliedCopyView,
           partialData,
           appliedDataLayout,
@@ -340,7 +340,7 @@ class CopyBetweenLinearDataAndTextureTest extends GPUTest {
           appliedCopyView,
           appliedCopySize
         );
-        this.device.defaultQueue.submit([encoder.finish()]);
+        this.device.queue.submit([encoder.finish()]);
 
         break;
       }
@@ -419,7 +419,7 @@ class CopyBetweenLinearDataAndTextureTest extends GPUTest {
       { buffer, bytesPerRow, rowsPerImage },
       mipSize
     );
-    this.device.defaultQueue.submit([encoder.finish()]);
+    this.device.queue.submit([encoder.finish()]);
 
     return buffer;
   }

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -32,7 +32,7 @@ export class BufferSyncTest extends GPUTest {
       format: 'r32uint',
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
-    this.device.defaultQueue.writeTexture(
+    this.device.queue.writeTexture(
       { texture, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
       data,
       { offset: 0, bytesPerRow: kSize, rowsPerImage: 1 },
@@ -199,7 +199,7 @@ export class BufferSyncTest extends GPUTest {
   // Write buffer via writeBuffer API on queue
   writeByWriteBuffer(buffer: GPUBuffer, value: number) {
     const data = new Uint32Array(kSize / 4).fill(value);
-    this.device.defaultQueue.writeBuffer(buffer, 0, data);
+    this.device.queue.writeBuffer(buffer, 0, data);
   }
 
   // Issue write operation via render pass, compute pass, copy, etc.
@@ -246,7 +246,7 @@ export class BufferSyncTest extends GPUTest {
     } else {
       const encoder = this.device.createCommandEncoder();
       await this.encodeWriteOp(encoder, writeOp, buffer, value);
-      this.device.defaultQueue.submit([encoder.finish()]);
+      this.device.queue.submit([encoder.finish()]);
     }
   }
 

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -126,7 +126,7 @@ export class BufferSyncTest extends GPUTest {
       .createTexture({
         size: { width: 1, height: 1, depth: 1 },
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
       })
       .createView();
     return encoder.beginRenderPass({

--- a/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
@@ -34,7 +34,7 @@ g.test('same_cmdbuf')
     const encoder = t.device.createCommandEncoder();
     await t.encodeWriteOp(encoder, firstWriteOp, buffer, 1);
     await t.encodeWriteOp(encoder, secondWriteOp, buffer, 2);
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     t.verifyData(buffer, 2);
   });
@@ -53,7 +53,7 @@ g.test('separate_cmdbufs')
     const command_buffers: GPUCommandBuffer[] = [];
     command_buffers.push(await t.createCommandBufferWithWriteOp(firstWriteOp, buffer, 1));
     command_buffers.push(await t.createCommandBufferWithWriteOp(secondWriteOp, buffer, 2));
-    t.device.defaultQueue.submit(command_buffers);
+    t.device.queue.submit(command_buffers);
 
     t.verifyData(buffer, 2);
   });
@@ -109,7 +109,7 @@ g.test('two_draws_in_the_same_render_pass')
     }
 
     passEncoder.endPass();
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
     t.verifyDataTwoValidValues(buffer, 1, 2);
   });
 
@@ -137,7 +137,7 @@ g.test('two_draws_in_the_same_render_bundle')
 
     passEncoder.executeBundles([renderEncoder.finish()]);
     passEncoder.endPass();
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
     t.verifyDataTwoValidValues(buffer, 1, 2);
   });
 
@@ -161,6 +161,6 @@ g.test('two_dispatches_in_the_same_compute_pass')
     }
 
     pass.endPass();
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
     t.verifyData(buffer, 2);
   });

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -103,7 +103,7 @@ g.test('render_pass_resolve')
         sampleCount: 4,
         mipLevelCount: 1,
         usage:
-          GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+          GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
       });
 
       if (t.params.slotsToResolve.includes(i)) {
@@ -113,7 +113,7 @@ g.test('render_pass_resolve')
           sampleCount: 4,
           mipLevelCount: 1,
           usage:
-            GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+            GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
         });
 
         const resolveTarget = t.device.createTexture({
@@ -125,7 +125,7 @@ g.test('render_pass_resolve')
           },
           sampleCount: 1,
           mipLevelCount: t.params.resolveTargetBaseMipLevel + 1,
-          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
         });
 
         // Clear to black for the load operation. After the draw, the top left half of the attachment

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -158,7 +158,7 @@ g.test('render_pass_resolve')
     pass.setPipeline(pipeline);
     pass.draw(3);
     pass.endPass();
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     // Verify the resolve targets contain the correct values.
     for (let i = 0; i < resolveTargets.length; i++) {

--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -69,7 +69,7 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
     const colorAttachment = t.device.createTexture({
       format: kColorFormat,
       size: { width: kWidth, height: kHeight, depth: 1 },
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     const colorAttachmentView = colorAttachment.createView();
@@ -79,7 +79,7 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
     const depthStencilAttachment = t.device.createTexture({
       format: kDepthStencilFormat,
       size: { width: kWidth, height: kHeight, depth: 1 },
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     // Color load operation will clear to {1.0, 1.0, 1.0, 1.0}.
@@ -157,7 +157,7 @@ g.test('render_pass_store_op,color_attachment_only')
       format: t.params.colorFormat,
       size: { width: kWidth, height: kHeight, depth: t.params.arrayLayer + 1 },
       mipLevelCount: kMipLevelCount,
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     const colorViewDesc: GPUTextureViewDescriptor = {
@@ -219,7 +219,7 @@ g.test('render_pass_store_op,multiple_color_attachments')
         t.device.createTexture({
           format: kColorFormat,
           size: { width: kWidth, height: kHeight, depth: 1 },
-          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
         })
       );
     }
@@ -283,7 +283,7 @@ TODO: Also test unsized depth/stencil formats
       format: t.params.depthStencilFormat,
       size: { width: kWidth, height: kHeight, depth: t.params.arrayLayer + 1 },
       mipLevelCount: kMipLevelCount,
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     const depthStencilViewDesc: GPUTextureViewDescriptor = {

--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -104,7 +104,7 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
     });
     pass.endPass();
 
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     // Check that the correct store operation occurred.
     let expectedColorValue: PerTexelComponent<number> = {};
@@ -182,7 +182,7 @@ g.test('render_pass_store_op,color_attachment_only')
       ],
     });
     pass.endPass();
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     // Check that the correct store operation occurred.
     let expectedValue: PerTexelComponent<number> = {};
@@ -241,7 +241,7 @@ g.test('render_pass_store_op,multiple_color_attachments')
       colorAttachments: renderPassColorAttachmentDescriptors,
     });
     pass.endPass();
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     // Check that the correct store operation occurred.
     let expectedValue: PerTexelComponent<number> = {};
@@ -309,7 +309,7 @@ TODO: Also test unsized depth/stencil formats
       },
     });
     pass.endPass();
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     let expectedValue: PerTexelComponent<number> = {};
     if (t.params.storeOperation === 'clear') {

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -18,7 +18,7 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
     const renderTexture = t.device.createTexture({
       size: { width: 1, height: 1, depth: 1 },
       format: 'r8unorm',
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     // create render pipeline

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -71,7 +71,7 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
     pass.setPipeline(renderPipeline);
     pass.draw(3);
     pass.endPass();
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     // expect the buffer to be clear
     t.expectSingleColor(renderTexture, 'r8unorm', {

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -150,7 +150,7 @@ g.test('culling')
     pass.draw(6, 1, 0, 0);
     pass.endPass();
 
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     // front facing color is green, non front facing is red, background is blue
     const kCCWTriangleTopLeftColor = faceColor('ccw', t.params.frontFace, t.params.cullMode);

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -63,14 +63,14 @@ g.test('culling')
     const texture = t.device.createTexture({
       size: { width: size, height: size, depth: 1 },
       format,
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
 
     const depthTexture = t.params.depthStencilFormat
       ? t.device.createTexture({
           size: { width: size, height: size, depth: 1 },
           format: t.params.depthStencilFormat,
-          usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+          usage: GPUTextureUsage.RENDER_ATTACHMENT,
         })
       : null;
 

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -314,7 +314,7 @@ class PrimitiveTopologyTest extends GPUTest {
 
     renderPass.endPass();
 
-    this.device.defaultQueue.submit([encoder.finish()]);
+    this.device.queue.submit([encoder.finish()]);
 
     for (const testPixel of testLocations) {
       this.expectSinglePixelIn2DTexture(

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -217,7 +217,7 @@ class PrimitiveTopologyTest extends GPUTest {
     return this.device.createTexture({
       format: kColorFormat,
       size: { width: kRTSize, height: kRTSize, depth: 1 },
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
   }
 

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -16,7 +16,7 @@ g.test('clear').fn(async t => {
   const colorAttachment = t.device.createTexture({
     format: 'rgba8unorm',
     size: { width: 1, height: 1, depth: 1 },
-    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
   });
   const colorAttachmentView = colorAttachment.createView();
 
@@ -50,7 +50,7 @@ g.test('fullscreen_quad').fn(async t => {
   const colorAttachment = t.device.createTexture({
     format: 'rgba8unorm',
     size: { width: 1, height: 1, depth: 1 },
-    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
   });
   const colorAttachmentView = colorAttachment.createView();
 

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -36,7 +36,7 @@ g.test('clear').fn(async t => {
     { buffer: dst, bytesPerRow: 256 },
     { width: 1, height: 1, depth: 1 }
   );
-  t.device.defaultQueue.submit([encoder.finish()]);
+  t.device.queue.submit([encoder.finish()]);
 
   t.expectContents(dst, new Uint8Array([0x00, 0xff, 0x00, 0xff]));
 });
@@ -107,7 +107,7 @@ g.test('fullscreen_quad').fn(async t => {
     { buffer: dst, bytesPerRow: 256 },
     { width: 1, height: 1, depth: 1 }
   );
-  t.device.defaultQueue.submit([encoder.finish()]);
+  t.device.queue.submit([encoder.finish()]);
 
   t.expectContents(dst, new Uint8Array([0x00, 0xff, 0x00, 0xff]));
 });

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -116,7 +116,7 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
     const renderTexture = t.device.createTexture({
       size: [width, height, 1],
       format: 'r8unorm',
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
       sampleCount: params.sampleCount,
     });
 
@@ -126,7 +126,7 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
       resolveTexture = t.device.createTexture({
         size: [width, height, 1],
         format: 'r8unorm',
-        usage: GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
       });
       resolveTarget = resolveTexture.createView();
     }

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -152,7 +152,7 @@ function getRequiredTextureUsage(
     case UninitializeMethod.Creation:
       break;
     case UninitializeMethod.StoreOpClear:
-      usage |= GPUConst.TextureUsage.OUTPUT_ATTACHMENT;
+      usage |= GPUConst.TextureUsage.RENDER_ATTACHMENT;
       break;
     default:
       unreachable();
@@ -172,7 +172,7 @@ function getRequiredTextureUsage(
     case ReadMethod.DepthTest:
     case ReadMethod.StencilTest:
     case ReadMethod.ColorBlending:
-      usage |= GPUConst.TextureUsage.OUTPUT_ATTACHMENT;
+      usage |= GPUConst.TextureUsage.RENDER_ATTACHMENT;
       break;
     default:
       unreachable();
@@ -181,14 +181,14 @@ function getRequiredTextureUsage(
   if (sampleCount > 1) {
     // Copies to multisampled textures are not allowed. We need OutputAttachment to initialize
     // canary data in multisampled textures.
-    usage |= GPUConst.TextureUsage.OUTPUT_ATTACHMENT;
+    usage |= GPUConst.TextureUsage.RENDER_ATTACHMENT;
   }
 
   if (!kUncompressedTextureFormatInfo[format].copyDst) {
     // Copies are not possible. We need OutputAttachment to initialize
     // canary data.
     assert(kUncompressedTextureFormatInfo[format].renderable);
-    usage |= GPUConst.TextureUsage.OUTPUT_ATTACHMENT;
+    usage |= GPUConst.TextureUsage.RENDER_ATTACHMENT;
   }
 
   return usage;
@@ -487,7 +487,7 @@ const paramsBuilder = params()
     const info = kUncompressedTextureFormatInfo[format];
 
     return (
-      ((usage & GPUConst.TextureUsage.OUTPUT_ATTACHMENT) !== 0 && !info.renderable) ||
+      ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 && !info.renderable) ||
       ((usage & GPUConst.TextureUsage.STORAGE) !== 0 && !info.storage)
     );
   })

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -135,7 +135,7 @@ class IndexFormatTest extends GPUTest {
     const colorAttachment = this.device.createTexture({
       format: kTextureFormat,
       size: { width: kWidth, height: kHeight, depth: 1 },
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     const result = this.device.createBuffer({

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -158,7 +158,7 @@ class IndexFormatTest extends GPUTest {
       { buffer: result, bytesPerRow, rowsPerImage },
       [kWidth, kHeight]
     );
-    this.device.defaultQueue.submit([encoder.finish()]);
+    this.device.queue.submit([encoder.finish()]);
 
     return result;
   }

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -31,7 +31,7 @@ class F extends ValidationTest {
       .createTexture({
         size: [1, 1, 1],
         format,
-        usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
         sampleCount,
       })
       .createView();

--- a/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture.ts
+++ b/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture.ts
@@ -53,7 +53,7 @@ export class CopyBetweenLinearDataAndTextureTest extends ValidationTest {
         const data = new Uint8Array(dataSize);
 
         this.expectValidationError(() => {
-          this.device.defaultQueue.writeTexture(textureCopyView, data, textureDataLayout, size);
+          this.device.queue.writeTexture(textureCopyView, data, textureDataLayout, size);
         }, !success);
 
         break;
@@ -70,7 +70,7 @@ export class CopyBetweenLinearDataAndTextureTest extends ValidationTest {
         if (submit) {
           const cmd = encoder.finish();
           this.expectValidationError(() => {
-            this.device.defaultQueue.submit([cmd]);
+            this.device.queue.submit([cmd]);
           }, !success);
         } else {
           this.expectValidationError(() => {
@@ -92,7 +92,7 @@ export class CopyBetweenLinearDataAndTextureTest extends ValidationTest {
         if (submit) {
           const cmd = encoder.finish();
           this.expectValidationError(() => {
-            this.device.defaultQueue.submit([cmd]);
+            this.device.queue.submit([cmd]);
           }, !success);
         } else {
           this.expectValidationError(() => {

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -100,7 +100,7 @@ class F extends ValidationTest {
 
     return this.device.createTexture({
       size: { width: 4, height: 4, depth: 1 },
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
       format,
       sampleCount,
     });

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -166,7 +166,7 @@ g.test('it_is_invalid_to_submit_a_destroyed_texture_before_and_after_encode')
     }, !_success);
   });
 
-g.test('it_is_invalid_to_have_an_RENDER_ATTACHMENT_texture_with_non_renderable_format')
+g.test('it_is_invalid_to_have_an_output_attachment_texture_with_non_renderable_format')
   .params(poptions('format', kAllTextureFormats))
   .fn(async t => {
     const format: GPUTextureFormat = t.params.format;

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -63,7 +63,7 @@ class F extends ValidationTest {
       sampleCount,
       dimension: '2d',
       format,
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.SAMPLED,
     };
   }
 }
@@ -166,7 +166,7 @@ g.test('it_is_invalid_to_submit_a_destroyed_texture_before_and_after_encode')
     }, !_success);
   });
 
-g.test('it_is_invalid_to_have_an_output_attachment_texture_with_non_renderable_format')
+g.test('it_is_invalid_to_have_an_RENDER_ATTACHMENT_texture_with_non_renderable_format')
   .params(poptions('format', kAllTextureFormats))
   .fn(async t => {
     const format: GPUTextureFormat = t.params.format;

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -99,7 +99,7 @@ class F extends ValidationTest {
     pass.drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
     pass.endPass();
 
-    this.device.defaultQueue.submit([encoder.finish()]);
+    this.device.queue.submit([encoder.finish()]);
   }
 
   drawIndexedIndirect(bufferArray: Uint32Array, indirectOffset: number) {
@@ -122,7 +122,7 @@ class F extends ValidationTest {
     pass.drawIndexedIndirect(indirectBuffer, indirectOffset);
     pass.endPass();
 
-    this.device.defaultQueue.submit([encoder.finish()]);
+    this.device.queue.submit([encoder.finish()]);
   }
 }
 

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -67,7 +67,7 @@ class F extends ValidationTest {
     const colorAttachment = this.device.createTexture({
       format: 'rgba8unorm',
       size: { width: 1, height: 1, depth: 1 },
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     return encoder.beginRenderPass({

--- a/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
@@ -51,7 +51,7 @@ class F extends ValidationTest {
     const attachment = this.device.createTexture({
       format: 'rgba8unorm',
       size: attachmentSize,
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     const encoder = this.device.createCommandEncoder();
@@ -79,7 +79,7 @@ class F extends ValidationTest {
     const attachment = this.device.createTexture({
       format: 'rgba8unorm',
       size: attachmentSize,
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     const encoder = this.device.createCommandEncoder();
@@ -109,7 +109,7 @@ class F extends ValidationTest {
     const attachment = this.device.createTexture({
       format: 'rgba8unorm',
       size: [1, 1, 1],
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     const encoder = this.device.createCommandEncoder();

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -63,7 +63,7 @@ class F extends ValidationTest {
     const attachmentTexture = this.device.createTexture({
       format: 'rgba8unorm',
       size: { width: 16, height: 16, depth: 1 },
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     return commandEncoder.beginRenderPass({

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -28,7 +28,7 @@ class F extends ValidationTest {
     return this.device.createTexture({
       format: 'rgba8unorm',
       size: { width: 16, height: 16, depth: 1 },
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
   }
 

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -74,7 +74,7 @@ class F extends ValidationTest {
     const attachmentTexture = this.device.createTexture({
       format: 'rgba8unorm',
       size: { width: 16, height: 16, depth: 1 },
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     return commandEncoder.beginRenderPass({

--- a/src/webgpu/api/validation/error_scope.spec.ts
+++ b/src/webgpu/api/validation/error_scope.spec.ts
@@ -44,7 +44,7 @@ class F extends Fixture {
       usage: 0xffff, // Invalid GPUBufferUsage
     });
     // TODO: Remove when chrome does it automatically.
-    this.device.defaultQueue.submit([]);
+    this.device.queue.submit([]);
   }
 
   // Expect an uncapturederror event to occur. Note: this MUST be awaited, because

--- a/src/webgpu/api/validation/fences.spec.ts
+++ b/src/webgpu/api/validation/fences.spec.ts
@@ -79,7 +79,7 @@ g.test('increasing_fence_value_by_more_than_1_succeeds').fn(async t => {
 g.test('signal_a_fence_on_a_different_device_than_it_was_created_on_is_invalid').fn(async t => {
   const anotherDevice = await t.device.adapter.requestDevice();
   assert(anotherDevice !== null);
-  const fence = anotherDevice.defaultQueue.createFence();
+  const fence = anotherDevice.queue.createFence();
 
   t.expectValidationError(() => {
     t.queue.signal(fence, 2);
@@ -89,7 +89,7 @@ g.test('signal_a_fence_on_a_different_device_than_it_was_created_on_is_invalid')
 g.test('signal_a_fence_on_a_different_device_does_not_update_fence_signaled_value').fn(async t => {
   const anotherDevice = await t.device.adapter.requestDevice();
   assert(anotherDevice !== null);
-  const fence = anotherDevice.defaultQueue.createFence({ initialValue: 1 });
+  const fence = anotherDevice.queue.createFence({ initialValue: 1 });
 
   t.expectValidationError(() => {
     t.queue.signal(fence, 2);
@@ -99,7 +99,7 @@ g.test('signal_a_fence_on_a_different_device_does_not_update_fence_signaled_valu
 
   anotherDevice.pushErrorScope('validation');
 
-  anotherDevice.defaultQueue.signal(fence, 2);
+  anotherDevice.queue.signal(fence, 2);
   await fence.onCompletion(2);
   t.expect(fence.getCompletedValue() === 2);
 

--- a/src/webgpu/api/validation/queue/copyImageBitmapToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyImageBitmapToTexture.spec.ts
@@ -159,19 +159,11 @@ class CopyImageBitmapToTextureTest extends ValidationTest {
     // the other is asynchronous validation error scope errors.
     if (exceptionName) {
       this.shouldThrow(exceptionName, () => {
-        this.device.defaultQueue.copyImageBitmapToTexture(
-          imageBitmapCopyView,
-          textureCopyView,
-          copySize
-        );
+        this.device.queue.copyImageBitmapToTexture(imageBitmapCopyView, textureCopyView, copySize);
       });
     } else {
       this.expectValidationError(() => {
-        this.device.defaultQueue.copyImageBitmapToTexture(
-          imageBitmapCopyView,
-          textureCopyView,
-          copySize
-        );
+        this.device.queue.copyImageBitmapToTexture(imageBitmapCopyView, textureCopyView, copySize);
       }, !validationScopeSuccess);
     }
   }

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -39,7 +39,7 @@ Also verifies that the specified data range:
 `
   )
   .fn(async t => {
-    const queue = t.device.defaultQueue;
+    const queue = t.device.queue;
 
     function runTest(arrayType: TypedArrayBufferViewConstructor, testBuffer: boolean) {
       const elementSize = arrayType.BYTES_PER_ELEMENT;

--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -18,7 +18,7 @@ Test various validation behaviors when a resolveTarget is provided.
 - base case (valid).
 - resolve source is not multisampled.
 - resolve target is not single sampled.
-- resolve target missing OUTPUT_ATTACHMENT usage.
+- resolve target missing RENDER_ATTACHMENT usage.
 - resolve target must have exactly one subresource:
     - base mip level {0, >0}, mip level count {1, >1}.
     - base array layer {0, >0}, array layer count {1, >1}.
@@ -37,7 +37,7 @@ Test various validation behaviors when a resolveTarget is provided.
     { colorAttachmentSamples: 1, _valid: false },
     // a multisampled resolve target should cause a validation error.
     { resolveTargetSamples: 4, _valid: false },
-    // resolveTargetUsage without OUTPUT_ATTACHMENT usage should cause a validation error.
+    // resolveTargetUsage without RENDER_ATTACHMENT usage should cause a validation error.
     { resolveTargetUsage: GPUConst.TextureUsage.COPY_SRC, _valid: false },
     // non-zero resolve target base mip level should be valid.
     {
@@ -80,7 +80,7 @@ Test various validation behaviors when a resolveTarget is provided.
       otherAttachmentFormat = 'rgba8unorm',
       colorAttachmentSamples = 4,
       resolveTargetSamples = 1,
-      resolveTargetUsage = GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+      resolveTargetUsage = GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
       resolveTargetViewMipCount = 1,
       resolveTargetViewBaseMipLevel = 0,
       resolveTargetViewArrayLayerCount = 1,
@@ -109,7 +109,7 @@ Test various validation behaviors when a resolveTarget is provided.
             format: colorAttachmentFormat,
             size: { width: colorAttachmentWidth, height: colorAttachmentHeight, depth: 1 },
             sampleCount: colorAttachmentSamples,
-            usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+            usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
           });
 
           const resolveTarget = t.device.createTexture({
@@ -142,7 +142,7 @@ Test various validation behaviors when a resolveTarget is provided.
             format: otherAttachmentFormat,
             size: { width: colorAttachmentWidth, height: colorAttachmentHeight, depth: 1 },
             sampleCount: colorAttachmentSamples,
-            usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+            usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
           });
 
           const resolveTarget = t.device.createTexture({
@@ -153,7 +153,7 @@ Test various validation behaviors when a resolveTarget is provided.
               depth: 1,
             },
             sampleCount: 1,
-            usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+            usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
           });
 
           renderPassColorAttachmentDescriptors.push({

--- a/src/webgpu/api/validation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/validation/render_pass/storeOp.spec.ts
@@ -50,7 +50,7 @@ g.test('store_op_and_read_only')
     const depthAttachment = t.device.createTexture({
       format: 'depth24plus-stencil8',
       size: { width: 1, height: 1, depth: 1 },
-      usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
     const depthAttachmentView = depthAttachment.createView();
 

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -28,7 +28,7 @@ class F extends ValidationTest {
       arrayLayerCount = 1,
       mipLevelCount = 1,
       sampleCount = 1,
-      usage = GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage = GPUTextureUsage.RENDER_ATTACHMENT,
     } = options;
 
     return this.device.createTexture({
@@ -418,7 +418,7 @@ g.test('it_is_invalid_to_use_a_resolve_target_with_mipmap_level_count_greater_th
   }
 );
 
-g.test('it_is_invalid_to_use_a_resolve_target_whose_usage_is_not_output_attachment').fn(async t => {
+g.test('it_is_invalid_to_use_a_resolve_target_whose_usage_is_not_RENDER_ATTACHMENT').fn(async t => {
   const multisampledColorTexture = t.createTexture({ sampleCount: 4 });
   const resolveTargetTexture = t.createTexture({
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -74,7 +74,7 @@ class TextureUsageTracking extends ValidationTest {
       mipLevelCount = 1,
       sampleCount = 1,
       format = 'rgba8unorm',
-      usage = GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.SAMPLED,
+      usage = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.SAMPLED,
     } = options;
 
     return this.device.createTexture({
@@ -445,7 +445,7 @@ g.test('subresources_and_binding_types_combination_for_color')
     const texture = t.createTexture({
       arrayLayerCount: TOTAL_LAYERS,
       mipLevelCount: TOTAL_LEVELS,
-      usage: GPUTextureUsage.SAMPLED | GPUTextureUsage.STORAGE | GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.SAMPLED | GPUTextureUsage.STORAGE | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     const dimension0 = layerCount0 !== 1 ? '2d-array' : '2d';
@@ -701,7 +701,7 @@ g.test('shader_stages_and_visibility')
     // vertex stage is not included. Otherwise, it uses output attachment instead.
     const writeHasVertexStage = Boolean(writeVisibility & GPUShaderStage.VERTEX);
     const texUsage = writeHasVertexStage
-      ? GPUTextureUsage.SAMPLED | GPUTextureUsage.OUTPUT_ATTACHMENT
+      ? GPUTextureUsage.SAMPLED | GPUTextureUsage.RENDER_ATTACHMENT
       : GPUTextureUsage.SAMPLED | GPUTextureUsage.STORAGE;
 
     const texture = t.createTexture({ usage: texUsage });
@@ -838,7 +838,7 @@ g.test('bindings_in_bundle')
     const view = t
       .createTexture({
         usage:
-          GPUTextureUsage.OUTPUT_ATTACHMENT | GPUTextureUsage.STORAGE | GPUTextureUsage.SAMPLED,
+          GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE | GPUTextureUsage.SAMPLED,
       })
       .createView();
 

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -24,7 +24,7 @@ export class ValidationTest extends GPUTest {
         GPUTextureUsage.COPY_DST |
         GPUTextureUsage.SAMPLED |
         GPUTextureUsage.STORAGE |
-        GPUTextureUsage.OUTPUT_ATTACHMENT,
+        GPUTextureUsage.RENDER_ATTACHMENT,
     };
 
     switch (state) {
@@ -259,7 +259,7 @@ export class ValidationTest extends GPUTest {
           .createTexture({
             format: colorFormat,
             size: { width: 16, height: 16, depth: 1 },
-            usage: GPUTextureUsage.OUTPUT_ATTACHMENT,
+            usage: GPUTextureUsage.RENDER_ATTACHMENT,
           })
           .createView();
         const encoder = commandEncoder.beginRenderPass({

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -225,7 +225,7 @@ export const kTextureUsageInfo: {
   [GPUConst.TextureUsage.COPY_DST]: {},
   [GPUConst.TextureUsage.SAMPLED]: {},
   [GPUConst.TextureUsage.STORAGE]: {},
-  [GPUConst.TextureUsage.OUTPUT_ATTACHMENT]: {},
+  [GPUConst.TextureUsage.RENDER_ATTACHMENT]: {},
 };
 export const kTextureUsages = numericKeysOf<GPUTextureUsage>(kTextureUsageInfo);
 

--- a/src/webgpu/constants.ts
+++ b/src/webgpu/constants.ts
@@ -19,7 +19,7 @@ export const GPUConst = {
     COPY_DST: 0x02,
     SAMPLED: 0x04,
     STORAGE: 0x08,
-    OUTPUT_ATTACHMENT: 0x10,
+    RENDER_ATTACHMENT: 0x10,
   },
 
   ColorWrite: {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -51,7 +51,7 @@ export class GPUTest extends Fixture {
   }
 
   get queue(): GPUQueue {
-    return this.device.defaultQueue;
+    return this.device.queue;
   }
 
   async init(): Promise<void> {

--- a/src/webgpu/idl/constants/flags.spec.ts
+++ b/src/webgpu/idl/constants/flags.spec.ts
@@ -35,7 +35,7 @@ const kTextureUsageExp = {
   COPY_DST: 0x02,
   SAMPLED: 0x04,
   STORAGE: 0x08,
-  OUTPUT_ATTACHMENT: 0x10,
+  RENDER_ATTACHMENT: 0x10,
 };
 g.test('TextureUsage,count').fn(t => {
   t.assertMemberCount(GPUTextureUsage, kTextureUsageExp);

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -168,7 +168,7 @@ class DrawCall {
     if (partialLastNumber) {
       size -= 3;
     }
-    this.device.defaultQueue.writeBuffer(vertexBuffer, 0, vertexArray, size);
+    this.device.queue.writeBuffer(vertexBuffer, 0, vertexArray, size);
     return vertexBuffer;
   }
 
@@ -178,7 +178,7 @@ class DrawCall {
       size: indexArray.byteLength,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
-    this.device.defaultQueue.writeBuffer(indexBuffer, 0, indexArray);
+    this.device.queue.writeBuffer(indexBuffer, 0, indexArray);
     return indexBuffer;
   }
 
@@ -429,7 +429,7 @@ g.test('vertexAccess')
     draw.insertInto(pass, p.indexed, p.indirect);
 
     pass.endPass();
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
 
     // Validate we see green instead of red, meaning no fragment ended up on-screen
     t.expectSinglePixelIn2DTexture(

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -406,7 +406,7 @@ g.test('vertexAccess')
     const colorAttachment = t.device.createTexture({
       format: 'rgba8unorm',
       size: { width: 1, height: 1, depth: 1 },
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.OUTPUT_ATTACHMENT,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
     const colorAttachmentView = colorAttachment.createView();
 

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -43,7 +43,7 @@ function doTest(
     usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED,
   });
 
-  t.device.defaultQueue.writeTexture(
+  t.device.queue.writeTexture(
     { texture },
     texelData,
     {
@@ -107,7 +107,7 @@ function doTest(
   pass.setBindGroup(0, bindGroup);
   pass.dispatch(1);
   pass.endPass();
-  t.device.defaultQueue.submit([encoder.finish()]);
+  t.device.queue.submit([encoder.finish()]);
 
   t.expectContents(
     outputBuffer,

--- a/src/webgpu/web_platform/copyImageBitmapToTexture.spec.ts
+++ b/src/webgpu/web_platform/copyImageBitmapToTexture.spec.ts
@@ -103,11 +103,7 @@ got [${failedByteActualValues.join(', ')}]`;
     bytesPerPixel: number,
     expectedData: Uint8ClampedArray
   ): void {
-    this.device.defaultQueue.copyImageBitmapToTexture(
-      imageBitmapCopyView,
-      dstTextureCopyView,
-      copySize
-    );
+    this.device.queue.copyImageBitmapToTexture(imageBitmapCopyView, dstTextureCopyView, copySize);
 
     const imageBitmap = imageBitmapCopyView.imageBitmap;
     const dstTexture = dstTextureCopyView.texture;
@@ -125,7 +121,7 @@ got [${failedByteActualValues.join(', ')}]`;
       { buffer: testBuffer, bytesPerRow },
       { width: imageBitmap.width, height: imageBitmap.height, depth: 1 }
     );
-    this.device.defaultQueue.submit([encoder.finish()]);
+    this.device.queue.submit([encoder.finish()]);
 
     this.checkCopyImageBitmapResult(
       testBuffer,

--- a/src/webgpu/web_platform/reftests/canvas_clear.ts
+++ b/src/webgpu/web_platform/reftests/canvas_clear.ts
@@ -23,5 +23,5 @@ runRefTest(async t => {
     ],
   });
   pass.endPass();
-  t.device.defaultQueue.submit([encoder.finish()]);
+  t.device.queue.submit([encoder.finish()]);
 });

--- a/src/webgpu/web_platform/reftests/canvas_complex.ts
+++ b/src/webgpu/web_platform/reftests/canvas_complex.ts
@@ -73,6 +73,6 @@ export function run(format: GPUTextureFormat) {
 
     const encoder = t.device.createCommandEncoder();
     encoder.copyBufferToTexture({ buffer, bytesPerRow }, { texture }, [2, 2, 1]);
-    t.device.defaultQueue.submit([encoder.finish()]);
+    t.device.queue.submit([encoder.finish()]);
   });
 }

--- a/src/webgpu/web_platform/reftests/gpu_ref_test.ts
+++ b/src/webgpu/web_platform/reftests/gpu_ref_test.ts
@@ -17,7 +17,7 @@ export async function runRefTest(fn: (t: GPURefTest) => Promise<void>): Promise<
   assert(adapter !== null);
   const device = await adapter.requestDevice();
   assert(device !== null);
-  const queue = device.defaultQueue;
+  const queue = device.queue;
 
   await fn({ device, queue });
 


### PR DESCRIPTION
Simple update of any  instance of `defaultQueue` to `queue`. This will bring the CTS inline with the most recent spec changes and, once it rolls, significantly reduce the amount of deprecation warnings spamming the Chrome build bots. :)

-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [ ] TypeScript readability
