### PR TITLE
Remove explicit storage class from samplers/textures

### DIFF
--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -53,7 +53,7 @@ export const checkContentsBySampling: CheckContents = (
             };
 
             [[group(0), binding(0)]] var<uniform> constants : Constants;
-            [[group(0), binding(1)]] var<uniform_constant> myTexture : texture${_multisampled}${_xd}<${shaderType}>;
+            [[group(0), binding(1)]] var myTexture : texture${_multisampled}${_xd}<${shaderType}>;
 
             [[block]] struct Result {
               [[offset(0)]] values : [[stride(4)]] array<${shaderType}>;

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -94,8 +94,8 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
       fragmentStage: {
         module: this.device.createShaderModule({
           code: `
-            [[set(0), binding(0)]] var<uniform_constant> sampler0 : sampler;
-            [[set(0), binding(1)]] var<uniform_constant> texture0 : texture_2d<f32>;
+            [[set(0), binding(0)]] var sampler0 : sampler;
+            [[set(0), binding(1)]] var texture0 : texture_2d<f32>;
 
             [[builtin(frag_coord)]] var<in> FragCoord : vec4<f32>;
 

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -55,7 +55,7 @@ function doTest(
   const { ReadbackTypedArray, shaderType } = getComponentReadbackTraits(getSingleDataType(format));
 
   const shader = `
-  [[group(0), binding(0)]] var<uniform_constant> tex : texture_2d<${shaderType}>;
+  [[group(0), binding(0)]] var tex : texture_2d<${shaderType}>;
 
   [[block]] struct Output {
     ${rep.componentOrder


### PR DESCRIPTION
WGSL specifies that texture and sampler variables must not have a
storage class decoration, as they implicitly have the `handle` storage
class.



-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
