### PR TITLE
add tools/deno runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,4 +185,6 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+trace/
+
 # End of https://www.gitignore.io/api/linux,macos,windows,node

--- a/docs/deno.md
+++ b/docs/deno.md
@@ -1,0 +1,25 @@
+# Running the CTS on Deno
+
+Since version 1.8, Deno experimentally implements the WebGPU API out of the box.
+You can use the `./tools/deno` script to run the CTS in Deno. To do this you
+will first need to install Deno: [stable](https://deno.land#installation), or
+build the main branch from source
+(`cargo install --git https://github.com/denoland/deno --bin deno`).
+
+On macOS and recent Linux, you can just run `./tools/deno` as is. On Windows and
+older Linux releases you will need to run
+`deno run --unstable --allow-read --allow-write --allow-env ./tools/deno`.
+
+## Usage
+
+```
+Usage:
+  tools/deno [OPTIONS...] QUERIES...
+  tools/deno 'unittests:*' 'webgpu:buffers,*'
+Options:
+  --verbose             Print result/log of every test as it runs.
+  --debug               Include debug messages in logging.
+  --print-json          Print the complete result JSON in the output.
+  --trace               Record a trace of the WebGPU operations into a ./trace directory.
+  --ignore-file=<file>  A line delimited text file containing names of tests to skip.
+```

--- a/tools/deno
+++ b/tools/deno
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --unstable --allow-read --no-check
+#!/usr/bin/env -S deno run --unstable --allow-read --allow-write --no-check
 
 /* eslint no-console: "off" */
 /* eslint no-process-exit: "off" */
@@ -25,6 +25,15 @@ if (!existsSync("src/common/runtime/cmdline.ts")) {
   console.log("Must be run from repository root");
   usage(1);
 }
+
+const badComment = `/// <reference types="@webgpu/types" />`;
+const navigatorGpuPath = "./out/webgpu/util/navigator_gpu.js";
+let navigatorGpuFile = await Deno.readTextFile(navigatorGpuPath);
+navigatorGpuFile = navigatorGpuFile.replace(
+  badComment,
+  " ".repeat(badComment.length)
+);
+await Deno.writeTextFile(navigatorGpuPath, navigatorGpuFile);
 
 let verbose = false;
 let debug = false;

--- a/tools/deno
+++ b/tools/deno
@@ -15,9 +15,11 @@ function usage(rc) {
   console.log("  tools/deno [OPTIONS...] QUERIES...");
   console.log("  tools/deno 'unittests:*' 'webgpu:buffers,*'");
   console.log("Options:");
-  console.log("  --verbose     Print result/log of every test as it runs.");
-  console.log("  --debug       Include debug messages in logging.");
-  console.log("  --print-json  Print the complete result JSON in the output.");
+  console.log("  --verbose             Print result/log of every test as it runs.");
+  console.log("  --debug               Include debug messages in logging.");
+  console.log("  --print-json          Print the complete result JSON in the output.");
+  console.log("  --trace               Record a trace of the WebGPU operations into a ./trace directory.");
+  console.log("  --ignore-file=<file>  A line delimited text file containing names of tests to skip.");
   return Deno.exit(rc);
 }
 
@@ -37,6 +39,14 @@ if (!existsSync("src/common/runtime/cmdline.ts")) {
   usage(1);
 }
 
+if (!existsSync("out/common/runtime/cmdline.js")) {
+  console.log("You must run `npm run standalone` before running ./tools/deno");
+  usage(1);
+}
+
+// Remove the `/// <reference types="@webgpu/types" />` comment, so Deno does not
+// parse it and try to import `@webgpu/types`. (Which it fails on because Deno
+// uses fully specified import specifiers).
 const badComment = `/// <reference types="@webgpu/types" />`;
 const navigatorGpuPath = "./out/webgpu/util/navigator_gpu.js";
 let navigatorGpuFile = await Deno.readTextFile(navigatorGpuPath);

--- a/tools/deno
+++ b/tools/deno
@@ -1,0 +1,151 @@
+#!/usr/bin/env -S deno run --unstable --allow-read --no-check
+
+/* eslint no-console: "off" */
+/* eslint no-process-exit: "off" */
+
+import { existsSync } from "https://deno.land/std@0.90.0/fs/exists.ts";
+
+import { DefaultTestFileLoader } from "../out/common/framework/file_loader.js";
+import { Logger } from "../out/common/framework/logging/logger.js";
+import { parseQuery } from "../out/common/framework/query/parseQuery.js";
+import { assert, unreachable } from "../out/common/framework/util/util.js";
+
+function usage(rc) {
+  console.log("Usage:");
+  console.log("  tools/deno [OPTIONS...] QUERIES...");
+  console.log("  tools/deno 'unittests:*' 'webgpu:buffers,*'");
+  console.log("Options:");
+  console.log("  --verbose     Print result/log of every test as it runs.");
+  console.log("  --debug       Include debug messages in logging.");
+  console.log("  --print-json  Print the complete result JSON in the output.");
+  return Deno.exit(rc);
+}
+
+if (!existsSync("src/common/runtime/cmdline.ts")) {
+  console.log("Must be run from repository root");
+  usage(1);
+}
+
+let verbose = false;
+let debug = false;
+let printJSON = false;
+const queries = [];
+for (const a of Deno.args) {
+  if (a.startsWith("-")) {
+    if (a === "--verbose") {
+      verbose = true;
+    } else if (a === "--debug") {
+      debug = true;
+    } else if (a === "--print-json") {
+      printJSON = true;
+    } else {
+      usage(1);
+    }
+  } else {
+    queries.push(a);
+  }
+}
+
+if (queries.length === 0) {
+  usage(0);
+}
+
+(async () => {
+  try {
+    const loader = new DefaultTestFileLoader();
+    assert(
+      queries.length === 1,
+      "currently, there must be exactly one query on the cmd line",
+    );
+    const testcases = await loader.loadCases(parseQuery(queries[0]));
+
+    const log = new Logger(debug);
+
+    const failed = [];
+    const warned = [];
+    const skipped = [];
+
+    let total = 0;
+
+    for (const testcase of testcases) {
+      const name = testcase.query.toString();
+      const [rec, res] = log.record(name);
+      await testcase.run(rec);
+
+      if (verbose) {
+        printResults([[name, res]]);
+      }
+
+      total++;
+      switch (res.status) {
+        case "pass":
+          break;
+        case "fail":
+          failed.push([name, res]);
+          break;
+        case "warn":
+          warned.push([name, res]);
+          break;
+        case "skip":
+          skipped.push([name, res]);
+          break;
+        default:
+          unreachable("unrecognized status");
+      }
+    }
+
+    assert(total > 0, "found no tests!");
+
+    // TODO: write results out somewhere (a file?)
+    if (printJSON) {
+      console.log(log.asJSON(2));
+    }
+
+    if (skipped.length) {
+      console.log("");
+      console.log("** Skipped **");
+      printResults(skipped);
+    }
+    if (warned.length) {
+      console.log("");
+      console.log("** Warnings **");
+      printResults(warned);
+    }
+    if (failed.length) {
+      console.log("");
+      console.log("** Failures **");
+      printResults(failed);
+    }
+
+    const passed = total - warned.length - failed.length - skipped.length;
+    const pct = (x) => ((100 * x) / total).toFixed(2);
+    const rpt = (x) => {
+      const xs = x.toString().padStart(1 + Math.log10(total), " ");
+      return `${xs} / ${total} = ${pct(x).padStart(6, " ")}%`;
+    };
+    console.log("");
+    console.log(`** Summary **
+Passed  w/o warnings = ${rpt(passed)}
+Passed with warnings = ${rpt(warned.length)}
+Skipped              = ${rpt(skipped.length)}
+Failed               = ${rpt(failed.length)}`);
+
+    if (failed.length || warned.length) {
+      Deno.exit(1);
+    }
+  } catch (ex) {
+    console.log(ex);
+    Deno.exit(1);
+  }
+})();
+
+function printResults(results) {
+  for (const [name, r] of results) {
+    console.log(`[${r.status}] ${name} (${r.timems}ms). Log:`);
+    if (r.logs) {
+      for (const l of r.logs) {
+        console.log("  - " + l.toJSON().replace(/\n/g, "\n    "));
+      }
+    }
+  }
+}

--- a/tools/deno
+++ b/tools/deno
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --unstable --allow-read --allow-write --no-check
+#!/usr/bin/env -S deno run --unstable --allow-read --allow-write --allow-env --no-check
 
 /* eslint no-console: "off" */
 /* eslint no-process-exit: "off" */
@@ -21,6 +21,17 @@ function usage(rc) {
   return Deno.exit(rc);
 }
 
+function printResults(results) {
+  for (const [name, r] of results) {
+    console.log(`[${r.status}] ${name} (${r.timems}ms). Log:`);
+    if (r.logs) {
+      for (const l of r.logs) {
+        console.log("  - " + l.toJSON().replace(/\n/g, "\n    "));
+      }
+    }
+  }
+}
+
 if (!existsSync("src/common/runtime/cmdline.ts")) {
   console.log("Must be run from repository root");
   usage(1);
@@ -31,11 +42,12 @@ const navigatorGpuPath = "./out/webgpu/util/navigator_gpu.js";
 let navigatorGpuFile = await Deno.readTextFile(navigatorGpuPath);
 navigatorGpuFile = navigatorGpuFile.replace(
   badComment,
-  " ".repeat(badComment.length)
+  " ".repeat(badComment.length),
 );
 await Deno.writeTextFile(navigatorGpuPath, navigatorGpuFile);
 
 let verbose = false;
+let trace = false;
 let debug = false;
 let printJSON = false;
 const queries = [];
@@ -43,6 +55,8 @@ for (const a of Deno.args) {
   if (a.startsWith("-")) {
     if (a === "--verbose") {
       verbose = true;
+    } else if (a === "--trace") {
+      trace = true;
     } else if (a === "--debug") {
       debug = true;
     } else if (a === "--print-json") {
@@ -59,102 +73,97 @@ if (queries.length === 0) {
   usage(0);
 }
 
-(async () => {
-  try {
-    const loader = new DefaultTestFileLoader();
-    assert(
-      queries.length === 1,
-      "currently, there must be exactly one query on the cmd line",
-    );
-    const testcases = await loader.loadCases(parseQuery(queries[0]));
+try {
+  const loader = new DefaultTestFileLoader();
+  assert(
+    queries.length === 1,
+    "currently, there must be exactly one query on the cmd line",
+  );
+  const testcases = await loader.loadCases(parseQuery(queries[0]));
 
-    const log = new Logger(debug);
+  const log = new Logger(debug);
 
-    const failed = [];
-    const warned = [];
-    const skipped = [];
+  const failed = [];
+  const warned = [];
+  const skipped = [];
 
-    let total = 0;
+  let total = 0;
 
-    for (const testcase of testcases) {
-      const name = testcase.query.toString();
-      const [rec, res] = log.record(name);
-      await testcase.run(rec);
+  for (const testcase of testcases) {
+    const name = testcase.query.toString();
+    if (verbose) {
+      console.log(`Starting ${name}`);
+    }
+    if (trace) {
+      const traceDir = `./trace/${name}`;
+      await Deno.mkdir(traceDir, { recursive: true });
+      Deno.env.set("DENO_WEBGPU_TRACE", traceDir);
+    }
+    const [rec, res] = log.record(name);
+    await testcase.run(rec);
 
-      if (verbose) {
-        printResults([[name, res]]);
-      }
-
-      total++;
-      switch (res.status) {
-        case "pass":
-          break;
-        case "fail":
-          failed.push([name, res]);
-          break;
-        case "warn":
-          warned.push([name, res]);
-          break;
-        case "skip":
-          skipped.push([name, res]);
-          break;
-        default:
-          unreachable("unrecognized status");
-      }
+    if (verbose) {
+      printResults([[name, res]]);
     }
 
-    assert(total > 0, "found no tests!");
+    total++;
+    switch (res.status) {
+      case "pass":
+        break;
+      case "fail":
+        failed.push([name, res]);
+        break;
+      case "warn":
+        warned.push([name, res]);
+        break;
+      case "skip":
+        skipped.push([name, res]);
+        break;
+      default:
+        unreachable("unrecognized status");
+    }
+  }
 
-    // TODO: write results out somewhere (a file?)
-    if (printJSON) {
-      console.log(log.asJSON(2));
-    }
+  assert(total > 0, "found no tests!");
 
-    if (skipped.length) {
-      console.log("");
-      console.log("** Skipped **");
-      printResults(skipped);
-    }
-    if (warned.length) {
-      console.log("");
-      console.log("** Warnings **");
-      printResults(warned);
-    }
-    if (failed.length) {
-      console.log("");
-      console.log("** Failures **");
-      printResults(failed);
-    }
+  // TODO: write results out somewhere (a file?)
+  if (printJSON) {
+    console.log(log.asJSON(2));
+  }
 
-    const passed = total - warned.length - failed.length - skipped.length;
-    const pct = (x) => ((100 * x) / total).toFixed(2);
-    const rpt = (x) => {
-      const xs = x.toString().padStart(1 + Math.log10(total), " ");
-      return `${xs} / ${total} = ${pct(x).padStart(6, " ")}%`;
-    };
+  if (skipped.length) {
     console.log("");
-    console.log(`** Summary **
+    console.log("** Skipped **");
+    printResults(skipped);
+  }
+  if (warned.length) {
+    console.log("");
+    console.log("** Warnings **");
+    printResults(warned);
+  }
+  if (failed.length) {
+    console.log("");
+    console.log("** Failures **");
+    printResults(failed);
+  }
+
+  const passed = total - warned.length - failed.length - skipped.length;
+  const pct = (x) => ((100 * x) / total).toFixed(2);
+  const rpt = (x) => {
+    const xs = x.toString().padStart(1 + Math.log10(total), " ");
+    return `${xs} / ${total} = ${pct(x).padStart(6, " ")}%`;
+  };
+  console.log("");
+  console.log(`** Summary **
 Passed  w/o warnings = ${rpt(passed)}
 Passed with warnings = ${rpt(warned.length)}
 Skipped              = ${rpt(skipped.length)}
 Failed               = ${rpt(failed.length)}`);
 
-    if (failed.length || warned.length) {
-      Deno.exit(1);
-    }
-  } catch (ex) {
-    console.log(ex);
+  if (failed.length || warned.length) {
     Deno.exit(1);
   }
-})();
-
-function printResults(results) {
-  for (const [name, r] of results) {
-    console.log(`[${r.status}] ${name} (${r.timems}ms). Log:`);
-    if (r.logs) {
-      for (const l of r.logs) {
-        console.log("  - " + l.toJSON().replace(/\n/g, "\n    "));
-      }
-    }
-  }
+} catch (ex) {
+  console.log(ex);
+  Deno.exit(1);
 }

--- a/tools/deno
+++ b/tools/deno
@@ -49,6 +49,7 @@ await Deno.writeTextFile(navigatorGpuPath, navigatorGpuFile);
 let verbose = false;
 let trace = false;
 let debug = false;
+let ignoreFile = undefined;
 let printJSON = false;
 const queries = [];
 for (const a of Deno.args) {
@@ -61,6 +62,8 @@ for (const a of Deno.args) {
       debug = true;
     } else if (a === "--print-json") {
       printJSON = true;
+    } else if (a.startsWith("--ignore-file=")) {
+      ignoreFile = a.slice("--ignore-file=".length);
     } else {
       usage(1);
     }
@@ -71,6 +74,13 @@ for (const a of Deno.args) {
 
 if (queries.length === 0) {
   usage(0);
+}
+
+let ignores = [];
+if (ignoreFile) {
+  const ignoreFileText = await Deno.readTextFile(ignoreFile);
+  ignores = ignoreFileText.split("\n").map((line) => line.split("#")[0].trim())
+    .filter((l) => l.length > 0);
 }
 
 try {
@@ -86,11 +96,17 @@ try {
   const failed = [];
   const warned = [];
   const skipped = [];
+  const ignored = [];
 
   let total = 0;
 
   for (const testcase of testcases) {
+    total++;
     const name = testcase.query.toString();
+    if (ignores.includes(name)) {
+      ignored.push(name);
+      continue;
+    }
     if (verbose) {
       console.log(`Starting ${name}`);
     }
@@ -106,7 +122,6 @@ try {
       printResults([[name, res]]);
     }
 
-    total++;
     switch (res.status) {
       case "pass":
         break;
@@ -158,7 +173,8 @@ try {
 Passed  w/o warnings = ${rpt(passed)}
 Passed with warnings = ${rpt(warned.length)}
 Skipped              = ${rpt(skipped.length)}
-Failed               = ${rpt(failed.length)}`);
+Failed               = ${rpt(failed.length)}
+Ignored              = ${rpt(ignored.length)}`);
 
   if (failed.length || warned.length) {
     Deno.exit(1);


### PR DESCRIPTION
This commit adds a `./tools/deno` runner for running CTS in Deno. It is
essentially a JS copy of the node runner, using Deno syscalls instead.

It requires you to have run `npm run standalone` before invoking.

![image](https://user-images.githubusercontent.com/7829205/111171302-18606280-85a5-11eb-9141-44e8ca863235.png)
