### PR TITLE
Make reftests work with dev server, add npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "fix": "grunt fix",
     "unittest": "grunt unittest",
     "gen_wpt_cts_html": "node tools/gen_wpt_cts_html",
+    "start": "node tools/dev_server",
     "dev": "node tools/dev_server"
   },
   "engines": {

--- a/src/common/tools/dev_server.ts
+++ b/src/common/tools/dev_server.ts
@@ -95,6 +95,8 @@ app.use(morgan('dev'));
 
 // Serve the standalone runner directory
 app.use('/standalone', express.static(path.resolve(srcDir, '../standalone')));
+// Add out-wpt/ build dir for convenience
+app.use('/out-wpt', express.static(path.resolve(srcDir, '../out-wpt')));
 
 // Serve a suite's listing.js file by crawling the filesystem for all tests.
 app.get('/out/:suite/listing.js', async (req, res, next) => {
@@ -165,3 +167,6 @@ portfinder.getPort({ host, port }, (err, port) => {
     });
   });
 });
+
+// Serve everything else (not .js) as static, and directories as directory listings.
+app.use('/out', express.static(path.resolve(srcDir, '../src')));


### PR DESCRIPTION
For anything in `out/**/*` other than `out/**/*.js`, serve it statically
from the `src/` directory. This makes reftests "work" by serving up their
html but still relying on the automatic compilation of their typescript.
(You can view the reftest html files but have to manually compare their results.)

Also adds 'start' script which makes `npm start` work.



-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
