### PR TITLE
Make ValidationTest.createEncoder work on any union of EncoderTypes

### DIFF
--- a/docs/helper_index.md
+++ b/docs/helper_index.md
@@ -24,8 +24,8 @@ Generally, see:
 - [`GPUTest`](../src/webgpu/gpu_test.ts)
 - [`ValidationTest`](../src/webgpu/api/validation/validation_test.ts)
     - `createEncoder`: Generically creates non-pass, compute pass, render pass, or render bundle
-        encoders. This allows callers to use write code using common interfaces between those types.
-    - TODO
+        encoders. This allows callers to write code using methods common to multiple encoder types.
+    - TODO: index everything else in `ValidationTest`
 - [`ShaderValidationTest`](../src/webgpu/shader/validation/shader_validation_test.ts)
     - `expectCompileResult` Allows checking for compile success/failure, or failure with a
       particular error substring.

--- a/docs/helper_index.md
+++ b/docs/helper_index.md
@@ -23,6 +23,9 @@ Generally, see:
 - TODO: Index existing helpers.
 - [`GPUTest`](../src/webgpu/gpu_test.ts)
 - [`ValidationTest`](../src/webgpu/api/validation/validation_test.ts)
+    - `createEncoder`: Generically creates non-pass, compute pass, render pass, or render bundle
+        encoders. This allows callers to use write code using common interfaces between those types.
+    - TODO
 - [`ShaderValidationTest`](../src/webgpu/shader/validation/shader_validation_test.ts)
     - `expectCompileResult` Allows checking for compile success/failure, or failure with a
       particular error substring.

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -65,7 +65,7 @@ class F extends ValidationTest {
     colorFormats: Iterable<GPUTextureFormat>,
     depthStencilFormat?: GPUTextureFormat,
     sampleCount?: number
-  ): CommandBufferMaker<GPURenderPassEncoder | GPURenderBundleEncoder> {
+  ): CommandBufferMaker<'render pass' | 'render bundle'> {
     const encoder = this.device.createCommandEncoder();
     const passDesc: GPURenderPassDescriptor = {
       colorAttachments: Array.from(colorFormats, desc =>

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -1,13 +1,18 @@
-import { assert } from '../../../common/framework/util/util.js';
+import { assert, unreachable } from '../../../common/framework/util/util.js';
 import { BindableResource } from '../../capability_info.js';
 import { GPUTest } from '../../gpu_test.js';
 
-type Encoder = GPUCommandEncoder | GPUProgrammablePassEncoder | GPURenderBundleEncoder;
 export const kEncoderTypes = ['non-pass', 'compute pass', 'render pass', 'render bundle'] as const;
 type EncoderType = typeof kEncoderTypes[number];
 
-export interface CommandBufferMaker<E extends Encoder> {
-  readonly encoder: E;
+export interface CommandBufferMaker<T extends EncoderType> {
+  // Look up the type of the encoder based on `T`. If `T` is a union, this will be too!
+  readonly encoder: {
+    'non-pass': GPUCommandEncoder;
+    'compute pass': GPUComputePassEncoder;
+    'render pass': GPURenderPassEncoder;
+    'render bundle': GPURenderBundleEncoder;
+  }[T];
   finish(): GPUCommandBuffer;
 }
 
@@ -203,29 +208,17 @@ export class ValidationTest extends GPUTest {
     return pipeline;
   }
 
-  createEncoder(encoderType: 'non-pass'): CommandBufferMaker<GPUCommandEncoder>;
-  createEncoder(encoderType: 'render pass'): CommandBufferMaker<GPURenderPassEncoder>;
-  createEncoder(encoderType: 'compute pass'): CommandBufferMaker<GPUComputePassEncoder>;
-  createEncoder(encoderType: 'render bundle'): CommandBufferMaker<GPURenderBundleEncoder>;
-  createEncoder(
-    encoderType: 'render pass' | 'render bundle'
-  ): CommandBufferMaker<GPURenderPassEncoder | GPURenderBundleEncoder>;
-  createEncoder(
-    encoderType: 'compute pass' | 'render pass' | 'render bundle'
-  ): CommandBufferMaker<GPUProgrammablePassEncoder>;
-  createEncoder(encoderType: EncoderType): CommandBufferMaker<Encoder>;
-  createEncoder(encoderType: EncoderType): CommandBufferMaker<Encoder> {
+  createEncoder<T extends EncoderType>(encoderType: T): CommandBufferMaker<T> {
     const colorFormat = 'rgba8unorm';
     switch (encoderType) {
       case 'non-pass': {
         const encoder = this.device.createCommandEncoder();
         return {
           encoder,
-
           finish: () => {
             return encoder.finish();
           },
-        };
+        } as CommandBufferMaker<T>;
       }
       case 'render bundle': {
         const device = this.device;
@@ -240,7 +233,7 @@ export class ValidationTest extends GPUTest {
             pass.encoder.executeBundles([bundle]);
             return pass.finish();
           },
-        };
+        } as CommandBufferMaker<T>;
       }
       case 'compute pass': {
         const commandEncoder = this.device.createCommandEncoder();
@@ -251,7 +244,7 @@ export class ValidationTest extends GPUTest {
             encoder.endPass();
             return commandEncoder.finish();
           },
-        };
+        } as CommandBufferMaker<T>;
       }
       case 'render pass': {
         const commandEncoder = this.device.createCommandEncoder();
@@ -276,9 +269,10 @@ export class ValidationTest extends GPUTest {
             encoder.endPass();
             return commandEncoder.finish();
           },
-        };
+        } as CommandBufferMaker<T>;
       }
     }
+    unreachable();
   }
 
   /**


### PR DESCRIPTION
Replaces the overloads with some TypeScript magic to generate a union of
Encoder types from a union of EncoderType types.

-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
