### PR TITLE
Clean code for createTexture validation tests

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -18,37 +18,7 @@ import { maxMipLevelCount } from '../../util/texture/base.js';
 
 import { ValidationTest } from './validation_test.js';
 
-class F extends ValidationTest {
-  getDescriptor(
-    options: {
-      width?: number;
-      height?: number;
-      arrayLayerCount?: number;
-      mipLevelCount?: number;
-      sampleCount?: number;
-      format?: GPUTextureFormat;
-    } = {}
-  ): GPUTextureDescriptor {
-    const {
-      width = 32,
-      height = 32,
-      arrayLayerCount = 1,
-      mipLevelCount = 1,
-      sampleCount = 1,
-      format = 'rgba8unorm',
-    } = options;
-    return {
-      size: { width, height, depthOrArrayLayers: arrayLayerCount },
-      mipLevelCount,
-      sampleCount,
-      dimension: '2d',
-      format,
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.SAMPLED,
-    };
-  }
-}
-
-export const g = makeTestGroup(F);
+export const g = makeTestGroup(ValidationTest);
 
 g.test('zero_size')
   .desc(

--- a/src/webgpu/api/validation/texture/destroy.spec.ts
+++ b/src/webgpu/api/validation/texture/destroy.spec.ts
@@ -3,17 +3,61 @@ Destroying a texture more than once is allowed.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUConst } from '../../../constants.js';
 import { ValidationTest } from '../validation_test.js';
+
+const descriptor: GPUTextureDescriptor = {
+  size: [1, 1, 1],
+  format: 'rgba8unorm',
+  usage: GPUConst.TextureUsage.RENDER_ATTACHMENT | GPUConst.TextureUsage.SAMPLED,
+};
 
 export const g = makeTestGroup(ValidationTest);
 
-g.test('twice').fn(async t => {
-  const tex = t.device.createTexture({
-    size: [1, 1, 1],
-    format: 'r8unorm',
-    usage: GPUTextureUsage.SAMPLED,
-  });
-
-  tex.destroy();
-  tex.destroy();
+g.test('it_is_valid_to_destroy_a_texture').fn(t => {
+  const texture = t.device.createTexture(descriptor);
+  texture.destroy();
 });
+
+g.test('it_is_valid_to_destroy_a_destroyed_texture').fn(t => {
+  const texture = t.device.createTexture(descriptor);
+  texture.destroy();
+  texture.destroy();
+});
+
+g.test('it_is_invalid_to_submit_a_destroyed_texture_before_and_after_encode')
+  .params([
+    { destroyBeforeEncode: false, destroyAfterEncode: false, _success: true },
+    { destroyBeforeEncode: true, destroyAfterEncode: false, _success: false },
+    { destroyBeforeEncode: false, destroyAfterEncode: true, _success: false },
+  ])
+  .fn(async t => {
+    const { destroyBeforeEncode, destroyAfterEncode, _success } = t.params;
+
+    const texture = t.device.createTexture(descriptor);
+    const textureView = texture.createView();
+
+    if (destroyBeforeEncode) {
+      texture.destroy();
+    }
+
+    const commandEncoder = t.device.createCommandEncoder();
+    const renderPass = commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          attachment: textureView,
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        },
+      ],
+    });
+    renderPass.endPass();
+    const commandBuffer = commandEncoder.finish();
+
+    if (destroyAfterEncode) {
+      texture.destroy();
+    }
+
+    t.expectValidationError(() => {
+      t.queue.submit([commandBuffer]);
+    }, !_success);
+  });

--- a/src/webgpu/api/validation/texture/destroy.spec.ts
+++ b/src/webgpu/api/validation/texture/destroy.spec.ts
@@ -3,29 +3,29 @@ Destroying a texture more than once is allowed.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { GPUConst } from '../../../constants.js';
 import { ValidationTest } from '../validation_test.js';
-
-const descriptor: GPUTextureDescriptor = {
-  size: [1, 1, 1],
-  format: 'rgba8unorm',
-  usage: GPUConst.TextureUsage.RENDER_ATTACHMENT | GPUConst.TextureUsage.SAMPLED,
-};
 
 export const g = makeTestGroup(ValidationTest);
 
-g.test('it_is_valid_to_destroy_a_texture').fn(t => {
-  const texture = t.device.createTexture(descriptor);
-  texture.destroy();
-});
+g.test('base')
+  .desc(`Test that it is valid to destroy a texture.`)
+  .fn(t => {
+    const texture = t.getSampledTexture();
+    texture.destroy();
+  });
 
-g.test('it_is_valid_to_destroy_a_destroyed_texture').fn(t => {
-  const texture = t.device.createTexture(descriptor);
-  texture.destroy();
-  texture.destroy();
-});
+g.test('twice')
+  .desc(`Test that it is valid to destroy a destroyed texture.`)
+  .fn(t => {
+    const texture = t.getSampledTexture();
+    texture.destroy();
+    texture.destroy();
+  });
 
