### PR TITLE
Use more subcases

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyBufferToBuffer.spec.ts
@@ -17,7 +17,7 @@ g.test('single')
   - covers the end of the dstBuffer
   - covers neither the beginning nor the end of the dstBuffer`
   )
-  .params(
+  .subcases(() =>
     params()
       .combine(poptions('srcOffset', [0, 4, 8, 16]))
       .combine(poptions('dstOffset', [0, 4, 8, 16]))

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -322,9 +322,9 @@ g.test('color_textures,non_compressed,non_array')
   - covers the mipmap level > 0
   `
   )
-  .params(
+  .cases(poptions('format', kRegularTextureFormats))
+  .subcases(() =>
     params()
-      .combine(poptions('format', kRegularTextureFormats))
       .combine(
         poptions('textureSize', [
           {
@@ -370,9 +370,9 @@ g.test('color_textures,compressed,non_array')
   the content of the whole dstTexture.
   `
   )
-  .params(
+  .cases(poptions('format', kCompressedTextureFormats))
+  .subcases(() =>
     params()
-      .combine(poptions('format', kCompressedTextureFormats))
       .combine(
         poptions('textureSize', [
           // The heights and widths are all power of 2
@@ -435,9 +435,9 @@ g.test('color_textures,non_compressed,array')
   CopyTextureToTexture() copy, and verifying the content of the whole dstTexture.
   `
   )
-  .params(
+  .cases(poptions('format', kRegularTextureFormats))
+  .subcases(() =>
     params()
-      .combine(poptions('format', kRegularTextureFormats))
       .combine(
         poptions('textureSize', [
           {
@@ -475,9 +475,9 @@ g.test('color_textures,compressed,array')
   CopyTextureToTexture() copy, and verifying the content of the whole dstTexture.
   `
   )
-  .params(
+  .cases(poptions('format', kCompressedTextureFormats))
+  .subcases(() =>
     params()
-      .combine(poptions('format', kCompressedTextureFormats))
       .combine(
         poptions('textureSize', [
           // The heights and widths are all power of 2
@@ -519,7 +519,7 @@ g.test('zero_sized')
   of that dimension.
   `
   )
-  .params(
+  .subcases(() =>
     params()
       .combine(
         poptions('copyBoxOffset', [

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -127,12 +127,21 @@ g.test('GPUBlendComponent')
     - dstFactor= {...all GPUBlendFactors}
     - operation= {...all GPUBlendOperations}`
   )
-  .cases(poptions('component', ['color', 'alpha'] as const))
-  .subcases(() =>
-    params()
-      .combine(poptions('operation', kBlendOperations))
+  .cases(
+    params() //
+      .combine(poptions('component', ['color', 'alpha'] as const))
       .combine(poptions('srcFactor', kBlendFactors))
       .combine(poptions('dstFactor', kBlendFactors))
+      .combine(poptions('operation', kBlendOperations))
+  )
+  .subcases(p => {
+    const needsBlendConstant =
+      p.srcFactor === 'one-minus-constant' ||
+      p.srcFactor === 'constant' ||
+      p.dstFactor === 'one-minus-constant' ||
+      p.dstFactor === 'constant';
+
+    return params()
       .combine(poptions('srcColor', [{ r: 0.11, g: 0.61, b: 0.81, a: 0.44 }]))
       .combine(
         poptions('dstColor', [
@@ -140,18 +149,13 @@ g.test('GPUBlendComponent')
           { r: 0.09, g: 0.73, b: 0.93, a: 0.81 },
         ])
       )
-      .expand(p => {
-        const needsBlendConstant =
-          p.srcFactor === 'one-minus-constant' ||
-          p.srcFactor === 'constant' ||
-          p.dstFactor === 'one-minus-constant' ||
-          p.dstFactor === 'constant';
-        return poptions(
+      .combine(
+        poptions(
           'blendConstant',
           needsBlendConstant ? [{ r: 0.91, g: 0.82, b: 0.73, a: 0.64 }] : [undefined]
-        );
-      })
-  )
+        )
+      );
+  })
   .fn(t => {
     const textureFormat: GPUTextureFormat = 'rgba32float';
     const srcColor = t.params.srcColor;

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 export const description = `
 Test blending results.
 
@@ -93,8 +92,13 @@ function computeBlendFactor(
   }
 }
 
-function computeBlendOperation(src: GPUColorDict, srcFactor: GPUColorDict,
-  dst: GPUColorDict, dstFactor: GPUColorDict, operation: GPUBlendOperation) {
+function computeBlendOperation(
+  src: GPUColorDict,
+  srcFactor: GPUColorDict,
+  dst: GPUColorDict,
+  dstFactor: GPUColorDict,
+  operation: GPUBlendOperation
+) {
   switch (operation) {
     case 'add':
       return mapColor(src, (_, k) => srcFactor[k] * src[k] + dstFactor[k] * dst[k]);
@@ -121,33 +125,33 @@ g.test('GPUBlendComponent')
     - component= {color, alpha} - whether to test blending the color or the alpha component.
     - srcFactor= {...all GPUBlendFactors}
     - dstFactor= {...all GPUBlendFactors}
-    - operation= {...all GPUBlendOperations}
-  `)
-  .cases(
-    params() //
-      .combine(poptions('component', ['color', 'alpha'] as const))
+    - operation= {...all GPUBlendOperations}`
+  )
+  .cases(poptions('component', ['color', 'alpha'] as const))
+  .subcases(() =>
+    params()
+      .combine(poptions('operation', kBlendOperations))
       .combine(poptions('srcFactor', kBlendFactors))
       .combine(poptions('dstFactor', kBlendFactors))
-      .combine(poptions('operation', kBlendOperations))
+      .combine(poptions('srcColor', [{ r: 0.11, g: 0.61, b: 0.81, a: 0.44 }]))
+      .combine(
+        poptions('dstColor', [
+          { r: 0.51, g: 0.22, b: 0.71, a: 0.33 },
+          { r: 0.09, g: 0.73, b: 0.93, a: 0.81 },
+        ])
+      )
+      .expand(p => {
+        const needsBlendConstant =
+          p.srcFactor === 'one-minus-constant' ||
+          p.srcFactor === 'constant' ||
+          p.dstFactor === 'one-minus-constant' ||
+          p.dstFactor === 'constant';
+        return poptions(
+          'blendConstant',
+          needsBlendConstant ? [{ r: 0.91, g: 0.82, b: 0.73, a: 0.64 }] : [undefined]
+        );
+      })
   )
-  .subcases((p) => {
-    const needsBlendConstant = (
-      p.srcFactor === 'one-minus-constant' || p.srcFactor === 'constant' ||
-      p.dstFactor === 'one-minus-constant' || p.dstFactor === 'constant'
-    );
-
-    return params()
-      .combine(poptions('srcColor', [
-        { r: 0.11, g: 0.61, b: 0.81, a: 0.44 }
-      ]))
-      .combine(poptions('dstColor', [
-        { r: 0.51, g: 0.22, b: 0.71, a: 0.33 },
-        { r: 0.09, g: 0.73, b: 0.93, a: 0.81 }
-      ]))
-      .combine(poptions('blendConstant', needsBlendConstant ? [
-        { r: 0.91, g: 0.82, b: 0.73, a: 0.64 },
-      ] : [ undefined ]));
-  })
   .fn(t => {
     const textureFormat: GPUTextureFormat = 'rgba32float';
     const srcColor = t.params.srcColor;
@@ -157,7 +161,13 @@ g.test('GPUBlendComponent')
     const srcFactor = computeBlendFactor(srcColor, dstColor, blendConstant, t.params.srcFactor);
     const dstFactor = computeBlendFactor(srcColor, dstColor, blendConstant, t.params.dstFactor);
 
-    const expectedColor = computeBlendOperation(srcColor, srcFactor, dstColor, dstFactor, t.params.operation);
+    const expectedColor = computeBlendOperation(
+      srcColor,
+      srcFactor,
+      dstColor,
+      dstFactor,
+      t.params.operation
+    );
 
     switch (t.params.component) {
       case 'color':
@@ -263,18 +273,24 @@ g.test('GPUBlendComponent')
     const expectedLow = mapColor(expectedColor, v => v - tolerance);
     const expectedHigh = mapColor(expectedColor, v => v + tolerance);
 
-    t.expectSinglePixelBetweenTwoValuesIn2DTexture(renderTarget, textureFormat, { x: 0, y: 0}, {
-      exp: [
-        new Float32Array([expectedLow.r, expectedLow.g, expectedLow.b, expectedLow.a]),
-        new Float32Array([expectedHigh.r, expectedHigh.g, expectedHigh.b, expectedHigh.a]),
-      ]
-    });
+    t.expectSinglePixelBetweenTwoValuesIn2DTexture(
+      renderTarget,
+      textureFormat,
+      { x: 0, y: 0 },
+      {
+        exp: [
+          new Float32Array([expectedLow.r, expectedLow.g, expectedLow.b, expectedLow.a]),
+          new Float32Array([expectedHigh.r, expectedHigh.g, expectedHigh.b, expectedHigh.a]),
+        ],
+      }
+    );
   });
 
 g.test('formats')
   .desc(
     `Test blending results works for all formats that support it, and that blending is not applied
-  for formats that do not. Blending should be done in linear space for srgb formats.`)
+  for formats that do not. Blending should be done in linear space for srgb formats.`
+  )
   .unimplemented();
 
 g.test('clamp,blend_factor')

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -532,7 +532,7 @@ const checkContentsImpl: { [k in ReadMethod]: CheckContents } = {
 export const g = makeTestGroup(TextureZeroInitTest);
 
 g.test('uninitialized_texture_is_zero')
-  .subcases(() => paramsBuilder)
+  .params(paramsBuilder)
   .fn(async t => {
     await t.selectDeviceOrSkipTestCase(kUncompressedTextureFormatInfo[t.params.format].feature);
 

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -532,7 +532,7 @@ const checkContentsImpl: { [k in ReadMethod]: CheckContents } = {
 export const g = makeTestGroup(TextureZeroInitTest);
 
 g.test('uninitialized_texture_is_zero')
-  .params(paramsBuilder)
+  .subcases(() => paramsBuilder)
   .fn(async t => {
     await t.selectDeviceOrSkipTestCase(kUncompressedTextureFormatInfo[t.params.format].feature);
 

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -112,16 +112,19 @@ g.test('copy_with_invalid_texture').fn(async t => {
 });
 
 g.test('mipmap_level')
-  .params([
-    { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 0 },
-    { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 1, dstCopyLevel: 0 },
-    { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 1 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 0 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 2, dstCopyLevel: 0 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 3, dstCopyLevel: 0 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 2 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 3 },
-  ] as const)
+  .subcases(
+    () =>
+      [
+        { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 0 },
+        { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 1, dstCopyLevel: 0 },
+        { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 1 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 0 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 2, dstCopyLevel: 0 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 3, dstCopyLevel: 0 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 2 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 3 },
+      ] as const
+  )
   .fn(async t => {
     const { srcLevelCount, dstLevelCount, srcCopyLevel, dstCopyLevel } = t.params;
 
@@ -210,7 +213,7 @@ g.test('sample_count')
   });
 
 g.test('multisampled_copy_restrictions')
-  .params(
+  .subcases(() =>
     params()
       .combine(
         poptions('srcCopyOrigin', [
@@ -262,7 +265,7 @@ g.test('multisampled_copy_restrictions')
   });
 
 g.test('texture_format_equality')
-  .params(
+  .subcases(() =>
     params()
       .combine(poptions('srcFormat', kAllTextureFormats))
       .combine(poptions('dstFormat', kAllTextureFormats))
@@ -297,9 +300,9 @@ g.test('texture_format_equality')
   });
 
 g.test('depth_stencil_copy_restrictions')
-  .params(
+  .cases(poptions('format', kDepthStencilFormats))
+  .subcases(() =>
     params()
-      .combine(poptions('format', kDepthStencilFormats))
       .combine(
         poptions('copyBoxOffsets', [
           { x: 0, y: 0, width: 0, height: 0 },
@@ -385,7 +388,7 @@ g.test('depth_stencil_copy_restrictions')
   });
 
 g.test('copy_ranges')
-  .params(
+  .subcases(() =>
     params()
       .combine(
         poptions('copyBoxOffsets', [
@@ -477,7 +480,7 @@ g.test('copy_ranges')
   });
 
 g.test('copy_within_same_texture')
-  .params(
+  .subcases(() =>
     params()
       .combine(poptions('srcCopyOriginZ', [0, 2, 4]))
       .combine(poptions('dstCopyOriginZ', [0, 2, 4]))
@@ -514,9 +517,9 @@ Test the validations on the member 'aspect' of GPUImageCopyTexture in CopyTextur
 - for all the stencil-only formats: the texture copy aspects must be either 'all' or 'stencil-only'.
 `
   )
-  .params(
+  .cases(poptions('format', ['rgba8unorm', ...kDepthStencilFormats] as const))
+  .subcases(() =>
     params()
-      .combine(poptions('format', ['rgba8unorm', ...kDepthStencilFormats] as const))
       .combine(poptions('sourceAspect', ['all', 'depth-only', 'stencil-only'] as const))
       .combine(poptions('destinationAspect', ['all', 'depth-only', 'stencil-only'] as const))
   )
@@ -565,9 +568,9 @@ Test the validations on the member 'aspect' of GPUImageCopyTexture in CopyTextur
   });
 
 g.test('copy_ranges_with_compressed_texture_formats')
-  .params(
+  .cases(poptions('format', kCompressedTextureFormats))
+  .subcases(() =>
     params()
-      .combine(poptions('format', kCompressedTextureFormats))
       .combine(
         poptions('copyBoxOffsets', [
           { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },


### PR DESCRIPTION
Use subcases more liberally, specifically for tests that had WAY too
many cases (and are spamming the output when run via WPT).





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
