### PR TITLE
Use new WGSL entry point IO syntax

### DIFF
--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -77,24 +77,20 @@ export class BufferSyncTest extends GPUTest {
   createStorageWriteRenderPipeline(value: number): GPURenderPipeline {
     const wgslShaders = {
       vertex: `
-      [[builtin(position)]] var<out> Position : vec4<f32>;
-      [[stage(vertex)]] fn vert_main() {
-        Position = vec4<f32>(0.5, 0.5, 0.0, 1.0);
-        return;
+      [[stage(vertex)]] fn vert_main() -> [[builtin(position)]] vec4<f32> {
+        return vec4<f32>(0.5, 0.5, 0.0, 1.0);
       }
     `,
 
       fragment: `
-      [[location(0)]] var<out> outColor : vec4<f32>;
       [[block]] struct Data {
         [[offset(0)]] a : i32;
       };
 
       [[group(0), binding(0)]] var<storage> data : [[access(read_write)]] Data;
-      [[stage(fragment)]] fn frag_main() {
+      [[stage(fragment)]] fn frag_main() -> [[location(0)]] vec4<f32> {
         data.a = ${value};
-        outColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);
-        return;
+        return vec4<f32>(1.0, 0.0, 0.0, 1.0);
       }
     `,
     };

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -52,16 +52,14 @@ g.test('render_pass_resolve')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-            [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[builtin(vertex_index)]] var<in> VertexIndex : i32;
-
-            [[stage(vertex)]] fn main() {
+            [[stage(vertex)]] fn main(
+              [[builtin(vertex_index)]] VertexIndex : i32
+              ) -> [[builtin(position)]] vec4<f32> {
               let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                   vec2<f32>(-1.0, -1.0),
                   vec2<f32>(-1.0,  1.0),
                   vec2<f32>( 1.0,  1.0));
-              Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-              return;
+              return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
             }`,
         }),
         entryPoint: 'main',
@@ -69,17 +67,20 @@ g.test('render_pass_resolve')
       fragment: {
         module: t.device.createShaderModule({
           code: `
-            [[location(0)]] var<out> fragColor0 : vec4<f32>;
-            [[location(1)]] var<out> fragColor1 : vec4<f32>;
-            [[location(2)]] var<out> fragColor2 : vec4<f32>;
-            [[location(3)]] var<out> fragColor3 : vec4<f32>;
+            struct Output {
+              [[location(0)]] fragColor0 : vec4<f32>;
+              [[location(1)]] fragColor1 : vec4<f32>;
+              [[location(2)]] fragColor2 : vec4<f32>;
+              [[location(3)]] fragColor3 : vec4<f32>;
+            };
 
-            [[stage(fragment)]] fn main() {
-              fragColor0 = vec4<f32>(1.0, 1.0, 1.0, 1.0);
-              fragColor1 = vec4<f32>(1.0, 1.0, 1.0, 1.0);
-              fragColor2 = vec4<f32>(1.0, 1.0, 1.0, 1.0);
-              fragColor3 = vec4<f32>(1.0, 1.0, 1.0, 1.0);
-              return;
+            [[stage(fragment)]] fn main() -> Output {
+              return Output(
+                vec4<f32>(1.0, 1.0, 1.0, 1.0),
+                vec4<f32>(1.0, 1.0, 1.0, 1.0),
+                vec4<f32>(1.0, 1.0, 1.0, 1.0),
+                vec4<f32>(1.0, 1.0, 1.0, 1.0)
+              );
             }`,
         }),
         entryPoint: 'main',

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -26,16 +26,14 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-            [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[builtin(vertex_index)]] var<in> VertexIndex : i32;
-
-            [[stage(vertex)]] fn main() {
+            [[stage(vertex)]] fn main(
+              [[builtin(vertex_index)]] VertexIndex : i32
+              ) -> [[builtin(position)]] vec4<f32> {
               let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                   vec2<f32>( 1.0, -1.0),
                   vec2<f32>( 1.0,  1.0),
                   vec2<f32>(-1.0,  1.0));
-              Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-              return;
+              return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
             }
             `,
         }),
@@ -44,10 +42,8 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
       fragment: {
         module: t.device.createShaderModule({
           code: `
-            [[location(0)]] var<out> fragColor : vec4<f32>;
-            [[stage(fragment)]] fn main() {
-              fragColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);
-              return;
+            [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+              return vec4<f32>(1.0, 0.0, 0.0, 1.0);
             }
             `,
         }),

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -101,10 +101,9 @@ g.test('culling')
         vertex: {
           module: t.device.createShaderModule({
             code: `
-              [[builtin(position)]] var<out> Position : vec4<f32>;
-              [[builtin(vertex_index)]] var<in> VertexIndex : i32;
-
-              [[stage(vertex)]] fn main() {
+              [[stage(vertex)]] fn main(
+                [[builtin(vertex_index)]] VertexIndex : i32
+                ) -> [[builtin(position)]] vec4<f32> {
                 let pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
                     vec2<f32>(-1.0,  1.0),
                     vec2<f32>(-1.0,  0.0),
@@ -112,8 +111,7 @@ g.test('culling')
                     vec2<f32>( 0.0, -1.0),
                     vec2<f32>( 1.0,  0.0),
                     vec2<f32>( 1.0, -1.0));
-                Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-                return;
+                return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
               }`,
           }),
           entryPoint: 'main',
@@ -121,16 +119,16 @@ g.test('culling')
         fragment: {
           module: t.device.createShaderModule({
             code: `
-              [[location(0)]] var<out> fragColor : vec4<f32>;
-              [[builtin(front_facing)]] var<in> FrontFacing : bool;
-
-              [[stage(fragment)]] fn main() {
+              [[stage(fragment)]] fn main(
+                [[builtin(front_facing)]] FrontFacing : bool
+                ) -> [[location(0)]] vec4<f32> {
+                var color : vec4<f32>;
                 if (FrontFacing) {
-                  fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+                  color = vec4<f32>(0.0, 1.0, 0.0, 1.0);
                 } else {
-                  fragColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);
+                  color = vec4<f32>(1.0, 0.0, 0.0, 1.0);
                 }
-                return;
+                return color;
               }`,
           }),
           entryPoint: 'main',

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -332,12 +332,10 @@ class PrimitiveTopologyTest extends GPUTest {
         vertex: {
           module: this.device.createShaderModule({
             code: `
-              [[location(0)]] var<in> pos : vec4<f32>;
-              [[builtin(position)]] var<out> Position : vec4<f32>;
-
-              [[stage(vertex)]] fn main() {
-                Position = pos;
-                return;
+              [[stage(vertex)]] fn main(
+                [[location(0)]] pos : vec4<f32>
+                ) -> [[builtin(position)]] vec4<f32> {
+                return pos;
               }`,
           }),
           entryPoint: 'main',
@@ -357,10 +355,8 @@ class PrimitiveTopologyTest extends GPUTest {
         fragment: {
           module: this.device.createShaderModule({
             code: `
-              [[location(0)]] var<out> fragColor : vec4<f32>;
-              [[stage(fragment)]] fn main() {
-                fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
-                return;
+              [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+                return vec4<f32>(0.0, 1.0, 0.0, 1.0);
               }`,
           }),
           entryPoint: 'main',

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -58,16 +58,14 @@ g.test('fullscreen_quad').fn(async t => {
     vertex: {
       module: t.device.createShaderModule({
         code: `
-          [[builtin(position)]] var<out> Position : vec4<f32>;
-          [[builtin(vertex_index)]] var<in> VertexIndex : i32;
-
-          [[stage(vertex)]] fn main() {
+        [[stage(vertex)]] fn main(
+          [[builtin(vertex_index)]] VertexIndex : i32
+          ) -> [[builtin(position)]] vec4<f32> {
             let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                 vec2<f32>(-1.0, -3.0),
                 vec2<f32>(3.0, 1.0),
                 vec2<f32>(-1.0, 1.0));
-            Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-            return;
+            return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
           }
           `,
       }),
@@ -76,10 +74,8 @@ g.test('fullscreen_quad').fn(async t => {
     fragment: {
       module: t.device.createShaderModule({
         code: `
-          [[location(0)]] var<out> fragColor : vec4<f32>;
-          [[stage(fragment)]] fn main() {
-            fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
-            return;
+          [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+            return vec4<f32>(0.0, 1.0, 0.0, 1.0);
           }
           `,
       }),

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -199,9 +199,8 @@ g.test('GPUBlendComponent')
 };
 [[group(0), binding(0)]] var<uniform> u : Uniform;
 
-[[location(0)]] var<out> output : vec4<f32>;
-[[stage(fragment)]] fn main() {
-  output = u.color;
+[[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+  return u.color;
 }
           `,
         }),
@@ -210,9 +209,8 @@ g.test('GPUBlendComponent')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-[[builtin(position)]] var<out> Position : vec4<f32>;
-[[stage(vertex)]] fn main() {
-    Position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+[[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+    return vec4<f32>(0.0, 0.0, 0.0, 1.0);
 }
           `,
         }),

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -6,17 +6,14 @@ import { CheckContents } from '../texture_zero.spec.js';
 function makeFullscreenVertexModule(device: GPUDevice) {
   return device.createShaderModule({
     code: `
-    [[builtin(position)]] var<out> Position : vec4<f32>;
-    [[builtin(vertex_index)]] var<in> VertexIndex : i32;
-
     [[stage(vertex)]]
-    fn main() {
+    fn main([[builtin(vertex_index)]] VertexIndex : i32)
+         -> [[builtin(position)]] vec4<f32> {
       let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
         vec2<f32>(-1.0, -3.0),
         vec2<f32>( 3.0,  1.0),
         vec2<f32>(-1.0,  1.0));
-      Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-      return;
+      return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
     }
     `,
   });
@@ -37,14 +34,17 @@ function getDepthTestEqualPipeline(
       entryPoint: 'main',
       module: t.device.createShaderModule({
         code: `
-        [[builtin(frag_depth)]] var<out> FragDepth : f32;
-        [[location(0)]] var<out> outSuccess : f32;
+        struct Outputs {
+          [[builtin(frag_depth)]] FragDepth : f32;
+          [[location(0)]] outSuccess : f32;
+        };
 
         [[stage(fragment)]]
-        fn main() {
-          FragDepth = f32(${expected});
-          outSuccess = 1.0;
-          return;
+        fn main() -> Outputs {
+          var output : Outputs;
+          output.FragDepth = f32(${expected});
+          output.outSuccess = 1.0;
+          return output;
         }
         `,
       }),
@@ -73,12 +73,9 @@ function getStencilTestEqualPipeline(
       entryPoint: 'main',
       module: t.device.createShaderModule({
         code: `
-        [[location(0)]] var<out> outSuccess : f32;
-
         [[stage(fragment)]]
-        fn main() {
-          outSuccess = 1.0;
-          return;
+        fn main() -> [[location(0)]] f32 {
+          return 1.0;
         }
         `,
       }),

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -60,10 +60,8 @@ export const checkContentsBySampling: CheckContents = (
             };
             [[group(0), binding(3)]] var<storage_buffer> result : Result;
 
-            [[builtin(global_invocation_id)]] var<in> GlobalInvocationID : vec3<u32>;
-
             [[stage(compute)]]
-            fn main() {
+            fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
               var flatIndex : u32 = ${width}u * GlobalInvocationID.y + GlobalInvocationID.x;
               flatIndex = flatIndex * ${componentCount}u;
               var texel : vec4<${shaderType}> = textureLoad(

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -57,11 +57,13 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-            [[builtin(vertex_index)]] var<in> VertexIndex : i32;
-            [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[location(0)]] var<out> fragUV : vec2<f32>;
+            struct Outputs {
+              [[builtin(position)]] Position : vec4<f32>;
+              [[location(0)]] fragUV : vec2<f32>;
+            };
 
-            [[stage(vertex)]] fn main() {
+            [[stage(vertex)]] fn main(
+              [[builtin(vertex_index)]] VertexIndex : i32) -> Outputs {
               let position : array<vec3<f32>, 6> = array<vec3<f32>, 6>(
                 vec3<f32>(-0.5, 0.5, -0.5),
                 vec3<f32>(0.5, 0.5, -0.5),
@@ -84,8 +86,10 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
                 vec4<f32>(0.0, -43.63650894165039, -43.232173919677734, -43.18894577026367),
                 vec4<f32>(0.0, 21.693578720092773, 21.789791107177734, 21.86800193786621));
 
-              fragUV = uv[VertexIndex];
-              Position = matrix * vec4<f32>(position[VertexIndex], 1.0);
+              var output : Outputs;
+              output.fragUV = uv[VertexIndex];
+              output.Position = matrix * vec4<f32>(position[VertexIndex], 1.0);
+              return output;
             }
             `,
         }),
@@ -97,14 +101,11 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
             [[set(0), binding(0)]] var sampler0 : sampler;
             [[set(0), binding(1)]] var texture0 : texture_2d<f32>;
 
-            [[builtin(position)]] var<in> FragCoord : vec4<f32>;
-
-            [[location(0)]] var<in> fragUV: vec2<f32>;
-
-            [[location(0)]] var<out> fragColor : vec4<f32>;
-
-            [[stage(fragment)]] fn main() {
-                fragColor = textureSample(texture0, sampler0, fragUV);
+            [[stage(fragment)]] fn main(
+              [[builtin(position)]] FragCoord : vec4<f32>,
+              [[location(0)]] fragUV: vec2<f32>)
+              -> [[location(0)]] vec4<f32> {
+                return textureSample(texture0, sampler0, fragUV);
             }
             `,
         }),

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -64,27 +64,25 @@ class IndexFormatTest extends GPUTest {
           vec2<f32>(0.99,  0.98),
           vec2<f32>(0.01, -0.98));
 
-        [[builtin(position)]] var<out> Position : vec4<f32>;
-        [[builtin(vertex_index)]] var<in> VertexIndex : u32;
-
         [[stage(vertex)]]
-        fn main() {
+        fn main([[builtin(vertex_index)]] VertexIndex : u32)
+             -> [[builtin(position)]] vec4<f32> {
+          var Position : vec4<f32>;
           if (VertexIndex == 0xFFFFu || VertexIndex == 0xFFFFFFFFu) {
             Position = vec4<f32>(-0.99, -0.98, 0.0, 1.0);
           } else {
             Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
           }
+          return Position;
         }
       `,
     });
 
     const fragmentModule = this.device.createShaderModule({
       code: `
-        [[location(0)]] var<out> fragColor : u32;
-
         [[stage(fragment)]]
-        fn main() {
-          fragColor = 1u;
+        fn main() -> [[location(0)]] u32 {
+          return 1u;
         }
       `,
     });

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -115,10 +115,8 @@ class F extends ValidationTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-            [[builtin(position)]] var<out> position : vec4<f32>;
-
-            [[stage(vertex)]] fn main() {
-              position = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+            [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+              return vec4<f32>(0.0, 0.0, 0.0, 0.0);
             }`,
         }),
         entryPoint: 'main',

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -65,10 +65,8 @@ class F extends ValidationTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-            [[builtin(position)]] var<out> Position : vec4<f32>;
-
-            [[stage(vertex)]] fn main() {
-              Position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+            [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+              return vec4<f32>(0.0, 0.0, 0.0, 1.0);
             }`,
         }),
         entryPoint: 'main',
@@ -76,9 +74,8 @@ class F extends ValidationTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            [[location(0)]] var<out> fragColor : vec4<${fragColorType}>;
-            [[stage(fragment)]] fn main() {
-              fragColor = vec4<${fragColorType}>(0${suffix}, 1${suffix}, 0${suffix}, 1${suffix});
+            [[stage(fragment)]] fn main() -> [[location(0)]] vec4<${fragColorType}> {
+              return vec4<${fragColorType}>(0${suffix}, 1${suffix}, 0${suffix}, 1${suffix});
             }`,
         }),
         entryPoint: 'main',

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -37,11 +37,8 @@ class F extends ValidationTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-            [[builtin(position)]] var<out> Position : vec4<f32>;
-
-            [[stage(vertex)]] fn main() {
-              Position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
-              return;
+            [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+              return vec4<f32>(0.0, 0.0, 0.0, 1.0);
             }`,
         }),
         entryPoint: 'main',
@@ -49,10 +46,8 @@ class F extends ValidationTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            [[location(0)]] var<out> fragColor : vec4<f32>;
-            [[stage(fragment)]] fn main() {
-              fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
-              return;
+            [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
             }`,
         }),
         entryPoint: 'main',

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -19,14 +19,15 @@ class F extends ValidationTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
+            struct Inputs {
             ${range(
               bufferCount,
-              i => `\n[[location(${i})]] var<in> a_position${i} : vec3<f32>;`
+              i => `\n[[location(${i})]] a_position${i} : vec3<f32>;`
             ).join('')}
-            [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[stage(vertex)]] fn main() {
-              Position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
-              return;
+            };
+            [[stage(vertex)]] fn main(input : Inputs
+              ) -> [[builtin(position)]] vec4<f32> {
+              return vec4<f32>(0.0, 0.0, 0.0, 1.0);
             }`,
         }),
         entryPoint: 'main',
@@ -44,10 +45,8 @@ class F extends ValidationTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            [[location(0)]] var<out> fragColor : vec4<f32>;
-            [[stage(fragment)]] fn main() {
-              fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
-              return;
+            [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
             }`,
         }),
         entryPoint: 'main',

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -20,10 +20,7 @@ class F extends ValidationTest {
         module: this.device.createShaderModule({
           code: `
             struct Inputs {
-            ${range(
-              bufferCount,
-              i => `\n[[location(${i})]] a_position${i} : vec3<f32>;`
-            ).join('')}
+            ${range(bufferCount, i => `\n[[location(${i})]] a_position${i} : vec3<f32>;`).join('')}
             };
             [[stage(vertex)]] fn main(input : Inputs
               ) -> [[builtin(position)]] vec4<f32> {

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -34,16 +34,15 @@ class F extends ValidationTest {
             };
             [[group(0), binding(0)]] var<uniform> uniforms : VertexUniforms;
 
-            [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[builtin(vertex_index)]] var<in> VertexIndex : i32;
-            [[stage(vertex)]] fn main() {
+            [[stage(vertex)]] fn main(
+              [[builtin(vertex_index)]] VertexIndex : i32
+              ) -> [[builtin(position)]] vec4<f32> {
               var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                 vec2<f32>(-1.0, -1.0),
                 vec2<f32>( 1.0, -1.0),
                 vec2<f32>(-1.0,  1.0)
               );
-              Position = vec4<f32>(uniforms.transform * pos[VertexIndex], 0.0, 1.0);
-              return;
+              return vec4<f32>(uniforms.transform * pos[VertexIndex], 0.0, 1.0);
             }`,
         }),
         entryPoint: 'main',
@@ -56,10 +55,8 @@ class F extends ValidationTest {
             };
             [[group(1), binding(0)]] var<uniform> uniforms : FragmentUniforms;
 
-            [[location(0)]] var<out> fragColor : vec4<f32>;
-            [[stage(fragment)]] fn main() {
-              fragColor = uniforms.color;
-              return;
+            [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+              return uniforms.color;
             }`,
         }),
         entryPoint: 'main',

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -13,9 +13,8 @@ import {
 import { ValidationTest } from './validation_test.js';
 
 const VERTEX_SHADER_CODE_WITH_NO_INPUT = `
-  [[builtin(position)]] var<out> Position : vec4<f32>;
-  [[stage(vertex)]] fn main() {
-    Position = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+  [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+    return vec4<f32>(0.0, 0.0, 0.0, 0.0);
   }
 `;
 
@@ -72,10 +71,8 @@ class F extends ValidationTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            [[location(0)]] var<out> fragColor : vec4<f32>;
-            [[stage(fragment)]] fn main() {
-              fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
-              return;
+            [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
             }`,
         }),
         entryPoint: 'main',
@@ -94,9 +91,8 @@ class F extends ValidationTest {
     const vsModule = this.device.createShaderModule({ code: vertexShader });
     const fsModule = this.device.createShaderModule({
       code: `
-        [[location(0)]] var<out> fragColor : vec4<f32>;
-        [[stage(fragment)]] fn main() {
-          fragColor = vec4<f32>(0.0, 1.0, 0.0, 1.0);
+        [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+          return vec4<f32>(0.0, 1.0, 0.0, 1.0);
         }`,
     });
 
@@ -123,17 +119,18 @@ class F extends ValidationTest {
 
     let count = 0;
     for (const input of inputs) {
-      interfaces += `[[location(${input.location})]] var<in> input${count} : ${input.type};\n`;
-      body += `var i${count} : ${input.type} = input${count};\n`;
+      interfaces += `[[location(${input.location})]] input${count} : ${input.type};\n`;
+      body += `var i${count} : ${input.type} = input.input${count};\n`;
       count++;
     }
 
     return `
-      [[builtin(position)]] var<out> Position : vec4<f32>;
-      ${interfaces}
-      [[stage(vertex)]] fn main() {
-        Position = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+      struct Inputs {
+        ${interfaces}
+      };
+      [[stage(vertex)]] fn main(input : Inputs) -> [[builtin(position)]] vec4<f32> {
         ${body}
+        return vec4<f32>(0.0, 0.0, 0.0, 0.0);
       }
     `;
   }

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -312,18 +312,19 @@ g.test('vertexAccess')
     );
 
     // Create attributes listing
-    let layoutStr = '';
+    let layoutStr = 'struct Attributes {';
     const attributeNames = [];
     {
       let currAttribute = 0;
       for (let i = 0; i < bufferContents.length; i++) {
         for (let j = 0; j < attributesPerBuffer; j++) {
-          layoutStr += `[[location(${currAttribute})]] var<in> a_${currAttribute} : ${typeInfo.wgslType};\n`;
+          layoutStr += `[[location(${currAttribute})]] a_${currAttribute} : ${typeInfo.wgslType};\n`;
           attributeNames.push(`a_${currAttribute}`);
           currAttribute++;
         }
       }
     }
+    layoutStr += '};'
 
     // Vertex buffer descriptors
     const buffers: GPUVertexBufferLayout[] = [];
@@ -354,8 +355,6 @@ g.test('vertexAccess')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-            [[builtin(position)]] var<out> Position : vec4<f32>;
-            [[builtin(vertex_index)]] var<in> VertexIndex : u32;
             ${layoutStr}
 
             fn valid(f : f32) -> bool {
@@ -366,14 +365,18 @@ g.test('vertexAccess')
               ${typeInfo.validationFunc}
             }
 
-            [[stage(vertex)]] fn main() {
+            [[stage(vertex)]] fn main(
+              [[builtin(vertex_index)]] VertexIndex : u32,
+              attributes : Attributes
+              ) -> [[builtin(position)]] vec4<f32> {
               var attributesInBounds : bool = ${attributeNames
-                .map(a => `validationFunc(${a})`)
+                .map(a => `validationFunc(attributes.${a})`)
                 .join(' && ')};
               var indexInBounds : bool = VertexIndex == 0u ||
                   (VertexIndex >= ${vertexIndexOffset}u &&
                    VertexIndex < ${vertexIndexOffset + numVertices}u);
 
+              var Position : vec4<f32>;
               if (attributesInBounds && (${!p.indexed} || indexInBounds)) {
                 // Success case, move the vertex out of the viewport
                 Position = vec4<f32>(-1.0, 0.0, 0.0, 1.0);
@@ -381,6 +384,7 @@ g.test('vertexAccess')
                 // Failure case, move the vertex inside the viewport
                 Position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
               }
+              return Position;
             }`,
         }),
         entryPoint: 'main',
@@ -389,9 +393,8 @@ g.test('vertexAccess')
       fragment: {
         module: t.device.createShaderModule({
           code: `
-            [[location(0)]] var<out> fragColor : vec4<f32>;
-            [[stage(fragment)]] fn main() {
-              fragColor = vec4<f32>(1.0, 0.0, 0.0, 1.0);
+            [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+              return vec4<f32>(1.0, 0.0, 0.0, 1.0);
             }`,
         }),
         entryPoint: 'main',

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -324,7 +324,7 @@ g.test('vertexAccess')
         }
       }
     }
-    layoutStr += '};'
+    layoutStr += '};';
 
     // Vertex buffer descriptors
     const buffers: GPUVertexBufferLayout[] = [];

--- a/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique.fail.wgsl
@@ -1,9 +1,9 @@
 // v-0011 - This fails because of the duplicated `a` variable.
 
-const a : vec2<f32> = vec2<f32>(0.1, 1.0);
-[[location (0)]] var<in> a : vec4<f32>;
+let a : vec2<f32> = vec2<f32>(0.1, 1.0);
+var<private> a : vec4<f32>;
 
-[[stage(vertex)]]
+[[stage(compute)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-f32.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0033: variable 'flag' store type is 'bool' however the initializer type is 'f32'.
 
-var<out> flag : bool  = 0.0;
+var<private> flag : bool  = 0.0;
 
-[[stage(vertex)]]
+[[stage(compute)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-i32.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0033: variable 'flag' store type is 'bool' however the initializer type is 'i32'.
 
-var<out> flag : bool  = 0;
+var<private> flag : bool  = 0;
 
-[[stage(vertex)]]
+[[stage(compute)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-u32.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0033: variable 'flag' store type is 'bool' however the initializer type is 'u32'.
 
-var<out> flag : bool  = 1u;
+var<private> flag : bool  = 1u;
 
-[[stage(vertex)]]
+[[stage(compute)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool.pass.wgsl
@@ -1,7 +1,7 @@
 // pass v-0033: variable 'a' and its initilizer have the same store type, 'bool'.
 
-var<out> flag : bool  = true;
+var<private> flag : bool  = true;
 
-[[stage(vertex)]]
+[[stage(compute)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-bool.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'f' store type is 'f32' however the initializer type is 'bool'.
 
-var<out> f : f32  = true;
+var<private> f : f32  = true;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-i32.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'f' store type is 'f32' however the initializer type is 'i32'.
 
-var<out> f : f32  = 0;
+var<private> f : f32  = 0;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-u32.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'f' store type is 'f32' however the initializer type is 'i32'.
 
-var<out> f : f32  = 0u;
+var<private> f : f32  = 0u;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32.pass.wgsl
@@ -1,6 +1,6 @@
 // pass v-0033: variable 'a' and its initializer have the same storetype, 'f32'.
 
-var<out> a : f32  = 0.0;
+var<private> a : f32  = 0.0;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-bool.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'a' store type is 'i32' however the initializer type is 'bool'.
 
-var<out> a : i32  = true;
+var<private> a : i32  = true;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-f32.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
 
-var<out> a : i32  = 123.0;
+var<private> a : i32  = 123.0;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-u32.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'a' store type is 'i32' however the initializer type is 'u32'.
 
-var<out> a : i32  = 1u;
+var<private> a : i32  = 1u;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32.pass.wgsl
@@ -1,6 +1,6 @@
 // pass v-0033: variable 'a' and its initializer have the same storetype, 'i32'.
 
-var<out> a : i32  = 0;
+var<private> a : i32  = 0;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-out.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-out.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'a' store type is 'i32' however the initializer type is 'f32'.
 
-var<out> a : i32  = 1.0;
+var<private> a : i32  = 1.0;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-bool.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'u' store type is 'u32' however the initializer type is 'bool'.
 
-var<out> u : u32  = true;
+var<private> u : u32  = true;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-f32.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'u' store type is 'u32' however the initializer type is 'f32'.
 
-var<out> f : u32  = 0.0;
+var<private> f : u32  = 0.0;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-i32.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'u' store type is 'u32' however the initializer type is 'i32'.
 
-var<out> f : u32  = 0;
+var<private> f : u32  = 0;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32.pass.wgsl
@@ -1,6 +1,6 @@
 // pass v-0033: variable 'a' and its initializer have the same storetype, 'u32'.
 
-var<out> a : u32  = 0u;
+var<private> a : u32  = 0u;
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-in.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-in.fail.wgsl
@@ -1,7 +1,0 @@
-// v-0032: variable 'a' has an initializer, however its storage class is 'in'.
-
-var<in> a : i32  = 1;
-
-[[stage(vertex)]]
-fn main() {
-}

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-out.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-out.pass.wgsl
@@ -1,6 +1,6 @@
 // pass v-0032: variable 'a' has an initializer and its storage class is 'out'.
 
-var<out> a : i32  = 1;
+var<private> a : i32  = 1;
 
 [[stage(vertex)]]
 fn main() {


### PR DESCRIPTION
WGSL now uses entry point function parameters and return values for
entry point IO, instead of module-scope variables.

<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented in `helper_index.md`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
