### PR TITLE
Updating CTS tests to use the new RenderPipelineDescriptor layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/morgan": "^1.9.2",
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
-    "@webgpu/types": "0.0.43",
+    "@webgpu/types": "0.0.44",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",
     "chokidar": "^3.4.3",

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -117,7 +117,7 @@ export class BufferSyncTest extends GPUTest {
         entryPoint: 'frag_main',
         targets: [{ format: 'rgba8unorm' }],
       },
-      primitive: { topology: 'point-list', }
+      primitive: { topology: 'point-list' },
     });
   }
 

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -104,20 +104,20 @@ export class BufferSyncTest extends GPUTest {
     };
 
     return this.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: this.device.createShaderModule({
           code: wgslShaders.vertex,
         }),
         entryPoint: 'vert_main',
       },
-      fragmentStage: {
+      fragment: {
         module: this.device.createShaderModule({
           code: wgslShaders.fragment,
         }),
         entryPoint: 'frag_main',
+        targets: [{ format: 'rgba8unorm' }],
       },
-      primitiveTopology: 'point-list',
-      colorStates: [{ format: 'rgba8unorm' }],
+      primitive: { topology: 'point-list', }
     });
   }
 

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -38,9 +38,9 @@ g.test('render_pass_resolve')
       .combine(poptions('resolveTargetBaseArrayLayer', [0, 1] as const))
   )
   .fn(t => {
-    const colorStateDescriptors: GPUColorStateDescriptor[] = [];
+    const targets: GPUColorTargetState[] = [];
     for (let i = 0; i < t.params.numColorAttachments; i++) {
-      colorStateDescriptors.push({ format: kFormat });
+      targets.push({ format: kFormat });
     }
 
     // These shaders will draw a white triangle into a texture. After draw, the top left
@@ -49,7 +49,7 @@ g.test('render_pass_resolve')
     // well as a line between the portions that contain the midpoint color due to the multisample
     // resolve.
     const pipeline = t.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: t.device.createShaderModule({
           code: `
             [[builtin(position)]] var<out> Position : vec4<f32>;
@@ -66,7 +66,7 @@ g.test('render_pass_resolve')
         }),
         entryPoint: 'main',
       },
-      fragmentStage: {
+      fragment: {
         module: t.device.createShaderModule({
           code: `
             [[location(0)]] var<out> fragColor0 : vec4<f32>;
@@ -83,10 +83,10 @@ g.test('render_pass_resolve')
             }`,
         }),
         entryPoint: 'main',
+        targets,
       },
-      primitiveTopology: 'triangle-list',
-      colorStates: colorStateDescriptors,
-      sampleCount: 4,
+      primitive: { topology: 'triangle-list', },
+      multisample: { count: 4, },
     });
 
     const resolveTargets: GPUTexture[] = [];

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -85,8 +85,8 @@ g.test('render_pass_resolve')
         entryPoint: 'main',
         targets,
       },
-      primitive: { topology: 'triangle-list', },
-      multisample: { count: 4, },
+      primitive: { topology: 'triangle-list' },
+      multisample: { count: 4 },
     });
 
     const resolveTargets: GPUTexture[] = [];

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -54,7 +54,7 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
         entryPoint: 'main',
         targets: [{ format: 'r8unorm' }],
       },
-      primitive: { topology: 'triangle-list', },
+      primitive: { topology: 'triangle-list' },
     });
 
     // encode pass and submit

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -23,7 +23,7 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
 
     // create render pipeline
     const renderPipeline = t.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: t.device.createShaderModule({
           code: `
             [[builtin(position)]] var<out> Position : vec4<f32>;
@@ -41,7 +41,7 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
         }),
         entryPoint: 'main',
       },
