### PR TITLE
Add validation tests for Timestamp Query

### DIFF
--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -5,10 +5,100 @@ TODO:
     - queryIndex {in, out of} range for GPUQuerySet
     - GPUQuerySet {valid, invalid}
         - or {undefined}, for occlusionQuerySet
-    - ?
+    - x = {occlusion, pipeline statistics, timestamp} query
 `;
 
+import { params, poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { kQueryTypes } from '../../../../capability_info.js';
 import { ValidationTest } from '../../validation_test.js';
 
+async function selectDeviceForQueryType(t: ValidationTest, type: GPUQueryType): Promise<void> {
+  const extensions: GPUExtensionName[] = [];
+  if (type === 'pipeline-statistics') {
+    extensions.push('pipeline-statistics-query');
+  } else if (type === 'timestamp') {
+    extensions.push('timestamp-query');
+  }
+
+  await t.selectDeviceOrSkipTestCase({ extensions });
+}
+
+export const enum EncoderType {
+  CommandEncoder = 'CommandEncoder',
+  ComputeEncoder = 'ComputeEncoder',
+  RenderEncoder = 'RenderEncoder',
+}
+
 export const g = makeTestGroup(ValidationTest);
+
+g.test('writeTimestamp')
+  .desc(
+    `
+Tests that write timestamp to all types of query set on all possible encoders:
+- queryIndex {in, out of} range for GPUQuerySet
+- GPUQuerySet {valid, invalid}
+- x= {occlusion, pipeline statistics, timestamp} query
+- x= {compute, render, non-pass} enconder
+  `
+  )
+  .params(
+    params()
+      .combine(
+        poptions('encoderType', [
+          EncoderType.CommandEncoder,
+          EncoderType.ComputeEncoder,
+          EncoderType.RenderEncoder,
+        ] as const)
+      )
+      .combine(poptions('type', kQueryTypes))
+      .combine(poptions('queryIndex', [0, 1, 2]))
+      .unless(({ type, queryIndex }) => type !== 'timestamp' && queryIndex !== 0)
+  )
+  .fn(async t => {
+    const { encoderType, type, queryIndex } = t.params;
+
+    await selectDeviceForQueryType(t, type);
+
+    const count = 2;
+    const pipelineStatistics =
+      type === 'pipeline-statistics' ? (['clipper-invocations'] as const) : ([] as const);
+    const querySet = t.device.createQuerySet({ type, count, pipelineStatistics });
+
+    const encoder = t.device.createCommandEncoder();
+
+    switch (encoderType) {
+      case EncoderType.CommandEncoder: {
+        encoder.writeTimestamp(querySet, queryIndex);
+        break;
+      }
+      case EncoderType.ComputeEncoder: {
+        const pass = encoder.beginComputePass();
+        pass.writeTimestamp(querySet, queryIndex);
+        pass.endPass();
+        break;
+      }
+      case EncoderType.RenderEncoder: {
+        const colorAttachment = t.device.createTexture({
+          format: 'rgba8unorm',
+          size: { width: 4, height: 4, depth: 1 },
+          usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        });
+        const pass = encoder.beginRenderPass({
+          colorAttachments: [
+            {
+              attachment: colorAttachment.createView(),
+              loadValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
+            },
+          ],
+        });
+        pass.writeTimestamp(querySet, queryIndex);
+        pass.endPass();
+        break;
+      }
+    }
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, type !== 'timestamp' || queryIndex >= count);
+  });

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -33,7 +33,7 @@ g.test('writeTimestamp,query_type_and_index')
 Tests that write timestamp to all types of query set on all possible encoders:
 - type {occlusion, pipeline statistics, timestamp}
 - queryIndex {in, out of} range for GPUQuerySet
-- x= {non-pass, compute, render} enconder
+- x= {non-pass, compute, render} encoder
   `
   )
   .cases(

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -41,7 +41,7 @@ Tests that resolve query set with invalid object.
 
     t.expectValidationError(() => {
       encoder.finish();
-    });
+    }, querySetState === 'invalid' || destinationState === 'invalid');
   });
 
 g.test('resolveQuerySet,first_query_and_query_count')

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -21,6 +21,7 @@ Tests that resolve query set with invalid object.
   .subcases(
     () =>
       [
+        { querySetState: 'valid', destinationState: 'valid' }, // control case
         { querySetState: 'invalid', destinationState: 'valid' },
         { querySetState: 'valid', destinationState: 'invalid' },
       ] as const

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -1,13 +1,94 @@
 export const description = `
-TODO:
-- invalid GPUQuerySet
-- firstQuery and/or queryCount out of range
-- invalid destination buffer
-- destinationOffset out of range
-- ?
+Validation tests for resolveQuerySet.
 `;
-
+import { poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUConst } from '../../../../constants.js';
 import { ValidationTest } from '../../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
+
+export const kQueryCount = 2;
+
+g.test('resolveQuerySet,first_query_and_query_count')
+  .desc(
+    `
+Tests that resolve query set with invalid firstQuery and queryCount:
+- firstQuery and/or queryCount out of range
+  `
+  )
+  .params([
+    { firstQuery: 0, queryCount: kQueryCount },
+    { firstQuery: 0, queryCount: kQueryCount + 1 },
+    { firstQuery: 1, queryCount: kQueryCount },
+    { firstQuery: kQueryCount, queryCount: 1 },
+  ])
+  .fn(async t => {
+    const { firstQuery, queryCount } = t.params;
+
+    const querySet = t.device.createQuerySet({ type: 'occlusion', count: kQueryCount });
+    const destination = t.device.createBuffer({
+      size: kQueryCount * 8,
+      usage: GPUBufferUsage.QUERY_RESOLVE,
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    encoder.resolveQuerySet(querySet, firstQuery, queryCount, destination, 0);
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, firstQuery + queryCount > kQueryCount);
+  });
+
+g.test('resolveQuerySet,destination_buffer')
+  .desc(
+    `
+Tests that resolve query set with invalid destinationBuffer:
+- Buffer usage {with, without} QUERY_RESOLVE
+  `
+  )
+  .params(
+    poptions('bufferUsage', [
+      GPUConst.BufferUsage.STORAGE,
+      GPUConst.BufferUsage.QUERY_RESOLVE,
+    ] as const)
+  )
+  .fn(async t => {
+    const querySet = t.device.createQuerySet({ type: 'occlusion', count: kQueryCount });
+    const destination = t.device.createBuffer({
+      size: kQueryCount * 8,
+      usage: t.params.bufferUsage,
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    encoder.resolveQuerySet(querySet, 0, kQueryCount, destination, 0);
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, t.params.bufferUsage !== GPUConst.BufferUsage.QUERY_RESOLVE);
+  });
+
+g.test('resolveQuerySet,destination_offset')
+  .desc(
+    `
+Tests that resolve query set with invalid destinationOffset:
+- destinationOffset is not a multiple of 8
+- The size of destinationBuffer - destinationOffset < queryCount * 8
+- destinationOffset out of range
+  `
+  )
+  .params(poptions('destinationOffset', [0, 6, 8, 16]))
+  .fn(async t => {
+    const querySet = t.device.createQuerySet({ type: 'occlusion', count: kQueryCount });
+    const destination = t.device.createBuffer({
+      size: kQueryCount * 8,
+      usage: GPUBufferUsage.QUERY_RESOLVE,
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    encoder.resolveQuerySet(querySet, 0, kQueryCount, destination, t.params.destinationOffset);
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, t.params.destinationOffset > 0);
+  });

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -52,7 +52,7 @@ Tests that resolve query set with invalid firstQuery and queryCount:
   `
   )
   .subcases(() => [
-    { firstQuery: 0, queryCount: kQueryCount },
+    { firstQuery: 0, queryCount: kQueryCount }, // control case
     { firstQuery: 0, queryCount: kQueryCount + 1 },
     { firstQuery: 1, queryCount: kQueryCount },
     { firstQuery: kQueryCount, queryCount: 1 },
@@ -84,7 +84,7 @@ Tests that resolve query set with invalid destinationBuffer:
   .subcases(() =>
     poptions('bufferUsage', [
       GPUConst.BufferUsage.STORAGE,
-      GPUConst.BufferUsage.QUERY_RESOLVE,
+      GPUConst.BufferUsage.QUERY_RESOLVE, // control case
     ] as const)
   )
   .fn(async t => {

--- a/src/webgpu/api/validation/queue/destroyed/buffer.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/buffer.spec.ts
@@ -15,3 +15,12 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
+
+g.test('resolveQuerySet')
+  .desc(
+    `
+Tests that use a destroyed buffer in resolveQuerySet.
+- x= {destroyed, not destroyed (control case)}
+  `
+  )
+  .unimplemented();

--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -9,7 +9,107 @@ TODO: implement. (Search for other places some of these cases may have already b
 Consider whether these tests should be distributed throughout the suite, instead of centralized.
 `;
 
+import { params, pbool, poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
+export const enum EncoderType {
+  CommandEncoder = 'CommandEncoder',
+  ComputeEncoder = 'ComputeEncoder',
+  RenderEncoder = 'RenderEncoder',
+}
+
 export const g = makeTestGroup(ValidationTest);
+
+g.test('writeTimestamp')
+  .desc(
+    `
+Tests that use a destroyed query set in writeTimestamp on {compute, render, non-pass} encoder.
+- x= {destroyed, not destroyed (control case)}
+  `
+  )
+  .params(
+    params()
+      .combine(
+        poptions('encoderType', [
+          EncoderType.CommandEncoder,
+          EncoderType.ComputeEncoder,
+          EncoderType.RenderEncoder,
+        ] as const)
+      )
+      .combine(pbool('destroyed'))
+  )
+  .fn(async t => {
+    await t.selectDeviceOrSkipTestCase({ extensions: ['timestamp-query'] });
+
+    const querySet = t.device.createQuerySet({ type: 'timestamp', count: 2 });
+
+    if (t.params.destroyed) {
+      querySet.destroy();
+    }
+
+    const encoder = t.device.createCommandEncoder();
+
+    switch (t.params.encoderType) {
+      case EncoderType.CommandEncoder: {
+        encoder.writeTimestamp(querySet, 0);
+        break;
+      }
+      case EncoderType.ComputeEncoder: {
+        const pass = encoder.beginComputePass();
+        pass.writeTimestamp(querySet, 0);
+        pass.endPass();
+        break;
+      }
+      case EncoderType.RenderEncoder: {
+        const colorAttachment = t.device.createTexture({
+          format: 'rgba8unorm',
+          size: { width: 4, height: 4, depth: 1 },
+          usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        });
+        const pass = encoder.beginRenderPass({
+          colorAttachments: [
+            {
+              attachment: colorAttachment.createView(),
+              loadValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
+            },
+          ],
+        });
+        pass.writeTimestamp(querySet, 0);
+        pass.endPass();
+        break;
+      }
+    }
+
+    t.expectValidationError(() => {
+      t.queue.submit([encoder.finish()]);
+    }, t.params.destroyed);
+  });
+
+g.test('resolveQuerySet')
+  .desc(
+    `
+Tests that use a destroyed query set in resolveQuerySet.
+- x= {destroyed, not destroyed (control case)}
+  `
+  )
+  .params(pbool('destroyed'))
+  .fn(async t => {
+    const querySet = t.device.createQuerySet({
+      type: 'occlusion',
+      count: 1,
+    });
+
+    if (t.params.destroyed) {
+      querySet.destroy();
+    }
+
+    const buffer = t.device.createBuffer({ size: 8, usage: GPUBufferUsage.QUERY_RESOLVE });
+
+    const encoder = t.device.createCommandEncoder();
+    encoder.resolveQuerySet(querySet, 0, 1, buffer, 0);
+
+    t.expectValidationError(() => {
+      t.queue.submit([encoder.finish()]);
+    }, t.params.destroyed);
+  });

--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -9,7 +9,7 @@ TODO: implement. (Search for other places some of these cases may have already b
 Consider whether these tests should be distributed throughout the suite, instead of centralized.
 `;
 
-import { params, pbool, poptions } from '../../../../../common/framework/params_builder.js';
+import { poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
@@ -24,66 +24,26 @@ export const g = makeTestGroup(ValidationTest);
 g.test('writeTimestamp')
   .desc(
     `
-Tests that use a destroyed query set in writeTimestamp on {compute, render, non-pass} encoder.
+Tests that use a destroyed query set in writeTimestamp on {non-pass, compute, render} encoder.
 - x= {destroyed, not destroyed (control case)}
   `
   )
-  .params(
-    params()
-      .combine(
-        poptions('encoderType', [
-          EncoderType.CommandEncoder,
-          EncoderType.ComputeEncoder,
-          EncoderType.RenderEncoder,
-        ] as const)
-      )
-      .combine(pbool('destroyed'))
-  )
+  .cases(poptions('encoderType', ['non-pass', 'compute pass', 'render pass'] as const))
+  .subcases(() => poptions('querySetState', ['valid', 'destroyed'] as const))
   .fn(async t => {
-    await t.selectDeviceOrSkipTestCase({ extensions: ['timestamp-query'] });
+    await t.selectDeviceOrSkipTestCase('timestamp-query');
 
-    const querySet = t.device.createQuerySet({ type: 'timestamp', count: 2 });
+    const querySet = t.createQuerySetWithState(t.params.querySetState, {
+      type: 'timestamp',
+      count: 2,
+    });
 
-    if (t.params.destroyed) {
-      querySet.destroy();
-    }
-
-    const encoder = t.device.createCommandEncoder();
-
-    switch (t.params.encoderType) {
-      case EncoderType.CommandEncoder: {
-        encoder.writeTimestamp(querySet, 0);
-        break;
-      }
-      case EncoderType.ComputeEncoder: {
-        const pass = encoder.beginComputePass();
-        pass.writeTimestamp(querySet, 0);
-        pass.endPass();
-        break;
-      }
-      case EncoderType.RenderEncoder: {
-        const colorAttachment = t.device.createTexture({
-          format: 'rgba8unorm',
-          size: { width: 4, height: 4, depth: 1 },
-          usage: GPUTextureUsage.RENDER_ATTACHMENT,
-        });
-        const pass = encoder.beginRenderPass({
-          colorAttachments: [
-            {
-              attachment: colorAttachment.createView(),
-              loadValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
-            },
-          ],
-        });
-        pass.writeTimestamp(querySet, 0);
-        pass.endPass();
-        break;
-      }
-    }
+    const encoder = t.createEncoder(t.params.encoderType);
+    encoder.encoder.writeTimestamp(querySet, 0);
 
     t.expectValidationError(() => {
       t.queue.submit([encoder.finish()]);
-    }, t.params.destroyed);
+    }, t.params.querySetState === 'destroyed');
   });
 
 g.test('resolveQuerySet')
@@ -93,16 +53,9 @@ Tests that use a destroyed query set in resolveQuerySet.
 - x= {destroyed, not destroyed (control case)}
   `
   )
-  .params(pbool('destroyed'))
+  .subcases(() => poptions('querySetState', ['valid', 'destroyed'] as const))
   .fn(async t => {
-    const querySet = t.device.createQuerySet({
-      type: 'occlusion',
-      count: 1,
-    });
-
-    if (t.params.destroyed) {
-      querySet.destroy();
-    }
+    const querySet = t.createQuerySetWithState(t.params.querySetState);
 
     const buffer = t.device.createBuffer({ size: 8, usage: GPUBufferUsage.QUERY_RESOLVE });
 
@@ -111,5 +64,5 @@ Tests that use a destroyed query set in resolveQuerySet.
 
     t.expectValidationError(() => {
       t.queue.submit([encoder.finish()]);
-    }, t.params.destroyed);
+    }, t.params.querySetState === 'destroyed');
   });


### PR DESCRIPTION
- Test writeTimestamp in all possible encoders.
- Test resolveQuerySet for all types of queries.
- Test destoryed query set in writeTimestamp and resolveQuerySet.



-----

<!-- Leave this section in the PR description. -->

- [ ] New helpers, if any, are documented in `helper_index.md`.
- [ ] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [ ] TypeScript readability
