### PR TITLE
More deprecations

### DIFF
--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -24,7 +24,7 @@ g.test('memcpy').fn(async t => {
   });
 
   const pipeline = t.device.createComputePipeline({
-    computeStage: {
+    compute: {
       module: t.device.createShaderModule({
         code: `
           [[block]] struct Data {

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -128,7 +128,7 @@ export class BufferSyncTest extends GPUTest {
     return encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: view,
+          view,
           loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -64,7 +64,7 @@ export class BufferSyncTest extends GPUTest {
     `;
 
     return this.device.createComputePipeline({
-      computeStage: {
+      compute: {
         module: this.device.createShaderModule({
           code: wgslCompute,
         }),

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -130,6 +130,7 @@ export class BufferSyncTest extends GPUTest {
         {
           attachment: view,
           loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+          storeOp: 'store',
         },
       ],
     });

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -131,7 +131,7 @@ g.test('render_pass_resolve')
         // Clear to black for the load operation. After the draw, the top left half of the attachment
         // will be white and the bottom right half will be black.
         renderPassColorAttachments.push({
-          attachment: colorAttachment.createView(),
+          view: colorAttachment.createView(),
           loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
           storeOp: t.params.storeOperation,
           resolveTarget: resolveTarget.createView({
@@ -143,7 +143,7 @@ g.test('render_pass_resolve')
         resolveTargets.push(resolveTarget);
       } else {
         renderPassColorAttachments.push({
-          attachment: colorAttachment.createView(),
+          view: colorAttachment.createView(),
           loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
           storeOp: t.params.storeOperation,
         });

--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -89,13 +89,13 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: colorAttachmentView,
+          view: colorAttachmentView,
           loadValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
           storeOp: t.params.colorStoreOperation,
         },
       ],
       depthStencilAttachment: {
-        attachment: depthStencilAttachment.createView(),
+        view: depthStencilAttachment.createView(),
         depthLoadValue: 1.0,
         depthStoreOp: t.params.depthStencilStoreOperation,
         stencilLoadValue: 1.0,
@@ -175,7 +175,7 @@ g.test('render_pass_store_op,color_attachment_only')
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: colorAttachmentView,
+          view: colorAttachmentView,
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: t.params.storeOperation,
         },
@@ -230,7 +230,7 @@ g.test('render_pass_store_op,multiple_color_attachments')
     const renderPassColorAttachments: GPURenderPassColorAttachment[] = [];
     for (let i = 0; i < t.params.colorAttachments; i++) {
       renderPassColorAttachments.push({
-        attachment: colorAttachments[i].createView(),
+        view: colorAttachments[i].createView(),
         loadValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
         storeOp: i % 2 === 0 ? t.params.storeOperation1 : t.params.storeOperation2,
       });
@@ -301,7 +301,7 @@ TODO: Also test unsized depth/stencil formats
     const pass = encoder.beginRenderPass({
       colorAttachments: [],
       depthStencilAttachment: {
-        attachment: depthStencilAttachmentView,
+        view: depthStencilAttachmentView,
         depthLoadValue: 1.0,
         depthStoreOp: t.params.storeOperation,
         stencilLoadValue: 1.0,

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -62,7 +62,7 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: renderTexture.createView(),
+          view: renderTexture.createView(),
           storeOp: t.params.storeOp,
           loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
         },

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -80,6 +80,7 @@ g.test('culling')
         {
           attachment: texture.createView(),
           loadValue: { r: 0.0, g: 0.0, b: 1.0, a: 1.0 },
+          storeOp: 'store',
         },
       ],
       depthStencilAttachment: depthTexture

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -78,14 +78,14 @@ g.test('culling')
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: texture.createView(),
+          view: texture.createView(),
           loadValue: { r: 0.0, g: 0.0, b: 1.0, a: 1.0 },
           storeOp: 'store',
         },
       ],
       depthStencilAttachment: depthTexture
         ? {
-            attachment: depthTexture.createView(),
+            view: depthTexture.createView(),
             depthLoadValue: 1.0,
             depthStoreOp: 'store',
             stencilLoadValue: 0,

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -311,7 +311,7 @@ class PrimitiveTopologyTest extends GPUTest {
     const renderPass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: colorAttachment.createView(),
+          view: colorAttachment.createView(),
           loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
           storeOp: 'store',
         },

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -313,6 +313,7 @@ class PrimitiveTopologyTest extends GPUTest {
         {
           attachment: colorAttachment.createView(),
           loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          storeOp: 'store',
         },
       ],
     });

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -24,7 +24,7 @@ g.test('clear').fn(async t => {
   const pass = encoder.beginRenderPass({
     colorAttachments: [
       {
-        attachment: colorAttachmentView,
+        view: colorAttachmentView,
         loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
         storeOp: 'store',
       },
@@ -93,7 +93,7 @@ g.test('fullscreen_quad').fn(async t => {
   const pass = encoder.beginRenderPass({
     colorAttachments: [
       {
-        attachment: colorAttachmentView,
+        view: colorAttachmentView,
         storeOp: 'store',
         loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
       },

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -235,6 +235,7 @@ g.test('GPUBlendComponent')
         {
           attachment: renderTarget.createView(),
           loadValue: dstColor,
+          storeOp: 'store',
         },
       ],
     });

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -10,7 +10,7 @@ TODO:
 
 import { params, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { assert } from '../../../../common/framework/util/util.js';
+import { assert, unreachable } from '../../../../common/framework/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -18,17 +18,17 @@ export const g = makeTestGroup(GPUTest);
 const kBlendFactors: GPUBlendFactor[] = [
   'zero',
   'one',
-  'src-color',
-  'one-minus-src-color',
+  'src',
+  'one-minus-src',
   'src-alpha',
   'one-minus-src-alpha',
-  'dst-color',
-  'one-minus-dst-color',
+  'dst',
+  'one-minus-dst',
   'dst-alpha',
   'one-minus-dst-alpha',
   'src-alpha-saturated',
-  'blend-color',
-  'one-minus-blend-color',
+  'constant',
+  'one-minus-constant',
 ];
 
 const kBlendOperations: GPUBlendOperation[] = [
@@ -63,20 +63,16 @@ function computeBlendFactor(
     case 'one':
       return { r: 1, g: 1, b: 1, a: 1 };
     case 'src':
-    case 'src-color':
       return { ...src };
     case 'one-minus-src':
-    case 'one-minus-src-color':
       return mapColor(src, v => 1 - v);
     case 'src-alpha':
       return mapColor(src, () => src.a);
     case 'one-minus-src-alpha':
       return mapColor(src, () => 1 - src.a);
     case 'dst':
-    case 'dst-color':
       return { ...dst };
     case 'one-minus-dst':
-    case 'one-minus-dst-color':
       return mapColor(dst, v => 1 - v);
     case 'dst-alpha':
       return mapColor(dst, () => dst.a);
@@ -87,13 +83,13 @@ function computeBlendFactor(
       return { r: f, g: f, b: f, a: 1 };
     }
     case 'constant':
-    case 'blend-color':
       assert(blendColor !== undefined);
       return { ...blendColor };
     case 'one-minus-constant':
-    case 'one-minus-blend-color':
       assert(blendColor !== undefined);
       return mapColor(blendColor, v => 1 - v);
+    default:
+      unreachable();
   }
 }
 
@@ -135,9 +131,9 @@ g.test('GPUBlendComponent')
       .combine(poptions('operation', kBlendOperations))
   )
   .subcases((p) => {
-    const needsBlendColor = (
-      p.srcFactor === 'one-minus-blend-color' || p.srcFactor === 'blend-color' ||
-      p.dstFactor === 'one-minus-blend-color' || p.dstFactor === 'blend-color'
+    const needsBlendConstant = (
+      p.srcFactor === 'one-minus-constant' || p.srcFactor === 'constant' ||
+      p.dstFactor === 'one-minus-constant' || p.dstFactor === 'constant'
     );
 
     return params()
@@ -148,7 +144,7 @@ g.test('GPUBlendComponent')
         { r: 0.51, g: 0.22, b: 0.71, a: 0.33 },
         { r: 0.09, g: 0.73, b: 0.93, a: 0.81 }
       ]))
-      .combine(poptions('blendColor', needsBlendColor ? [
+      .combine(poptions('blendConstant', needsBlendConstant ? [
         { r: 0.91, g: 0.82, b: 0.73, a: 0.64 },
       ] : [ undefined ]));
   })
@@ -156,10 +152,10 @@ g.test('GPUBlendComponent')
     const textureFormat: GPUTextureFormat = 'rgba32float';
     const srcColor = t.params.srcColor;
     const dstColor = t.params.dstColor;
-    const blendColor = t.params.blendColor;
+    const blendConstant = t.params.blendConstant;
 
-    const srcFactor = computeBlendFactor(srcColor, dstColor, blendColor, t.params.srcFactor);
-    const dstFactor = computeBlendFactor(srcColor, dstColor, blendColor, t.params.dstFactor);
+    const srcFactor = computeBlendFactor(srcColor, dstColor, blendConstant, t.params.srcFactor);
+    const dstFactor = computeBlendFactor(srcColor, dstColor, blendConstant, t.params.dstFactor);
 
     const expectedColor = computeBlendOperation(srcColor, srcFactor, dstColor, dstFactor, t.params.operation);
 
@@ -233,16 +229,15 @@ g.test('GPUBlendComponent')
     const renderPass = commandEncoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: renderTarget.createView(),
+          view: renderTarget.createView(),
           loadValue: dstColor,
           storeOp: 'store',
         },
       ],
     });
     renderPass.setPipeline(pipeline);
-    if (blendColor) {
-      /* eslint-disable-next-line deprecation/deprecation */
-      renderPass.setBlendColor(blendColor);
+    if (blendConstant) {
+      renderPass.setBlendConstant(blendConstant);
     }
     renderPass.setBindGroup(
       0,
@@ -282,10 +277,6 @@ g.test('formats')
   .desc(
     `Test blending results works for all formats that support it, and that blending is not applied
   for formats that do not. Blending should be done in linear space for srgb formats.`)
-  .unimplemented();
-
-g.test('multiple_color_attachments')
-  .desc('Test that if there are multiple color attachments, "src-color" refers to attachment index 0.')
   .unimplemented();
 
 g.test('clamp,blend_factor')

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -123,13 +123,13 @@ g.test('depth_compare_func')
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: colorAttachmentView,
+          view: colorAttachmentView,
           storeOp: 'store',
           loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
         },
       ],
       depthStencilAttachment: {
-        attachment: depthTextureView,
+        view: depthTextureView,
 
         depthLoadValue,
         depthStoreOp: 'store',
@@ -231,13 +231,13 @@ g.test('reverse_depth')
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: colorAttachmentView,
+          view: colorAttachmentView,
           storeOp: 'store',
           loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
         },
       ],
       depthStencilAttachment: {
-        attachment: depthTextureView,
+        view: depthTextureView,
 
         depthLoadValue: t.params.reversed ? 0.0 : 1.0,
         depthStoreOp: 'store',

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -176,6 +176,7 @@ Params:
         {
           attachment: renderTarget.createView(),
           loadValue: [0, 0, 0, 0],
+          storeOp: 'store',
         },
       ],
     });
@@ -567,6 +568,7 @@ ${shaderLocations
             })
             .createView(),
           loadValue: [0, 0, 0, 0],
+          storeOp: 'store',
         },
       ],
     });

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -174,7 +174,7 @@ Params:
     const renderPass = commandEncoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: renderTarget.createView(),
+          view: renderTarget.createView(),
           loadValue: [0, 0, 0, 0],
           storeOp: 'store',
         },
@@ -560,7 +560,7 @@ ${shaderLocations
       colorAttachments: [
         {
           // Dummy render attachment - not used.
-          attachment: t.device
+          view: t.device
             .createTexture({
               usage: GPUTextureUsage.RENDER_ATTACHMENT,
               size: [1],

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -131,14 +131,14 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
     const pass = commandEncoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: renderTexture.createView(),
+          view: renderTexture.createView(),
           resolveTarget,
           loadValue: [0, 0, 0, 0],
           storeOp: 'store',
         },
       ],
       depthStencilAttachment: {
-        attachment: texture.createView(viewDescriptor),
+        view: texture.createView(viewDescriptor),
         depthStoreOp: 'store',
         depthLoadValue: 'load',
         stencilStoreOp: 'store',

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -44,7 +44,7 @@ export const checkContentsBySampling: CheckContents = (
     const _xd = '_' + params.dimension;
     const _multisampled = params.sampleCount > 1 ? '_multisampled' : '';
     const computePipeline = t.device.createComputePipeline({
-      computeStage: {
+      compute: {
         entryPoint: 'main',
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -309,7 +309,7 @@ export class TextureZeroInitTest extends GPUTest {
           .beginRenderPass({
             colorAttachments: [
               {
-                attachment: texture.createView(viewDescriptor),
+                view: texture.createView(viewDescriptor),
                 storeOp: 'store',
                 loadValue: initializedStateAsColor(state, this.p.format),
               },
@@ -321,7 +321,7 @@ export class TextureZeroInitTest extends GPUTest {
           .beginRenderPass({
             colorAttachments: [],
             depthStencilAttachment: {
-              attachment: texture.createView(viewDescriptor),
+              view: texture.createView(viewDescriptor),
               depthStoreOp: 'store',
               depthLoadValue: initializedStateAsDepth[state],
               stencilStoreOp: 'store',
@@ -412,7 +412,7 @@ export class TextureZeroInitTest extends GPUTest {
           .beginRenderPass({
             colorAttachments: [
               {
-                attachment: texture.createView(desc),
+                view: texture.createView(desc),
                 storeOp: 'clear',
                 loadValue: 'load',
               },
@@ -424,7 +424,7 @@ export class TextureZeroInitTest extends GPUTest {
           .beginRenderPass({
             colorAttachments: [],
             depthStencilAttachment: {
-              attachment: texture.createView(desc),
+              view: texture.createView(desc),
               depthStoreOp: 'clear',
               depthLoadValue: 'load',
               stencilStoreOp: 'clear',

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -139,7 +139,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: colorAttachmentView,
+          view: colorAttachmentView,
           storeOp: 'store',
           loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
         },

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -149,7 +149,7 @@ class IndexFormatTest extends GPUTest {
     const encoder = this.device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
       colorAttachments: [
-        { attachment: colorAttachment.createView(), loadValue: [0, 0, 0, 0], storeOp: 'store' },
+        { view: colorAttachment.createView(), loadValue: [0, 0, 0, 0], storeOp: 'store' },
       ],
     });
     pass.setPipeline(pipeline);

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -44,6 +44,7 @@ class F extends ValidationTest {
     return {
       attachment: this.createAttachmentTextureView(format, sampleCount),
       loadValue: [0, 0, 0, 0],
+      storeOp: 'store',
     };
   }
 

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -42,7 +42,7 @@ class F extends ValidationTest {
     sampleCount?: number
   ): GPURenderPassColorAttachment {
     return {
-      attachment: this.createAttachmentTextureView(format, sampleCount),
+      view: this.createAttachmentTextureView(format, sampleCount),
       loadValue: [0, 0, 0, 0],
       storeOp: 'store',
     };
@@ -53,7 +53,7 @@ class F extends ValidationTest {
     sampleCount?: number
   ): GPURenderPassDepthStencilAttachment {
     return {
-      attachment: this.createAttachmentTextureView(format, sampleCount),
+      view: this.createAttachmentTextureView(format, sampleCount),
       depthLoadValue: 0,
       depthStoreOp: 'clear',
       stencilLoadValue: 1,

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -199,7 +199,7 @@ g.test('sample_count_must_be_equal_to_the_one_of_every_attachment_in_the_render_
     const renderPassDescriptorWithoutDepthStencil = {
       colorAttachments: [
         {
-          attachment: colorTexture.createView(),
+          view: colorTexture.createView(),
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },
@@ -208,7 +208,7 @@ g.test('sample_count_must_be_equal_to_the_one_of_every_attachment_in_the_render_
     const renderPassDescriptorWithDepthStencilOnly = {
       colorAttachments: [],
       depthStencilAttachment: {
-        attachment: depthStencilTexture.createView(),
+        view: depthStencilTexture.createView(),
         depthLoadValue: 1.0,
         depthStoreOp: 'store',
         stencilLoadValue: 0,

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -201,9 +201,10 @@ g.test('sample_count_must_be_equal_to_the_one_of_every_attachment_in_the_render_
         {
           attachment: colorTexture.createView(),
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          storeOp: 'store',
         },
       ],
-    };
+    } as const;
     const renderPassDescriptorWithDepthStencilOnly = {
       colorAttachments: [],
       depthStencilAttachment: {
@@ -213,7 +214,7 @@ g.test('sample_count_must_be_equal_to_the_one_of_every_attachment_in_the_render_
         stencilLoadValue: 0,
         stencilStoreOp: 'store',
       },
-    };
+    } as const;
 
     const pipelineWithoutDepthStencil = t.device.createRenderPipeline(
       t.getDescriptor({

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -295,6 +295,7 @@ g.test('it_is_invalid_to_use_a_texture_view_created_from_a_destroyed_texture').f
       {
         attachment: texture.createView(),
         loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        storeOp: 'store',
       },
     ],
   });

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -293,7 +293,7 @@ g.test('it_is_invalid_to_use_a_texture_view_created_from_a_destroyed_texture').f
   const renderPass = commandEncoder.beginRenderPass({
     colorAttachments: [
       {
-        attachment: texture.createView(),
+        view: texture.createView(),
         loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
         storeOp: 'store',
       },

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -75,7 +75,7 @@ class F extends ValidationTest {
     return encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: colorAttachment.createView(),
+          view: colorAttachment.createView(),
           loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },

--- a/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
@@ -58,7 +58,7 @@ class F extends ValidationTest {
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: attachment.createView(),
+          view: attachment.createView(),
           loadValue: 'load',
           storeOp: 'store',
         },
@@ -87,7 +87,7 @@ class F extends ValidationTest {
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: attachment.createView(),
+          view: attachment.createView(),
           loadValue: 'load',
           storeOp: 'store',
         },
@@ -118,7 +118,7 @@ class F extends ValidationTest {
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: attachment.createView(),
+          view: attachment.createView(),
           loadValue: 'load',
           storeOp: 'store',
         },

--- a/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
@@ -1,8 +1,6 @@
 export const description = `
 API validation tests for dynamic state commands (setViewport/ScissorRect/BlendColor...).
 
-TODO: update setBlendColor -> setBlendConstant
-
 TODO: ensure existing tests cover these notes. Note many of these may be operation tests instead.
 > - setViewport
 >     - {x, y} = {0, invalid values if any}
@@ -16,7 +14,7 @@ TODO: ensure existing tests cover these notes. Note many of these may be operati
 > - setScissorRect
 >     - {width, height} = 0
 >     - {x+width, y+height} = attachment size + 1
-> - setBlendColor
+> - setBlendConstant
 >     - color {slightly, very} out of range
 >     - used with a simple pipeline that {does, doesn't} use it
 > - setStencilReference
@@ -288,8 +286,8 @@ g.test('setScissorRect,xy_rect_contained_in_attachment')
     );
   });
 
-g.test('setBlendColor')
-  .desc('Test that almost any color value is valid for setBlendColor')
+g.test('setBlendConstant')
+  .desc('Test that almost any color value is valid for setBlendConstant')
   .params([
     { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
     { r: -1.0, g: -1.0, b: -1.0, a: -1.0 },
@@ -298,8 +296,7 @@ g.test('setBlendColor')
   .fn(t => {
     const { r, g, b, a } = t.params;
     const encoders = t.createDummyRenderPassEncoder();
-    /* eslint-disable-next-line deprecation/deprecation */
-    encoders.pass.setBlendColor({ r, g, b, a });
+    encoders.pass.setBlendConstant({ r, g, b, a });
     encoders.pass.endPass();
     encoders.encoder.finish();
   });

--- a/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
@@ -62,6 +62,7 @@ class F extends ValidationTest {
         {
           attachment: attachment.createView(),
           loadValue: 'load',
+          storeOp: 'store',
         },
       ],
     });
@@ -90,6 +91,7 @@ class F extends ValidationTest {
         {
           attachment: attachment.createView(),
           loadValue: 'load',
+          storeOp: 'store',
         },
       ],
     });
@@ -120,6 +122,7 @@ class F extends ValidationTest {
         {
           attachment: attachment.createView(),
           loadValue: 'load',
+          storeOp: 'store',
         },
       ],
     });

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -67,7 +67,7 @@ class F extends ValidationTest {
     return commandEncoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: attachmentTexture.createView(),
+          view: attachmentTexture.createView(),
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -69,6 +69,7 @@ class F extends ValidationTest {
         {
           attachment: attachmentTexture.createView(),
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          storeOp: 'store',
         },
       ],
     });

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -82,6 +82,7 @@ class F extends ValidationTest {
         {
           attachment: attachmentTexture.createView(),
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          storeOp: 'store',
         },
       ],
     });

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -80,7 +80,7 @@ class F extends ValidationTest {
     return commandEncoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: attachmentTexture.createView(),
+          view: attachmentTexture.createView(),
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },

--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -130,7 +130,7 @@ Test various validation behaviors when a resolveTarget is provided.
           });
 
           renderPassColorAttachmentDescriptors.push({
-            attachment: resolveSourceColorAttachment.createView(),
+            view: resolveSourceColorAttachment.createView(),
             loadValue: 'load',
             storeOp: 'clear',
             resolveTarget: resolveTarget.createView({
@@ -167,7 +167,7 @@ Test various validation behaviors when a resolveTarget is provided.
           });
 
           renderPassColorAttachmentDescriptors.push({
-            attachment: colorAttachment.createView(),
+            view: colorAttachment.createView(),
             loadValue: 'load',
             storeOp: 'clear',
             resolveTarget: resolveTarget.createView(),

--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -132,6 +132,7 @@ Test various validation behaviors when a resolveTarget is provided.
           renderPassColorAttachmentDescriptors.push({
             attachment: resolveSourceColorAttachment.createView(),
             loadValue: 'load',
+            storeOp: 'clear',
             resolveTarget: resolveTarget.createView({
               dimension: resolveTargetViewArrayLayerCount === 1 ? '2d' : '2d-array',
               mipLevelCount: resolveTargetViewMipCount,
@@ -168,6 +169,7 @@ Test various validation behaviors when a resolveTarget is provided.
           renderPassColorAttachmentDescriptors.push({
             attachment: colorAttachment.createView(),
             loadValue: 'load',
+            storeOp: 'clear',
             resolveTarget: resolveTarget.createView(),
           });
         }

--- a/src/webgpu/api/validation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/validation/render_pass/storeOp.spec.ts
@@ -58,7 +58,7 @@ g.test('store_op_and_read_only')
     const pass = encoder.beginRenderPass({
       colorAttachments: [],
       depthStencilAttachment: {
-        attachment: depthAttachmentView,
+        view: depthAttachmentView,
         depthLoadValue: 'load',
         depthStoreOp,
         depthReadOnly,

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -49,6 +49,7 @@ class F extends ValidationTest {
     return {
       attachment,
       loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+      storeOp: 'store',
     };
   }
 
@@ -340,6 +341,7 @@ g.test('it_is_invalid_to_set_resolve_target_if_color_attachment_is_non_multisamp
           attachment: colorTexture.createView(),
           resolveTarget: resolveTargetTexture.createView(),
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          storeOp: 'store',
         },
       ],
     };

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -44,10 +44,10 @@ class F extends ValidationTest {
     texture: GPUTexture,
     textureViewDescriptor?: GPUTextureViewDescriptor
   ): GPURenderPassColorAttachment {
-    const attachment = texture.createView(textureViewDescriptor);
+    const view = texture.createView(textureViewDescriptor);
 
     return {
-      attachment,
+      view,
       loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
       storeOp: 'store',
     };
@@ -57,10 +57,10 @@ class F extends ValidationTest {
     texture: GPUTexture,
     textureViewDescriptor?: GPUTextureViewDescriptor
   ): GPURenderPassDepthStencilAttachment {
-    const attachment = texture.createView(textureViewDescriptor);
+    const view = texture.createView(textureViewDescriptor);
 
     return {
-      attachment,
+      view,
       depthLoadValue: 1.0,
       depthStoreOp: 'store',
       stencilLoadValue: 0,
@@ -338,7 +338,7 @@ g.test('it_is_invalid_to_set_resolve_target_if_color_attachment_is_non_multisamp
     const descriptor: GPURenderPassDescriptor = {
       colorAttachments: [
         {
-          attachment: colorTexture.createView(),
+          view: colorTexture.createView(),
           resolveTarget: resolveTargetTexture.createView(),
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: 'store',

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -126,7 +126,7 @@ class TextureUsageTracking extends ValidationTest {
     return encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: view,
+          view,
           loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },
@@ -476,12 +476,12 @@ g.test('subresources_and_binding_types_combination_for_color')
       const pass = encoder.beginRenderPass({
         colorAttachments: [
           {
-            attachment: view0,
+            view: view0,
             loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
             storeOp: 'store',
           },
           {
-            attachment: view1,
+            view: view1,
             loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
             storeOp: 'store',
           },
@@ -633,7 +633,7 @@ g.test('subresources_and_binding_types_combination_for_aspect')
       : encoder.beginRenderPass({
           colorAttachments: [
             {
-              attachment: t.createTexture({ width: size, height: size }).createView(),
+              view: t.createTexture({ width: size, height: size }).createView(),
               loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
               storeOp: 'store',
             },
@@ -642,7 +642,7 @@ g.test('subresources_and_binding_types_combination_for_aspect')
             type1 !== 'render-target'
               ? undefined
               : {
-                  attachment: view1,
+                  view: view1,
                   depthStoreOp: 'clear',
                   depthLoadValue: 'load',
                   stencilStoreOp: 'clear',
@@ -979,7 +979,7 @@ g.test('unused_bindings_in_pipeline')
       : encoder.beginRenderPass({
           colorAttachments: [
             {
-              attachment: t.createTexture().createView(),
+              view: t.createTexture().createView(),
               loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
               storeOp: 'store',
             },

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -949,7 +949,7 @@ g.test('unused_bindings_in_pipeline')
 
     const pipeline = compute
       ? t.device.createComputePipeline({
-          computeStage: {
+          compute: {
             module: t.device.createShaderModule({
               code: wgslCompute,
             }),

--- a/src/webgpu/api/validation/texture/destroy.spec.ts
+++ b/src/webgpu/api/validation/texture/destroy.spec.ts
@@ -45,7 +45,7 @@ g.test('submit_a_destroyed_texture')
     const renderPass = commandEncoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: textureView,
+          view: textureView,
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
           storeOp: 'store',
         },

--- a/src/webgpu/api/validation/texture/destroy.spec.ts
+++ b/src/webgpu/api/validation/texture/destroy.spec.ts
@@ -47,6 +47,7 @@ g.test('submit_a_destroyed_texture')
         {
           attachment: textureView,
           loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          storeOp: 'store',
         },
       ],
     });

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -302,6 +302,7 @@ export class ValidationTest extends GPUTest {
             {
               attachment,
               loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+              storeOp: 'store',
             },
           ],
         });

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -227,7 +227,7 @@ export class ValidationTest extends GPUTest {
 
   createNoOpComputePipeline(): GPUComputePipeline {
     return this.device.createComputePipeline({
-      computeStage: {
+      compute: {
         module: this.device.createShaderModule({
           code: '[[stage(compute)]] fn main() -> void {}',
         }),
@@ -239,7 +239,7 @@ export class ValidationTest extends GPUTest {
   createErrorComputePipeline(): GPUComputePipeline {
     this.device.pushErrorScope('validation');
     const pipeline = this.device.createComputePipeline({
-      computeStage: {
+      compute: {
         module: this.device.createShaderModule({
           code: '',
         }),

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -290,7 +290,7 @@ export class ValidationTest extends GPUTest {
       }
       case 'render pass': {
         const commandEncoder = this.device.createCommandEncoder();
-        const attachment = this.device
+        const view = this.device
           .createTexture({
             format: colorFormat,
             size: { width: 16, height: 16, depthOrArrayLayers: 1 },
@@ -300,7 +300,7 @@ export class ValidationTest extends GPUTest {
         const encoder = commandEncoder.beginRenderPass({
           colorAttachments: [
             {
-              attachment,
+              view,
               loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
               storeOp: 'store',
             },

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -415,7 +415,7 @@ g.test('vertexAccess')
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
-          attachment: colorAttachmentView,
+          view: colorAttachmentView,
           storeOp: 'store',
           loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
         },

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -72,7 +72,7 @@ function doTest(
   }`;
 
   const pipeline = t.device.createComputePipeline({
-    computeStage: {
+    compute: {
       module: t.device.createShaderModule({
         code: shader,
       }),

--- a/src/webgpu/web_platform/reftests/canvas_clear.ts
+++ b/src/webgpu/web_platform/reftests/canvas_clear.ts
@@ -16,7 +16,7 @@ runRefTest(async t => {
   const pass = encoder.beginRenderPass({
     colorAttachments: [
       {
-        attachment: colorAttachmentView,
+        view: colorAttachmentView,
         loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
         storeOp: 'store',
       },


### PR DESCRIPTION
The deprecation lint is quite incomplete in what it can catch, so for this PR I deleted everything deprecated from the types file, then fixed errors. Still outstanding:

- Removal of GPUFence
- Binding changes

Status: Chromium can't pass these QUITE yet, but soon.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
