### PR TITLE
Add validation tests on B2T and T2B copies with depth stencil formats - Part I

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -1,8 +1,8 @@
 export const description = `
 copyTextureToBuffer and copyBufferToTexture validation tests not covered by
-copy_between_linear_data_and_texture or destroyed,*.
+the general image_copy tests, or by destroyed,*.
 
-TODO: plan
+TODO: plan further
 `;
 
 import { poptions, params } from '../../../../../common/framework/params_builder.js';

--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -5,7 +5,88 @@ copy_between_linear_data_and_texture or destroyed,*.
 TODO: plan
 `;
 
+import { poptions, params } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { kDepthStencilFormats } from '../../../../capability_info.js';
 import { ValidationTest } from '../../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
+
+g.test('depth_stencil_format,copy_usage_and_aspect')
+  .desc(
+    `
+  Validate the combination of usage and aspect of each depth stencil format in copyBufferToTexture
+  and copyTextureToBuffer. See https://gpuweb.github.io/gpuweb/#depth-formats for more details.
+  TODO(jiawei.shao@intel.com): add tests on depth16norm when it is supported.
+`
+  )
+  .cases(
+    params()
+      .combine(poptions('format', kDepthStencilFormats))
+      .combine(poptions('aspect', ['all', 'depth-only', 'stencil-only'] as const))
+  )
+  .fn(async t => {
+    const { format, aspect } = t.params;
+
+    const textureSize = { width: 1, height: 1, depth: 1 };
+    const texture = t.device.createTexture({
+      size: textureSize,
+      format,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+    });
+
+    const buffer = t.device.createBuffer({
+      size: 32,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+
+    const emptyStringArray: string[] = [];
+
+    const kDepthStencilFormatCapabilityInBufferTextureCopy = {
+      // kUnsizedDepthStencilFormats
+      depth24plus: {
+        AspectsSupportedInB2T: emptyStringArray,
+        AspectsSupportedInT2B: emptyStringArray,
+      },
+      'depth24plus-stencil8': {
+        AspectsSupportedInB2T: ['stencil-only'],
+        AspectsSupportedInT2B: ['stencil-only'],
+      },
+
+      // kSizedDepthStencilFormats
+      depth32float: {
+        AspectsSupportedInB2T: emptyStringArray,
+        AspectsSupportedInT2B: ['all', 'depth-only'],
+      },
+      stencil8: {
+        AspectsSupportedInB2T: ['all', 'stencil-only'],
+        AspectsSupportedInT2B: ['all', 'stencil-only'],
+      },
+    };
+
+    {
+      const success = kDepthStencilFormatCapabilityInBufferTextureCopy[
+        format
+      ].AspectsSupportedInB2T.includes(aspect);
+
+      const encoder = t.device.createCommandEncoder();
+      encoder.copyBufferToTexture({ buffer }, { texture, aspect }, textureSize);
+
+      t.expectValidationError(() => {
+        t.device.queue.submit([encoder.finish()]);
+      }, !success);
+    }
+
+    {
+      const success = kDepthStencilFormatCapabilityInBufferTextureCopy[
+        format
+      ].AspectsSupportedInT2B.includes(aspect);
+
+      const encoder = t.device.createCommandEncoder();
+      encoder.copyTextureToBuffer({ texture, aspect }, { buffer }, textureSize);
+
+      t.expectValidationError(() => {
+        t.device.queue.submit([encoder.finish()]);
+      }, !success);
+    }
+  });

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -227,6 +227,50 @@ export const kTextureAspectInfo: {
 };
 export const kTextureAspects = keysOf(kTextureAspectInfo);
 
+export function depthStencilBufferTextureCopySupported(
+  type: 'CopyB2T' | 'CopyT2B',
+  format: DepthStencilFormat,
+  aspect: GPUTextureAspect
+): boolean {
+  const emptyStringArray: string[] = [];
+
+  const kDepthStencilFormatCapabilityInBufferTextureCopy = {
+    // kUnsizedDepthStencilFormats
+    depth24plus: {
+      CopyB2T: emptyStringArray,
+      CopyT2B: emptyStringArray,
+    },
+    'depth24plus-stencil8': {
+      CopyB2T: ['stencil-only'],
+      CopyT2B: ['stencil-only'],
+    },
+
+    // kSizedDepthStencilFormats
+    depth16unorm: {
+      CopyB2T: ['all', 'depth-only'],
+      CopyT2B: ['all', 'depth-only'],
+    },
+    depth32float: {
+      CopyB2T: emptyStringArray,
+      CopyT2B: ['all', 'depth-only'],
+    },
+    'depth24unorm-stencil8': {
+      CopyB2T: ['stencil-only'],
+      CopyT2B: ['depth-only', 'stencil-only'],
+    },
+    'depth32float-stencil8': {
+      CopyB2T: ['stencil-only'],
+      CopyT2B: ['depth-only', 'stencil-only'],
+    },
+    stencil8: {
+      CopyB2T: ['all', 'stencil-only'],
+      CopyT2B: ['all', 'stencil-only'],
+    },
+  };
+
+  return kDepthStencilFormatCapabilityInBufferTextureCopy[format][type].includes(aspect);
+}
+
 export const kTextureUsageInfo: {
   readonly [k in GPUTextureUsage]: {};
 } = {

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -227,48 +227,48 @@ export const kTextureAspectInfo: {
 };
 export const kTextureAspects = keysOf(kTextureAspectInfo);
 
+const kDepthStencilFormatCapabilityInBufferTextureCopy = {
+  // kUnsizedDepthStencilFormats
+  depth24plus: {
+    CopyB2T: [],
+    CopyT2B: [],
+  },
+  'depth24plus-stencil8': {
+    CopyB2T: ['stencil-only'],
+    CopyT2B: ['stencil-only'],
+  },
+
+  // kSizedDepthStencilFormats
+  depth16unorm: {
+    CopyB2T: ['all', 'depth-only'],
+    CopyT2B: ['all', 'depth-only'],
+  },
+  depth32float: {
+    CopyB2T: [],
+    CopyT2B: ['all', 'depth-only'],
+  },
+  'depth24unorm-stencil8': {
+    CopyB2T: ['stencil-only'],
+    CopyT2B: ['depth-only', 'stencil-only'],
+  },
+  'depth32float-stencil8': {
+    CopyB2T: ['stencil-only'],
+    CopyT2B: ['depth-only', 'stencil-only'],
+  },
+  stencil8: {
+    CopyB2T: ['all', 'stencil-only'],
+    CopyT2B: ['all', 'stencil-only'],
+  },
+} as const;
+
 export function depthStencilBufferTextureCopySupported(
   type: 'CopyB2T' | 'CopyT2B',
   format: DepthStencilFormat,
   aspect: GPUTextureAspect
 ): boolean {
-  const emptyStringArray: string[] = [];
-
-  const kDepthStencilFormatCapabilityInBufferTextureCopy = {
-    // kUnsizedDepthStencilFormats
-    depth24plus: {
-      CopyB2T: emptyStringArray,
-      CopyT2B: emptyStringArray,
-    },
-    'depth24plus-stencil8': {
-      CopyB2T: ['stencil-only'],
-      CopyT2B: ['stencil-only'],
-    },
-
-    // kSizedDepthStencilFormats
-    depth16unorm: {
-      CopyB2T: ['all', 'depth-only'],
-      CopyT2B: ['all', 'depth-only'],
-    },
-    depth32float: {
-      CopyB2T: emptyStringArray,
-      CopyT2B: ['all', 'depth-only'],
-    },
-    'depth24unorm-stencil8': {
-      CopyB2T: ['stencil-only'],
-      CopyT2B: ['depth-only', 'stencil-only'],
-    },
-    'depth32float-stencil8': {
-      CopyB2T: ['stencil-only'],
-      CopyT2B: ['depth-only', 'stencil-only'],
-    },
-    stencil8: {
-      CopyB2T: ['all', 'stencil-only'],
-      CopyT2B: ['all', 'stencil-only'],
-    },
-  };
-
-  return kDepthStencilFormatCapabilityInBufferTextureCopy[format][type].includes(aspect);
+  const supportedAspects: readonly GPUTextureAspect[] =
+    kDepthStencilFormatCapabilityInBufferTextureCopy[format][type];
+  return supportedAspects.includes(aspect);
 }
 
 export const kTextureUsageInfo: {


### PR DESCRIPTION

-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
