### PR TITLE
Added some CompilationInfo tests.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1212,9 +1212,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.2.tgz",
-      "integrity": "sha512-x2xc4dfBRNNE2ACsgn/x633ETgkXQMLSfrmNdfy3DH0zno3AAsIVB5xQqYPDOb2ANE6vpJpDrHGDlrRVSsgomA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.3.tgz",
+      "integrity": "sha512-rvqmSxoSMqwIjtvMHOvdvgCtJaz8PS4okXTL47Jyf/X5rDTiRoKEW1U3+XPsWcfY9Hp5gir3A0ksi+Eh81bbyg==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "^0.1.2",
+    "@webgpu/types": "^0.1.3",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",
     "chokidar": "^3.4.3",

--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -12,19 +12,19 @@ const kValidShaderSources = [
   {
     valid: true,
     unicode: false,
-    codeFn: () => `
-  [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
-    return vec4<f32>(0.0, 0.0, 0.0, 1.0);
-  }`,
+    _code: `
+      [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+        return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+      }`,
   },
   {
     valid: true,
     unicode: true,
-    codeFn: () => `
-  // 頂点シェーダー
-  [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
-    return vec4<f32>(0.0, 0.0, 0.0, 1.0);
-  }`,
+    _code: `
+      // 頂点シェーダー 👩‍💻
+      [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+        return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+      }`,
   },
 ];
 
@@ -32,23 +32,23 @@ const kInvalidShaderSources = [
   {
     valid: false,
     unicode: false,
-    errorLine: 4,
-    codeFn: () => `
-  [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
-    // Expected Error: vec4 should be vec4<f32>
-    return vec4(0.0, 0.0, 0.0, 1.0);
-  }`,
+    _errorLine: 4,
+    _code: `
+      [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+        // Expected Error: vec4 should be vec4<f32>
+        return vec4(0.0, 0.0, 0.0, 1.0);
+      }`,
   },
   {
     valid: false,
     unicode: true,
-    errorLine: 5,
-    codeFn: () => `
-  // 頂点シェーダー
-  [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
-    // Expected Error: vec4 should be vec4<f32>
-    return vec4(0.0, 0.0, 0.0, 1.0);
-  }`,
+    _errorLine: 5,
+    _code: `
+      // 頂点シェーダー 👩‍💻
+      [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+        // Expected Error: vec4 should be vec4<f32>
+        return vec4(0.0, 0.0, 0.0, 1.0);
+      }`,
   },
 ];
 
