### PR TITLE
fix "INFO: subcase:" prints

### DIFF
--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -2,7 +2,7 @@ import { CaseParams } from '../params_utils.js';
 import { assert } from '../util/util.js';
 
 import { encodeURIComponentSelectively } from './encode_selectively.js';
-import { kBigSeparator, kPathSeparator, kWildcard, kParamSeparator } from './separators.js';
+import { kBigSeparator, kPathSeparator, kWildcard } from './separators.js';
 import { stringifyPublicParams } from './stringify_params.js';
 
 /**
@@ -104,12 +104,11 @@ export class TestQueryMultiCase extends TestQueryMultiTest {
   }
 
   protected toStringHelper(): string[] {
-    const paramsParts = stringifyPublicParams(this.params);
     return [
       this.suite,
       this.filePathParts.join(kPathSeparator),
       this.testPathParts.join(kPathSeparator),
-      [...paramsParts, kWildcard].join(kParamSeparator),
+      stringifyPublicParams(this.params, true),
     ];
   }
 }
@@ -128,12 +127,11 @@ export class TestQuerySingleCase extends TestQueryMultiCase {
   }
 
   protected toStringHelper(): string[] {
-    const paramsParts = stringifyPublicParams(this.params);
     return [
       this.suite,
       this.filePathParts.join(kPathSeparator),
       this.testPathParts.join(kPathSeparator),
-      paramsParts.join(kParamSeparator),
+      stringifyPublicParams(this.params),
     ];
   }
 }

--- a/src/common/framework/query/stringify_params.ts
+++ b/src/common/framework/query/stringify_params.ts
@@ -7,12 +7,16 @@ import {
 import { assert } from '../util/util.js';
 
 import { stringifyParamValue, stringifyParamValueUniquely } from './json_param_value.js';
-import { kBigSeparator, kParamKVSeparator } from './separators.js';
+import { kParamKVSeparator, kParamSeparator, kWildcard } from './separators.js';
 
-export function stringifyPublicParams(p: CaseParams): string[] {
-  return Object.keys(p)
+export function stringifyPublicParams(p: CaseParams, addWildcard = false): string {
+  const parts = Object.keys(p)
     .filter(k => paramKeyIsPublic(k))
     .map(k => stringifySingleParam(k, p[k]));
+
+  if (addWildcard) parts.push(kWildcard);
+
+  return parts.join(kParamSeparator);
 }
 
 /**
@@ -23,7 +27,7 @@ export function stringifyPublicParamsUniquely(p: CaseParams): string {
   return keys
     .filter(k => paramKeyIsPublic(k))
     .map(k => stringifySingleParamUniquely(k, p[k]))
-    .join(kBigSeparator);
+    .join(kParamSeparator);
 }
 
 export function stringifySingleParam(k: string, v: ParamArgument) {

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -278,7 +278,7 @@ class RunCaseSpecific<
       let totalCount = 0;
       let skipCount = 0;
       for (const subParams of this.subParamGen(this.params)) {
-        rec.info(new Error('subcase: ' + stringifyPublicParamsUniquely(subParams)));
+        rec.info(new Error('subcase: ' + stringifyPublicParams(subParams)));
         try {
           await this.runTest(rec, mergeParams(this.params, subParams), true);
         } catch (ex) {


### PR DESCRIPTION
Fixes the "INFO: subcase:" prints to `b=1;a=2` style instead of `a=1:b=2` (uses the wrong separator and sorts the params lexicographically instead of keeping the original order). Moves the `.join()` inside stringifyPublicParams for convenience.

-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
