### PR TITLE
Add validation tests plan for Occlusion Query

### DIFF
--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -1,4 +1,6 @@
 export const description = `
+Note: render pass 'occlusionQuerySet' validation is tested in queries/general.spec.ts
+
 TODO: check for duplication (render_pass/, etc.), plan, and implement.
 Note possibly a lot of this should be operation tests instead.
 Notes:

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -17,8 +17,6 @@ Notes:
 >     - {all possible {depth, stencil} load ops, load values {in range, negative, too large}}
 >     - all possible {depth, stencil} store ops
 >     - depthReadOnly {t,f}, stencilReadOnly {t,f}
-> - occlusion query set
->     - tested in queries/general.spec.ts
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -15,6 +15,8 @@ Notes:
 >     - {all possible {depth, stencil} load ops, load values {in range, negative, too large}}
 >     - all possible {depth, stencil} store ops
 >     - depthReadOnly {t,f}, stencilReadOnly {t,f}
+> - occlusion query set
+>     - tested in queries/general.spec.ts
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';

--- a/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
@@ -9,15 +9,50 @@ TODO:
     - begin 2, end 2
     - }
     - x= {
-        - render pass + occlusion
         - render pass + pipeline statistics
         - compute pass + pipeline statistics
         - }
-- nesting: test whether it's allowed to nest various types of queries
-  (including writeTimestamp inside begin/endable queries).
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
+
+g.test('occlusion_query,begin_end')
+  .desc(
+    `
+Tests that begin/end occlusion query on render pass:
+- begin 0
+- begin 0, end (control case)
+- begin 0, begin 1, end
+- begin 0, end, end
+- end
+  `
+  )
+  .unimplemented();
+
+  g.test('occlusion_query,begin_with_same_query_index')
+  .desc(
+    `
+Tests that begin occlusion query with same query index twice:
+- on {same, different (control case)} render pass
+  `
+  )
+  .unimplemented();
+
+g.test('nesting')
+  .desc(
+    `
+Tests that whether it's allowed to nest various types of queries:
+- beginOcclusionQuery, writeTimestamp, endOcclusionQuery
+- beginOcclusionQuery, beginPipelineStatisticsQuery, endPipelineStatisticsQuery, endOcclusionQuery
+- beginOcclusionQuery, beginPipelineStatisticsQuery, endOcclusionQuery, endPipelineStatisticsQuery
+- beginPipelineStatisticsQuery, writeTimestamp, endPipelineStatisticsQuery
+- beginPipelineStatisticsQuery, beginOcclusionQuery, endOcclusionQuery, endPipelineStatisticsQuery
+- beginPipelineStatisticsQuery, beginOcclusionQuery, endPipelineStatisticsQuery, endOcclusionQuery
+- writeTimestamp, beginOcclusionQuery, writeTimestamp, endOcclusionQuery
+- writeTimestamp, beginPipelineStatisticsQuery, writeTimestamp, endPipelineStatisticsQuery
+  `
+  )
+  .unimplemented();

--- a/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
@@ -32,7 +32,7 @@ Tests that begin/end occlusion query on render pass:
   )
   .unimplemented();
 
-  g.test('occlusion_query,begin_with_same_query_index')
+g.test('occlusion_query,begin_with_same_query_index')
   .desc(
     `
 Tests that begin occlusion query with same query index twice:

--- a/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
@@ -14,31 +14,55 @@ TODO:
         - }
 `;
 
+import { pbool } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
 
-g.test('occlusion_query,begin_end')
+g.test('occlusion_query,begin_end_balance')
   .desc(
     `
