### PR TITLE
Review createBindGroupLayout spec

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -28,16 +28,22 @@ export const g = makeTestGroup(ValidationTest);
 
 g.test('duplicate_bindings')
   .desc('Test that uniqueness of binding numbers across entries is enforced.')
-  .subcases(() => poptions('bindings', [
-    { numbers: [0, 1], valid: true, },
-    { numbers: [0, 0], valid: false, }
-  ]))
+  .subcases(() =>
+    poptions('bindings', [
+      { numbers: [0, 1], valid: true },
+      { numbers: [0, 0], valid: false },
+    ])
+  )
   .fn(async t => {
     const { bindings } = t.params;
-    const entries : Array<GPUBindGroupLayoutEntry> = [];
+    const entries: Array<GPUBindGroupLayoutEntry> = [];
 
     for (const binding of bindings.numbers) {
-      entries.push({ binding, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' as const } });
+      entries.push({
+        binding,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'storage' as const },
+      });
     }
 
     t.expectValidationError(() => {
@@ -99,9 +105,11 @@ g.test('max_dynamic_buffers')
     - TODO(#230): Update to enforce per-stage and per-pipeline-layout limits on BGLs as well.`
   )
   .cases(poptions('type', kBufferBindingTypes))
-  .subcases(() => params()
-    .combine(poptions('extraDynamicBuffers', [0, 1]))
-    .combine(poptions('staticBuffers', [0, 1])))
+  .subcases(() =>
+    params()
+      .combine(poptions('extraDynamicBuffers', [0, 1]))
+      .combine(poptions('staticBuffers', [0, 1]))
+  )
   .fn(async t => {
     const { type, extraDynamicBuffers, staticBuffers } = t.params;
     const info = bufferBindingTypeInfo({ type });
@@ -117,7 +125,7 @@ g.test('max_dynamic_buffers')
       });
     }
 
-    for (let i = dynamicBufferCount; i < dynamicBufferCount+staticBuffers; i++) {
+    for (let i = dynamicBufferCount; i < dynamicBufferCount + staticBuffers; i++) {
       entries.push({
         binding: i,
         visibility: GPUShaderStage.COMPUTE,

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -1,7 +1,7 @@
 export const description = `
 createBindGroupLayout validation tests.
 
-TODO: review existing tests, write descriptions, and make sure tests are complete.
+TODO: make sure tests are complete.
 `;
 
 import { poptions, params } from '../../../common/framework/params_builder.js';
@@ -26,27 +26,35 @@ function clone<T extends GPUBindGroupLayoutDescriptor>(descriptor: T): T {
 
 export const g = makeTestGroup(ValidationTest);
 
-g.test('some_binding_index_was_specified_more_than_once').fn(async t => {
-  const goodDescriptor = {
-    entries: [
-      { binding: 0, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' as const },
-      { binding: 1, visibility: GPUShaderStage.COMPUTE, type: 'storage-buffer' as const },
-    ],
-  };
+g.test('some_binding_index_was_specified_more_than_once')
+  .desc('Test that uniqueness of binding numbers across entries is enforced.')
+  .fn(async t => {
+    const goodDescriptor = {
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' as const } },
+        { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' as const } },
+      ],
+    };
 
-  // Control case
-  t.device.createBindGroupLayout(goodDescriptor);
+    // Control case
+    t.device.createBindGroupLayout(goodDescriptor);
 
-  const badDescriptor = clone(goodDescriptor);
-  badDescriptor.entries[1].binding = 0;
+    const badDescriptor = clone(goodDescriptor);
+    badDescriptor.entries[1].binding = 0;
 
-  // Binding index 0 can't be specified twice.
-  t.expectValidationError(() => {
-    t.device.createBindGroupLayout(badDescriptor);
+    // Binding index 0 can't be specified twice.
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout(badDescriptor);
+    });
   });
-});
 
 g.test('visibility')
+  .desc(
+    `
+    Test that only the appropriate combinations of visibilities are allowed for each resource type.
+    - Test each possible combination of shader stage visibilities.
+    - Test each type of bind group resource.`
+  )
   .cases(poptions('visibility', kShaderStageCombinations))
   .subcases(() => poptions('entry', allBindingEntries(false)))
   .fn(async t => {
@@ -63,7 +71,8 @@ g.test('visibility')
   });
 
 g.test('multisample_requires_2d_view_dimension')
-  .params(params().combine(poptions('viewDimension', [undefined, ...kTextureViewDimensions])))
+  .desc('Test that multisampling is only allowed with "2d" view dimensions.')
+  .subcases(() => poptions('viewDimension', [undefined, ...kTextureViewDimensions]))
   .fn(async t => {
     const { viewDimension } = t.params;
 
@@ -84,9 +93,11 @@ g.test('multisample_requires_2d_view_dimension')
 
 g.test('number_of_dynamic_buffers_exceeds_the_maximum_value')
   .desc(
-    `TODO: describe
-
-TODO(#230): Update to enforce per-stage and per-pipeline-layout limits on BGLs as well.`
+    `
+    Test that limits on the maximum number of dynamic buffers are enforced.
+    - Test creation of a bind group layout using the maximum number of dynamic buffers works.
+    - Test creation of a bind group layout using the maximum number of dynamic buffers + 1 fails.
+    - TODO(#230): Update to enforce per-stage and per-pipeline-layout limits on BGLs as well.`
   )
   .cases(poptions('type', kBufferBindingTypes))
   .fn(async t => {
@@ -153,26 +164,32 @@ function* pickExtraBindingTypesForPerStage(
   }
 }
 
-const kCasesForMaxResourcesPerStageTests = params()
-  .combine(poptions('maxedEntry', allBindingEntries(false)))
-  .combine(poptions('maxedVisibility', kShaderStages))
-  .filter(p => (bindingTypeInfo(p.maxedEntry).validStages & p.maxedVisibility) !== 0)
-  .expand(function* (p) {
-    yield* poptions('extraEntry', pickExtraBindingTypesForPerStage(p.maxedEntry, true));
-    yield* poptions('extraEntry', pickExtraBindingTypesForPerStage(p.maxedEntry, false));
-  })
-  .combine(poptions('extraVisibility', kShaderStages))
-  .filter(p => (bindingTypeInfo(p.extraEntry).validStages & p.extraVisibility) !== 0);
+function subcasesForMaxResourcesPerStageTests(caseParams: { maxedEntry: BGLEntry }) {
+  return params()
+    .combine(poptions('maxedVisibility', kShaderStages))
+    .filter(p => (bindingTypeInfo(caseParams.maxedEntry).validStages & p.maxedVisibility) !== 0)
+    .expand(function* () {
+      yield* poptions('extraEntry', pickExtraBindingTypesForPerStage(caseParams.maxedEntry, true));
+      yield* poptions('extraEntry', pickExtraBindingTypesForPerStage(caseParams.maxedEntry, false));
+    })
+    .combine(poptions('extraVisibility', kShaderStages))
+    .filter(p => (bindingTypeInfo(p.extraEntry).validStages & p.extraVisibility) !== 0);
+}
 
 // Should never fail unless kMaxBindingsPerBindGroup is exceeded, because the validation for
 // resources-of-type-per-stage is in pipeline layout creation.
 g.test('max_resources_per_stage,in_bind_group_layout')
   .desc(
-    `TODO: describe
-
-TODO(#230): Update to enforce per-stage and per-pipeline-layout limits on BGLs as well.`
+    `
+    Test that the maximum number of bindings of a given type per-stage cannot be exceeded in a
+    single bind group layout.
+    - Test each binding type.
+    - Test that creation of a bind group layout using the maximum number of bindings works.
+    - Test that creation of a bind group layout using the maximum number of bindings + 1 fails.
+    - TODO(#230): Update to enforce per-stage and per-pipeline-layout limits on BGLs as well.`
   )
-  .params(kCasesForMaxResourcesPerStageTests)
+  .cases(poptions('maxedEntry', allBindingEntries(false)))
+  .subcases(cp => subcasesForMaxResourcesPerStageTests(cp))
   .fn(async t => {
     const { maxedEntry, extraEntry, maxedVisibility, extraVisibility } = t.params;
     const maxedTypeInfo = bindingTypeInfo(maxedEntry);
@@ -210,7 +227,17 @@ TODO(#230): Update to enforce per-stage and per-pipeline-layout limits on BGLs a
 // different for each type). Test that the max works, then add one more binding of same-or-different
 // type and same-or-different visibility.
 g.test('max_resources_per_stage,in_pipeline_layout')
-  .params(kCasesForMaxResourcesPerStageTests)
+  .desc(
+    `
+    Test that the maximum number of bindings of a given type per-stage cannot be exceeded across
+    multiple bind group layouts when creating a pipeline layout.
+    - Test each binding type.
+    - Test that creation of a pipeline using the maximum number of bindings works.
+    - Test that creation of a pipeline using the maximum number of bindings + 1 fails.
+  `
+  )
+  .cases(poptions('maxedEntry', allBindingEntries(false)))
+  .subcases(cp => subcasesForMaxResourcesPerStageTests(cp))
   .fn(async t => {
     const { maxedEntry, extraEntry, maxedVisibility, extraVisibility } = t.params;
     const maxedTypeInfo = bindingTypeInfo(maxedEntry);


### PR DESCRIPTION
 - Added descriptions to all tests
 - Updated BindGroupLayout entry format to match latest spec
 - Split some tests into multiple cases

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

(Author's note: Test contents is unchanged aside from updating to newer BindGroupLayout syntax. Tests that were previously failing still fail.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
