### PR TITLE
capability_checks tests should expect exceptions not validation errors

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/README.txt
+++ b/src/webgpu/api/validation/capability_checks/features/README.txt
@@ -1,7 +1,10 @@
-Test every method or option that shouldn't be valid without a feature enabled.
+Test every method or option that shouldn't be allowed without a feature enabled.
+If the feature is not enabled, any use of an enum value added by a feature must be an
+*exception*, per <https://github.com/gpuweb/gpuweb/blob/main/design/ErrorConventions.md>.
 
 - x= that feature {enabled, disabled}
 
-One file for each feature name.
+Generally one file for each feature name, but some may be grouped (e.g. one file for all optional
+query types, one file for all optional texture formats).
 
 TODO: implement

--- a/src/webgpu/api/validation/capability_checks/features/queries.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/queries.spec.ts
@@ -13,6 +13,10 @@ Tests that creating query set shouldn't be valid without the required feature en
 - createQuerySet
   - type {occlusion, pipeline-statistics, timestamp}
   - x= {pipeline statistics, timestamp} query {enable, disable}
+
+TODO: This test should expect *synchronous* exceptions, not validation errors, per
+<https://github.com/gpuweb/gpuweb/blob/main/design/ErrorConventions.md>.
+As of this writing, the spec needs to be fixed as well.
   `
   )
   .params(


### PR DESCRIPTION
Alternatively we can decide to change ErrorConventions.md to allow the difference.
(Or change all of the places in the spec that take enums to take strings instead so we can validate them asynchronously - gross.)

<hr>

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [ ] WebGPU readability
- [x] TypeScript readability
