### PR TITLE
Add validation tests for occlusion query

### DIFF
--- a/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
@@ -1,7 +1,7 @@
 export const description = `
 Validation for encoding begin/endable queries.
 
-TODO:
+TODO: tests for pipeline statistics queries:
 - balance: {
     - begin 0, end 1
     - begin 1, end 0
@@ -72,9 +72,9 @@ Tests the invalid nesting of begin/end occlusion queries:
   .subcases(
     () =>
       [
-        { calls: [0, 'end', 1, 'end'] }, // control case
-        { calls: [0, 0, 'end', 'end'] },
-        { calls: [0, 1, 'end', 'end'] },
+        { calls: [0, 'end', 1, 'end'], _valid: true }, // control case
+        { calls: [0, 0, 'end', 'end'], _valid: false },
+        { calls: [0, 1, 'end', 'end'], _valid: false },
       ] as const
   )
   .fn(async t => {
@@ -82,17 +82,17 @@ Tests the invalid nesting of begin/end occlusion queries:
 
     const encoder = createRenderEncoderWithQuerySet(t, querySet);
 
-    t.params.calls.forEach(i => {
+    for (const i of t.params.calls) {
       if (i !== 'end') {
-        encoder.encoder.beginOcclusionQuery(Number(i));
+        encoder.encoder.beginOcclusionQuery(i);
       } else {
         encoder.encoder.endOcclusionQuery();
       }
-    });
+    }
 
     t.expectValidationError(() => {
       encoder.finish();
-    }, t.params.calls[1] !== 'end');
+    }, !t.params._valid);
   });
 
 g.test('occlusion_query,disjoint_queries_with_same_query_index')

--- a/src/webgpu/api/validation/encoding/queries/common.ts
+++ b/src/webgpu/api/validation/encoding/queries/common.ts
@@ -1,0 +1,53 @@
+import { GPUTest } from '../../../../gpu_test.js';
+import { CommandBufferMaker } from '../../validation_test.js';
+
+export function createQuerySetWithType(
+  t: GPUTest,
+  type: GPUQueryType,
+  count: GPUSize32
+): GPUQuerySet {
+  return t.device.createQuerySet({
+    type,
+    count,
+    pipelineStatistics:
+      type === 'pipeline-statistics' ? (['clipper-invocations'] as const) : ([] as const),
+  });
+}
+
+export function beginRenderPassWithQuerySet(
+  t: GPUTest,
+  encoder: GPUCommandEncoder,
+  querySet?: GPUQuerySet
+): GPURenderPassEncoder {
+  const attachment = t.device
+    .createTexture({
+      format: 'rgba8unorm' as const,
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    })
+    .createView();
+  return encoder.beginRenderPass({
+    colorAttachments: [
+      {
+        attachment,
+        loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+      },
+    ],
+    occlusionQuerySet: querySet,
+  });
+}
+
+export function createRenderEncoderWithQuerySet(
+  t: GPUTest,
+  querySet?: GPUQuerySet
+): CommandBufferMaker<'render pass'> {
+  const commandEncoder = t.device.createCommandEncoder();
+  const encoder = beginRenderPassWithQuerySet(t, commandEncoder, querySet);
+  return {
+    encoder,
+    finish: () => {
+      encoder.endPass();
+      return commandEncoder.finish();
+    },
+  } as CommandBufferMaker<'render pass'>;
+}

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -12,6 +12,8 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kQueryTypes } from '../../../../capability_info.js';
 import { ValidationTest } from '../../validation_test.js';
 
+import { createQuerySetWithType, createRenderEncoderWithQuerySet } from './common.js';
+
 export const g = makeTestGroup(ValidationTest);
 
 g.test('occlusion_query,query_type')
@@ -22,8 +24,24 @@ Tests that set occlusion query set with all types in render pass descriptor:
 - {undefined} for occlusion query set in render pass descriptor
   `
   )
