### PR TITLE
Expand operation tests for copyToTexture,ImageBitmap

### DIFF
--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -36,8 +36,8 @@ enum Color {
 }
 // Cache for generated pixels.
 const generatedPixelCache: Map<GPUTextureFormat, Map<Color, Uint8Array>> = new Map();
-type transparentOp = 'premultiply' | 'none' | 'non-transparent';
-type orientationOp = 'flipY' | 'none';
+type TransparentOp = 'premultiply' | 'none' | 'non-transparent';
+type OrientationOp = 'flipY' | 'none';
 
 class F extends GPUTest {
   checkCopyImageBitmapResult(
@@ -187,11 +187,11 @@ got [${failedByteActualValues.join(', ')}]`;
     format: UncompressedTextureFormat,
     width: number,
     height: number,
-    transparenetOp: transparentOp,
-    orientationOp: orientationOp
+    transparentOp: TransparentOp,
+    orientationOp: OrientationOp
   ): Uint8ClampedArray {
     const bytesPerPixel = kUncompressedTextureFormatInfo[format].bytesPerBlock;
-    if (typeof bytesPerPixel === 'undefined') {
+    if (bytesPerPixel === undefined) {
       return new Uint8ClampedArray(0);
     }
 
@@ -203,7 +203,7 @@ got [${failedByteActualValues.join(', ')}]`;
       const pixelData = this.generatePixel(currentPixel, format);
       for (let j = 0; j < bytesPerPixel; ++j) {
         // All pixels are 0 due to premultiply alpha
-        if (transparenetOp === 'premultiply' && currentPixel === Color.TransparentBlack) {
+        if (transparentOp === 'premultiply' && currentPixel === Color.TransparentBlack) {
           imagePixels[i * bytesPerPixel + j] = 0;
         } else {
           imagePixels[i * bytesPerPixel + j] = pixelData[j];
@@ -213,7 +213,7 @@ got [${failedByteActualValues.join(', ')}]`;
       // Refresh the iteration when hit OpaqueBlack color with 'non-transparent' config or
       // hit the TransparentBlack color(The last element in 'Color' enum).
       if (
-        (transparenetOp === 'non-transparent' && currentPixel === Color.OpaqueBlack) ||
+        (transparentOp === 'non-transparent' && currentPixel === Color.OpaqueBlack) ||
         currentPixel === Color.TransparentBlack
       ) {
         currentPixel = Color.Red;
@@ -247,7 +247,7 @@ g.test('from_ImageData')
     `
   Test ImageBitmap generated from ImageData can be copied to WebGPU
   texture correctly. These imageBitmaps are highly possible living
-  in CPU back resource. 
+  in CPU back resource.
   `
   )
   .cases(
@@ -321,7 +321,7 @@ g.test('from_canvas')
   .desc(
     `
   Test ImageBitmap generated from canvas/offscreenCanvas can be copied to WebGPU
-  texture correctly. These imageBitmaps are highly possible living in GPU back resource. 
+  texture correctly. These imageBitmaps are highly possible living in GPU back resource.
   `
   )
   .cases(

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -36,6 +36,8 @@ enum Color {
 }
 // Cache for generated pixels.
 const generatedPixelCache: Map<GPUTextureFormat, Map<Color, Uint8Array>> = new Map();
+type transparentOp = 'premultiply' | 'none' | 'non-transparent';
+type orientationOp = 'flipY' | 'none';
 
 class F extends GPUTest {
   checkCopyImageBitmapResult(
@@ -179,15 +181,79 @@ got [${failedByteActualValues.join(', ')}]`;
 
     return entry.get(color)!;
   }
+
+  // Helper functions to generate imagePixels based input configs.
+  getImagePixels(
+    format: UncompressedTextureFormat,
+    width: number,
+    height: number,
+    transparenetOp: transparentOp,
+    orientationOp: orientationOp
+  ): Uint8ClampedArray {
+    const bytesPerPixel = kUncompressedTextureFormatInfo[format].bytesPerBlock;
+    if (typeof bytesPerPixel === 'undefined') {
+      return new Uint8ClampedArray(0);
+    }
+
+    // Generate input contents by iterating 'Color' enum
+    const imagePixels = new Uint8ClampedArray(bytesPerPixel * width * height);
+    const flipYPixels = new Uint8ClampedArray(bytesPerPixel * width * height);
+    const startPixel = Color.Red;
+    for (let i = 0, currentPixel = startPixel; i < width * height; ++i) {
+      const pixelData = this.generatePixel(currentPixel, format);
+      for (let j = 0; j < bytesPerPixel; ++j) {
+        // All pixels are 0 due to premultiply alpha
+        if (transparenetOp === 'premultiply' && currentPixel === Color.TransparentBlack) {
+          imagePixels[i * bytesPerPixel + j] = 0;
+        } else {
+          imagePixels[i * bytesPerPixel + j] = pixelData[j];
+        }
+      }
+
+      // Refresh the iteration when hit OpaqueBlack color with 'non-transparent' config or
+      // hit the TransparentBlack color(The last element in 'Color' enum).
+      if (
+        (transparenetOp === 'non-transparent' && currentPixel === Color.OpaqueBlack) ||
+        currentPixel === Color.TransparentBlack
+      ) {
+        currentPixel = Color.Red;
+      } else {
+        ++currentPixel;
+      }
+    }
+
+    // Handle flipY if necessary and return the flipYPixels
+    if (orientationOp === 'flipY') {
+      for (let i = 0; i < height; ++i) {
+        for (let j = 0; j < width * bytesPerPixel; ++j) {
+          const posImagePixel = (height - i - 1) * width * bytesPerPixel + j;
+          const posExpectedValue = i * width * bytesPerPixel + j;
+          flipYPixels[posExpectedValue] = imagePixels[posImagePixel];
+        }
+      }
+
+      return flipYPixels;
+    }
+
+    // No flipY, return the origin imagePixels
+    return imagePixels;
+  }
 }
 
 export const g = makeTestGroup(F);
 
 g.test('from_ImageData')
+  .desc(
+    `
+  Test ImageBitmap generated from ImageData can be copied to WebGPU
+  texture correctly. These imageBitmaps are highly possible living
+  in CPU back resource. 
+  `
+  )
   .cases(
     params()
-      .combine(poptions('alpha', ['none', 'premultiply']))
-      .combine(poptions('orientation', ['none', 'flipY']))
+      .combine(poptions('alpha', ['none', 'premultiply'] as const))
+      .combine(poptions('orientation', ['none', 'flipY'] as const))
       .combine(
         poptions('dstColorFormat', [
           'rgba8unorm',
@@ -210,23 +276,14 @@ g.test('from_ImageData')
   .fn(async t => {
     const { width, height, alpha, orientation, dstColorFormat } = t.params;
 
-    const format = 'rgba8unorm';
-    const srcBytesPerPixel = kUncompressedTextureFormatInfo[format].bytesPerBlock;
-
     // Generate input contents by iterating 'Color' enum
-    const imagePixels = new Uint8ClampedArray(srcBytesPerPixel * width * height);
-    const startPixel = Color.Red;
-    for (let i = 0, currentPixel = startPixel; i < width * height; ++i) {
-      const pixels = t.generatePixel(currentPixel, format);
-      if (currentPixel === Color.TransparentBlack) {
-        currentPixel = Color.Red;
-      } else {
-        ++currentPixel;
-      }
-      for (let j = 0; j < srcBytesPerPixel; ++j) {
-        imagePixels[i * srcBytesPerPixel + j] = pixels[j];
-      }
-    }
+    const imagePixels = t.getImagePixels(
+      'rgba8unorm',
+      width,
+      height,
+      'none', // transparent op
+      'none' // orientation op
+    );
 
     // Generate correct expected values
     const imageData = new ImageData(imagePixels, width, height);
@@ -243,42 +300,13 @@ g.test('from_ImageData')
         depthOrArrayLayers: 1,
       },
       format: dstColorFormat,
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+      usage:
+        GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     // Construct expected value for different dst color format
     const dstBytesPerPixel = kUncompressedTextureFormatInfo[dstColorFormat].bytesPerBlock!;
-    const dstPixels = new Uint8ClampedArray(dstBytesPerPixel * width * height);
-    let expectedPixels = new Uint8ClampedArray(dstBytesPerPixel * width * height);
-    for (let i = 0, currentPixel = startPixel; i < width * height; ++i) {
-      const pixels = t.generatePixel(currentPixel, dstColorFormat);
-      for (let j = 0; j < dstBytesPerPixel; ++j) {
-        // All pixels are 0 due to premultiply alpha
-        if (alpha === 'premultiply' && currentPixel === Color.TransparentBlack) {
-          dstPixels[i * dstBytesPerPixel + j] = 0;
-        } else {
-          dstPixels[i * dstBytesPerPixel + j] = pixels[j];
-        }
-      }
-
-      if (currentPixel === Color.TransparentBlack) {
-        currentPixel = Color.Red;
-      } else {
-        ++currentPixel;
-      }
-    }
-
-    if (orientation === 'flipY') {
-      for (let i = 0; i < height; ++i) {
-        for (let j = 0; j < width * dstBytesPerPixel; ++j) {
-          const posImagePixel = (height - i - 1) * width * dstBytesPerPixel + j;
-          const posExpectedValue = i * width * dstBytesPerPixel + j;
-          expectedPixels[posExpectedValue] = dstPixels[posImagePixel];
-        }
-      }
-    } else {
-      expectedPixels = dstPixels;
-    }
+    const expectedPixels = t.getImagePixels(dstColorFormat, width, height, alpha, orientation);
 
     t.doTestAndCheckResult(
       { imageBitmap, origin: { x: 0, y: 0 } },
@@ -290,13 +318,36 @@ g.test('from_ImageData')
   });
 
 g.test('from_canvas')
+  .desc(
+    `
+  Test ImageBitmap generated from canvas/offscreenCanvas can be copied to WebGPU
+  texture correctly. These imageBitmaps are highly possible living in GPU back resource. 
+  `
+  )
+  .cases(
+    params()
+      .combine(poptions('orientation', ['none', 'flipY'] as const))
+      .combine(
+        poptions('dstColorFormat', [
+          'rgba8unorm',
+          'bgra8unorm',
+          'rgba8unorm-srgb',
+          'bgra8unorm-srgb',
+          'rgb10a2unorm',
+          'rgba16float',
+          'rgba32float',
+          'rg8unorm',
+          'rg16float',
+        ] as const)
+      )
+  )
   .subcases(() =>
     params()
       .combine(poptions('width', [1, 2, 4, 15, 255, 256]))
       .combine(poptions('height', [1, 2, 4, 15, 255, 256]))
   )
   .fn(async t => {
-    const { width, height } = t.params;
+    const { width, height, orientation, dstColorFormat } = t.params;
 
     // CTS sometimes runs on worker threads, where document is not available.
     // In this case, OffscreenCanvas can be used instead of <canvas>.
@@ -320,19 +371,27 @@ g.test('from_canvas')
       return;
     }
 
-    // The texture format is rgba8unorm, so the bytes per pixel is 4.
-    const bytesPerPixel = 4;
-
-    // Generate original data.
-    const imagePixels = new Uint8ClampedArray(bytesPerPixel * width * height);
-    for (let i = 0; i < width * height * bytesPerPixel; ++i) {
-      imagePixels[i] = i % 4 === 3 ? 255 : i % 256;
-    }
+    // Generate non-transparent pixel data to avoid canvas
+    // different opt behaviour on putImageData()
+    // from browsers.
+    const imagePixels = t.getImagePixels(
+      'rgba8unorm',
+      width,
+      height,
+      'non-transparent', // transparent op
+      'none' // orientation op
+    );
 
     const imageData = new ImageData(imagePixels, width, height);
+
+    // Use putImageData to prevent color space conversion.
     imageCanvasContext.putImageData(imageData, 0, 0);
 
-    const imageBitmap = await createImageBitmap(imageCanvas);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const imageBitmap = await (createImageBitmap as any)(imageCanvas, {
+      premultiplyAlpha: 'premultiply',
+      imageOrientation: orientation,
+    });
 
     const dst = t.device.createTexture({
       size: {
@@ -340,23 +399,25 @@ g.test('from_canvas')
         height: imageBitmap.height,
         depthOrArrayLayers: 1,
       },
-      format: 'rgba8unorm',
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+      format: dstColorFormat,
+      usage:
+        GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
-    // This will get origin data and even it has premultiplied-alpha
-    const expectedData = imageCanvasContext.getImageData(
-      0,
-      0,
-      imageBitmap.width,
-      imageBitmap.height
-    ).data;
+    const dstBytesPerPixel = kUncompressedTextureFormatInfo[dstColorFormat].bytesPerBlock!;
+    const expectedData = t.getImagePixels(
+      dstColorFormat,
+      width,
+      height,
+      'non-transparent', // transparent op
+      orientation
+    );
 
     t.doTestAndCheckResult(
       { imageBitmap, origin: { x: 0, y: 0 } },
       { texture: dst },
       { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 },
-      bytesPerPixel,
+      dstBytesPerPixel,
       expectedData
     );
   });


### PR DESCRIPTION
 - Add all valid {dstColorFormat} for `from_canvas` test
 - Add {orientation} config for `from_canvas` test
 - Add generateImagePixels() helper function to reduce duplicate code
 - Verify `from_canvas` tests can cover gpu uploading path.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
