### PR TITLE
Reviewed createBindGroup spec

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -1,8 +1,4 @@
-export const description = `
-createBindGroup validation tests.
-
-TODO: review existing tests, write descriptions, and make sure tests are complete.
-`;
+export const description = `createBindGroup validation tests.`;
 
 import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
@@ -12,6 +8,7 @@ import {
   bindingTypeInfo,
   kBindableResources,
   kTextureUsages,
+  kTextureViewDimensions,
   sampledAndStorageBindingEntries,
   texBindingTypeInfo,
 } from '../../capability_info.js';
@@ -25,60 +22,69 @@ function clone<T extends GPUTextureDescriptor>(descriptor: T): T {
 
 export const g = makeTestGroup(ValidationTest);
 
-g.test('binding_count_mismatch').fn(async t => {
-  const bindGroupLayout = t.device.createBindGroupLayout({
-    entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } }],
+g.test('binding_count_mismatch')
+  .desc('Test that the number of entries must match the number of entries in the BindGroupLayout.')
+  .fn(async t => {
+    const bindGroupLayout = t.device.createBindGroupLayout({
+      entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } }],
+    });
+
+    const goodDescriptor = {
+      entries: [{ binding: 0, resource: { buffer: t.getStorageBuffer() } }],
+      layout: bindGroupLayout,
+    };
+
+    // Control case
+    t.device.createBindGroup(goodDescriptor);
+
+    // Another binding is not expected.
+    const badDescriptor = {
+      entries: [
+        { binding: 0, resource: { buffer: t.getStorageBuffer() } },
+        // Another binding is added.
+        { binding: 1, resource: { buffer: t.getStorageBuffer() } },
+      ],
+      layout: bindGroupLayout,
+    };
+
+    t.expectValidationError(() => {
+      t.device.createBindGroup(badDescriptor);
+    });
   });
 
-  const goodDescriptor = {
-    entries: [{ binding: 0, resource: { buffer: t.getStorageBuffer() } }],
-    layout: bindGroupLayout,
-  };
+g.test('binding_must_be_present_in_layout')
+  .desc(
+    'Test that the binding slot for each entry matches a binding slot defined in the BindGroupLayout.'
+  )
+  .fn(async t => {
+    const bindGroupLayout = t.device.createBindGroupLayout({
+      entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } }],
+    });
 
-  // Control case
-  t.device.createBindGroup(goodDescriptor);
+    const goodDescriptor = {
+      entries: [{ binding: 0, resource: { buffer: t.getStorageBuffer() } }],
+      layout: bindGroupLayout,
+    };
 
-  // Another binding is not expected.
-  const badDescriptor = {
-    entries: [
-      { binding: 0, resource: { buffer: t.getStorageBuffer() } },
-      // Another binding is added.
-      { binding: 1, resource: { buffer: t.getStorageBuffer() } },
-    ],
-    layout: bindGroupLayout,
-  };
+    // Control case
+    t.device.createBindGroup(goodDescriptor);
 
-  t.expectValidationError(() => {
-    t.device.createBindGroup(badDescriptor);
+    // Binding index 0 must be present.
+    const badDescriptor = {
+      entries: [{ binding: 1, resource: { buffer: t.getStorageBuffer() } }],
+      layout: bindGroupLayout,
+    };
+
+    t.expectValidationError(() => {
+      t.device.createBindGroup(badDescriptor);
+    });
   });
-});
 
-g.test('binding_must_be_present_in_layout').fn(async t => {
-  const bindGroupLayout = t.device.createBindGroupLayout({
-    entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } }],
-  });
-
-  const goodDescriptor = {
-    entries: [{ binding: 0, resource: { buffer: t.getStorageBuffer() } }],
-    layout: bindGroupLayout,
-  };
-
-  // Control case
-  t.device.createBindGroup(goodDescriptor);
-
-  // Binding index 0 must be present.
-  const badDescriptor = {
-    entries: [{ binding: 1, resource: { buffer: t.getStorageBuffer() } }],
-    layout: bindGroupLayout,
-  };
-
-  t.expectValidationError(() => {
-    t.device.createBindGroup(badDescriptor);
-  });
-});
-
-g.test('buffer_binding_must_contain_exactly_one_buffer_of_its_type')
-  .params(
+g.test('binding_must_contain_resource_defined_in_layout')
+  .desc(
+    'Test that only the resource type specified in the BindGroupLayout is allowed for each entry.'
+  )
+  .subcases(() =>
     params()
       .combine(poptions('resourceType', kBindableResources))
       .combine(poptions('entry', allBindingEntries(false)))
@@ -100,7 +106,8 @@ g.test('buffer_binding_must_contain_exactly_one_buffer_of_its_type')
   });
 
 g.test('texture_binding_must_have_correct_usage')
