### PR TITLE
Add a tool to verify tracking spreadsheet

### DIFF
--- a/src/common/framework/file_loader.ts
+++ b/src/common/framework/file_loader.ts
@@ -3,6 +3,7 @@ import { TestQuery } from './query/query.js';
 import { IterableTestGroup } from './test_group.js';
 import { TestSuiteListing } from './test_suite_listing.js';
 import { loadTreeForQuery, TestTree, TestTreeLeaf } from './tree.js';
+import { assert } from './util/util.js';
 
 // A listing file, e.g. either of:
 // - `src/webgpu/listing.ts` (which is dynamically computed, has a Promise<TestSuiteListing>)
@@ -30,7 +31,11 @@ export abstract class TestFileLoader {
     return loadTreeForQuery(
       this,
       query,
-      subqueriesToExpand.map(q => parseQuery(q))
+      subqueriesToExpand.map(s => {
+        const q = parseQuery(s);
+        assert(q.level >= 2, () => `subqueriesToExpand entries should not be multi-file:\n  ${q}`);
+        return q;
+      })
     );
   }
 

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -70,8 +70,8 @@ export class TestTree {
     this.root = root;
   }
 
-  iterateCollapsedQueries(): IterableIterator<TestQuery> {
-    return TestTree.iterateSubtreeCollapsedQueries(this.root);
+  iterateCollapsedQueries(includeEmptySubtrees: boolean): IterableIterator<TestQuery> {
+    return TestTree.iterateSubtreeCollapsedQueries(this.root, includeEmptySubtrees);
   }
 
   iterateLeaves(): IterableIterator<TestTreeLeaf> {
@@ -95,14 +95,17 @@ export class TestTree {
     return TestTree.subtreeToString('(root)', this.root, '');
   }
 
-  static *iterateSubtreeCollapsedQueries(subtree: TestSubtree): IterableIterator<TestQuery> {
+  static *iterateSubtreeCollapsedQueries(
+    subtree: TestSubtree,
+    includeEmptySubtrees: boolean
+  ): IterableIterator<TestQuery> {
     for (const [, child] of subtree.children) {
       if ('children' in child) {
         // Is a subtree
-        if (!child.collapsible) {
-          yield* TestTree.iterateSubtreeCollapsedQueries(child);
-        } else if (child.children.size) {
-          // Don't yield empty subtrees (e.g. files with no tests)
+        if (child.children.size > 0 && !child.collapsible) {
+          yield* TestTree.iterateSubtreeCollapsedQueries(child, includeEmptySubtrees);
+        } else if (child.children.size > 0 || includeEmptySubtrees) {
+          // Don't yield empty subtrees (e.g. files with no tests) unless includeEmptySubtrees
           yield child.query;
         }
       } else {

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -258,8 +258,8 @@ export async function loadTreeForQuery(
     const subquerySeen = seenSubqueriesToExpand[i];
     if (!subquerySeen) {
       throw new StacklessError(
-        `subqueriesToExpand entry did not match anything (can happen if the subquery was larger \
-than one file, or due to overlap with another subquery):\n  ${sq.toString()}`
+        `subqueriesToExpand entry did not match anything \
+(could be wrong, or could be redundant with a previous subquery):\n  ${sq.toString()}`
       );
     }
   }

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -192,6 +192,9 @@ export async function loadTreeForQuery(
       // Entry is a README that is an ancestor or descendant of the query.
       // (It's included for display in the standalone runner.)
 
+      // Mark any applicable subqueriesToExpand as seen.
+      isCollapsible(new TestQueryMultiFile(suite, entry.file));
+
       // readmeSubtree is suite:a,b,*
       // (This is always going to dedup with a file path, if there are any test spec files under
       // the directory that has the README).

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -12,7 +12,7 @@ import {
 import { kBigSeparator, kWildcard, kPathSeparator, kParamSeparator } from './query/separators.js';
 import { stringifySingleParam } from './query/stringify_params.js';
 import { RunCase, RunFn } from './test_group.js';
-import { assert } from './util/util.js';
+import { assert, StacklessError } from './util/util.js';
 
 // `loadTreeForQuery()` loads a TestTree for a given queryToLoad.
 // The resulting tree is a linked-list all the way from `suite:*` to queryToLoad,
@@ -252,12 +252,13 @@ export async function loadTreeForQuery(
   }
 
   for (const [i, sq] of subqueriesToExpandEntries) {
-    const seen = seenSubqueriesToExpand[i];
-    assert(
-      seen,
-      `subqueriesToExpand entry did not match anything (can happen if the subquery was larger \
-than one file, or due to overlap with another subquery): ${sq.toString()}`
-    );
+    const subquerySeen = seenSubqueriesToExpand[i];
+    if (!subquerySeen) {
+      throw new StacklessError(
+        `subqueriesToExpand entry did not match anything (can happen if the subquery was larger \
+than one file, or due to overlap with another subquery):\n  ${sq.toString()}`
+      );
+    }
   }
   assert(foundCase, 'Query does not match any cases');
 

--- a/src/common/framework/util/util.ts
+++ b/src/common/framework/util/util.ts
@@ -1,5 +1,16 @@
 import { timeout } from './timeout.js';
 
+/**
+ * Error without a stack, which can be used to fatally exit from `tool/` scripts with a
+ * user-friendly message (and no confusing stack).
+ */
+export class StacklessError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.stack = undefined;
+  }
+}
+
 export function assert(condition: boolean, msg?: string | (() => string)): asserts condition {
   if (!condition) {
     throw new Error(msg && (typeof msg === 'string' ? msg : msg()));

--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -51,90 +51,88 @@ if (queries.length === 0) {
 }
 
 (async () => {
-  try {
-    const loader = new DefaultTestFileLoader();
-    assert(queries.length === 1, 'currently, there must be exactly one query on the cmd line');
-    const testcases = await loader.loadCases(parseQuery(queries[0]));
+  const loader = new DefaultTestFileLoader();
+  assert(queries.length === 1, 'currently, there must be exactly one query on the cmd line');
+  const testcases = await loader.loadCases(parseQuery(queries[0]));
 
-    const log = new Logger(debug);
+  const log = new Logger(debug);
 
-    const failed: Array<[string, LiveTestCaseResult]> = [];
-    const warned: Array<[string, LiveTestCaseResult]> = [];
-    const skipped: Array<[string, LiveTestCaseResult]> = [];
+  const failed: Array<[string, LiveTestCaseResult]> = [];
+  const warned: Array<[string, LiveTestCaseResult]> = [];
+  const skipped: Array<[string, LiveTestCaseResult]> = [];
 
-    let total = 0;
+  let total = 0;
 
-    for (const testcase of testcases) {
-      const name = testcase.query.toString();
-      const [rec, res] = log.record(name);
-      await testcase.run(rec);
+  for (const testcase of testcases) {
+    const name = testcase.query.toString();
+    const [rec, res] = log.record(name);
+    await testcase.run(rec);
 
-      if (verbose) {
-        printResults([[name, res]]);
-      }
-
-      total++;
-      switch (res.status) {
-        case 'pass':
-          break;
-        case 'fail':
-          failed.push([name, res]);
-          break;
-        case 'warn':
-          warned.push([name, res]);
-          break;
-        case 'skip':
-          skipped.push([name, res]);
-          break;
-        default:
-          unreachable('unrecognized status');
-      }
+    if (verbose) {
+      printResults([[name, res]]);
     }
 
-    assert(total > 0, 'found no tests!');
+    total++;
+    switch (res.status) {
+      case 'pass':
+        break;
+      case 'fail':
+        failed.push([name, res]);
+        break;
+      case 'warn':
+        warned.push([name, res]);
+        break;
+      case 'skip':
+        skipped.push([name, res]);
+        break;
+      default:
+        unreachable('unrecognized status');
+    }
+  }
 
-    // TODO: write results out somewhere (a file?)
-    if (printJSON) {
-      console.log(log.asJSON(2));
-    }
+  assert(total > 0, 'found no tests!');
 
-    if (skipped.length) {
-      console.log('');
-      console.log('** Skipped **');
-      printResults(skipped);
-    }
-    if (warned.length) {
-      console.log('');
-      console.log('** Warnings **');
-      printResults(warned);
-    }
-    if (failed.length) {
-      console.log('');
-      console.log('** Failures **');
-      printResults(failed);
-    }
+  // TODO: write results out somewhere (a file?)
+  if (printJSON) {
+    console.log(log.asJSON(2));
+  }
 
-    const passed = total - warned.length - failed.length - skipped.length;
-    const pct = (x: number) => ((100 * x) / total).toFixed(2);
-    const rpt = (x: number) => {
-      const xs = x.toString().padStart(1 + Math.log10(total), ' ');
-      return `${xs} / ${total} = ${pct(x).padStart(6, ' ')}%`;
-    };
+  if (skipped.length) {
     console.log('');
-    console.log(`** Summary **
+    console.log('** Skipped **');
+    printResults(skipped);
+  }
+  if (warned.length) {
+    console.log('');
+    console.log('** Warnings **');
+    printResults(warned);
+  }
+  if (failed.length) {
+    console.log('');
+    console.log('** Failures **');
+    printResults(failed);
+  }
+
+  const passed = total - warned.length - failed.length - skipped.length;
+  const pct = (x: number) => ((100 * x) / total).toFixed(2);
+  const rpt = (x: number) => {
+    const xs = x.toString().padStart(1 + Math.log10(total), ' ');
+    return `${xs} / ${total} = ${pct(x).padStart(6, ' ')}%`;
+  };
+  console.log('');
+  console.log(`** Summary **
 Passed  w/o warnings = ${rpt(passed)}
 Passed with warnings = ${rpt(warned.length)}
 Skipped              = ${rpt(skipped.length)}
 Failed               = ${rpt(failed.length)}`);
 
-    if (failed.length || warned.length) {
-      process.exit(1);
-    }
-  } catch (ex) {
-    console.log(ex);
+  if (failed.length || warned.length) {
     process.exit(1);
   }
-})();
+})().catch(ex => {
+  console.log(ex.stack ?? ex.toString());
+  process.exit(1);
+});
 
 function printResults(results: Array<[string, LiveTestCaseResult]>): void {
   for (const [name, r] of results) {

--- a/src/common/tools/checklist.ts
+++ b/src/common/tools/checklist.ts
@@ -1,0 +1,101 @@
+import * as fs from 'fs';
+import * as process from 'process';
+
+import { DefaultTestFileLoader } from '../framework/file_loader.js';
+import { Ordering, compareQueries } from '../framework/query/compare.js';
+import { parseQuery } from '../framework/query/parseQuery.js';
+import { TestQuery, TestQueryMultiFile } from '../framework/query/query.js';
+import { loadTreeForQuery, TestTree } from '../framework/tree.js';
+import { assert, StacklessError } from '../framework/util/util.js';
+
+function usage(rc: number): void {
+  console.error('Usage:');
+  console.error('  tools/checklist FILE');
+  console.error('  tools/checklist my/list.txt');
+  process.exit(rc);
+}
+
+if (process.argv.length === 2) usage(0);
+if (process.argv.length !== 3) usage(1);
+
+type QueriesBySuite = Map<string, TestQuery[]>;
+async function loadQueryListFromTextFile(filename: string): Promise<QueriesBySuite> {
+  const lines = (await fs.promises.readFile(filename, 'utf8')).split('\n');
+  const allQueries = lines.filter(l => l).map(l => parseQuery(l.trim()));
+
+  const queriesBySuite: QueriesBySuite = new Map();
+  for (const query of allQueries) {
+    let suiteQueries = queriesBySuite.get(query.suite);
+    if (suiteQueries === undefined) {
+      suiteQueries = [];
+      queriesBySuite.set(query.suite, suiteQueries);
+    }
+
+    suiteQueries.push(query);
+  }
+
+  return queriesBySuite;
+}
+
+function checkForOverlappingQueries(queries: TestQuery[]): void {
+  for (const q1 of queries) {
+    for (const q2 of queries) {
+      if (q1 !== q2 && compareQueries(q1, q2) !== Ordering.Unordered) {
+        throw new StacklessError(`The following checklist items overlap:\n    ${q1}\n    ${q2}`);
+      }
+    }
+  }
+}
+
+function checkForUnmatchedSubtrees(tree: TestTree, matchQueries: TestQuery[]): number {
+  let subtreeCount = 0;
+  const unmatchedSubtrees: TestQuery[] = [];
+  const overbroadMatches: [TestQuery, TestQuery][] = [];
+  for (const collapsedSubtree of tree.iterateCollapsedQueries(true)) {
+    subtreeCount++;
+    let subtreeMatched = false;
+    for (const q of matchQueries) {
+      const comparison = compareQueries(q, collapsedSubtree);
+      assert(comparison !== Ordering.StrictSubset); // shouldn't happen, due to subqueriesToExpand
+      if (comparison === Ordering.StrictSuperset) overbroadMatches.push([q, collapsedSubtree]);
+      if (comparison !== Ordering.Unordered) subtreeMatched = true;
+    }
+    if (!subtreeMatched) unmatchedSubtrees.push(collapsedSubtree);
+  }
+
+  if (overbroadMatches.length) {
+    // (note, this doesn't show ALL multi-test queries - just ones that actually match any .spec.ts)
+    console.log(`  FYI, the following checklist items were broader than one file:`);
+    for (const [q, collapsedSubtree] of overbroadMatches) {
+      console.log(`    ${q}  >  ${collapsedSubtree}`);
+    }
+  }
+
+  if (unmatchedSubtrees.length) {
+    throw new StacklessError(`Found unmatched tests:\n    ${unmatchedSubtrees.join('\n    ')}`);
+  }
+  return subtreeCount;
+}
+
+(async () => {
+  console.log('Loading queries...');
+  const queriesBySuite = await loadQueryListFromTextFile(process.argv[2]);
+  console.log('  Found suites: ' + Array.from(queriesBySuite.keys()).join(' '));
+
+  const loader = new DefaultTestFileLoader();
+  for (const [suite, queriesInSuite] of queriesBySuite.entries()) {
+    console.log(`Suite "${suite}":`);
+    console.log(`  Checking overlaps between ${queriesInSuite.length} checklist items...`);
+    checkForOverlappingQueries(queriesInSuite);
+    const suiteQuery = new TestQueryMultiFile(suite, []);
+    console.log(`  Loading tree ${suiteQuery}...`);
+    const tree = await loadTreeForQuery(loader, suiteQuery, queriesInSuite);
+    console.log('  Found no invalid queries in the checklist. Checking for unmatched tests...');
+    const subtreeCount = checkForUnmatchedSubtrees(tree, queriesInSuite);
+    console.log(`  No unmatched tests among ${subtreeCount} subtrees!`);
+  }
+  console.log(`Checklist looks good!`);
+})().catch(ex => {
+  console.log(ex.stack ?? ex.toString());
+  process.exit(1);
+});

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -101,7 +101,10 @@ Try broadening suppressions to avoid long test variant names. ' +
     }
     await generateFile(lines);
   }
-})();
+})().catch(ex => {
+  console.log(ex.stack ?? ex.toString());
+  process.exit(1);
+});
 
 async function generateFile(lines: Array<string | undefined>): Promise<void> {
   let result = '';

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -85,7 +85,7 @@ const [
       const tree = await loader.loadTree(rootQuery, expectations.get(prefix)!);
 
       lines.push(undefined); // output blank line between prefixes
-      for (const q of tree.iterateCollapsedQueries()) {
+      for (const q of tree.iterateCollapsedQueries(false)) {
         const urlQueryString = prefix + q.toString(); // "?worker=0&q=..."
         // Check for a safe-ish path length limit. Filename must be <= 255, and on Windows the whole
         // path must be <= 259. Leave room for e.g.:

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -276,11 +276,6 @@ g.test('iterateCollapsed').fn(async t => {
   await testIterateCollapsed(t, [], ['suite1:foo:*', 'suite1:bar,buzz,buzz:*', 'suite1:baz:*']);
   await testIterateCollapsed(
     t,
-    ['suite1:*'],
-    ['suite1:foo:*', 'suite1:bar,buzz,buzz:*', 'suite1:baz:*']
-  );
-  await testIterateCollapsed(
-    t,
     ['suite1:foo:*'],
     ['suite1:foo:*', 'suite1:bar,buzz,buzz:*', 'suite1:baz:*']
   );
@@ -365,5 +360,6 @@ g.test('iterateCollapsed').fn(async t => {
   await testIterateCollapsed(t, ['suite1:doesntexist:*'], 'throws');
   await testIterateCollapsed(t, ['suite2:foo:*'], 'throws');
   // Can't expand subqueries bigger than one suite.
+  await testIterateCollapsed(t, ['suite1:*'], 'throws');
   await testIterateCollapsed(t, ['suite1:bar,*'], 'throws');
 });

--- a/tools/checklist
+++ b/tools/checklist
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+// Takes a list of queries and checks that:
+//   - Every query matches something in the repository
+//   - Every case in the repository matches exactly one query
+// This is used to ensure that tracking spreadsheet is complete (not missing any tests)
+// and every query in it is valid (e.g. renames have been applied, and new tests added
+// to the spreadsheet have also been added to the CTS).
+
+require('../src/common/tools/setup-ts-in-node.js');
+require('../src/common/tools/checklist.ts');


### PR DESCRIPTION
Ensures that a list of queries, from the work-tracking spreadsheet, is
comprehensive and up-to-date with the actual tests.

Example outputs:

```
Loading queries...
  Found suites: webgpu
Suite "webgpu":
  Checking overlaps between 194 checklist items...
Error: The following checklist items overlap:
    webgpu:api,operation,buffers,map_detach:*
    webgpu:api,operation,buffers,map_detach:create_mapped:*
```

```
Loading queries...
  Found suites: webgpu
Suite "webgpu":
  Checking overlaps between 193 checklist items...
  Loading tree webgpu:*...
Error: subqueriesToExpand entry did not match anything (could be wrong, or could be redundant with a previous subquery):
  webgpu:api,operation,buffers,thhhreading:*
```

```
Loading queries...
  Found suites: webgpu
Suite "webgpu":
  Checking overlaps between 193 checklist items...
  Loading tree webgpu:*...
  Found no invalid queries in the checklist. Checking for unmatched tests...
  FYI, the following checklist items (if any) supersetted some files:
    webgpu:api,validation,capability_checks,features,*  >  webgpu:api,validation,capability_checks,features,queries:*
    webgpu:shader,*  >  webgpu:shader,execution,robust_access_vertex:*
    webgpu:shader,*  >  webgpu:shader,regression,*
    webgpu:shader,*  >  webgpu:shader,validation,variable_and_const:*
    webgpu:shader,*  >  webgpu:shader,validation,wgsl,basic:*
  No unmatched tests among 196 subtrees!
Success!
```

-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
