### PR TITLE
Fix some storage buffers

### DIFF
--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -31,8 +31,8 @@ g.test('memcpy').fn(async t => {
               [[offset(0)]] value : u32;
           };
 
-          [[group(0), binding(0)]] var<storage_buffer> src : Data;
-          [[group(0), binding(1)]] var<storage_buffer> dst : Data;
+          [[group(0), binding(0)]] var<storage> src : [[access(read)]] Data;
+          [[group(0), binding(1)]] var<storage> dst : [[access(read_write)]] Data;
 
           [[stage(compute)]] fn main() -> void {
             dst.value = src.value;

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -56,7 +56,7 @@ export class BufferSyncTest extends GPUTest {
         [[offset(0)]] a : i32;
       };
 
-      [[group(0), binding(0)]] var<storage_buffer> data : Data;
+      [[group(0), binding(0)]] var<storage> data : [[access(read_write)]] Data;
       [[stage(compute)]] fn main() -> void {
         data.a = ${value};
         return;
@@ -90,7 +90,7 @@ export class BufferSyncTest extends GPUTest {
         [[offset(0)]] a : i32;
       };
 
-      [[group(0), binding(0)]] var<storage_buffer> data : Data;
+      [[group(0), binding(0)]] var<storage> data : [[access(read_write)]] Data;
       [[stage(fragment)]] fn frag_main() -> void {
         data.a = ${value};
         outColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -115,7 +115,7 @@ Params:
   value : u32;
 };
 
-[[group(0), binding(0)]] var<storage> output : Output;
+[[group(0), binding(0)]] var<storage> output : [[access(read_write)]] Output;
 
 [[location(0)]] var<out> fragColor : vec4<f32>;
 [[stage(fragment)]] fn frag_main() -> void {

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -62,7 +62,7 @@ function doTest(
       .map((C, i) => `[[offset(${i * 4})]] result${C} : ${shaderType};`)
       .join('\n')}
   };
-  [[group(0), binding(1)]] var<storage_buffer> output : Output;
+  [[group(0), binding(1)]] var<storage> output : [[access(read_write)]] Output;
 
   [[stage(compute)]]
   fn main() -> void {


### PR DESCRIPTION
* Change storage class to storage (from storage_buffer)
* add read_write access qualifier





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented in `helper_index.md`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