-Tests that begin/end occlusion query on render pass:
-- begin 0
-- begin 0, end (control case)
-- begin 0, begin 1, end
-- begin 0, end, end
-- end
+Tests that begin/end occlusion queries mismatch on render pass:
+- begin 0, end 1 (begin no queries, then end one query)
+- begin 1, end 0 (begin one query, then end no queries)
+- begin 1, end 1 (begin one query, then end one query)(control case)
+- begin 1, end 2 (begin one query, then end two queries)
+- begin 2, end 1 (begin two queries, then end one query)
   `
+  )
+  .subcases(
+    () =>
+      [
+        { begin: 0, end: 1 },
+        { begin: 1, end: 0 },
+        { begin: 1, end: 1 },
+        { begin: 1, end: 2 },
+        { begin: 2, end: 1 },
+      ] as const
   )
   .unimplemented();
 
-g.test('occlusion_query,begin_with_same_query_index')
+g.test('occlusion_query,begin_end_invalid_nesting')
   .desc(
     `
-Tests that begin occlusion query with same query index twice:
-- on {same, different (control case)} render pass
+Tests the invalid nesting of begin/end occlusion queries:
+- begin index 0, begin index 0, end, end
+- begin index 0, begin index 1, end, end
   `
   )
+  .subcases(() => [{ calls: [0, 0, 'end', 'end'] }, { calls: [0, 1, 'end', 'end'] }] as const)
+  .unimplemented();
+
+g.test('occlusion_query,disjoint_queries_with_same_query_index')
+  .desc(
+    `
+Tests that two disjoint occlusion queries cannot be begun with same query index on same render pass:
+- begin index 0, end, begin index 0, end
+- call on {same (invalid), different (control case)} render pass
+  `
+  )
+  .subcases(() => pbool('isOnSameRenderPass'))
   .unimplemented();
 
 g.test('nesting')
@@ -46,13 +70,35 @@ g.test('nesting')
     `
 Tests that whether it's allowed to nest various types of queries:
 - beginOcclusionQuery, writeTimestamp, endOcclusionQuery
+- beginOcclusionQuery, beginOcclusionQuery, endOcclusionQuery, endOcclusionQuery
 - beginOcclusionQuery, beginPipelineStatisticsQuery, endPipelineStatisticsQuery, endOcclusionQuery
 - beginOcclusionQuery, beginPipelineStatisticsQuery, endOcclusionQuery, endPipelineStatisticsQuery
 - beginPipelineStatisticsQuery, writeTimestamp, endPipelineStatisticsQuery
+- beginPipelineStatisticsQuery, beginPipelineStatisticsQuery, endPipelineStatisticsQuery, endPipelineStatisticsQuery
 - beginPipelineStatisticsQuery, beginOcclusionQuery, endOcclusionQuery, endPipelineStatisticsQuery
 - beginPipelineStatisticsQuery, beginOcclusionQuery, endPipelineStatisticsQuery, endOcclusionQuery
 - writeTimestamp, beginOcclusionQuery, writeTimestamp, endOcclusionQuery
 - writeTimestamp, beginPipelineStatisticsQuery, writeTimestamp, endPipelineStatisticsQuery
   `
+  )
+  .subcases(
+    () =>
+      [
+        { begin: 'occlusion', nest: 'timestamp', end: 'occlusion', _valid: true },
+        { begin: 'occlusion', nest: 'occlusion', end: 'occlusion', _valid: false },
+        { begin: 'occlusion', nest: 'pipeline-statistcs', end: 'occlusion', _valid: true },
+        { begin: 'occlusion', nest: 'pipeline-statistcs', end: 'pipeline-statistcs', _valid: true },
+        { begin: 'pipeline-statistcs', nest: 'timestamp', end: 'pipeline-statistcs', _valid: true },
+        {
+          begin: 'pipeline-statistcs',
+          nest: 'pipeline-statistcs',
+          end: 'pipeline-statistcs',
+          _valid: false,
+        },
+        { begin: 'pipeline-statistcs', nest: 'occlusion', end: 'pipeline-statistcs', _valid: true },
+        { begin: 'pipeline-statistcs', nest: 'occlusion', end: 'occlusion', _valid: true },
+        { begin: 'timestamp', nest: 'occlusion', end: 'occlusion', _valid: true },
+        { begin: 'timestamp', nest: 'pipeline-statistcs', end: 'pipeline-statistcs', _valid: true },
+      ] as const
   )
   .unimplemented();

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -27,15 +27,24 @@ class F extends ValidationTest {
 
 export const g = makeTestGroup(F);
 
-g.test('occlusion_query,invalid_query_set')
+g.test('occlusion_query,query_type')
   .desc(
     `
 Tests that set occlusion query set with all types in render pass descriptor:
 - type {occlusion (control case), pipeline statistics, timestamp}
