### PR TITLE
gen_wpt_cts_html: always split down to individual tests

### DIFF
--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -20,11 +20,13 @@ export type TestQuery =
   | TestQueryMultiTest
   | TestQueryMultiFile;
 
-export type TestQueryLevel =
-  | 1 // MultiFile
-  | 2 // MultiTest
-  | 3 // MultiCase
-  | 4; // SingleCase
+/**
+ * - 1 = MultiFile.
+ * - 2 = MultiTest.
+ * - 3 = MultiCase.
+ * - 4 = SingleCase.
+ */
+export type TestQueryLevel = 1 | 2 | 3 | 4;
 
 export interface TestQueryWithExpectation {
   query: TestQuery;

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -78,16 +78,13 @@ export class TestTree {
   }
 
   /**
-   * If a parent and its child are at different levels, then
-   * generally the parent has only one child, i.e.:
+   * Dissolve nodes which have only one child, e.g.:
    *   a,* { a,b,* { a,b:* { ... } } }
-   * Collapse that down into:
+   * collapses down into:
    *   a,* { a,b:* { ... } }
    * which is less needlessly verbose when displaying the tree in the standalone runner.
-   *
-   * TODO: fix the name of this
    */
-  dissolveLevelBoundaries(): void {
+  dissolveSingleChildTrees(): void {
     const newRoot = dissolveSingleChildTrees(this.root);
     assert(newRoot === this.root);
   }

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -84,6 +84,8 @@ export class TestTree {
    * Collapse that down into:
    *   a,* { a,b:* { ... } }
    * which is less needlessly verbose when displaying the tree in the standalone runner.
+   *
+   * TODO: fix the name of this
    */
   dissolveLevelBoundaries(): void {
     const newRoot = dissolveSingleChildTrees(this.root);
@@ -213,8 +215,7 @@ export async function loadTreeForQuery(
     const subtreeL1: TestSubtree<TestQueryMultiTest> = addSubtreeForFilePath(
       subtreeL0,
       entry.file,
-      description,
-      isCollapsible
+      description
     );
 
     for (const t of spec.g.iterate()) {
@@ -299,8 +300,7 @@ function addSubtreeForDirPath(
 function addSubtreeForFilePath(
   tree: TestSubtree<TestQueryMultiFile>,
   file: string[],
-  description: string,
-  checkCollapsible: (sq: TestQuery) => boolean
+  description: string
 ): TestSubtree<TestQueryMultiTest> {
   // To start, tree is suite:*
   // This goes from that -> suite:a,* -> suite:a,b,*
@@ -313,7 +313,7 @@ function addSubtreeForFilePath(
       readableRelativeName: file[file.length - 1] + kBigSeparator + kWildcard,
       query,
       description,
-      collapsible: checkCollapsible(query),
+      collapsible: false,
     };
   });
   return subtree;

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -297,7 +297,7 @@ let lastQueryLevelToExpand: TestQueryLevel = 2;
   }
   const tree = await loader.loadTree(rootQuery);
 
-  tree.dissolveLevelBoundaries();
+  tree.dissolveSingleChildTrees();
 
   const { runSubtree, generateSubtreeHTML } = makeSubtreeHTML(tree.root, 1);
   const setTreeCheckedRecursively = generateSubtreeHTML(resultsVis);

--- a/src/common/tools/checklist.ts
+++ b/src/common/tools/checklist.ts
@@ -51,7 +51,8 @@ function checkForUnmatchedSubtrees(tree: TestTree, matchQueries: TestQuery[]): n
   let subtreeCount = 0;
   const unmatchedSubtrees: TestQuery[] = [];
   const overbroadMatches: [TestQuery, TestQuery][] = [];
-  for (const collapsedSubtree of tree.iterateCollapsedQueries(true, 1)) {
+  const alwaysExpandThroughLevel = 1; // expand to, at minimum, every file.
+  for (const collapsedSubtree of tree.iterateCollapsedQueries(true, alwaysExpandThroughLevel)) {
     subtreeCount++;
     let subtreeMatched = false;
     for (const q of matchQueries) {

--- a/src/common/tools/checklist.ts
+++ b/src/common/tools/checklist.ts
@@ -51,7 +51,7 @@ function checkForUnmatchedSubtrees(tree: TestTree, matchQueries: TestQuery[]): n
   let subtreeCount = 0;
   const unmatchedSubtrees: TestQuery[] = [];
   const overbroadMatches: [TestQuery, TestQuery][] = [];
-  for (const collapsedSubtree of tree.iterateCollapsedQueries(true)) {
+  for (const collapsedSubtree of tree.iterateCollapsedQueries(true, 1)) {
     subtreeCount++;
     let subtreeMatched = false;
     for (const q of matchQueries) {

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -83,7 +83,7 @@ const [
     const tree = await loader.loadTree(rootQuery, expectations.get(prefix)!);
 
     lines.push(undefined); // output blank line between prefixes
-    for (const q of tree.iterateCollapsedQueries(false)) {
+    for (const q of tree.iterateCollapsedQueries(false, 2)) {
       const urlQueryString = prefix + q.toString(); // "?worker=0&q=..."
       // Check for a safe-ish path length limit. Filename must be <= 255, and on Windows the whole
       // path must be <= 259. Leave room for e.g.:

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -83,7 +83,8 @@ const [
     const tree = await loader.loadTree(rootQuery, expectations.get(prefix)!);
 
     lines.push(undefined); // output blank line between prefixes
-    for (const q of tree.iterateCollapsedQueries(false, 2)) {
+    const alwaysExpandThroughLevel = 2; // expand to, at minimum, every test.
+    for (const q of tree.iterateCollapsedQueries(false, alwaysExpandThroughLevel)) {
       const urlQueryString = prefix + q.toString(); // "?worker=0&q=..."
       // Check for a safe-ish path length limit. Filename must be <= 255, and on Windows the whole
       // path must be <= 259. Leave room for e.g.:

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -49,10 +49,11 @@ const [
 
   if (process.argv.length >= 7) {
     // Prefixes sorted from longest to shortest
-    argsPrefixes = (await fs.readFile(argsPrefixesFile, 'utf8'))
+    const argsPrefixesFromFile = (await fs.readFile(argsPrefixesFile, 'utf8'))
       .split(/\r?\n/)
       .filter(a => a.length)
       .sort((a, b) => b.length - a.length);
+    if (argsPrefixesFromFile.length) argsPrefixes = argsPrefixesFromFile;
     expectationLines = new Set(
       (await fs.readFile(expectationsFile, 'utf8')).split(/\r?\n/).filter(l => l.length)
     );

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -1,13 +1,13 @@
 import { promises as fs } from 'fs';
 
 import { DefaultTestFileLoader } from '../framework/file_loader.js';
-import { TestQueryMultiTest, TestQueryMultiFile } from '../framework/query/query.js';
+import { TestQueryMultiFile } from '../framework/query/query.js';
 import { assert } from '../framework/util/util.js';
 
 function printUsageAndExit(rc: number): void {
   console.error(`\
 Usage:
-  tools/gen_wpt_cts_html OUTPUT_FILE TEMPLATE_FILE [ARGUMENTS_PREFIXES_FILE EXPECTATIONS_FILE EXPECTATIONS_PREFIX SUITE]
+  tools/gen_wpt_cts_html OUTPUT_FILE TEMPLATE_FILE [ARGUMENTS_PREFIXES_FILE EXPECTATIONS_FILE EXPECTATIONS_PREFIX [SUITE]]
   tools/gen_wpt_cts_html out-wpt/cts.html templates/cts.html
   tools/gen_wpt_cts_html my/path/to/cts.html templates/cts.html arguments.txt myexpectations.txt 'path/to/cts.html' cts
 
@@ -28,7 +28,7 @@ and myexpectations.txt is a file containing a list of WPT paths to suppress, e.g
   process.exit(rc);
 }
 
-if (process.argv.length !== 4 && process.argv.length !== 8) {
+if (process.argv.length !== 5 && process.argv.length !== 7 && process.argv.length !== 8) {
   printUsageAndExit(0);
 }
 
@@ -40,67 +40,63 @@ const [
   argsPrefixesFile,
   expectationsFile,
   expectationsPrefix,
-  suite,
+  suite = 'webgpu',
 ] = process.argv;
 
 (async () => {
-  if (process.argv.length === 4) {
-    const entries = await (await import('../../webgpu/listing.js')).listing;
-    const lines = entries
-      // Exclude READMEs.
-      .filter(l => !('readme' in l))
-      .map(l => '?q=' + new TestQueryMultiTest('webgpu', l.file, []).toString());
-    await generateFile(lines);
-  } else {
+  let argsPrefixes = [''];
+  let expectationLines = new Set<string>();
+
+  if (process.argv.length >= 7) {
     // Prefixes sorted from longest to shortest
-    const argsPrefixes = (await fs.readFile(argsPrefixesFile, 'utf8'))
+    argsPrefixes = (await fs.readFile(argsPrefixesFile, 'utf8'))
       .split(/\r?\n/)
       .filter(a => a.length)
       .sort((a, b) => b.length - a.length);
-    const expectationLines = new Set(
+    expectationLines = new Set(
       (await fs.readFile(expectationsFile, 'utf8')).split(/\r?\n/).filter(l => l.length)
     );
-
-    const expectations: Map<string, string[]> = new Map();
-    for (const prefix of argsPrefixes) {
-      expectations.set(prefix, []);
-    }
-
-    expLoop: for (const exp of expectationLines) {
-      // Take each expectation for the longest prefix it matches.
-      for (const argsPrefix of argsPrefixes) {
-        const prefix = expectationsPrefix + argsPrefix;
-        if (exp.startsWith(prefix)) {
-          expectations.get(argsPrefix)!.push(exp.substring(prefix.length));
-          continue expLoop;
-        }
-      }
-      console.log('note: ignored expectation: ' + exp);
-    }
-
-    const loader = new DefaultTestFileLoader();
-    const lines: Array<string | undefined> = [];
-    for (const prefix of argsPrefixes) {
-      const rootQuery = new TestQueryMultiFile(suite, []);
-      const tree = await loader.loadTree(rootQuery, expectations.get(prefix)!);
-
-      lines.push(undefined); // output blank line between prefixes
-      for (const q of tree.iterateCollapsedQueries(false)) {
-        const urlQueryString = prefix + q.toString(); // "?worker=0&q=..."
-        // Check for a safe-ish path length limit. Filename must be <= 255, and on Windows the whole
-        // path must be <= 259. Leave room for e.g.:
-        // 'c:\b\s\w\xxxxxxxx\layout-test-results\external\wpt\webgpu\cts_worker=0_q=...-actual.txt'
-        assert(
-          urlQueryString.length < 185,
-          'Generated test variant would produce too-long -actual.txt filename. \
-Try broadening suppressions to avoid long test variant names. ' +
-            urlQueryString
-        );
-        lines.push(urlQueryString);
-      }
-    }
-    await generateFile(lines);
   }
+
+  const expectations: Map<string, string[]> = new Map();
+  for (const prefix of argsPrefixes) {
+    expectations.set(prefix, []);
+  }
+
+  expLoop: for (const exp of expectationLines) {
+    // Take each expectation for the longest prefix it matches.
+    for (const argsPrefix of argsPrefixes) {
+      const prefix = expectationsPrefix + argsPrefix;
+      if (exp.startsWith(prefix)) {
+        expectations.get(argsPrefix)!.push(exp.substring(prefix.length));
+        continue expLoop;
+      }
+    }
+    console.log('note: ignored expectation: ' + exp);
+  }
+
+  const loader = new DefaultTestFileLoader();
+  const lines: Array<string | undefined> = [];
+  for (const prefix of argsPrefixes) {
+    const rootQuery = new TestQueryMultiFile(suite, []);
+    const tree = await loader.loadTree(rootQuery, expectations.get(prefix)!);
+
+    lines.push(undefined); // output blank line between prefixes
+    for (const q of tree.iterateCollapsedQueries(false)) {
+      const urlQueryString = prefix + q.toString(); // "?worker=0&q=..."
+      // Check for a safe-ish path length limit. Filename must be <= 255, and on Windows the whole
+      // path must be <= 259. Leave room for e.g.:
+      // 'c:\b\s\w\xxxxxxxx\layout-test-results\external\wpt\webgpu\cts_worker=0_q=...-actual.txt'
+      assert(
+        urlQueryString.length < 185,
+        'Generated test variant would produce too-long -actual.txt filename. \
+Try broadening suppressions to avoid long test variant names. ' +
+          urlQueryString
+      );
+      lines.push(urlQueryString);
+    }
+  }
+  await generateFile(lines);
 })().catch(ex => {
   console.log(ex.stack ?? ex.toString());
   process.exit(1);

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -28,7 +28,7 @@ and myexpectations.txt is a file containing a list of WPT paths to suppress, e.g
   process.exit(rc);
 }
 
-if (process.argv.length !== 5 && process.argv.length !== 7 && process.argv.length !== 8) {
+if (process.argv.length !== 4 && process.argv.length !== 7 && process.argv.length !== 8) {
   printUsageAndExit(0);
 }
 

--- a/src/demo/a/b/c.spec.ts
+++ b/src/demo/a/b/c.spec.ts
@@ -1,5 +1,6 @@
 export const description = 'Description for c.spec.ts';
 
+import { params, poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { unreachable } from '../../../common/framework/util/util.js';
 import { UnitTest } from '../../../unittests/unit_test.js';
@@ -17,11 +18,20 @@ g.test('f')
 g.test('f,g').fn(() => {});
 
 g.test('f,g,h')
-  .params([{}, { x: 0 }, { x: 0, y: 0 }])
+  .cases([{}, { x: 0 }, { x: 0, y: 0 }])
   .fn(() => {});
 
 g.test('case_depth_2_in_single_child_test')
-  .params([{ x: 0, y: 0 }])
+  .cases([{ x: 0, y: 0 }])
+  .fn(() => {});
+
+g.test('deep_case_tree')
+  .cases(
+    params()
+      .combine(poptions('x', [1, 2]))
+      .combine(poptions('y', [1, 2]))
+      .combine(poptions('z', [1, 2]))
+  )
   .fn(() => {});
 
 g.test('statuses,debug').fn(t => {


### PR DESCRIPTION
This increases the number of variants from 117 to 262.
Since all tests are handwritten, this number won't grow out of control.

An equivalent change was made in the standalone viewer a while ago,
to give a better overview of the CTS and test plan.





<hr>
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