-  .params(
+  .desc('Tests that texture bindings must have the correct usage.')
+  .subcases(() =>
     params()
       .combine(poptions('entry', sampledAndStorageBindingEntries(false)))
       .combine(poptions('usage', kTextureUsages))
@@ -136,7 +143,13 @@ g.test('texture_binding_must_have_correct_usage')
   });
 
 g.test('texture_must_have_correct_component_type')
-  .subcases(() => poptions('sampleType', ['float', 'sint', 'uint'] as const))
+  .desc(
+    `
+    Tests that texture bindings must have a format that matches the sample type specified in the BindGroupLayout.
+    - Tests a compatible format for every sample type
+    - Tests an incompatible format for every sample type`
+  )
+  .cases(poptions('sampleType', ['float', 'sint', 'uint'] as const))
   .fn(async t => {
     const { sampleType } = t.params;
 
@@ -204,49 +217,55 @@ g.test('texture_must_have_correct_component_type')
     }
   });
 
-// TODO: Write test for all dimensions.
-g.test('texture_must_have_correct_dimension').fn(async t => {
-  const bindGroupLayout = t.device.createBindGroupLayout({
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.FRAGMENT,
-        texture: {},
-      },
-    ],
-  });
-
-  const goodDescriptor = {
-    size: { width: 16, height: 16, depthOrArrayLayers: 1 },
-    format: 'rgba8unorm' as const,
-    usage: GPUTextureUsage.SAMPLED,
-  };
-
-  // Control case
-  t.device.createBindGroup({
-    entries: [{ binding: 0, resource: t.device.createTexture(goodDescriptor).createView() }],
-    layout: bindGroupLayout,
-  });
-
-  // Mismatched texture binding formats are not valid.
-  const badDescriptor = clone(goodDescriptor);
-  badDescriptor.size.depthOrArrayLayers = 2;
-
-  t.expectValidationError(() => {
-    t.device.createBindGroup({
-      entries: [{ binding: 0, resource: t.device.createTexture(badDescriptor).createView() }],
-      layout: bindGroupLayout,
+g.test('texture_must_have_correct_dimension')
+  .desc(
+    `
+    Test that bound texture views match the dimensions supplied in the BindGroupLayout
+    - Test for every GPUTextureViewDimension`
+  )
+  .cases(poptions('viewDimension', kTextureViewDimensions))
+  .fn(async t => {
+    const { viewDimension } = t.params;
+    const bindGroupLayout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          texture: { viewDimension },
+        },
+      ],
     });
+
+    const textureDescriptor = {
+      size: { width: 16, height: 16, depthOrArrayLayers: 6 },
+      format: 'rgba8unorm' as const,
+      usage: GPUTextureUsage.SAMPLED,
+    };
+
+    const texture = t.device.createTexture(textureDescriptor);
+
+    for (const dimension of kTextureViewDimensions) {
+      const shouldError = viewDimension !== dimension;
+      const arrayLayerCount = dimension === '2d' ? 1 : undefined;
+      const viewDescriptor = { dimension, arrayLayerCount };
+
+      t.expectValidationError(() => {
+        t.device.createBindGroup({
+          entries: [{ binding: 0, resource: texture.createView(viewDescriptor) }],
+          layout: bindGroupLayout,
+        });
+      }, shouldError);
+    }
   });
-});
 
 g.test('buffer_offset_and_size_for_bind_groups_match')
   .desc(
-    `TODO: describe
-
-TODO(#234): disallow zero-sized bindings`
+    `
+    Test that a buffer binding's [offset, offset + size) must be contained in the BindGroup entry's buffer.
+    - Test for various offsets and sizes
+    - TODO(#234): disallow zero-sized bindings`
   )
-  .params([
+  .subcases(() => [
     { offset: 0, size: 512, _success: true }, // offset 0 is valid
     { offset: 256, size: 256, _success: true }, // offset 256 (aligned) is valid
 

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -1,7 +1,7 @@
 export const description = `
 createBindGroupLayout validation tests.
 
-TODO: update for new binding structure, remove eslint-disable.
+TODO: update for new binding structure.
 TODO: review existing tests, write descriptions, and make sure tests are complete.
 `;
 

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -1,7 +1,6 @@
 export const description = `
 createBindGroupLayout validation tests.
 
-TODO: update for new binding structure.
 TODO: review existing tests, write descriptions, and make sure tests are complete.
 `;
 

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -588,7 +588,7 @@ export function sampledAndStorageBindingEntries(
   ] as const;
 }
 /** Generates all different types of binding entries.
- * Does not generate variats with different:
+ * Does not generate variants with different:
  * - buffer.hasDynamicOffset
  * - texture.sampleType
  * - texture.viewDimension


### PR DESCRIPTION
- Added descriptions to all tests
- Fixed naming where appropriate
- Added more test cases to the viewDimensions test.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