-      fragmentStage: {
+      fragment: {
         module: t.device.createShaderModule({
           code: `
             [[location(0)]] var<out> fragColor : vec4<f32>;
@@ -52,9 +52,9 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
             `,
         }),
         entryPoint: 'main',
+        targets: [{ format: 'r8unorm' }],
       },
-      primitiveTopology: 'triangle-list',
-      colorStates: [{ format: 'r8unorm' }],
+      primitive: { topology: 'triangle-list', },
     });
 
     // encode pass and submit

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -98,7 +98,7 @@ g.test('culling')
     // 2. The bottom-right one is clockwise (CW)
     pass.setPipeline(
       t.device.createRenderPipeline({
-        vertexStage: {
+        vertex: {
           module: t.device.createShaderModule({
             code: `
               [[builtin(position)]] var<out> Position : vec4<f32>;
@@ -118,7 +118,7 @@ g.test('culling')
           }),
           entryPoint: 'main',
         },
-        fragmentStage: {
+        fragment: {
           module: t.device.createShaderModule({
             code: `
               [[location(0)]] var<out> fragColor : vec4<f32>;
@@ -134,14 +134,14 @@ g.test('culling')
               }`,
           }),
           entryPoint: 'main',
+          targets: [{ format }],
         },
-        primitiveTopology: t.params.primitiveTopology,
-        rasterizationState: {
+        primitive: {
+          topology: t.params.primitiveTopology,
           frontFace: t.params.frontFace,
           cullMode: t.params.cullMode,
         },
-        colorStates: [{ format }],
-        depthStencilState: depthTexture
+        depthStencil: depthTexture
           ? { format: t.params.depthStencilFormat as GPUTextureFormat }
           : undefined,
       })

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -222,7 +222,7 @@ class PrimitiveTopologyTest extends GPUTest {
   }
 
   run(
-    primitiveTopology: GPUPrimitiveTopology,
+    topology: GPUPrimitiveTopology,
     testLocations: TestLocation[],
     usePrimitiveRestart: boolean
   ): void {
@@ -239,9 +239,9 @@ class PrimitiveTopologyTest extends GPUTest {
       ],
     });
 
-    let indexFormat = undefined;
-    if (primitiveTopology === 'triangle-strip' || primitiveTopology === 'line-strip') {
-      indexFormat = 'uint32' as const;
+    let stripIndexFormat = undefined;
+    if (topology === 'triangle-strip' || topology === 'line-strip') {
+      stripIndexFormat = 'uint32' as const;
     }
 
     // Draw a primitive using 6 vertices based on the type.
@@ -251,7 +251,7 @@ class PrimitiveTopologyTest extends GPUTest {
     // Output color is solid green.
     renderPass.setPipeline(
       this.device.createRenderPipeline({
-        vertexStage: {
+        vertex: {
           module: this.device.createShaderModule({
             code: `
               [[location(0)]] var<in> pos : vec4<f32>;
@@ -263,23 +263,7 @@ class PrimitiveTopologyTest extends GPUTest {
               }`,
           }),
           entryPoint: 'main',
-        },
-        fragmentStage: {
-          module: this.device.createShaderModule({
-            code: `
-              [[location(0)]] var<out> fragColor : vec4<f32>;
-              [[stage(fragment)]] fn main() -> void {
-                fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
-                return;
-              }`,
-          }),
-          entryPoint: 'main',
-        },
-        primitiveTopology,
-        colorStates: [{ format: kColorFormat }],
-        vertexState: {
-          indexFormat,
-          vertexBuffers: [
+          buffers: [
             {
               arrayStride: 4 * Float32Array.BYTES_PER_ELEMENT,
               attributes: [
@@ -291,6 +275,22 @@ class PrimitiveTopologyTest extends GPUTest {
               ],
             },
           ],
+        },
+        fragment: {
+          module: this.device.createShaderModule({
+            code: `
+              [[location(0)]] var<out> fragColor : vec4<f32>;
+              [[stage(fragment)]] fn main() -> void {
+                fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+                return;
+              }`,
+          }),
+          entryPoint: 'main',
+          targets: [{ format: kColorFormat }],
+        },
+        primitive: {
+          topology,
+          stripIndexFormat,
         },
       })
     );

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -55,7 +55,7 @@ g.test('fullscreen_quad').fn(async t => {
   const colorAttachmentView = colorAttachment.createView();
 
   const pipeline = t.device.createRenderPipeline({
-    vertexStage: {
+    vertex: {
       module: t.device.createShaderModule({
         code: `
           [[builtin(position)]] var<out> Position : vec4<f32>;
@@ -73,7 +73,7 @@ g.test('fullscreen_quad').fn(async t => {
       }),
       entryPoint: 'main',
     },
-    fragmentStage: {
+    fragment: {
       module: t.device.createShaderModule({
         code: `
           [[location(0)]] var<out> fragColor : vec4<f32>;
@@ -84,9 +84,9 @@ g.test('fullscreen_quad').fn(async t => {
           `,
       }),
       entryPoint: 'main',
+      targets: [{ format: 'rgba8unorm' }],
     },
-    primitiveTopology: 'triangle-list',
-    colorStates: [{ format: 'rgba8unorm' }],
+    primitive: { topology: 'triangle-list', },
   });
 
   const encoder = t.device.createCommandEncoder();

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -86,7 +86,7 @@ g.test('fullscreen_quad').fn(async t => {
       entryPoint: 'main',
       targets: [{ format: 'rgba8unorm' }],
     },
-    primitive: { topology: 'triangle-list', },
+    primitive: { topology: 'triangle-list' },
   });
 
   const encoder = t.device.createCommandEncoder();

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -54,8 +54,8 @@ function getDepthTestEqualPipeline(
       format,
       depthCompare: 'equal',
     },
-    primitive: { topology: 'triangle-list', },
-    multisample: { count: sampleCount, },
+    primitive: { topology: 'triangle-list' },
+    multisample: { count: sampleCount },
   });
 }
 
@@ -89,8 +89,8 @@ function getStencilTestEqualPipeline(
       stencilFront: { compare: 'equal' },
       stencilBack: { compare: 'equal' },
     },
