### PR TITLE
Add selectDeviceForQueryTypeOrSkipTestCase to gpu_test.ts

### DIFF
--- a/docs/helper_index.md
+++ b/docs/helper_index.md
@@ -24,6 +24,8 @@ Generally, see:
 - [`GPUTest`](../src/webgpu/gpu_test.ts)
     - `selectDeviceForTextureFormatOrSkipTestCase`: Create device with texture format(s) required
         extension(s). If the device creation fails, then skip the test for that format(s).
+    - `selectDeviceForQueryTypeOrSkipTestCase`: Create device with query type(s) required
+        extension(s). If the device creation fails, then skip the test for that type(s).
 - [`ValidationTest`](../src/webgpu/api/validation/validation_test.ts)
     - `createEncoder`: Generically creates non-pass, compute pass, render pass, or render bundle
         encoders. This allows callers to write code using methods common to multiple encoder types.

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -12,19 +12,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kQueryTypes } from '../../../../capability_info.js';
 import { ValidationTest } from '../../validation_test.js';
 
-class F extends ValidationTest {
-  async selectDeviceForQuerySetOrSkipTestCase(type: GPUQueryType): Promise<void> {
-    return this.selectDeviceOrSkipTestCase(
-      type === 'pipeline-statistics'
-        ? 'pipeline-statistics-query'
-        : type === 'timestamp'
-        ? 'timestamp-query'
-        : undefined
-    );
-  }
-}
-
-export const g = makeTestGroup(F);
+export const g = makeTestGroup(ValidationTest);
 
 g.test('occlusion_query,query_type')
   .desc(
@@ -56,7 +44,7 @@ Tests that begin occlusion query with query index:
   .subcases(() => poptions('queryIndex', [0, 2]))
   .unimplemented();
 
-g.test('writeTimestamp,query_type_and_index')
+g.test('timestamp_query,query_type_and_index')
   .desc(
     `
 Tests that write timestamp to all types of query set on all possible encoders:
@@ -74,7 +62,7 @@ Tests that write timestamp to all types of query set on all possible encoders:
   .fn(async t => {
     const { encoderType, type, queryIndex } = t.params;
 
-    await t.selectDeviceForQuerySetOrSkipTestCase(type);
+    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
 
     const count = 2;
     const pipelineStatistics =
@@ -89,7 +77,7 @@ Tests that write timestamp to all types of query set on all possible encoders:
     }, type !== 'timestamp' || queryIndex >= count);
   });
 
-g.test('writeTimestamp,invalid_query_set')
+g.test('timestamp_query,invalid_query_set')
   .desc(
     `
 Tests that write timestamp to a invalid query set that failed during creation:

--- a/src/webgpu/api/validation/query_set/create.spec.ts
+++ b/src/webgpu/api/validation/query_set/create.spec.ts
@@ -2,21 +2,10 @@ export const description = `
 Tests for validation in createQuerySet.
 `;
 
-import { params, poptions } from '../../../../common/framework/params_builder.js';
+import { poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { kQueryTypes, kMaxQueryCount } from '../../../capability_info.js';
 import { ValidationTest } from '../validation_test.js';
-
-async function selectDeviceForQueryType(t: ValidationTest, type: GPUQueryType): Promise<void> {
-  const extensions: GPUExtensionName[] = [];
-  if (type === 'pipeline-statistics') {
-    extensions.push('pipeline-statistics-query');
-  } else if (type === 'timestamp') {
-    extensions.push('timestamp-query');
-  }
-
-  await t.selectDeviceOrSkipTestCase({ extensions });
-}
 
 export const g = makeTestGroup(ValidationTest);
 
@@ -28,15 +17,12 @@ Tests that create query set with the count for all query types:
 - x= {occlusion, pipeline-statistics, timestamp} query
   `
   )
-  .params(
-    params()
-      .combine(poptions('type', kQueryTypes))
-      .combine(poptions('count', [0, kMaxQueryCount, kMaxQueryCount + 1]))
-  )
+  .cases(poptions('type', kQueryTypes))
+  .subcases(() => poptions('count', [0, kMaxQueryCount, kMaxQueryCount + 1]))
   .fn(async t => {
     const { type, count } = t.params;
 
-    await selectDeviceForQueryType(t, type);
+    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
 
     const pipelineStatistics =
       type === 'pipeline-statistics' ? (['clipper-invocations'] as const) : ([] as const);
@@ -55,17 +41,14 @@ Tests that create query set with the GPUPipelineStatisticName for all query type
 - x= {occlusion, pipeline-statistics, timestamp} query
   `
   )
-  .params(
-    params()
-      .combine(poptions('type', kQueryTypes))
-      .combine(
-        poptions('pipelineStatistics', [undefined, [] as const, ['clipper-invocations'] as const])
-      )
+  .cases(poptions('type', kQueryTypes))
+  .subcases(() =>
+    poptions('pipelineStatistics', [undefined, [] as const, ['clipper-invocations'] as const])
   )
   .fn(async t => {
     const { type, pipelineStatistics } = t.params;
 
-    await selectDeviceForQueryType(t, type);
+    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
 
     const count = 1;
     const shouldError =
@@ -86,7 +69,7 @@ g.test('pipelineStatistics,duplicates_and_all')
 Tests that create query set with the duplicate values and all values of GPUPipelineStatisticName for pipeline-statistics query.
   `
   )
-  .params(
+  .subcases(() =>
     poptions('pipelineStatistics', [
       ['clipper-invocations', 'clipper-invocations'] as const,
       [
@@ -101,7 +84,7 @@ Tests that create query set with the duplicate values and all values of GPUPipel
   .fn(async t => {
     const type = 'pipeline-statistics';
 
-    await selectDeviceForQueryType(t, type);
+    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
 
     const count = 1;
     const pipelineStatistics = t.params.pipelineStatistics;

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -47,7 +47,17 @@ function makeTable<
 // Queries
 
 export const kMaxQueryCount = 8192;
-export const kQueryTypes = ['occlusion', 'pipeline-statistics', 'timestamp'] as const;
+export const kQueryTypeInfo: {
+  readonly [k in GPUQueryType]: {
+    readonly extension: GPUExtensionName | undefined;
+  };
+} = /* prettier-ignore */ {
+  // Occlusion query does not require any extensions.
+  'occlusion':           { extension:  undefined },
+  'pipeline-statistics': { extension: 'pipeline-statistics-query' },
+  'timestamp':           { extension: 'timestamp-query' },
+};
+export const kQueryTypes = keysOf(kQueryTypeInfo);
 
 // Buffers
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -6,6 +6,7 @@ import {
   EncodableTextureFormat,
   SizedTextureFormat,
   kAllTextureFormatInfo,
+  kQueryTypeInfo,
 } from './capability_info.js';
 import { makeBufferWithContents } from './util/buffer.js';
 import { DevicePool, DeviceProvider, TestOOMedShouldAttemptGC } from './util/device_pool.js';
@@ -107,6 +108,27 @@ export class GPUTest extends Fixture {
         const formatExtension = kAllTextureFormatInfo[format].extension;
         if (formatExtension !== undefined) {
           extensions.add(formatExtension);
+        }
+      }
+    }
+
+    if (extensions.size) {
+      await this.selectDeviceOrSkipTestCase({ extensions });
+    }
+  }
+
+  async selectDeviceForQueryTypeOrSkipTestCase(
+    types: GPUQueryType | undefined | (GPUQueryType | undefined)[]
+  ): Promise<void> {
+    if (!Array.isArray(types)) {
+      types = [types];
+    }
+    const extensions = new Set<GPUExtensionName>();
+    for (const type of types) {
+      if (type !== undefined) {
+        const queryExtension = kQueryTypeInfo[type].extension;
+        if (queryExtension !== undefined) {
+          extensions.add(queryExtension);
         }
       }
     }


### PR DESCRIPTION
- Move the helper of selecting device for query type to gpu_test.ts
  from test cases.
- Update test name and use cases or subcases in the existing queries
  tests.


<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
