### PR TITLE
WIP image copy operation test work

### DIFF
--- a/src/webgpu/api/operation/image_copies_v2.spec.ts
+++ b/src/webgpu/api/operation/image_copies_v2.spec.ts
@@ -1,0 +1,97 @@
+export const description = `
+writeTexture + copyBufferToTexture + copyTextureToBuffer operation tests.
+`;
+
+import { params, poptions } from '../../../common/framework/params_builder.js';
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { unreachable } from '../../../common/framework/util/util.js';
+import { RegularTextureFormat } from '../../capability_info.js';
+import { GPUTest } from '../../gpu_test.js';
+import {
+  createTextureWithData,
+  TextureInitMethod,
+  arbitraryTextureData,
+} from '../../util/texture/create.js';
+
+/**
+ * - PartialCopyT2B: do CopyT2B to check that the part of the texture we copied to with InitMethod
+ *   matches the data we were copying and that we don't overwrite any data in the target buffer that
+ *   we're not supposed to - that's primarily for testing CopyT2B functionality.
+ * - FullCopyT2B: do CopyT2B on the whole texture and check wether the part we copied to matches
+ *   the data we were copying and that the nothing else was modified - that's primarily for testing
+ *   WriteTexture and CopyB2T.
+ */
+type CheckMethod = 'PartialCopyT2B' | 'FullCopyT2B';
+
+/** Each combination of methods assume that the ones before it were tested and work correctly. */
+const kMethodsToTest = [
+  // We make sure that CopyT2B works when copying the whole texture for renderable formats:
+  // TODO
+  // Then we make sure that WriteTexture works for all formats:
+  { initMethod: 'WriteTexture', checkMethod: 'FullCopyT2B' },
+  // Then we make sure that CopyB2T works for all formats:
+  { initMethod: 'CopyB2T', checkMethod: 'FullCopyT2B' },
+  // Then we make sure that CopyT2B works for all formats:
+  { initMethod: 'WriteTexture', checkMethod: 'PartialCopyT2B' },
+] as const;
+
+class F extends GPUTest {
+  generateData(byteSize: number, start: number = 0): Uint8Array {
+    const arr = new Uint8Array(byteSize);
+    for (let i = 0; i < byteSize; ++i) {
+      arr[i] = (i ** 3 + i + start) % 251;
+    }
+    return arr;
+  }
+
+  uploadTextureAndVerifyCopy(
+    { initMethod, checkMethod }: { initMethod: TextureInitMethod; checkMethod: CheckMethod },
+    // TODO: Expand to EncodableTextureFormat
+    textureDesc: GPUTextureDescriptor & { format: RegularTextureFormat },
+    layout: GPUImageDataLayout,
+    region: Omit<GPUImageCopyTexture, 'texture'>,
+    copySize: GPUExtent3D
+  ) {
+    const texture = createTextureWithData(
+      this.device,
+      initMethod,
+      textureDesc,
+      arbitraryTextureData(textureDesc.format)
+    );
+    const copyTexture: GPUImageCopyTexture = { texture, ...region };
+
+    switch (checkMethod) {
+      case 'PartialCopyT2B':
+        unreachable('TODO');
+      case 'FullCopyT2B':
+        unreachable('TODO');
+      default:
+        unreachable();
+    }
+  }
+}
+
+export const g = makeTestGroup(F);
+
+g.test('bytesPerRow_undefined')
+  .desc(`Test the behavior when bytesPerRow is (validly) undefined is same as when it's defined`)
+  .cases(
+    params()
+      .combine(kMethodsToTest)
+      .combine(poptions('bytesPerRow', [256, undefined]))
+  )
+  .fn(t => {
+    const { initMethod, checkMethod, bytesPerRow } = t.params;
+
+    t.uploadTextureAndVerifyCopy(
+      { initMethod, checkMethod },
+      {
+        size: [100, 3, 2],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+      },
+      { offset: 0, bytesPerRow, rowsPerImage: 256 },
+      { mipLevel: 0, origin: [0, 0, 0] },
+      [3, 1, 1]
+    );
+  });

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -203,6 +203,7 @@ export class ValidationTest extends GPUTest {
     return pipeline;
   }
 
+  // TODO: move this to a more general utils file so it can be used for operation tests
   createEncoder(encoderType: 'non-pass'): CommandBufferMaker<GPUCommandEncoder>;
   createEncoder(encoderType: 'render pass'): CommandBufferMaker<GPURenderPassEncoder>;
   createEncoder(encoderType: 'compute pass'): CommandBufferMaker<GPUComputePassEncoder>;