-    primitive: { topology: 'triangle-list', },
-    multisample: { count: sampleCount, },
+    primitive: { topology: 'triangle-list' },
+    multisample: { count: sampleCount },
   });
 }
 

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -82,11 +82,7 @@ function getStencilTestEqualPipeline(
         }
         `,
       }),
-      targets: [
-        {
-          format: 'r8unorm',
-        },
-      ],
+      targets: [{ format: 'r8unorm' }],
     },
     depthStencil: {
       format,

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -29,11 +29,11 @@ function getDepthTestEqualPipeline(
   expected: number
 ): GPURenderPipeline {
   return t.device.createRenderPipeline({
-    vertexStage: {
+    vertex: {
       entryPoint: 'main',
       module: makeFullscreenVertexModule(t.device),
     },
-    fragmentStage: {
+    fragment: {
       entryPoint: 'main',
       module: t.device.createShaderModule({
         code: `
@@ -48,14 +48,14 @@ function getDepthTestEqualPipeline(
         }
         `,
       }),
+      targets: [{ format: 'r8unorm' }],
     },
-    colorStates: [{ format: 'r8unorm' }],
-    depthStencilState: {
+    depthStencil: {
       format,
       depthCompare: 'equal',
     },
-    primitiveTopology: 'triangle-list',
-    sampleCount,
+    primitive: { topology: 'triangle-list', },
+    multisample: { count: sampleCount, },
   });
 }
 
@@ -65,11 +65,11 @@ function getStencilTestEqualPipeline(
   sampleCount: number
 ): GPURenderPipeline {
   return t.device.createRenderPipeline({
-    vertexStage: {
+    vertex: {
       entryPoint: 'main',
       module: makeFullscreenVertexModule(t.device),
     },
-    fragmentStage: {
+    fragment: {
       entryPoint: 'main',
       module: t.device.createShaderModule({
         code: `
@@ -82,19 +82,19 @@ function getStencilTestEqualPipeline(
         }
         `,
       }),
+      targets: [
+        {
+          format: 'r8unorm',
+        },
+      ],
     },
-    colorStates: [
-      {
-        format: 'r8unorm',
-      },
-    ],
-    depthStencilState: {
+    depthStencil: {
       format,
       stencilFront: { compare: 'equal' },
       stencilBack: { compare: 'equal' },
     },
-    primitiveTopology: 'triangle-list',
-    sampleCount,
+    primitive: { topology: 'triangle-list', },
+    multisample: { count: sampleCount, },
   });
 }
 

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -54,7 +54,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
     await super.init();
 
     this.pipeline = this.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: this.device.createShaderModule({
           code: `
             [[builtin(vertex_index)]] var<in> VertexIndex : i32;
@@ -91,7 +91,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
         }),
         entryPoint: 'main',
       },
-      fragmentStage: {
+      fragment: {
         module: this.device.createShaderModule({
           code: `
             [[set(0), binding(0)]] var sampler0 : sampler;
@@ -109,9 +109,9 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
             `,
         }),
         entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
       },
-      primitiveTopology: 'triangle-list',
-      colorStates: [{ format: 'rgba8unorm' }],
+      primitive: { topology: 'triangle-list', },
     });
   }
 

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -111,7 +111,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm' }],
       },
