### PR TITLE
Simplify TestBuilder, generalize ParamArgument, rename CaseParams

### DIFF
--- a/docs/terms.md
+++ b/docs/terms.md
@@ -174,10 +174,10 @@ test function. They do _not_ appear individually in `/standalone/` or WPT.
 
 If `TestBuilder.subcases()` is not used, there is exactly one subcase.
 
-## Parameters / Params
+## Test Parameters / Params
 
-Each Test Subcase has a (possibly empty) set of Parameters.
-The parameters are available to the Test Function `f(t)` via `t.params`.
+Each Test Subcase has a (possibly empty) set of Test Parameters,
+The parameters are passed to the Test Function `f(t)` via `t.params`.
 
 A set of Public Parameters identifies a Test Case or Test Subcase within a Test.
 
@@ -185,7 +185,7 @@ There are also Private Parameters: any parameter name beginning with an undersco
 These parameters are not part of the Test Case identification, but are still passed into
 the Test Function. They can be used, e.g., to manually specify expected results.
 
-**Type:** `CaseParams`
+**Type:** `TestParams`
 
 ## Test Fixture / Fixture
 

--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -1,5 +1,5 @@
 import { TestCaseRecorder } from './logging/test_case_recorder.js';
-import { CaseParams } from './params_utils.js';
+import { TestParams } from './params_utils.js';
 import { assert } from './util/util.js';
 
 export class SkipTestCase extends Error {}
@@ -14,7 +14,7 @@ export class Fixture {
   private eventualExpectations: Array<Promise<unknown>> = [];
   private numOutstandingAsyncExpectations = 0;
 
-  constructor(rec: TestCaseRecorder, params: CaseParams) {
+  constructor(rec: TestCaseRecorder, params: TestParams) {
     this.rec = rec;
     this._params = params;
   }

--- a/src/common/framework/params_builder.ts
+++ b/src/common/framework/params_builder.ts
@@ -1,6 +1,6 @@
 import {
-  CaseParams,
-  CaseParamsIterable,
+  TestParams,
+  TestParamsIterable,
   FlattenUnionOfInterfaces,
   Merged,
   mergeParams,
@@ -83,11 +83,11 @@ export function params(): ParamsBuilder<{}> {
   return new ParamsBuilder();
 }
 
-export class ParamsBuilder<A extends {}> implements CaseParamsIterable {
-  private paramSpecs: CaseParamsIterable = [{}];
+export class ParamsBuilder<A extends {}> implements TestParamsIterable {
+  private paramSpecs: TestParamsIterable = [{}];
 
   [Symbol.iterator](): Iterator<A> {
-    const iter: Iterator<CaseParams> = this.paramSpecs[Symbol.iterator]();
+    const iter: Iterator<TestParams> = this.paramSpecs[Symbol.iterator]();
     return iter as Iterator<A>;
   }
 
@@ -99,7 +99,7 @@ export class ParamsBuilder<A extends {}> implements CaseParamsIterable {
           yield mergeParams(a, b);
         }
       }
-    }) as CaseParamsIterable;
+    }) as TestParamsIterable;
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     return this as any;
   }
@@ -112,7 +112,7 @@ export class ParamsBuilder<A extends {}> implements CaseParamsIterable {
           yield mergeParams(a, b);
         }
       }
-    }) as CaseParamsIterable;
+    }) as TestParamsIterable;
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     return this as any;
   }
@@ -133,7 +133,7 @@ export class ParamsBuilder<A extends {}> implements CaseParamsIterable {
     return this.filter(x => !pred(x));
   }
 
