### PR TITLE
Some depth related tests

### DIFF
--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -115,10 +115,3 @@ g.test('fullscreen_quad').fn(async t => {
 g.test('large_draw')
   .desc(`Test reasonably-sized large {draw, drawIndexed} (see also stress tests).`)
   .unimplemented();
-
-g.test('reverse_depth')
-  .desc(
-    `Tests simple rendering with reversed depth buffer, ensures depth test works properly.
-  (see https://developer.nvidia.com/content/depth-precision-visualized).`
-  )
-  .unimplemented();

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -1,0 +1,266 @@
+export const description = `
+Test related to depth buffer, depth op, compare func, etc.
+`;
+
+import { pbool, params, poptions } from '../../../../common/framework/params_builder.js';
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { kDepthStencilFormats } from '../../../capability_info.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+const backgroundColor = [0x00, 0x00, 0x00, 0xff];
+const triangleColor = [0xff, 0xff, 0xff, 0xff];
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('depth_compare_func')
+  .desc(
+    `Tests each depth compare function works properly. The depth of the triangle is always 0.5.`
+  )
+  .cases(
+    params()
+      .combine(
+        poptions(
+          'format',
+          kDepthStencilFormats.filter(format => format !== 'stencil8')
+        )
+      )
+      .combine([
+        { depthCompare: 'never', depthLoadValue: 1.0, expected: backgroundColor },
+        { depthCompare: 'never', depthLoadValue: 0.5, expected: backgroundColor },
+        { depthCompare: 'never', depthLoadValue: 0.0, expected: backgroundColor },
+        { depthCompare: 'less', depthLoadValue: 1.0, expected: triangleColor },
+        { depthCompare: 'less', depthLoadValue: 0.5, expected: backgroundColor },
+        { depthCompare: 'less', depthLoadValue: 0.0, expected: backgroundColor },
+        { depthCompare: 'less-equal', depthLoadValue: 1.0, expected: triangleColor },
+        { depthCompare: 'less-equal', depthLoadValue: 0.5, expected: triangleColor },
+        { depthCompare: 'less-equal', depthLoadValue: 0.0, expected: backgroundColor },
+        { depthCompare: 'equal', depthLoadValue: 1.0, expected: backgroundColor },
+        { depthCompare: 'equal', depthLoadValue: 0.5, expected: triangleColor },
+        { depthCompare: 'equal', depthLoadValue: 0.0, expected: backgroundColor },
+        { depthCompare: 'not-equal', depthLoadValue: 1.0, expected: triangleColor },
+        { depthCompare: 'not-equal', depthLoadValue: 0.5, expected: backgroundColor },
+        { depthCompare: 'not-equal', depthLoadValue: 0.0, expected: triangleColor },
+        { depthCompare: 'greater-equal', depthLoadValue: 1.0, expected: backgroundColor },
+        { depthCompare: 'greater-equal', depthLoadValue: 0.5, expected: triangleColor },
+        { depthCompare: 'greater-equal', depthLoadValue: 0.0, expected: triangleColor },
+        { depthCompare: 'greater', depthLoadValue: 1.0, expected: backgroundColor },
+        { depthCompare: 'greater', depthLoadValue: 0.5, expected: backgroundColor },
+        { depthCompare: 'greater', depthLoadValue: 0.0, expected: triangleColor },
+        { depthCompare: 'always', depthLoadValue: 1.0, expected: triangleColor },
+        { depthCompare: 'always', depthLoadValue: 0.5, expected: triangleColor },
+        { depthCompare: 'always', depthLoadValue: 0.0, expected: triangleColor },
+      ])
+  )
+  .fn(async t => {
+    const { depthCompare, depthLoadValue, expected, format } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
+
+    const dst = t.device.createBuffer({
+      size: 4,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+
+    const colorAttachment = t.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    const colorAttachmentView = colorAttachment.createView();
+
+    const depthTexture = t.device.createTexture({
+      size: { width: 1, height: 1 },
+      format,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.SAMPLED,
+    });
+    const depthTextureView = depthTexture.createView();
+
+    const pipelineDescriptor: GPURenderPipelineDescriptor = {
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+            [[builtin(position)]] var<out> Position : vec4<f32>;
+            [[builtin(vertex_index)]] var<in> VertexIndex : u32;
+
+            [[location(0)]] var<out> color : vec4<f32>;
+
+            [[stage(vertex)]] fn main() -> void {
+              const pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+                  vec2<f32>(-1.0, -3.0),
+                  vec2<f32>(3.0, 1.0),
+                  vec2<f32>(-1.0, 1.0));
+              Position = vec4<f32>(pos[VertexIndex], 0.5, 1.0);
+            }
+            `,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `
+            [[location(0)]] var<out> fragColor : vec4<f32>;
+            [[stage(fragment)]] fn main() -> void {
+              fragColor = vec4<f32>(1.0, 1.0, 1.0, 1.0);
+            }
+            `,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+      primitive: { topology: 'triangle-list' },
+      depthStencil: {
+        depthWriteEnabled: true,
+        depthCompare: depthCompare as GPUCompareFunction,
+        format,
+      },
+    };
+    const pipeline = t.device.createRenderPipeline(pipelineDescriptor);
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          attachment: colorAttachmentView,
+          storeOp: 'store',
+          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+        },
+      ],
+      depthStencilAttachment: {
+        attachment: depthTextureView,
+
+        depthLoadValue,
+        depthStoreOp: 'store',
+        stencilLoadValue: 0,
+        stencilStoreOp: 'store',
+      },
+    });
+    pass.setPipeline(pipeline);
+    pass.draw(3, 2);
+    pass.endPass();
+    encoder.copyTextureToBuffer(
+      { texture: colorAttachment, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: dst, bytesPerRow: 256 },
+      { width: 1, height: 1, depthOrArrayLayers: 1 }
+    );
+    t.device.queue.submit([encoder.finish()]);
+
+    t.expectContents(dst, new Uint8Array(expected));
+  });
+
+g.test('reverse_depth')
+  .desc(
+    `Tests simple rendering with reversed depth buffer, ensures depth test works properly: triangles are in correct order and out of range triangles are clipped.
+    Note that in real use case the depth range remapping is done by the modified projection matrix.
+(see https://developer.nvidia.com/content/depth-precision-visualized).`
+  )
+  .cases(pbool('reversed'))
+  .fn(async t => {
+    const dst = t.device.createBuffer({
+      size: 4,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+
+    const colorAttachment = t.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    const colorAttachmentView = colorAttachment.createView();
+
+    const depthBufferFormat = 'depth32float';
+    const depthTexture = t.device.createTexture({
+      size: { width: 1, height: 1 },
+      format: depthBufferFormat,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.SAMPLED,
+    });
+    const depthTextureView = depthTexture.createView();
+
+    const pipelineDescriptor: GPURenderPipelineDescriptor = {
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+            [[builtin(position)]] var<out> Position : vec4<f32>;
+            [[builtin(vertex_index)]] var<in> VertexIndex : u32;
+            [[builtin(instance_index)]] var<in> InstanceIndex : u32;
+
+            [[location(0)]] var<out> color : vec4<f32>;
+
+            [[stage(vertex)]] fn main() -> void {
+              const pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+                  vec2<f32>(-1.0, -3.0),
+                  vec2<f32>(3.0, 1.0),
+                  vec2<f32>(-1.0, 1.0));
+              // TODO: remove workaround for Tint unary array access broke
+              const zv : array<vec2<f32>, 4> = array<vec2<f32>, 4>(
+                  vec2<f32>(0.2, 0.2),
+                  vec2<f32>(0.3, 0.3),
+                  vec2<f32>(-0.1, -0.1),
+                  vec2<f32>(1.1, 1.1));
+              const z : f32 = zv[InstanceIndex].x;
+              Position = vec4<f32>(pos[VertexIndex], z, 1.0);
+              const colors : array<vec4<f32>, 4> = array<vec4<f32>, 4>(
+                  vec4<f32>(1.0, 0.0, 0.0, 1.0),
+                  vec4<f32>(0.0, 1.0, 0.0, 1.0),
+                  vec4<f32>(0.0, 0.0, 1.0, 1.0),
+                  vec4<f32>(1.0, 1.0, 1.0, 1.0)
+              );
+              color = colors[InstanceIndex];
+            }
+            `,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `
+            [[location(0)]] var<in> color : vec4<f32>;
+            [[location(0)]] var<out> fragColor : vec4<f32>;
+            [[stage(fragment)]] fn main() -> void {
+              fragColor = color;
+            }
+            `,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+      primitive: { topology: 'triangle-list' },
+      depthStencil: {
+        depthWriteEnabled: true,
+        depthCompare: t.params.reversed ? 'greater' : 'less',
+        format: depthBufferFormat,
+      },
+    };
+    const pipeline = t.device.createRenderPipeline(pipelineDescriptor);
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          attachment: colorAttachmentView,
+          storeOp: 'store',
+          loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+        },
+      ],
+      depthStencilAttachment: {
+        attachment: depthTextureView,
+
+        depthLoadValue: t.params.reversed ? 0.0 : 1.0,
+        depthStoreOp: 'store',
+        stencilLoadValue: 0,
+        stencilStoreOp: 'store',
+      },
+    });
+    pass.setPipeline(pipeline);
+    pass.draw(3, 2);
+    pass.endPass();
+    encoder.copyTextureToBuffer(
+      { texture: colorAttachment, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: dst, bytesPerRow: 256 },
+      { width: 1, height: 1, depthOrArrayLayers: 1 }
+    );
+    t.device.queue.submit([encoder.finish()]);
+
+    t.expectContents(
+      dst,
+      new Uint8Array(t.params.reversed ? [0x00, 0xff, 0x00, 0xff] : [0xff, 0x00, 0x00, 0xff])
+    );
+  });


### PR DESCRIPTION
Some depth related tests. For complete depth/stencil tests I think there's still a lot to port from dawn end2end tests. But this should be something to get started and can fill in in the future.

The reverse depth test actually only test depth compare func and clipping range.

depth16unorm fails because it's not implemented yet.

-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
