### PR TITLE
Add texture size tests for 1D/2D/3D textures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1141,9 +1141,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.0.41",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.0.41.tgz",
-      "integrity": "sha512-u7FZWJYWKeLavoU/hVccfQSBy2YvfandISPCupILt0XNnBMgt0fP4nQY/aL5BkHtdXCzBAGmiUn7yIB5FIAG2A==",
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.0.42.tgz",
+      "integrity": "sha512-X3NTj7/7miodS8fc15hpwxP+AfNjzPt6IMUaasBsnicmUIRM/bCLQKazIaRK7Kxh37VPMRKT1vjJ2YQyUELQew==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/morgan": "^1.9.2",
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
-    "@webgpu/types": "0.0.41",
+    "@webgpu/types": "0.0.42",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",
     "chokidar": "^3.4.3",

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -23,7 +23,12 @@ TODO: move destroy tests out of this file
 
 import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { kAllTextureFormats, kAllTextureFormatInfo } from '../../capability_info.js';
+import {
+  kAllTextureFormats,
+  kAllTextureFormatInfo,
+  kUncompressedTextureFormats,
+  kUncompressedTextureFormatInfo,
+} from '../../capability_info.js';
 import { DefaultLimits } from '../../constants.js';
 import { maxMipLevelCount } from '../../util/texture/base.js';
 
@@ -266,49 +271,45 @@ g.test('texture_size,1d_texture')
   });
 
 g.test('texture_size,2d_texture')
-  .desc(`Test texture size requirement for 2D texture`)
+  .desc(
+    `Test texture size requirement for 2D texture.
+	TODO: add tests for compressed texture.`
+  )
   .subcases(() =>
     params()
-      .combine(poptions('format', kAllTextureFormats))
-      .combine(
-        poptions('width', [
-          DefaultLimits.maxTextureDimension2D - 1,
-          DefaultLimits.maxTextureDimension2D,
-          DefaultLimits.maxTextureDimension2D + 1,
-        ])
-      )
-      .combine(
-        poptions('height', [
-          DefaultLimits.maxTextureDimension2D - 1,
-          DefaultLimits.maxTextureDimension2D,
-          DefaultLimits.maxTextureDimension2D + 1,
-        ])
-      )
-      .combine(
-        poptions('depthOrArrayLayers', [
-          DefaultLimits.maxTextureArrayLayers - 1,
-          DefaultLimits.maxTextureArrayLayers,
-          DefaultLimits.maxTextureArrayLayers + 1,
-        ])
-      )
+      .combine(poptions('format', kUncompressedTextureFormats))
       .combine(poptions('dimension', [undefined, '2d'] as const))
+      .combine([
+        // Test the bound of width
+        { size: [DefaultLimits.maxTextureDimension2D - 1, 1, 1] },
+        { size: [DefaultLimits.maxTextureDimension2D, 1, 1] },
+        { size: [DefaultLimits.maxTextureDimension2D + 1, 1, 1] },
+        // Test the bound of height
+        { size: [1, DefaultLimits.maxTextureDimension2D - 1, 1] },
+        { size: [1, DefaultLimits.maxTextureDimension2D, 1] },
+        { size: [1, DefaultLimits.maxTextureDimension2D + 1, 1] },
+        // Test the bound of array layers
+        { size: [1, 1, DefaultLimits.maxTextureArrayLayers - 1] },
+        { size: [1, 1, DefaultLimits.maxTextureArrayLayers] },
+        { size: [1, 1, DefaultLimits.maxTextureArrayLayers + 1] },
+      ])
   )
   .fn(async t => {
-    const { format, width, height, depthOrArrayLayers, dimension } = t.params;
+    const { format, dimension, size } = t.params;
 
-    await t.selectDeviceOrSkipTestCase(kAllTextureFormatInfo[format].extension);
+    await t.selectDeviceOrSkipTestCase(kUncompressedTextureFormatInfo[format].extension);
 
     const descriptor: GPUTextureDescriptor = {
-      size: [width, height, depthOrArrayLayers],
+      size,
       dimension,
       format,
       usage: GPUTextureUsage.SAMPLED,
     };
 
     const success =
-      width <= DefaultLimits.maxTextureDimension2D &&
-      height <= DefaultLimits.maxTextureDimension2D &&
-      depthOrArrayLayers <= DefaultLimits.maxTextureArrayLayers;
+      size[0] <= DefaultLimits.maxTextureDimension2D &&
+      size[1] <= DefaultLimits.maxTextureDimension2D &&
+      size[2] <= DefaultLimits.maxTextureArrayLayers;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);
@@ -316,48 +317,44 @@ g.test('texture_size,2d_texture')
   });
 
 g.test('texture_size,3d_texture')