--- a/src/webgpu/util/texture/create.ts
+++ b/src/webgpu/util/texture/create.ts
@@ -20,7 +20,7 @@ export type DataCallback = (pos: {
 
 // TODO: expand with CopyT2T, RenderPassStore, RenderPassResolve, CopyImageBitmapToTexture, ...?
 export type TextureInitMethod = 'WriteTexture' | 'CopyB2T';
-export const kTextureInitMethods = ['WriteTexture', 'CopyB2T'];
+export const kTextureInitMethods = ['WriteTexture', 'CopyB2T'] as const;
 
 class TextureInitAccumulator {
   private device: GPUDevice;

--- a/src/webgpu/util/texture/create.ts
+++ b/src/webgpu/util/texture/create.ts
@@ -1,0 +1,178 @@
+import { assert, unreachable } from '../../../common/framework/util/util.js';
+import {
+  EncodableTextureFormat,
+  kEncodableTextureFormatInfo,
+  RegularTextureFormat,
+} from '../../capability_info.js';
+import { makeBufferWithContents } from '../buffer.js';
+import { align } from '../math.js';
+import { standardizeExtent3D } from '../unions.js';
+import { dataBytesForCopy } from './image_copy.js';
+import { physicalMipSize } from './subresource.js';
+import { ComponentInfo, kTexelRepresentationInfo } from './texel_data.js';
+
+type Texel = readonly [number, number?, number?, number?];
+export type DataCallback = (pos: {
+  readonly mip: number;
+  readonly coords: readonly [number, number, number];
+  readonly uv: readonly [number, number, number];
+}) => Texel;
+
+// TODO: expand with CopyT2T, RenderPassStore, RenderPassResolve, CopyImageBitmapToTexture, ...?
+export type TextureInitMethod = 'WriteTexture' | 'CopyB2T';
+export const kTextureInitMethods = ['WriteTexture', 'CopyB2T'];
+
+class TextureInitAccumulator {
+  private device: GPUDevice;
+  private buffers: GPUBuffer[] = [];
+  private encoder: GPUCommandEncoder | undefined;
+
+  constructor(device: GPUDevice) {
+    this.device = device;
+  }
+
+  write(
+    method: TextureInitMethod,
+    destination: GPUImageCopyTexture,
+    layout: GPUImageDataLayout,
+    sizeAtLevel: GPUExtent3DDict,
+    bytes: Uint8Array
+  ): void {
+    if (method === 'CopyB2T') {
+      this.encoder ??= this.device.createCommandEncoder();
+
+      const buffer = makeBufferWithContents(this.device, bytes, GPUBufferUsage.COPY_SRC);
+      this.buffers.push(buffer);
+
+      this.encoder.copyBufferToTexture({ buffer, ...layout }, destination, sizeAtLevel);
+    } else if (method === 'WriteTexture') {
+      this.device.queue.writeTexture(destination, bytes, layout, sizeAtLevel);
+    } else {
+      unreachable();
+    }
+  }
+
+  finish(): void {
+    if (this.encoder) {
+      this.device.queue.submit([this.encoder.finish()]);
+    }
+    for (const buffer of this.buffers) {
+      buffer.destroy();
+    }
+  }
+}
+
+/**
+ * Returns a "representative" range (and integer-ness) for a component type/length.
+ * For int/norm, returns the full range.
+ * For floats (which have big limits), picks some range bigger than 1.0.
+ */
+export function representativeRangeForComponent({
+  dataType,
+  bitLength,
+}: ComponentInfo): { min: number; max: number; integral: boolean } {
+  assert(bitLength <= 32);
+  switch (dataType) {
+    case 'uint':
+      return { min: 0, max: 2 ** bitLength - 1, integral: true };
+    case 'sint':
+      const absMin = 2 ** (bitLength - 1);
+      return { min: -absMin, max: absMin - 1, integral: true };
+    case 'unorm':
+      return { min: 0, max: 1, integral: false };
+    case 'float':
+      return { min: -1, max: 1, integral: false };
+    case 'ufloat':
+      return { min: 0, max: 10, integral: false };
+    case 'snorm':
+      return { min: -10, max: 10, integral: false };
+  }
+  unreachable();
+}
+
+export function arbitraryTextureData(format: EncodableTextureFormat): DataCallback {
+  const rep = kTexelRepresentationInfo[format];
+  const gen = (component: ComponentInfo | undefined, v: number) => {
+    if (!component) return 0;
+    const { min, max, integral } = representativeRangeForComponent(component);
+    return integral //
+      ? Math.round(Math.sin(v) ** 2 * (max - min) + min)
+      : Math.sin(v) ** 2 * (max - min) + min;
+  };
+
+  return ({ mip, uv: [x, y, z] }) => [
+    gen(rep.componentInfo.R, mip + 0.2 + x * 2 + y * 3 + z * 5),
+    gen(rep.componentInfo.G, mip + 0.4 + x * 2 + y * 3 + z * 5),
+    gen(rep.componentInfo.B, mip + 0.6 + x * 2 + y * 3 + z * 5),
+    gen(rep.componentInfo.A, mip + 0.8 + x * 2 + y * 3 + z * 5),
+  ];
+}
+
+export function createTextureWithData(
+  device: GPUDevice,
+  method: TextureInitMethod,
+  // TODO: Expand to EncodableTextureFormat
+  desc: GPUTextureDescriptor & { format: RegularTextureFormat },
+  data: DataCallback
+): GPUTexture {
+  const info = kEncodableTextureFormatInfo[desc.format];
+  // Creating compressed textures requires pre-compressed data for each block, not color values.
+  assert(info.blockWidth === 1 && info.blockHeight === 1);
+
+  const size = standardizeExtent3D(desc.size);
+  const mipLevelCount = desc.mipLevelCount ?? 1;
+  const rep = kTexelRepresentationInfo[desc.format];
+
+  let toComponents;
+  if (info.color) {
+    assert(!info.depth && !info.stencil);
+    toComponents = ([R, G, B, A]: Texel) => ({ R, G, B, A });
+  } else {
+    unreachable();
+  }
+
+  const texture = device.createTexture(desc);
+
+  const accumulator = new TextureInitAccumulator(device);
+  for (let mip = 0; mip < mipLevelCount; ++mip) {
+    const mipLevelSize = physicalMipSize(size, desc.format, desc.dimension ?? '2d', mip);
+    const bytesPerRow = align(mipLevelSize.width * info.bytesPerBlock, 256);
+    assert(mipLevelSize.height % info.blockHeight === 0);
+    const rowsPerImage = mipLevelSize.height / info.blockHeight;
+
+    const { minDataSize, valid } = dataBytesForCopy(
+      { bytesPerRow, rowsPerImage },
+      desc.format,
+      mipLevelSize,
+      // validate against the most conservative image layout rules
+      { method: 'CopyB2T' }
+    );
+    assert(valid);
+
+    const bytes = new Uint8Array(minDataSize);
+
+    for (let z = 0; z < mipLevelSize.depth; ++z) {
+      for (let y = 0; y < mipLevelSize.height; ++y) {
+        for (let x = 0; x < mipLevelSize.width; ++x) {
+          const coords = [x, y, z] as const;
+          const uv = [
+            x / mipLevelSize.width,
+            y / mipLevelSize.height,
+            z / mipLevelSize.depth,
+          ] as const;
+          const texel = toComponents(data({ mip, coords, uv }));
+          const texelBytes = new Uint8Array(rep.pack(rep.encode(texel)));
+
+          const offset = (z * rowsPerImage + y) * bytesPerRow + x * info.bytesPerBlock;
+          bytes.set(texelBytes, offset);
+        }
+      }
+    }
+
+    console.log(bytes);
+    accumulator.write(method, { texture }, { bytesPerRow, rowsPerImage }, mipLevelSize, bytes);
+  }
+  accumulator.finish();
+
+  return texture;
+}

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -23,10 +23,11 @@ export type PerTexelComponent<T> = { [c in TexelComponent]?: T };
 
 export type ComponentDataType = 'uint' | 'sint' | 'unorm' | 'snorm' | 'float' | 'ufloat' | null;
 
-type TexelComponentInfo = PerTexelComponent<{
+export type ComponentInfo = {
   dataType: ComponentDataType;
   bitLength: number;
-}>;
+};
+type TexelComponentInfo = PerTexelComponent<ComponentInfo>;
 
 /**
  * Maps component values to component values

--- a/src/webgpu/util/unions.ts
+++ b/src/webgpu/util/unions.ts
@@ -1,7 +1,15 @@
-export function standardizeExtent3D(v: GPUExtent3D): Required<GPUExtent3DDict> {
+export function standardizeExtent3D(v: Readonly<GPUExtent3D>): Required<GPUExtent3DDict> {
   if (v instanceof Array) {
     return { width: v[0] ?? 1, height: v[1] ?? 1, depth: v[2] ?? 1 };
   } else {
     return { width: v.width ?? 1, height: v.height ?? 1, depth: v.depth ?? 1 };
+  }
+}
+
+export function standardizeOrigin3D(v: Readonly<GPUOrigin3D>): Required<GPUOrigin3DDict> {
+  if (v instanceof Array) {
+    return { x: v[0] ?? 1, y: v[1] ?? 1, z: v[2] ?? 1 };
+  } else {
+    return { x: v.x ?? 1, y: v.y ?? 1, z: v.z ?? 1 };
   }
 }


### PR DESCRIPTION
VERY DRAFT

Trying to partially rewrite one of the image copy operation tests while building a helper to create textures initialized in various ways. Too much going on in this patch right now and I'm not sure this is the right direction.

dependent on #462

-----

<!-- Leave this section in the PR description. -->

- [ ] New helpers, if any, are documented in `helper_index.md`.
- [ ] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
