### PR TITLE
Update texture zero init tests for 3D textures

### DIFF
--- a/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
@@ -13,7 +13,7 @@ export const checkContentsByBufferCopy: CheckContents = (
   subresourceRange
 ) => {
   for (const { level: mipLevel, slice } of subresourceRange.each()) {
-    assert(params.dimension === '2d');
+    assert(params.dimension !== '1d');
     assert(params.format in kEncodableTextureFormatInfo);
     const format = params.format as EncodableTextureFormat;
 
@@ -35,7 +35,7 @@ export const checkContentsByTextureCopy: CheckContents = (
   subresourceRange
 ) => {
   for (const { level, slice } of subresourceRange.each()) {
-    assert(params.dimension === '2d');
+    assert(params.dimension !== '1d');
     assert(params.format in kEncodableTextureFormatInfo);
     const format = params.format as EncodableTextureFormat;
 

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -1,6 +1,6 @@
 import { assert } from '../../../../../common/framework/util/util.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { mipSize } from '../../../../util/texture/subresource.js';
+import { getMipSizePassthroughLayers } from '../../../../util/texture/layout.js';
 import { CheckContents } from '../texture_zero.spec.js';
 
 function makeFullscreenVertexModule(device: GPUDevice) {
@@ -104,7 +104,11 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
     subresourceRange
   )) {
     assert(viewDescriptor.baseMipLevel !== undefined);
-    const [width, height] = mipSize([t.textureWidth, t.textureHeight], viewDescriptor.baseMipLevel);
+    const [width, height] = getMipSizePassthroughLayers(
+      '2d',
+      [t.textureWidth, t.textureHeight, 1],
+      viewDescriptor.baseMipLevel
+    );
 
     const renderTexture = t.device.createTexture({
       size: [width, height, 1],


### PR DESCRIPTION
I'm not 100% sure if this works since 3D textures are still being implemented. Running with unsafe_apis doesn't yield validation errors though.


<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