-  .desc(`Test texture size requirement for 3D texture`)
+  .desc(
+    `Test texture size requirement for 3D texture.
+	TODO: add tests for compressed texture.`
+  )
   .subcases(() =>
     params()
-      .combine(poptions('format', kAllTextureFormats))
-      .combine(
-        poptions('width', [
-          DefaultLimits.maxTextureDimension3D - 1,
-          DefaultLimits.maxTextureDimension3D,
-          DefaultLimits.maxTextureDimension3D + 1,
-        ])
-      )
-      .combine(
-        poptions('height', [
-          DefaultLimits.maxTextureDimension3D - 1,
-          DefaultLimits.maxTextureDimension3D,
-          DefaultLimits.maxTextureDimension3D + 1,
-        ])
-      )
-      .combine(
-        poptions('depthOrArrayLayers', [
-          DefaultLimits.maxTextureDimension3D - 1,
-          DefaultLimits.maxTextureDimension3D,
-          DefaultLimits.maxTextureDimension3D + 1,
-        ])
-      )
+      .combine(poptions('format', kUncompressedTextureFormats))
+      .combine([
+        // Test the bound of width
+        { size: [DefaultLimits.maxTextureDimension3D - 1, 1, 1] },
+        { size: [DefaultLimits.maxTextureDimension3D, 1, 1] },
+        { size: [DefaultLimits.maxTextureDimension3D + 1, 1, 1] },
+        // Test the bound of height
+        { size: [1, DefaultLimits.maxTextureDimension3D - 1, 1] },
+        { size: [1, DefaultLimits.maxTextureDimension3D, 1] },
+        { size: [1, DefaultLimits.maxTextureDimension3D + 1, 1] },
+        // Test the bound of depth
+        { size: [1, 1, DefaultLimits.maxTextureDimension3D - 1] },
+        { size: [1, 1, DefaultLimits.maxTextureDimension3D] },
+        { size: [1, 1, DefaultLimits.maxTextureDimension3D + 1] },
+      ])
   )
   .fn(async t => {
-    const { format, width, height, depthOrArrayLayers } = t.params;
+    const { format, size } = t.params;
 
-    await t.selectDeviceOrSkipTestCase(kAllTextureFormatInfo[format].extension);
+    await t.selectDeviceOrSkipTestCase(kUncompressedTextureFormatInfo[format].extension);
 
     const descriptor: GPUTextureDescriptor = {
-      size: [width, height, depthOrArrayLayers],
+      size,
       dimension: '3d' as const,
       format,
       usage: GPUTextureUsage.SAMPLED,
     };
 
     const success =
-      width <= DefaultLimits.maxTextureDimension3D &&
-      height <= DefaultLimits.maxTextureDimension3D &&
-      depthOrArrayLayers <= DefaultLimits.maxTextureDimension3D;
+      size[0] <= DefaultLimits.maxTextureDimension3D &&
+      size[1] <= DefaultLimits.maxTextureDimension3D &&
+      size[2] <= DefaultLimits.maxTextureDimension3D;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);

--- a/src/webgpu/constants.ts
+++ b/src/webgpu/constants.ts
@@ -44,6 +44,10 @@ export const GPUConst = {
 
 // Type ensures every field is specified.
 export const DefaultLimits: ResolveType<Required<Readonly<GPULimits>>> = {
+  maxTextureDimension1D: 8192,
+  maxTextureDimension2D: 8192,
+  maxTextureDimension3D: 2048,
+  maxTextureArrayLayers: 2048,
   maxBindGroups: 4,
   maxDynamicUniformBuffersPerPipelineLayout: 8,
   maxDynamicStorageBuffersPerPipelineLayout: 4,


### PR DESCRIPTION

-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
