### PR TITLE
Add validation tests on buffer offset in B2T and T2B copies with depth stencil formats

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -29,7 +29,7 @@ class ImageCopyTest extends ValidationTest {
     }, !isSuccess);
   }
 
-  testCopyTexturetoBuffer(
+  testCopyTextureToBuffer(
     source: GPUImageCopyTexture,
     destination: GPUImageCopyBuffer,
     copySize: GPUExtent3DStrict,
@@ -78,7 +78,7 @@ g.test('depth_stencil_format,copy_usage_and_aspect')
 
     {
       const success = depthStencilBufferTextureCopySupported('CopyT2B', format, aspect);
-      t.testCopyTexturetoBuffer({ texture, aspect }, { buffer }, textureSize, success);
+      t.testCopyTextureToBuffer({ texture, aspect }, { buffer }, textureSize, success);
     }
   });
 
@@ -156,13 +156,13 @@ g.test('depth_stencil_format,copy_buffer_size')
       );
     } else {
       assert(copyType === 'CopyT2B');
-      t.testCopyTexturetoBuffer(
+      t.testCopyTextureToBuffer(
         { texture, aspect },
         { buffer: bigEnoughBuffer, bytesPerRow, rowsPerImage },
         copySize,
         true
       );
-      t.testCopyTexturetoBuffer(
+      t.testCopyTextureToBuffer(
         { texture, aspect },
         { buffer: smallerBuffer, bytesPerRow, rowsPerImage },
         copySize,
@@ -229,15 +229,15 @@ g.test('depth_stencil_format,buffer_offset')
       const isSuccess = offset % texelAspectSize === 0;
 
       if (copyType === 'CopyB2T') {
-        t.testCopyTexturetoBuffer(
-          { texture, aspect },
+        t.testCopyBufferToTexture(
           { buffer, offset, bytesPerRow, rowsPerImage },
+          { texture, aspect },
           textureSize,
           isSuccess
         );
       } else {
         assert(copyType === 'CopyT2B');
-        t.testCopyTexturetoBuffer(
+        t.testCopyTextureToBuffer(
           { texture, aspect },
           { buffer, offset, bytesPerRow, rowsPerImage },
           textureSize,

--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -61,6 +61,7 @@ g.test('depth_stencil_format,copy_usage_and_aspect')
   )
   .fn(async t => {
     const { format, aspect } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const textureSize = { width: 1, height: 1, depthOrArrayLayers: 1 };
     const texture = t.device.createTexture({
@@ -118,6 +119,7 @@ g.test('depth_stencil_format,copy_buffer_size')
   )
   .fn(async t => {
     const { format, aspect, copyType, copySize } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const texture = t.device.createTexture({
       size: copySize,
@@ -193,7 +195,6 @@ g.test('depth_stencil_format,copy_buffer_offset')
   .subcases(() => poptions('offset', [1, 2, 4, 6, 8]))
   .fn(async t => {
     const { format, aspect, copyType, offset } = t.params;
-
     await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const textureSize = { width: 4, height: 4, depthOrArrayLayers: 1 };

--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -1,6 +1,9 @@
 export const description = `
 copyTextureToBuffer and copyBufferToTexture validation tests not covered by
 the general image_copy tests, or by destroyed,*.
+
+TODO:
+- Move all the tests here to mage_copy/ and test writeTexture() with depth/stencil formats.
 `;
 
 import { poptions, params } from '../../../../../common/framework/params_builder.js';
@@ -100,9 +103,9 @@ g.test('depth_stencil_format,copy_buffer_size')
       .combine(poptions('format', kDepthStencilFormats))
       .combine(poptions('aspect', ['depth-only', 'stencil-only'] as const))
       .combine(poptions('copyType', ['CopyB2T', 'CopyT2B'] as const))
-      .filter(param => {
-        return depthStencilBufferTextureCopySupported(param.copyType, param.format, param.aspect);
-      })
+      .filter(param =>
+        depthStencilBufferTextureCopySupported(param.copyType, param.format, param.aspect)
+      )
   )
   .subcases(() =>
     params().combine(
@@ -183,13 +186,15 @@ g.test('depth_stencil_format,copy_buffer_offset')
       .combine(poptions('format', kDepthStencilFormats))
       .combine(poptions('aspect', ['depth-only', 'stencil-only'] as const))
       .combine(poptions('copyType', ['CopyB2T', 'CopyT2B'] as const))
-      .filter(param => {
-        return depthStencilBufferTextureCopySupported(param.copyType, param.format, param.aspect);
-      })
+      .filter(param =>
+        depthStencilBufferTextureCopySupported(param.copyType, param.format, param.aspect)
+      )
   )
-  .subcases(() => params().combine(poptions('offset', [1, 2, 4, 6, 8])))
+  .subcases(() => poptions('offset', [1, 2, 4, 6, 8]))
   .fn(async t => {
     const { format, aspect, copyType, offset } = t.params;
+
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const textureSize = { width: 4, height: 4, depthOrArrayLayers: 1 };
 
@@ -210,7 +215,7 @@ g.test('depth_stencil_format,copy_buffer_offset')
     assert(minimumBufferSize > kBufferCopyAlignment);
 
     const buffer = t.device.createBuffer({
-      size: minimumBufferSize + offset,
+      size: align(minimumBufferSize + offset, kBufferCopyAlignment),
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
 

--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -3,7 +3,7 @@ copyTextureToBuffer and copyBufferToTexture validation tests not covered by
 the general image_copy tests, or by destroyed,*.
 
 TODO:
-- Move all the tests here to mage_copy/ and test writeTexture() with depth/stencil formats.
+- Move all the tests here to image_copy/ and test writeTexture() with depth/stencil formats.
 `;
 
 import { poptions, params } from '../../../../../common/framework/params_builder.js';


### PR DESCRIPTION

-----

<!-- ***** For uploader to fill out ***** -->

- [ ] New helpers, if any, are documented in `helper_index.md`.
- [ ] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [ ] WebGPU readability
- [ ] TypeScript readability
