### PR TITLE
add todos in createView tests

### DIFF
--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -88,6 +88,11 @@ class F extends ValidationTest {
 export const g = makeTestGroup(F);
 
 g.test('creating_texture_view_on_a_2D_non_array_texture')
+  .desc(
+    `TODO: write description, and shorten name
+
+  TODO: mipLevelCount == 0 should mean 0, not "auto". "undefined" means "auto".`
+  )
   .params([
     { _success: true }, // default view works
     { arrayLayerCount: 1, _success: true }, // it is OK to create a 2D texture view on a 2D texture
@@ -125,6 +130,11 @@ g.test('creating_texture_view_on_a_2D_non_array_texture')
   });
 
 g.test('creating_texture_view_on_a_2D_array_texture')
+  .desc(
+    `TODO: write description, and shorten name
+
+  TODO: arrayLayerCount == 0 should mean 0, not "auto". "undefined" means "auto".`
+  )
   .params([
     { _success: true }, // default view works
     { dimension: '2d' as const, arrayLayerCount: 1, _success: true }, // it is OK to create a 2D texture view on a 2D array texture


### PR DESCRIPTION
Spec change:
https://github.com/gpuweb/gpuweb/pull/945

Came up here:
https://dawn-review.googlesource.com/c/dawn/+/39600/2/src/tests/unittests/validation/TextureViewValidationTests.cpp#227

-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
