### PR TITLE
Fix bugs for texture creation validation

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -296,8 +296,8 @@ export function dimensionTypeAndFormatCombinationError(
 ): boolean {
   const info = kAllTextureFormatInfo[format];
   return (
-    ((dimension === '1d' || dimension === '3d') && info.blockWidth > 1) ||
-    (dimension === '3d' && (info.depth || info.stencil))
+    (dimension === '1d' || dimension === '3d') &&
+    (info.blockWidth > 1 || info.depth || info.stencil)
   );
 }
 

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -290,12 +290,12 @@ export function depthStencilFormatAspectSize(
   return texelAspectSize;
 }
 
-export function dimensionTypeAndFormatCombinationError(
+export function textureDimensionAndFormatCompatible(
   dimension: undefined | GPUTextureDimension,
   format: GPUTextureFormat
 ): boolean {
   const info = kAllTextureFormatInfo[format];
-  return (
+  return !(
     (dimension === '1d' || dimension === '3d') &&
     (info.blockWidth > 1 || info.depth || info.stencil)
   );

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -290,6 +290,17 @@ export function depthStencilFormatAspectSize(
   return texelAspectSize;
 }
 
+export function dimensionTypeAndFormatCombinationError(
+  dimension: undefined | GPUTextureDimension,
+  format: GPUTextureFormat
+): boolean {
+  const info = kAllTextureFormatInfo[format];
+  return (
+    ((dimension === '1d' || dimension === '3d') && info.blockWidth > 1) ||
+    (dimension === '3d' && (info.depth || info.stencil))
+  );
+}
+
 export const kTextureUsageInfo: {
   readonly [k in GPUTextureUsage]: {};
 } = {


### PR DESCRIPTION
This change filters out these dimenstion type and format combination
errors for texture creation validation:
  - Compressed formats are invalid for 1D and 3D,
  - Depth/stencil formats are invalid for 3D,

See the discussion about these validation rules at
https://github.com/gpuweb/gpuweb/issues/1522 and
https://bugs.chromium.org/p/dawn/issues/detail?id=730


<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
