### PR TITLE
Remove unnecessary step from wpt runtime

### DIFF
--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -43,12 +43,10 @@ setup({
         await testcase.run(rec);
       }
 
-      t.step(() => {
-        // Unfortunately, it seems not possible to surface any logs for warn/skip.
-        if (res.status === 'fail') {
-          throw (res.logs || []).map(s => s.toJSON()).join('\n\n');
-        }
-      });
+      // Unfortunately, it seems not possible to surface any logs for warn/skip.
+      if (res.status === 'fail') {
+        throw (res.logs || []).map(s => s.toJSON()).join('\n\n');
+      }
     };
 
     promise_test(wpt_fn, name);

--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -35,7 +35,7 @@ setup({
 
   for (const testcase of testcases) {
     const name = testcase.query.toString();
-    const wpt_fn = async (t: WptTestObject) => {
+    const wpt_fn = async () => {
       const [rec, res] = log.record(name);
       if (worker) {
         await worker.run(rec, name);


### PR DESCRIPTION
https://web-platform-tests.org/writing-tests/testharness-api.html#:~:text=Note%20that%20in%20the%20promise%20chain

-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
