### PR TITLE
node.tsconfig.json: include more files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # Build files
 /out/
 /out-wpt/
-/out-node-tools/
+/out-node/
 .tscache/
 *.tmp.txt
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
     pkg: grunt.file.readJSON('package.json'),
 
     clean: {
-      out: ['out/', 'out-wpt/', 'out-node-tools/'],
+      out: ['out/', 'out-wpt/', 'out-node/'],
     },
 
     run: {
@@ -56,12 +56,12 @@ module.exports = function (grunt) {
           '--ignore=src/webgpu/listing.ts',
         ],
       },
-      'build-out-node-tools': {
+      'build-out-node': {
         cmd: 'node',
         args: [
           'node_modules/typescript/lib/tsc.js',
-          '--project', 'node-tools.tsconfig.json',
-          '--outDir', 'out-node-tools/',
+          '--project', 'node.tsconfig.json',
+          '--outDir', 'out-node/',
           '--noEmit', 'false',
           '--declaration', 'false'
         ],
@@ -156,7 +156,7 @@ module.exports = function (grunt) {
     'clean',
     'build-standalone',
     'build-wpt',
-    'run:build-out-node-tools',
+    'run:build-out-node',
     'build-done-message',
     'ts:check',
     'run:unittest',

--- a/node.tsconfig.json
+++ b/node.tsconfig.json
@@ -8,8 +8,9 @@
     "module": "commonjs"
   },
 
-  // Minimum sources required to run transpiled tools.
-  "include": [
-    "src/common/tools/**/*.ts"
+  "exclude": [
+    "src/common/runtime/wpt.ts",
+    "src/common/runtime/standalone.ts",
+    "src/common/runtime/helper/test_worker.ts"
   ]
 }


### PR DESCRIPTION
Now node.tsconfig.json only excludes files that use or transitively
use import.meta.url. This is not available until more recent versions
of Node.js.



-----

<!-- ***** For uploader to fill out ***** -->

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] Incomplete tests, if any, are marked with TODO or `.unimplemented()`.

<!-- For reviewers to fill out (uploader may pre-check these off at their own discretion) -->
**[Review requirement](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) checklist:**

- [x] WebGPU readability
- [x] TypeScript readability
