### PR TITLE
Update to types 0.0.41

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1141,9 +1141,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.0.40.tgz",
-      "integrity": "sha512-oCegMGf7FASpIcUUO/ug7m29H7FLh3USfu4CWYJcTdXlyT9iiEvQ+vy8YvEeVFwUA1/6XPqMWTec1CoJPbNZoQ==",
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.0.41.tgz",
+      "integrity": "sha512-u7FZWJYWKeLavoU/hVccfQSBy2YvfandISPCupILt0XNnBMgt0fP4nQY/aL5BkHtdXCzBAGmiUn7yIB5FIAG2A==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/morgan": "^1.9.2",
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
-    "@webgpu/types": "0.0.40",
+    "@webgpu/types": "0.0.41",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",
     "chokidar": "^3.4.3",

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -19,7 +19,7 @@ import { physicalMipSize } from '../../../util/texture/subresource.js';
 
 class F extends GPUTest {
   GetInitialDataPerMipLevel(
-    textureSize: GPUExtent3DDict,
+    textureSize: Required<GPUExtent3DDict>,
     format: SizedTextureFormat,
     mipLevel: number
   ): Uint8Array {
@@ -42,13 +42,13 @@ class F extends GPUTest {
   }
 
   DoCopyTextureToTextureTest(
-    srcTextureSize: GPUExtent3DDict,
-    dstTextureSize: GPUExtent3DDict,
+    srcTextureSize: Required<GPUExtent3DDict>,
+    dstTextureSize: Required<GPUExtent3DDict>,
     format: SizedTextureFormat,
     copyBoxOffsets: {
       srcOffset: { x: number; y: number; z: number };
       dstOffset: { x: number; y: number; z: number };
-      copyExtent: GPUExtent3DDict;
+      copyExtent: Required<GPUExtent3DDict>;
     },
     srcCopyLevel: number,
     dstCopyLevel: number

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -65,10 +65,10 @@ class F extends ValidationTest {
   }
 
   GetPhysicalSubresourceSize(
-    textureSize: GPUExtent3DDict,
+    textureSize: Required<GPUExtent3DDict>,
     format: GPUTextureFormat,
     mipLevel: number
-  ): GPUExtent3DDict {
+  ): Required<GPUExtent3DDict> {
     const virtualWidthAtLevel = Math.max(textureSize.width >> mipLevel, 1);
     const virtualHeightAtLevel = Math.max(textureSize.height >> mipLevel, 1);
     const physicalWidthAtLevel = align(

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -83,7 +83,7 @@ export class ImageCopyTest extends ValidationTest {
   // precise about its size as long as it's big enough and properly aligned.
   createAlignedTexture(
     format: SizedTextureFormat,
-    copySize: GPUExtent3DDict = { width: 1, height: 1, depthOrArrayLayers: 1 },
+    copySize: Required<GPUExtent3DDict> = { width: 1, height: 1, depthOrArrayLayers: 1 },
     origin: Required<GPUOrigin3DDict> = { x: 0, y: 0, z: 0 }
   ): GPUTexture {
     const info = kSizedTextureFormatInfo[format];

--- a/src/webgpu/util/texture/subresource.ts
+++ b/src/webgpu/util/texture/subresource.ts
@@ -1,6 +1,7 @@
 import { assert } from '../../../common/framework/util/util.js';
 import { kAllTextureFormatInfo } from '../../capability_info.js';
 import { align } from '../../util/math.js';
+import { standardizeExtent3D } from '../unions.js';
 
 export interface BeginCountRange {
   begin: number;
@@ -58,30 +59,31 @@ export class SubresourceRange {
   }
 }
 
-export function mipSize(size: [number], level: number): [number];
-export function mipSize(size: [number, number], level: number): [number, number];
-export function mipSize(size: [number, number, number], level: number): [number, number, number];
+export function mipSize(size: readonly [number], level: number): [number];
+export function mipSize(size: readonly [number, number], level: number): [number, number];
+export function mipSize(size: readonly [number, number, number], level: number): [number, number, number];
 export function mipSize(size: GPUExtent3DDict, level: number): GPUExtent3DDict;
-export function mipSize(size: GPUExtent3D, level: number): GPUExtent3D {
+export function mipSize(size: Readonly<GPUExtent3D>, level: number): GPUExtent3D {
   const rShiftMax1 = (s: number) => Math.max(s >> level, 1);
   if (size instanceof Array) {
     return size.map(rShiftMax1);
   } else {
+    const size_ = standardizeExtent3D(size);
     return {
-      width: rShiftMax1(size.width),
-      height: rShiftMax1(size.height),
-      depthOrArrayLayers: rShiftMax1(size.depthOrArrayLayers),
+      width: rShiftMax1(size_.width),
+      height: rShiftMax1(size_.height),
+      depthOrArrayLayers: rShiftMax1(size_.depthOrArrayLayers),
     };
   }
 }
 
 // TODO(jiawei.shao@intel.com): support 1D and 3D textures
 export function physicalMipSize(
-  size: GPUExtent3DDict,
+  size: Required<GPUExtent3DDict>,
   format: GPUTextureFormat,
   dimension: GPUTextureDimension,
   level: number
-): GPUExtent3DDict {
+): Required<GPUExtent3DDict> {
   assert(dimension === '2d');
   assert(Math.max(size.width, size.height) >> level > 0);
 

--- a/src/webgpu/util/texture/subresource.ts
+++ b/src/webgpu/util/texture/subresource.ts
@@ -61,7 +61,10 @@ export class SubresourceRange {
 
 export function mipSize(size: readonly [number], level: number): [number];
 export function mipSize(size: readonly [number, number], level: number): [number, number];
-export function mipSize(size: readonly [number, number, number], level: number): [number, number, number];
+export function mipSize(
+  size: readonly [number, number, number],
+  level: number
+): [number, number, number];
 export function mipSize(size: GPUExtent3DDict, level: number): GPUExtent3DDict;
 export function mipSize(size: Readonly<GPUExtent3D>, level: number): GPUExtent3D {
   const rShiftMax1 = (s: number) => Math.max(s >> level, 1);


### PR DESCRIPTION
Fixes for GPUExtent3DDict members becoming optional.



-----

<!-- Leave this section in the PR description. -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

**[Review requirements](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) are satisfied for:**

- [x] WebGPU readability
- [x] TypeScript readability
