### PR TITLE
Support passing skip/fail test expectations in wpt or by command line

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -3,6 +3,7 @@ import { CaseParams } from './params_utils.js';
 import { assert } from './util/util.js';
 
 export class SkipTestCase extends Error {}
+export class UnexpectedPassError extends Error {}
 
 // A Fixture is a class used to instantiate each test case at run time.
 // A new instance of the Fixture is created for every single test case

--- a/src/common/framework/logging/result.ts
+++ b/src/common/framework/logging/result.ts
@@ -1,6 +1,9 @@
 import { LogMessageWithStack } from './log_message.js';
 
-export type Status = 'running' | 'pass' | 'skip' | 'warn' | 'fail';
+// TODO: Add warn expectations
+export type Expectation = 'pass' | 'skip' | 'fail';
+
+export type Status = 'running' | 'warn' | Expectation;
 
 export interface TestCaseResult {
   status: Status;

--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -1,3 +1,4 @@
+import { Expectation } from '../logging/result.js';
 import { CaseParams } from '../params_utils.js';
 import { assert } from '../util/util.js';
 
@@ -21,6 +22,16 @@ export type TestQueryLevel =
   | 2 // MultiTest
   | 3 // MultiCase
   | 4; // SingleCase
+
+export interface RawTestQueryStringWithExpectation {
+  query: string;
+  expectation: string;
+}
+
+export interface TestQueryWithExpectation {
+  query: TestQuery;
+  expectation: Expectation;
+}
 
 /**
  * A multi-file test query, like `s:*` or `s:a,b,*`.

--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -1,8 +1,11 @@
+import { optionEnabled } from '../../runtime/helper/options.js';
 import { Expectation } from '../logging/result.js';
 import { CaseParams } from '../params_utils.js';
-import { assert } from '../util/util.js';
+import { assert, unreachable } from '../util/util.js';
 
+import { compareQueries, Ordering } from './compare.js';
 import { encodeURIComponentSelectively } from './encode_selectively.js';
+import { parseQuery } from './parseQuery.js';
 import { kBigSeparator, kPathSeparator, kWildcard } from './separators.js';
 import { stringifyPublicParams } from './stringify_params.js';
 
@@ -22,11 +25,6 @@ export type TestQueryLevel =
   | 2 // MultiTest
   | 3 // MultiCase
   | 4; // SingleCase
-
-export interface RawTestQueryStringWithExpectation {
-  query: string;
-  expectation: string;
-}
 
 export interface TestQueryWithExpectation {
   query: TestQuery;
@@ -145,4 +143,87 @@ export class TestQuerySingleCase extends TestQueryMultiCase {
       stringifyPublicParams(this.params),
     ];
   }
+}
+
+/**
+ * Parse raw expectations input into TestQueryWithExpectation[], filtering so that only
+ * expectations that are relevant for the provided query and wptURL.
+ *
+ * `rawExpectations` should be @type {{ query: string, expectation: Expectation }[]}
+ *
+ * The `rawExpectations` are parsed and validated that they are in the correct format.
+ * If `wptURL` is passed, the query string should be of the full path format such
+ * as `path/to/cts.html?worker=0&q=suite:test_path:test_name:foo=1;bar=2;*`.
+ * If `wptURL` is `undefined`, the query string should be only the query
+ * `suite:test_path:test_name:foo=1;bar=2;*`.
+ */
+export function parseExpectationsForTestQuery(
+  rawExpectations:
+    | unknown
+    | {
+        query: string;
+        expectation: Expectation;
+      }[],
+  query: TestQuery,
+  wptURL?: URL
+) {
+  if (!Array.isArray(rawExpectations)) {
+    unreachable('Expectations should be an array');
+  }
+  const expectations: TestQueryWithExpectation[] = [];
+  for (const entry of rawExpectations) {
+    assert(typeof entry === 'object');
+    const rawExpectation = <
+      {
+        query?: string;
+        expectation?: string;
+      }
+    >entry;
+    assert(rawExpectation.query !== undefined, 'Expectation missing query string');
+    assert(rawExpectation.expectation !== undefined, 'Expectation missing expectation string');
+
+    let expectationQuery: TestQuery;
+    if (wptURL !== undefined) {
+      const expectationURL = new URL(`${wptURL.origin}/${entry.query}`);
+      if (expectationURL.pathname !== wptURL.pathname) {
+        continue;
+      }
+      assert(
+        expectationURL.pathname === wptURL.pathname,
+        `Invalid expectation path ${expectationURL.pathname}
+Expectation should be of the form path/to/cts.html?worker=0&q=suite:test_path:test_name:foo=1;bar=2;...
+        `
+      );
+
+      const params = expectationURL.searchParams;
+      if (optionEnabled('worker', params) !== optionEnabled('worker', wptURL.searchParams)) {
+        continue;
+      }
+
+      const qs = params.getAll('q');
+      assert(qs.length === 1, 'currently, there must be exactly one ?q= in the expectation string');
+      expectationQuery = parseQuery(qs[0]);
+    } else {
+      expectationQuery = parseQuery(entry.query);
+    }
+
+    if (compareQueries(query, expectationQuery) === Ordering.Unordered) {
+      continue;
+    }
+
+    switch (entry.expectation) {
+      case 'pass':
+      case 'skip':
+      case 'fail':
+        break;
+      default:
+        unreachable(`Invalid expectation ${entry.expectation}`);
+    }
+
+    expectations.push({
+      query: expectationQuery,
+      expectation: entry.expectation,
+    });
+  }
+  return expectations;
 }

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -1,12 +1,18 @@
-import { Fixture, SkipTestCase } from './fixture.js';
+import { Fixture, SkipTestCase, UnexpectedPassError } from './fixture.js';
+import { Expectation } from './logging/result.js';
 import { TestCaseRecorder } from './logging/test_case_recorder.js';
 import { CaseParams, extractPublicParams, Merged, mergeParams } from './params_utils.js';
+import { compareQueries, Ordering } from './query/compare.js';
+import { TestQuerySingleCase, TestQueryWithExpectation } from './query/query.js';
 import { kPathSeparator } from './query/separators.js';
 import { stringifyPublicParams, stringifyPublicParamsUniquely } from './query/stringify_params.js';
 import { validQueryPart } from './query/validQueryPart.js';
-import { assert } from './util/util.js';
+import { assert, unreachable } from './util/util.js';
 
-export type RunFn = (rec: TestCaseRecorder) => Promise<void>;
+export type RunFn = (
+  rec: TestCaseRecorder,
+  expectations?: TestQueryWithExpectation[]
+) => Promise<void>;
 
 export interface TestCaseID {
   readonly test: readonly string[];
@@ -15,7 +21,11 @@ export interface TestCaseID {
 
 export interface RunCase {
   readonly id: TestCaseID;
-  run: RunFn;
+  run(
+    rec: TestCaseRecorder,
+    selfQuery: TestQuerySingleCase,
+    expectations: TestQueryWithExpectation[]
+  ): Promise<void>;
 }
 
 // Interface for defining tests
@@ -212,7 +222,8 @@ class TestBuilder<F extends Fixture, P extends {}, SubP extends {}> {
         params,
         this.subcaseParams,
         this.fixture,
-        this.testFn
+        this.testFn,
+        this.testCreationStack
       );
     }
   }
@@ -230,27 +241,35 @@ class RunCaseSpecific<
   private readonly subParamGen?: (_: P) => Iterable<SubP>;
   private readonly fixture: FixtureClass<F>;
   private readonly fn: FN;
+  private readonly testCreationStack: Error;
 
   constructor(
     testPath: string[],
     params: P,
     subParamGen: ((_: P) => Iterable<SubP>) | undefined,
     fixture: FixtureClass<F>,
-    fn: FN
+    fn: FN,
+    testCreationStack: Error
   ) {
     this.id = { test: testPath, params: extractPublicParams(params) };
     this.params = params;
     this.subParamGen = subParamGen;
     this.fixture = fixture;
     this.fn = fn;
+    this.testCreationStack = testCreationStack;
   }
 
   async runTest(
     rec: TestCaseRecorder,
     params: P | Merged<P, SubP>,
-    throwSkip: boolean
+    throwSkip: boolean,
+    expectedStatus: Expectation
   ): Promise<void> {
     try {
+      rec.beginSubCase();
+      if (expectedStatus === 'skip') {
+        throw new SkipTestCase('Skipped by expectations');
+      }
       const inst = new this.fixture(rec, params);
 
       try {
@@ -270,10 +289,47 @@ class RunCaseSpecific<
         throw ex;
       }
       rec.threw(ex);
+    } finally {
+      try {
+        rec.endSubCase(expectedStatus);
+      } catch (ex) {
+        assert(ex instanceof UnexpectedPassError);
+        ex.message = `Testcase passed unexpectedly.`;
+        ex.stack = this.testCreationStack.stack;
+        rec.warn(ex);
+      }
     }
   }
 
-  async run(rec: TestCaseRecorder): Promise<void> {
+  async run(
+    rec: TestCaseRecorder,
+    selfQuery: TestQuerySingleCase,
+    expectations: TestQueryWithExpectation[]
+  ): Promise<void> {
+    const getExpectedStatus = (selfQueryWithSubParams: TestQuerySingleCase) => {
+      let didSeeFail = false;
+      for (const exp of expectations) {
+        const ordering = compareQueries(exp.query, selfQueryWithSubParams);
+        if (ordering === Ordering.Unordered || ordering === Ordering.StrictSubset) {
+          continue;
+        }
+
+        switch (exp.expectation) {
+          // Skip takes precendence. If there is any expecation indicating a skip,
+          // signal it immediately.
+          case 'skip':
+            return 'skip';
+          case 'fail':
+            // Otherwise, indicate that we might expect a failure.
+            didSeeFail = true;
+            break;
+          default:
+            unreachable();
+        }
+      }
+      return didSeeFail ? 'fail' : 'pass';
+    };
+
     rec.start();
     if (this.subParamGen) {
       let totalCount = 0;
@@ -281,7 +337,20 @@ class RunCaseSpecific<
       for (const subParams of this.subParamGen(this.params)) {
         rec.info(new Error('subcase: ' + stringifyPublicParams(subParams)));
         try {
-          await this.runTest(rec, mergeParams(this.params, subParams), true);
+          const params = mergeParams(this.params, subParams);
+          await this.runTest(
+            rec,
+            params,
+            true,
+            getExpectedStatus(
+              new TestQuerySingleCase(
+                selfQuery.suite,
+                selfQuery.filePathParts,
+                selfQuery.testPathParts,
+                <CaseParams>params
+              )
+            )
+          );
         } catch (ex) {
           if (ex instanceof SkipTestCase) {
             // Convert SkipTestCase to info messages
@@ -299,7 +368,7 @@ class RunCaseSpecific<
         rec.skipped(new SkipTestCase('all subcases were skipped'));
       }
     } else {
-      await this.runTest(rec, this.params, false);
+      await this.runTest(rec, this.params, false, getExpectedStatus(selfQuery));
     }
     rec.finish();
   }

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -315,7 +315,7 @@ class RunCaseSpecific<
         }
 
         switch (exp.expectation) {
-          // Skip takes precendence. If there is any expecation indicating a skip,
+          // Skip takes precendence. If there is any expectation indicating a skip,
           // signal it immediately.
           case 'skip':
             return 'skip';
@@ -338,19 +338,13 @@ class RunCaseSpecific<
         rec.info(new Error('subcase: ' + stringifyPublicParams(subParams)));
         try {
           const params = mergeParams(this.params, subParams);
-          await this.runTest(
-            rec,
-            params,
-            true,
-            getExpectedStatus(
-              new TestQuerySingleCase(
-                selfQuery.suite,
-                selfQuery.filePathParts,
-                selfQuery.testPathParts,
-                <CaseParams>params
-              )
-            )
+          const subcaseQuery = new TestQuerySingleCase(
+            selfQuery.suite,
+            selfQuery.filePathParts,
+            selfQuery.testPathParts,
+            <CaseParams>params
           );
+          await this.runTest(rec, params, true, getExpectedStatus(subcaseQuery));
         } catch (ex) {
           if (ex instanceof SkipTestCase) {
             // Convert SkipTestCase to info messages

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -1,5 +1,4 @@
 import { TestFileLoader } from './file_loader.js';
-import { TestCaseRecorder } from './logging/test_case_recorder.js';
 import { CaseParamsRW } from './params_utils.js';
 import { compareQueries, Ordering } from './query/compare.js';
 import {
@@ -421,7 +420,7 @@ function insertLeaf(parent: TestSubtree, query: TestQuerySingleCase, t: RunCase)
   const leaf: TestTreeLeaf = {
     readableRelativeName: readableNameForCase(query),
     query,
-    run: (rec: TestCaseRecorder) => t.run(rec),
+    run: (rec, expectations) => t.run(rec, query, expectations || []),
   };
   assert(!parent.children.has(key));
   parent.children.set(key, leaf);

--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -62,11 +62,11 @@ if (queries.length === 0) {
 (async () => {
   const loader = new DefaultTestFileLoader();
   assert(queries.length === 1, 'currently, there must be exactly one query on the cmd line');
-  const testcaseQuery = parseQuery(queries[0]);
-  const testcases = await loader.loadCases(testcaseQuery);
+  const filterQuery = parseQuery(queries[0]);
+  const testcases = await loader.loadCases(filterQuery);
   const expectations = parseExpectationsForTestQuery(
     await (loadWebGPUExpectations ?? []),
-    testcaseQuery
+    filterQuery
   );
 
   const log = new Logger(debug);

--- a/src/common/runtime/helper/options.ts
+++ b/src/common/runtime/helper/options.ts
@@ -1,6 +1,15 @@
-const url = new URL(window.location.toString());
+let windowURL: URL | undefined = undefined;
+function getWindowURL() {
+  if (windowURL === undefined) {
+    windowURL = new URL(window.location.toString());
+  }
+  return windowURL;
+}
 
-export function optionEnabled(opt: string): boolean {
-  const val = url.searchParams.get(opt);
+export function optionEnabled(
+  opt: string,
+  searchParams: URLSearchParams = getWindowURL().searchParams
+): boolean {
+  const val = searchParams.get(opt);
   return val !== null && val !== '0';
 }

--- a/src/common/runtime/helper/test_worker-worker.ts
+++ b/src/common/runtime/helper/test_worker-worker.ts
@@ -1,6 +1,7 @@
 import { DefaultTestFileLoader } from '../../framework/file_loader.js';
 import { Logger } from '../../framework/logging/logger.js';
 import { parseQuery } from '../../framework/query/parseQuery.js';
+import { TestQueryWithExpectation } from '../../framework/query/query.js';
 import { assert } from '../../framework/util/util.js';
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -10,6 +11,7 @@ const loader = new DefaultTestFileLoader();
 
 self.onmessage = async (ev: MessageEvent) => {
   const query: string = ev.data.query;
+  const expectations: TestQueryWithExpectation[] = ev.data.expectations;
   const debug: boolean = ev.data.debug;
 
   const log = new Logger(debug);
@@ -19,7 +21,7 @@ self.onmessage = async (ev: MessageEvent) => {
 
   const testcase = testcases[0];
   const [rec, result] = log.record(testcase.query.toString());
-  await testcase.run(rec);
+  await testcase.run(rec, expectations);
 
   self.postMessage({ query, result });
 };

--- a/src/common/runtime/helper/test_worker.ts
+++ b/src/common/runtime/helper/test_worker.ts
@@ -1,6 +1,7 @@
 import { LogMessageWithStack } from '../../framework/logging/log_message.js';
 import { TransferredTestCaseResult, LiveTestCaseResult } from '../../framework/logging/result.js';
 import { TestCaseRecorder } from '../../framework/logging/test_case_recorder.js';
+import { TestQueryWithExpectation } from '../../framework/query/query.js';
 
 export class TestWorker {
   private readonly debug: boolean;
@@ -29,8 +30,12 @@ export class TestWorker {
     };
   }
 
-  async run(rec: TestCaseRecorder, query: string): Promise<void> {
-    this.worker.postMessage({ query, debug: this.debug });
+  async run(
+    rec: TestCaseRecorder,
+    query: string,
+    expectations: TestQueryWithExpectation[] = []
+  ): Promise<void> {
+    this.worker.postMessage({ query, expectations, debug: this.debug });
     const workerResult = await new Promise<LiveTestCaseResult>(resolve => {
       this.resolvers.set(query, resolve);
     });

--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -33,12 +33,12 @@ setup({
   const loader = new DefaultTestFileLoader();
   const qs = new URLSearchParams(window.location.search).getAll('q');
   assert(qs.length === 1, 'currently, there must be exactly one ?q=');
-  const testcaseQuery = parseQuery(qs[0]);
-  const testcases = await loader.loadCases(testcaseQuery);
+  const filterQuery = parseQuery(qs[0]);
+  const testcases = await loader.loadCases(filterQuery);
 
   const expectations = parseExpectationsForTestQuery(
     await (loadWebGPUExpectations ?? []),
-    testcaseQuery,
+    filterQuery,
     new URL(window.location.href)
   );
 

--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -2,13 +2,9 @@
 
 import { DefaultTestFileLoader } from '../framework/file_loader.js';
 import { Logger } from '../framework/logging/logger.js';
-import { compareQueries, Ordering } from '../framework/query/compare.js';
 import { parseQuery } from '../framework/query/parseQuery.js';
-import {
-  RawTestQueryStringWithExpectation,
-  TestQueryWithExpectation,
-} from '../framework/query/query.js';
-import { assert, unreachable } from '../framework/util/util.js';
+import { parseExpectationsForTestQuery } from '../framework/query/query.js';
+import { assert } from '../framework/util/util.js';
 
 import { optionEnabled } from './helper/options.js';
 import { TestWorker } from './helper/test_worker.js';
@@ -22,7 +18,7 @@ declare function setup(properties: { explicit_done?: boolean }): void;
 declare function promise_test(f: (t: WptTestObject) => Promise<void>, name: string): void;
 declare function done(): void;
 
-declare let loadWebGPUExpectations: Promise<RawTestQueryStringWithExpectation[]> | undefined;
+declare const loadWebGPUExpectations: Promise<unknown> | undefined;
 
 setup({
   // It's convenient for us to asynchronously add tests to the page. Prevent done() from being
@@ -40,42 +36,11 @@ setup({
   const testcaseQuery = parseQuery(qs[0]);
   const testcases = await loader.loadCases(testcaseQuery);
 
-  const expectations: TestQueryWithExpectation[] = [];
-  if (typeof loadWebGPUExpectations !== 'undefined') {
-    (await loadWebGPUExpectations).forEach(entry => {
-      const url = new URL(`${window.location.origin}/${entry.query}`);
-      if (url.pathname !== window.location.pathname) {
-        return;
-      }
-
-      const params = url.searchParams;
-      if (workerEnabled !== optionEnabled('worker', params)) {
-        return;
-      }
-
-      const qs = params.getAll('q');
-      assert(qs.length === 1, 'currently, there must be exactly one ?q=');
-      const query = parseQuery(qs[0]);
-
-      if (compareQueries(testcaseQuery, query) === Ordering.Unordered) {
-        return;
-      }
-
-      switch (entry.expectation) {
-        case 'pass':
-        case 'skip':
-        case 'fail':
-          break;
-        default:
-          unreachable();
-      }
-
-      expectations.push({
-        query,
-        expectation: entry.expectation,
-      });
-    });
-  }
+  const expectations = parseExpectationsForTestQuery(
+    await (loadWebGPUExpectations ?? []),
+    testcaseQuery,
+    new URL(window.location.href)
+  );
 
   const log = new Logger(false);
 

--- a/src/common/templates/cts.html
+++ b/src/common/templates/cts.html
@@ -25,4 +25,7 @@
 
 <script src=/resources/testharness.js></script>
 <script src=/resources/testharnessreport.js></script>
+<script>
+    const loadWebGPUExpectations = undefined;
+</script>
 <script type=module src=/webgpu/common/runtime/wpt.js></script>

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -3,6 +3,7 @@ Tests for queries/filtering, loading, and running.
 `;
 
 import { TestFileLoader, SpecFile } from '../common/framework/file_loader.js';
+import { Fixture } from '../common/framework/fixture.js';
 import { Logger } from '../common/framework/logging/logger.js';
 import { Status } from '../common/framework/logging/result.js';
 import { parseQuery } from '../common/framework/query/parseQuery.js';
@@ -12,6 +13,7 @@ import {
   TestQueryMultiCase,
   TestQueryMultiTest,
   TestQueryMultiFile,
+  TestQueryWithExpectation,
 } from '../common/framework/query/query.js';
 import { makeTestGroup, makeTestGroupForUnitTesting } from '../common/framework/test_group.js';
 import { TestSuiteListing, TestSuiteListingEntry } from '../common/framework/test_suite_listing.js';
@@ -198,44 +200,443 @@ g.test('case').fn(async t => {
   }
 });
 
+async function runTestcase(
+  t: Fixture,
+  log: Logger,
+  testcases: TestTreeLeaf[],
+  i: number,
+  query: TestQuery,
+  expectations: TestQueryWithExpectation[],
+  status: Status,
+  logs: (s: string[]) => boolean
+) {
+  t.expect(objectEquals(testcases[i].query, query));
+  const name = testcases[i].query.toString();
+  const [rec, res] = log.record(name);
+  await testcases[i].run(rec, expectations);
+
+  t.expect(log.results.get(name) === res);
+  t.expect(res.status === status);
+  t.expect(res.timems >= 0);
+  assert(res.logs !== undefined); // only undefined while pending
+  t.expect(logs(res.logs.map(l => JSON.stringify(l))));
+}
+
 g.test('end2end').fn(async t => {
   const l = await t.load('suite2:foof:*');
   assert(l.length === 3, 'listing length');
 
   const log = new Logger(true);
 
-  const exp = async (
-    i: number,
-    query: TestQuery,
-    status: Status,
-    logs: (s: string[]) => boolean
-  ) => {
-    t.expect(objectEquals(l[i].query, query));
-    const name = l[i].query.toString();
-    const [rec, res] = log.record(name);
-    await l[i].run(rec);
-
-    t.expect(log.results.get(name) === res);
-    t.expect(res.status === status);
-    t.expect(res.timems >= 0);
-    assert(res.logs !== undefined); // only undefined while pending
-    t.expect(logs(res.logs.map(l => JSON.stringify(l))));
-  };
-
-  await exp(0, new TestQuerySingleCase('suite2', ['foof'], ['blah'], {}), 'pass', logs =>
-    objectEquals(logs, ['"DEBUG: OK"'])
+  await runTestcase(
+    t,
+    log,
+    l,
+    0,
+    new TestQuerySingleCase('suite2', ['foof'], ['blah'], {}),
+    [],
+    'pass',
+    logs => objectEquals(logs, ['"DEBUG: OK"'])
   );
-  await exp(1, new TestQuerySingleCase('suite2', ['foof'], ['bleh'], { a: 1 }), 'pass', logs =>
-    objectEquals(logs, ['"DEBUG: OK"', '"DEBUG: OK"'])
+  await runTestcase(
+    t,
+    log,
+    l,
+    1,
+    new TestQuerySingleCase('suite2', ['foof'], ['bleh'], { a: 1 }),
+    [],
+    'pass',
+    logs => objectEquals(logs, ['"DEBUG: OK"', '"DEBUG: OK"'])
   );
-  await exp(
+  await runTestcase(
+    t,
+    log,
+    l,
     2,
     new TestQuerySingleCase('suite2', ['foof'], ['bluh', 'a'], {}),
+    [],
     'fail',
     logs =>
       logs.length === 1 &&
       logs[0].startsWith('"EXPECTATION FAILED: goodbye\\n') &&
       logs[0].indexOf('loaders_and_trees.spec.') !== -1
+  );
+});
+
+g.test('expectations,single_case').fn(async t => {
+  const log = new Logger(true);
+  const zedCases = await t.load('suite1:baz:zed:*');
+
+  // Single-case. Covers one case.
+  const zedExpectationsSkipA1B2 = [
+    {
+      query: new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 2 }),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    0,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 2 }),
+    zedExpectationsSkipA1B2,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    1,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 3 }),
+    zedExpectationsSkipA1B2,
+    'pass',
+    logs => logs.length === 0
+  );
+});
+
+g.test('expectations,single_case,none').fn(async t => {
+  const log = new Logger(true);
+  const zedCases = await t.load('suite1:baz:zed:*');
+  // Single-case. Doesn't cover any cases.
+  const zedExpectationsSkipA1B0 = [
+    {
+      query: new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 0 }),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    0,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 2 }),
+    zedExpectationsSkipA1B0,
+    'pass',
+    logs => logs.length === 0
+  );
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    1,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 3 }),
+    zedExpectationsSkipA1B0,
+    'pass',
+    logs => logs.length === 0
+  );
+});
+
+g.test('expectations,multi_case').fn(async t => {
+  const log = new Logger(true);
+  const zedCases = await t.load('suite1:baz:zed:*');
+  // Multi-case, not all cases covered.
+  const zedExpectationsSkipB3 = [
+    {
+      query: new TestQueryMultiCase('suite1', ['baz'], ['zed'], { b: 3 }),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    0,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 2 }),
+    zedExpectationsSkipB3,
+    'pass',
+    logs => logs.length === 0
+  );
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    1,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 3 }),
+    zedExpectationsSkipB3,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+});
+
+g.test('expectations,multi_case_all').fn(async t => {
+  const log = new Logger(true);
+  const zedCases = await t.load('suite1:baz:zed:*');
+  // Multi-case, all cases covered.
+  const zedExpectationsSkipA1 = [
+    {
+      query: new TestQueryMultiCase('suite1', ['baz'], ['zed'], { a: 1 }),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    0,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 2 }),
+    zedExpectationsSkipA1,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    1,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 3 }),
+    zedExpectationsSkipA1,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+});
+
+g.test('expectations,multi_case_none').fn(async t => {
+  const log = new Logger(true);
+  const zedCases = await t.load('suite1:baz:zed:*');
+  // Multi-case, no params, all cases covered.
+  const zedExpectationsSkipZed = [
+    {
+      query: new TestQueryMultiCase('suite1', ['baz'], ['zed'], {}),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    0,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 2 }),
+    zedExpectationsSkipZed,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+
+  await runTestcase(
+    t,
+    log,
+    zedCases,
+    1,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 3 }),
+    zedExpectationsSkipZed,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+});
+
+g.test('expectations,multi_test').fn(async t => {
+  const log = new Logger(true);
+  const suite1Cases = await t.load('suite1:*');
+
+  // Multi-test, all cases covered.
+  const expectationsSkipAllInBaz = [
+    {
+      query: new TestQueryMultiTest('suite1', ['baz'], []),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    suite1Cases,
+    4,
+    new TestQuerySingleCase('suite1', ['baz'], ['wye'], {}),
+    expectationsSkipAllInBaz,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+
+  await runTestcase(
+    t,
+    log,
+    suite1Cases,
+    6,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 2 }),
+    expectationsSkipAllInBaz,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+});
+
+g.test('expectations,multi_test,none').fn(async t => {
+  const log = new Logger(true);
+  const suite1Cases = await t.load('suite1:*');
+
+  // Multi-test, no cases covered.
+  const expectationsSkipAllInFoo = [
+    {
+      query: new TestQueryMultiTest('suite1', ['foo'], []),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    suite1Cases,
+    4,
+    new TestQuerySingleCase('suite1', ['baz'], ['wye'], {}),
+    expectationsSkipAllInFoo,
+    'pass',
+    logs => logs.length === 0
+  );
+
+  await runTestcase(
+    t,
+    log,
+    suite1Cases,
+    6,
+    new TestQuerySingleCase('suite1', ['baz'], ['zed'], { a: 1, b: 2 }),
+    expectationsSkipAllInFoo,
+    'pass',
+    logs => logs.length === 0
+  );
+});
+
+g.test('expectations,multi_file').fn(async t => {
+  const log = new Logger(true);
+  const suite1Cases = await t.load('suite1:*');
+
+  // Multi-file
+  const expectationsSkipAll = [
+    {
+      query: new TestQueryMultiFile('suite1', []),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    suite1Cases,
+    0,
+    new TestQuerySingleCase('suite1', ['foo'], ['hello'], {}),
+    expectationsSkipAll,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+
+  await runTestcase(
+    t,
+    log,
+    suite1Cases,
+    3,
+    new TestQuerySingleCase('suite1', ['bar', 'buzz', 'buzz'], ['zap'], {}),
+    expectationsSkipAll,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+});
+
+g.test('expectations,catches_failure').fn(async t => {
+  const log = new Logger(true);
+  const suite2Cases = await t.load('suite2:*');
+
+  // Catches failure
+  const expectedFailures = [
+    {
+      query: new TestQueryMultiCase('suite2', ['foof'], ['bluh', 'a'], {}),
+      expectation: 'fail' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    suite2Cases,
+    0,
+    new TestQuerySingleCase('suite2', ['foof'], ['blah'], {}),
+    expectedFailures,
+    'pass',
+    logs => objectEquals(logs, ['"DEBUG: OK"'])
+  );
+
+  // Status is passed, but failure is logged.
+  await runTestcase(
+    t,
+    log,
+    suite2Cases,
+    2,
+    new TestQuerySingleCase('suite2', ['foof'], ['bluh', 'a'], {}),
+    expectedFailures,
+    'pass',
+    logs => logs.length === 1 && logs[0].startsWith('"EXPECTATION FAILED: goodbye\\n')
+  );
+});
+
+g.test('expectations,skip_dominates_failure').fn(async t => {
+  const log = new Logger(true);
+  const suite2Cases = await t.load('suite2:*');
+
+  const expectedFailures = [
+    {
+      query: new TestQueryMultiCase('suite2', ['foof'], ['bluh', 'a'], {}),
+      expectation: 'fail' as const,
+    },
+    {
+      query: new TestQueryMultiCase('suite2', ['foof'], ['bluh', 'a'], {}),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    suite2Cases,
+    2,
+    new TestQuerySingleCase('suite2', ['foof'], ['bluh', 'a'], {}),
+    expectedFailures,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+});
+
+g.test('expectations,skip_inside_failure').fn(async t => {
+  const log = new Logger(true);
+  const suite2Cases = await t.load('suite2:*');
+
+  const expectedFailures = [
+    {
+      query: new TestQueryMultiFile('suite2', []),
+      expectation: 'fail' as const,
+    },
+    {
+      query: new TestQueryMultiCase('suite2', ['foof'], ['blah'], {}),
+      expectation: 'skip' as const,
+    },
+  ];
+
+  await runTestcase(
+    t,
+    log,
+    suite2Cases,
+    0,
+    new TestQuerySingleCase('suite2', ['foof'], ['blah'], {}),
+    expectedFailures,
+    'skip',
+    logs => logs.length === 1 && logs[0].startsWith('"SKIP: Skipped by expectations"')
+  );
+
+  await runTestcase(
+    t,
+    log,
+    suite2Cases,
+    2,
+    new TestQuerySingleCase('suite2', ['foof'], ['bluh', 'a'], {}),
+    expectedFailures,
+    'pass',
+    logs => logs.length === 1 && logs[0].startsWith('"EXPECTATION FAILED: goodbye\\n')
   );
 });
 

--- a/src/unittests/test_group_test.ts
+++ b/src/unittests/test_group_test.ts
@@ -12,7 +12,7 @@ export class TestGroupTest extends UnitTest {
       for (const rc of t.iterate()) {
         const query = new TestQuerySingleCase('xx', ['yy'], rc.id.test, rc.id.params);
         const [rec] = logger.record(query.toString());
-        await rc.run(rec);
+        await rc.run(rec, query, []);
       }
     }
     return logger.results;

--- a/tools/deno
+++ b/tools/deno
@@ -11,6 +11,7 @@ import { Logger } from "../out/common/framework/logging/logger.js";
 import { parseQuery } from "../out/common/framework/query/parseQuery.js";
 import { compareQueries, Ordering } from '../out/common/framework/query/compare.js';
 import { assert, unreachable } from "../out/common/framework/util/util.js";
+import { parseExpectationsForTestQuery } from "../src/common/framework/query/query.js";
 
 function usage(rc) {
   console.log("Usage:");
@@ -109,31 +110,10 @@ try {
   );
   const testcaseQuery = parseQuery(queries[0]);
   const testcases = await loader.loadCases(testcaseQuery);
-
-  const expectations = [];
-  if (typeof loadWebGPUExpectations !== 'undefined') {
-    (await loadWebGPUExpectations).forEach(entry => {
-      const query = parseQuery(entry.query);
-
-      if (compareQueries(testcaseQuery, query) === Ordering.Unordered) {
-        return;
-      }
-
-      switch (entry.expectation) {
-        case 'pass':
-        case 'skip':
-        case 'fail':
-          break;
-        default:
-          unreachable();
-      }
-
-      expectations.push({
-        query,
-        expectation: entry.expectation,
-      });
-    });
-  }
+  const expectations = parseExpectationsForTestQuery(
+    await (loadWebGPUExpectations ?? []),
+    testcaseQuery
+  );
 
   const log = new Logger(debug);
 

--- a/tools/deno
+++ b/tools/deno
@@ -108,11 +108,11 @@ try {
     queries.length === 1,
     "currently, there must be exactly one query on the cmd line",
   );
-  const testcaseQuery = parseQuery(queries[0]);
-  const testcases = await loader.loadCases(testcaseQuery);
+  const filterQuery = parseQuery(queries[0]);
+  const testcases = await loader.loadCases(filterQuery);
   const expectations = parseExpectationsForTestQuery(
     await (loadWebGPUExpectations ?? []),
-    testcaseQuery
+    filterQuery
   );
 
   const log = new Logger(debug);

--- a/tools/deno
+++ b/tools/deno
@@ -80,7 +80,7 @@ for (const a of Deno.args) {
     } else if (a.startsWith("--ignore-file=")) {
       ignoreFile = a.slice("--ignore-file=".length);
     } else if (a === '--expectations') {
-      const expectationsFile = pathResolve(Deno.cwd(), process.argv[++i]);
+      const expectationsFile = pathResolve(Deno.cwd(), Deno.args[++i]);
       loadWebGPUExpectations = import(expectationsFile).then(m => m.expectations);
     } else {
       usage(1);

--- a/tools/deno
+++ b/tools/deno
@@ -4,10 +4,12 @@
 /* eslint no-process-exit: "off" */
 
 import { existsSync } from "https://deno.land/std@0.90.0/fs/exists.ts";
+import { resolve as pathResolve } from "https://deno.land/std@0.90.0/path/mod.ts"
 
 import { DefaultTestFileLoader } from "../out/common/framework/file_loader.js";
 import { Logger } from "../out/common/framework/logging/logger.js";
 import { parseQuery } from "../out/common/framework/query/parseQuery.js";
+import { compareQueries, Ordering } from '../out/common/framework/query/compare.js';
 import { assert, unreachable } from "../out/common/framework/util/util.js";
 
 function usage(rc) {
@@ -20,6 +22,7 @@ function usage(rc) {
   console.log("  --print-json          Print the complete result JSON in the output.");
   console.log("  --trace               Record a trace of the WebGPU operations into a ./trace directory.");
   console.log("  --ignore-file=<file>  A line delimited text file containing names of tests to skip.");
+  console.log('  --expectations        Path to expectations file. Must be absolute, or relative to')
   return Deno.exit(rc);
 }
 
@@ -61,6 +64,8 @@ let trace = false;
 let debug = false;
 let ignoreFile = undefined;
 let printJSON = false;
+let loadWebGPUExpectations = undefined;
+
 const queries = [];
 for (const a of Deno.args) {
   if (a.startsWith("-")) {
@@ -74,6 +79,9 @@ for (const a of Deno.args) {
       printJSON = true;
     } else if (a.startsWith("--ignore-file=")) {
       ignoreFile = a.slice("--ignore-file=".length);
+    } else if (a === '--expectations') {
+      const expectationsFile = pathResolve(Deno.cwd(), process.argv[++i]);
+      loadWebGPUExpectations = import(expectationsFile).then(m => m.expectations);
     } else {
       usage(1);
     }
@@ -99,7 +107,33 @@ try {
     queries.length === 1,
     "currently, there must be exactly one query on the cmd line",
   );
-  const testcases = await loader.loadCases(parseQuery(queries[0]));
+  const testcaseQuery = parseQuery(queries[0]);
+  const testcases = await loader.loadCases(testcaseQuery);
+
+  const expectations = [];
+  if (typeof loadWebGPUExpectations !== 'undefined') {
+    (await loadWebGPUExpectations).forEach(entry => {
+      const query = parseQuery(entry.query);
+
+      if (compareQueries(testcaseQuery, query) === Ordering.Unordered) {
+        return;
+      }
+
+      switch (entry.expectation) {
+        case 'pass':
+        case 'skip':
+        case 'fail':
+          break;
+        default:
+          unreachable();
+      }
+
+      expectations.push({
+        query,
+        expectation: entry.expectation,
+      });
+    });
+  }
 
   const log = new Logger(debug);
 
@@ -126,7 +160,7 @@ try {
       Deno.env.set("DENO_WEBGPU_TRACE", traceDir);
     }
     const [rec, res] = log.record(name);
-    await testcase.run(rec);
+    await testcase.run(rec, expectations);
 
     if (verbose) {
       printResults([[name, res]]);


### PR DESCRIPTION
On the command line, test expectations are accepted by a command line
flag `--expectations path/to/expectations.ts`, where `expectations.ts` is
a module that exports `RawTestQueryStringWithExpectation[]` as
`expectations`. In WPT, the page should define a global variable
`loadWebGPUExpectations` which is a
`Promise<RawTestQueryStringWithExpectation[]>`.

The test expectations are filtered down to only what is relevant for
the running test query, and applied to the testcases before they run.
A `'skip'` expectation will entirely skip a testcase, and a `'fail'`
expectation will surface failures as passes. If a `'fail'` expectation
is found, but a test actually passes, the harness will log an warning
for the unexpected pass.



-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [ ] TypeScript readability