-  exclude(exclude: CaseParamsIterable): ParamsBuilder<A> {
+  exclude(exclude: TestParamsIterable): ParamsBuilder<A> {
     const excludeArray = Array.from(exclude);
     const paramSpecs = this.paramSpecs;
     this.paramSpecs = makeReusableIterable(function* () {

--- a/src/common/framework/params_utils.ts
+++ b/src/common/framework/params_utils.ts
@@ -12,21 +12,21 @@ export type JSONWithUndefined =
   | readonly JSONWithUndefined[]
   // Ideally this would recurse into JSONWithUndefined, but it breaks code.
   | { readonly [k: string]: unknown };
-// FIXME: rename to TestParams ("the params passed to a test").
-export type CaseParams = {
+/** The fully-general type for params passed to a test function invocation. */
+export type TestParams = {
   readonly [k: string]: JSONWithUndefined;
 };
-export interface CaseParamsRW {
+export interface TestParamsRW {
   [k: string]: JSONWithUndefined;
 }
-export type CaseParamsIterable = Iterable<CaseParams>;
+export type TestParamsIterable = Iterable<TestParams>;
 
 export function paramKeyIsPublic(key: string): boolean {
   return !key.startsWith('_');
 }
 
-export function extractPublicParams(params: CaseParams): CaseParams {
-  const publicParams: CaseParamsRW = {};
+export function extractPublicParams(params: TestParams): TestParams {
+  const publicParams: TestParamsRW = {};
   for (const k of Object.keys(params)) {
     if (paramKeyIsPublic(k)) {
       publicParams[k] = params[k];
@@ -39,7 +39,7 @@ export const badParamValueChars = new RegExp(
   '[' + kParamKVSeparator + kParamSeparator + kWildcard + ']'
 );
 
-export function publicParamsEquals(x: CaseParams, y: CaseParams): boolean {
+export function publicParamsEquals(x: TestParams, y: TestParams): boolean {
   return comparePublicParamsPaths(x, y) === Ordering.Equal;
 }
 

--- a/src/common/framework/params_utils.ts
+++ b/src/common/framework/params_utils.ts
@@ -3,24 +3,21 @@ import { kWildcard, kParamSeparator, kParamKVSeparator } from './query/separator
 import { UnionToIntersection } from './util/types.js';
 import { assert } from './util/util.js';
 
-// Consider adding more types here if needed
-//
-// TODO: This type isn't actually used to constrain what you're allowed to do in
-// `.cases()`/`.subcases()`, so it's not really serving its purpose. Figure out how to fix that?
-export type ParamArgument =
+export type JSONWithUndefined =
   | undefined
   | null
   | number
   | string
   | boolean
-  | number[]
-  | { readonly [k: string]: undefined | null | number | string | boolean };
+  | readonly JSONWithUndefined[]
+  // Ideally this would recurse into JSONWithUndefined, but it breaks code.
+  | { readonly [k: string]: unknown };
 // FIXME: rename to TestParams ("the params passed to a test").
 export type CaseParams = {
-  readonly [k: string]: ParamArgument;
+  readonly [k: string]: JSONWithUndefined;
 };
 export interface CaseParamsRW {
-  [k: string]: ParamArgument;
+  [k: string]: JSONWithUndefined;
 }
 export type CaseParamsIterable = Iterable<CaseParams>;
 

--- a/src/common/framework/params_utils.ts
+++ b/src/common/framework/params_utils.ts
@@ -15,6 +15,7 @@ export type ParamArgument =
   | boolean
   | number[]
   | { readonly [k: string]: undefined | null | number | string | boolean };
+// FIXME: rename to TestParams ("the params passed to a test").
 export type CaseParams = {
   readonly [k: string]: ParamArgument;
 };

--- a/src/common/framework/query/compare.ts
+++ b/src/common/framework/query/compare.ts
@@ -1,4 +1,4 @@
-import { CaseParams, paramKeyIsPublic } from '../params_utils.js';
+import { TestParams, paramKeyIsPublic } from '../params_utils.js';
 import { assert, objectEquals } from '../util/util.js';
 
 import { TestQuery } from './query.js';
@@ -74,7 +74,7 @@ function comparePaths(a: readonly string[], b: readonly string[]): Ordering {
   }
 }
 
-export function comparePublicParamsPaths(a: CaseParams, b: CaseParams): Ordering {
+export function comparePublicParamsPaths(a: TestParams, b: TestParams): Ordering {
   const aKeys = Object.keys(a).filter(k => paramKeyIsPublic(k));
   const commonKeys = new Set(aKeys.filter(k => k in b));
 

--- a/src/common/framework/query/json_param_value.ts
+++ b/src/common/framework/query/json_param_value.ts
@@ -1,4 +1,4 @@
-import { ParamArgument } from '../params_utils.js';
+import { JSONWithUndefined } from '../params_utils.js';
 import { assert, sortObjectByKey } from '../util/util.js';
 
 // JSON can't represent `undefined` and by default stores it as `null`.
@@ -12,14 +12,14 @@ function stringifyFilter(k: string, v: unknown): unknown {
   return v === undefined ? jsUndefinedMagicValue : v;
 }
 
-export function stringifyParamValue(value: ParamArgument): string {
+export function stringifyParamValue(value: JSONWithUndefined): string {
   return JSON.stringify(value, stringifyFilter);
 }
 
 /**
  * Like stringifyParamValue but sorts dictionaries by key, for hashing.
  */
-export function stringifyParamValueUniquely(value: ParamArgument): string {
+export function stringifyParamValueUniquely(value: JSONWithUndefined): string {
   return JSON.stringify(value, (k, v) => {
     if (typeof v === 'object' && v !== null) {
       return sortObjectByKey(v);
@@ -29,6 +29,6 @@ export function stringifyParamValueUniquely(value: ParamArgument): string {
   });
 }
 
-export function parseParamValue(s: string): ParamArgument {
+export function parseParamValue(s: string): JSONWithUndefined {
   return JSON.parse(s, (k, v) => (v === jsUndefinedMagicValue ? undefined : v));
 }

--- a/src/common/framework/query/parseQuery.ts
+++ b/src/common/framework/query/parseQuery.ts
@@ -1,5 +1,5 @@
 import {
-  CaseParamsRW,
+  TestParamsRW,
   JSONWithUndefined,
   badParamValueChars,
   paramKeyIsPublic,
@@ -90,7 +90,7 @@ function parseQueryImpl(s: string): TestQuery {
 
   assert(test.length > 0, 'Test part of case-level query was empty (::)');
 
-  const params: CaseParamsRW = {};
+  const params: TestParamsRW = {};
   for (const paramPart of paramsParts) {
     const [k, v] = parseSingleParam(paramPart);
     assert(validQueryPart.test(k), 'param key names must match ' + validQueryPart);

--- a/src/common/framework/query/parseQuery.ts
+++ b/src/common/framework/query/parseQuery.ts
@@ -1,6 +1,6 @@
 import {
   CaseParamsRW,
-  ParamArgument,
+  JSONWithUndefined,
   badParamValueChars,
   paramKeyIsPublic,
 } from '../params_utils.js';
@@ -134,7 +134,7 @@ function parseBigPart(
   return { parts, wildcard: endsWithWildcard };
 }
 
-function parseSingleParam(paramSubstring: string): [string, ParamArgument] {
+function parseSingleParam(paramSubstring: string): [string, JSONWithUndefined] {
   assert(paramSubstring !== '', 'Param in a query must not be blank (is there a trailing comma?)');
   const i = paramSubstring.indexOf('=');
   assert(i !== -1, 'Param in a query must be of form key=value');
@@ -144,7 +144,7 @@ function parseSingleParam(paramSubstring: string): [string, ParamArgument] {
   return [k, parseSingleParamValue(v)];
 }
 
-function parseSingleParamValue(s: string): ParamArgument {
+function parseSingleParamValue(s: string): JSONWithUndefined {
   assert(
     !badParamValueChars.test(s),
     `param value must not match ${badParamValueChars} - was ${s}`

--- a/src/common/framework/query/query.ts
+++ b/src/common/framework/query/query.ts
@@ -1,6 +1,6 @@
 import { optionEnabled } from '../../runtime/helper/options.js';
 import { Expectation } from '../logging/result.js';
-import { CaseParams } from '../params_utils.js';
+import { TestParams } from '../params_utils.js';
 import { assert, unreachable } from '../util/util.js';
 
 import { compareQueries, Ordering } from './compare.js';
@@ -96,15 +96,15 @@ export class TestQueryMultiTest extends TestQueryMultiFile {
  * A multi-case test query, like `s:f:t:*` or `s:f:t:a,b,*`.
  *
  * Immutable (makes copies of constructor args), except for param values
- * (which aren't normally supposed to change; they're marked readonly in CaseParams).
+ * (which aren't normally supposed to change; they're marked readonly in TestParams).
  */
 export class TestQueryMultiCase extends TestQueryMultiTest {
   readonly level: TestQueryLevel = 3;
   readonly isMultiTest: false = false;
   readonly isMultiCase: boolean = true;
-  readonly params: CaseParams;
+  readonly params: TestParams;
 
-  constructor(suite: string, file: readonly string[], test: readonly string[], params: CaseParams) {
+  constructor(suite: string, file: readonly string[], test: readonly string[], params: TestParams) {
     super(suite, file, test);
     assert(test.length > 0, 'multi-case (or finer) query must have test-path');
     this.params = { ...params };

--- a/src/common/framework/query/stringify_params.ts
+++ b/src/common/framework/query/stringify_params.ts
@@ -1,5 +1,5 @@
 import {
-  CaseParams,
+  TestParams,
   JSONWithUndefined,
   badParamValueChars,
   paramKeyIsPublic,
@@ -9,7 +9,7 @@ import { assert } from '../util/util.js';
 import { stringifyParamValue, stringifyParamValueUniquely } from './json_param_value.js';
 import { kParamKVSeparator, kParamSeparator, kWildcard } from './separators.js';
 
-export function stringifyPublicParams(p: CaseParams, addWildcard = false): string {
+export function stringifyPublicParams(p: TestParams, addWildcard = false): string {
   const parts = Object.keys(p)
     .filter(k => paramKeyIsPublic(k))
     .map(k => stringifySingleParam(k, p[k]));
@@ -22,7 +22,7 @@ export function stringifyPublicParams(p: CaseParams, addWildcard = false): strin
 /**
  * An _approximately_ unique string representing a CaseParams value.
  */
-export function stringifyPublicParamsUniquely(p: CaseParams): string {
+export function stringifyPublicParamsUniquely(p: TestParams): string {
   const keys = Object.keys(p).sort();
   return keys
     .filter(k => paramKeyIsPublic(k))

--- a/src/common/framework/query/stringify_params.ts
+++ b/src/common/framework/query/stringify_params.ts
@@ -1,6 +1,6 @@
 import {
   CaseParams,
-  ParamArgument,
+  JSONWithUndefined,
   badParamValueChars,
   paramKeyIsPublic,
 } from '../params_utils.js';
@@ -30,15 +30,15 @@ export function stringifyPublicParamsUniquely(p: CaseParams): string {
     .join(kParamSeparator);
 }
 
-export function stringifySingleParam(k: string, v: ParamArgument) {
+export function stringifySingleParam(k: string, v: JSONWithUndefined) {
   return `${k}${kParamKVSeparator}${stringifySingleParamValue(v)}`;
 }
 
-function stringifySingleParamUniquely(k: string, v: ParamArgument) {
+function stringifySingleParamUniquely(k: string, v: JSONWithUndefined) {
   return `${k}${kParamKVSeparator}${stringifyParamValueUniquely(v)}`;
 }
 
-function stringifySingleParamValue(v: ParamArgument): string {
+function stringifySingleParamValue(v: JSONWithUndefined): string {
   const s = stringifyParamValue(v);
   assert(
     !badParamValueChars.test(s),

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -111,13 +111,13 @@ class TestGroup<F extends Fixture> implements TestGroupBuilder<F> {
 interface TestBuilderWithName<F extends Fixture> extends TestBuilderWithCases<F, {}> {
   desc(description: string): this;
   /** @deprecated use cases() and/or subcases() instead */
-  params<NewP extends {}>(specs: Iterable<NewP>): TestBuilderWithSubcases<F, NewP>;
-  cases<NewP extends {}>(specs: Iterable<NewP>): TestBuilderWithCases<F, NewP>;
+  params<NewP extends CaseParams>(specs: Iterable<NewP>): TestBuilderWithSubcases<F, NewP>;
+  cases<NewP extends CaseParams>(specs: Iterable<NewP>): TestBuilderWithCases<F, NewP>;
 }
 
 interface TestBuilderWithCases<F extends Fixture, P extends {}>
   extends TestBuilderWithSubcases<F, P> {
-  subcases<SubP extends {}>(
+  subcases<SubP extends CaseParams>(
     specs: (_: P) => Iterable<SubP>
   ): TestBuilderWithSubcases<F, Merged<P, SubP>>;
 }

--- a/src/common/framework/test_group.ts
+++ b/src/common/framework/test_group.ts
@@ -1,7 +1,7 @@
 import { Fixture, SkipTestCase, UnexpectedPassError } from './fixture.js';
 import { Expectation } from './logging/result.js';
 import { TestCaseRecorder } from './logging/test_case_recorder.js';
-import { CaseParams, extractPublicParams, Merged, mergeParams } from './params_utils.js';
+import { TestParams, extractPublicParams, Merged, mergeParams } from './params_utils.js';
 import { compareQueries, Ordering } from './query/compare.js';
 import { TestQuerySingleCase, TestQueryWithExpectation } from './query/query.js';
 import { kPathSeparator } from './query/separators.js';
@@ -16,7 +16,7 @@ export type RunFn = (
 
 export interface TestCaseID {
   readonly test: readonly string[];
-  readonly params: CaseParams;
+  readonly params: TestParams;
 }
 
 export interface RunCase {
@@ -56,7 +56,7 @@ export function makeTestGroupForUnitTesting<F extends Fixture>(
 
 type FixtureClass<F extends Fixture = Fixture> = new (
   log: TestCaseRecorder,
-  params: CaseParams
+  params: TestParams
 ) => F;
 type TestFn<F extends Fixture, P extends {}> = (t: F & { params: P }) => Promise<void> | void;
 
@@ -111,13 +111,13 @@ class TestGroup<F extends Fixture> implements TestGroupBuilder<F> {
 interface TestBuilderWithName<F extends Fixture> extends TestBuilderWithCases<F, {}> {
   desc(description: string): this;
   /** @deprecated use cases() and/or subcases() instead */
-  params<NewP extends CaseParams>(specs: Iterable<NewP>): TestBuilderWithSubcases<F, NewP>;
-  cases<NewP extends CaseParams>(specs: Iterable<NewP>): TestBuilderWithCases<F, NewP>;
+  params<NewP extends TestParams>(specs: Iterable<NewP>): TestBuilderWithSubcases<F, NewP>;
+  cases<NewP extends TestParams>(specs: Iterable<NewP>): TestBuilderWithCases<F, NewP>;
 }
 
 interface TestBuilderWithCases<F extends Fixture, P extends {}>
   extends TestBuilderWithSubcases<F, P> {
-  subcases<SubP extends CaseParams>(
+  subcases<SubP extends TestParams>(
     specs: (_: P) => Iterable<SubP>
   ): TestBuilderWithSubcases<F, Merged<P, SubP>>;
 }

--- a/src/common/framework/tree.ts
+++ b/src/common/framework/tree.ts
@@ -1,5 +1,5 @@
 import { TestFileLoader } from './file_loader.js';
-import { CaseParamsRW } from './params_utils.js';
+import { TestParamsRW } from './params_utils.js';
 import { compareQueries, Ordering } from './query/compare.js';
 import {
   TestQuery,
@@ -417,7 +417,7 @@ function addLeafForCase(
 ): void {
   const query = tree.query;
   let name: string = '';
-  const subqueryParams: CaseParamsRW = {};
+  const subqueryParams: TestParamsRW = {};
 
   // To start, tree is suite:a,b:c,d:*
   // This loop goes from that -> suite:a,b:c,d:x=1;* -> suite:a,b:c,d:x=1;y=2;*

--- a/src/unittests/params_builder_and_utils.spec.ts
+++ b/src/unittests/params_builder_and_utils.spec.ts
@@ -4,8 +4,8 @@ Unit tests for parameterization helpers.
 
 import { poptions, params } from '../common/framework/params_builder.js';
 import {
-  CaseParams,
-  CaseParamsIterable,
+  TestParams,
+  TestParamsIterable,
   publicParamsEquals,
 } from '../common/framework/params_utils.js';
 import { makeTestGroup } from '../common/framework/test_group.js';
@@ -13,7 +13,7 @@ import { makeTestGroup } from '../common/framework/test_group.js';
 import { UnitTest } from './unit_test.js';
 
 class ParamsTest extends UnitTest {
-  expectSpecEqual(act: CaseParamsIterable, exp: CaseParams[]): void {
+  expectSpecEqual(act: TestParamsIterable, exp: TestParams[]): void {
     const a = Array.from(act);
     this.expect(a.length === exp.length && a.every((x, i) => publicParamsEquals(x, exp[i])));
   }

--- a/src/unittests/params_builder_toplevel.spec.ts
+++ b/src/unittests/params_builder_toplevel.spec.ts
@@ -3,7 +3,7 @@ Unit tests for parameterization.
 `;
 
 import { params } from '../common/framework/params_builder.js';
-import { CaseParams } from '../common/framework/params_utils.js';
+import { TestParams } from '../common/framework/params_utils.js';
 import { makeTestGroup, makeTestGroupForUnitTesting } from '../common/framework/test_group.js';
 
 import { TestGroupTest } from './test_group_test.js';
@@ -68,11 +68,11 @@ g.test('exclude')
 g.test('generator').fn(t0 => {
   const g = makeTestGroupForUnitTesting(UnitTest);
 
-  const ran: CaseParams[] = [];
+  const ran: TestParams[] = [];
 
   g.test('generator')
     .params(
-      (function* (): IterableIterator<CaseParams> {
+      (function* (): IterableIterator<TestParams> {
         for (let x = 0; x < 3; ++x) {
           for (let y = 0; y < 2; ++y) {
             yield { x, y };

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -17,7 +17,7 @@ import {
   pbool,
   ParamsBuilder,
 } from '../../../../common/framework/params_builder.js';
-import { CaseParams } from '../../../../common/framework/params_utils.js';
+import { TestParams } from '../../../../common/framework/params_utils.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, unreachable } from '../../../../common/framework/util/util.js';
 import {
@@ -198,7 +198,7 @@ export class TextureZeroInitTest extends GPUTest {
   readonly stateToTexelComponents: { [k in InitializedState]: PerTexelComponent<number> };
 
   private p: Params;
-  constructor(rec: TestCaseRecorder, params: CaseParams) {
+  constructor(rec: TestCaseRecorder, params: TestParams) {
     super(rec, params);
     this.p = params as Params;
 


### PR DESCRIPTION
- the TestBuilder types now just have one "params" type (i.e. the value
  passed to the test function), instead of tracking cases and subcases
  params types separately.
- this file already has to use type system escape hatches, so just lean
  into it and remove all of the generics on TestBuilder and
  RunCaseSpecific as they're not really providing any real benefit
  (except to verify TestBuilder implements the associated interfaces)
- replace ParamArgument with JSONWithUndefined, enforce CaseParams in .cases()/.subcases()
- rename CaseParams to TestParams ("the parameters passed to a test (function)")

<hr>

**Author checklist for test code/plans:**

- [x] New helpers, if any, are documented in `helper_index.md`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
