### PR TITLE
Document cases/subcases and ParamsBuilder better

### DIFF
--- a/docs/helper_index.md
+++ b/docs/helper_index.md
@@ -21,6 +21,20 @@ Generally, see:
 ## Index
 
 - TODO: Index existing helpers.
+- [Parameterization helpers](../src/common/framework/params_builder.ts) for `.cases()`/`.subcases()`.
+    - `poptions('key', [1, 2, 3])` creates an iterator over `{ key: 1 }, { key: 2 }, { key: 3 }`.
+    - `pbool('key')` creates an iterator over `{ key: true }, { key: false }`.
+    - `ParamsBuilder` is an object that iterates over params, e.g:
+        `const example = params().combine(poptions('x', [1, 2])).combine(poptions('y', [1, 2])`
+        produces `{ x: 1, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 1 }, { x: 2, y: 2 }`.
+        - `params()`: creates a new `ParamsBuilder` with one item with no parameters: `{}`.
+        - `xs.combine(ys)`: cartesian product of the `ParamsBuilder` `xs` with the iterable `ys`.
+        - `xs.expand(x => ys)`: like `.combine`, but each `ys` can depend on the value of `x`.
+        - `xs.filter(x => boolean)`: filters the current items according to a predicate.
+        - `xs.unless(x => boolean)`: same as `.filter`, but inverted.
+        - `xs.exclude([ p1, p2 ])`: removes cases equalling `p1` or `p2`, e.g.:
+            `example.exclude([{ x: 2, y: 1 }])`
+            produces `{ x: 1, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 2 }`.
 - [`GPUTest`](../src/webgpu/gpu_test.ts)
     - `selectDeviceForTextureFormatOrSkipTestCase`: Create device with texture format(s) required
         feature(s). If the device creation fails, then skip the test for that format(s).

--- a/docs/implementing.md
+++ b/docs/implementing.md
@@ -30,9 +30,9 @@ Later, there may be multiple `GPUDevice`s to allow multiple test cases to run co
 ## Test parameterization
 
 The CTS provides helpers (`params().combine()`) for creating large cartesian products of test parameters.
-The harnesses runs one "test case" for each one.
+The harnesses runs one "test case" or "test subcase" for each one.
 
-TODO(github.com/gpuweb/cts/issues/305): document test subcases, once they exist.
+TODO(github.com/gpuweb/cts/issues/305): document test subcases better
 
 See `basic,params_builder` in `examples.spec.ts` for an example.
 

--- a/docs/intro/plans.md
+++ b/docs/intro/plans.md
@@ -21,13 +21,19 @@ important cases that need to be covered. Here's an example:
 
 ```ts
 g.test('x,some_detail').desc(`
-Tests [some detail] about x. Tests calling x with various values of 'arg' and checks correctness
-of the result. Tries to trigger [some conditional path].
+Tests [some detail] about x. Tests calling x in various 'mode's { mode1, mode2 },
+with various values of 'arg', and checks correctness of the result.
+Tries to trigger [some conditional path].
 
-- Valid values (control case) // <- to make sure the test function works well).
-- Unaligned values (should fail) // <- only include cases like this in validation tests)
+- Valid values (control case) // <- (to make sure the test function works well)
+- Unaligned values (should fail) // <- (only validation tests need to intentionally hit invalid cases)
 - Extreme values`
-).params(poptions('arg', [ // <- If complex, params should be added during implementation, instead of planning.
+).cases(
+  poptions('mode', [
+    'mode1',
+    'mode2',
+  ])
+).subcases(poptions('arg', [
   // Valid  // <- Comment params as you see fit.
   4,
   8,
@@ -38,6 +44,13 @@ of the result. Tries to trigger [some conditional path].
   1e30,
 ])).unimplemented();
 ```