-- invalid query set that failed during creation
 - {undefined} for occlusion query set in render pass descriptor
   `
   )
+  .subcases(() => poptions('type', ['undefined'].concat(kQueryTypes)))
+  .unimplemented();
+
+g.test('occlusion_query,invalid_query_set')
+  .desc(
+    `
+Tests that begin occlusion query with a invalid query set that failed during creation.
+  `
+  )
+  .subcases(() => poptions('querySetState', ['valid', 'invalid'] as const))
   .unimplemented();
 
 g.test('occlusion_query,query_index')
@@ -45,6 +54,7 @@ Tests that begin occlusion query with query index:
 - queryIndex {in, out of} range for GPUQuerySet
   `
   )
+  .subcases(() => poptions('queryIndex', [0, 2]))
   .unimplemented();
 
 g.test('writeTimestamp,query_type_and_index')

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -27,6 +27,26 @@ class F extends ValidationTest {
 
 export const g = makeTestGroup(F);
 
+g.test('occlusion_query,invalid_query_set')
+  .desc(
+    `
+Tests that set occlusion query set with all types in render pass descriptor:
+- type {occlusion (control case), pipeline statistics, timestamp}
+- invalid query set that failed during creation
+- {undefined} for occlusion query set in render pass descriptor
+  `
+  )
+  .unimplemented();
+
+g.test('occlusion_query,query_index')
+  .desc(
+    `
+Tests that begin occlusion query with query index:
+- queryIndex {in, out of} range for GPUQuerySet
+  `
+  )
+  .unimplemented();
+
 g.test('writeTimestamp,query_type_and_index')
   .desc(
     `
@@ -60,10 +80,10 @@ Tests that write timestamp to all types of query set on all possible encoders:
     }, type !== 'timestamp' || queryIndex >= count);
   });
 
-g.test('writeTimestamp,invalid_queryset')
+g.test('writeTimestamp,invalid_query_set')
   .desc(
     `
-Tests that write timestamp to a invalid queryset that failed during creation:
+Tests that write timestamp to a invalid query set that failed during creation:
 - x= {non-pass, compute, render} enconder
   `
   )

--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -21,13 +21,14 @@ export const enum EncoderType {
 
 export const g = makeTestGroup(ValidationTest);
 
-g.test('beginRenderPass')
+g.test('beginOcclusionQuery')
   .desc(
     `
-Tests that use a destroyed query set in beginRenderPass for occlusion query.
+Tests that use a destroyed query set in occlusion query on render pass encoder.
 - x= {destroyed, not destroyed (control case)}
   `
   )
+  .subcases(() => poptions('querySetState', ['valid', 'destroyed'] as const))
   .unimplemented();
 
 g.test('writeTimestamp')

--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -21,6 +21,15 @@ export const enum EncoderType {
 
 export const g = makeTestGroup(ValidationTest);
 
+g.test('beginRenderPass')
+  .desc(
+    `
+Tests that use a destroyed query set in beginRenderPass for occlusion query.
+- x= {destroyed, not destroyed (control case)}
+  `
+  )
+  .unimplemented();
+
 g.test('writeTimestamp')
   .desc(
     `


### PR DESCRIPTION
This is tests plan for Occlusion Query validation on:
- {all types, invalid, undefined, destoryed} query set
- query index {out of bounds, write twice}
- begin/end balance
- nesting



-----

<!-- ***** For uploader to fill out ***** -->

- [ ] New helpers, if any, are documented in `helper_index.md`.
- [ ] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [ ] WebGPU readability
- [ ] TypeScript readability