@@ -65,11 +65,11 @@ g.test('compilationInfo_returns')
   )
   .cases(kAllShaderSources)
   .fn(async t => {
-    const { codeFn, valid } = t.params;
+    const { _code, valid } = t.params;
 
     const shaderModule = t.expectGPUError(
       'validation',
-      () => t.device.createShaderModule({ code: codeFn() }),
+      () => t.device.createShaderModule({ code: _code }),
       !valid
     );
 
@@ -105,10 +105,10 @@ g.test('line_number_and_position')
   )
   .cases(kInvalidShaderSources)
   .fn(async t => {
-    const { codeFn, errorLine } = t.params;
+    const { _code, _errorLine } = t.params;
 
     const shaderModule = t.expectGPUError('validation', () =>
-      t.device.createShaderModule({ code: codeFn() })
+      t.device.createShaderModule({ code: _code })
     );
 
     const info = await shaderModule.compilationInfo();
@@ -124,7 +124,7 @@ g.test('line_number_and_position')
           "GPUCompilationMessages that don't report a line number should not report a line position."
         );
 
-        if (message.lineNum === 0 || message.lineNum === errorLine) {
+        if (message.lineNum === 0 || message.lineNum === _errorLine) {
           foundAppropriateError = true;
 
           // Various backends may choose to report the error at different positions within the line,
@@ -147,12 +147,11 @@ g.test('offset_and_length')
   )
   .cases(kAllShaderSources)
   .fn(async t => {
-    const { codeFn, valid } = t.params;
-    const code = codeFn();
+    const { _code, valid } = t.params;
 
     const shaderModule = t.expectGPUError(
       'validation',
-      () => t.device.createShaderModule({ code }),
+      () => t.device.createShaderModule({ code: _code }),
       !valid
     );
 
@@ -160,9 +159,9 @@ g.test('offset_and_length')
 
     for (const message of info.messages) {
       // Any offsets and lengths should reference valid spans of the shader code.
-      t.expect(message.offset <= code.length, 'Message offset should be within the shader source');
+      t.expect(message.offset <= _code.length, 'Message offset should be within the shader source');
       t.expect(
-        message.offset + message.length <= code.length,
+        message.offset + message.length <= _code.length,
         'Message offset and length should be within the shader source'
       );
 

--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -1,0 +1,156 @@
+export const description = `
+ShaderModule CompilationInfo tests.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+import { assert } from '../../../../common/framework/util/util.js';
+
+export const g = makeTestGroup(GPUTest);
+
+const BAD_SHADER_SOURCE = `
+  [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+    // Expected Error: vec4 should be vec4<f32>
+    return vec4(0.0, 0.0, 0.0, 1.0);
+  }
+`;
+
+g.test('compilationInfo_valid_shader')
+  .desc(
+    `Ensures that compilationInfo() can be called on a valid ShaderModules.`
+  )
+  .fn(async t => {
+    const shaderModule = t.device.createShaderModule({
+      code: `
+        [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+          return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }
+      `,
+    });
+
+    const info = await shaderModule.compilationInfo();
+
+    t.expect(info instanceof GPUCompilationInfo, "Expected a GPUCompilationInfo object to be returned");
+
+    // Expect that we get zero error messages from a valid shader.
+    // Message types other than errors are OK.
+    let errorCount = 0;
+    for (const message of info.messages) {
+      if (message.type == 'error') {
+        errorCount++;
+      }
+    }
+    t.expect(errorCount == 0, "Expected zero GPUCompilationMessages of type 'error'");
+});
+
+g.test('compilationInfo_invalid_shader')
+  .desc(
+    `Ensures that compilationInfo() can be called on an invalid ShaderModules.`
+  )
+  .fn(async t => {
+
+    const shaderModule = t.expectGPUError(
+      'validation', // Should be a validation error since the shader is invalid.
+      () =>
+        t.device.createShaderModule({
+          code: BAD_SHADER_SOURCE,
+        })
+    );
+
+    const info = await shaderModule.compilationInfo();
+
+    t.expect(info instanceof GPUCompilationInfo, "Expected a GPUCompilationInfo object to be returned");
+
+    // Expect that we get at least one error message.
+    // Additional errors or other message types are also OK.
+    let errorCount = 0;
+    for (const message of info.messages) {
+      if (message.type == 'error') {
+        errorCount++;
+      }
+    }
+    t.expect(errorCount > 0, "Expected at least one GPUCompilationMessages of type 'error'");
+});
+
+g.test('compilationInfo_line_position')
+  .desc(
+    `Ensures that line numbers reported by compilationInfo either point at an appropriate line and
+    position or at 0:0, indicating an unknown position.`
+  )
+  .fn(async t => {
+
+    const shaderModule = t.expectGPUError(
+      'validation', // Should be a validation error since the shader is invalid.
+      () =>
+        t.device.createShaderModule({
+          code: BAD_SHADER_SOURCE,
+        })
+    );
+
+    const info = await shaderModule.compilationInfo();
+
+    let foundAppropriateError = false;
+    for (const message of info.messages) {
+      if (message.type == 'error') {
+        // Some backends may not be able to indicate a precise location for the error. In those
+        // cases a line and position of 0 should be reported.
+        if (message.lineNum == 0) {
+          foundAppropriateError = true;
+          t.expect(message.linePos == 0, "GPUCompilationMessages that don't report a line number should not report a line position.")
+          break;
+        }
+
+        // If a line is reported, it should point at the correct line (1-based).
+        if (message.lineNum == 4) {
+          foundAppropriateError = true;
+
+          // Various backends may choose to report the error at different positions within the line,
+          // so it's difficult to meaningfully validate them.
+          break;
+        }
+      }
+    }
+    t.expect(foundAppropriateError, "Expected to find an error which corresponded with the erronious line");
+});
+
+
+g.test('compilationInfo_offset_length')
+  .desc(
+    `Ensures message offsets and lengths are valid and align with any reported lineNum and linePos.`
+  )
+  .fn(async t => {
+
+    const shaderModule = t.expectGPUError(
+      'validation', // Should be a validation error since the shader is invalid.
+      () =>
+        t.device.createShaderModule({
+          code: BAD_SHADER_SOURCE,
+        })
+    );
+
+    const info = await shaderModule.compilationInfo();
+
+    for (const message of info.messages) {
+      // Any offsets and lengths should reference valid spans of the shader code.
+      t.expect(message.offset < BAD_SHADER_SOURCE.length, "Message offset should be within the shader source");
+      t.expect(message.offset + message.length < BAD_SHADER_SOURCE.length, "Message offset and length should be within the shader source");
+
+      // If a valid line number and position are given the offset should point the the same location in the shader source.
+      if (message.lineNum != 0 && message.linePos != 0) {
+        let lineOffset = 0;
+        for (let i = 0; i < message.lineNum-1; ++i) {
+          lineOffset = BAD_SHADER_SOURCE.indexOf('\n', lineOffset);
+          assert(lineOffset != -1);
+          lineOffset+=1;
+        }
+
+        t.expect(message.offset == lineOffset + message.linePos-1, "lineNum and linePos should point to the same location as offset");
+      }
+    }
+});
+
+g.test('compilationInfo_offset_unicode')
+  .desc(
+    `Ensures that message offsets properly take into account unicode characters`
+  )
+  .unimplemented();

--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -165,11 +165,12 @@ g.test('offset_and_length')
         'Message offset and length should be within the shader source'
       );
 
-      // If a valid line number and position are given the offset should point the the same location in the shader source.
+      // If a valid line number and position are given, the offset should point the the same
+      // location in the shader source.
       if (message.lineNum !== 0 && message.linePos !== 0) {
         let lineOffset = 0;
         for (let i = 0; i < message.lineNum - 1; ++i) {
-          lineOffset = code.indexOf('\n', lineOffset);
+          lineOffset = _code.indexOf('\n', lineOffset);
           assert(lineOffset !== -1);
           lineOffset += 1;
         }

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>WebGPU CTS</title>
     <link
       id="favicon"


### PR DESCRIPTION
Adds some simple tests to ensure CompilationInfo reported from ShaderModules is sane. This is difficult to test strictly since different implementations have a fair amount of leeway in how the identify and report shader errors, but we can at least validate that the messages reported are sane (i.e: reference actual positions within the shader code) and internally consistent.

These will pass in Chrome once https://chromium-review.googlesource.com/c/chromium/src/+/2861210 lands, though there will be known issues with reporting offsets if there is unicode in the shader.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
