### PR TITLE
update webgpu/types to 0.0.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1141,9 +1141,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.0.37",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.0.37.tgz",
-      "integrity": "sha512-nOjfT6pfwza8KOA/KZO2Y1zm15Lv/47AMOUnmEe98Lv+BojuxVSGfKeziXoGICS0X8T3nSvaf95747B/Icomqg==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.0.38.tgz",
+      "integrity": "sha512-CKVImHIx+Ojhuc0dyDad9F++Wvs5RGzGWYv0rIq0H19TQO0Bl+WOxKY6GuPoGrAa7zMsvV0AeQ690uWx/Tshfg==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/morgan": "^1.9.2",
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
-    "@webgpu/types": "0.0.37",
+    "@webgpu/types": "0.0.38",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",
     "chokidar": "^3.4.3",

--- a/src/webgpu/api/operation/command_buffer/basic.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/basic.spec.ts
@@ -30,7 +30,7 @@ g.test('b2t2b').fn(async t => {
   });
 
   const mid = t.device.createTexture({
-    size: { width: 1, height: 1, depth: 1 },
+    size: { width: 1, height: 1, depthOrArrayLayers: 1 },
     format: 'rgba8uint',
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
   });
@@ -39,12 +39,12 @@ g.test('b2t2b').fn(async t => {
   encoder.copyBufferToTexture(
     { buffer: src, bytesPerRow: 256 },
     { texture: mid, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
-    { width: 1, height: 1, depth: 1 }
+    { width: 1, height: 1, depthOrArrayLayers: 1 }
   );
   encoder.copyTextureToBuffer(
     { texture: mid, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
     { buffer: dst, bytesPerRow: 256 },
-    { width: 1, height: 1, depth: 1 }
+    { width: 1, height: 1, depthOrArrayLayers: 1 }
   );
   t.device.queue.submit([encoder.finish()]);
 
@@ -68,7 +68,7 @@ g.test('b2t2t2b').fn(async t => {
   });
 
   const midDesc: GPUTextureDescriptor = {
-    size: { width: 1, height: 1, depth: 1 },
+    size: { width: 1, height: 1, depthOrArrayLayers: 1 },
     format: 'rgba8uint',
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
   };
@@ -79,17 +79,17 @@ g.test('b2t2t2b').fn(async t => {
   encoder.copyBufferToTexture(
     { buffer: src, bytesPerRow: 256 },
     { texture: mid1, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
-    { width: 1, height: 1, depth: 1 }
+    { width: 1, height: 1, depthOrArrayLayers: 1 }
   );
   encoder.copyTextureToTexture(
     { texture: mid1, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
     { texture: mid2, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
-    { width: 1, height: 1, depth: 1 }
+    { width: 1, height: 1, depthOrArrayLayers: 1 }
   );
   encoder.copyTextureToBuffer(
     { texture: mid2, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
     { buffer: dst, bytesPerRow: 256 },
-    { width: 1, height: 1, depth: 1 }
+    { width: 1, height: 1, depthOrArrayLayers: 1 }
   );
   t.device.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -32,7 +32,7 @@ class F extends GPUTest {
       (textureSizeAtLevel.width / blockWidthInTexel) *
       (textureSizeAtLevel.height / blockHeightInTexel);
 
-    const byteSize = bytesPerBlock * blocksPerSubresource * textureSizeAtLevel.depth;
+    const byteSize = bytesPerBlock * blocksPerSubresource * textureSizeAtLevel.depthOrArrayLayers;
     const initialData = new Uint8Array(new ArrayBuffer(byteSize));
 
     for (let i = 0; i < byteSize; ++i) {
@@ -120,8 +120,8 @@ class F extends GPUTest {
     assert(appliedCopyWidth % blockWidth === 0 && appliedCopyHeight % blockHeight === 0);
 
     const appliedCopyDepth =
-      srcTextureSize.depth +
-      copyBoxOffsets.copyExtent.depth -
+      srcTextureSize.depthOrArrayLayers +
+      copyBoxOffsets.copyExtent.depthOrArrayLayers -
       Math.max(appliedSrcOffset.z, appliedDstOffset.z);
     assert(appliedCopyDepth >= 0);
 
@@ -129,7 +129,7 @@ class F extends GPUTest {
     encoder.copyTextureToTexture(
       { texture: srcTexture, mipLevel: srcCopyLevel, origin: appliedSrcOffset },
       { texture: dstTexture, mipLevel: dstCopyLevel, origin: appliedDstOffset },
-      { width: appliedCopyWidth, height: appliedCopyHeight, depth: appliedCopyDepth }
+      { width: appliedCopyWidth, height: appliedCopyHeight, depthOrArrayLayers: appliedCopyDepth }
     );
 
     // Copy the whole content of dstTexture at dstCopyLevel to dstBuffer.
@@ -137,7 +137,8 @@ class F extends GPUTest {
     const dstBlockRowsPerImage = dstTextureSizeAtLevel.height / blockHeight;
     const bytesPerDstAlignedBlockRow = align(dstBlocksPerRow * bytesPerBlock, 256);
     const dstBufferSize =
-      (dstBlockRowsPerImage * dstTextureSizeAtLevel.depth - 1) * bytesPerDstAlignedBlockRow +
+      (dstBlockRowsPerImage * dstTextureSizeAtLevel.depthOrArrayLayers - 1) *
+        bytesPerDstAlignedBlockRow +
       align(dstBlocksPerRow * bytesPerBlock, 4);
     const dstBufferDesc: GPUBufferDescriptor = {
       size: dstBufferSize,
@@ -211,45 +212,45 @@ class F extends GPUTest {
     {
       srcOffset: { x: 0, y: 0, z: 0 },
       dstOffset: { x: 0, y: 0, z: 0 },
-      copyExtent: { width: 0, height: 0, depth: 0 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
     },
     // From (0, 0) of src to (blockWidth, 0) of dst.
     {
       srcOffset: { x: 0, y: 0, z: 0 },
       dstOffset: { x: 1, y: 0, z: 0 },
-      copyExtent: { width: 0, height: 0, depth: 0 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
     },
     // From (0, 0) of src to (0, blockHeight) of dst.
     {
       srcOffset: { x: 0, y: 0, z: 0 },
       dstOffset: { x: 0, y: 1, z: 0 },
-      copyExtent: { width: 0, height: 0, depth: 0 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
     },
     // From (blockWidth, 0) of src to (0, 0) of dst.
     {
       srcOffset: { x: 1, y: 0, z: 0 },
       dstOffset: { x: 0, y: 0, z: 0 },
-      copyExtent: { width: 0, height: 0, depth: 0 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
     },
     // From (0, blockHeight) of src to (0, 0) of dst.
     {
       srcOffset: { x: 0, y: 1, z: 0 },
       dstOffset: { x: 0, y: 0, z: 0 },
-      copyExtent: { width: 0, height: 0, depth: 0 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
     },
     // From (blockWidth, 0) of src to (0, 0) of dst, and the copy extent will not cover the last
     // texel block column of both source and destination texture.
     {
       srcOffset: { x: 1, y: 0, z: 0 },
       dstOffset: { x: 0, y: 0, z: 0 },
-      copyExtent: { width: -1, height: 0, depth: 0 },
+      copyExtent: { width: -1, height: 0, depthOrArrayLayers: 0 },
     },
     // From (0, blockHeight) of src to (0, 0) of dst, and the copy extent will not cover the last
     // texel block row of both source and destination texture.
     {
       srcOffset: { x: 0, y: 1, z: 0 },
       dstOffset: { x: 0, y: 0, z: 0 },
-      copyExtent: { width: 0, height: -1, depth: 0 },
+      copyExtent: { width: 0, height: -1, depthOrArrayLayers: 0 },
     },
   ];
 
@@ -264,42 +265,42 @@ class F extends GPUTest {
     {
       srcOffset: { x: 0, y: 0, z: 0 },
       dstOffset: { x: 0, y: 0, z: 0 },
-      copyExtent: { width: 0, height: 0, depth: -2 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: -2 },
     },
     // Copy 1 texture slice from the 2nd slice of the source texture to the 2nd slice of the
     // destination texture.
     {
       srcOffset: { x: 0, y: 0, z: 1 },
       dstOffset: { x: 0, y: 0, z: 1 },
-      copyExtent: { width: 0, height: 0, depth: -3 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: -3 },
     },
     // Copy 1 texture slice from the 1st slice of the source texture to the 2nd slice of the
     // destination texture.
     {
       srcOffset: { x: 0, y: 0, z: 0 },
       dstOffset: { x: 0, y: 0, z: 1 },
-      copyExtent: { width: 0, height: 0, depth: -1 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: -1 },
     },
     // Copy 1 texture slice from the 2nd slice of the source texture to the 1st slice of the
     // destination texture.
     {
       srcOffset: { x: 0, y: 0, z: 1 },
       dstOffset: { x: 0, y: 0, z: 0 },
-      copyExtent: { width: 0, height: 0, depth: -1 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: -1 },
     },
     // Copy 2 texture slices from the 1st slice of the source texture to the 1st slice of the
     // destination texture.
     {
       srcOffset: { x: 0, y: 0, z: 0 },
       dstOffset: { x: 0, y: 0, z: 0 },
-      copyExtent: { width: 0, height: 0, depth: -3 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: -3 },
     },
     // Copy 3 texture slices from the 2nd slice of the source texture to the 2nd slice of the
     // destination texture.
     {
       srcOffset: { x: 0, y: 0, z: 1 },
       dstOffset: { x: 0, y: 0, z: 1 },
-      copyExtent: { width: 0, height: 0, depth: -1 },
+      copyExtent: { width: 0, height: 0, depthOrArrayLayers: -1 },
     },
   ];
 }
@@ -327,20 +328,20 @@ g.test('color_textures,non_compressed,non_array')
       .combine(
         poptions('textureSize', [
           {
-            srcTextureSize: { width: 32, height: 32, depth: 1 },
-            dstTextureSize: { width: 32, height: 32, depth: 1 },
+            srcTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
           },
           {
-            srcTextureSize: { width: 31, height: 33, depth: 1 },
-            dstTextureSize: { width: 31, height: 33, depth: 1 },
+            srcTextureSize: { width: 31, height: 33, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 31, height: 33, depthOrArrayLayers: 1 },
           },
           {
-            srcTextureSize: { width: 32, height: 32, depth: 1 },
-            dstTextureSize: { width: 64, height: 64, depth: 1 },
+            srcTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 64, height: 64, depthOrArrayLayers: 1 },
           },
           {
-            srcTextureSize: { width: 32, height: 32, depth: 1 },
-            dstTextureSize: { width: 63, height: 61, depth: 1 },
+            srcTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 63, height: 61, depthOrArrayLayers: 1 },
           },
         ])
       )
@@ -376,35 +377,35 @@ g.test('color_textures,compressed,non_array')
         poptions('textureSize', [
           // The heights and widths are all power of 2
           {
-            srcTextureSize: { width: 64, height: 32, depth: 1 },
-            dstTextureSize: { width: 64, height: 32, depth: 1 },
+            srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
           },
           // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
           {
-            srcTextureSize: { width: 60, height: 32, depth: 1 },
-            dstTextureSize: { width: 64, height: 32, depth: 1 },
+            srcTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
           },
           // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
           // of 4
           {
-            srcTextureSize: { width: 64, height: 32, depth: 1 },
-            dstTextureSize: { width: 60, height: 32, depth: 1 },
+            srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
           },
           // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
           {
-            srcTextureSize: { width: 64, height: 52, depth: 1 },
-            dstTextureSize: { width: 64, height: 32, depth: 1 },
+            srcTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
           },
           // The virtual height of the destination texture at mipmap level 2 (13) is not a
           // multiple of 4
           {
-            srcTextureSize: { width: 64, height: 32, depth: 1 },
-            dstTextureSize: { width: 64, height: 52, depth: 1 },
+            srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
           },
           // None of the widths or heights are power of 2
           {
-            srcTextureSize: { width: 60, height: 52, depth: 1 },
-            dstTextureSize: { width: 60, height: 52, depth: 1 },
+            srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
+            dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
           },
         ])
       )
@@ -442,12 +443,12 @@ g.test('color_textures,non_compressed,array')
       .combine(
         poptions('textureSize', [
           {
-            srcTextureSize: { width: 64, height: 32, depth: 5 },
-            dstTextureSize: { width: 64, height: 32, depth: 5 },
+            srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 5 },
+            dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 5 },
           },
           {
-            srcTextureSize: { width: 31, height: 33, depth: 5 },
-            dstTextureSize: { width: 31, height: 33, depth: 5 },
+            srcTextureSize: { width: 31, height: 33, depthOrArrayLayers: 5 },
+            dstTextureSize: { width: 31, height: 33, depthOrArrayLayers: 5 },
           },
         ])
       )
@@ -483,13 +484,13 @@ g.test('color_textures,compressed,array')
         poptions('textureSize', [
           // The heights and widths are all power of 2
           {
-            srcTextureSize: { width: 8, height: 8, depth: 5 },
-            dstTextureSize: { width: 8, height: 8, depth: 5 },
+            srcTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
+            dstTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
           },
           // None of the widths or heights are power of 2
           {
-            srcTextureSize: { width: 60, height: 52, depth: 5 },
-            dstTextureSize: { width: 60, height: 52, depth: 5 },
+            srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
+            dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
           },
         ])
       )
@@ -530,55 +531,55 @@ g.test('zero_sized')
           {
             srcOffset: { x: 0, y: 0, z: 0 },
             dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: -64, height: 0, depth: 0 },
+            copyExtent: { width: -64, height: 0, depthOrArrayLayers: 0 },
           },
           // copyExtent.width === 0 && srcOffset.x === textureWidth
           {
             srcOffset: { x: 64, y: 0, z: 0 },
             dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: -64, height: 0, depth: 0 },
+            copyExtent: { width: -64, height: 0, depthOrArrayLayers: 0 },
           },
           // copyExtent.width === 0 && dstOffset.x === textureWidth
           {
             srcOffset: { x: 0, y: 0, z: 0 },
             dstOffset: { x: 64, y: 0, z: 0 },
-            copyExtent: { width: -64, height: 0, depth: 0 },
+            copyExtent: { width: -64, height: 0, depthOrArrayLayers: 0 },
           },
           // copyExtent.height === 0
           {
             srcOffset: { x: 0, y: 0, z: 0 },
             dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: 0, height: -32, depth: 0 },
+            copyExtent: { width: 0, height: -32, depthOrArrayLayers: 0 },
           },
           // copyExtent.height === 0 && srcOffset.y === textureHeight
           {
             srcOffset: { x: 0, y: 32, z: 0 },
             dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: 0, height: -32, depth: 0 },
+            copyExtent: { width: 0, height: -32, depthOrArrayLayers: 0 },
           },
           // copyExtent.height === 0 && dstOffset.y === textureHeight
           {
             srcOffset: { x: 0, y: 0, z: 0 },
             dstOffset: { x: 0, y: 32, z: 0 },
-            copyExtent: { width: 0, height: -32, depth: 0 },
+            copyExtent: { width: 0, height: -32, depthOrArrayLayers: 0 },
           },
-          // copyExtent.depth === 0
+          // copyExtent.depthOrArrayLayers === 0
           {
             srcOffset: { x: 0, y: 0, z: 0 },
             dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: 0, height: 0, depth: -5 },
+            copyExtent: { width: 0, height: 0, depthOrArrayLayers: -5 },
           },
-          // copyExtent.depth === 0 && srcOffset.z === textureDepth
+          // copyExtent.depthOrArrayLayers === 0 && srcOffset.z === textureDepth
           {
             srcOffset: { x: 0, y: 0, z: 5 },
             dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: 0, height: 0, depth: 0 },
+            copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
           },
-          // copyExtent.depth === 0 && dstOffset.z === textureDepth
+          // copyExtent.depthOrArrayLayers === 0 && dstOffset.z === textureDepth
           {
             srcOffset: { x: 0, y: 0, z: 0 },
             dstOffset: { x: 0, y: 0, z: 5 },
-            copyExtent: { width: 0, height: 0, depth: 0 },
+            copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
           },
         ])
       )
@@ -589,7 +590,7 @@ g.test('zero_sized')
     const { copyBoxOffset, srcCopyLevel, dstCopyLevel } = t.params;
 
     const format = 'rgba8unorm';
-    const textureSize = { width: 64, height: 32, depth: 5 };
+    const textureSize = { width: 64, height: 32, depthOrArrayLayers: 5 };
 
     t.DoCopyTextureToTextureTest(
       textureSize,

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -28,7 +28,7 @@ export class BufferSyncTest extends GPUTest {
     const fence = this.queue.createFence();
     const data = new Uint32Array(kSize / 4).fill(initValue);
     const texture = this.device.createTexture({
-      size: { width: kSize / 4, height: 1, depth: 1 },
+      size: { width: kSize / 4, height: 1, depthOrArrayLayers: 1 },
       format: 'r32uint',
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
@@ -36,7 +36,7 @@ export class BufferSyncTest extends GPUTest {
       { texture, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
       data,
       { offset: 0, bytesPerRow: kSize, rowsPerImage: 1 },
-      { width: kSize / 4, height: 1, depth: 1 }
+      { width: kSize / 4, height: 1, depthOrArrayLayers: 1 }
     );
     this.queue.signal(fence, 1);
     await fence.onCompletion(1);
@@ -124,7 +124,7 @@ export class BufferSyncTest extends GPUTest {
   beginSimpleRenderPass(encoder: GPUCommandEncoder): GPURenderPassEncoder {
     const view = this.device
       .createTexture({
-        size: { width: 1, height: 1, depth: 1 },
+        size: { width: 1, height: 1, depthOrArrayLayers: 1 },
         format: 'rgba8unorm',
         usage: GPUTextureUsage.RENDER_ATTACHMENT,
       })
@@ -192,7 +192,7 @@ export class BufferSyncTest extends GPUTest {
     encoder.copyTextureToBuffer(
       { texture: tmpTexture, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
       { buffer, bytesPerRow: 256 },
-      { width: 1, height: 1, depth: 1 }
+      { width: 1, height: 1, depthOrArrayLayers: 1 }
     );
   }
 

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -99,7 +99,7 @@ g.test('render_pass_resolve')
     for (let i = 0; i < t.params.numColorAttachments; i++) {
       const colorAttachment = t.device.createTexture({
         format: kFormat,
-        size: { width: kSize, height: kSize, depth: 1 },
+        size: { width: kSize, height: kSize, depthOrArrayLayers: 1 },
         sampleCount: 4,
         mipLevelCount: 1,
         usage:
@@ -109,7 +109,7 @@ g.test('render_pass_resolve')
       if (t.params.slotsToResolve.includes(i)) {
         const colorAttachment = t.device.createTexture({
           format: kFormat,
-          size: { width: kSize, height: kSize, depth: 1 },
+          size: { width: kSize, height: kSize, depthOrArrayLayers: 1 },
           sampleCount: 4,
           mipLevelCount: 1,
           usage:
@@ -121,7 +121,7 @@ g.test('render_pass_resolve')
           size: {
             width: kResolveTargetSize,
             height: kResolveTargetSize,
-            depth: t.params.resolveTargetBaseArrayLayer + 1,
+            depthOrArrayLayers: t.params.resolveTargetBaseArrayLayer + 1,
           },
           sampleCount: 1,
           mipLevelCount: t.params.resolveTargetBaseMipLevel + 1,

--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -68,7 +68,7 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
     const kColorFormat: GPUTextureFormat = 'rgba8unorm';
     const colorAttachment = t.device.createTexture({
       format: kColorFormat,
-      size: { width: kWidth, height: kHeight, depth: 1 },
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
@@ -78,7 +78,7 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
     const kDepthStencilFormat: GPUTextureFormat = 'depth32float';
     const depthStencilAttachment = t.device.createTexture({
       format: kDepthStencilFormat,
-      size: { width: kWidth, height: kHeight, depth: 1 },
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
@@ -155,7 +155,7 @@ g.test('render_pass_store_op,color_attachment_only')
   .fn(t => {
     const colorAttachment = t.device.createTexture({
       format: t.params.colorFormat,
-      size: { width: kWidth, height: kHeight, depth: t.params.arrayLayer + 1 },
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: t.params.arrayLayer + 1 },
       mipLevelCount: kMipLevelCount,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
@@ -218,7 +218,7 @@ g.test('render_pass_store_op,multiple_color_attachments')
       colorAttachments.push(
         t.device.createTexture({
           format: kColorFormat,
-          size: { width: kWidth, height: kHeight, depth: 1 },
+          size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
           usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
         })
       );
@@ -281,7 +281,7 @@ TODO: Also test unsized depth/stencil formats
   .fn(t => {
     const depthStencilAttachment = t.device.createTexture({
       format: t.params.depthStencilFormat,
-      size: { width: kWidth, height: kHeight, depth: t.params.arrayLayer + 1 },
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: t.params.arrayLayer + 1 },
       mipLevelCount: kMipLevelCount,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -16,7 +16,7 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
   ] as const)
   .fn(async t => {
     const renderTexture = t.device.createTexture({
-      size: { width: 1, height: 1, depth: 1 },
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       format: 'r8unorm',
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -61,14 +61,14 @@ g.test('culling')
     const format = 'rgba8unorm';
 
     const texture = t.device.createTexture({
-      size: { width: size, height: size, depth: 1 },
+      size: { width: size, height: size, depthOrArrayLayers: 1 },
       format,
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
 
     const depthTexture = t.params.depthStencilFormat
       ? t.device.createTexture({
-          size: { width: size, height: size, depth: 1 },
+          size: { width: size, height: size, depthOrArrayLayers: 1 },
           format: t.params.depthStencilFormat,
           usage: GPUTextureUsage.RENDER_ATTACHMENT,
         })

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -216,7 +216,7 @@ class PrimitiveTopologyTest extends GPUTest {
   makeAttachmentTexture(): GPUTexture {
     return this.device.createTexture({
       format: kColorFormat,
-      size: { width: kRTSize, height: kRTSize, depth: 1 },
+      size: { width: kRTSize, height: kRTSize, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
   }

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -15,7 +15,7 @@ g.test('clear').fn(async t => {
 
   const colorAttachment = t.device.createTexture({
     format: 'rgba8unorm',
-    size: { width: 1, height: 1, depth: 1 },
+    size: { width: 1, height: 1, depthOrArrayLayers: 1 },
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
   });
   const colorAttachmentView = colorAttachment.createView();
@@ -34,7 +34,7 @@ g.test('clear').fn(async t => {
   encoder.copyTextureToBuffer(
     { texture: colorAttachment, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
     { buffer: dst, bytesPerRow: 256 },
-    { width: 1, height: 1, depth: 1 }
+    { width: 1, height: 1, depthOrArrayLayers: 1 }
   );
   t.device.queue.submit([encoder.finish()]);
 
@@ -49,7 +49,7 @@ g.test('fullscreen_quad').fn(async t => {
 
   const colorAttachment = t.device.createTexture({
     format: 'rgba8unorm',
-    size: { width: 1, height: 1, depth: 1 },
+    size: { width: 1, height: 1, depthOrArrayLayers: 1 },
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
   });
   const colorAttachmentView = colorAttachment.createView();
@@ -105,7 +105,7 @@ g.test('fullscreen_quad').fn(async t => {
   encoder.copyTextureToBuffer(
     { texture: colorAttachment, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
     { buffer: dst, bytesPerRow: 256 },
-    { width: 1, height: 1, depth: 1 }
+    { width: 1, height: 1, depthOrArrayLayers: 1 }
   );
   t.device.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
@@ -52,7 +52,7 @@ export const checkContentsByTextureCopy: CheckContents = (
     commandEncoder.copyTextureToTexture(
       { texture, mipLevel: level, origin: { x: 0, y: 0, z: slice } },
       { texture: dst, mipLevel: 0 },
-      { width, height, depth: 1 }
+      { width, height, depthOrArrayLayers: 1 }
     );
     t.queue.submit([commandEncoder.finish()]);
 

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -378,7 +378,7 @@ export class TextureZeroInitTest extends GPUTest {
           rowsPerImage,
         },
         { texture, mipLevel: level, origin: { x: 0, y: 0, z: slice } },
-        { width, height, depth: 1 }
+        { width, height, depthOrArrayLayers: 1 }
       );
     }
     this.queue.submit([commandEncoder.finish()]);

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -42,7 +42,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
     commandEncoder.copyTextureToBuffer(
       { texture: rt, mipLevel: 0, origin: [0, 0, 0] },
       { buffer, bytesPerRow: kBytesPerRow, rowsPerImage: kRTSize },
-      { width: kRTSize, height: kRTSize, depth: 1 }
+      { width: kRTSize, height: kRTSize, depthOrArrayLayers: 1 }
     );
     this.queue.submit([commandEncoder.finish()]);
 
@@ -130,7 +130,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
 
     const colorAttachment = this.device.createTexture({
       format: kColorAttachmentFormat,
-      size: { width: kRTSize, height: kRTSize, depth: 1 },
+      size: { width: kRTSize, height: kRTSize, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
     const colorAttachmentView = colorAttachment.createView();
@@ -172,7 +172,7 @@ g.test('anisotropic_filter_checkerboard')
     const textureSize = 32;
     const texture = t.device.createTexture({
       mipLevelCount: 1,
-      size: { width: textureSize, height: textureSize, depth: 1 },
+      size: { width: textureSize, height: textureSize, depthOrArrayLayers: 1 },
       format: kTextureFormat,
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED,
     });

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -134,7 +134,7 @@ class IndexFormatTest extends GPUTest {
 
     const colorAttachment = this.device.createTexture({
       format: kTextureFormat,
-      size: { width: kWidth, height: kHeight, depth: 1 },
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 

--- a/src/webgpu/api/validation/copy_between_linear_data_and_texture/README.txt
+++ b/src/webgpu/api/validation/copy_between_linear_data_and_texture/README.txt
@@ -25,7 +25,7 @@ Test coverage:
 	- bound_on_offset: for various combinations of offset and dataSize.
 
 * texture copy range:
-	- 1d_texture: copyExtent.height isn't 1, copyExtent.depth isn't 1.
+	- 1d_texture: copyExtent.height isn't 1, copyExtent.depthOrArrayLayers isn't 1.
 	- texel_block_alignment_on_size: for all formats and coordinates.
 	- texture_range_conditons: for all coordinate and various combinations of origin, copyExtent, textureSize and mipLevel.
 

--- a/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture.ts
+++ b/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture.ts
@@ -83,7 +83,7 @@ export class CopyBetweenLinearDataAndTextureTest extends ValidationTest {
   // precise about its size as long as it's big enough and properly aligned.
   createAlignedTexture(
     format: SizedTextureFormat,
-    copySize: GPUExtent3DDict = { width: 1, height: 1, depth: 1 },
+    copySize: GPUExtent3DDict = { width: 1, height: 1, depthOrArrayLayers: 1 },
     origin: Required<GPUOrigin3DDict> = { x: 0, y: 0, z: 0 }
   ): GPUTexture {
     const info = kSizedTextureFormatInfo[format];
@@ -91,7 +91,7 @@ export class CopyBetweenLinearDataAndTextureTest extends ValidationTest {
       size: {
         width: Math.max(1, copySize.width + origin.x) * info.blockWidth,
         height: Math.max(1, copySize.height + origin.y) * info.blockHeight,
-        depth: Math.max(1, copySize.depth + origin.z),
+        depthOrArrayLayers: Math.max(1, copySize.depthOrArrayLayers + origin.z),
       },
       format,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
@@ -158,7 +158,7 @@ export function texelBlockAlignmentTestExpanderForValueToCoordinate({
       );
 
     case 'z':
-    case 'depth':
+    case 'depthOrArrayLayers':
       return poptions('valueToCoordinate', valuesToTestDivisibilityBy(1));
   }
 }

--- a/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture_textureRelated.spec.ts
+++ b/src/webgpu/api/validation/copy_between_linear_data_and_texture/copyBetweenLinearDataAndTexture_textureRelated.spec.ts
@@ -27,7 +27,7 @@ g.test('texture_must_be_valid')
 
     // A valid texture.
     let texture = t.device.createTexture({
-      size: { width: 4, height: 4, depth: 1 },
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
@@ -49,7 +49,7 @@ g.test('texture_must_be_valid')
     t.testRun(
       { texture },
       { bytesPerRow: 0 },
-      { width: 0, height: 0, depth: 0 },
+      { width: 0, height: 0, depthOrArrayLayers: 0 },
       { dataSize: 1, method, success, submit }
     );
   });
@@ -67,7 +67,7 @@ g.test('texture_usage_must_be_valid')
     const { usage, method } = t.params;
 
     const texture = t.device.createTexture({
-      size: { width: 4, height: 4, depth: 1 },
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage,
     });
@@ -80,7 +80,7 @@ g.test('texture_usage_must_be_valid')
     t.testRun(
       { texture },
       { bytesPerRow: 0 },
-      { width: 0, height: 0, depth: 0 },
+      { width: 0, height: 0, depthOrArrayLayers: 0 },
       { dataSize: 1, method, success }
     );
   });
@@ -92,7 +92,7 @@ g.test('sample_count_must_be_1')
     const { sampleCount, method } = t.params;
 
     const texture = t.device.createTexture({
-      size: { width: 4, height: 4, depth: 1 },
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       sampleCount,
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED,
@@ -103,7 +103,7 @@ g.test('sample_count_must_be_1')
     t.testRun(
       { texture },
       { bytesPerRow: 0 },
-      { width: 0, height: 0, depth: 0 },
+      { width: 0, height: 0, depthOrArrayLayers: 0 },
       { dataSize: 1, method, success }
     );
   });
@@ -119,7 +119,7 @@ g.test('mip_level_must_be_in_range')
     const { mipLevelCount, mipLevel, method } = t.params;
 
     const texture = t.device.createTexture({
-      size: { width: 32, height: 32, depth: 1 },
+      size: { width: 32, height: 32, depthOrArrayLayers: 1 },
       mipLevelCount,
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
@@ -130,7 +130,7 @@ g.test('mip_level_must_be_in_range')
     t.testRun(
       { texture, mipLevel },
       { bytesPerRow: 0 },
-      { width: 0, height: 0, depth: 0 },
+      { width: 0, height: 0, depthOrArrayLayers: 0 },
       { dataSize: 1, method, success }
     );
   });
@@ -155,7 +155,7 @@ g.test('texel_block_alignments_on_origin')
     await t.selectDeviceOrSkipTestCase(info.extension);
 
     const origin = { x: 0, y: 0, z: 0 };
-    const size = { width: 0, height: 0, depth: 0 };
+    const size = { width: 0, height: 0, depthOrArrayLayers: 0 };
     let success = true;
 
     origin[coordinateToTest] = valueToCoordinate;
@@ -185,19 +185,19 @@ g.test('1d_texture')
     params()
       .combine(poptions('width', [0, 1]))
       .combine([
-        { height: 1, depth: 1 },
-        { height: 1, depth: 0 },
-        { height: 1, depth: 2 },
-        { height: 0, depth: 1 },
-        { height: 2, depth: 1 },
+        { height: 1, depthOrArrayLayers: 1 },
+        { height: 1, depthOrArrayLayers: 0 },
+        { height: 1, depthOrArrayLayers: 2 },
+        { height: 0, depthOrArrayLayers: 1 },
+        { height: 2, depthOrArrayLayers: 1 },
       ])
   )
   .fn(async t => {
-    const { method, width, height, depth } = t.params;
-    const size = { width, height, depth };
+    const { method, width, height, depthOrArrayLayers } = t.params;
+    const size = { width, height, depthOrArrayLayers };
 
     const texture = t.device.createTexture({
-      size: { width: 2, height: 1, depth: 1 },
+      size: { width: 2, height: 1, depthOrArrayLayers: 1 },
       dimension: '1d',
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
@@ -205,7 +205,7 @@ g.test('1d_texture')
 
     // For 1d textures we require copyHeight and copyDepth to be 1,
     // copyHeight or copyDepth being 0 should cause a validation error.
-    const success = size.height === 1 && size.depth === 1;
+    const success = size.height === 1 && size.depthOrArrayLayers === 1;
 
     t.testRun({ texture }, { bytesPerRow: 256, rowsPerImage: 4 }, size, {
       dataSize: 16,
@@ -223,7 +223,7 @@ g.test('texel_block_alignments_on_size')
   )
   .subcases(p =>
     params()
-      .combine(poptions('coordinateToTest', ['width', 'height', 'depth'] as const))
+      .combine(poptions('coordinateToTest', ['width', 'height', 'depthOrArrayLayers'] as const))
       .expand(({ coordinateToTest }) =>
         texelBlockAlignmentTestExpanderForValueToCoordinate({ format: p.format, coordinateToTest })
       )
@@ -234,7 +234,7 @@ g.test('texel_block_alignments_on_size')
     await t.selectDeviceOrSkipTestCase(info.extension);
 
     const origin = { x: 0, y: 0, z: 0 };
-    const size = { width: 0, height: 0, depth: 0 };
+    const size = { width: 0, height: 0, depthOrArrayLayers: 0 };
     let success = true;
 
     size[coordinateToTest] = valueToCoordinate;
@@ -286,7 +286,7 @@ g.test('texture_range_conditions')
 
     const origin: GPUOrigin3D = [0, 0, 0];
     const copySize: GPUExtent3D = [0, 0, 0];
-    const textureSize = { width: 16 << mipLevel, height: 16 << mipLevel, depth: 16 };
+    const textureSize = { width: 16 << mipLevel, height: 16 << mipLevel, depthOrArrayLayers: 16 };
     const success = originValue + copySizeValue <= textureSizeValue;
 
     origin[coordinateToTest] = originValue;
@@ -301,7 +301,7 @@ g.test('texture_range_conditions')
         break;
       }
       case 2: {
-        textureSize.depth = textureSizeValue;
+        textureSize.depthOrArrayLayers = textureSizeValue;
         break;
       }
     }

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -123,7 +123,7 @@ g.test('texture_binding_must_have_correct_usage')
     });
 
     const descriptor = {
-      size: { width: 16, height: 16, depth: 1 },
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
       format: 'rgba8unorm' as const,
       usage,
       sampleCount: info.resource === 'sampledTexMS' ? 4 : 1,
@@ -168,7 +168,7 @@ g.test('texture_must_have_correct_component_type')
     }
 
     const goodDescriptor = {
-      size: { width: 16, height: 16, depth: 1 },
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
       format,
       usage: GPUTextureUsage.SAMPLED,
     };
@@ -224,7 +224,7 @@ g.test('texture_must_have_correct_dimension').fn(async t => {
   });
 
   const goodDescriptor = {
-    size: { width: 16, height: 16, depth: 1 },
+    size: { width: 16, height: 16, depthOrArrayLayers: 1 },
     format: 'rgba8unorm' as const,
     usage: GPUTextureUsage.SAMPLED,
   };
@@ -237,7 +237,7 @@ g.test('texture_must_have_correct_dimension').fn(async t => {
 
   // Mismatched texture binding formats are not valid.
   const badDescriptor = clone(goodDescriptor);
-  badDescriptor.size.depth = 2;
+  badDescriptor.size.depthOrArrayLayers = 2;
 
   t.expectValidationError(() => {
     t.device.createBindGroup({

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -99,7 +99,7 @@ class F extends ValidationTest {
     const { format, sampleCount } = params;
 
     return this.device.createTexture({
-      size: { width: 4, height: 4, depth: 1 },
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
       format,
       sampleCount,

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -10,14 +10,14 @@ TODO: review existing tests and merge with this plan:
 >     - with format that supports multisample, with all possible dimensions
 >     - with dimension that support multisample, with all possible formats
 >     - with format-dimension that support multisample, with {mipLevelCount, array layer count} = {1, 2}
-> - 1d, {width, height, depth} > whatever the max is
+> - 1d, {width, height, depthOrArrayLayers} > whatever the max is
 >     - height max is 1 (unless 1d-array is added)
->     - depth max is 1
+>     - depthOrArrayLayers max is 1
 >     - x= every texture format
-> - 2d, {width, height, depth} > whatever the max is
->     - depth (array layers) max differs from width/height
+> - 2d, {width, height, depthOrArrayLayers} > whatever the max is
+>     - depthOrArrayLayers max differs from width/height
 >     - x= every texture format
-> - 3d, {width, height, depth} > whatever the max is
+> - 3d, {width, height, depthOrArrayLayers} > whatever the max is
 >     - x= every texture format
 > - usage flags
 >     - {0, ... each single usage flag}
@@ -57,7 +57,7 @@ class F extends ValidationTest {
       format = 'rgba8unorm',
     } = options;
     return {
-      size: { width, height, depth: arrayLayerCount },
+      size: { width, height, depthOrArrayLayers: arrayLayerCount },
       mipLevelCount,
       sampleCount,
       dimension: '2d',

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -47,7 +47,7 @@ class F extends ValidationTest {
     } = options;
 
     return this.device.createTexture({
-      size: { width, height, depth: arrayLayerCount },
+      size: { width, height, depthOrArrayLayers: arrayLayerCount },
       mipLevelCount,
       sampleCount,
       dimension: '2d',

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -23,13 +23,13 @@ Test Plan: (TODO(jiawei.shao@intel.com): add tests on 1D/3D textures)
       textureCopyView.
     - (srcOrigin.y + copyExtent.height) {>, =, <} the height of the subresource size of source
       textureCopyView.
-    - (srcOrigin.z + copyExtent.depth) {>, =, <} the depth of the subresource size of source
+    - (srcOrigin.z + copyExtent.depthOrArrayLayers) {>, =, <} the depthOrArrayLayers of the subresource size of source
       textureCopyView.
     - (dstOrigin.x + copyExtent.width) {>, =, <} the width of the subresource size of destination
       textureCopyView.
     - (dstOrigin.y + copyExtent.height) {>, =, <} the height of the subresource size of destination
       textureCopyView.
-    - (dstOrigin.z + copyExtent.depth) {>, =, <} the depth of the subresource size of destination
+    - (dstOrigin.z + copyExtent.depthOrArrayLayers) {>, =, <} the depthOrArrayLayers of the subresource size of destination
       textureCopyView.
 * when the source and destination texture are the same one:
   - the set of source texture subresources {has, doesn't have} overlaps with the one of destination
@@ -79,7 +79,11 @@ class F extends ValidationTest {
       virtualHeightAtLevel,
       kAllTextureFormatInfo[format].blockHeight
     );
-    return { width: physicalWidthAtLevel, height: physicalHeightAtLevel, depth: textureSize.depth };
+    return {
+      width: physicalWidthAtLevel,
+      height: physicalHeightAtLevel,
+      depthOrArrayLayers: textureSize.depthOrArrayLayers,
+    };
   }
 }
 
@@ -87,7 +91,7 @@ export const g = makeTestGroup(F);
 
 g.test('copy_with_invalid_texture').fn(async t => {
   const validTexture = t.device.createTexture({
-    size: { width: 4, height: 4, depth: 1 },
+    size: { width: 4, height: 4, depthOrArrayLayers: 1 },
     format: 'rgba8unorm',
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
   });
@@ -97,13 +101,13 @@ g.test('copy_with_invalid_texture').fn(async t => {
   t.TestCopyTextureToTexture(
     { texture: errorTexture },
     { texture: validTexture },
-    { width: 1, height: 1, depth: 1 },
+    { width: 1, height: 1, depthOrArrayLayers: 1 },
     false
   );
   t.TestCopyTextureToTexture(
     { texture: validTexture },
     { texture: errorTexture },
-    { width: 1, height: 1, depth: 1 },
+    { width: 1, height: 1, depthOrArrayLayers: 1 },
     false
   );
 });
@@ -123,13 +127,13 @@ g.test('mipmap_level')
     const { srcLevelCount, dstLevelCount, srcCopyLevel, dstCopyLevel } = t.params;
 
     const srcTexture = t.device.createTexture({
-      size: { width: 32, height: 32, depth: 1 },
+      size: { width: 32, height: 32, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC,
       mipLevelCount: srcLevelCount,
     });
     const dstTexture = t.device.createTexture({
-      size: { width: 32, height: 32, depth: 1 },
+      size: { width: 32, height: 32, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_DST,
       mipLevelCount: dstLevelCount,
@@ -139,7 +143,7 @@ g.test('mipmap_level')
     t.TestCopyTextureToTexture(
       { texture: srcTexture, mipLevel: srcCopyLevel },
       { texture: dstTexture, mipLevel: dstCopyLevel },
-      { width: 1, height: 1, depth: 1 },
+      { width: 1, height: 1, depthOrArrayLayers: 1 },
       isSuccess
     );
   });
@@ -154,12 +158,12 @@ g.test('texture_usage')
     const { srcUsage, dstUsage } = t.params;
 
     const srcTexture = t.device.createTexture({
-      size: { width: 4, height: 4, depth: 1 },
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: srcUsage,
     });
     const dstTexture = t.device.createTexture({
-      size: { width: 4, height: 4, depth: 1 },
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: dstUsage,
     });
@@ -170,7 +174,7 @@ g.test('texture_usage')
     t.TestCopyTextureToTexture(
       { texture: srcTexture },
       { texture: dstTexture },
-      { width: 1, height: 1, depth: 1 },
+      { width: 1, height: 1, depthOrArrayLayers: 1 },
       isSuccess
     );
   });
@@ -185,13 +189,13 @@ g.test('sample_count')
     const { srcSampleCount, dstSampleCount } = t.params;
 
     const srcTexture = t.device.createTexture({
-      size: { width: 4, height: 4, depth: 1 },
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC,
       sampleCount: srcSampleCount,
     });
     const dstTexture = t.device.createTexture({
-      size: { width: 4, height: 4, depth: 1 },
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_DST,
       sampleCount: dstSampleCount,
@@ -201,7 +205,7 @@ g.test('sample_count')
     t.TestCopyTextureToTexture(
       { texture: srcTexture },
       { texture: dstTexture },
-      { width: 4, height: 4, depth: 1 },
+      { width: 4, height: 4, depthOrArrayLayers: 1 },
       isSuccess
     );
   });
@@ -237,13 +241,13 @@ g.test('multisampled_copy_restrictions')
     // Currently we don't support multisampled 2D array textures and the mipmap level count of the
     // multisampled textures must be 1.
     const srcTexture = t.device.createTexture({
-      size: { width: kWidth, height: kHeight, depth: 1 },
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC,
       sampleCount: 4,
     });
     const dstTexture = t.device.createTexture({
-      size: { width: kWidth, height: kHeight, depth: 1 },
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_DST,
       sampleCount: 4,
@@ -253,7 +257,7 @@ g.test('multisampled_copy_restrictions')
     t.TestCopyTextureToTexture(
       { texture: srcTexture, origin: srcCopyOrigin },
       { texture: dstTexture, origin: dstCopyOrigin },
-      { width: copyWidth, height: copyHeight, depth: 1 },
+      { width: copyWidth, height: copyHeight, depthOrArrayLayers: 1 },
       isSuccess
     );
   });
@@ -281,7 +285,7 @@ g.test('texture_format_equality')
       await t.selectDeviceOrSkipTestCase({ extensions });
     }
 
-    const kTextureSize = { width: 16, height: 16, depth: 1 };
+    const kTextureSize = { width: 16, height: 16, depthOrArrayLayers: 1 };
 
     const srcTexture = t.device.createTexture({
       size: kTextureSize,
@@ -319,16 +323,16 @@ g.test('depth_stencil_copy_restrictions')
       )
       .combine(
         poptions('srcTextureSize', [
-          { width: 64, height: 64, depth: 1 },
-          { width: 64, height: 32, depth: 1 },
-          { width: 32, height: 32, depth: 1 },
+          { width: 64, height: 64, depthOrArrayLayers: 1 },
+          { width: 64, height: 32, depthOrArrayLayers: 1 },
+          { width: 32, height: 32, depthOrArrayLayers: 1 },
         ])
       )
       .combine(
         poptions('dstTextureSize', [
-          { width: 64, height: 64, depth: 1 },
-          { width: 64, height: 32, depth: 1 },
-          { width: 32, height: 32, depth: 1 },
+          { width: 64, height: 64, depthOrArrayLayers: 1 },
+          { width: 64, height: 32, depthOrArrayLayers: 1 },
+          { width: 32, height: 32, depthOrArrayLayers: 1 },
         ])
       )
       .combine(poptions('srcCopyLevel', [1, 2]))
@@ -346,13 +350,13 @@ g.test('depth_stencil_copy_restrictions')
 
     const kMipLevelCount = 3;
     const srcTexture = t.device.createTexture({
-      size: { width: srcTextureSize.width, height: srcTextureSize.height, depth: 1 },
+      size: { width: srcTextureSize.width, height: srcTextureSize.height, depthOrArrayLayers: 1 },
       format,
       mipLevelCount: kMipLevelCount,
       usage: GPUTextureUsage.COPY_SRC,
     });
     const dstTexture = t.device.createTexture({
-      size: { width: dstTextureSize.width, height: dstTextureSize.height, depth: 1 },
+      size: { width: dstTextureSize.width, height: dstTextureSize.height, depthOrArrayLayers: 1 },
       format,
       mipLevelCount: kMipLevelCount,
       usage: GPUTextureUsage.COPY_DST,
@@ -379,13 +383,13 @@ g.test('depth_stencil_copy_restrictions')
     t.TestCopyTextureToTexture(
       { texture: srcTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: srcCopyLevel },
       { texture: dstTexture, origin: copyOrigin, mipLevel: dstCopyLevel },
-      { width: copyWidth, height: copyHeight, depth: 1 },
+      { width: copyWidth, height: copyHeight, depthOrArrayLayers: 1 },
       isSuccess
     );
     t.TestCopyTextureToTexture(
       { texture: srcTexture, origin: copyOrigin, mipLevel: srcCopyLevel },
       { texture: dstTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: dstCopyLevel },
-      { width: copyWidth, height: copyHeight, depth: 1 },
+      { width: copyWidth, height: copyHeight, depthOrArrayLayers: 1 },
       isSuccess
     );
   });
@@ -395,19 +399,19 @@ g.test('copy_ranges')
     params()
       .combine(
         poptions('copyBoxOffsets', [
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depth: -2 },
-          { x: 1, y: 0, z: 0, width: 0, height: 0, depth: -2 },
-          { x: 1, y: 0, z: 0, width: -1, height: 0, depth: -2 },
-          { x: 0, y: 1, z: 0, width: 0, height: 0, depth: -2 },
-          { x: 0, y: 1, z: 0, width: 0, height: -1, depth: -2 },
-          { x: 0, y: 0, z: 1, width: 0, height: 1, depth: -2 },
-          { x: 0, y: 0, z: 2, width: 0, height: 1, depth: 0 },
-          { x: 0, y: 0, z: 0, width: 1, height: 0, depth: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: 1, depth: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depth: 1 },
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depth: 0 },
-          { x: 0, y: 0, z: 1, width: 0, height: 0, depth: -1 },
-          { x: 0, y: 0, z: 2, width: 0, height: 0, depth: -1 },
+          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+          { x: 1, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+          { x: 1, y: 0, z: 0, width: -1, height: 0, depthOrArrayLayers: -2 },
+          { x: 0, y: 1, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+          { x: 0, y: 1, z: 0, width: 0, height: -1, depthOrArrayLayers: -2 },
+          { x: 0, y: 0, z: 1, width: 0, height: 1, depthOrArrayLayers: -2 },
+          { x: 0, y: 0, z: 2, width: 0, height: 1, depthOrArrayLayers: 0 },
+          { x: 0, y: 0, z: 0, width: 1, height: 0, depthOrArrayLayers: -2 },
+          { x: 0, y: 0, z: 0, width: 0, height: 1, depthOrArrayLayers: -2 },
+          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: 1 },
+          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: 0 },
+          { x: 0, y: 0, z: 1, width: 0, height: 0, depthOrArrayLayers: -1 },
+          { x: 0, y: 0, z: 2, width: 0, height: 0, depthOrArrayLayers: -1 },
         ])
       )
       .combine(poptions('srcCopyLevel', [0, 1, 3]))
@@ -416,7 +420,7 @@ g.test('copy_ranges')
   .fn(async t => {
     const { copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
 
-    const kTextureSize = { width: 16, height: 8, depth: 3 };
+    const kTextureSize = { width: 16, height: 8, depthOrArrayLayers: 3 };
     const kMipLevelCount = 4;
     const kFormat = 'rgba8unorm';
 
@@ -446,7 +450,8 @@ g.test('copy_ranges')
       Math.min(srcSizeAtLevel.height, dstSizeAtLevel.height) + copyBoxOffsets.height - copyOrigin.y,
       0
     );
-    const copyDepth = kTextureSize.depth + copyBoxOffsets.depth - copyOrigin.z;
+    const copyDepth =
+      kTextureSize.depthOrArrayLayers + copyBoxOffsets.depthOrArrayLayers - copyOrigin.z;
 
     {
       const isSuccess =
@@ -454,12 +459,12 @@ g.test('copy_ranges')
         copyHeight <= srcSizeAtLevel.height &&
         copyOrigin.x + copyWidth <= dstSizeAtLevel.width &&
         copyOrigin.y + copyHeight <= dstSizeAtLevel.height &&
-        copyOrigin.z + copyDepth <= kTextureSize.depth;
+        copyOrigin.z + copyDepth <= kTextureSize.depthOrArrayLayers;
 
       t.TestCopyTextureToTexture(
         { texture: srcTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: srcCopyLevel },
         { texture: dstTexture, origin: copyOrigin, mipLevel: dstCopyLevel },
-        { width: copyWidth, height: copyHeight, depth: copyDepth },
+        { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },
         isSuccess
       );
     }
@@ -470,12 +475,12 @@ g.test('copy_ranges')
         copyOrigin.y + copyHeight <= srcSizeAtLevel.height &&
         copyWidth <= dstSizeAtLevel.width &&
         copyHeight <= dstSizeAtLevel.height &&
-        copyOrigin.z + copyDepth <= kTextureSize.depth;
+        copyOrigin.z + copyDepth <= kTextureSize.depthOrArrayLayers;
 
       t.TestCopyTextureToTexture(
         { texture: srcTexture, origin: copyOrigin, mipLevel: srcCopyLevel },
         { texture: dstTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: dstCopyLevel },
-        { width: copyWidth, height: copyHeight, depth: copyDepth },
+        { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },
         isSuccess
       );
     }
@@ -494,7 +499,7 @@ g.test('copy_within_same_texture')
     const kArrayLayerCount = 7;
 
     const testTexture = t.device.createTexture({
-      size: { width: 16, height: 16, depth: kArrayLayerCount },
+      size: { width: 16, height: 16, depthOrArrayLayers: kArrayLayerCount },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
@@ -505,7 +510,7 @@ g.test('copy_within_same_texture')
     t.TestCopyTextureToTexture(
       { texture: testTexture, origin: { x: 0, y: 0, z: srcCopyOriginZ } },
       { texture: testTexture, origin: { x: 0, y: 0, z: dstCopyOriginZ } },
-      { width: 16, height: 16, depth: copyExtentDepth },
+      { width: 16, height: 16, depthOrArrayLayers: copyExtentDepth },
       isSuccess
     );
   });
@@ -528,7 +533,7 @@ Test the validations on the member 'aspect' of GPUTextureCopyView in CopyTexture
   .fn(async t => {
     const { format, sourceAspect, destinationAspect } = t.params;
 
-    const kTextureSize = { width: 16, height: 8, depth: 1 };
+    const kTextureSize = { width: 16, height: 8, depthOrArrayLayers: 1 };
 
     const srcTexture = t.device.createTexture({
       size: kTextureSize,
@@ -571,17 +576,17 @@ g.test('copy_ranges_with_compressed_texture_formats')
       .combine(poptions('format', kCompressedTextureFormats))
       .combine(
         poptions('copyBoxOffsets', [
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depth: -2 },
-          { x: 1, y: 0, z: 0, width: 0, height: 0, depth: -2 },
-          { x: 4, y: 0, z: 0, width: 0, height: 0, depth: -2 },
-          { x: 0, y: 0, z: 0, width: -1, height: 0, depth: -2 },
-          { x: 0, y: 0, z: 0, width: -4, height: 0, depth: -2 },
-          { x: 0, y: 1, z: 0, width: 0, height: 0, depth: -2 },
-          { x: 0, y: 4, z: 0, width: 0, height: 0, depth: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: -1, depth: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: -4, depth: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depth: 0 },
-          { x: 0, y: 0, z: 1, width: 0, height: 0, depth: -1 },
+          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+          { x: 1, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+          { x: 4, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+          { x: 0, y: 0, z: 0, width: -1, height: 0, depthOrArrayLayers: -2 },
+          { x: 0, y: 0, z: 0, width: -4, height: 0, depthOrArrayLayers: -2 },
+          { x: 0, y: 1, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+          { x: 0, y: 4, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+          { x: 0, y: 0, z: 0, width: 0, height: -1, depthOrArrayLayers: -2 },
+          { x: 0, y: 0, z: 0, width: 0, height: -4, depthOrArrayLayers: -2 },
+          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: 0 },
+          { x: 0, y: 0, z: 1, width: 0, height: 0, depthOrArrayLayers: -1 },
         ])
       )
       .combine(poptions('srcCopyLevel', [0, 1, 2]))
@@ -594,7 +599,7 @@ g.test('copy_ranges_with_compressed_texture_formats')
     assert(extension !== undefined);
     await t.selectDeviceOrSkipTestCase({ extensions: [extension] });
 
-    const kTextureSize = { width: 60, height: 48, depth: 3 };
+    const kTextureSize = { width: 60, height: 48, depthOrArrayLayers: 3 };
     const kMipLevelCount = 4;
 
     const srcTexture = t.device.createTexture({
@@ -623,7 +628,8 @@ g.test('copy_ranges_with_compressed_texture_formats')
       Math.min(srcSizeAtLevel.height, dstSizeAtLevel.height) + copyBoxOffsets.height - copyOrigin.y,
       0
     );
-    const copyDepth = kTextureSize.depth + copyBoxOffsets.depth - copyOrigin.z;
+    const copyDepth =
+      kTextureSize.depthOrArrayLayers + copyBoxOffsets.depthOrArrayLayers - copyOrigin.z;
 
     const texelBlockWidth = kAllTextureFormatInfo[format].blockWidth;
     const texelBlockHeight = kAllTextureFormatInfo[format].blockHeight;
@@ -641,12 +647,12 @@ g.test('copy_ranges_with_compressed_texture_formats')
         copyHeight <= srcSizeAtLevel.height &&
         copyOrigin.x + copyWidth <= dstSizeAtLevel.width &&
         copyOrigin.y + copyHeight <= dstSizeAtLevel.height &&
-        copyOrigin.z + copyDepth <= kTextureSize.depth;
+        copyOrigin.z + copyDepth <= kTextureSize.depthOrArrayLayers;
 
       t.TestCopyTextureToTexture(
         { texture: srcTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: srcCopyLevel },
         { texture: dstTexture, origin: copyOrigin, mipLevel: dstCopyLevel },
-        { width: copyWidth, height: copyHeight, depth: copyDepth },
+        { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },
         isSuccess
       );
     }
@@ -658,12 +664,12 @@ g.test('copy_ranges_with_compressed_texture_formats')
         copyOrigin.y + copyHeight <= srcSizeAtLevel.height &&
         copyWidth <= dstSizeAtLevel.width &&
         copyHeight <= dstSizeAtLevel.height &&
-        copyOrigin.z + copyDepth <= kTextureSize.depth;
+        copyOrigin.z + copyDepth <= kTextureSize.depthOrArrayLayers;
 
       t.TestCopyTextureToTexture(
         { texture: srcTexture, origin: copyOrigin, mipLevel: srcCopyLevel },
         { texture: dstTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: dstCopyLevel },
-        { width: copyWidth, height: copyHeight, depth: copyDepth },
+        { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },
         isSuccess
       );
     }

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -66,7 +66,7 @@ class F extends ValidationTest {
   beginRenderPass(encoder: GPUCommandEncoder) {
     const colorAttachment = this.device.createTexture({
       format: 'rgba8unorm',
-      size: { width: 1, height: 1, depth: 1 },
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 

--- a/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
@@ -46,7 +46,7 @@ class F extends ValidationTest {
   testViewportCall(
     success: boolean,
     v: ViewportCall,
-    attachmentSize: GPUExtent3D = { width: 1, height: 1, depth: 1 }
+    attachmentSize: GPUExtent3D = { width: 1, height: 1, depthOrArrayLayers: 1 }
   ) {
     const attachment = this.device.createTexture({
       format: 'rgba8unorm',
@@ -74,7 +74,7 @@ class F extends ValidationTest {
   testScissorCall(
     success: boolean | 'type-error',
     s: ScissorCall,
-    attachmentSize: GPUExtent3D = { width: 1, height: 1, depth: 1 }
+    attachmentSize: GPUExtent3D = { width: 1, height: 1, depthOrArrayLayers: 1 }
   ) {
     const attachment = this.device.createTexture({
       format: 'rgba8unorm',
@@ -189,7 +189,7 @@ g.test('setViewport,xy_rect_contained_in_attachment')
     t.testViewportCall(
       success,
       { x, y, w, h, minDepth: 0, maxDepth: 1 },
-      { width: attachmentWidth, height: attachmentHeight, depth: 1 }
+      { width: attachmentWidth, height: attachmentHeight, depthOrArrayLayers: 1 }
     );
   });
 
@@ -279,7 +279,7 @@ g.test('setScissorRect,xy_rect_contained_in_attachment')
     t.testScissorCall(
       success,
       { x, y, w, h },
-      { width: attachmentWidth, height: attachmentHeight, depth: 1 }
+      { width: attachmentWidth, height: attachmentHeight, depthOrArrayLayers: 1 }
     );
   });
 

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -62,7 +62,7 @@ class F extends ValidationTest {
   beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
     const attachmentTexture = this.device.createTexture({
       format: 'rgba8unorm',
-      size: { width: 16, height: 16, depth: 1 },
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -27,7 +27,7 @@ class F extends ValidationTest {
   makeAttachmentTexture(): GPUTexture {
     return this.device.createTexture({
       format: 'rgba8unorm',
-      size: { width: 16, height: 16, depth: 1 },
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
   }

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -73,7 +73,7 @@ class F extends ValidationTest {
   beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
     const attachmentTexture = this.device.createTexture({
       format: 'rgba8unorm',
-      size: { width: 16, height: 16, depth: 1 },
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
 

--- a/src/webgpu/api/validation/queue/copyImageBitmapToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyImageBitmapToTexture.spec.ts
@@ -68,20 +68,20 @@ interface WithDstOriginMipLevel extends WithMipLevel {
 function generateCopySizeForSrcOOB({ srcOrigin }: { srcOrigin: Required<GPUOrigin2DDict> }) {
   // OOB origin fails even with no-op copy.
   if (srcOrigin.x > kDefaultWidth || srcOrigin.y > kDefaultHeight) {
-    return poptions('copySize', [{ width: 0, height: 0, depth: 0 }]);
+    return poptions('copySize', [{ width: 0, height: 0, depthOrArrayLayers: 0 }]);
   }
 
   const justFitCopySize = {
     width: kDefaultWidth - srcOrigin.x,
     height: kDefaultHeight - srcOrigin.y,
-    depth: 1,
+    depthOrArrayLayers: 1,
   };
 
   return poptions('copySize', [
     justFitCopySize, // correct size, maybe no-op copy.
-    { width: justFitCopySize.width + 1, height: justFitCopySize.height, depth: 1 }, // OOB in width
-    { width: justFitCopySize.width, height: justFitCopySize.height + 1, depth: 1 }, // OOB in height
-    { width: justFitCopySize.width, height: justFitCopySize.height, depth: 2 }, // OOB in depth
+    { width: justFitCopySize.width + 1, height: justFitCopySize.height, depthOrArrayLayers: 1 }, // OOB in width
+    { width: justFitCopySize.width, height: justFitCopySize.height + 1, depthOrArrayLayers: 1 }, // OOB in height
+    { width: justFitCopySize.width, height: justFitCopySize.height, depthOrArrayLayers: 2 }, // OOB in depthOrArrayLayers
   ]);
 }
 
@@ -112,13 +112,13 @@ function generateCopySizeForDstOOB({ mipLevel, dstOrigin }: WithDstOriginMipLeve
     dstOrigin.y > dstMipMapSize.mipHeight ||
     dstOrigin.z > kDefaultDepth
   ) {
-    return poptions('copySize', [{ width: 0, height: 0, depth: 0 }]);
+    return poptions('copySize', [{ width: 0, height: 0, depthOrArrayLayers: 0 }]);
   }
 
   const justFitCopySize = {
     width: dstMipMapSize.mipWidth - dstOrigin.x,
     height: dstMipMapSize.mipHeight - dstOrigin.y,
-    depth: kDefaultDepth - dstOrigin.z,
+    depthOrArrayLayers: kDefaultDepth - dstOrigin.z,
   };
 
   return poptions('copySize', [
@@ -126,18 +126,18 @@ function generateCopySizeForDstOOB({ mipLevel, dstOrigin }: WithDstOriginMipLeve
     {
       width: justFitCopySize.width + 1,
       height: justFitCopySize.height,
-      depth: justFitCopySize.depth,
+      depthOrArrayLayers: justFitCopySize.depthOrArrayLayers,
     }, // OOB in width
     {
       width: justFitCopySize.width,
       height: justFitCopySize.height + 1,
-      depth: justFitCopySize.depth,
+      depthOrArrayLayers: justFitCopySize.depthOrArrayLayers,
     }, // OOB in height
     {
       width: justFitCopySize.width,
       height: justFitCopySize.height,
-      depth: justFitCopySize.depth + 1,
-    }, // OOB in depth
+      depthOrArrayLayers: justFitCopySize.depthOrArrayLayers + 1,
+    }, // OOB in depthOrArrayLayers
   ]);
 }
 
@@ -177,8 +177,8 @@ g.test('source_imageBitmap,state')
       .combine(pbool('closed'))
       .combine(
         poptions('copySize', [
-          { width: 0, height: 0, depth: 0 },
-          { width: 1, height: 1, depth: 1 },
+          { width: 0, height: 0, depthOrArrayLayers: 0 },
+          { width: 1, height: 1, depthOrArrayLayers: 1 },
         ])
       )
   )
@@ -186,7 +186,7 @@ g.test('source_imageBitmap,state')
     const { closed, copySize } = t.params;
     const imageBitmap = await createImageBitmap(t.getImageData(1, 1));
     const dstTexture = t.device.createTexture({
-      size: { width: 1, height: 1, depth: 1 },
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       format: 'bgra8unorm',
       usage: GPUTextureUsage.COPY_DST,
     });
@@ -208,8 +208,8 @@ g.test('destination_texture,state')
       .combine(poptions('state', ['valid', 'invalid', 'destroyed'] as const))
       .combine(
         poptions('copySize', [
-          { width: 0, height: 0, depth: 0 },
-          { width: 1, height: 1, depth: 1 },
+          { width: 0, height: 0, depthOrArrayLayers: 0 },
+          { width: 1, height: 1, depthOrArrayLayers: 1 },
         ])
       )
   )
@@ -227,8 +227,8 @@ g.test('destination_texture,usage')
       .combine(poptions('usage', kTextureUsages))
       .combine(
         poptions('copySize', [
-          { width: 0, height: 0, depth: 0 },
-          { width: 1, height: 1, depth: 1 },
+          { width: 0, height: 0, depthOrArrayLayers: 0 },
+          { width: 1, height: 1, depthOrArrayLayers: 1 },
         ])
       )
   )
@@ -236,7 +236,7 @@ g.test('destination_texture,usage')
     const { usage, copySize } = t.params;
     const imageBitmap = await createImageBitmap(t.getImageData(1, 1));
     const dstTexture = t.device.createTexture({
-      size: { width: 1, height: 1, depth: 1 },
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage,
     });
@@ -255,8 +255,8 @@ g.test('destination_texture,sample_count')
       .combine(poptions('sampleCount', [1, 4]))
       .combine(
         poptions('copySize', [
-          { width: 0, height: 0, depth: 0 },
-          { width: 1, height: 1, depth: 1 },
+          { width: 0, height: 0, depthOrArrayLayers: 0 },
+          { width: 1, height: 1, depthOrArrayLayers: 1 },
         ])
       )
   )
@@ -264,7 +264,7 @@ g.test('destination_texture,sample_count')
     const { sampleCount, copySize } = t.params;
     const imageBitmap = await createImageBitmap(t.getImageData(1, 1));
     const dstTexture = t.device.createTexture({
-      size: { width: 1, height: 1, depth: 1 },
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       sampleCount,
       format: 'bgra8unorm',
       usage: GPUTextureUsage.COPY_DST,
@@ -279,8 +279,8 @@ g.test('destination_texture,mipLevel')
       .combine(poptions('mipLevel', [0, kDefaultMipLevelCount - 1, kDefaultMipLevelCount]))
       .combine(
         poptions('copySize', [
-          { width: 0, height: 0, depth: 0 },
-          { width: 1, height: 1, depth: 1 },
+          { width: 0, height: 0, depthOrArrayLayers: 0 },
+          { width: 1, height: 1, depthOrArrayLayers: 1 },
         ])
       )
   )
@@ -288,7 +288,7 @@ g.test('destination_texture,mipLevel')
     const { mipLevel, copySize } = t.params;
     const imageBitmap = await createImageBitmap(t.getImageData(1, 1));
     const dstTexture = t.device.createTexture({
-      size: { width: kDefaultWidth, height: kDefaultHeight, depth: kDefaultDepth },
+      size: { width: kDefaultWidth, height: kDefaultHeight, depthOrArrayLayers: kDefaultDepth },
       mipLevelCount: kDefaultMipLevelCount,
       format: 'bgra8unorm',
       usage: GPUTextureUsage.COPY_DST,
@@ -308,8 +308,8 @@ g.test('destination_texture,format')
       .combine(poptions('format', kAllTextureFormats))
       .combine(
         poptions('copySize', [
-          { width: 0, height: 0, depth: 0 },
-          { width: 1, height: 1, depth: 1 },
+          { width: 0, height: 0, depthOrArrayLayers: 0 },
+          { width: 1, height: 1, depthOrArrayLayers: 1 },
         ])
       )
   )
@@ -321,7 +321,7 @@ g.test('destination_texture,format')
     // compressed texture format.
     t.device.pushErrorScope('validation');
     const dstTexture = t.device.createTexture({
-      size: { width: 1, height: 1, depth: 1 },
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       format,
       usage: GPUTextureUsage.COPY_DST,
     });
@@ -357,7 +357,11 @@ g.test('OOB,source')
     const { srcOrigin, copySize } = t.params;
     const imageBitmap = await createImageBitmap(t.getImageData(kDefaultWidth, kDefaultHeight));
     const dstTexture = t.device.createTexture({
-      size: { width: kDefaultWidth + 1, height: kDefaultHeight + 1, depth: kDefaultDepth },
+      size: {
+        width: kDefaultWidth + 1,
+        height: kDefaultHeight + 1,
+        depthOrArrayLayers: kDefaultDepth,
+      },
       mipLevelCount: kDefaultMipLevelCount,
       format: 'bgra8unorm',
       usage: GPUTextureUsage.COPY_DST,
@@ -368,7 +372,7 @@ g.test('OOB,source')
     if (
       srcOrigin.x + copySize.width > kDefaultWidth ||
       srcOrigin.y + copySize.height > kDefaultHeight ||
-      copySize.depth > 1
+      copySize.depthOrArrayLayers > 1
     ) {
       success = false;
     }
@@ -393,7 +397,7 @@ g.test('OOB,destination')
       size: {
         width: kDefaultWidth,
         height: kDefaultHeight,
-        depth: kDefaultDepth,
+        depthOrArrayLayers: kDefaultDepth,
       },
       format: 'bgra8unorm',
       mipLevelCount: kDefaultMipLevelCount,
@@ -404,10 +408,10 @@ g.test('OOB,destination')
     const dstMipMapSize = computeMipMapSize(kDefaultWidth, kDefaultHeight, mipLevel);
 
     if (
-      copySize.depth > 1 ||
+      copySize.depthOrArrayLayers > 1 ||
       dstOrigin.x + copySize.width > dstMipMapSize.mipWidth ||
       dstOrigin.y + copySize.height > dstMipMapSize.mipHeight ||
-      dstOrigin.z + copySize.depth > kDefaultDepth
+      dstOrigin.z + copySize.depthOrArrayLayers > kDefaultDepth
     ) {
       success = false;
     }

--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -107,7 +107,11 @@ Test various validation behaviors when a resolveTarget is provided.
           // Create the color attachment with resolve target with the configurable parameters.
           const resolveSourceColorAttachment = t.device.createTexture({
             format: colorAttachmentFormat,
-            size: { width: colorAttachmentWidth, height: colorAttachmentHeight, depth: 1 },
+            size: {
+              width: colorAttachmentWidth,
+              height: colorAttachmentHeight,
+              depthOrArrayLayers: 1,
+            },
             sampleCount: colorAttachmentSamples,
             usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
           });
@@ -117,7 +121,8 @@ Test various validation behaviors when a resolveTarget is provided.
             size: {
               width: resolveTargetWidth,
               height: resolveTargetHeight,
-              depth: resolveTargetViewBaseArrayLayer + resolveTargetViewArrayLayerCount,
+              depthOrArrayLayers:
+                resolveTargetViewBaseArrayLayer + resolveTargetViewArrayLayerCount,
             },
             sampleCount: resolveTargetSamples,
             mipLevelCount: resolveTargetViewBaseMipLevel + resolveTargetViewMipCount,
@@ -140,7 +145,11 @@ Test various validation behaviors when a resolveTarget is provided.
           // and sample count must match the resolve source color attachment to be valid.
           const colorAttachment = t.device.createTexture({
             format: otherAttachmentFormat,
-            size: { width: colorAttachmentWidth, height: colorAttachmentHeight, depth: 1 },
+            size: {
+              width: colorAttachmentWidth,
+              height: colorAttachmentHeight,
+              depthOrArrayLayers: 1,
+            },
             sampleCount: colorAttachmentSamples,
             usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
           });
@@ -150,7 +159,7 @@ Test various validation behaviors when a resolveTarget is provided.
             size: {
               width: colorAttachmentWidth,
               height: colorAttachmentHeight,
-              depth: 1,
+              depthOrArrayLayers: 1,
             },
             sampleCount: 1,
             usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,

--- a/src/webgpu/api/validation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/validation/render_pass/storeOp.spec.ts
@@ -49,7 +49,7 @@ g.test('store_op_and_read_only')
 
     const depthAttachment = t.device.createTexture({
       format: 'depth24plus-stencil8',
-      size: { width: 1, height: 1, depth: 1 },
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
     const depthAttachmentView = depthAttachment.createView();

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -32,7 +32,7 @@ class F extends ValidationTest {
     } = options;
 
     return this.device.createTexture({
-      size: { width, height, depth: arrayLayerCount },
+      size: { width, height, depthOrArrayLayers: arrayLayerCount },
       format,
       mipLevelCount,
       sampleCount,

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -78,7 +78,7 @@ class TextureUsageTracking extends ValidationTest {
     } = options;
 
     return this.device.createTexture({
-      size: { width, height, depth: arrayLayerCount },
+      size: { width, height, depthOrArrayLayers: arrayLayerCount },
       mipLevelCount,
       sampleCount,
       dimension: '2d',

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -17,7 +17,7 @@ export class ValidationTest extends GPUTest {
     descriptor?: Readonly<GPUTextureDescriptor>
   ): GPUTexture {
     descriptor = descriptor ?? {
-      size: { width: 1, height: 1, depth: 1 },
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage:
         GPUTextureUsage.COPY_SRC |
@@ -101,7 +101,7 @@ export class ValidationTest extends GPUTest {
 
   getSampledTexture(sampleCount: number = 1): GPUTexture {
     return this.device.createTexture({
-      size: { width: 16, height: 16, depth: 1 },
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.SAMPLED,
       sampleCount,
@@ -110,7 +110,7 @@ export class ValidationTest extends GPUTest {
 
   getStorageTexture(): GPUTexture {
     return this.device.createTexture({
-      size: { width: 16, height: 16, depth: 1 },
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.STORAGE,
     });
@@ -119,7 +119,7 @@ export class ValidationTest extends GPUTest {
   getErrorTexture(): GPUTexture {
     this.device.pushErrorScope('validation');
     const texture = this.device.createTexture({
-      size: { width: 0, height: 0, depth: 0 },
+      size: { width: 0, height: 0, depthOrArrayLayers: 0 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.SAMPLED,
     });
@@ -258,7 +258,7 @@ export class ValidationTest extends GPUTest {
         const attachment = this.device
           .createTexture({
             format: colorFormat,
-            size: { width: 16, height: 16, depth: 1 },
+            size: { width: 16, height: 16, depthOrArrayLayers: 1 },
             usage: GPUTextureUsage.RENDER_ATTACHMENT,
           })
           .createView();

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -565,7 +565,7 @@ got [${failedByteActualValues.join(', ')}]`;
     const textureSizeMipmap0 = 1 << (mipLevelCount - 1);
     const texture = this.device.createTexture({
       mipLevelCount,
-      size: { width: textureSizeMipmap0, height: textureSizeMipmap0, depth: 1 },
+      size: { width: textureSizeMipmap0, height: textureSizeMipmap0, depthOrArrayLayers: 1 },
       format,
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED,
     });

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -405,7 +405,7 @@ g.test('vertexAccess')
     // Pipeline setup, texture setup
     const colorAttachment = t.device.createTexture({
       format: 'rgba8unorm',
-      size: { width: 1, height: 1, depth: 1 },
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
     const colorAttachmentView = colorAttachment.createView();

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -11,6 +11,7 @@ export function maxMipLevelCount({
 
   let maxMippedDimension = sizeDict.width;
   if (dimension !== '1d') maxMippedDimension = Math.max(maxMippedDimension, sizeDict.height);
-  if (dimension === '3d') maxMippedDimension = Math.max(maxMippedDimension, sizeDict.depth);
+  if (dimension === '3d')
+    maxMippedDimension = Math.max(maxMippedDimension, sizeDict.depthOrArrayLayers);
   return Math.floor(Math.log2(maxMippedDimension)) + 1;
 }

--- a/src/webgpu/util/texture/image_copy.ts
+++ b/src/webgpu/util/texture/image_copy.ts
@@ -50,8 +50,8 @@ export function dataBytesForCopy(
 
     // If heightInBlocks > 1, layout.bytesPerRow must be specified.
     if (heightInBlocks > 1 && bytesPerRow === undefined) valid = false;
-    // If copyExtent.depth > 1, layout.bytesPerRow and layout.rowsPerImage must be specified.
-    if (copyExtent.depth > 1 && rowsPerImage === undefined) valid = false;
+    // If copyExtent.depthOrArrayLayers > 1, layout.bytesPerRow and layout.rowsPerImage must be specified.
+    if (copyExtent.depthOrArrayLayers > 1 && rowsPerImage === undefined) valid = false;
     // If specified, layout.bytesPerRow must be greater than or equal to bytesInLastRow.
     if (bytesPerRow !== undefined && bytesPerRow < bytesInLastRow) valid = false;
     // If specified, layout.rowsPerImage must be greater than or equal to heightInBlocks.
@@ -60,12 +60,12 @@ export function dataBytesForCopy(
     bytesPerRow ??= align(info.bytesPerBlock * widthInBlocks, 256);
     rowsPerImage ??= heightInBlocks;
 
-    if (copyExtent.depth > 1) {
+    if (copyExtent.depthOrArrayLayers > 1) {
       const bytesPerImage = bytesPerRow * rowsPerImage;
-      const bytesBeforeLastImage = bytesPerImage * (copyExtent.depth - 1);
+      const bytesBeforeLastImage = bytesPerImage * (copyExtent.depthOrArrayLayers - 1);
       requiredBytesInCopy += bytesBeforeLastImage;
     }
-    if (copyExtent.depth > 0) {
+    if (copyExtent.depthOrArrayLayers > 0) {
       if (heightInBlocks > 1) requiredBytesInCopy += bytesPerRow * (heightInBlocks - 1);
       if (heightInBlocks > 0) requiredBytesInCopy += bytesInLastRow;
     }

--- a/src/webgpu/util/texture/subresource.ts
+++ b/src/webgpu/util/texture/subresource.ts
@@ -70,7 +70,7 @@ export function mipSize(size: GPUExtent3D, level: number): GPUExtent3D {
     return {
       width: rShiftMax1(size.width),
       height: rShiftMax1(size.height),
-      depth: rShiftMax1(size.depth),
+      depthOrArrayLayers: rShiftMax1(size.depthOrArrayLayers),
     };
   }
 }
@@ -92,5 +92,9 @@ export function physicalMipSize(
     virtualHeightAtLevel,
     kAllTextureFormatInfo[format].blockHeight
   );
-  return { width: physicalWidthAtLevel, height: physicalHeightAtLevel, depth: size.depth };
+  return {
+    width: physicalWidthAtLevel,
+    height: physicalHeightAtLevel,
+    depthOrArrayLayers: size.depthOrArrayLayers,
+  };
 }

--- a/src/webgpu/util/unions.ts
+++ b/src/webgpu/util/unions.ts
@@ -1,7 +1,11 @@
 export function standardizeExtent3D(v: GPUExtent3D): Required<GPUExtent3DDict> {
   if (v instanceof Array) {
-    return { width: v[0] ?? 1, height: v[1] ?? 1, depth: v[2] ?? 1 };
+    return { width: v[0] ?? 1, height: v[1] ?? 1, depthOrArrayLayers: v[2] ?? 1 };
   } else {
-    return { width: v.width ?? 1, height: v.height ?? 1, depth: v.depth ?? 1 };
+    return {
+      width: v.width ?? 1,
+      height: v.height ?? 1,
+      depthOrArrayLayers: v.depthOrArrayLayers ?? 1,
+    };
   }
 }

--- a/src/webgpu/web_platform/copyImageBitmapToTexture.spec.ts
+++ b/src/webgpu/web_platform/copyImageBitmapToTexture.spec.ts
@@ -119,7 +119,7 @@ got [${failedByteActualValues.join(', ')}]`;
     encoder.copyTextureToBuffer(
       { texture: dstTexture, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
       { buffer: testBuffer, bytesPerRow },
-      { width: imageBitmap.width, height: imageBitmap.height, depth: 1 }
+      { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 }
     );
     this.device.queue.submit([encoder.finish()]);
 
@@ -231,7 +231,7 @@ g.test('from_ImageData')
       size: {
         width: imageBitmap.width,
         height: imageBitmap.height,
-        depth: 1,
+        depthOrArrayLayers: 1,
       },
       format: dstColorFormat,
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
@@ -274,7 +274,7 @@ g.test('from_ImageData')
     t.doTestAndCheckResult(
       { imageBitmap, origin: { x: 0, y: 0 } },
       { texture: dst },
-      { width: imageBitmap.width, height: imageBitmap.height, depth: 1 },
+      { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 },
       dstBytesPerPixel,
       expectedPixels
     );
@@ -329,7 +329,7 @@ g.test('from_canvas')
       size: {
         width: imageBitmap.width,
         height: imageBitmap.height,
-        depth: 1,
+        depthOrArrayLayers: 1,
       },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
@@ -346,7 +346,7 @@ g.test('from_canvas')
     t.doTestAndCheckResult(
       { imageBitmap, origin: { x: 0, y: 0 } },
       { texture: dst },
-      { width: imageBitmap.width, height: imageBitmap.height, depth: 1 },
+      { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 },
       bytesPerPixel,
       expectedData
     );


### PR DESCRIPTION
The main change is to rename depth to depthOrArrayLayers



-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