-      primitive: { topology: 'triangle-list', },
+      primitive: { topology: 'triangle-list' },
     });
   }
 

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -51,8 +51,8 @@ const { byteLength, bytesPerRow, rowsPerImage } = getTextureCopyLayout(kTextureF
 
 class IndexFormatTest extends GPUTest {
   MakeRenderPipeline(
-    primitiveTopology: GPUPrimitiveTopology,
-    indexFormat?: GPUIndexFormat
+    topology: GPUPrimitiveTopology,
+    stripIndexFormat?: GPUIndexFormat
   ): GPURenderPipeline {
     const vertexModule = this.device.createShaderModule({
       // TODO?: These positions will create triangles that cut right through pixel centers. If this
@@ -91,12 +91,15 @@ class IndexFormatTest extends GPUTest {
 
     return this.device.createRenderPipeline({
       layout: this.device.createPipelineLayout({ bindGroupLayouts: [] }),
-      vertexStage: { module: vertexModule, entryPoint: 'main' },
-      fragmentStage: { module: fragmentModule, entryPoint: 'main' },
-      primitiveTopology,
-      colorStates: [{ format: kTextureFormat }],
-      vertexState: {
-        indexFormat,
+      vertex: { module: vertexModule, entryPoint: 'main' },
+      fragment: {
+        module: fragmentModule,
+        entryPoint: 'main',
+        targets: [{ format: kTextureFormat }],
+      },
+      primitive: {
+        topology,
+        stripIndexFormat,
       },
     });
   }

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -107,12 +107,12 @@ class F extends ValidationTest {
   }
 
   createRenderPipeline(
-    colorStates: Iterable<GPUColorStateDescriptor>,
-    depthStencilState?: GPUDepthStencilStateDescriptor,
+    targets: Iterable<GPUColorTargetState>,
+    depthStencil?: GPUDepthStencilState,
     sampleCount?: number
   ) {
     return this.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: this.device.createShaderModule({
           code: `
             [[builtin(position)]] var<out> position : vec4<f32>;
@@ -123,16 +123,16 @@ class F extends ValidationTest {
         }),
         entryPoint: 'main',
       },
-      fragmentStage: {
+      fragment: {
         module: this.device.createShaderModule({
           code: '[[stage(fragment)]] fn main() -> void {}',
         }),
         entryPoint: 'main',
+        targets,
       },
-      primitiveTopology: 'triangle-list',
-      colorStates,
-      depthStencilState,
-      sampleCount,
+      primitive: { topology: 'triangle-list', },
+      depthStencil,
+      multisample: { count: sampleCount, }
     });
   }
 }

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -130,9 +130,9 @@ class F extends ValidationTest {
         entryPoint: 'main',
         targets,
       },
-      primitive: { topology: 'triangle-list', },
+      primitive: { topology: 'triangle-list' },
       depthStencil,
-      multisample: { count: sampleCount, }
+      multisample: { count: sampleCount },
     });
   }
 }

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -85,8 +85,8 @@ class F extends ValidationTest {
         targets,
       },
       layout: this.getPipelineLayout(),
-      primitive: { topology, },
-      multisample: { count: sampleCount, },
+      primitive: { topology },
+      multisample: { count: sampleCount },
       depthStencil,
     };
   }

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -8,12 +8,12 @@ TODO: review existing tests, write descriptions, and make sure tests are complet
 > - interface matching between vertex and fragment shader
 >     - superset, subset, etc.
 >
-> - vertexStage {valid, invalid}
-> - fragmentStage {valid, invalid}
-> - primitiveTopology all possible values
+> - vertex stage {valid, invalid}
+> - fragment stage {valid, invalid}
+> - primitive topology all possible values
 > - rasterizationState various values
-> - sampleCount {0, 1, 3, 4, 8, 16, 1024}
-> - sampleMask {0, 0xFFFFFFFF}
+> - multisample count {0, 1, 3, 4, 8, 16, 1024}
+> - multisample mask {0, 0xFFFFFFFF}
 > - alphaToCoverage:
 >     - alphaToCoverageEnabled is { true, false } and sampleCount { = 1, = 4 }.
 >       The only failing case is (true, 1).
@@ -32,21 +32,21 @@ import { ValidationTest } from './validation_test.js';
 class F extends ValidationTest {
   getDescriptor(
     options: {
-      primitiveTopology?: GPUPrimitiveTopology;
-      colorStates?: GPUColorStateDescriptor[];
+      topology?: GPUPrimitiveTopology;
+      targets?: GPUColorTargetState[];
       sampleCount?: number;
-      depthStencilState?: GPUDepthStencilStateDescriptor;
+      depthStencil?: GPUDepthStencilState;
     } = {}
   ): GPURenderPipelineDescriptor {
-    const defaultColorStates: GPUColorStateDescriptor[] = [{ format: 'rgba8unorm' }];
+    const defaultTargets: GPUColorTargetState[] = [{ format: 'rgba8unorm' }];
     const {
-      primitiveTopology = 'triangle-list',
-      colorStates = defaultColorStates,
+      topology = 'triangle-list',
+      targets = defaultTargets,
       sampleCount = 1,
-      depthStencilState,
+      depthStencil,
     } = options;
 
-    const format = colorStates.length ? colorStates[0].format : 'rgba8unorm';
+    const format = targets.length ? targets[0].format : 'rgba8unorm';
 
     let fragColorType;
     let suffix;
@@ -62,7 +62,7 @@ class F extends ValidationTest {
     }
 
     return {
-      vertexStage: {
+      vertex: {
         module: this.device.createShaderModule({
           code: `
             [[builtin(position)]] var<out> Position : vec4<f32>;
@@ -73,7 +73,7 @@ class F extends ValidationTest {
         }),
         entryPoint: 'main',
       },
-      fragmentStage: {
+      fragment: {
         module: this.device.createShaderModule({
           code: `
             [[location(0)]] var<out> fragColor : vec4<${fragColorType}>;
@@ -82,12 +82,12 @@ class F extends ValidationTest {
             }`,
         }),
         entryPoint: 'main',
+        targets,
       },
       layout: this.getPipelineLayout(),
-      primitiveTopology,
-      colorStates,
-      sampleCount,
-      depthStencilState,
+      primitive: { topology, },
+      multisample: { count: sampleCount, },
+      depthStencil,
     };
   }
 
@@ -117,7 +117,7 @@ g.test('basic_use_of_createRenderPipeline').fn(t => {
 
 g.test('at_least_one_color_state_is_required').fn(async t => {
   const goodDescriptor = t.getDescriptor({
-    colorStates: [{ format: 'rgba8unorm' }],
+    targets: [{ format: 'rgba8unorm' }],
   });
 
   // Control case
@@ -125,7 +125,7 @@ g.test('at_least_one_color_state_is_required').fn(async t => {
 
   // Fail because lack of color states
   const badDescriptor = t.getDescriptor({
-    colorStates: [],
+    targets: [],
   });
 
   t.expectValidationError(() => {
@@ -141,7 +141,7 @@ g.test('color_formats_must_be_renderable')
 
     await t.selectDeviceOrSkipTestCase(info.extension);
 
-    const descriptor = t.getDescriptor({ colorStates: [{ format }] });
+    const descriptor = t.getDescriptor({ targets: [{ format }] });
 
     if (info.renderable && info.color) {
       // Succeeds when color format is renderable
@@ -223,8 +223,8 @@ g.test('sample_count_must_be_equal_to_the_one_of_every_attachment_in_the_render_
     );
     const pipelineWithDepthStencilOnly = t.device.createRenderPipeline(
       t.getDescriptor({
-        colorStates: [],
-        depthStencilState: { format: 'depth24plus-stencil8' },
+        targets: [],
+        depthStencil: { format: 'depth24plus-stencil8' },
         sampleCount: pipelineSamples,
       })
     );

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -34,7 +34,7 @@ class F extends ValidationTest {
 
   createRenderPipeline(): GPURenderPipeline {
     return this.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: this.device.createShaderModule({
           code: `
             [[builtin(position)]] var<out> Position : vec4<f32>;
@@ -46,7 +46,7 @@ class F extends ValidationTest {
         }),
         entryPoint: 'main',
       },
-      fragmentStage: {
+      fragment: {
         module: this.device.createShaderModule({
           code: `
             [[location(0)]] var<out> fragColor : vec4<f32>;
@@ -56,10 +56,12 @@ class F extends ValidationTest {
             }`,
         }),
         entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
       },
-      primitiveTopology: 'triangle-strip',
-      colorStates: [{ format: 'rgba8unorm' }],
-      vertexState: { indexFormat: 'uint32' },
+      primitive: {
+        topology: 'triangle-strip',
+        stripIndexFormat: 'uint32',
+      },
     });
   }
 

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -53,7 +53,7 @@ class F extends ValidationTest {
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm' }],
       },
-      primitive: { topology: 'triangle-list', },
+      primitive: { topology: 'triangle-list' },
     });
   }
 

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -16,7 +16,7 @@ class F extends ValidationTest {
 
   createRenderPipeline(bufferCount: number): GPURenderPipeline {
     return this.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: this.device.createShaderModule({
           code: `
             ${range(
@@ -30,22 +30,7 @@ class F extends ValidationTest {
             }`,
         }),
         entryPoint: 'main',
-      },
-      fragmentStage: {
-        module: this.device.createShaderModule({
-          code: `
-            [[location(0)]] var<out> fragColor : vec4<f32>;
-            [[stage(fragment)]] fn main() -> void {
-              fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
-              return;
-            }`,
-        }),
-        entryPoint: 'main',
-      },
-      primitiveTopology: 'triangle-list',
-      colorStates: [{ format: 'rgba8unorm' }],
-      vertexState: {
-        vertexBuffers: [
+        buffers: [
           {
             arrayStride: 3 * 4,
             attributes: range(bufferCount, i => ({
@@ -56,6 +41,19 @@ class F extends ValidationTest {
           },
         ],
       },
+      fragment: {
+        module: this.device.createShaderModule({
+          code: `
+            [[location(0)]] var<out> fragColor : vec4<f32>;
+            [[stage(fragment)]] fn main() -> void {
+              fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+              return;
+            }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+      primitive: { topology: 'triangle-list', },
     });
   }
 

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -65,7 +65,7 @@ class F extends ValidationTest {
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm' }],
       },
-      primitive: { topology: 'triangle-list', },
+      primitive: { topology: 'triangle-list' },
     });
     return pipeline;
   }

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -26,7 +26,7 @@ class F extends ValidationTest {
 
   createRenderPipeline(): GPURenderPipeline {
     const pipeline = this.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: this.device.createShaderModule({
           code: `
             [[block]] struct VertexUniforms {
@@ -48,7 +48,7 @@ class F extends ValidationTest {
         }),
         entryPoint: 'main',
       },
-      fragmentStage: {
+      fragment: {
         module: this.device.createShaderModule({
           code: `
             [[block]] struct FragmentUniforms {
@@ -63,9 +63,9 @@ class F extends ValidationTest {
             }`,
         }),
         entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
       },
-      primitiveTopology: 'triangle-list',
-      colorStates: [{ format: 'rgba8unorm' }],
+      primitive: { topology: 'triangle-list', },
     });
     return pipeline;
   }

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -955,20 +955,20 @@ g.test('unused_bindings_in_pipeline')
           },
         })
       : t.device.createRenderPipeline({
-          vertexStage: {
+          vertex: {
             module: t.device.createShaderModule({
               code: wgslVertex,
             }),
             entryPoint: 'main',
           },
-          fragmentStage: {
+          fragment: {
             module: t.device.createShaderModule({
               code: wgslFragment,
             }),
             entryPoint: 'main',
+            targets: [{ format: 'rgba8unorm' }],
           },
-          primitiveTopology: 'triangle-list',
-          colorStates: [{ format: 'rgba8unorm' }],
+          primitive: { topology: 'triangle-list', },
         });
 
     const encoder = t.device.createCommandEncoder();

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -968,7 +968,7 @@ g.test('unused_bindings_in_pipeline')
             entryPoint: 'main',
             targets: [{ format: 'rgba8unorm' }],
           },
-          primitive: { topology: 'triangle-list', },
+          primitive: { topology: 'triangle-list' },
         });
 
     const encoder = t.device.createCommandEncoder();

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -204,20 +204,20 @@ export class ValidationTest extends GPUTest {
 
   createNoOpRenderPipeline(): GPURenderPipeline {
     return this.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: this.device.createShaderModule({
           code: '[[stage(vertex)]] fn main() -> void {}',
         }),
         entryPoint: 'main',
       },
-      fragmentStage: {
+      fragment: {
         module: this.device.createShaderModule({
           code: '[[stage(fragment)]] fn main() -> void {}',
         }),
         entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
       },
-      primitiveTopology: 'triangle-list',
-      colorStates: [{ format: 'rgba8unorm' }],
+      primitive: { topology: 'triangle-list', },
     });
   }
 

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -217,7 +217,7 @@ export class ValidationTest extends GPUTest {
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm' }],
       },
-      primitive: { topology: 'triangle-list', },
+      primitive: { topology: 'triangle-list' },
     });
   }
 

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -20,14 +20,14 @@ const VERTEX_SHADER_CODE_WITH_NO_INPUT = `
 `;
 
 function addTestAttributes(
-  attributes: GPUVertexAttributeDescriptor[],
+  attributes: GPUVertexAttribute[],
   {
     testAttribute,
     testAttributeAtStart = true,
     extraAttributeCount = 0,
     extraAttributeSkippedLocations = [],
   }: {
-    testAttribute?: GPUVertexAttributeDescriptor;
+    testAttribute?: GPUVertexAttribute;
     testAttributeAtStart?: boolean;
     extraAttributeCount?: Number;
     extraAttributeSkippedLocations?: Number[];
@@ -60,15 +60,16 @@ function addTestAttributes(
 
 class F extends ValidationTest {
   getDescriptor(
-    vertexState: GPUVertexStateDescriptor,
+    buffers: Iterable<GPUVertexBufferLayout>,
     vertexShaderCode: string
   ): GPURenderPipelineDescriptor {
     const descriptor: GPURenderPipelineDescriptor = {
-      vertexStage: {
+      vertex: {
         module: this.device.createShaderModule({ code: vertexShaderCode }),
         entryPoint: 'main',
+        buffers,
       },
-      fragmentStage: {
+      fragment: {
         module: this.device.createShaderModule({
           code: `
             [[location(0)]] var<out> fragColor : vec4<f32>;
@@ -78,17 +79,16 @@ class F extends ValidationTest {
             }`,
         }),
         entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
       },
-      primitiveTopology: 'triangle-list',
-      colorStates: [{ format: 'rgba8unorm' }],
-      vertexState,
+      primitive: { topology: 'triangle-list', },
     };
     return descriptor;
   }
 
   testVertexState(
     success: boolean,
-    vertexState: GPUVertexStateDescriptor,
+    buffers: Iterable<GPUVertexBufferLayout>,
     vertexShader: string = VERTEX_SHADER_CODE_WITH_NO_INPUT
   ) {
     const vsModule = this.device.createShaderModule({ code: vertexShader });
@@ -102,17 +102,17 @@ class F extends ValidationTest {
 
     this.expectValidationError(() => {
       this.device.createRenderPipeline({
-        vertexState,
-        vertexStage: {
+        vertex: {
           module: vsModule,
           entryPoint: 'main',
+          buffers,
         },
-        fragmentStage: {
+        fragment: {
           module: fsModule,
           entryPoint: 'main',
+          targets: [{ format: 'rgba8unorm' }],
         },
-        primitiveTopology: 'triangle-list',
-        colorStates: [{ format: 'rgba8unorm' }],
+        primitive: { topology: 'triangle-list', },
       });
     }, !success);
   }
@@ -169,7 +169,7 @@ g.test('max_vertex_buffer_limit')
     }
 
     const success = count <= kMaxVertexBuffers;
-    t.testVertexState(success, { vertexBuffers });
+    t.testVertexState(success, vertexBuffers);
   });
 
 g.test('max_vertex_attribute_limit')
@@ -206,7 +206,7 @@ g.test('max_vertex_attribute_limit')
     }
 
     const success = attribCount <= kMaxVertexAttributes;
-    t.testVertexState(success, { vertexBuffers });
+    t.testVertexState(success, vertexBuffers);
   });
 
 g.test('max_vertex_buffer_array_stride_limit')
@@ -236,7 +236,7 @@ g.test('max_vertex_buffer_array_stride_limit')
     vertexBuffers[vertexBufferIndex] = { arrayStride, attributes: [] };
 
     const success = arrayStride <= kMaxVertexBufferArrayStride;
-    t.testVertexState(success, { vertexBuffers });
+    t.testVertexState(success, vertexBuffers);
   });
 
 g.test('vertex_buffer_array_stride_limit_alignment')
@@ -267,7 +267,7 @@ g.test('vertex_buffer_array_stride_limit_alignment')
     vertexBuffers[vertexBufferIndex] = { arrayStride, attributes: [] };
 
     const success = arrayStride % 4 === 0;
-    t.testVertexState(success, { vertexBuffers });
+    t.testVertexState(success, vertexBuffers);
   });
 
 g.test('vertex_attribute_shaderLocation_limit')
@@ -294,7 +294,7 @@ g.test('vertex_attribute_shaderLocation_limit')
       testAttributeAtStart,
     } = t.params;
 
-    const attributes: GPUVertexAttributeDescriptor[] = [];
+    const attributes: GPUVertexAttribute[] = [];
     addTestAttributes(attributes, {
       testAttribute: { format: 'float32', offset: 0, shaderLocation: testShaderLocation },
       testAttributeAtStart,
@@ -306,7 +306,7 @@ g.test('vertex_attribute_shaderLocation_limit')
     vertexBuffers[vertexBufferIndex] = { arrayStride: 256, attributes };
 
     const success = testShaderLocation < kMaxVertexAttributes;
-    t.testVertexState(success, { vertexBuffers });
+    t.testVertexState(success, vertexBuffers);
   });
 
 g.test('vertex_attribute_shaderLocation_unique')
@@ -371,7 +371,7 @@ g.test('vertex_attribute_shaderLocation_unique')
     // Note that an empty vertex shader will be used so errors only happens because of the conflict
     // in the vertex state.
     const success = shaderLocationA !== shaderLocationB;
-    t.testVertexState(success, { vertexBuffers });
+    t.testVertexState(success, vertexBuffers);
   });
 
 g.test('vertex_shader_input_location_limit')
@@ -408,7 +408,7 @@ g.test('vertex_shader_input_location_limit')
     ];
 
     const success = testLocation < kMaxVertexAttributes;
-    t.testVertexState(success, { vertexBuffers }, shader);
+    t.testVertexState(success, vertexBuffers, shader);
   });
 
 g.test('vertex_shader_input_location_in_vertex_state')
@@ -439,7 +439,7 @@ g.test('vertex_shader_input_location_in_vertex_state')
       },
     ]);
 
-    const attributes: GPUVertexAttributeDescriptor[] = [];
+    const attributes: GPUVertexAttribute[] = [];
     const vertexBuffers = [];
     vertexBuffers[vertexBufferIndex] = { arrayStride: 256, attributes };
 
@@ -449,14 +449,14 @@ g.test('vertex_shader_input_location_in_vertex_state')
       extraAttributeCount,
       extraAttributeSkippedLocations: [testShaderLocation],
     });
-    t.testVertexState(false, { vertexBuffers }, shader);
+    t.testVertexState(false, vertexBuffers, shader);
 
     // Add an attribute for the test location and try again.
     addTestAttributes(attributes, {
       testAttribute: { format: 'float32', shaderLocation: testShaderLocation, offset: 0 },
       testAttributeAtStart,
     });
-    t.testVertexState(true, { vertexBuffers }, shader);
+    t.testVertexState(true, vertexBuffers, shader);
   });
 
 g.test('vertex_shader_type_matches_attribute_format')
@@ -499,14 +499,10 @@ g.test('vertex_shader_type_matches_attribute_format')
     const success = requiredBaseType === shaderBaseType;
     t.testVertexState(
       success,
-      {
-        vertexBuffers: [
-          {
-            arrayStride: 0,
-            attributes: [{ offset: 0, shaderLocation: 0, format }],
-          },
-        ],
-      },
+      [{
+        arrayStride: 0,
+        attributes: [{ offset: 0, shaderLocation: 0, format }],
+      }],
       shader
     );
   });
@@ -557,7 +553,7 @@ g.test('vertex_attribute_offset_alignment')
       testAttributeAtStart,
     } = t.params;
 
-    const attributes: GPUVertexAttributeDescriptor[] = [];
+    const attributes: GPUVertexAttribute[] = [];
     addTestAttributes(attributes, {
       testAttribute: { format, offset, shaderLocation: 0 },
       testAttributeAtStart,
@@ -569,7 +565,7 @@ g.test('vertex_attribute_offset_alignment')
     vertexBuffers[vertexBufferIndex] = { arrayStride, attributes };
 
     const success = offset % kVertexFormatInfo[format].bytesPerComponent === 0;
-    t.testVertexState(success, { vertexBuffers });
+    t.testVertexState(success, vertexBuffers);
   });
 
 g.test('vertex_attribute_contained_in_stride')
@@ -625,7 +621,7 @@ g.test('vertex_attribute_contained_in_stride')
       testAttributeAtStart,
     } = t.params;
 
-    const attributes: GPUVertexAttributeDescriptor[] = [];
+    const attributes: GPUVertexAttribute[] = [];
     addTestAttributes(attributes, {
       testAttribute: { format, offset, shaderLocation: 0 },
       testAttributeAtStart,
@@ -641,7 +637,7 @@ g.test('vertex_attribute_contained_in_stride')
     const limit = arrayStride === 0 ? kMaxVertexBufferArrayStride : arrayStride;
 
     const success = offset + formatSize <= limit;
-    t.testVertexState(success, { vertexBuffers });
+    t.testVertexState(success, vertexBuffers);
   });
 
 g.test('many_attributes_overlapping')
@@ -654,7 +650,5 @@ g.test('many_attributes_overlapping')
       attributes.push({ format: formats[i % 3], offset: i * 4, shaderLocation: i } as const);
     }
 
-    t.testVertexState(true, {
-      vertexBuffers: [{ arrayStride: 0, attributes }],
-    });
+    t.testVertexState(true, [{ arrayStride: 0, attributes }]);
   });

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -81,7 +81,7 @@ class F extends ValidationTest {
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm' }],
       },
-      primitive: { topology: 'triangle-list', },
+      primitive: { topology: 'triangle-list' },
     };
     return descriptor;
   }
@@ -112,7 +112,7 @@ class F extends ValidationTest {
           entryPoint: 'main',
           targets: [{ format: 'rgba8unorm' }],
         },
-        primitive: { topology: 'triangle-list', },
+        primitive: { topology: 'triangle-list' },
       });
     }, !success);
   }
@@ -499,10 +499,12 @@ g.test('vertex_shader_type_matches_attribute_format')
     const success = requiredBaseType === shaderBaseType;
     t.testVertexState(
       success,
-      [{
-        arrayStride: 0,
-        attributes: [{ offset: 0, shaderLocation: 0, format }],
-      }],
+      [
+        {
+          arrayStride: 0,
+          attributes: [{ offset: 0, shaderLocation: 0, format }],
+        },
+      ],
       shader
     );
   });

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -397,7 +397,7 @@ g.test('vertexAccess')
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm' }],
       },
-      primitive: { topology: 'point-list', },
+      primitive: { topology: 'point-list' },
     });
 
     // Pipeline setup, texture setup

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -326,11 +326,11 @@ g.test('vertexAccess')
     }
 
     // Vertex buffer descriptors
-    const vertexBuffers: GPUVertexBufferLayoutDescriptor[] = [];
+    const buffers: GPUVertexBufferLayout[] = [];
     {
       let currAttribute = 0;
       for (let i = 0; i < bufferContents.length; i++) {
-        vertexBuffers.push({
+        buffers.push({
           arrayStride: attributesPerBuffer * typeInfo.size,
           stepMode: i === 0 ? 'instance' : 'vertex',
           attributes: Array(attributesPerBuffer)
@@ -351,7 +351,7 @@ g.test('vertexAccess')
     }
 
     const pipeline = t.device.createRenderPipeline({
-      vertexStage: {
+      vertex: {
         module: t.device.createShaderModule({
           code: `
             [[builtin(position)]] var<out> Position : vec4<f32>;
@@ -384,8 +384,9 @@ g.test('vertexAccess')
             }`,
         }),
         entryPoint: 'main',
+        buffers,
       },
-      fragmentStage: {
+      fragment: {
         module: t.device.createShaderModule({
           code: `
             [[location(0)]] var<out> fragColor : vec4<f32>;
@@ -394,12 +395,9 @@ g.test('vertexAccess')
             }`,
         }),
         entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
       },
-      primitiveTopology: 'point-list',
-      colorStates: [{ format: 'rgba8unorm' }],
-      vertexState: {
-        vertexBuffers,
-      },
+      primitive: { topology: 'point-list', },
     });
 
     // Pipeline setup, texture setup


### PR DESCRIPTION
This change updates all of the RenderPipelineDescriptors (that I could find) to the new format. It isn't merge-able just yet, primarily due to it's dependency on https://github.com/gpuweb/types/pull/61 which has not yet been published to NPM. Posting here for early feedback and to prevent duplicate work.