### PR TITLE
Break gen_listings dep on ts-node / fast-glob. Add src_dir/out_dir args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Build files
 /out/
 /out-wpt/
+/out-node/
 .tscache/
 *.tmp.txt
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
     pkg: grunt.file.readJSON('package.json'),
 
     clean: {
-      out: ['out/', 'out-wpt/'],
+      out: ['out/', 'out-wpt/', 'out-node/'],
     },
 
     run: {
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
       },
       'generate-listings': {
         cmd: 'node',
-        args: ['tools/gen_listings', 'webgpu', 'unittests', 'demo'],
+        args: ['tools/gen_listings', 'out/', 'src/', 'webgpu', 'unittests', 'demo'],
       },
       'generate-wpt-cts-html': {
         cmd: 'node',
@@ -54,6 +54,16 @@ module.exports = function (grunt) {
           // These files will be generated, instead of compiled from TypeScript.
           '--ignore=src/common/framework/version.ts',
           '--ignore=src/webgpu/listing.ts',
+        ],
+      },
+      'build-out-node': {
+        cmd: 'node',
+        args: [
+          'node_modules/typescript/lib/tsc.js',
+          '--project', 'node.tsconfig.json',
+          '--outDir', 'out-node/',
+          '--noEmit', 'false',
+          '--declaration', 'false'
         ],
       },
       lint: {
@@ -146,6 +156,7 @@ module.exports = function (grunt) {
     'clean',
     'build-standalone',
     'build-wpt',
+    'run:build-out-node',
     'build-done-message',
     'ts:check',
     'run:unittest',

--- a/node.tsconfig.json
+++ b/node.tsconfig.json
@@ -1,0 +1,13 @@
+// Typescript configuration for compile sources and
+// dependent files for usage directly with Node.js. This
+// is useful for running scripts in tools/ directly with Node
+// without including extra dependencies.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+
+  // Can't be compiled for Node.js as it uses import.metal.url.
+  "exclude": ["src/common/runtime/**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-ban": "^1.5.1",
     "eslint-plugin-import": "^2.22.1",
     "express": "^4.17.1",
-    "fast-glob": "^3.2.4",
     "grunt": "^1.3.0",
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-copy": "^1.0.0",

--- a/src/common/tools/crawl.ts
+++ b/src/common/tools/crawl.ts
@@ -10,27 +10,57 @@ import { validQueryPart } from '../framework/query/validQueryPart.js';
 import { TestSuiteListingEntry, TestSuiteListing } from '../framework/test_suite_listing.js';
 import { assert, unreachable } from '../framework/util/util.js';
 
-const fg = require('fast-glob');
+const specFileSuffix = __filename.endsWith('.ts') ? '.spec.ts' : '.spec.js';
 
-const specFileSuffix = '.spec.ts';
+async function crawlFilesRecursively(dir: string): Promise<string[]> {
+  const subpathInfo = await Promise.all(
+    (await fs.promises.readdir(dir)).map(async d => {
+      const p = path.join(dir, d);
+      const stats = await fs.promises.stat(p);
+      return {
+        path: p,
+        isDirectory: stats.isDirectory(),
+        isFile: stats.isFile(),
+      };
+    })
+  );
 
-export async function crawl(suite: string): Promise<TestSuiteListingEntry[]> {
-  const suiteDir = 'src/' + suite;
+  const files = subpathInfo
+    .filter(
+      i =>
+        i.isFile &&
+        (i.path.endsWith(specFileSuffix) ||
+          i.path.endsWith(`${path.sep}README.txt`) ||
+          i.path === 'README.txt')
+    )
+    .map(i => i.path);
+
+  return files.concat(
+    await subpathInfo
+      .filter(i => i.isDirectory)
+      .map(i => crawlFilesRecursively(i.path))
+      .reduce(async (a, b) => (await a).concat(await b), Promise.resolve([]))
+  );
+}
+
+export async function crawl(suiteDir: string): Promise<TestSuiteListingEntry[]> {
   if (!fs.existsSync(suiteDir)) {
     console.error(`Could not find ${suiteDir}`);
     process.exit(1);
   }
 
-  const glob = `${suiteDir}/**/{README.txt,*${specFileSuffix}}`;
-  const filesToEnumerate: string[] = await fg(glob, { onlyFiles: true });
-  filesToEnumerate.sort();
+  // Crawl files and convert paths to be POSIX-style, relative to suiteDir.
+  const filesToEnumerate = (await crawlFilesRecursively(suiteDir))
+    .map(f => path.relative(suiteDir, f).replace(/\\/g, '/'))
+    .sort();
 
   const entries: TestSuiteListingEntry[] = [];
   for (const file of filesToEnumerate) {
-    const f = file.substring((suiteDir + '/').length); // Suite-relative file path
-    if (f.endsWith(specFileSuffix)) {
-      const filepathWithoutExtension = f.substring(0, f.length - specFileSuffix.length);
-      const filename = `../../../${suiteDir}/${filepathWithoutExtension}.spec.js`;
+    // |file| is the suite-relative file path.
+    if (file.endsWith(specFileSuffix)) {
+      const filepathWithoutExtension = file.substring(0, file.length - specFileSuffix.length);
+      const suite = path.basename(suiteDir);
+      const filename = `../../${suite}/${filepathWithoutExtension}.spec.js`;
 
       let mod: SpecFile;
       if (process.env.STANDALONE_DEV_SERVER) {
@@ -45,19 +75,19 @@ export async function crawl(suite: string): Promise<TestSuiteListingEntry[]> {
 
       mod.g.validate();
 
-      const path = filepathWithoutExtension.split('/');
-      for (const p of path) {
+      const pathSegments = filepathWithoutExtension.split('/');
+      for (const p of pathSegments) {
         assert(validQueryPart.test(p), `Invalid directory name ${p}; must match ${validQueryPart}`);
       }
-      entries.push({ file: path, description: mod.description.trim() });
+      entries.push({ file: pathSegments, description: mod.description.trim() });
     } else if (path.basename(file) === 'README.txt') {
-      const filepathWithoutExtension = f.substring(0, f.length - '/README.txt'.length);
-      const readme = fs.readFileSync(file, 'utf8').trim();
+      const dirname = path.dirname(file);
+      const readme = fs.readFileSync(path.join(suiteDir, file), 'utf8').trim();
 
-      const path = filepathWithoutExtension ? filepathWithoutExtension.split('/') : [];
-      entries.push({ file: path, readme });
+      const pathSegments = dirname !== '.' ? dirname.split('/') : [];
+      entries.push({ file: pathSegments, readme });
     } else {
-      unreachable(`glob ${glob} matched an unrecognized filename ${file}`);
+      unreachable(`Matched an unrecognized filename ${file}`);
     }
   }
 
@@ -65,6 +95,5 @@ export async function crawl(suite: string): Promise<TestSuiteListingEntry[]> {
 }
 
 export function makeListing(filename: string): Promise<TestSuiteListing> {
-  const suite = path.basename(path.dirname(filename));
-  return crawl(suite);
+  return crawl(path.dirname(filename));
 }

--- a/src/common/tools/gen_listings.ts
+++ b/src/common/tools/gen_listings.ts
@@ -6,27 +6,26 @@ import { crawl } from './crawl.js';
 
 function usage(rc: number): void {
   console.error('Usage:');
-  console.error('  tools/gen_listings [SUITES...]');
-  console.error('  tools/gen_listings webgpu unittests');
+  console.error('  tools/gen_listings [OUT_DIR] [SRC_DIR] [SUITES...]');
+  console.error('  tools/gen_listings out/ src/ webgpu unittests');
   process.exit(rc);
 }
 
-if (process.argv.length <= 2) {
+if (process.argv.length <= 4) {
   usage(0);
 }
 
 const myself = 'src/common/tools/gen_listings.ts';
-if (!fs.existsSync(myself)) {
-  console.error('Must be run from repository root');
-  usage(1);
-}
+
+const outDir = process.argv[2];
+const srcDir = process.argv[3];
 
 (async () => {
-  for (const suite of process.argv.slice(2)) {
-    const listing = await crawl(suite);
+  for (const suite of process.argv.slice(4)) {
+    const listing = await crawl(path.join(srcDir, suite));
 
-    const outFile = path.normalize(`out/${suite}/listing.js`);
-    fs.mkdirSync(`out/${suite}`, { recursive: true });
+    const outFile = path.normalize(path.join(outDir, `${suite}/listing.js`));
+    fs.mkdirSync(path.join(outDir, suite), { recursive: true });
     fs.writeFileSync(
       outFile,
       `\


### PR DESCRIPTION
Previous to this patch, it was necessary to run gen_listings from the
root of the source tree using ts-node. These requirements make it
necessary for listing generation to take extra dependencies which may
be problematic in environments where the set of dependencies are vendored
and downloading many dependencies with npm is undesirable. Even with no
dependencies, running from the root of the source tree means the
transpiled .js file can't be run directly.

This patch adds a tsconfig for transpiling tools/ for usage directly
with Node.js, and a build step in the grunt presubmit check for it.



-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [[x]](url) WebGPU readability
- [ ] TypeScript readability
