### PR TITLE
Deduplicate texture table header

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -70,8 +70,9 @@ export const kBufferUsages = numericKeysOf<GPUBufferUsage>(kBufferUsageInfo);
 
 // Textures
 
-export const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
-                           ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',              'extension'] as const,
+/* prettier-ignore */
+const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',              'extension'] as const;
+export const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [            ,          true,    true,   false,     false,          ,      true,      true,                ,            1,             1,                         ] as const, {
   // 8-bit formats
   'r8unorm':               [        true,              ,        ,        ,          ,     false,          ,          ,               1],
@@ -116,8 +117,6 @@ export const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
   'rgba32sint':            [        true,              ,        ,        ,          ,      true,          ,          ,              16],
   'rgba32float':           [        true,              ,        ,        ,          ,      true,          ,          ,              16],
 } as const);
-/* prettier-ignore */
-const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',              'extension'] as const;
 export const kSizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [        true,          true,   false,        ,          ,     false,          ,          ,                ,            1,             1,                         ] as const, {
   'depth32float':          [        true,              ,   false,    true,     false,          ,     false,     false,               4],


### PR DESCRIPTION
Not sure why I duplicated it in the first place.


-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
