### PR TITLE
Add tests for mipmap with various formats

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -46,12 +46,8 @@ g.test('zero_size')
           'depth24plus-stencil8',
         ] as const)
       )
-      .unless(
-        ({ format }) =>
-          (format === 'bc1-rgba-unorm' || format === 'depth24plus-stencil8') &&
-          dimension !== '2d' &&
-          dimension !== undefined
-      )
+      // Filter out incompatible dimension type and format combinations.
+      .filter(({ format }) => textureDimensionAndFormatCompatible(dimension, format))
   )
   .fn(async t => {
     const { dimension, zeroArgument, format } = t.params;

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -24,8 +24,7 @@ export const g = makeTestGroup(ValidationTest);
 g.test('zero_size')
   .desc(
     `Test texture creation with zero or nonzero size of
-    width, height, depthOrArrayLayers and mipLevelCount for every dimension, and representative formats.
-    TODO: add tests for depth/stencil format if depth/stencil format can support mipmaps.`
+    width, height, depthOrArrayLayers and mipLevelCount for every dimension, and representative formats.`
   )
   .cases(poptions('dimension', [undefined, ...kTextureDimensions]))
   .subcases(({ dimension }) =>
@@ -39,9 +38,19 @@ g.test('zero_size')
           'mipLevelCount',
         ] as const)
       )
-      .combine(poptions('format', ['rgba8unorm', 'rgb10a2unorm', 'bc1-rgba-unorm'] as const))
+      .combine(
+        poptions('format', [
+          'rgba8unorm',
+          'rgb10a2unorm',
+          'bc1-rgba-unorm',
+          'depth24plus-stencil8',
+        ] as const)
+      )
       .unless(
-        ({ format }) => format === 'bc1-rgba-unorm' && dimension !== '2d' && dimension !== undefined
+        ({ format }) =>
+          (format === 'bc1-rgba-unorm' || format === 'depth24plus-stencil8') &&
+          dimension !== '2d' &&
+          dimension !== undefined
       )
   )
   .fn(async t => {
@@ -113,23 +122,31 @@ g.test('dimension_type_and_format_compatibility')
 g.test('mipLevelCount,format')
   .desc(
     `Test texture creation with no mipmap chain, partial mipmap chain, full mipmap chain, out-of-bounds mipmap chain
-    for every format with different texture dimension types.
-    TODO: test 1D and 3D dimensions. Note that it is invalid for some formats with 1D/3D and/or mipmapping.`
+    for every format with different texture dimension types.`
   )
-  .subcases(() =>
+  .cases(poptions('dimension', [undefined, ...kTextureDimensions]))
+  .subcases(({ dimension }) =>
     params()
       .combine(poptions('format', kAllTextureFormats))
       .combine(poptions('mipLevelCount', [1, 3, 6, 7]))
+      // Filter out incompatible dimension type and format combinations.
+      .filter(({ format }) => textureDimensionAndFormatCompatible(dimension, format))
   )
   .fn(async t => {
-    const { format, mipLevelCount } = t.params;
+    const { dimension, format, mipLevelCount } = t.params;
 
-    await t.selectDeviceOrSkipTestCase(kAllTextureFormatInfo[format].extension);
+    const info = kAllTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.extension);
 
-    const size = [32, 32, 1];
+    // Note that compressed formats are not valid for 1D. They have already been filtered out for 1D in this test.
+    // So there is no dilemma about size.width equals 1 vs size.width % info.blockHeight equals 0 for 1D compressed formats.
+    const size = dimension === '1d' ? [32, 1, 1] : [32, 32, 1];
+    assert(32 % info.blockWidth === 0 && 32 % info.blockHeight === 0);
+
     const descriptor = {
       size,
       mipLevelCount,
+      dimension,
       format,
       usage: GPUTextureUsage.SAMPLED,
     };


### PR DESCRIPTION
According to my investigation about mipmap support on various
formats on D3D12 and GLES 3.2, I didn'd find there are any
limitations. Let's assume that there are no limitations for now
unless we find some later. I also updated this assumption at
https://github.com/gpuweb/gpuweb/issues/1522.

This PR adds tests for mipmap support with various formats. These
new tests implement the last two TODOs in createTexture validation
test.


<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
