### PR TITLE
gen_wpt_cts_html: Split lines by either \r\n or \n

### DIFF
--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -54,11 +54,11 @@ const [
   } else {
     // Prefixes sorted from longest to shortest
     const argsPrefixes = (await fs.readFile(argsPrefixesFile, 'utf8'))
-      .split('\n')
+      .split(/\r?\n/)
       .filter(a => a.length)
       .sort((a, b) => b.length - a.length);
     const expectationLines = new Set(
-      (await fs.readFile(expectationsFile, 'utf8')).split('\n').filter(l => l.length)
+      (await fs.readFile(expectationsFile, 'utf8')).split(/\r?\n/).filter(l => l.length)
     );
 
     const expectations: Map<string, string[]> = new Map();


### PR DESCRIPTION

-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
