### PR TITLE
Some more cases for index_access.spec.ts

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -134,6 +134,7 @@ g.test('out_of_bounds')
       .combine(pbool('indirect')) // indirect drawIndexed
       .combine([
         { indexCount: 6, firstIndex: 1 }, // indexCount + firstIndex out of bound
+        { indexCount: 0, firstIndex: 6 }, // indexCount is 0 but firstIndex out of bound
         { indexCount: 6, firstIndex: 6 }, // only firstIndex out of bound
         { indexCount: 6, firstIndex: 10000 }, // firstIndex much larger than the bound
         { indexCount: 7, firstIndex: 0 }, // only indexCount out of bound
@@ -150,8 +151,6 @@ g.test('out_of_bounds')
     if (indirect) {
       t.drawIndexedIndirect(new Uint32Array([indexCount, instanceCount, firstIndex, 0, 0]), 0);
     } else {
-      t.expectValidationError(() => {
-        t.drawIndexed(indexCount, instanceCount, firstIndex, 0, 0);
-      });
+      t.drawIndexed(indexCount, instanceCount, firstIndex, 0, 0);
     }
   });

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -129,7 +129,7 @@ class F extends ValidationTest {
 export const g = makeTestGroup(F);
 
 g.test('out_of_bounds')
-  .params(
+  .cases(
     params()
       .combine(pbool('indirect')) // indirect drawIndexed
       .combine([
@@ -141,12 +141,14 @@ g.test('out_of_bounds')
       ] as const)
       .combine(poptions('instanceCount', [1, 10000])) // normal and large instanceCount
   )
-  .fn(t => {
+  .fn(async t => {
     const { indirect, indexCount, firstIndex, instanceCount } = t.params;
 
     if (indirect) {
       t.drawIndexedIndirect(new Uint32Array([indexCount, instanceCount, firstIndex, 0, 0]), 0);
     } else {
-      t.drawIndexed(indexCount, instanceCount, firstIndex, 0, 0);
+      t.expectValidationError(() => {
+        t.drawIndexed(indexCount, instanceCount, firstIndex, 0, 0);
+      });
     }
   });

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -138,6 +138,9 @@ g.test('out_of_bounds')
         { indexCount: 6, firstIndex: 10000 }, // firstIndex much larger than the bound
         { indexCount: 7, firstIndex: 0 }, // only indexCount out of bound
         { indexCount: 10000, firstIndex: 0 }, // indexCount much larger than the bound
+        { indexCount: 0xffffffff, firstIndex: 0xffffffff }, // max uint32 value
+        { indexCount: 0xffffffff, firstIndex: 2 }, // max uint32 indexCount and small firstIndex
+        { indexCount: 2, firstIndex: 0xffffffff }, // small indexCount and max uint32 firstIndex
       ] as const)
       .combine(poptions('instanceCount', [1, 10000])) // normal and large instanceCount
   )

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -129,23 +129,24 @@ class F extends ValidationTest {
 export const g = makeTestGroup(F);
 
 g.test('out_of_bounds')
-  .cases(
-    params()
-      .combine(pbool('indirect')) // indirect drawIndexed
-      .combine([
-        { indexCount: 6, firstIndex: 1 }, // indexCount + firstIndex out of bound
-        { indexCount: 0, firstIndex: 6 }, // indexCount is 0 but firstIndex out of bound
-        { indexCount: 6, firstIndex: 6 }, // only firstIndex out of bound
-        { indexCount: 6, firstIndex: 10000 }, // firstIndex much larger than the bound
-        { indexCount: 7, firstIndex: 0 }, // only indexCount out of bound
-        { indexCount: 10000, firstIndex: 0 }, // indexCount much larger than the bound
-        { indexCount: 0xffffffff, firstIndex: 0xffffffff }, // max uint32 value
-        { indexCount: 0xffffffff, firstIndex: 2 }, // max uint32 indexCount and small firstIndex
-        { indexCount: 2, firstIndex: 0xffffffff }, // small indexCount and max uint32 firstIndex
-      ] as const)
-      .combine(poptions('instanceCount', [1, 10000])) // normal and large instanceCount
+  .cases(pbool('indirect'))
+  .subcases(
+    () =>
+      params()
+        .combine([
+          { indexCount: 6, firstIndex: 1 }, // indexCount + firstIndex out of bound
+          { indexCount: 0, firstIndex: 6 }, // indexCount is 0 but firstIndex out of bound
+          { indexCount: 6, firstIndex: 6 }, // only firstIndex out of bound
+          { indexCount: 6, firstIndex: 10000 }, // firstIndex much larger than the bound
+          { indexCount: 7, firstIndex: 0 }, // only indexCount out of bound
+          { indexCount: 10000, firstIndex: 0 }, // indexCount much larger than the bound
+          { indexCount: 0xffffffff, firstIndex: 0xffffffff }, // max uint32 value
+          { indexCount: 0xffffffff, firstIndex: 2 }, // max uint32 indexCount and small firstIndex
+          { indexCount: 2, firstIndex: 0xffffffff }, // small indexCount and max uint32 firstIndex
+        ] as const)
+        .combine(poptions('instanceCount', [1, 10000])) // normal and large instanceCount
   )
-  .fn(async t => {
+  .fn(t => {
     const { indirect, indexCount, firstIndex, instanceCount } = t.params;
 
     if (indirect) {


### PR DESCRIPTION
Related to https://crbug.com/dawn/622

~~Now drawIndexed with index count out of bounds of index buffer size should be invalid~~

-----

<!-- Leave this section in the PR description. -->

- [ ] New helpers, if any, are documented in `helper_index.md`.
- [ ] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
