### PR TITLE
Update copyBetweenLinearDataAndTexture tests for new bytesPerRow/rowsPerImage rules

### DIFF
--- a/src/common/framework/logging/log_message.ts
+++ b/src/common/framework/logging/log_message.ts
@@ -28,7 +28,7 @@ export class LogMessageWithStack extends Error {
       m += '\n' + extractImportantStackTrace(this);
     }
     if (this.timesSeen > 1) {
-      m += `\n(seen ${this.timesSeen} times with identical stack, not necessarily in a row)`;
+      m += `\n(seen ${this.timesSeen} times with identical stack, not necessarily in a row; enable ?debug=1 to stop)`;
     }
     return m;
   }

--- a/src/common/framework/logging/test_case_recorder.ts
+++ b/src/common/framework/logging/test_case_recorder.ts
@@ -98,7 +98,7 @@ export class TestCaseRecorder {
     const logMessage = new LogMessageWithStack(name, baseException);
 
     // Deduplicate errors with the exact same stack
-    if (logMessage.stack) {
+    if (!this.debugging && logMessage.stack) {
       const seen = this.messagesForPreviouslySeenStacks.get(logMessage.stack);
       if (seen) {
         seen.incrementTimesSeen();

--- a/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture.ts
+++ b/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture.ts
@@ -1,9 +1,11 @@
 import { poptions } from '../../../../common/framework/params_builder.js';
 import { assert } from '../../../../common/framework/util/util.js';
 import { kSizedTextureFormatInfo, SizedTextureFormat } from '../../../capability_info.js';
+import { align } from '../../../util/math.js';
 import { ValidationTest } from '../validation_test.js';
 
-export const kAllTestMethods = [
+type TestMethod = 'WriteTexture' | 'CopyBufferToTexture' | 'CopyTextureToBuffer';
+export const kAllTestMethods: readonly TestMethod[] = [
   'WriteTexture',
   'CopyBufferToTexture',
   'CopyTextureToBuffer',
@@ -16,25 +18,60 @@ export class CopyBetweenLinearDataAndTextureTest extends ValidationTest {
     return (info.bytesPerBlock * copyWidth) / info.blockWidth;
   }
 
-  requiredBytesInCopy(
-    layout: Required<GPUTextureDataLayout>,
+  /**
+   * Validate a copy and compute the number of bytes it needs. If the copy is invalid, computes a
+   * guess assuming `bytesPerRow` and `rowsPerImage` should be optimal.
+   */
+  dataBytesForCopy(
+    layout: GPUTextureDataLayout,
     format: SizedTextureFormat,
-    copyExtent: GPUExtent3DDict
-  ): number {
+    copyExtent: GPUExtent3DDict,
+    { method }: { method: TestMethod }
+  ): { minDataSize: number; valid: boolean } {
     const info = kSizedTextureFormatInfo[format];
-    assert(layout.rowsPerImage % info.blockHeight === 0);
-    assert(copyExtent.height % info.blockHeight === 0);
     assert(copyExtent.width % info.blockWidth === 0);
-    if (copyExtent.width === 0 || copyExtent.height === 0 || copyExtent.depth === 0) {
-      return 0;
-    } else {
-      const texelBlockRowsPerImage = layout.rowsPerImage / info.blockHeight;
-      const bytesPerImage = layout.bytesPerRow * texelBlockRowsPerImage;
-      const bytesInLastSlice =
-        layout.bytesPerRow * (copyExtent.height / info.blockHeight - 1) +
-        (copyExtent.width / info.blockWidth) * info.bytesPerBlock;
-      return bytesPerImage * (copyExtent.depth - 1) + bytesInLastSlice;
+    const widthInBlocks = copyExtent.width / info.blockWidth;
+    assert(copyExtent.height % info.blockHeight === 0);
+    const heightInBlocks = copyExtent.height / info.blockHeight;
+    const bytesInLastRow = widthInBlocks * info.bytesPerBlock;
+
+    let valid = true;
+    const offset = layout.offset ?? 0;
+    if (method !== 'WriteTexture') {
+      if (offset % info.bytesPerBlock !== 0) valid = false;
+      if (layout.bytesPerRow && layout.bytesPerRow % 256 !== 0) valid = false;
     }
+    if (layout.bytesPerRow !== undefined && bytesInLastRow > layout.bytesPerRow) valid = false;
+    if (layout.rowsPerImage !== undefined && heightInBlocks > layout.rowsPerImage) valid = false;
+
+    let requiredBytesInCopy = 0;
+    {
+      let { bytesPerRow, rowsPerImage } = layout;
+
+      // If heightInBlocks > 1, layout.bytesPerRow must be specified.
+      if (heightInBlocks > 1 && bytesPerRow === undefined) valid = false;
+      // If copyExtent.depth > 1, layout.bytesPerRow and layout.rowsPerImage must be specified.
+      if (copyExtent.depth > 1 && rowsPerImage === undefined) valid = false;
+      // If specified, layout.bytesPerRow must be greater than or equal to bytesInLastRow.
+      if (bytesPerRow !== undefined && bytesPerRow < bytesInLastRow) valid = false;
+      // If specified, layout.rowsPerImage must be greater than or equal to heightInBlocks.
+      if (rowsPerImage !== undefined && rowsPerImage < heightInBlocks) valid = false;
+
+      bytesPerRow ??= align(info.bytesPerBlock * widthInBlocks, 256);
+      rowsPerImage ??= heightInBlocks;
+
+      if (copyExtent.depth > 1) {
+        const bytesPerImage = bytesPerRow * rowsPerImage;
+        const bytesBeforeLastImage = bytesPerImage * (copyExtent.depth - 1);
+        requiredBytesInCopy += bytesBeforeLastImage;
+      }
+      if (copyExtent.depth > 0) {
+        if (heightInBlocks > 1) requiredBytesInCopy += bytesPerRow * (heightInBlocks - 1);
+        if (heightInBlocks > 0) requiredBytesInCopy += bytesInLastRow;
+      }
+    }
+
+    return { minDataSize: offset + requiredBytesInCopy, valid };
   }
 
   testRun(
@@ -42,11 +79,18 @@ export class CopyBetweenLinearDataAndTextureTest extends ValidationTest {
     textureDataLayout: GPUTextureDataLayout,
     size: GPUExtent3D,
     {
-      dataSize,
       method,
+      dataSize,
       success,
-      submit = false, // If submit is true, the validaton error is expected to come from the submit and encoding should succeed.
-    }: { dataSize: number; method: string; success: boolean; submit?: boolean }
+      submit = false,
+    }: {
+      method: TestMethod;
+      dataSize: number;
+      success: boolean;
+      /** If submit is true, the validaton error is expected to come from the submit and encoding
+       * should succeed. */
+      submit?: boolean;
+    }
   ): void {
     switch (method) {
       case 'WriteTexture': {

--- a/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture_dataRelated.spec.ts
+++ b/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture_dataRelated.spec.ts
@@ -24,7 +24,7 @@ g.test('bound_on_rows_per_image')
   .cases(poptions('method', kAllTestMethods))
   .subcases(() =>
     params()
-      .combine(poptions('rowsPerImage', [undefined, 0, 1, 2]))
+      .combine(poptions('rowsPerImage', [undefined, 0, 1, 2, 1024]))
       .combine(poptions('copyHeightInBlocks', [0, 1, 2]))
       .combine(poptions('copyDepth', [1, 3]))
   )
@@ -121,7 +121,6 @@ g.test('required_bytes_in_copy')
       format,
       method,
     } = t.params;
-
     const info = kSizedTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.extension);
 
@@ -255,9 +254,10 @@ g.test('bound_on_bytes_per_row')
     const copySize = { width: copyWidth, height: copyHeight, depth: copyDepth };
 
     const texture = t.createAlignedTexture(format, {
-      width: Math.max(info.blockWidth, copyWidth),
-      height: Math.max(info.blockHeight, copyHeight),
-      depth: Math.max(1, copyDepth),
+      width: copyWidth,
+      // size 0 is not valid; round up if needed
+      height: copyHeight || info.blockHeight,
+      depth: copyDepth || 1,
     });
 
     const layout = { bytesPerRow, rowsPerImage: copyHeight };

--- a/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture_dataRelated.spec.ts
+++ b/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture_dataRelated.spec.ts
@@ -2,6 +2,7 @@ export const description = '';
 
 import { params, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { assert } from '../../../../common/framework/util/util.js';
 import {
   kUncompressedTextureFormatInfo,
   kSizedTextureFormats,
@@ -20,18 +21,17 @@ import {
 export const g = makeTestGroup(CopyBetweenLinearDataAndTextureTest);
 
 g.test('bound_on_rows_per_image')
-  .params(
+  .cases(poptions('method', kAllTestMethods))
+  .subcases(() =>
     params()
-      .combine(poptions('method', kAllTestMethods))
-      .combine(poptions('rowsPerImageInBlocks', [0, 1, 2]))
+      .combine(poptions('rowsPerImage', [undefined, 0, 1, 2]))
       .combine(poptions('copyHeightInBlocks', [0, 1, 2]))
       .combine(poptions('copyDepth', [1, 3]))
   )
   .fn(async t => {
-    const { rowsPerImageInBlocks, copyHeightInBlocks, copyDepth, method } = t.params;
+    const { rowsPerImage, copyHeightInBlocks, copyDepth, method } = t.params;
 
     const format = 'rgba8unorm';
-    const rowsPerImage = rowsPerImageInBlocks * kUncompressedTextureFormatInfo[format].blockHeight;
     const copyHeight = copyHeightInBlocks * kUncompressedTextureFormatInfo[format].blockHeight;
 
     const texture = t.device.createTexture({
@@ -40,35 +40,24 @@ g.test('bound_on_rows_per_image')
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
 
-    // The WebGPU spec:
-    // If layout.rowsPerImage is not 0, it must be greater than or equal to copyExtent.height.
-    // If copyExtent.depth is greater than 1: layout.rowsPerImage must be greater than or equal to copyExtent.height.
-    // TODO: Update this if https://github.com/gpuweb/gpuweb/issues/984 changes the spec.
+    const layout = { bytesPerRow: 1024, rowsPerImage };
+    const size = { width: 0, height: copyHeight, depth: copyDepth };
+    const { minDataSize, valid } = t.dataBytesForCopy(layout, format, size, { method });
 
-    let success = true;
-    if (rowsPerImage < copyHeight) {
-      success &&= rowsPerImage === 0;
-      success &&= copyDepth <= 1;
-    }
-
-    t.testRun(
-      { texture },
-      { bytesPerRow: 1024, rowsPerImage },
-      { width: 0, height: copyHeight, depth: copyDepth },
-      { dataSize: 1, method, success }
-    );
+    t.testRun({ texture }, layout, size, {
+      dataSize: minDataSize,
+      method,
+      success: valid,
+    });
   });
 
 // Test with offset + requiredBytesIsCopy overflowing GPUSize64.
 g.test('offset_plus_required_bytes_in_copy_overflow')
-  .params(
-    params()
-      .combine(poptions('method', kAllTestMethods))
-      .combine([
-        { bytesPerRow: 2 ** 31, rowsPerImage: 2 ** 31, depth: 1, _success: true }, // success case
-        { bytesPerRow: 2 ** 31, rowsPerImage: 2 ** 31, depth: 16, _success: false }, // bytesPerRow * rowsPerImage * (depth - 1) overflows.
-      ])
-  )
+  .cases(poptions('method', kAllTestMethods))
+  .subcases(() => [
+    { bytesPerRow: 2 ** 31, rowsPerImage: 2 ** 31, depth: 1, _success: true }, // success case
+    { bytesPerRow: 2 ** 31, rowsPerImage: 2 ** 31, depth: 16, _success: false }, // bytesPerRow * rowsPerImage * (depth - 1) overflows.
+  ])
   .fn(async t => {
     const { method, bytesPerRow, rowsPerImage, depth, _success } = t.params;
 
@@ -94,9 +83,14 @@ g.test('offset_plus_required_bytes_in_copy_overflow')
 // In the success case, we test the exact value.
 // In the failing case, we test the exact value minus 1.
 g.test('required_bytes_in_copy')
-  .params(
+  .cases(
     params()
       .combine(poptions('method', kAllTestMethods))
+      .combine(poptions('format', kSizedTextureFormats))
+      .filter(formatCopyableWithMethod)
+  )
+  .subcases(() =>
+    params()
       .combine([
         { bytesPerRowPadding: 0, rowsPerImagePaddingInBlocks: 0 }, // no padding
         { bytesPerRowPadding: 0, rowsPerImagePaddingInBlocks: 6 }, // rowsPerImage padding
@@ -115,8 +109,6 @@ g.test('required_bytes_in_copy')
         { copyWidthInBlocks: 5, copyHeightInBlocks: 4, copyDepth: 1, offsetInBlocks: 0 }, // copyDepth = 1
         { copyWidthInBlocks: 7, copyHeightInBlocks: 1, copyDepth: 1, offsetInBlocks: 0 }, // copyHeight = 1 and copyDepth = 1
       ])
-      .combine(poptions('format', kSizedTextureFormats))
-      .filter(formatCopyableWithMethod)
   )
   .fn(async t => {
     const {
@@ -130,12 +122,14 @@ g.test('required_bytes_in_copy')
       method,
     } = t.params;
 
+    const info = kSizedTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.extension);
+
     // In the CopyB2T and CopyT2B cases we need to have bytesPerRow 256-aligned,
     // to make this happen we align the bytesInACompleteRow value and multiply
     // bytesPerRowPadding by 256.
     const bytesPerRowAlignment = method === 'WriteTexture' ? 1 : 256;
 
-    const info = kSizedTextureFormatInfo[format];
     const copyWidth = copyWidthInBlocks * info.blockWidth;
     const copyHeight = copyHeightInBlocks * info.blockHeight;
     const offset = offsetInBlocks * info.bytesPerBlock;
@@ -145,8 +139,9 @@ g.test('required_bytes_in_copy')
       bytesPerRowPadding * bytesPerRowAlignment;
     const size = { width: copyWidth, height: copyHeight, depth: copyDepth };
 
-    const minDataSize =
-      offset + t.requiredBytesInCopy({ offset, bytesPerRow, rowsPerImage }, format, size);
+    const layout = { offset, bytesPerRow, rowsPerImage };
+    const { minDataSize, valid } = t.dataBytesForCopy(layout, format, size, { method });
+    assert(valid);
 
     const texture = t.createAlignedTexture(format, size);
 
@@ -165,53 +160,63 @@ g.test('required_bytes_in_copy')
     }
   });
 
-g.test('texel_block_alignment_on_rows_per_image')
-  .params(
+g.test('rows_per_image_alignment')
+  .desc(`rowsPerImage is measured in multiples of block height, so has no alignment constraints.`)
+  .cases(
     params()
       .combine(poptions('method', kAllTestMethods))
       .combine(poptions('format', kSizedTextureFormats))
       .filter(formatCopyableWithMethod)
-      .expand(texelBlockAlignmentTestExpanderForRowsPerImage)
   )
+  .subcases(texelBlockAlignmentTestExpanderForRowsPerImage)
   .fn(async t => {
     const { rowsPerImage, format, method } = t.params;
+    const info = kSizedTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.extension);
+
     const size = { width: 0, height: 0, depth: 0 };
 
     const texture = t.createAlignedTexture(format, size);
-
-    const success = rowsPerImage % kSizedTextureFormatInfo[format].blockHeight! === 0;
 
     t.testRun({ texture }, { bytesPerRow: 0, rowsPerImage }, size, {
       dataSize: 1,
       method,
-      success,
+      success: true,
     });
   });
 
-// TODO: Update this if https://github.com/gpuweb/gpuweb/issues/985 changes the spec.
 g.test('texel_block_alignment_on_offset')
-  .params(
+  .cases(
     params()
       .combine(poptions('method', kAllTestMethods))
       .combine(poptions('format', kSizedTextureFormats))
       .filter(formatCopyableWithMethod)
-      .expand(texelBlockAlignmentTestExpanderForOffset)
   )
+  .subcases(texelBlockAlignmentTestExpanderForOffset)
   .fn(async t => {
     const { format, offset, method } = t.params;
+    const info = kSizedTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.extension);
+
     const size = { width: 0, height: 0, depth: 0 };
 
     const texture = t.createAlignedTexture(format, size);
 
-    const success = offset % kSizedTextureFormatInfo[format].bytesPerBlock! === 0;
+    const success =
+      method === 'WriteTexture' || offset % kSizedTextureFormatInfo[format].bytesPerBlock === 0;
 
     t.testRun({ texture }, { offset, bytesPerRow: 0 }, size, { dataSize: offset, method, success });
   });
 
 g.test('bound_on_bytes_per_row')
-  .params(
+  .cases(
     params()
       .combine(poptions('method', kAllTestMethods))
+      .combine(poptions('format', kSizedTextureFormats))
+      .filter(formatCopyableWithMethod)
+  )
+  .subcases(() =>
+    params()
       .combine([
         { blocksPerRow: 2, additionalPaddingPerRow: 0, copyWidthInBlocks: 2 }, // success
         { blocksPerRow: 2, additionalPaddingPerRow: 5, copyWidthInBlocks: 3 }, // success if bytesPerBlock <= 5
@@ -224,8 +229,6 @@ g.test('bound_on_bytes_per_row')
         { copyHeightInBlocks: 2, copyDepth: 1 }, // we have to check the bound
         { copyHeightInBlocks: 0, copyDepth: 2 }, // we have to check the bound
       ])
-      .combine(poptions('format', kSizedTextureFormats))
-      .filter(formatCopyableWithMethod)
   )
   .fn(async t => {
     const {
@@ -237,37 +240,40 @@ g.test('bound_on_bytes_per_row')
       format,
       method,
     } = t.params;
+    const info = kSizedTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.extension);
 
-    // In the CopyB2T and CopyT2B cases we need to have bytesPerRow 256-aligned,
-    // to make this happen we multiply copyWidth and bytesPerRow by 256, so that
-    // the appropriate inequalities still hold.
+    // In the CopyB2T and CopyT2B cases we need to have bytesPerRow 256-aligned.
     const bytesPerRowAlignment = method === 'WriteTexture' ? 1 : 256;
 
-    const info = kSizedTextureFormatInfo[format];
-    const copyWidth = copyWidthInBlocks * info.blockWidth * bytesPerRowAlignment;
+    const copyWidth = align(copyWidthInBlocks * info.blockWidth, bytesPerRowAlignment);
     const copyHeight = copyHeightInBlocks * info.blockHeight;
-    const bytesPerRow =
-      (blocksPerRow * info.bytesPerBlock + additionalPaddingPerRow) * bytesPerRowAlignment;
-    const size = { width: copyWidth, height: copyHeight, depth: copyDepth };
+    const bytesPerRow = align(
+      blocksPerRow * info.bytesPerBlock + additionalPaddingPerRow,
+      bytesPerRowAlignment
+    );
+    const copySize = { width: copyWidth, height: copyHeight, depth: copyDepth };
 
-    const texture = t.createAlignedTexture(format, size);
+    const texture = t.createAlignedTexture(format, {
+      width: Math.max(info.blockWidth, copyWidth),
+      height: Math.max(info.blockHeight, copyHeight),
+      depth: Math.max(1, copyDepth),
+    });
 
-    let success = true;
-    if (copyHeight > 1 || copyDepth > 1) {
-      success = bytesPerRow >= t.bytesInACompleteRow(copyWidth, format);
-    }
+    const layout = { bytesPerRow, rowsPerImage: copyHeight };
+    const { minDataSize, valid } = t.dataBytesForCopy(layout, format, copySize, { method });
 
-    t.testRun({ texture }, { bytesPerRow, rowsPerImage: copyHeight }, size, {
-      dataSize: 1024,
+    t.testRun({ texture }, layout, copySize, {
+      dataSize: minDataSize,
       method,
-      success,
+      success: valid,
     });
   });
 
 g.test('bound_on_offset')
-  .params(
+  .cases(poptions('method', kAllTestMethods))
+  .subcases(() =>
     params()
-      .combine(poptions('method', kAllTestMethods))
       .combine(poptions('offsetInBlocks', [0, 1, 2]))
       .combine(poptions('dataSizeInBlocks', [0, 1, 2]))
   )
@@ -276,8 +282,8 @@ g.test('bound_on_offset')
 
     const format = 'rgba8unorm';
     const info = kSizedTextureFormatInfo[format];
-    const offset = offsetInBlocks * info.bytesPerBlock!;
-    const dataSize = dataSizeInBlocks * info.bytesPerBlock!;
+    const offset = offsetInBlocks * info.bytesPerBlock;
+    const dataSize = dataSizeInBlocks * info.bytesPerBlock;
 
     const texture = t.device.createTexture({
       size: { width: 4, height: 4, depth: 1 },

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -63,12 +63,18 @@ export class GPUTest extends Fixture {
   /**
    * When a GPUTest test accesses `.device` for the first time, a "default" GPUDevice
    * (descriptor = `undefined`) is provided by default.
-   * However, some tests or cases need particular extensions to be enabled. Call this function with
-   * a descriptor (or undefined) to select a GPUDevice matching that descriptor.
+   * However, some tests or cases need particular nonGuaranteedFeatures to be enabled.
+   * Call this function with a descriptor or feature name (or `undefined`) to select a
+   * GPUDevice with matching capabilities.
    *
    * If the request descriptor can't be supported, throws an exception to skip the entire test case.
    */
-  async selectDeviceOrSkipTestCase(descriptor: GPUDeviceDescriptor | undefined): Promise<void> {
+  async selectDeviceOrSkipTestCase(
+    descriptor: GPUDeviceDescriptor | GPUExtensionName | undefined
+  ): Promise<void> {
+    if (descriptor === undefined) return;
+    if (typeof descriptor === 'string') descriptor = { extensions: [descriptor] };
+
     assert(this.provider !== undefined);
     // Make sure the device isn't replaced after it's been retrieved once.
     assert(


### PR DESCRIPTION
- Update copyBetweenLinearDataAndTexture tests for new bytesPerRow/rowsPerImage rules.
- Use `.cases().subcases()`.
- Fix tests for compressed texture formats.

-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
