### PR TITLE
Fix incorrect indexing bug in resource_init/check_texture/by_sampling.ts

### DIFF
--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -69,8 +69,8 @@ export const checkContentsBySampling: CheckContents = (
               var texel : vec4<${shaderType}> = textureLoad(
                 myTexture, vec2<i32>(GlobalInvocationID.xy), constants.level);
 
-              for (var i : u32 = flatIndex; i < flatIndex + ${componentCount}u; i = i + 1) {
-                result.values[i] = texel.${indexExpression};
+              for (var i : u32 = 0u; i < ${componentCount}u; i = i + 1u) {
+                result.values[flatIndex + i] = texel.${indexExpression};
               }
               return;
             }`,


### PR DESCRIPTION
This fixes a ton of texture zero init tests on Windows, and potentially other platforms as well.

-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [ ] WebGPU readability
- [x] TypeScript readability