-g.test('it_is_invalid_to_submit_a_destroyed_texture_before_and_after_encode')
+g.test('submit_a_destroyed_texture')
+  .desc(
+    `Test that it is invalid to submit a destroyed texture before or after command encoder is finished.`
+  )
   .params([
     { destroyBeforeEncode: false, destroyAfterEncode: false, _success: true },
     { destroyBeforeEncode: true, destroyAfterEncode: false, _success: false },
@@ -34,7 +34,7 @@ g.test('it_is_invalid_to_submit_a_destroyed_texture_before_and_after_encode')
   .fn(async t => {
     const { destroyBeforeEncode, destroyAfterEncode, _success } = t.params;
 
-    const texture = t.device.createTexture(descriptor);
+    const texture = t.getRenderTexture();
     const textureView = texture.createView();
 
     if (destroyBeforeEncode) {

--- a/src/webgpu/api/validation/texture/destroy.spec.ts
+++ b/src/webgpu/api/validation/texture/destroy.spec.ts
@@ -24,7 +24,7 @@ g.test('twice')
 
 g.test('submit_a_destroyed_texture')
   .desc(
-    `Test that it is invalid to submit a destroyed texture before or after command encoder is finished.`
+    `Test that it is invalid to submit with a texture that was destroyed {before, after} encoding finishes.`
   )
   .params([
     { destroyBeforeEncode: false, destroyAfterEncode: false, _success: true },

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -151,6 +151,14 @@ export class ValidationTest extends GPUTest {
     });
   }
 
+  getRenderTexture(): GPUTexture {
+    return this.device.createTexture({
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+  }
+
   getErrorTexture(): GPUTexture {
     this.device.pushErrorScope('validation');
     const texture = this.device.createTexture({

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -70,8 +70,8 @@ export const kBufferUsages = numericKeysOf<GPUBufferUsage>(kBufferUsageInfo);
 
 // Textures
 
-export const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
-                           ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',              'extension'] as const,
+const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',              'extension'] as const;
+export const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [            ,          true,    true,   false,     false,          ,      true,      true,                ,            1,             1,                         ] as const, {
   // 8-bit formats
   'r8unorm':               [        true,              ,        ,        ,          ,     false,          ,          ,               1],
@@ -117,20 +117,19 @@ export const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
   'rgba32float':           [        true,              ,        ,        ,          ,      true,          ,          ,              16],
 } as const);
 /* prettier-ignore */
-const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',              'extension'] as const;
 export const kSizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [        true,          true,   false,        ,          ,     false,          ,          ,                ,            1,             1,                         ] as const, {
-  'depth32float':          [        true,              ,   false,    true,     false,          ,     false,     false,               4],
-  'depth16unorm':          [        true,              ,   false,    true,     false,          ,     false,     false,               2],
-  'stencil8':              [        true,              ,        ,   false,      true,          ,     false,     false,               1],
+                           [        true,          true,   false,        ,          ,     false,     false,     false,                ,            1,             1,                         ] as const, {
+  'depth32float':          [        true,              ,        ,    true,     false,          ,          ,          ,               4],
+  'depth16unorm':          [        true,              ,        ,    true,     false,          ,          ,          ,               2],
+  'stencil8':              [        true,              ,        ,   false,      true,          ,          ,          ,               1],
 } as const);
 export const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [        true,          true,   false,        ,          ,     false,          ,          ,       undefined,            1,             1,                         ] as const, {
-  'depth24plus':           [            ,              ,        ,    true,     false,          ,     false,     false],
-  'depth24plus-stencil8':  [            ,              ,        ,    true,      true,          ,     false,     false],
+                           [        true,          true,   false,        ,          ,     false,     false,     false,       undefined,            1,             1,                         ] as const, {
+  'depth24plus':           [            ,              ,        ,    true,     false,          ,          ,          ],
+  'depth24plus-stencil8':  [            ,              ,        ,    true,      true,          ,          ,          ],
   // bytesPerBlock only makes sense on a per-aspect basis. But this table can't express that. So we put depth24unorm-stencil8 and depth32float-stencil8 to be unsized formats for now.
-  'depth24unorm-stencil8': [            ,              ,        ,    true,      true,          ,     false,     false,                ,             ,              ,  'depth24unorm-stencil8'],
-  'depth32float-stencil8': [            ,              ,        ,    true,      true,          ,     false,     false,                ,             ,              ,  'depth32float-stencil8'],
+  'depth24unorm-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,                ,             ,              ,  'depth24unorm-stencil8'],
+  'depth32float-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,                ,             ,              ,  'depth32float-stencil8'],
 } as const);
 export const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [       false,         false,    true,   false,     false,     false,      true,      true,                ,            4,             4,                         ] as const, {

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -70,8 +70,9 @@ export const kBufferUsages = numericKeysOf<GPUBufferUsage>(kBufferUsageInfo);
 
 // Textures
 
-const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',              'extension'] as const;
-export const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
+// Note that we repeat the header multiple times in order to make it easier to read.
+export const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
+                           ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',              'extension'] as const,
                            [            ,          true,    true,   false,     false,          ,      true,      true,                ,            1,             1,                         ] as const, {
   // 8-bit formats
   'r8unorm':               [        true,              ,        ,        ,          ,     false,          ,          ,               1],
@@ -117,6 +118,7 @@ export const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmt
   'rgba32float':           [        true,              ,        ,        ,          ,      true,          ,          ,              16],
 } as const);
 /* prettier-ignore */
+const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',              'extension'] as const;
 export const kSizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [        true,          true,   false,        ,          ,     false,     false,     false,                ,            1,             1,                         ] as const, {
   'depth32float':          [        true,              ,        ,    true,     false,          ,          ,          ,               4],


### PR DESCRIPTION
It includes:
  - move destroy related tests in createTexture.spec.ts to texture/destroy.spec.ts
  - remove duplicated tests in texture/destroy.spec.ts
  - remove unneeded comments in createTexture.spec.ts
  - add a few more tests about texture size in createTexture.spec.ts
  - add 'undefined' as a dimension type in tests
  - move kTexFmtInfoHeader to the top in capability_info.js
  - set and use default values in TextureFormatInfo if we can in capability_info.js



-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [ ] WebGPU readability
- [ ] TypeScript readability
