### PR TITLE
[CI] Reduce expire field to 10 days

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -64,7 +64,7 @@ jobs:
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
-          expires: 30d
+          expires: 10d
           channelId: cts-prs-${{ env.PR }}-${{ github.event.workflow_run.head_sha }}
       - uses: peter-evans/create-or-update-comment@v1
         continue-on-error: true


### PR DESCRIPTION
This can help with reducing the number of build errors by reducing live time to be just enough for discussions.