### PR TITLE
Don't validate test modules in `makeListing`

### DIFF
--- a/src/common/tools/crawl.ts
+++ b/src/common/tools/crawl.ts
@@ -96,5 +96,7 @@ export async function crawl(
 }
 
 export function makeListing(filename: string): Promise<TestSuiteListing> {
-  return crawl(path.dirname(filename));
+  // Don't validate. This path is only used for the dev server and running tests with Node.
+  // Validation is done for listing generation and presubmit.
+  return crawl(path.dirname(filename), false);
 }


### PR DESCRIPTION
Validation is a build-time check, and is not needed for runtime
usages like makeListing.



-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
