### PR TITLE
Reuse interface in dataBytesForCopyOrOverestimate

### DIFF
--- a/src/webgpu/util/texture/image_copy.ts
+++ b/src/webgpu/util/texture/image_copy.ts
@@ -85,12 +85,7 @@ export function dataBytesForCopyOrOverestimate({
   format,
   copySize: copySize_,
   method,
-}: {
-  layout: GPUImageDataLayout;
-  format: SizedTextureFormat;
-  copySize: GPUExtent3D;
-  method: ImageCopyType;
-}): { minDataSizeOrOverestimate: number; copyValid: boolean } {
+}: DataBytesForCopyArgs): { minDataSizeOrOverestimate: number; copyValid: boolean } {
   const copyExtent = standardizeExtent3D(copySize_);
 
   const info = kSizedTextureFormatInfo[format];


### PR DESCRIPTION
It was meant to be reused between these two functions but I forgot.



-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
