### PR TITLE
Add button to print creation stack to console in /standalone/

### DIFF
--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -279,7 +279,7 @@ class RunCaseSpecific<
       let totalCount = 0;
       let skipCount = 0;
       for (const subParams of this.subParamGen(this.params)) {
-        rec.info(new Error('subcase: ' + stringifyPublicParamsUniquely(subParams)));
+        rec.info(new Error('subcase: ' + stringifyPublicParams(subParams)));
         try {
           await this.runTest(rec, mergeParams(this.params, subParams), true);
         } catch (ex) {

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -34,6 +34,7 @@ export interface IterableTestGroup {
 export interface IterableTest {
   testPath: string[];
   description: string | undefined;
+  readonly testCreationStack: Error;
   iterate(): Iterable<RunCase>;
 }
 
@@ -118,12 +119,12 @@ interface TestBuilderWithSubParams<F extends Fixture, P extends {}, SubP extends
 class TestBuilder<F extends Fixture, P extends {}, SubP extends {}> {
   readonly testPath: string[];
   description: string | undefined;
+  readonly testCreationStack: Error;
 
   private readonly fixture: FixtureClass<F>;
   private testFn: TestFn<F, P, SubP> | undefined;
   private caseParams?: Iterable<P> = undefined;
   private subcaseParams?: (_: P) => Iterable<SubP> = undefined;
-  private testCreationStack: Error;
 
   constructor(testPath: string[], fixture: FixtureClass<F>, testCreationStack: Error) {
     this.testPath = testPath;
@@ -278,7 +279,7 @@ class RunCaseSpecific<
       let totalCount = 0;
       let skipCount = 0;
       for (const subParams of this.subParamGen(this.params)) {
-        rec.info(new Error('subcase: ' + stringifyPublicParams(subParams)));
+        rec.info(new Error('subcase: ' + stringifyPublicParamsUniquely(subParams)));
         try {
           await this.runTest(rec, mergeParams(this.params, subParams), true);
         } catch (ex) {

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -49,6 +49,7 @@ export interface TestSubtree<T extends TestQuery = TestQuery> {
   readonly children: Map<string, TestTreeNode>;
   readonly collapsible: boolean;
   description?: string;
+  readonly testCreationStack?: Error;
 }
 
 export interface TestTreeLeaf {
@@ -226,6 +227,7 @@ export async function loadTreeForQuery(
         subtreeL1,
         t.testPath,
         t.description,
+        t.testCreationStack,
         isCollapsible
       );
 
@@ -315,6 +317,7 @@ function addSubtreeForTestPath(
   tree: TestSubtree<TestQueryMultiTest>,
   test: readonly string[],
   description: string | undefined,
+  testCreationStack: Error,
   isCollapsible: (sq: TestQuery) => boolean
 ): TestSubtree<TestQueryMultiCase> {
   const subqueryTest: string[] = [];
@@ -349,6 +352,7 @@ function addSubtreeForTestPath(
       kWildcard,
       query,
       description,
+      testCreationStack,
       collapsible: isCollapsible(query),
     };
   });

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -243,6 +243,17 @@ function makeTreeNodeHeaderHTML(
     .attr('alt', 'Open')
     .attr('title', 'Open')
     .appendTo(div);
+  if ('testCreationStack' in n && n.testCreationStack) {
+    $('<button>')
+      .addClass('testcaselogbtn')
+      .attr('alt', 'Log test creation stack to console')
+      .attr('title', 'Log test creation stack to console')
+      .appendTo(div)
+      .on('click', () => {
+        /* eslint-disable-next-line no-console */
+        console.log(n.testCreationStack);
+      });
+  }
   const nodetitle = $('<div>').addClass('nodetitle').appendTo(div);
   $('<input>')
     .attr('type', 'text')


### PR DESCRIPTION


-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
