### PR TITLE
Add compute,basic,large_dispatch test.

### DIFF
--- a/docs/helper_index.md
+++ b/docs/helper_index.md
@@ -26,6 +26,10 @@ Generally, see:
         feature(s). If the device creation fails, then skip the test for that format(s).
     - `selectDeviceForQueryTypeOrSkipTestCase`: Create device with query type(s) required
         feature(s). If the device creation fails, then skip the test for that type(s).
+    - `expectSingleValueContents`: Expect a buffer's contents to be a single constant value,
+        specified as a TypedArrayBufferView.
+    - `checkSingleValueBuffer`: checks that an actual TypedArrayBufferView's contents are all a
+        single constant value, specified as a TypedArrayBufferView containing one element.
 - [`ValidationTest`](../src/webgpu/api/validation/validation_test.ts)
     - `createEncoder`: Generically creates non-pass, compute pass, render pass, or render bundle
         encoders. This allows callers to write code using methods common to multiple encoder types.

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -116,8 +116,7 @@ Test reasonably-sized large dispatches (see also stress tests).
     const data = new Uint32Array([val]);
 
     const wgSize = t.params.workgroupSize;
-    const bufferSize =
-      Uint32Array.BYTES_PER_ELEMENT * t.params.dispatchSize * wgSize;
+    const bufferSize = Uint32Array.BYTES_PER_ELEMENT * t.params.dispatchSize * wgSize;
     const dst = t.device.createBuffer({
       size: bufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -75,39 +75,17 @@ Test reasonably-sized large dispatches (see also stress tests).
   .cases(
     params()
       .combine(
-        poptions('dispatchSize', [
-          // Reasonably-sized powers of two
-          256,
-          512,
-          1024,
-          2048,
-          // Some stranger larger sizes
-          315,
-          628,
-          1053,
-          2179,
-        ] as const)
+        // Reasonably-sized powers of two, and some stranger larger sizes.
+        poptions('dispatchSize', [256, 512, 1024, 2048, 315, 628, 1053, 2179] as const)
       )
       .combine(
-        poptions('workgroupSize', [
-          // Test some reasonable workgroup sizes.
-          1,
-          2,
-          4,
-          8,
-          16,
-          32,
-          64,
-        ] as const)
+        // Test some reasonable workgroup sizes.
+        poptions('workgroupSize', [1, 2, 4, 8, 16, 32, 64] as const)
       )
   )
   .subcases(() =>
-    poptions('largeDimension', [
-      // 0 == x axis; 1 == y axis; 2 == z axis
-      0,
-      1,
-      2,
-    ] as const)
+    // 0 == x axis; 1 == y axis; 2 == z axis.
+    poptions('largeDimension', [0, 1, 2] as const)
   )
   .fn(async t => {
     // The output storage buffer is filled with this value.
@@ -142,15 +120,18 @@ Test reasonably-sized large dispatches (see also stress tests).
             fn main(
               [[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>
             ) {
+              var xExtent : u32 = ${dims[0]}u * ${wgSizes[0]}u;
+              var yExtent : u32 = ${dims[1]}u * ${wgSizes[1]}u;
+              var zExtent : u32 = ${dims[2]}u * ${wgSizes[2]}u;
               var index : u32 = (
-                GlobalInvocationID.z * ${dims[0]}u * ${wgSizes[0]}u * ${dims[1]}u * ${wgSizes[1]}u +
-                GlobalInvocationID.y * ${dims[0]}u * ${wgSizes[0]}u +
+                GlobalInvocationID.z * xExtent * yExtent +
+                GlobalInvocationID.y * xExtent +
                 GlobalInvocationID.x);
               var val : u32 = ${val}u;
               // Trivial error checking in the indexing and invocation.
-              if ((GlobalInvocationID.x > ${dims[0]}u * ${wgSizes[0]}u) ||
-                  (GlobalInvocationID.y > ${dims[1]}u * ${wgSizes[1]}u) ||
-                  (GlobalInvocationID.z > ${dims[2]}u * ${wgSizes[2]}u)) {
+              if (GlobalInvocationID.x > xExtent ||
+                  GlobalInvocationID.y > yExtent ||
+                  GlobalInvocationID.z > zExtent) {
                 val = ${badVal}u;
               }
               dst.value[index] = val;

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -112,16 +112,8 @@ Test reasonably-sized large dispatches (see also stress tests).
   .fn(async t => {
     // The output storage buffer is filled with this value.
     const val = 0x01020304;
-    const badVal = 0xBAADF00D;
+    const badVal = 0xbaadf00d;
     const data = new Uint32Array([val]);
-
-    const src = t.device.createBuffer({
-      mappedAtCreation: true,
-      size: Uint32Array.BYTES_PER_ELEMENT,
-      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
-    });
-    new Uint32Array(src.getMappedRange()).set(data);
-    src.unmap();
 
     const wgSize = t.params.workgroupSize;
     const bufferSize =
@@ -163,7 +155,6 @@ Test reasonably-sized large dispatches (see also stress tests).
                 val = ${badVal}u;
               }
               dst.value[index] = val;
-              return;
             }
           `,
         }),

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -449,8 +449,8 @@ got [${failedByteActualValues.join(', ')}]`;
   ): string | undefined {
     assert(actual.constructor === exp.constructor);
 
-    const size = exp.length;
-    if (1 !== size) {
+    const size = actual.length;
+    if (1 !== exp.length) {
       return 'expected single value typed array for expected value';
     }
     const failedByteIndices: string[] = [];

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -229,6 +229,32 @@ export class GPUTest extends Fixture {
     });
   }
 
+  expectSingleValueContents(
+    src: GPUBuffer,
+    expected: TypedArrayBufferView,
+    byteSize: number,
+    srcOffset: number = 0,
+    { generateWarningOnly = false }: { generateWarningOnly?: boolean } = {}
+  ): void {
+    const { dst, begin, end } = this.createAlignedCopyForMapRead(src, byteSize, srcOffset);
+
+    this.eventualAsyncExpectation(async niceStack => {
+      const constructor = expected.constructor as TypedArrayBufferViewConstructor;
+      await dst.mapAsync(GPUMapMode.READ);
+      const actual = new constructor(dst.getMappedRange());
+      const check = this.checkSingleValueBuffer(actual.subarray(begin, end), expected);
+      if (check !== undefined) {
+        niceStack.message = check;
+        if (generateWarningOnly) {
+          this.rec.warn(niceStack);
+        } else {
+          this.rec.expectationFailed(niceStack);
+        }
+      }
+      dst.destroy();
+    });
+  }
+
   expectContentsBetweenTwoValues(
     src: GPUBuffer,
     expected: [TypedArrayBufferView, TypedArrayBufferView],
@@ -375,6 +401,72 @@ export class GPUTest extends Fixture {
         }
         failedByteIndices.push(i.toString());
         failedByteExpectedValues.push(exp[i].toString());
+        failedByteActualValues.push(actual[i].toString());
+      }
+    }
+    const summary = `at [${failedByteIndices.join(', ')}], \
+expected [${failedByteExpectedValues.join(', ')}], \
+got [${failedByteActualValues.join(', ')}]`;
+    const lines = [summary];
+
+    // TODO: Could make a more convenient message, which could look like e.g.:
+    //
+    //   Starting at offset 48,
+    //              got 22222222 ABCDABCD 99999999
+    //     but expected 22222222 55555555 99999999
+    //
+    // or
+    //
+    //   Starting at offset 0,
+    //              got 00000000 00000000 00000000 00000000 (... more)
+    //     but expected 00FF00FF 00FF00FF 00FF00FF 00FF00FF (... more)
+    //
+    // Or, maybe these diffs aren't actually very useful (given we have the prints just above here),
+    // and we should remove them. More important will be logging of texture data in a visual format.
+
+    if (size <= 256 && failedByteIndices.length > 0) {
+      const expHex = Array.from(new Uint8Array(exp.buffer, exp.byteOffset, exp.byteLength))
+        .map(x => x.toString(16).padStart(2, '0'))
+        .join('');
+      const actHex = Array.from(new Uint8Array(actual.buffer, actual.byteOffset, actual.byteLength))
+        .map(x => x.toString(16).padStart(2, '0'))
+        .join('');
+      lines.push('EXPECT:\t  ' + exp.join(' '));
+      lines.push('\t0x' + expHex);
+      lines.push('ACTUAL:\t  ' + actual.join(' '));
+      lines.push('\t0x' + actHex);
+    }
+    if (failedByteIndices.length) {
+      return lines.join('\n');
+    }
+    return undefined;
+  }
+
+  checkSingleValueBuffer(
+    actual: TypedArrayBufferView,
+    exp: TypedArrayBufferView,
+    tolerance: number | ((i: number) => number) = 0
+  ): string | undefined {
+    assert(actual.constructor === exp.constructor);
+
+    const size = exp.length;
+    if (1 !== size) {
+      return 'expected single value typed array for expected value';
+    }
+    const failedByteIndices: string[] = [];
+    const failedByteExpectedValues: string[] = [];
+    const failedByteActualValues: string[] = [];
+    for (let i = 0; i < size; ++i) {
+      const tol = typeof tolerance === 'function' ? tolerance(i) : tolerance;
+      if (Math.abs(actual[i] - exp[0]) > tol) {
+        if (failedByteIndices.length >= 4) {
+          failedByteIndices.push('...');
+          failedByteExpectedValues.push('...');
+          failedByteActualValues.push('...');
+          break;
+        }
+        failedByteIndices.push(i.toString());
+        failedByteExpectedValues.push(exp.toString());
         failedByteActualValues.push(actual[i].toString());
       }
     }


### PR DESCRIPTION
Test compute dispatches with a single large parameter along one of the
X, Y, or Z workgroup grid dimensions. Within this, also test a few
workgroup sizes - which increase runtime significantly since they
increase the size along all 3 dimensions simultaneously.

Add and document helpers for ensuring a buffer's contents are all a
single value.


<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented in `helper_index.md`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
