### PR TITLE
Use subcases in copyImageBitmapToTexture tests

### DIFF
--- a/src/webgpu/web_platform/copyImageBitmapToTexture.spec.ts
+++ b/src/webgpu/web_platform/copyImageBitmapToTexture.spec.ts
@@ -176,24 +176,27 @@ export const g = makeTestGroup(F);
 
 g.test('from_ImageData')
   .cases(
-    poptions('dstColorFormat', [
-      'rgba8unorm',
-      'bgra8unorm',
-      'rgba8unorm-srgb',
-      'bgra8unorm-srgb',
-      'rgb10a2unorm',
-      'rgba16float',
-      'rgba32float',
-      'rg8unorm',
-      'rg16float',
-    ] as const)
+    params()
+      .combine(poptions('alpha', ['none', 'premultiply']))
+      .combine(poptions('orientation', ['none', 'flipY']))
+      .combine(
+        poptions('dstColorFormat', [
+          'rgba8unorm',
+          'bgra8unorm',
+          'rgba8unorm-srgb',
+          'bgra8unorm-srgb',
+          'rgb10a2unorm',
+          'rgba16float',
+          'rgba32float',
+          'rg8unorm',
+          'rg16float',
+        ] as const)
+      )
   )
   .subcases(() =>
     params()
       .combine(poptions('width', [1, 2, 4, 15, 255, 256]))
       .combine(poptions('height', [1, 2, 4, 15, 255, 256]))
-      .combine(poptions('alpha', ['none', 'premultiply']))
-      .combine(poptions('orientation', ['none', 'flipY']))
   )
   .fn(async t => {
     const { width, height, alpha, orientation, dstColorFormat } = t.params;

--- a/src/webgpu/web_platform/copyImageBitmapToTexture.spec.ts
+++ b/src/webgpu/web_platform/copyImageBitmapToTexture.spec.ts
@@ -175,25 +175,25 @@ got [${failedByteActualValues.join(', ')}]`;
 export const g = makeTestGroup(F);
 
 g.test('from_ImageData')
-  .params(
+  .cases(
+    poptions('dstColorFormat', [
+      'rgba8unorm',
+      'bgra8unorm',
+      'rgba8unorm-srgb',
+      'bgra8unorm-srgb',
+      'rgb10a2unorm',
+      'rgba16float',
+      'rgba32float',
+      'rg8unorm',
+      'rg16float',
+    ] as const)
+  )
+  .subcases(() =>
     params()
       .combine(poptions('width', [1, 2, 4, 15, 255, 256]))
       .combine(poptions('height', [1, 2, 4, 15, 255, 256]))
       .combine(poptions('alpha', ['none', 'premultiply']))
       .combine(poptions('orientation', ['none', 'flipY']))
-      .combine(
-        poptions('dstColorFormat', [
-          'rgba8unorm',
-          'bgra8unorm',
-          'rgba8unorm-srgb',
-          'bgra8unorm-srgb',
-          'rgb10a2unorm',
-          'rgba16float',
-          'rgba32float',
-          'rg8unorm',
-          'rg16float',
-        ] as const)
-      )
   )
   .fn(async t => {
     const { width, height, alpha, orientation, dstColorFormat } = t.params;
@@ -278,7 +278,7 @@ g.test('from_ImageData')
   });
 
 g.test('from_canvas')
-  .params(
+  .subcases(() =>
     params()
       .combine(poptions('width', [1, 2, 4, 15, 255, 256]))
       .combine(poptions('height', [1, 2, 4, 15, 255, 256]))


### PR DESCRIPTION
Reduces unnecessary case granularity by using the new `.subcases()`, and simplifies splitting the test into multiple parts for automated testing.

-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
