### PR TITLE
Fix check of `loadWebGPUExpectations` for undefined

### DIFF
--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -36,11 +36,14 @@ setup({
   const filterQuery = parseQuery(qs[0]);
   const testcases = await loader.loadCases(filterQuery);
 
-  const expectations = parseExpectationsForTestQuery(
-    await (loadWebGPUExpectations ?? []),
-    filterQuery,
-    new URL(window.location.href)
-  );
+  const expectations =
+    typeof loadWebGPUExpectations !== 'undefined'
+      ? parseExpectationsForTestQuery(
+          await loadWebGPUExpectations,
+          filterQuery,
+          new URL(window.location.href)
+        )
+      : [];
 
   const log = new Logger(false);
 


### PR DESCRIPTION
`if (someVariable)` does not work if the variable is
truly undefined. `typeof someVariable !== 'undefined'` should
be used instead.



-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [ ] TypeScript readability
