### PR TITLE
Make the intent of the expand/collapse UI clearer using details elements

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -209,9 +209,9 @@ function makeTreeNodeHeaderHTML(
 
   const href = `?${worker ? 'worker&' : ''}${debug ? 'debug&' : ''}q=${n.query.toString()}`;
   if (onChange) {
-      div.on('toggle', function (this) {
-        onChange((this as HTMLDetailsElement).open);
-      });
+    div.on('toggle', function (this) {
+      onChange((this as HTMLDetailsElement).open);
+    });
 
     // Expand the shallower parts of the tree at load.
     // Also expand completely within subtrees that are at the same query level

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -199,27 +199,19 @@ function makeTreeNodeHeaderHTML(
   onChange: (checked: boolean) => void
 ): [HTMLElement, SetCheckedRecursively] {
   const isLeaf = 'run' in n;
-  const div = $('<div>').addClass('nodeheader');
+  const div = $('<details>').addClass('nodeheader');
+  const header = $('<summary>').appendTo(div);
 
   const setChecked = () => {
-    if (checkbox) {
-      checkbox.prop('checked', true); // (does not fire onChange)
-      onChange(true);
-    }
+    div.prop('open', true); // (does not fire onChange)
+    onChange(true);
   };
 
-  let checkbox: JQuery<HTMLElement> | undefined;
   const href = `?${worker ? 'worker&' : ''}${debug ? 'debug&' : ''}q=${n.query.toString()}`;
   if (onChange) {
-    checkbox = $('<input>')
-      .attr('type', 'checkbox')
-      .addClass('collapsebtn')
-      .on('change', function (this) {
-        onChange((this as HTMLInputElement).checked);
-      })
-      .attr('alt', 'Expand')
-      .attr('title', 'Expand')
-      .appendTo(div);
+      div.on('toggle', function (this) {
+        onChange((this as HTMLDetailsElement).open);
+      });
 
     // Expand the shallower parts of the tree at load.
     // Also expand completely within subtrees that are at the same query level
@@ -236,25 +228,25 @@ function makeTreeNodeHeaderHTML(
     .on('click', async () => {
       await runSubtree();
     })
-    .appendTo(div);
+    .appendTo(header);
   $('<a>')
     .addClass('nodelink')
     .attr('href', href)
     .attr('alt', 'Open')
     .attr('title', 'Open')
-    .appendTo(div);
+    .appendTo(header);
   if ('testCreationStack' in n && n.testCreationStack) {
     $('<button>')
       .addClass('testcaselogbtn')
       .attr('alt', 'Log test creation stack to console')
       .attr('title', 'Log test creation stack to console')
-      .appendTo(div)
+      .appendTo(header)
       .on('click', () => {
         /* eslint-disable-next-line no-console */
         console.log(n.testCreationStack);
       });
   }
-  const nodetitle = $('<div>').addClass('nodetitle').appendTo(div);
+  const nodetitle = $('<div>').addClass('nodetitle').appendTo(header);
   $('<input>')
     .attr('type', 'text')
     .prop('readonly', true)
@@ -266,7 +258,7 @@ function makeTreeNodeHeaderHTML(
     $('<pre>') //
       .addClass('nodedescription')
       .text(n.description)
-      .appendTo(nodetitle);
+      .appendTo(header);
   }
   return [div[0], setChecked];
 }

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -89,6 +89,7 @@
         background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMAQMAAABsu86kAAAABlBMVEUAAAAAAAClZ7nPAAAAAXRSTlMAQObYZgAAACRJREFUCNdjYGBg+P+BoUGAYesFhj4BhvsFDPYNDHwMCMTAAACqJwbp3VgbrAAAAABJRU5ErkJggg==);
       }
       .nodetitle {
+        display: inline;
         flex: 10 0 4em;
       }
       .nodequery {
@@ -102,7 +103,7 @@
         width: calc(100vw - 360px);
       }
       .nodedescription {
-        margin: 0;
+        margin: 0 0 0 1em;
         color: gray;
         white-space: pre-wrap;
         font-size: 80%;


### PR DESCRIPTION
When working with the CTS I found that I was repeatedly confused by the fact that the expand/collapse widget was represented by a checkbox. To me this suggested that only the "checked" tests would be run (as is the case with the WebGL conformance suite), and gave the impression that the test suite was much shallower than it actually was.

To avoid this confusion, I've made a change that uses the HTML `<details>` element rather than a checkbox to handled expanding and collapsing sections. I believe this helps make the intent clearer.

Before:
<img width="899" alt="Screenshot 2021-03-12 151134" src="https://user-images.githubusercontent.com/805273/111008426-eb624480-8345-11eb-9c5d-9576d6b81cd7.png">

After:
<img width="898" alt="Screenshot 2021-03-12 151030" src="https://user-images.githubusercontent.com/805273/111008433-ef8e6200-8345-11eb-87ab-b6f91a4338dd.png">
