### PR TITLE
Fix multicase test expectation filtering

### DIFF
--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -207,7 +207,20 @@ Expectation should be of the form path/to/cts.html?worker=0&q=suite:test_path:te
       expectationQuery = parseQuery(entry.query);
     }
 
-    if (compareQueries(query, expectationQuery) === Ordering.Unordered) {
+    // Strip params from multicase expectations so that an expectation of foo=2;*
+    // is stored if the test query is bar=3;*
+    const queryForFilter =
+      expectationQuery instanceof TestQueryMultiCase
+        ? new TestQueryMultiCase(
+            expectationQuery.suite,
+            expectationQuery.filePathParts,
+            expectationQuery.testPathParts,
+            {}
+          )
+        : expectationQuery;
+
+
+    if (compareQueries(query, queryForFilter) === Ordering.Unordered) {
       continue;
     }
 

--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -219,7 +219,6 @@ Expectation should be of the form path/to/cts.html?worker=0&q=suite:test_path:te
           )
         : expectationQuery;
 
-
     if (compareQueries(query, queryForFilter) === Ordering.Unordered) {
       continue;
     }


### PR DESCRIPTION
The filter was removing multicase expectations that did not have
overlapping params with the test query. Strip the params since a
multicase expectation (ending in "*") could match a test query
even if the explicitly listed params are different.

ex.) foo=2;* may match bar=3;*



-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