+
+"Cases" each appear as individual items in the `/standalone/` runner.
+"Subcases" run inside each case, like a for-loop wrapping the `.fn(`test function`)`.
+Documentation on the parameter builder can be found in the [helper index](../helper_index.md).
+
+It's often impossible to predict the exact case/subcase structure before implementing tests, so they
+can be added during implementation, instead of planning.
 
 For any notes which are not specific to a single test, or for preliminary notes for tests that
 haven't been planned in full detail, put them in the test file's `description` variable at

--- a/docs/intro/tests.md
+++ b/docs/intro/tests.md
@@ -12,6 +12,7 @@ Implement some tests and open a pull request. You can open a PR any time you're 
 (If two tests are non-trivial but independent, consider separate pull requests.)
 
 Before uploading, you can run pre-submit checks (`npm test`) to make sure it will pass CI.
+Use `npm run fix` to fix linting issues.
 
 ## Test Helpers
 

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -141,12 +141,14 @@ It may represent multiple _test cases_, each of which runs the same Test Functio
 Parameters.
 
 A test is named using `TestGroup.test()`, which returns a `TestBuilder`.
-`TestBuilder.params()` can optionally be used to parameterize the test.
-Then, `TestBuilder.fn()` provides the Test Function.
+`TestBuilder.cases()` and `TestBuilder.subcases()` can optionally be used to parametrically
+generate instances of the test.
+Finally, `TestBuilder.fn()` provides the Test Function
+(or, a test can be marked unimplemented with `TestBuilder.unimplemented()`).
 
 ### Test Function
 
-When a test case is run, the Test Function receives an instance of the
+When a test subcase is run, the Test Function receives an instance of the
 Test Fixture provided to the Test Group, producing test results.
 
 **Type:** `TestFn`
@@ -155,18 +157,33 @@ Test Fixture provided to the Test Group, producing test results.
 
 A single case of a test. It is identified by a `TestCaseID`: a test name, and its parameters.
 
+Each case appears as an individual item (tree leaf) in `/standalone/`,
+and as an individual "step" in WPT.
+
+If `TestBuilder.cases()` is not used, there is exactly one case.
+
 **Type:** During test run time, a case is encapsulated as a `RunCase`.
+
+## Test Subcase / Subcase
+
+A single "subcase" of a test. It can also be identified by a `TestCaseID`, though
+not all contexts allow subdividing cases into subcases.
+
+All of the subcases of a case will run _inside_ the case, essentially as a for-loop wrapping the
+test function. They do _not_ appear individually in `/standalone/` or WPT.
+
+If `TestBuilder.subcases()` is not used, there is exactly one subcase.
 
 ## Parameters / Params
 
-Each Test Case has a (possibly empty) set of Parameters.
+Each Test Subcase has a (possibly empty) set of Parameters.
 The parameters are available to the Test Function `f(t)` via `t.params`.
 
-A set of Public Parameters identifies a Test Case within a Test.
+A set of Public Parameters identifies a Test Case or Test Subcase within a Test.
 
-There are also Private Paremeters: any parameter name beginning with an underscore (`_`).
+There are also Private Parameters: any parameter name beginning with an underscore (`_`).
 These parameters are not part of the Test Case identification, but are still passed into
-the Test Function. They can be used to manually specify expected results.
+the Test Function. They can be used, e.g., to manually specify expected results.
 
 **Type:** `CaseParams`
 

--- a/src/common/framework/params_utils.ts
+++ b/src/common/framework/params_utils.ts
@@ -5,8 +5,8 @@ import { assert } from './util/util.js';
 
 // Consider adding more types here if needed
 //
-// TODO: This type isn't actually used to constrain what you're allowed to do in `.params()`, so
-// it's not really serving its purpose. Figure out how to fix that?
+// TODO: This type isn't actually used to constrain what you're allowed to do in
+// `.cases()`/`.subcases()`, so it's not really serving its purpose. Figure out how to fix that?
 export type ParamArgument =
   | undefined
   | null


### PR DESCRIPTION

<hr>

**Author checklist for test code/plans:**

- [x] New helpers, if any, are documented in `helper_index.md`.