-  .subcases(() => poptions('type', ['undefined'].concat(kQueryTypes)))
-  .unimplemented();
+  .subcases(() => poptions('type', [undefined, ...kQueryTypes]))
+  .fn(async t => {
+    const type = t.params.type;
+
+    if (type) {
+      await t.selectDeviceForQueryTypeOrSkipTestCase(type);
+    }
+
+    const querySet = type === undefined ? undefined : createQuerySetWithType(t, type, 1);
+
+    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    encoder.encoder.beginOcclusionQuery(0);
+    encoder.encoder.endOcclusionQuery();
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, type !== 'occlusion');
+  });
 
 g.test('occlusion_query,invalid_query_set')
   .desc(
@@ -32,7 +50,17 @@ Tests that begin occlusion query with a invalid query set that failed during cre
   `
   )
   .subcases(() => poptions('querySetState', ['valid', 'invalid'] as const))
-  .unimplemented();
+  .fn(t => {
+    const querySet = t.createQuerySetWithState(t.params.querySetState);
+
+    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    encoder.encoder.beginOcclusionQuery(0);
+    encoder.encoder.endOcclusionQuery();
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, t.params.querySetState === 'invalid');
+  });
 
 g.test('occlusion_query,query_index')
   .desc(
@@ -42,7 +70,17 @@ Tests that begin occlusion query with query index:
   `
   )
   .subcases(() => poptions('queryIndex', [0, 2]))
-  .unimplemented();
+  .fn(t => {
+    const querySet = createQuerySetWithType(t, 'occlusion', 2);
+
+    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    encoder.encoder.beginOcclusionQuery(t.params.queryIndex);
+    encoder.encoder.endOcclusionQuery();
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, t.params.queryIndex > 0);
+  });
 
 g.test('timestamp_query,query_type_and_index')
   .desc(
@@ -65,9 +103,7 @@ Tests that write timestamp to all types of query set on all possible encoders:
     await t.selectDeviceForQueryTypeOrSkipTestCase(type);
 
     const count = 2;
-    const pipelineStatistics =
-      type === 'pipeline-statistics' ? (['clipper-invocations'] as const) : ([] as const);
-    const querySet = t.device.createQuerySet({ type, count, pipelineStatistics });
+    const querySet = createQuerySetWithType(t, type, count);
 
     const encoder = t.createEncoder(encoderType);
     encoder.encoder.writeTimestamp(querySet, queryIndex);

--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -9,12 +9,6 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { createRenderEncoderWithQuerySet } from '../../encoding/queries/common.js';
 import { ValidationTest } from '../../validation_test.js';
 
-export const enum EncoderType {
-  CommandEncoder = 'CommandEncoder',
-  ComputeEncoder = 'ComputeEncoder',
-  RenderEncoder = 'RenderEncoder',
-}
-
 export const g = makeTestGroup(ValidationTest);
 
 g.test('beginOcclusionQuery')

--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -6,6 +6,7 @@ TODO: Test with pipeline statistics queries on {compute, render} as well.
 
 import { poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { createRenderEncoderWithQuerySet } from '../../encoding/queries/common.js';
 import { ValidationTest } from '../../validation_test.js';
 
 export const enum EncoderType {
@@ -24,7 +25,17 @@ Tests that use a destroyed query set in occlusion query on render pass encoder.
   `
   )
   .subcases(() => poptions('querySetState', ['valid', 'destroyed'] as const))
-  .unimplemented();
+  .fn(t => {
+    const querySet = t.createQuerySetWithState(t.params.querySetState);
+
+    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    encoder.encoder.beginOcclusionQuery(0);
+    encoder.encoder.endOcclusionQuery();
+
+    t.expectValidationError(() => {
+      t.queue.submit([encoder.finish()]);
+    }, t.params.querySetState === 'destroyed');
+  });
 
 g.test('writeTimestamp')
   .desc(


### PR DESCRIPTION
- Validation tests including {valid, invalid, destroyed} query set,
  query index {out of bounds, rewrite} and begin/end nesting.
- Not add nesting with various types of queries due to pipeline
  statistics query is not implemented.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
