### PR TITLE
Add {Case,Subcase}ParamsBuilder to replace .cases().subcases()

### DIFF
--- a/docs/helper_index.md
+++ b/docs/helper_index.md
@@ -21,20 +21,23 @@ Generally, see:
 ## Index
 
 - TODO: Index existing helpers.
-- [Parameterization helpers](../src/common/framework/params_builder.ts) for `.cases()`/`.subcases()`.
-    - `poptions('key', [1, 2, 3])` creates an iterator over `{ key: 1 }, { key: 2 }, { key: 3 }`.
-    - `pbool('key')` creates an iterator over `{ key: true }, { key: false }`.
-    - `ParamsBuilder` is an object that iterates over params, e.g:
-        `const example = params().combine(poptions('x', [1, 2])).combine(poptions('y', [1, 2])`
-        produces `{ x: 1, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 1 }, { x: 2, y: 2 }`.
-        - `params()`: creates a new `ParamsBuilder` with one item with no parameters: `{}`.
-        - `xs.combine(ys)`: cartesian product of the `ParamsBuilder` `xs` with the iterable `ys`.
-        - `xs.expand(x => ys)`: like `.combine`, but each `ys` can depend on the value of `x`.
-        - `xs.filter(x => boolean)`: filters the current items according to a predicate.
-        - `xs.unless(x => boolean)`: same as `.filter`, but inverted.
-        - `xs.exclude([ p1, p2 ])`: removes cases equalling `p1` or `p2`, e.g.:
-            `example.exclude([{ x: 2, y: 1 }])`
-            produces `{ x: 1, y: 1 }, { x: 1, y: 2 }, { x: 2, y: 2 }`.
+- [`CaseParamsBuilder` and `SubcaseParamsBuilder`](../src/common/framework/params_builder.ts)
+    are objects that iterate over params. These are used in `.params()`/`.paramsSubcasesOnly()`.
+    See `examples.spec.ts` for basic examples of how this behaves.
+    - `CaseParamsBuilder`
+        - `xs.expandP(x => ys)`: Expands each item in `xs` into multiple items,
+          each extended with an item of `y`.
+        - `xs.combineP(ys)`: like `.expandP()` but `ys` doesn't depend on the value of `x`.
+          In other words, the cartesian product of `xs` with `ys`.
+        - `xs.combine('key', [1, 2, 3])`: common case of `.combineP()`;
+          combines over `{ key: 1 }, { key: 2 }, { key: 3 }`.
+        - `xs.expand('key', x => ys)`: common case of `.expandP()`;
+          expands each `x` over `{ key: y[0] }, { key: y[1] }, ...`.
+        - `xs.filter(x => boolean)` and `xs.unless(x => boolean)`:
+          filter the current items according to a predicate.
+        - `xs.beginSubcases()`: finalizes the "cases" of the builder, returning a `SubcaseParamsBuilder`.
+    - `SubcaseParamsBuilder` has the same methods, except for `.beginSubcases()`.
+        They generate more subcases, rather than more cases.
 - [`GPUTest`](../src/webgpu/gpu_test.ts)
     - `selectDeviceForTextureFormatOrSkipTestCase`: Create device with texture format(s) required
         feature(s). If the device creation fails, then skip the test for that format(s).

--- a/docs/implementing.md
+++ b/docs/implementing.md
@@ -29,14 +29,12 @@ Later, there may be multiple `GPUDevice`s to allow multiple test cases to run co
 
 ## Test parameterization
 
-The CTS provides helpers (`params().combine()`) for creating large cartesian products of test parameters.
-The harnesses runs one "test case" or "test subcase" for each one.
+The CTS provides helpers (`.params()` and friends) for creating large cartesian products of test parameters.
+These generate "test cases" further subdivided into "test subcases".
+See `basic,*` in `examples.spec.ts` for examples, and the [helper index](./helper_index.md)
+for a list of capabilities.
 
-TODO(github.com/gpuweb/cts/issues/305): document test subcases better
-
-See `basic,params_builder` in `examples.spec.ts` for an example.
-
-Test parameterization and `.combine()` should be applied liberally to ensure the maximum coverage
+Test parameterization should be applied liberally to ensure the maximum coverage
 possible within reasonable time. You can skip some with `.filter()`. And remember: computers are
 pretty fast - thousands of test cases can be reasonable.
 

--- a/docs/intro/plans.md
+++ b/docs/intro/plans.md
@@ -20,7 +20,9 @@ There should be one test plan for each test. It should describe what it tests, h
 important cases that need to be covered. Here's an example:
 
 ```ts
-g.test('x,some_detail').desc(`
+g.test('x,some_detail')
+  .desc(
+    `
 Tests [some detail] about x. Tests calling x in various 'mode's { mode1, mode2 },
 with various values of 'arg', and checks correctness of the result.
 Tries to trigger [some conditional path].
@@ -28,21 +30,23 @@ Tries to trigger [some conditional path].
 - Valid values (control case) // <- (to make sure the test function works well)
 - Unaligned values (should fail) // <- (only validation tests need to intentionally hit invalid cases)
 - Extreme values`
-).cases(
-  poptions('mode', [
-    'mode1',
-    'mode2',
-  ])
-).subcases(poptions('arg', [
-  // Valid  // <- Comment params as you see fit.
-  4,
-  8,
-  100,
-  // Invalid
-  2,
-  6,
-  1e30,
-])).unimplemented();
+  )
+  .params(u =>
+    u //
+      .combine('mode', ['mode1', 'mode2'])
+      .beginSubcases()
+      .combine('arg', [
+        // Valid  // <- Comment params as you see fit.
+        4,
+        8,
+        100,
+        // Invalid
+        2,
+        6,
+        1e30,
+      ])
+  )
+  .unimplemented();
 ```
 
 "Cases" each appear as individual items in the `/standalone/` runner.

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -141,8 +141,8 @@ It may represent multiple _test cases_, each of which runs the same Test Functio
 Parameters.
 
 A test is named using `TestGroup.test()`, which returns a `TestBuilder`.
-`TestBuilder.cases()` and `TestBuilder.subcases()` can optionally be used to parametrically
-generate instances of the test.
+`TestBuilder.params()`/`.paramsSimple()`/`.paramsSubcasesOnly()`
+can optionally be used to parametrically generate instances (cases and subcases) of the test.
 Finally, `TestBuilder.fn()` provides the Test Function
 (or, a test can be marked unimplemented with `TestBuilder.unimplemented()`).
 
@@ -160,7 +160,8 @@ A single case of a test. It is identified by a `TestCaseID`: a test name, and it
 Each case appears as an individual item (tree leaf) in `/standalone/`,
 and as an individual "step" in WPT.
 
-If `TestBuilder.cases()` is not used, there is exactly one case.
+If `TestBuilder.params()`/`.paramsSimple()`/`.paramsSubcasesOnly()` are not used,
+there is exactly one case with one subcase, with parameters `{}`.
 
 **Type:** During test run time, a case is encapsulated as a `RunCase`.
 
@@ -172,7 +173,7 @@ not all contexts allow subdividing cases into subcases.
 All of the subcases of a case will run _inside_ the case, essentially as a for-loop wrapping the
 test function. They do _not_ appear individually in `/standalone/` or WPT.
 
-If `TestBuilder.subcases()` is not used, there is exactly one subcase.
+If `CaseParamsBuilder.beginSubcases()` is not used, there is exactly one subcase per case.
 
 ## Test Parameters / Params
 

--- a/src/common/framework/params_builder.ts
+++ b/src/common/framework/params_builder.ts
@@ -1,154 +1,312 @@
-import {
-  TestParams,
-  TestParamsIterable,
-  FlattenUnionOfInterfaces,
-  Merged,
-  mergeParams,
-  publicParamsEquals,
-} from './params_utils.js';
-import { ResolveType, UnionToIntersection } from './util/types.js';
+import { Merged, mergeParams } from './params_utils.js';
 
-/** Conditionally chooses between two types depending on whether T is a union. */
-type CheckForUnion<T, TErr, TOk> = [T] extends [UnionToIntersection<T>] ? TOk : TErr;
+// ================================================================
+// "Public" ParamsBuilder API / Documentation
+// ================================================================
 
-/** Conditionally chooses a type (or void) depending on whether T is a string. */
-type CheckForStringLiteralType<T, TOk> = string extends T ? void : CheckForUnion<T, void, TOk>;
-
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-function typeAssert<T extends 'pass'>() {}
-{
-  type Test<T, U> = [T] extends [U]
-    ? [U] extends [T]
-      ? 'pass'
-      : { actual: ResolveType<T>; expected: U }
-    : { actual: ResolveType<T>; expected: U };
-
-  type T01 = { a: number } | { b: string };
-  type T02 = { a: number } | { b?: string };
-  type T03 = { a: number } | { a?: number };
-  type T04 = { a: number } | { a: string };
-  type T05 = { a: number } | { a?: string };
-
-  type T11 = { a: number; b?: undefined } | { a?: undefined; b: string };
-
-  type T21 = { a: number; b?: undefined } | { b: string };
-  type T22 = { a: number; b?: undefined } | { b?: string };
-  type T23 = { a: number; b?: undefined } | { a?: number };
-  type T24 = { a: number; b?: undefined } | { a: string };
-  type T25 = { a: number; b?: undefined } | { a?: string };
-  type T26 = { a: number; b?: undefined } | { a: undefined };
-  type T27 = { a: number; b?: undefined } | { a: undefined; b: undefined };
-
-  /* prettier-ignore */ {
-    typeAssert<Test<FlattenUnionOfInterfaces<T01>, { a: number | undefined; b: string | undefined }>>();
-    typeAssert<Test<FlattenUnionOfInterfaces<T02>, { a: number | undefined; b: string | undefined }>>();
-    typeAssert<Test<FlattenUnionOfInterfaces<T03>, { a: number | undefined }>>();
-    typeAssert<Test<FlattenUnionOfInterfaces<T04>, { a: number | string }>>();
-    typeAssert<Test<FlattenUnionOfInterfaces<T05>, { a: number | string | undefined }>>();
-
-    typeAssert<Test<FlattenUnionOfInterfaces<T11>, { a: number | undefined; b: string | undefined }>>();
-
-    typeAssert<Test<FlattenUnionOfInterfaces<T22>, { a: number | undefined; b: string | undefined }>>();
-    typeAssert<Test<FlattenUnionOfInterfaces<T23>, { a: number | undefined; b: undefined }>>();
-    typeAssert<Test<FlattenUnionOfInterfaces<T24>, { a: number | string; b: undefined }>>();
-    typeAssert<Test<FlattenUnionOfInterfaces<T25>, { a: number | string | undefined; b: undefined }>>();
-    typeAssert<Test<FlattenUnionOfInterfaces<T27>, { a: number | undefined; b: undefined }>>();
-
-    // Unexpected test results - hopefully okay to ignore these
-    typeAssert<Test<FlattenUnionOfInterfaces<T21>, { b: string | undefined }>>();
-    typeAssert<Test<FlattenUnionOfInterfaces<T26>, { a: number | undefined }>>();
-  }
-}
-
-export function poptions<Name extends string, V>(
-  name: Name,
-  values: Iterable<V>
-): CheckForStringLiteralType<Name, Iterable<{ [name in Name]: V }>> {
-  const iter = makeReusableIterable(function* () {
-    for (const value of values) {
-      yield { [name]: value };
-    }
-  });
+/**
+ * Provides doc comments for the methods of CaseParamsBuilder and SubcaseParamsBuilder.
+ * (Also enforces rough interface match between them.)
+ */
+interface ParamsBuilder {
+  /**
+   * Expands each item in `this` into zero or more items.
+   * Each item has its parameters expanded with those returned by the `expander`.
+   *
+   * **Note:** When only a single key is being added, use the simpler `expand` for readability.
+   *
+   * ```text
+   *               this = [     a       ,      b     ,       c       ]
+   * this.map(expander) = [   f(a)           f(b)          f(c)      ]
+   *                    = [[a1, a2, a3] ,    [ b1 ]  ,       []      ]
+   *  merge and flatten = [ merge(a, a1), merge(a, a2), merge(a, a3), merge(b, b1) ]
+   * ```
+   */
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  return iter as any;
+  expandWithParams(expander: (_: any) => any): any;
+
+  /**
+   * Expands each item in `this` into zero or more items. Each item has its parameters expanded
+   * with one new key, `key`, and the values returned by `expander`.
+   */
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  expand(key: string, expander: (_: any) => any): any;
+
+  /**
+   * Expands each item in `this` to multiple items, one for each item in `newParams`.
+   *
+   * In other words, takes the cartesian product of [ the items in `this` ] and `newParams`.
+   *
+   * **Note:** When only a single key is being added, use the simpler `combine` for readability.
+   *
+   * ```text
+   *                     this = [ {a:1}, {b:2} ]
+   *                newParams = [ {x:1}, {y:2} ]
+   * this.combineP(newParams) = [ {a:1,x:1}, {a:1,y:2}, {b:2,x:1}, {b:2,y:2} ]
+   * ```
+   */
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  combineWithParams(newParams: Iterable<any>): any;
+
+  /**
+   * Expands each item in `this` to multiple items with `{ [name]: value }` for each value.
+   *
+   * In other words, takes the cartesian product of [ the items in `this` ]
+   * and `[ {[name]: value} for each value in values ]`
+   */
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  combine(key: string, newParams: Iterable<any>): any;
+
+  /**
+   * Filters `this` to only items for which `pred` returns true.
+   */
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  filter(pred: (_: any) => boolean): any;
+
+  /**
+   * Filters `this` to only items for which `pred` returns false.
+   */
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  unless(pred: (_: any) => boolean): any;
 }
 
-export function pbool<Name extends string>(
-  name: Name
-): CheckForStringLiteralType<Name, Iterable<{ [name in Name]: boolean }>> {
-  return poptions(name, [false, true]);
+/**
+ * Determines the resulting parameter object type which would be generated by an object of
+ * the given ParamsBuilder type.
+ */
+export type ParamTypeOf<
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  T extends ParamsBuilder
+> = T extends SubcaseParamsBuilder<infer CaseP, infer SubcaseP>
+  ? Merged<CaseP, SubcaseP>
+  : T extends CaseParamsBuilder<infer CaseP>
+  ? CaseP
+  : never;
+
+// ================================================================
+// Implementation
+// ================================================================
+
+/**
+ * Iterable over pairs of either:
+ * - `[case params, Iterable<subcase params>]` if there are subcases.
+ * - `[case params, undefined]` if not.
+ */
+export type CaseSubcaseIterable<CaseP, SubcaseP> = Iterable<
+  readonly [CaseP, Iterable<SubcaseP> | undefined]
+>;
+
+/**
+ * Base class for `CaseParamsBuilder` and `SubcaseParamsBuilder`.
+ */
+export abstract class ParamsBuilderBase<CaseP extends {}, SubcaseP extends {}> {
+  protected readonly cases: () => Generator<CaseP>;
+
+  constructor(cases: () => Generator<CaseP>) {
+    this.cases = cases;
+  }
+
+  /**
+   * Hidden from test files. Use `builderIterateCasesWithSubcases` to access this.
+   */
+  protected abstract iterateCasesWithSubcases(): CaseSubcaseIterable<CaseP, SubcaseP>;
 }
 
-export function params(): ParamsBuilder<{}> {
-  return new ParamsBuilder();
+/**
+ * Calls the (normally hidden) `iterateCasesWithSubcases()` method.
+ */
+export function builderIterateCasesWithSubcases(builder: ParamsBuilderBase<{}, {}>) {
+  interface IterableParamsBuilder {
+    iterateCasesWithSubcases(): CaseSubcaseIterable<{}, {}>;
+  }
+
+  return ((builder as unknown) as IterableParamsBuilder).iterateCasesWithSubcases();
 }
 
-export class ParamsBuilder<A extends {}> implements TestParamsIterable {
-  private paramSpecs: TestParamsIterable = [{}];
-
-  [Symbol.iterator](): Iterator<A> {
-    const iter: Iterator<TestParams> = this.paramSpecs[Symbol.iterator]();
-    return iter as Iterator<A>;
+/**
+ * Builder for combinatorial test **case** parameters.
+ *
+ * CaseParamsBuilder is immutable. Each method call returns a new, immutable object,
+ * modifying the list of cases according to the method called.
+ *
+ * This means, for example, that the `unit` passed into `TestBuilder.params()` can be reused.
+ */
+export class CaseParamsBuilder<CaseP extends {}>
+  extends ParamsBuilderBase<CaseP, {}>
+  implements Iterable<CaseP>, ParamsBuilder {
+  *iterateCasesWithSubcases(): CaseSubcaseIterable<CaseP, {}> {
+    for (const a of this.cases()) {
+      yield [a, undefined];
+    }
   }
 
-  combine<B extends {}>(newParams: Iterable<B>): ParamsBuilder<Merged<A, B>> {
-    const paramSpecs = this.paramSpecs as Iterable<A>;
-    this.paramSpecs = makeReusableIterable(function* () {
-      for (const a of paramSpecs) {
-        for (const b of newParams) {
-          yield mergeParams(a, b);
-        }
-      }
-    }) as TestParamsIterable;
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    return this as any;
+  [Symbol.iterator](): Iterator<CaseP> {
+    return this.cases();
   }
 
-  expand<B extends {}>(expander: (_: A) => Iterable<B>): ParamsBuilder<Merged<A, B>> {
-    const paramSpecs = this.paramSpecs as Iterable<A>;
-    this.paramSpecs = makeReusableIterable(function* () {
-      for (const a of paramSpecs) {
-        for (const b of expander(a)) {
-          yield mergeParams(a, b);
-        }
-      }
-    }) as TestParamsIterable;
-    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    return this as any;
+  /** @inheritdoc */
+  expandWithParams<NewP extends {}>(
+    expander: (_: Merged<{}, CaseP>) => Iterable<NewP>
+  ): CaseParamsBuilder<Merged<CaseP, NewP>> {
+    const newGenerator = expanderGenerator(this.cases, expander);
+    return new CaseParamsBuilder(() => newGenerator({}));
   }
 
-  filter(pred: (_: A) => boolean): ParamsBuilder<A> {
-    const paramSpecs = this.paramSpecs as Iterable<A>;
-    this.paramSpecs = makeReusableIterable(function* () {
-      for (const p of paramSpecs) {
-        if (pred(p)) {
-          yield p;
-        }
+  /** @inheritdoc */
+  expand<NewPKey extends string, NewPValue>(
+    key: NewPKey,
+    expander: (_: Merged<{}, CaseP>) => Iterable<NewPValue>
+  ): CaseParamsBuilder<Merged<CaseP, { [name in NewPKey]: NewPValue }>> {
+    return this.expandWithParams(function* (p) {
+      for (const value of expander(p)) {
+        yield { [key]: value } as { [name in NewPKey]: NewPValue };
       }
     });
-    return this;
   }
 
-  unless(pred: (_: A) => boolean): ParamsBuilder<A> {
+  /** @inheritdoc */
+  combineWithParams<NewP extends {}>(
+    newParams: Iterable<NewP>
+  ): CaseParamsBuilder<Merged<CaseP, NewP>> {
+    return this.expandWithParams(() => newParams);
+  }
+
+  /** @inheritdoc */
+  combine<NewPKey extends string, NewPValue>(
+    key: NewPKey,
+    values: Iterable<NewPValue>
+  ): CaseParamsBuilder<Merged<CaseP, { [name in NewPKey]: NewPValue }>> {
+    return this.expand(key, () => values);
+  }
+
+  /** @inheritdoc */
+  filter(pred: (_: Merged<{}, CaseP>) => boolean): CaseParamsBuilder<CaseP> {
+    const newGenerator = filterGenerator(this.cases, pred);
+    return new CaseParamsBuilder(() => newGenerator({}));
+  }
+
+  /** @inheritdoc */
+  unless(pred: (_: Merged<{}, CaseP>) => boolean): CaseParamsBuilder<CaseP> {
     return this.filter(x => !pred(x));
   }
 
-  exclude(exclude: TestParamsIterable): ParamsBuilder<A> {
-    const excludeArray = Array.from(exclude);
-    const paramSpecs = this.paramSpecs;
-    this.paramSpecs = makeReusableIterable(function* () {
-      for (const p of paramSpecs) {
-        if (excludeArray.every(e => !publicParamsEquals(p, e))) {
-          yield p;
-        }
+  /**
+   * "Finalize" the list of cases and begin defining subcases.
+   * Returns a new SubcaseParamsBuilder. Methods called on SubcaseParamsBuilder
+   * generate new subcases instead of new cases.
+   */
+  beginSubcases(): SubcaseParamsBuilder<CaseP, {}> {
+    return new SubcaseParamsBuilder(
+      () => this.cases(),
+      function* () {
+        yield {};
       }
-    });
-    return this;
+    );
   }
 }
 
-// If you create an Iterable by calling a generator function (e.g. in IIFE), it is exhausted after
-// one use. This just wraps a generator function in an object so it be iterated multiple times.
-function makeReusableIterable<P>(generatorFn: () => Generator<P>): Iterable<P> {
-  return { [Symbol.iterator]: generatorFn };
+/**
+ * The unit CaseParamsBuilder, representing a single case with no params: `[ {} ]`.
+ *
+ * `punit` is passed to every `.params()`/`.paramsSubcasesOnly()` call, so `kUnitCaseParamsBuilder`
+ * is only explicitly needed if constructing a ParamsBuilder outside of a test builder.
+ */
+export const kUnitCaseParamsBuilder = new CaseParamsBuilder(function* () {
+  yield {};
+});
+
+/**
+ * Builder for combinatorial test _subcase_ parameters.
+ *
+ * SubcaseParamsBuilder is immutable. Each method call returns a new, immutable object,
+ * modifying the list of subcases according to the method called.
+ */
+export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
+  extends ParamsBuilderBase<CaseP, SubcaseP>
+  implements ParamsBuilder {
+  protected readonly subcases: (_: CaseP) => Generator<SubcaseP>;
+
+  constructor(cases: () => Generator<CaseP>, generator: (_: CaseP) => Generator<SubcaseP>) {
+    super(cases);
+    this.subcases = generator;
+  }
+
+  *iterateCasesWithSubcases(): CaseSubcaseIterable<CaseP, SubcaseP> {
+    for (const caseP of this.cases()) {
+      const subcases = Array.from(this.subcases(caseP));
+      if (subcases.length) {
+        yield [caseP, subcases];
+      }
+    }
+  }
+
+  /** @inheritdoc */
+  expandWithParams<NewP extends {}>(
+    expander: (_: Merged<CaseP, SubcaseP>) => Iterable<NewP>
+  ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, NewP>> {
+    return new SubcaseParamsBuilder(this.cases, expanderGenerator(this.subcases, expander));
+  }
+
+  /** @inheritdoc */
+  expand<NewPKey extends string, NewPValue>(
+    key: NewPKey,
+    expander: (_: Merged<CaseP, SubcaseP>) => Iterable<NewPValue>
+  ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, { [name in NewPKey]: NewPValue }>> {
+    return this.expandWithParams(function* (p) {
+      for (const value of expander(p)) {
+        yield { [key]: value } as { [name in NewPKey]: NewPValue };
+      }
+    });
+  }
+
+  /** @inheritdoc */
+  combineWithParams<NewP extends {}>(
+    newParams: Iterable<NewP>
+  ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, NewP>> {
+    return this.expandWithParams(() => newParams);
+  }
+
+  /** @inheritdoc */
+  combine<NewPKey extends string, NewPValue>(
+    key: NewPKey,
+    values: Iterable<NewPValue>
+  ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, { [name in NewPKey]: NewPValue }>> {
+    return this.expand(key, () => values);
+  }
+
+  /** @inheritdoc */
+  filter(pred: (_: Merged<CaseP, SubcaseP>) => boolean): SubcaseParamsBuilder<CaseP, SubcaseP> {
+    return new SubcaseParamsBuilder(this.cases, filterGenerator(this.subcases, pred));
+  }
+
+  /** @inheritdoc */
+  unless(pred: (_: Merged<CaseP, SubcaseP>) => boolean): SubcaseParamsBuilder<CaseP, SubcaseP> {
+    return this.filter(x => !pred(x));
+  }
+}
+
+function expanderGenerator<Base, A, B>(
+  baseGenerator: (_: Base) => Generator<A>,
+  expander: (_: Merged<Base, A>) => Iterable<B>
+): (_: Base) => Generator<Merged<A, B>> {
+  return function* (base: Base) {
+    for (const a of baseGenerator(base)) {
+      for (const b of expander(mergeParams(base, a))) {
+        yield mergeParams(a, b);
+      }
+    }
+  };
+}
+
+function filterGenerator<Base, A>(
+  baseGenerator: (_: Base) => Generator<A>,
+  pred: (_: Merged<Base, A>) => boolean
+): (_: Base) => Generator<A> {
+  return function* (base: Base) {
+    for (const a of baseGenerator(base)) {
+      if (pred(mergeParams(base, a))) {
+        yield a;
+      }
+    }
+  };
 }

--- a/src/common/framework/params_utils.ts
+++ b/src/common/framework/params_utils.ts
@@ -67,6 +67,52 @@ export type FlattenUnionOfInterfaces<T> = {
   >;
 };
 
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+function typeAssert<T extends 'pass'>() {}
+{
+  type Test<T, U> = [T] extends [U]
+    ? [U] extends [T]
+      ? 'pass'
+      : { actual: ResolveType<T>; expected: U }
+    : { actual: ResolveType<T>; expected: U };
+
+  type T01 = { a: number } | { b: string };
+  type T02 = { a: number } | { b?: string };
+  type T03 = { a: number } | { a?: number };
+  type T04 = { a: number } | { a: string };
+  type T05 = { a: number } | { a?: string };
+
+  type T11 = { a: number; b?: undefined } | { a?: undefined; b: string };
+
+  type T21 = { a: number; b?: undefined } | { b: string };
+  type T22 = { a: number; b?: undefined } | { b?: string };
+  type T23 = { a: number; b?: undefined } | { a?: number };
+  type T24 = { a: number; b?: undefined } | { a: string };
+  type T25 = { a: number; b?: undefined } | { a?: string };
+  type T26 = { a: number; b?: undefined } | { a: undefined };
+  type T27 = { a: number; b?: undefined } | { a: undefined; b: undefined };
+
+  /* prettier-ignore */ {
+    typeAssert<Test<FlattenUnionOfInterfaces<T01>, { a: number | undefined; b: string | undefined }>>();
+    typeAssert<Test<FlattenUnionOfInterfaces<T02>, { a: number | undefined; b: string | undefined }>>();
+    typeAssert<Test<FlattenUnionOfInterfaces<T03>, { a: number | undefined }>>();
+    typeAssert<Test<FlattenUnionOfInterfaces<T04>, { a: number | string }>>();
+    typeAssert<Test<FlattenUnionOfInterfaces<T05>, { a: number | string | undefined }>>();
+
+    typeAssert<Test<FlattenUnionOfInterfaces<T11>, { a: number | undefined; b: string | undefined }>>();
+
+    typeAssert<Test<FlattenUnionOfInterfaces<T22>, { a: number | undefined; b: string | undefined }>>();
+    typeAssert<Test<FlattenUnionOfInterfaces<T23>, { a: number | undefined; b: undefined }>>();
+    typeAssert<Test<FlattenUnionOfInterfaces<T24>, { a: number | string; b: undefined }>>();
+    typeAssert<Test<FlattenUnionOfInterfaces<T25>, { a: number | string | undefined; b: undefined }>>();
+    typeAssert<Test<FlattenUnionOfInterfaces<T27>, { a: number | undefined; b: undefined }>>();
+
+    // Unexpected test results - hopefully okay to ignore these
+    typeAssert<Test<FlattenUnionOfInterfaces<T21>, { b: string | undefined }>>();
+    typeAssert<Test<FlattenUnionOfInterfaces<T26>, { a: number | undefined }>>();
+  }
+}
+
 export type Merged<A, B> = ResolveType<MergedFromFlat<A, FlattenUnionOfInterfaces<B>>>;
 export type MergedFromFlat<A, B> = {
   [K in keyof A | keyof B]: K extends keyof B ? B[K] : K extends keyof A ? A[K] : never;

--- a/src/demo/a/b/c.spec.ts
+++ b/src/demo/a/b/c.spec.ts
@@ -1,6 +1,5 @@
 export const description = 'Description for c.spec.ts';
 
-import { params, poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { unreachable } from '../../../common/framework/util/util.js';
 import { UnitTest } from '../../../unittests/unit_test.js';
@@ -18,19 +17,19 @@ g.test('f')
 g.test('f,g').fn(() => {});
 
 g.test('f,g,h')
-  .cases([{}, { x: 0 }, { x: 0, y: 0 }])
+  .paramsSimple([{}, { x: 0 }, { x: 0, y: 0 }])
   .fn(() => {});
 
 g.test('case_depth_2_in_single_child_test')
-  .cases([{ x: 0, y: 0 }])
+  .paramsSimple([{ x: 0, y: 0 }])
   .fn(() => {});
 
 g.test('deep_case_tree')
-  .cases(
-    params()
-      .combine(poptions('x', [1, 2]))
-      .combine(poptions('y', [1, 2]))
-      .combine(poptions('z', [1, 2]))
+  .params(u =>
+    u //
+      .combine('x', [1, 2])
+      .combine('y', [1, 2])
+      .combine('z', [1, 2])
   )
   .fn(() => {});
 

--- a/src/demo/json.spec.ts
+++ b/src/demo/json.spec.ts
@@ -6,5 +6,5 @@ import { UnitTest } from '../unittests/unit_test.js';
 export const g = makeTestGroup(UnitTest);
 
 g.test('json')
-  .params([{ p: { x: 1, y: 'two' } }])
+  .paramsSimple([{ p: { x: 1, y: 'two' } }])
   .fn(() => {});

--- a/src/unittests/basic.spec.ts
+++ b/src/unittests/basic.spec.ts
@@ -15,19 +15,19 @@ g.test('test,sync').fn(t => {});
 g.test('test,async').fn(async t => {});
 
 g.test('test_with_params,sync')
-  .params([{}])
+  .paramsSimple([{}])
   .fn(t => {
     t.debug(JSON.stringify(t.params));
   });
 
 g.test('test_with_params,async')
-  .params([{}])
+  .paramsSimple([{}])
   .fn(async t => {
     t.debug(JSON.stringify(t.params));
   });
 
 g.test('test_with_params,private_params')
-  .params([
+  .paramsSimple([
     { a: 1, b: 2, _result: 3 }, //
     { a: 4, b: -3, _result: 1 },
   ])

--- a/src/unittests/getStackTrace.spec.ts
+++ b/src/unittests/getStackTrace.spec.ts
@@ -10,7 +10,7 @@ import { UnitTest } from './unit_test.js';
 export const g = makeTestGroup(UnitTest);
 
 g.test('stacks')
-  .params([
+  .paramsSimple([
     {
       case: 'node_fail',
       _expectedLines: 3,

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -63,10 +63,10 @@ const specsData: { [k: string]: SpecFile } = {
     g: (() => {
       const g = makeTestGroupForUnitTesting(UnitTest);
       g.test('wye')
-        .cases([{}, { x: 1 }])
+        .paramsSimple([{}, { x: 1 }])
         .fn(() => {});
       g.test('zed')
-        .cases([
+        .paramsSimple([
           { a: 1, b: 2, _c: 0 },
           { b: 3, a: 1, _c: 0 },
         ])
@@ -82,7 +82,7 @@ const specsData: { [k: string]: SpecFile } = {
         t.debug('OK');
       });
       g.test('bleh')
-        .cases([{ a: 1 }])
+        .paramsSimple([{ a: 1 }])
         .fn(t => {
           t.debug('OK');
           t.debug('OK');

--- a/src/unittests/logger.spec.ts
+++ b/src/unittests/logger.spec.ts
@@ -122,7 +122,7 @@ g.test('fail,threw').fn(t => {
 });
 
 g.test('debug')
-  .params([
+  .paramsSimple([
     { debug: true, _logsCount: 5 }, //
     { debug: false, _logsCount: 3 },
   ])

--- a/src/unittests/params_builder_and_utils.spec.ts
+++ b/src/unittests/params_builder_and_utils.spec.ts
@@ -2,127 +2,410 @@ export const description = `
 Unit tests for parameterization helpers.
 `;
 
-import { poptions, params } from '../common/framework/params_builder.js';
 import {
-  TestParams,
-  TestParamsIterable,
-  publicParamsEquals,
-} from '../common/framework/params_utils.js';
+  kUnitCaseParamsBuilder,
+  CaseSubcaseIterable,
+  ParamsBuilderBase,
+  builderIterateCasesWithSubcases,
+} from '../common/framework/params_builder.js';
+import { mergeParams, publicParamsEquals } from '../common/framework/params_utils.js';
 import { makeTestGroup } from '../common/framework/test_group.js';
+import { assert, objectEquals } from '../common/framework/util/util.js';
 
 import { UnitTest } from './unit_test.js';
 
 class ParamsTest extends UnitTest {
-  expectSpecEqual(act: TestParamsIterable, exp: TestParams[]): void {
-    const a = Array.from(act);
-    this.expect(a.length === exp.length && a.every((x, i) => publicParamsEquals(x, exp[i])));
+  expectParams<CaseP, SubcaseP>(
+    act: ParamsBuilderBase<CaseP, SubcaseP>,
+    exp: CaseSubcaseIterable<{}, {}>
+  ): void {
+    const a = Array.from(builderIterateCasesWithSubcases(act)).map(([caseP, subcases]) => [
+      caseP,
+      subcases ? Array.from(subcases) : undefined,
+    ]);
+    const e = Array.from(exp);
+    this.expect(
+      objectEquals(a, e),
+      `
+got      ${JSON.stringify(a)}
+expected ${JSON.stringify(e)}`
+    );
   }
 }
 
 export const g = makeTestGroup(ParamsTest);
 
-g.test('options').fn(t => {
-  t.expectSpecEqual(poptions('hello', [1, 2, 3]), [{ hello: 1 }, { hello: 2 }, { hello: 3 }]);
+const u = kUnitCaseParamsBuilder;
+
+g.test('combine').fn(t => {
+  t.expectParams<{ hello: number }, {}>(u.combine('hello', [1, 2, 3]), [
+    [{ hello: 1 }, undefined],
+    [{ hello: 2 }, undefined],
+    [{ hello: 3 }, undefined],
+  ]);
+  t.expectParams<{ hello: 1 | 2 | 3 }, {}>(u.combine('hello', [1, 2, 3] as const), [
+    [{ hello: 1 }, undefined],
+    [{ hello: 2 }, undefined],
+    [{ hello: 3 }, undefined],
+  ]);
+  t.expectParams<{}, { hello: number }>(u.beginSubcases().combine('hello', [1, 2, 3]), [
+    [{}, [{ hello: 1 }, { hello: 2 }, { hello: 3 }]],
+  ]);
+  t.expectParams<{}, { hello: 1 | 2 | 3 }>(u.beginSubcases().combine('hello', [1, 2, 3] as const), [
+    [{}, [{ hello: 1 }, { hello: 2 }, { hello: 3 }]],
+  ]);
 });
 
-g.test('params').fn(t => {
-  t.expectSpecEqual(params(), [{}]);
+g.test('empty').fn(t => {
+  t.expectParams<{}, {}>(u, [
+    [{}, undefined], //
+  ]);
+  t.expectParams<{}, {}>(u.beginSubcases(), [
+    [{}, [{}]], //
+  ]);
 });
 
 g.test('combine,zeroes_and_ones').fn(t => {
-  t.expectSpecEqual(params().combine([]).combine([]), []);
-  t.expectSpecEqual(params().combine([]).combine([{}]), []);
-  t.expectSpecEqual(params().combine([{}]).combine([]), []);
-  t.expectSpecEqual(params().combine([{}]).combine([{}]), [{}]);
+  t.expectParams<{}, {}>(u.combineWithParams([]).combineWithParams([]), []);
+  t.expectParams<{}, {}>(u.combineWithParams([]).combineWithParams([{}]), []);
+  t.expectParams<{}, {}>(u.combineWithParams([{}]).combineWithParams([]), []);
+  t.expectParams<{}, {}>(u.combineWithParams([{}]).combineWithParams([{}]), [
+    [{}, undefined], //
+  ]);
+
+  t.expectParams<{}, {}>(u.combine('x', []).combine('y', []), []);
+  t.expectParams<{}, {}>(u.combine('x', []).combine('y', [1]), []);
+  t.expectParams<{}, {}>(u.combine('x', [1]).combine('y', []), []);
+  t.expectParams<{}, {}>(u.combine('x', [1]).combine('y', [1]), [
+    [{ x: 1, y: 1 }, undefined], //
+  ]);
 });
 
 g.test('combine,mixed').fn(t => {
-  t.expectSpecEqual(
-    params()
-      .combine(poptions('x', [1, 2]))
-      .combine(poptions('y', ['a', 'b']))
-      .combine([{ p: 4 }, { q: 5 }])
-      .combine([{}]),
+  t.expectParams<{ x: number; y: string; p: number | undefined; q: number | undefined }, {}>(
+    u
+      .combine('x', [1, 2])
+      .combine('y', ['a', 'b'])
+      .combineWithParams([{ p: 4 }, { q: 5 }])
+      .combineWithParams([{}]),
     [
-      { x: 1, y: 'a', p: 4 },
-      { x: 1, y: 'a', q: 5 },
-      { x: 1, y: 'b', p: 4 },
-      { x: 1, y: 'b', q: 5 },
-      { x: 2, y: 'a', p: 4 },
-      { x: 2, y: 'a', q: 5 },
-      { x: 2, y: 'b', p: 4 },
-      { x: 2, y: 'b', q: 5 },
+      [{ x: 1, y: 'a', p: 4 }, undefined],
+      [{ x: 1, y: 'a', q: 5 }, undefined],
+      [{ x: 1, y: 'b', p: 4 }, undefined],
+      [{ x: 1, y: 'b', q: 5 }, undefined],
+      [{ x: 2, y: 'a', p: 4 }, undefined],
+      [{ x: 2, y: 'a', q: 5 }, undefined],
+      [{ x: 2, y: 'b', p: 4 }, undefined],
+      [{ x: 2, y: 'b', q: 5 }, undefined],
     ]
   );
 });
 
 g.test('filter').fn(t => {
-  t.expectSpecEqual(
-    params()
-      .combine([
+  t.expectParams<{ a: boolean; x: number | undefined; y: number | undefined }, {}>(
+    u
+      .combineWithParams([
         { a: true, x: 1 },
         { a: false, y: 2 },
       ])
       .filter(p => p.a),
-    [{ a: true, x: 1 }]
+    [
+      [{ a: true, x: 1 }, undefined], //
+    ]
+  );
+
+  t.expectParams<{ a: boolean; x: number | undefined; y: number | undefined }, {}>(
+    u
+      .combineWithParams([
+        { a: true, x: 1 },
+        { a: false, y: 2 },
+      ])
+      .beginSubcases()
+      .filter(p => p.a),
+    [
+      [{ a: true, x: 1 }, [{}]], //
+      // Case with no subcases is filtered out.
+    ]
+  );
+
+  t.expectParams<{}, { a: boolean; x: number | undefined; y: number | undefined }>(
+    u
+      .beginSubcases()
+      .combineWithParams([
+        { a: true, x: 1 },
+        { a: false, y: 2 },
+      ])
+      .filter(p => p.a),
+    [
+      [{}, [{ a: true, x: 1 }]], //
+    ]
   );
 });
 
 g.test('unless').fn(t => {
-  t.expectSpecEqual(
-    params()
-      .combine([
+  t.expectParams<{ a: boolean; x: number | undefined; y: number | undefined }, {}>(
+    u
+      .combineWithParams([
         { a: true, x: 1 },
         { a: false, y: 2 },
       ])
       .unless(p => p.a),
-    [{ a: false, y: 2 }]
+    [
+      [{ a: false, y: 2 }, undefined], //
+    ]
   );
-});
 
-g.test('exclude').fn(t => {
-  t.expectSpecEqual(
-    params()
-      .combine([
+  t.expectParams<{ a: boolean; x: number | undefined; y: number | undefined }, {}>(
+    u
+      .combineWithParams([
         { a: true, x: 1 },
         { a: false, y: 2 },
       ])
-      .exclude([{ a: true }, { a: false, y: 2 }]),
-    [{ a: true, x: 1 }]
+      .beginSubcases()
+      .unless(p => p.a),
+    [
+      // Case with no subcases is filtered out.
+      [{ a: false, y: 2 }, [{}]], //
+    ]
   );
-});
 
-g.test('expand').fn(t => {
-  t.expectSpecEqual(
-    params()
-      .combine([
+  t.expectParams<{}, { a: boolean; x: number | undefined; y: number | undefined }>(
+    u
+      .beginSubcases()
+      .combineWithParams([
         { a: true, x: 1 },
         { a: false, y: 2 },
       ])
-      .expand(function* (p) {
+      .unless(p => p.a),
+    [
+      [{}, [{ a: false, y: 2 }]], //
+    ]
+  );
+});
+
+g.test('expandP').fn(t => {
+  // simple
+  t.expectParams<{}, {}>(
+    u.expandWithParams(function* () {}),
+    []
+  );
+  t.expectParams<{}, {}>(
+    u.expandWithParams(function* () {
+      yield {};
+    }),
+    [[{}, undefined]]
+  );
+  t.expectParams<{ z: number | undefined; w: number | undefined }, {}>(
+    u.expandWithParams(function* () {
+      yield* kUnitCaseParamsBuilder.combine('z', [3, 4]);
+      yield { w: 5 };
+    }),
+    [
+      [{ z: 3 }, undefined],
+      [{ z: 4 }, undefined],
+      [{ w: 5 }, undefined],
+    ]
+  );
+  t.expectParams<{}, { z: number | undefined; w: number | undefined }>(
+    u.beginSubcases().expandWithParams(function* () {
+      yield* kUnitCaseParamsBuilder.combine('z', [3, 4]);
+      yield { w: 5 };
+    }),
+    [[{}, [{ z: 3 }, { z: 4 }, { w: 5 }]]]
+  );
+
+  // more complex
+  t.expectParams<
+    {
+      a: boolean;
+      x: number | undefined;
+      y: number | undefined;
+      z: number | undefined;
+      w: number | undefined;
+    },
+    {}
+  >(
+    u
+      .combineWithParams([
+        { a: true, x: 1 },
+        { a: false, y: 2 },
+      ])
+      .expandWithParams(function* (p) {
         if (p.a) {
-          yield* poptions('z', [3, 4]);
+          yield { z: 3 };
+          yield { z: 4 };
         } else {
           yield { w: 5 };
         }
       }),
     [
-      { a: true, x: 1, z: 3 },
-      { a: true, x: 1, z: 4 },
-      { a: false, y: 2, w: 5 },
+      [{ a: true, x: 1, z: 3 }, undefined],
+      [{ a: true, x: 1, z: 4 }, undefined],
+      [{ a: false, y: 2, w: 5 }, undefined],
+    ]
+  );
+  t.expectParams<
+    { a: boolean; x: number | undefined; y: number | undefined },
+    { z: number | undefined; w: number | undefined }
+  >(
+    u
+      .combineWithParams([
+        { a: true, x: 1 },
+        { a: false, y: 2 },
+      ])
+      .beginSubcases()
+      .expandWithParams(function* (p) {
+        if (p.a) {
+          yield { z: 3 };
+          yield { z: 4 };
+        } else {
+          yield { w: 5 };
+        }
+      }),
+    [
+      [{ a: true, x: 1 }, [{ z: 3 }, { z: 4 }]],
+      [{ a: false, y: 2 }, [{ w: 5 }]],
     ]
   );
 });
 
-g.test('expand,invalid').fn(t => {
-  const p = params()
-    .combine([{ x: 1 }])
-    .expand(function* (p) {
-      yield p; // causes key 'x' to be duplicated
+g.test('expand').fn(t => {
+  // simple
+  t.expectParams<{}, {}>(
+    u.expand('x', function* () {}),
+    []
+  );
+  t.expectParams<{ z: number }, {}>(
+    u.expand('z', function* () {
+      yield 3;
+      yield 4;
+    }),
+    [
+      [{ z: 3 }, undefined],
+      [{ z: 4 }, undefined],
+    ]
+  );
+  t.expectParams<{}, { z: number }>(
+    u.beginSubcases().expand('z', function* () {
+      yield 3;
+      yield 4;
+    }),
+    [[{}, [{ z: 3 }, { z: 4 }]]]
+  );
+
+  // more complex
+  t.expectParams<{ a: boolean; x: number | undefined; y: number | undefined; z: number }, {}>(
+    u
+      .combineWithParams([
+        { a: true, x: 1 },
+        { a: false, y: 2 },
+      ])
+      .expand('z', function* (p) {
+        if (p.a) {
+          yield 3;
+        } else {
+          yield 5;
+        }
+      }),
+    [
+      [{ a: true, x: 1, z: 3 }, undefined],
+      [{ a: false, y: 2, z: 5 }, undefined],
+    ]
+  );
+  t.expectParams<{ a: boolean; x: number | undefined; y: number | undefined }, { z: number }>(
+    u
+      .combineWithParams([
+        { a: true, x: 1 },
+        { a: false, y: 2 },
+      ])
+      .beginSubcases()
+      .expand('z', function* (p) {
+        if (p.a) {
+          yield 3;
+        } else {
+          yield 5;
+        }
+      }),
+    [
+      [{ a: true, x: 1 }, [{ z: 3 }]],
+      [{ a: false, y: 2 }, [{ z: 5 }]],
+    ]
+  );
+});
+
+g.test('invalid,shadowing').fn(t => {
+  // Existing CaseP is shadowed by a new CaseP.
+  {
+    const p = u
+      .combineWithParams([
+        { a: true, x: 1 },
+        { a: false, x: 2 },
+      ])
+      .expandWithParams(function* (p) {
+        if (p.a) {
+          yield { x: 3 };
+        } else {
+          yield { w: 5 };
+        }
+      });
+    // Iterating causes e.g. mergeParams({x:1}, {x:3}), which fails.
+    t.shouldThrow('Error', () => {
+      Array.from(p.iterateCasesWithSubcases());
     });
-  t.shouldThrow('Error', () => {
-    Array.from(p);
-  });
+  }
+  // Existing SubcaseP is shadowed by a new SubcaseP.
+  {
+    const p = u
+      .beginSubcases()
+      .combineWithParams([
+        { a: true, x: 1 },
+        { a: false, x: 2 },
+      ])
+      .expandWithParams(function* (p) {
+        if (p.a) {
+          yield { x: 3 };
+        } else {
+          yield { w: 5 };
+        }
+      });
+    // Iterating causes e.g. mergeParams({x:1}, {x:3}), which fails.
+    t.shouldThrow('Error', () => {
+      Array.from(p.iterateCasesWithSubcases());
+    });
+  }
+  // Existing CaseP is shadowed by a new SubcaseP.
+  {
+    const p = u
+      .combineWithParams([
+        { a: true, x: 1 },
+        { a: false, x: 2 },
+      ])
+      .beginSubcases()
+      .expandWithParams(function* (p) {
+        if (p.a) {
+          yield { x: 3 };
+        } else {
+          yield { w: 5 };
+        }
+      });
+    const cases = Array.from(p.iterateCasesWithSubcases());
+    // Iterating cases is fine...
+    for (const [caseP, subcases] of cases) {
+      assert(subcases !== undefined);
+      // Iterating subcases is fine...
+      for (const subcaseP of subcases) {
+        if (caseP.a) {
+          assert(subcases !== undefined);
+          // Only errors once we try to e.g. mergeParams({x:1}, {x:3}).
+          t.shouldThrow('Error', () => {
+            mergeParams(caseP, subcaseP);
+          });
+        } else {
+          mergeParams(caseP, subcaseP);
+        }
+      }
+    }
+  }
 });
 
 g.test('undefined').fn(t => {
@@ -135,6 +418,23 @@ g.test('private').fn(t => {
   t.expect(publicParamsEquals({}, { _a: 0 }));
 });
 
-g.test('arrays').fn(t => {
-  t.expectSpecEqual([{ a: [1, 2] }], [{ a: [1, 2] }]);
+g.test('value,array').fn(t => {
+  t.expectParams<{ a: number[] }, {}>(u.combineWithParams([{ a: [1, 2] }]), [
+    [{ a: [1, 2] }, undefined], //
+  ]);
+  t.expectParams<{}, { a: number[] }>(u.beginSubcases().combineWithParams([{ a: [1, 2] }]), [
+    [{}, [{ a: [1, 2] }]], //
+  ]);
+});
+
+g.test('value,object').fn(t => {
+  t.expectParams<{ a: { [k: string]: number } }, {}>(u.combineWithParams([{ a: { x: 1 } }]), [
+    [{ a: { x: 1 } }, undefined], //
+  ]);
+  t.expectParams<{}, { a: { [k: string]: number } }>(
+    u.beginSubcases().combineWithParams([{ a: { x: 1 } }]),
+    [
+      [{}, [{ a: { x: 1 } }]], //
+    ]
+  );
 });

--- a/src/unittests/params_builder_toplevel.spec.ts
+++ b/src/unittests/params_builder_toplevel.spec.ts
@@ -2,7 +2,7 @@ export const description = `
 Unit tests for parameterization.
 `;
 
-import { params } from '../common/framework/params_builder.js';
+import { kUnitCaseParamsBuilder } from '../common/framework/params_builder.js';
 import { TestParams } from '../common/framework/params_utils.js';
 import { makeTestGroup, makeTestGroupForUnitTesting } from '../common/framework/test_group.js';
 
@@ -11,22 +11,52 @@ import { UnitTest } from './unit_test.js';
 
 export const g = makeTestGroup(TestGroupTest);
 
-g.test('none')
-  .params([])
+g.test('combine_none,arg_unit')
+  .params(u => u.combineWithParams([]))
   .fn(t => {
     t.fail("this test shouldn't run");
   });
 
-g.test('combine_none')
-  .params(params().combine([]))
+g.test('combine_none,arg_ignored')
+  .params(() => kUnitCaseParamsBuilder.combineWithParams([]))
   .fn(t => {
     t.fail("this test shouldn't run");
+  });
+
+g.test('combine_none,plain_builder')
+  .params(kUnitCaseParamsBuilder.combineWithParams([]))
+  .fn(t => {
+    t.fail("this test shouldn't run");
+  });
+
+g.test('combine_none,plain_array')
+  .paramsSimple([])
+  .fn(t => {
+    t.fail("this test shouldn't run");
+  });
+
+g.test('combine_one,case')
+  .params(u =>
+    u //
+      .combineWithParams([{ x: 1 }])
+  )
+  .fn(t => {
+    t.expect(t.params.x === 1);
+  });
+
+g.test('combine_one,subcase')
+  .paramsSubcasesOnly(u =>
+    u //
+      .combineWithParams([{ x: 1 }])
+  )
+  .fn(t => {
+    t.expect(t.params.x === 1);
   });
 
 g.test('filter')
-  .params(
-    params()
-      .combine([
+  .params(u =>
+    u
+      .combineWithParams([
         { a: true, x: 1 }, //
         { a: false, y: 2 },
       ])
@@ -37,9 +67,9 @@ g.test('filter')
   });
 
 g.test('unless')
-  .params(
-    params()
-      .combine([
+  .params(u =>
+    u
+      .combineWithParams([
         { a: true, x: 1 }, //
         { a: false, y: 2 },
       ])
@@ -49,36 +79,22 @@ g.test('unless')
     t.expect(!t.params.a);
   });
 
-g.test('exclude')
-  .params(
-    params()
-      .combine([
-        { a: true, x: 1 },
-        { a: false, y: 2 },
-      ])
-      .exclude([
-        { a: true }, //
-        { a: false, y: 2 },
-      ])
-  )
-  .fn(t => {
-    t.expect(t.params.a);
-  });
-
 g.test('generator').fn(t0 => {
   const g = makeTestGroupForUnitTesting(UnitTest);
 
   const ran: TestParams[] = [];
 
   g.test('generator')
-    .params(
-      (function* (): IterableIterator<TestParams> {
-        for (let x = 0; x < 3; ++x) {
-          for (let y = 0; y < 2; ++y) {
-            yield { x, y };
+    .params(u =>
+      u.combineWithParams(
+        (function* () {
+          for (let x = 0; x < 3; ++x) {
+            for (let y = 0; y < 2; ++y) {
+              yield { x, y };
+            }
           }
-        }
-      })()
+        })()
+      )
     )
     .fn(t => {
       ran.push(t.params);

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -22,7 +22,7 @@ g.test('UnitTest_fixture').fn(async t0 => {
 
   g.test('test').fn(count);
   g.test('testp')
-    .cases([{ a: 1 }])
+    .paramsSimple([{ a: 1 }])
     .fn(count);
 
   await t0.run(g);
@@ -43,7 +43,7 @@ g.test('custom_fixture').fn(async t0 => {
     t.count();
   });
   g.test('testp')
-    .cases([{ a: 1 }])
+    .paramsSimple([{ a: 1 }])
     .fn(t => {
       t.count();
     });
@@ -107,7 +107,7 @@ g.test('duplicate_test_params,none').fn(() => {
   {
     const g = makeTestGroupForUnitTesting(UnitTest);
     g.test('abc')
-      .cases([])
+      .paramsSimple([])
       .fn(() => {});
     g.validate();
   }
@@ -121,7 +121,7 @@ g.test('duplicate_test_params,none').fn(() => {
   {
     const g = makeTestGroupForUnitTesting(UnitTest);
     g.test('abc')
-      .cases([
+      .paramsSimple([
         { a: 1 }, //
       ])
       .fn(() => {});
@@ -133,7 +133,7 @@ g.test('duplicate_test_params,basic').fn(t => {
   {
     const g = makeTestGroupForUnitTesting(UnitTest);
     g.test('abc')
-      .cases([
+      .paramsSimple([
         { a: 1 }, //
         { a: 1 },
       ])
@@ -145,7 +145,7 @@ g.test('duplicate_test_params,basic').fn(t => {
   {
     const g = makeTestGroupForUnitTesting(UnitTest);
     g.test('abc')
-      .cases([
+      .paramsSimple([
         { a: 1, b: 3 }, //
         { b: 3, a: 1 },
       ])
@@ -159,7 +159,7 @@ g.test('duplicate_test_params,basic').fn(t => {
 g.test('duplicate_test_params,with_different_private_params').fn(t => {
   const g = makeTestGroupForUnitTesting(UnitTest);
   g.test('abc')
-    .cases([
+    .paramsSimple([
       { a: 1, _b: 1 }, //
       { a: 1, _b: 2 },
     ])
@@ -187,13 +187,13 @@ g.test('invalid_test_name').fn(t => {
 
 g.test('param_value,valid').fn(() => {
   const g = makeTestGroup(UnitTest);
-  g.test('a').cases([{ x: JSON.stringify({ a: 1, b: 2 }) }]);
+  g.test('a').paramsSimple([{ x: JSON.stringify({ a: 1, b: 2 }) }]);
 });
 
 g.test('param_value,invalid').fn(t => {
   for (const badChar of ';=*') {
     const g = makeTestGroupForUnitTesting(UnitTest);
-    g.test('a').cases([{ badChar }]);
+    g.test('a').paramsSimple([{ badChar }]);
     t.shouldThrow('Error', () => {
       g.validate();
     });
@@ -203,7 +203,10 @@ g.test('param_value,invalid').fn(t => {
 g.test('subcases').fn(async t0 => {
   const g = makeTestGroupForUnitTesting(UnitTest);
   g.test('a')
-    .subcases(() => [{ a: 1 }])
+    .paramsSubcasesOnly(u =>
+      u //
+        .combineWithParams([{ a: 1 }])
+    )
     .fn(t => {
       t.expect(t.params.a === 1, 'a must be 1');
     });
@@ -218,8 +221,12 @@ g.test('subcases').fn(async t0 => {
     }
   }
   g.test('b')
-    .cases([{ a: 1 }, { b: 2 }])
-    .subcases(gen)
+    .params(u =>
+      u
+        .combineWithParams([{ a: 1 }, { b: 2 }])
+        .beginSubcases()
+        .expandWithParams(gen)
+    )
     .fn(t => {
       const { a, b, ret } = t.params;
       t.expect((a === 1 && ret === 1) || (b === 2 && ret === 2));

--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -8,7 +8,6 @@ TODO: Test that mapping-for-write again shows the values previously written.
 TODO: Some testing (probably minimal) of accessing with different TypedArray/DataView types.
 `;
 
-import { params, pbool, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert } from '../../../../common/framework/util/util.js';
 
@@ -70,12 +69,13 @@ g.test('mapAsync,write')
     `Use map-write to write to various ranges of variously-sized buffers, then expectContents
 (which does copyBufferToBuffer + map-read) to ensure the contents were written.`
   )
-  .cases(
-    params()
-      .combine(poptions('mapAsyncRegionLeft', mapRegionBoundModes))
-      .combine(poptions('mapAsyncRegionRight', mapRegionBoundModes))
+  .params(u =>
+    u
+      .combine('mapAsyncRegionLeft', mapRegionBoundModes)
+      .combine('mapAsyncRegionRight', mapRegionBoundModes)
+      .beginSubcases()
+      .combineWithParams(kSubcases)
   )
-  .subcases(() => kSubcases)
   .fn(async t => {
     const { size, range } = t.params;
     const [rangeOffset, rangeSize] = reifyMapRange(size, range);
@@ -96,12 +96,13 @@ g.test('mapAsync,read')
     `Use mappedAtCreation to initialize various ranges of variously-sized buffers, then
 map-read and check the read-back result.`
   )
-  .cases(
-    params()
-      .combine(poptions('mapAsyncRegionLeft', mapRegionBoundModes))
-      .combine(poptions('mapAsyncRegionRight', mapRegionBoundModes))
+  .params(u =>
+    u
+      .combine('mapAsyncRegionLeft', mapRegionBoundModes)
+      .combine('mapAsyncRegionRight', mapRegionBoundModes)
+      .beginSubcases()
+      .combineWithParams(kSubcases)
   )
-  .subcases(() => kSubcases)
   .fn(async t => {
     const { size, range } = t.params;
     const [rangeOffset, rangeSize] = reifyMapRange(size, range);
@@ -133,8 +134,12 @@ g.test('mappedAtCreation')
 with or without the MAP_WRITE usage (since this could affect the mappedAtCreation upload path),
 then expectContents (which does copyBufferToBuffer + map-read) to ensure the contents were written.`
   )
-  .cases(pbool('mappable'))
-  .subcases(() => kSubcases)
+  .params(u =>
+    u //
+      .combine('mappable', [false, true])
+      .beginSubcases()
+      .combineWithParams(kSubcases)
+  )
   .fn(async t => {
     const { size, range, mappable } = t.params;
     const [, rangeSize] = reifyMapRange(size, range);

--- a/src/webgpu/api/operation/buffers/map_detach.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_detach.spec.ts
@@ -20,7 +20,7 @@ class F extends GPUTest {
 export const g = makeTestGroup(F);
 
 g.test('mapAsync,write')
-  .params([
+  .paramsSimple([
     { unmap: true, destroy: false }, //
     { unmap: false, destroy: true },
     { unmap: true, destroy: true },
@@ -33,7 +33,7 @@ g.test('mapAsync,write')
   });
 
 g.test('mapAsync,read')
-  .params([
+  .paramsSimple([
     { unmap: true, destroy: false }, //
     { unmap: false, destroy: true },
     { unmap: true, destroy: true },
@@ -46,7 +46,7 @@ g.test('mapAsync,read')
   });
 
 g.test('create_mapped')
-  .params([
+  .paramsSimple([
     { unmap: true, destroy: false },
     { unmap: false, destroy: true },
     { unmap: true, destroy: true },

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -1,7 +1,7 @@
 export const description =
   'Test out-of-memory conditions creating large mappable/mappedAtCreation buffers.';
 
-import { poptions, params, pbool } from '../../../../common/framework/params_builder.js';
+import { kUnitCaseParamsBuilder } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { kBufferUsages } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
@@ -11,17 +11,15 @@ import { GPUTest } from '../../../gpu_test.js';
 // physical memory - so test cases are also needed to try to trigger "true" OOM.)
 const MAX_ALIGNED_SAFE_INTEGER = Number.MAX_SAFE_INTEGER - 7;
 
-const oomAndSizeParams = params()
-  .combine(pbool('oom'))
-  .expand(({ oom }) => {
-    if (oom) {
-      return poptions('size', [
-        MAX_ALIGNED_SAFE_INTEGER,
-        0x2000000000, // 128 GB
-      ]);
-    } else {
-      return poptions('size', [16]);
-    }
+const oomAndSizeParams = kUnitCaseParamsBuilder
+  .combine('oom', [false, true])
+  .expand('size', ({ oom }) => {
+    return oom
+      ? [
+          MAX_ALIGNED_SAFE_INTEGER,
+          0x2000000000, // 128 GB
+        ]
+      : [16];
   });
 
 export const g = makeTestGroup(GPUTest);
@@ -34,8 +32,11 @@ g.test('mapAsync')
   - unmap() throws an OperationError if mapping failed, and otherwise should detach the ArrayBuffer.
 `
   )
-  .cases(oomAndSizeParams)
-  .subcases(() => params().combine(pbool('write')))
+  .params(
+    oomAndSizeParams //
+      .beginSubcases()
+      .combine('write', [false, true])
+  )
   .fn(async t => {
     const { oom, write, size } = t.params;
 
@@ -86,8 +87,11 @@ an out-of-memory error if allocation fails.
   - unmap() should not throw.
   `
   )
-  .cases(oomAndSizeParams)
-  .subcases(() => params().combine(poptions('usage', kBufferUsages)))
+  .params(
+    oomAndSizeParams //
+      .beginSubcases()
+      .combine('usage', kBufferUsages)
+  )
   .fn(async t => {
     const { oom, usage, size } = t.params;
 
@@ -119,8 +123,11 @@ an out-of-memory error if allocation fails.
   - unmap() should detach the ArrayBuffer.
   `
   )
-  .cases(oomAndSizeParams)
-  .subcases(() => poptions('usage', kBufferUsages))
+  .params(
+    oomAndSizeParams //
+      .beginSubcases()
+      .combine('usage', kBufferUsages)
+  )
   .fn(async t => {
     const { usage, size } = t.params;
 

--- a/src/webgpu/api/operation/command_buffer/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyBufferToBuffer.spec.ts
@@ -1,6 +1,5 @@
 export const description = 'copyBufferToBuffer operation tests';
 
-import { poptions, params } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
@@ -17,17 +16,13 @@ g.test('single')
   - covers the end of the dstBuffer
   - covers neither the beginning nor the end of the dstBuffer`
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('srcOffset', [0, 4, 8, 16]))
-      .combine(poptions('dstOffset', [0, 4, 8, 16]))
-      .combine(poptions('copySize', [0, 4, 8, 16]))
-      .expand(p =>
-        poptions('srcBufferSize', [p.srcOffset + p.copySize, p.srcOffset + p.copySize + 8])
-      )
-      .expand(p =>
-        poptions('dstBufferSize', [p.dstOffset + p.copySize, p.dstOffset + p.copySize + 8])
-      )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('srcOffset', [0, 4, 8, 16])
+      .combine('dstOffset', [0, 4, 8, 16])
+      .combine('copySize', [0, 4, 8, 16])
+      .expand('srcBufferSize', p => [p.srcOffset + p.copySize, p.srcOffset + p.copySize + 8])
+      .expand('dstBufferSize', p => [p.dstOffset + p.copySize, p.dstOffset + p.copySize + 8])
   )
   .fn(async t => {
     const { srcOffset, dstOffset, copySize, srcBufferSize, dstBufferSize } = t.params;

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -3,7 +3,6 @@ export const description = `copyTexturetoTexture operation tests
 TODO(jiawei.shao@intel.com): support all WebGPU texture formats.
 `;
 
-import { poptions, params } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert } from '../../../../common/framework/util/util.js';
 import {
@@ -322,32 +321,31 @@ g.test('color_textures,non_compressed,non_array')
   - covers the mipmap level > 0
   `
   )
-  .cases(poptions('format', kRegularTextureFormats))
-  .subcases(() =>
-    params()
-      .combine(
-        poptions('textureSize', [
-          {
-            srcTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
-          },
-          {
-            srcTextureSize: { width: 31, height: 33, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 31, height: 33, depthOrArrayLayers: 1 },
-          },
-          {
-            srcTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 64, height: 64, depthOrArrayLayers: 1 },
-          },
-          {
-            srcTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 63, height: 61, depthOrArrayLayers: 1 },
-          },
-        ])
-      )
-      .combine(poptions('copyBoxOffsets', kCopyBoxOffsetsForWholeDepth))
-      .combine(poptions('srcCopyLevel', [0, 3]))
-      .combine(poptions('dstCopyLevel', [0, 3]))
+  .params(u =>
+    u
+      .combine('format', kRegularTextureFormats)
+      .beginSubcases()
+      .combine('textureSize', [
+        {
+          srcTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
+        },
+        {
+          srcTextureSize: { width: 31, height: 33, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 31, height: 33, depthOrArrayLayers: 1 },
+        },
+        {
+          srcTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 64, height: 64, depthOrArrayLayers: 1 },
+        },
+        {
+          srcTextureSize: { width: 32, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 63, height: 61, depthOrArrayLayers: 1 },
+        },
+      ])
+      .combine('copyBoxOffsets', kCopyBoxOffsetsForWholeDepth)
+      .combine('srcCopyLevel', [0, 3])
+      .combine('dstCopyLevel', [0, 3])
   )
   .fn(async t => {
     const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
@@ -370,48 +368,47 @@ g.test('color_textures,compressed,non_array')
   the content of the whole dstTexture.
   `
   )
-  .cases(poptions('format', kCompressedTextureFormats))
-  .subcases(() =>
-    params()
-      .combine(
-        poptions('textureSize', [
-          // The heights and widths are all power of 2
-          {
-            srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-          },
-          // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
-          {
-            srcTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-          },
-          // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
-          // of 4
-          {
-            srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
-          },
-          // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
-          {
-            srcTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-          },
-          // The virtual height of the destination texture at mipmap level 2 (13) is not a
-          // multiple of 4
-          {
-            srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
-          },
-          // None of the widths or heights are power of 2
-          {
-            srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
-            dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
-          },
-        ])
-      )
-      .combine(poptions('copyBoxOffsets', kCopyBoxOffsetsForWholeDepth))
-      .combine(poptions('srcCopyLevel', [0, 2]))
-      .combine(poptions('dstCopyLevel', [0, 2]))
+  .params(u =>
+    u
+      .combine('format', kCompressedTextureFormats)
+      .beginSubcases()
+      .combine('textureSize', [
+        // The heights and widths are all power of 2
+        {
+          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+        },
+        // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
+        {
+          srcTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+        },
+        // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
+        // of 4
+        {
+          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
+        },
+        // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
+        {
+          srcTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+        },
+        // The virtual height of the destination texture at mipmap level 2 (13) is not a
+        // multiple of 4
+        {
+          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
+        },
+        // None of the widths or heights are power of 2
+        {
+          srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
+        },
+      ])
+      .combine('copyBoxOffsets', kCopyBoxOffsetsForWholeDepth)
+      .combine('srcCopyLevel', [0, 2])
+      .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
     const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
@@ -435,24 +432,24 @@ g.test('color_textures,non_compressed,array')
   CopyTextureToTexture() copy, and verifying the content of the whole dstTexture.
   `
   )
-  .cases(poptions('format', kRegularTextureFormats))
-  .subcases(() =>
-    params()
-      .combine(
-        poptions('textureSize', [
-          {
-            srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 5 },
-            dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 5 },
-          },
-          {
-            srcTextureSize: { width: 31, height: 33, depthOrArrayLayers: 5 },
-            dstTextureSize: { width: 31, height: 33, depthOrArrayLayers: 5 },
-          },
-        ])
-      )
-      .combine(poptions('copyBoxOffsets', kCopyBoxOffsetsFor2DArrayTextures))
-      .combine(poptions('srcCopyLevel', [0, 3]))
-      .combine(poptions('dstCopyLevel', [0, 3]))
+  .params(u =>
+    u
+      .combine('format', kRegularTextureFormats)
+      .beginSubcases()
+      .combine('textureSize', [
+        {
+          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 5 },
+          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 5 },
+        },
+        {
+          srcTextureSize: { width: 31, height: 33, depthOrArrayLayers: 5 },
+          dstTextureSize: { width: 31, height: 33, depthOrArrayLayers: 5 },
+        },
+      ])
+
+      .combine('copyBoxOffsets', kCopyBoxOffsetsFor2DArrayTextures)
+      .combine('srcCopyLevel', [0, 3])
+      .combine('dstCopyLevel', [0, 3])
   )
   .fn(async t => {
     const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
@@ -475,26 +472,26 @@ g.test('color_textures,compressed,array')
   CopyTextureToTexture() copy, and verifying the content of the whole dstTexture.
   `
   )
-  .cases(poptions('format', kCompressedTextureFormats))
-  .subcases(() =>
-    params()
-      .combine(
-        poptions('textureSize', [
-          // The heights and widths are all power of 2
-          {
-            srcTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
-            dstTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
-          },
-          // None of the widths or heights are power of 2
-          {
-            srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
-            dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
-          },
-        ])
-      )
-      .combine(poptions('copyBoxOffsets', kCopyBoxOffsetsFor2DArrayTextures))
-      .combine(poptions('srcCopyLevel', [0, 2]))
-      .combine(poptions('dstCopyLevel', [0, 2]))
+  .params(u =>
+    u
+      .combine('format', kCompressedTextureFormats)
+      .beginSubcases()
+      .combine('textureSize', [
+        // The heights and widths are all power of 2
+        {
+          srcTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
+          dstTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
+        },
+        // None of the widths or heights are power of 2
+        {
+          srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
+          dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
+        },
+      ])
+
+      .combine('copyBoxOffsets', kCopyBoxOffsetsFor2DArrayTextures)
+      .combine('srcCopyLevel', [0, 2])
+      .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
     const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
@@ -519,68 +516,66 @@ g.test('zero_sized')
   of that dimension.
   `
   )
-  .subcases(() =>
-    params()
-      .combine(
-        poptions('copyBoxOffset', [
-          // copyExtent.width === 0
-          {
-            srcOffset: { x: 0, y: 0, z: 0 },
-            dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: -64, height: 0, depthOrArrayLayers: 0 },
-          },
-          // copyExtent.width === 0 && srcOffset.x === textureWidth
-          {
-            srcOffset: { x: 64, y: 0, z: 0 },
-            dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: -64, height: 0, depthOrArrayLayers: 0 },
-          },
-          // copyExtent.width === 0 && dstOffset.x === textureWidth
-          {
-            srcOffset: { x: 0, y: 0, z: 0 },
-            dstOffset: { x: 64, y: 0, z: 0 },
-            copyExtent: { width: -64, height: 0, depthOrArrayLayers: 0 },
-          },
-          // copyExtent.height === 0
-          {
-            srcOffset: { x: 0, y: 0, z: 0 },
-            dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: 0, height: -32, depthOrArrayLayers: 0 },
-          },
-          // copyExtent.height === 0 && srcOffset.y === textureHeight
-          {
-            srcOffset: { x: 0, y: 32, z: 0 },
-            dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: 0, height: -32, depthOrArrayLayers: 0 },
-          },
-          // copyExtent.height === 0 && dstOffset.y === textureHeight
-          {
-            srcOffset: { x: 0, y: 0, z: 0 },
-            dstOffset: { x: 0, y: 32, z: 0 },
-            copyExtent: { width: 0, height: -32, depthOrArrayLayers: 0 },
-          },
-          // copyExtent.depthOrArrayLayers === 0
-          {
-            srcOffset: { x: 0, y: 0, z: 0 },
-            dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: 0, height: 0, depthOrArrayLayers: -5 },
-          },
-          // copyExtent.depthOrArrayLayers === 0 && srcOffset.z === textureDepth
-          {
-            srcOffset: { x: 0, y: 0, z: 5 },
-            dstOffset: { x: 0, y: 0, z: 0 },
-            copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
-          },
-          // copyExtent.depthOrArrayLayers === 0 && dstOffset.z === textureDepth
-          {
-            srcOffset: { x: 0, y: 0, z: 0 },
-            dstOffset: { x: 0, y: 0, z: 5 },
-            copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
-          },
-        ])
-      )
-      .combine(poptions('srcCopyLevel', [0, 3]))
-      .combine(poptions('dstCopyLevel', [0, 3]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('copyBoxOffset', [
+        // copyExtent.width === 0
+        {
+          srcOffset: { x: 0, y: 0, z: 0 },
+          dstOffset: { x: 0, y: 0, z: 0 },
+          copyExtent: { width: -64, height: 0, depthOrArrayLayers: 0 },
+        },
+        // copyExtent.width === 0 && srcOffset.x === textureWidth
+        {
+          srcOffset: { x: 64, y: 0, z: 0 },
+          dstOffset: { x: 0, y: 0, z: 0 },
+          copyExtent: { width: -64, height: 0, depthOrArrayLayers: 0 },
+        },
+        // copyExtent.width === 0 && dstOffset.x === textureWidth
+        {
+          srcOffset: { x: 0, y: 0, z: 0 },
+          dstOffset: { x: 64, y: 0, z: 0 },
+          copyExtent: { width: -64, height: 0, depthOrArrayLayers: 0 },
+        },
+        // copyExtent.height === 0
+        {
+          srcOffset: { x: 0, y: 0, z: 0 },
+          dstOffset: { x: 0, y: 0, z: 0 },
+          copyExtent: { width: 0, height: -32, depthOrArrayLayers: 0 },
+        },
+        // copyExtent.height === 0 && srcOffset.y === textureHeight
+        {
+          srcOffset: { x: 0, y: 32, z: 0 },
+          dstOffset: { x: 0, y: 0, z: 0 },
+          copyExtent: { width: 0, height: -32, depthOrArrayLayers: 0 },
+        },
+        // copyExtent.height === 0 && dstOffset.y === textureHeight
+        {
+          srcOffset: { x: 0, y: 0, z: 0 },
+          dstOffset: { x: 0, y: 32, z: 0 },
+          copyExtent: { width: 0, height: -32, depthOrArrayLayers: 0 },
+        },
+        // copyExtent.depthOrArrayLayers === 0
+        {
+          srcOffset: { x: 0, y: 0, z: 0 },
+          dstOffset: { x: 0, y: 0, z: 0 },
+          copyExtent: { width: 0, height: 0, depthOrArrayLayers: -5 },
+        },
+        // copyExtent.depthOrArrayLayers === 0 && srcOffset.z === textureDepth
+        {
+          srcOffset: { x: 0, y: 0, z: 5 },
+          dstOffset: { x: 0, y: 0, z: 0 },
+          copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
+        },
+        // copyExtent.depthOrArrayLayers === 0 && dstOffset.z === textureDepth
+        {
+          srcOffset: { x: 0, y: 0, z: 0 },
+          dstOffset: { x: 0, y: 0, z: 5 },
+          copyExtent: { width: 0, height: 0, depthOrArrayLayers: 0 },
+        },
+      ])
+      .combine('srcCopyLevel', [0, 3])
+      .combine('dstCopyLevel', [0, 3])
   )
   .fn(async t => {
     const { copyBoxOffset, srcCopyLevel, dstCopyLevel } = t.params;

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Basic command buffer compute tests.
 `;
 
-import { params, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
@@ -72,20 +71,15 @@ TODO: add query for the maximum dispatch size and test closer to those limits.
 Test reasonably-sized large dispatches (see also stress tests).
 `
   )
-  .cases(
-    params()
-      .combine(
-        // Reasonably-sized powers of two, and some stranger larger sizes.
-        poptions('dispatchSize', [256, 512, 1024, 2048, 315, 628, 1053, 2179] as const)
-      )
-      .combine(
-        // Test some reasonable workgroup sizes.
-        poptions('workgroupSize', [1, 2, 4, 8, 16, 32, 64] as const)
-      )
-  )
-  .subcases(() =>
-    // 0 == x axis; 1 == y axis; 2 == z axis.
-    poptions('largeDimension', [0, 1, 2] as const)
+  .params(u =>
+    u
+      // Reasonably-sized powers of two, and some stranger larger sizes.
+      .combine('dispatchSize', [256, 512, 1024, 2048, 315, 628, 1053, 2179] as const)
+      // Test some reasonable workgroup sizes.
+      .combine('workgroupSize', [1, 2, 4, 8, 16, 32, 64] as const)
+      .beginSubcases()
+      // 0 == x axis; 1 == y axis; 2 == z axis.
+      .combine('largeDimension', [0, 1, 2] as const)
   )
   .fn(async t => {
     // The output storage buffer is filled with this value.

--- a/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
@@ -11,7 +11,6 @@ Wait on another fence, then call expectContents to verify the written buffer.
   - if not single pass, x= writes in {same cmdbuf, separate cmdbufs, separate submits, separate queues}
 `;
 
-import { pbool, poptions, params } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 
 import { kAllWriteOps, BufferSyncTest } from './buffer_sync_test.js';
@@ -20,10 +19,10 @@ export const g = makeTestGroup(BufferSyncTest);
 
 g.test('same_cmdbuf')
   .desc('Test write-after-write operations in the same command buffer.')
-  .params(
-    params()
-      .combine(poptions('firstWriteOp', kAllWriteOps))
-      .combine(poptions('secondWriteOp', kAllWriteOps))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('firstWriteOp', kAllWriteOps)
+      .combine('secondWriteOp', kAllWriteOps)
   )
   .fn(async t => {
     const { firstWriteOp, secondWriteOp } = t.params;
@@ -39,10 +38,10 @@ g.test('same_cmdbuf')
 
 g.test('separate_cmdbufs')
   .desc('Test write-after-write operations in separate command buffers via the same submit.')
-  .params(
-    params()
-      .combine(poptions('firstWriteOp', kAllWriteOps))
-      .combine(poptions('secondWriteOp', kAllWriteOps))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('firstWriteOp', kAllWriteOps)
+      .combine('secondWriteOp', kAllWriteOps)
   )
   .fn(async t => {
     const { firstWriteOp, secondWriteOp } = t.params;
@@ -58,10 +57,10 @@ g.test('separate_cmdbufs')
 
 g.test('separate_submits')
   .desc('Test write-after-write operations via separate submits in the same queue.')
-  .params(
-    params()
-      .combine(poptions('firstWriteOp', ['write-buffer', ...kAllWriteOps] as const))
-      .combine(poptions('secondWriteOp', ['write-buffer', ...kAllWriteOps] as const))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('firstWriteOp', ['write-buffer', ...kAllWriteOps] as const)
+      .combine('secondWriteOp', ['write-buffer', ...kAllWriteOps] as const)
   )
   .fn(async t => {
     const { firstWriteOp, secondWriteOp } = t.params;
@@ -83,7 +82,11 @@ g.test('two_draws_in_the_same_render_pass')
     a storage buffer. The second write will write 2 into the same buffer in the same pass. Expected
     data in buffer is either 1 or 2. It may use bundle in each draw.`
   )
-  .params(params().combine(pbool('firstDrawUseBundle')).combine(pbool('secondDrawUseBundle')))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('firstDrawUseBundle', [false, true])
+      .combine('secondDrawUseBundle', [false, true])
+  )
   .fn(async t => {
     const { firstDrawUseBundle, secondDrawUseBundle } = t.params;
     const buffer = await t.createBufferWithValue(0);

--- a/src/webgpu/api/operation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/operation/queue/writeBuffer.spec.ts
@@ -1,6 +1,5 @@
 export const description = 'Operation tests for GPUQueue.writeBuffer()';
 
-import { params, pbool, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/framework/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
@@ -103,7 +102,11 @@ const kTestData = range<number>(16, i => i);
 
 g.test('array_types')
   .desc('Tests that writeBuffer correctly handles different TypedArrays and ArrayBuffer.')
-  .cases(params().combine(poptions('arrayType', kTypedArrays)).combine(pbool('useArrayBuffer')))
+  .params(u =>
+    u //
+      .combine('arrayType', kTypedArrays)
+      .combine('useArrayBuffer', [false, true])
+  )
   .fn(t => {
     const { arrayType, useArrayBuffer } = t.params;
     const dataOffset = 1;
@@ -130,7 +133,7 @@ Tests that writeBuffer currently handles different offsets and writes. This incl
 - Multiple overlapping writes with decreasing sizes
     `
   )
-  .cases([
+  .paramsSubcasesOnly([
     {
       // Concatenate 2 Uint32Arrays
       writes: [

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -13,7 +13,6 @@ Tests a render pass with a resolveTarget resolves correctly for many combination
     (different z from colorAttachment)
 `;
 
-import { params, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
@@ -29,13 +28,14 @@ const kFormat: GPUTextureFormat = 'rgba8unorm';
 export const g = makeTestGroup(GPUTest);
 
 g.test('render_pass_resolve')
-  .params(
-    params()
-      .combine(poptions('storeOperation', ['clear', 'store'] as const))
-      .combine(poptions('numColorAttachments', [2, 4] as const))
-      .combine(poptions('slotsToResolve', kSlotsToResolve))
-      .combine(poptions('resolveTargetBaseMipLevel', [0, 1] as const))
-      .combine(poptions('resolveTargetBaseArrayLayer', [0, 1] as const))
+  .params(u =>
+    u
+      .combine('storeOperation', ['clear', 'store'] as const)
+      .beginSubcases()
+      .combine('numColorAttachments', [2, 4] as const)
+      .combine('slotsToResolve', kSlotsToResolve)
+      .combine('resolveTargetBaseMipLevel', [0, 1] as const)
+      .combine('resolveTargetBaseArrayLayer', [0, 1] as const)
   )
   .fn(t => {
     const targets: GPUColorTargetState[] = [];

--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -27,7 +27,6 @@ export const description = `API Operation Tests for RenderPass StoreOp.
       TODO: depth slice set to {'0', slice > '0'} for 3D textures
       TODO: test with more interesting loadOp values`;
 
-import { params, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import {
   kEncodableTextureFormatInfo,
@@ -58,10 +57,10 @@ export const g = makeTestGroup(GPUTest);
 // Tests a render pass with both a color and depth stencil attachment to ensure store operations are
 // set independently.
 g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
-  .params(
-    params()
-      .combine(poptions('colorStoreOperation', kStoreOps))
-      .combine(poptions('depthStencilStoreOperation', kStoreOps))
+  .params(u =>
+    u //
+      .combine('colorStoreOperation', kStoreOps)
+      .combine('depthStencilStoreOperation', kStoreOps)
   )
   .fn(t => {
     // Create a basic color attachment.
@@ -140,17 +139,18 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
 // Tests that render pass color attachment store operations work correctly for all renderable color
 // formats, mip levels and array layers.
 g.test('render_pass_store_op,color_attachment_only')
-  .params(
-    params()
-      .combine(poptions('colorFormat', kEncodableTextureFormats))
+  .params(u =>
+    u
+      .combine('colorFormat', kEncodableTextureFormats)
       // Filter out any non-renderable formats
       .filter(({ colorFormat }) => {
         const info = kEncodableTextureFormatInfo[colorFormat];
         return info.color && info.renderable;
       })
-      .combine(poptions('storeOperation', kStoreOps))
-      .combine(poptions('mipLevel', kMipLevel))
-      .combine(poptions('arrayLayer', kArrayLayers))
+      .combine('storeOperation', kStoreOps)
+      .beginSubcases()
+      .combine('mipLevel', kMipLevel)
+      .combine('arrayLayer', kArrayLayers)
   )
   .fn(t => {
     const colorAttachment = t.device.createTexture({
@@ -204,11 +204,12 @@ g.test('render_pass_store_op,color_attachment_only')
 
 // Test with multiple color attachments to ensure each attachment's storeOp is set independently.
 g.test('render_pass_store_op,multiple_color_attachments')
-  .params(
-    params()
-      .combine(poptions('colorAttachments', kNumColorAttachments))
-      .combine(poptions('storeOperation1', kStoreOps))
-      .combine(poptions('storeOperation2', kStoreOps))
+  .params(u =>
+    u
+      .combine('storeOperation1', kStoreOps)
+      .combine('storeOperation2', kStoreOps)
+      .beginSubcases()
+      .combine('colorAttachments', kNumColorAttachments)
   )
   .fn(t => {
     const kColorFormat: GPUTextureFormat = 'rgba8unorm';
@@ -271,12 +272,13 @@ formats, mip levels and array layers.
 TODO: Also test unsized depth/stencil formats
   `
   )
-  .params(
-    params()
-      .combine(poptions('depthStencilFormat', kSizedDepthStencilFormats)) // TODO
-      .combine(poptions('storeOperation', kStoreOps))
-      .combine(poptions('mipLevel', kMipLevel))
-      .combine(poptions('arrayLayer', kArrayLayers))
+  .params(u =>
+    u
+      .combine('depthStencilFormat', kSizedDepthStencilFormats) // TODO
+      .combine('storeOperation', kStoreOps)
+      .beginSubcases()
+      .combine('mipLevel', kMipLevel)
+      .combine('arrayLayer', kArrayLayers)
   )
   .fn(t => {
     const depthStencilAttachment = t.device.createTexture({

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -10,7 +10,7 @@ import { GPUTest } from '../../../gpu_test.js';
 export const g = makeTestGroup(GPUTest);
 
 g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
-  .params([
+  .paramsSimple([
     { storeOp: 'store', _expected: 1 }, //
     { storeOp: 'clear', _expected: 0 },
   ] as const)

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -18,7 +18,6 @@ Use 2 triangles with different winding orders:
   - Some primitive topologies (triangle-list, TODO: triangle-strip)
 `;
 
-import { poptions, params } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
@@ -41,20 +40,19 @@ function faceColor(face: 'cw' | 'ccw', frontFace: GPUFrontFace, cullMode: GPUCul
 export const g = makeTestGroup(GPUTest);
 
 g.test('culling')
-  .params(
-    params()
-      .combine(poptions('frontFace', ['ccw', 'cw'] as const))
-      .combine(poptions('cullMode', ['none', 'front', 'back'] as const))
-      .combine(
-        poptions('depthStencilFormat', [
-          null,
-          'depth24plus',
-          'depth32float',
-          'depth24plus-stencil8',
-        ] as const)
-      )
+  .params(u =>
+    u
+      .combine('frontFace', ['ccw', 'cw'] as const)
+      .combine('cullMode', ['none', 'front', 'back'] as const)
+      .beginSubcases()
+      .combine('depthStencilFormat', [
+        null,
+        'depth24plus',
+        'depth32float',
+        'depth24plus-stencil8',
+      ] as const)
       // TODO: test triangle-strip as well
-      .combine(poptions('primitiveTopology', ['triangle-list'] as const))
+      .combine('primitiveTopology', ['triangle-list'] as const)
   )
   .fn(t => {
     const size = 4;

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -55,7 +55,6 @@ Test locations are framebuffer coordinates:
                                                                 and {v3, v4, v5}.
 `;
 
-import { params, pbool, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
@@ -445,11 +444,11 @@ g.test('basic')
     - primitiveRestart= { true, false } - always false for non-strip topologies
   `
   )
-  .cases(
-    params() //
-      .combine(poptions('topology', topologies))
-      .combine(pbool('indirect'))
-      .combine(pbool('primitiveRestart'))
+  .params(u =>
+    u //
+      .combine('topology', topologies)
+      .combine('indirect', [false, true])
+      .combine('primitiveRestart', [false, true])
       .unless(
         p => p.primitiveRestart && p.topology !== 'line-strip' && p.topology !== 'triangle-strip'
       )
@@ -472,18 +471,18 @@ g.test('unaligned_vertex_count')
                    One smaller for line-list. One or two smaller for triangle-list.
     `
   )
-  .cases(
-    params() //
-      .combine(poptions('topology', ['line-list', 'triangle-list'] as const))
-      .combine(pbool('indirect'))
-      .expand(function* (p) {
+  .params(u =>
+    u //
+      .combine('topology', ['line-list', 'triangle-list'] as const)
+      .combine('indirect', [false, true])
+      .expand('drawCount', function* (p) {
         switch (p.topology) {
           case 'line-list':
-            yield { drawCount: kDefaultDrawCount - 1 };
+            yield kDefaultDrawCount - 1;
             break;
           case 'triangle-list':
-            yield { drawCount: kDefaultDrawCount - 1 };
-            yield { drawCount: kDefaultDrawCount - 2 };
+            yield kDefaultDrawCount - 1;
+            yield kDefaultDrawCount - 2;
             break;
         }
       })

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -7,7 +7,6 @@ TODO:
 - ?
 `;
 
-import { params, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, unreachable } from '../../../../common/framework/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
@@ -127,35 +126,27 @@ g.test('GPUBlendComponent')
     - dstFactor= {...all GPUBlendFactors}
     - operation= {...all GPUBlendOperations}`
   )
-  .cases(
-    params() //
-      .combine(poptions('component', ['color', 'alpha'] as const))
-      .combine(poptions('srcFactor', kBlendFactors))
-      .combine(poptions('dstFactor', kBlendFactors))
-      .combine(poptions('operation', kBlendOperations))
+  .params(u =>
+    u //
+      .combine('component', ['color', 'alpha'] as const)
+      .combine('srcFactor', kBlendFactors)
+      .combine('dstFactor', kBlendFactors)
+      .combine('operation', kBlendOperations)
+      .beginSubcases()
+      .combine('srcColor', [{ r: 0.11, g: 0.61, b: 0.81, a: 0.44 }])
+      .combine('dstColor', [
+        { r: 0.51, g: 0.22, b: 0.71, a: 0.33 },
+        { r: 0.09, g: 0.73, b: 0.93, a: 0.81 },
+      ])
+      .expand('blendConstant', p => {
+        const needsBlendConstant =
+          p.srcFactor === 'one-minus-constant' ||
+          p.srcFactor === 'constant' ||
+          p.dstFactor === 'one-minus-constant' ||
+          p.dstFactor === 'constant';
+        return needsBlendConstant ? [{ r: 0.91, g: 0.82, b: 0.73, a: 0.64 }] : [undefined];
+      })
   )
-  .subcases(p => {
-    const needsBlendConstant =
-      p.srcFactor === 'one-minus-constant' ||
-      p.srcFactor === 'constant' ||
-      p.dstFactor === 'one-minus-constant' ||
-      p.dstFactor === 'constant';
-
-    return params()
-      .combine(poptions('srcColor', [{ r: 0.11, g: 0.61, b: 0.81, a: 0.44 }]))
-      .combine(
-        poptions('dstColor', [
-          { r: 0.51, g: 0.22, b: 0.71, a: 0.33 },
-          { r: 0.09, g: 0.73, b: 0.93, a: 0.81 },
-        ])
-      )
-      .combine(
-        poptions(
-          'blendConstant',
-          needsBlendConstant ? [{ r: 0.91, g: 0.82, b: 0.73, a: 0.64 }] : [undefined]
-        )
-      );
-  })
   .fn(t => {
     const textureFormat: GPUTextureFormat = 'rgba32float';
     const srcColor = t.params.srcColor;

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Test related to depth buffer, depth op, compare func, etc.
 `;
 
-import { pbool, params, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { kDepthStencilFormats } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
@@ -28,15 +27,13 @@ g.test('depth_compare_func')
   .desc(
     `Tests each depth compare function works properly. Clears the depth attachment to various values, and renders a point at depth 0.5 with various depthCompare modes.`
   )
-  .cases(
-    params()
+  .params(u =>
+    u
       .combine(
-        poptions(
-          'format',
-          kDepthStencilFormats.filter(format => format !== 'stencil8')
-        )
+        'format',
+        kDepthStencilFormats.filter(format => format !== 'stencil8')
       )
-      .combine([
+      .combineWithParams([
         { depthCompare: 'never', depthLoadValue: 1.0, _expected: backgroundColor },
         { depthCompare: 'never', depthLoadValue: 0.5, _expected: backgroundColor },
         { depthCompare: 'never', depthLoadValue: 0.0, _expected: backgroundColor },
@@ -158,7 +155,7 @@ g.test('reverse_depth')
     Note that in real use case the depth range remapping is done by the modified projection matrix.
 (see https://developer.nvidia.com/content/depth-precision-visualized).`
   )
-  .cases(pbool('reversed'))
+  .params(u => u.combine('reversed', [false, true]))
   .fn(async t => {
     const colorAttachmentFormat = 'rgba8unorm';
     const colorAttachment = t.device.createTexture({

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -12,7 +12,6 @@ TODO:
   - mode= {draw, drawIndexed}
 `;
 
-import { params, pbool, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert } from '../../../../common/framework/util/util.js';
 import {
@@ -46,17 +45,17 @@ Params:
   - base_vertex= {0, 9} - only for indexed draws
   `
   )
-  .cases(
-    params()
-      .combine(poptions('first', [0, 3] as const))
-      .combine(poptions('count', [0, 3, 6] as const))
-      .combine(poptions('first_instance', [0, 2] as const))
-      .combine(poptions('instance_count', [0, 1, 4] as const))
-      .combine(pbool('indexed'))
-      .combine(pbool('indirect'))
-      .combine(poptions('vertex_buffer_offset', [0, 32] as const))
-      .expand(p => poptions('index_buffer_offset', p.indexed ? ([0, 16] as const) : [undefined]))
-      .expand(p => poptions('base_vertex', p.indexed ? ([0, 9] as const) : [undefined]))
+  .params(u =>
+    u
+      .combine('first', [0, 3] as const)
+      .combine('count', [0, 3, 6] as const)
+      .combine('first_instance', [0, 2] as const)
+      .combine('instance_count', [0, 1, 4] as const)
+      .combine('indexed', [false, true])
+      .combine('indirect', [false, true])
+      .combine('vertex_buffer_offset', [0, 32] as const)
+      .expand('index_buffer_offset', p => (p.indexed ? ([0, 16] as const) : [undefined]))
+      .expand('base_vertex', p => (p.indexed ? ([0, 9] as const) : [undefined]))
   )
   .fn(t => {
     const renderTargetSize = [72, 36];
@@ -337,12 +336,12 @@ g.test('vertex_attributes,basic')
   - step_mode= {undefined, vertex, instance, mixed} - where mixed only applies for vertex_buffer_count > 1
   `
   )
-  .cases(
-    params()
-      .combine(poptions('vertex_attribute_count', [1, 4, 8, 16]))
-      .combine(poptions('vertex_buffer_count', [1, 4, 8]))
-      .combine(poptions('vertex_format', ['uint32', 'float32'] as const))
-      .combine(poptions('step_mode', [undefined, 'vertex', 'instance', 'mixed'] as const))
+  .params(u =>
+    u
+      .combine('vertex_attribute_count', [1, 4, 8, 16])
+      .combine('vertex_buffer_count', [1, 4, 8])
+      .combine('vertex_format', ['uint32', 'float32'] as const)
+      .combine('step_mode', [undefined, 'vertex', 'instance', 'mixed'] as const)
       .unless(p => p.vertex_attribute_count < p.vertex_buffer_count)
       .unless(p => p.step_mode === 'mixed' && p.vertex_buffer_count <= 1)
   )

--- a/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Tests for the indirect-specific aspects of drawIndirect/drawIndexedIndirect.
 `;
 
-import { params, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
@@ -27,9 +26,9 @@ Params:
     - indirectOffset= {0, 4, k * sizeof(args struct), k * sizeof(args struct) + 4}
     `
   )
-  .subcases(() =>
-    params().combine(
-      poptions('indirectOffset', [
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('indirectOffset', [
         0,
         Uint32Array.BYTES_PER_ELEMENT,
         1 * kDrawIndirectParametersSize,
@@ -39,7 +38,6 @@ Params:
         99 * kDrawIndirectParametersSize,
         99 * kDrawIndirectParametersSize + Uint32Array.BYTES_PER_ELEMENT,
       ] as const)
-    )
   )
   .fn(t => {
     const { indirectOffset } = t.params;

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -260,7 +260,7 @@ g.test('anisotropic_filter_mipmap_color')
     if it fits expectations.
     A similar webgl demo is at https://jsfiddle.net/t8k7c95o/5/`
   )
-  .params([
+  .paramsSimple([
     {
       maxAnisotropy: 1,
       _results: [

--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -63,7 +63,7 @@ g.test('compilationInfo_returns')
     - Test that the compilation info for valid shader modules contains no errors.
     - Test that the compilation info for invalid shader modules contains at least one error.`
   )
-  .cases(kAllShaderSources)
+  .paramsSimple(kAllShaderSources)
   .fn(async t => {
     const { _code, valid } = t.params;
 
@@ -103,7 +103,7 @@ g.test('line_number_and_position')
     - Test for invalid shader modules containing containing at least one error.
     - Test for shader modules containing only ASCII and those containing unicode characters.`
   )
-  .cases(kInvalidShaderSources)
+  .paramsSimple(kInvalidShaderSources)
   .fn(async t => {
     const { _code, _errorLine } = t.params;
 
@@ -145,7 +145,7 @@ g.test('offset_and_length')
     - Test for valid and invalid shader modules.
     - Test for shader modules containing only ASCII and those containing unicode characters.`
   )
-  .cases(kAllShaderSources)
+  .paramsSimple(kAllShaderSources)
   .fn(async t => {
     const { _code, valid } = t.params;
 

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Test indexing, index format and primitive restart.
 `;
 
-import { params, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { getTextureCopyLayout } from '../../../util/texture/layout.js';
@@ -183,7 +182,7 @@ export const g = makeTestGroup(IndexFormatTest);
 
 g.test('index_format,uint16')
   .desc('Test rendering result of indexed draw with index format of uint16.')
-  .params([
+  .paramsSubcasesOnly([
     { indexOffset: 0, _expectedShape: kSquare },
     { indexOffset: 6, _expectedShape: kBottomLeftTriangle },
     { indexOffset: 18, _expectedShape: kNothing },
@@ -205,7 +204,7 @@ g.test('index_format,uint16')
 
 g.test('index_format,uint32')
   .desc('Test rendering result of indexed draw with index format of uint32.')
-  .params([
+  .paramsSubcasesOnly([
     { indexOffset: 0, _expectedShape: kSquare },
     { indexOffset: 12, _expectedShape: kBottomLeftTriangle },
     { indexOffset: 36, _expectedShape: kNothing },
@@ -316,10 +315,10 @@ is different from what you would get if the topology were incorrect.
         |########|
 `
   )
-  .params(
-    params()
-      .combine(poptions('indexFormat', ['uint16', 'uint32'] as const))
-      .combine([
+  .params(u =>
+    u //
+      .combine('indexFormat', ['uint16', 'uint32'] as const)
+      .combineWithParams([
         {
           primitiveTopology: 'point-list',
           _indices: [0, 1, -1, 2, 3, 0],

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -4,7 +4,6 @@ Validation for attachment compatibility between render passes, bundles, and pipe
 TODO: Add sparse color attachment compatibility test when defined by specification
 `;
 
-import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { range } from '../../../common/framework/util/util.js';
 import {
@@ -145,10 +144,10 @@ const kColorAttachmentFormats = kRegularTextureFormats.filter(format => {
 
 g.test('render_pass_and_bundle,color_format')
   .desc('Test that color attachment formats in render passes and bundles must match.')
-  .params(
-    params()
-      .combine(poptions('passFormat', kColorAttachmentFormats))
-      .combine(poptions('bundleFormat', kColorAttachmentFormats))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('passFormat', kColorAttachmentFormats)
+      .combine('bundleFormat', kColorAttachmentFormats)
   )
   .fn(t => {
     const { passFormat, bundleFormat } = t.params;
@@ -175,10 +174,10 @@ g.test('render_pass_and_bundle,color_count')
   TODO: Add sparse color attachment compatibility test when defined by specification
   `
   )
-  .params(
-    params()
-      .combine(poptions('passCount', kColorAttachmentCounts))
-      .combine(poptions('bundleCount', kColorAttachmentCounts))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('passCount', kColorAttachmentCounts)
+      .combine('bundleCount', kColorAttachmentCounts)
   )
   .fn(t => {
     const { passCount, bundleCount } = t.params;
@@ -200,10 +199,10 @@ g.test('render_pass_and_bundle,color_count')
 
 g.test('render_pass_and_bundle,depth_format')
   .desc('Test that the depth attachment format in render passes and bundles must match.')
-  .params(
-    params()
-      .combine(poptions('passFormat', kDepthStencilAttachmentFormats))
-      .combine(poptions('bundleFormat', kDepthStencilAttachmentFormats))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('passFormat', kDepthStencilAttachmentFormats)
+      .combine('bundleFormat', kDepthStencilAttachmentFormats)
   )
   .fn(async t => {
     const { passFormat, bundleFormat } = t.params;
@@ -229,10 +228,10 @@ g.test('render_pass_and_bundle,depth_format')
 
 g.test('render_pass_and_bundle,sample_count')
   .desc('Test that the sample count in render passes and bundles must match.')
-  .params(
-    params()
-      .combine(poptions('renderSampleCount', kTextureSampleCounts))
-      .combine(poptions('bundleSampleCount', kTextureSampleCounts))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('renderSampleCount', kTextureSampleCounts)
+      .combine('bundleSampleCount', kTextureSampleCounts)
   )
   .fn(t => {
     const { renderSampleCount, bundleSampleCount } = t.params;
@@ -258,11 +257,12 @@ g.test('render_pass_or_bundle_and_pipeline,color_format')
 Test that color attachment formats in render passes or bundles match the pipeline color format.
 `
   )
-  .params(
-    params()
-      .combine(poptions('encoderType', ['render pass', 'render bundle'] as const))
-      .combine(poptions('encoderFormat', kColorAttachmentFormats))
-      .combine(poptions('pipelineFormat', kColorAttachmentFormats))
+  .params(u =>
+    u
+      .combine('encoderType', ['render pass', 'render bundle'] as const)
+      .beginSubcases()
+      .combine('encoderFormat', kColorAttachmentFormats)
+      .combine('pipelineFormat', kColorAttachmentFormats)
   )
   .fn(t => {
     const { encoderType, encoderFormat, pipelineFormat } = t.params;
@@ -285,11 +285,12 @@ count.
 TODO: Add sparse color attachment compatibility test when defined by specification
 `
   )
-  .params(
-    params()
-      .combine(poptions('encoderType', ['render pass', 'render bundle'] as const))
-      .combine(poptions('encoderCount', kColorAttachmentCounts))
-      .combine(poptions('pipelineCount', kColorAttachmentCounts))
+  .params(u =>
+    u
+      .combine('encoderType', ['render pass', 'render bundle'] as const)
+      .beginSubcases()
+      .combine('encoderCount', kColorAttachmentCounts)
+      .combine('pipelineCount', kColorAttachmentCounts)
   )
   .fn(t => {
     const { encoderType, encoderCount, pipelineCount } = t.params;
@@ -312,11 +313,12 @@ g.test('render_pass_or_bundle_and_pipeline,depth_format')
 Test that the depth attachment format in render passes or bundles match the pipeline depth format.
 `
   )
-  .params(
-    params()
-      .combine(poptions('encoderType', ['render pass', 'render bundle'] as const))
-      .combine(poptions('encoderFormat', kDepthStencilAttachmentFormats))
-      .combine(poptions('pipelineFormat', kDepthStencilAttachmentFormats))
+  .params(u =>
+    u
+      .combine('encoderType', ['render pass', 'render bundle'] as const)
+      .beginSubcases()
+      .combine('encoderFormat', kDepthStencilAttachmentFormats)
+      .combine('pipelineFormat', kDepthStencilAttachmentFormats)
   )
   .fn(async t => {
     const { encoderType, encoderFormat, pipelineFormat } = t.params;
@@ -345,11 +347,12 @@ g.test('render_pass_or_bundle_and_pipeline,sample_count')
 Test that the sample count in render passes or bundles match the pipeline sample count.
 `
   )
-  .params(
-    params()
-      .combine(poptions('encoderType', ['render pass', 'render bundle'] as const))
-      .combine(poptions('encoderSampleCount', kTextureSampleCounts))
-      .combine(poptions('pipelineSampleCount', kTextureSampleCounts))
+  .params(u =>
+    u
+      .combine('encoderType', ['render pass', 'render bundle'] as const)
+      .beginSubcases()
+      .combine('encoderSampleCount', kTextureSampleCounts)
+      .combine('pipelineSampleCount', kTextureSampleCounts)
   )
   .fn(t => {
     const { encoderType, encoderSampleCount, pipelineSampleCount } = t.params;

--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Tests for validation in createBuffer.
 `;
 
-import { params, pbool, poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert } from '../../../../common/framework/util/util.js';
 import { kBufferSizeAlignment } from '../../../capability_info.js';
@@ -13,30 +12,28 @@ export const g = makeTestGroup(ValidationTest);
 assert(kBufferSizeAlignment === 4);
 g.test('size')
   .desc('Test buffer size alignment.')
-  .params(
-    params()
-      .combine(pbool('mappedAtCreation'))
-      .combine(
-        poptions('size', [
-          0,
-          kBufferSizeAlignment * 0.5,
-          kBufferSizeAlignment,
-          kBufferSizeAlignment * 1.5,
-          kBufferSizeAlignment * 2,
-        ])
-      )
+  .params(u =>
+    u
+      .combine('mappedAtCreation', [false, true])
+      .beginSubcases()
+      .combine('size', [
+        0,
+        kBufferSizeAlignment * 0.5,
+        kBufferSizeAlignment,
+        kBufferSizeAlignment * 1.5,
+        kBufferSizeAlignment * 2,
+      ])
   )
   .unimplemented();
 
 g.test('usage')
   .desc('Test combinations of (one to two?) usage flags.')
-  .params(
-    params() //
-      .combine(pbool('mappedAtCreation'))
-      .combine(
-        poptions('usage', [
-          // TODO
-        ])
-      )
+  .params(u =>
+    u //
+      .beginSubcases()
+      .combine('mappedAtCreation', [false, true])
+      .combine('usage', [
+        // TODO
+      ])
   )
   .unimplemented();

--- a/src/webgpu/api/validation/buffer/destroy.spec.ts
+++ b/src/webgpu/api/validation/buffer/destroy.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Destroying a buffer more than once is allowed.
 `;
 
-import { params, pbool } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUConst } from '../../../constants.js';
 import { ValidationTest } from '../validation_test.js';
@@ -11,10 +10,10 @@ export const g = makeTestGroup(ValidationTest);
 
 g.test('twice')
   .desc('Tests various mapping-related descripton options that could affect how state is tracked.')
-  .params(
-    params()
-      .combine(pbool('mappedAtCreation'))
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('mappedAtCreation', [false, true])
+      .combineWithParams([
         { size: 4, usage: GPUConst.BufferUsage.COPY_SRC },
         { size: 4, usage: GPUConst.BufferUsage.MAP_WRITE | GPUConst.BufferUsage.COPY_SRC },
         { size: 4, usage: GPUConst.BufferUsage.COPY_DST | GPUConst.BufferUsage.MAP_READ },

--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -24,7 +24,6 @@ TODO: review existing tests and merge with this plan:
 >     - check x.size == 0, y.size == mapping size
 `;
 
-import { pbool, poptions, params } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { attemptGarbageCollection } from '../../../../common/framework/util/collect_garbage.js';
 import { assert, unreachable } from '../../../../common/framework/util/util.js';
@@ -92,7 +91,7 @@ class F extends ValidationTest {
 
 export const g = makeTestGroup(F);
 
-const kMapModeOptions = poptions('mapMode', [GPUConst.MapMode.READ, GPUConst.MapMode.WRITE]);
+const kMapModeOptions = [GPUConst.MapMode.READ, GPUConst.MapMode.WRITE];
 const kOffsetAlignment = 8;
 const kSizeAlignment = 4;
 
@@ -105,15 +104,15 @@ g.test('mapAsync,usage')
     Test that the mapAsync call is valid iff the mapping usage is not 0 and the buffer usage
     the mapMode flag.`
   )
-  .subcases(() =>
-    params()
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u //
+      .combineWithParams([
         { mapMode: GPUConst.MapMode.READ, validUsage: GPUConst.BufferUsage.MAP_READ },
         { mapMode: GPUConst.MapMode.WRITE, validUsage: GPUConst.BufferUsage.MAP_WRITE },
         // Using mapMode 0 is never valid, so there is no validUsage.
         { mapMode: 0, validUsage: null },
       ])
-      .combine(poptions('usage', kBufferUsages))
+      .combine('usage', kBufferUsages)
   )
   .fn(async t => {
     const { mapMode, validUsage, usage } = t.params;
@@ -129,7 +128,7 @@ g.test('mapAsync,usage')
 
 g.test('mapAsync,invalidBuffer')
   .desc('Test that mapAsync is an error when called on an invalid buffer.')
-  .subcases(() => kMapModeOptions)
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
     const { mapMode } = t.params;
     const buffer = t.getErrorBuffer();
@@ -138,7 +137,7 @@ g.test('mapAsync,invalidBuffer')
 
 g.test('mapAsync,state,destroyed')
   .desc('Test that mapAsync is an error when called on a destroyed buffer.')
-  .subcases(() => kMapModeOptions)
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
     const { mapMode } = t.params;
     const buffer = t.createMappableBuffer(mapMode, 16);
@@ -151,7 +150,7 @@ g.test('mapAsync,state,mappedAtCreation')
     `Test that mapAsync is an error when called on a buffer mapped at creation,
     but succeeds after unmapping it.`
   )
-  .subcases(() => [
+  .paramsSubcasesOnly([
     { mapMode: GPUConst.MapMode.READ, validUsage: GPUConst.BufferUsage.MAP_READ },
     { mapMode: GPUConst.MapMode.WRITE, validUsage: GPUConst.BufferUsage.MAP_WRITE },
   ])
@@ -174,7 +173,7 @@ g.test('mapAsync,state,mapped')
     `Test that mapAsync is an error when called on a mapped buffer, but succeeds
     after unmapping it.`
   )
-  .subcases(() => kMapModeOptions)
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
     const { mapMode } = t.params;
 
@@ -191,7 +190,7 @@ g.test('mapAsync,state,mappingPending')
     `Test that mapAsync is an error when called on a buffer that is being mapped,
     but succeeds after the previous mapping request is cancelled.`
   )
-  .subcases(() => kMapModeOptions)
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
     const { mapMode } = t.params;
 
@@ -219,10 +218,10 @@ g.test('mapAsync,sizeUnspecifiedOOB')
     with various cases at the limits of the buffer size or with a misaligned offset.
     Also test for an empty buffer.`
   )
-  .subcases(() =>
-    params()
-      .combine(kMapModeOptions)
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('mapMode', kMapModeOptions)
+      .combineWithParams([
         // 0 size buffer.
         { bufferSize: 0, offset: 0 },
         { bufferSize: 0, offset: 1 },
@@ -246,10 +245,10 @@ g.test('mapAsync,sizeUnspecifiedOOB')
 
 g.test('mapAsync,offsetAndSizeAlignment')
   .desc("Test that mapAsync fails if the alignment of offset and size isn't correct.")
-  .subcases(() =>
-    params()
-      .combine(kMapModeOptions)
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('mapMode', kMapModeOptions)
+      .combineWithParams([
         // Valid cases, 0 and required alignments values are valid.
         { offset: 0, size: 0 },
         { offset: kOffsetAlignment, size: kSizeAlignment },
@@ -271,10 +270,10 @@ g.test('mapAsync,offsetAndSizeAlignment')
 
 g.test('mapAsync,offsetAndSizeOOB')
   .desc('Test that mapAsync fails if offset + size is larger than the buffer size.')
-  .subcases(() =>
-    params()
-      .combine(kMapModeOptions)
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('mapMode', kMapModeOptions)
+      .combineWithParams([
         // For a 0 size buffer
         { bufferSize: 0, offset: 0, size: 0 },
         { bufferSize: 0, offset: 0, size: 4 },
@@ -313,7 +312,7 @@ g.test('mapAsync,offsetAndSizeOOB')
 
 g.test('getMappedRange,state,mapped')
   .desc('Test that it is valid to call getMappedRange in the mapped state')
-  .subcases(() => kMapModeOptions)
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
     const { mapMode } = t.params;
     const buffer = t.createMappableBuffer(mapMode, 16);
@@ -326,7 +325,7 @@ g.test('getMappedRange,state,mappedAtCreation')
   .desc(
     'Test that it is valid to call getMappedRange in the mapped at creation state, for all buffer usages'
   )
-  .subcases(() => poptions('bufferUsage', kBufferUsages))
+  .paramsSubcasesOnly(u => u.combine('bufferUsage', kBufferUsages))
   .fn(async t => {
     const { bufferUsage } = t.params;
     const buffer = t.device.createBuffer({
@@ -405,7 +404,7 @@ Test for various cases of being destroyed: at creation, after a mapAsync call or
 
 g.test('getMappedRange,state,mappingPending')
   .desc('Test that it is invalid to call getMappedRange in the mappingPending state.')
-  .params(kMapModeOptions)
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(t => {
     const { mapMode } = t.params;
     const buffer = t.createMappableBuffer(mapMode, 16);
@@ -419,10 +418,11 @@ g.test('getMappedRange,offsetAndSizeAlignment')
     `Test that getMappedRange fails if the alignment of offset and size isn't correct.
   TODO: x= {mappedAtCreation, mapAsync at {0, >0}`
   )
-  .params(
-    params()
-      .combine(kMapModeOptions)
-      .combine([
+  .params(u =>
+    u
+      .combine('mapMode', kMapModeOptions)
+      .beginSubcases()
+      .combineWithParams([
         // Valid cases, 0 and required alignments values are valid.
         { offset: 0, size: 0 },
         { offset: kOffsetAlignment, size: kSizeAlignment },
@@ -448,7 +448,7 @@ g.test('getMappedRange,sizeAndOffsetOOB,forMappedAtCreation')
     `Test that getMappedRange size + offset must be less than the buffer size for a
     buffer mapped at creation. (and offset has not constraints on its own)`
   )
-  .subcases(() => [
+  .paramsSubcasesOnly([
     // Tests for a zero-sized buffer, with and without a size defined.
     { bufferSize: 0, offset: undefined, size: undefined },
     { bufferSize: 0, offset: undefined, size: 0 },
@@ -495,10 +495,10 @@ g.test('getMappedRange,sizeAndOffsetOOB,forMappedAtCreation')
 
 g.test('getMappedRange,sizeAndOffsetOOB,forMapped')
   .desc('Test that getMappedRange size + offset must be less than the mapAsync range.')
-  .subcases(() =>
-    params()
-      .combine(kMapModeOptions)
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('mapMode', kMapModeOptions)
+      .combineWithParams([
         // Tests for an empty buffer, and implicit mapAsync size.
         { bufferSize: 0, mapOffset: 0, mapSize: undefined, offset: undefined, size: undefined },
         { bufferSize: 0, mapOffset: 0, mapSize: undefined, offset: undefined, size: 0 },
@@ -609,10 +609,10 @@ g.test('getMappedRange,sizeAndOffsetOOB,forMapped')
 
 g.test('getMappedRange,disjointRanges')
   .desc('Test that the ranges asked through getMappedRange must be disjoint.')
-  .subcases(() =>
-    params()
-      .combine(pbool('remapBetweenCalls'))
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('remapBetweenCalls', [false, true])
+      .combineWithParams([
         // Disjoint ranges with one that's empty.
         { offset1: 8, size1: 0, offset2: 8, size2: 8 },
         { offset1: 16, size1: 0, offset2: 8, size2: 8 },
@@ -764,7 +764,10 @@ g.test('unmap,state,destroyed')
 
 g.test('unmap,state,mappedAtCreation')
   .desc('Test it is valid to call unmap on a buffer mapped at creation, for various usages')
-  .subcases(() => poptions('bufferUsage', kBufferUsages))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('bufferUsage', kBufferUsages)
+  )
   .fn(t => {
     const { bufferUsage } = t.params;
     const buffer = t.device.createBuffer({ size: 16, usage: bufferUsage, mappedAtCreation: true });
@@ -774,7 +777,7 @@ g.test('unmap,state,mappedAtCreation')
 
 g.test('unmap,state,mapped')
   .desc("Test it is valid to call unmap on a buffer that's mapped")
-  .subcases(() => kMapModeOptions)
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
     const { mapMode } = t.params;
     const buffer = t.createMappableBuffer(mapMode, 16);
@@ -785,7 +788,7 @@ g.test('unmap,state,mapped')
 
 g.test('unmap,state,mappingPending')
   .desc("Test it is valid to call unmap on a buffer that's being mapped")
-  .subcases(() => kMapModeOptions)
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(t => {
     const { mapMode } = t.params;
     const buffer = t.createMappableBuffer(mapMode, 16);
@@ -832,7 +835,7 @@ g.test('gc_behavior,mapAsync')
   .desc(
     "Test that GCing the buffer while mappings are handed out doesn't invalidate them - mapAsync case"
   )
-  .subcases(() => kMapModeOptions)
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
     const { mapMode } = t.params;
 

--- a/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Tests for capability checking for features enabling optional query types.
 `;
 
-import { params, pbool, poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
@@ -21,11 +20,11 @@ TODO: This test should expect *synchronous* exceptions, not validation errors, p
 As of this writing, the spec needs to be fixed as well.
   `
   )
-  .params(
-    params()
-      .combine(poptions('type', ['occlusion', 'pipeline-statistics', 'timestamp'] as const))
-      .combine(pbool('pipelineStatisticsQueryEnable'))
-      .combine(pbool('timestampQueryEnable'))
+  .params(u =>
+    u
+      .combine('type', ['occlusion', 'pipeline-statistics', 'timestamp'] as const)
+      .combine('pipelineStatisticsQueryEnable', [false, true])
+      .combine('timestampQueryEnable', [false, true])
   )
   .fn(async t => {
     const { type, pipelineStatisticsQueryEnable, timestampQueryEnable } = t.params;

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -4,7 +4,6 @@ export const description = `
   TODO: Ensure sure tests cover all createBindGroup validation rules.
 `;
 
-import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { unreachable } from '../../../common/framework/util/util.js';
 import {
@@ -28,10 +27,10 @@ export const g = makeTestGroup(ValidationTest);
 
 g.test('binding_count_mismatch')
   .desc('Test that the number of entries must match the number of entries in the BindGroupLayout.')
-  .subcases(() =>
-    params()
-      .combine(poptions('layoutEntryCount', [1, 2, 3]))
-      .combine(poptions('bindGroupEntryCount', [1, 2, 3]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('layoutEntryCount', [1, 2, 3])
+      .combine('bindGroupEntryCount', [1, 2, 3])
   )
   .fn(async t => {
     const { layoutEntryCount, bindGroupEntryCount } = t.params;
@@ -67,10 +66,10 @@ g.test('binding_must_be_present_in_layout')
   .desc(
     'Test that the binding slot for each entry matches a binding slot defined in the BindGroupLayout.'
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('layoutBinding', [0, 1, 2]))
-      .combine(poptions('binding', [0, 1, 2]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('layoutBinding', [0, 1, 2])
+      .combine('binding', [0, 1, 2])
   )
   .fn(async t => {
     const { layoutBinding, binding } = t.params;
@@ -96,10 +95,10 @@ g.test('binding_must_contain_resource_defined_in_layout')
   .desc(
     'Test that only the resource type specified in the BindGroupLayout is allowed for each entry.'
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('resourceType', kBindableResources))
-      .combine(poptions('entry', allBindingEntries(false)))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('resourceType', kBindableResources)
+      .combine('entry', allBindingEntries(false))
   )
   .fn(t => {
     const { resourceType, entry } = t.params;
@@ -119,10 +118,10 @@ g.test('binding_must_contain_resource_defined_in_layout')
 
 g.test('texture_binding_must_have_correct_usage')
   .desc('Tests that texture bindings must have the correct usage.')
-  .subcases(() =>
-    params()
-      .combine(poptions('entry', sampledAndStorageBindingEntries(false)))
-      .combine(poptions('usage', kTextureUsages))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('entry', sampledAndStorageBindingEntries(false))
+      .combine('usage', kTextureUsages)
       .unless(({ entry, usage }) => {
         const info = texBindingTypeInfo(entry);
         // Can't create the texture for this (usage=STORAGE and sampleCount=4), so skip.
@@ -161,7 +160,7 @@ g.test('texture_must_have_correct_component_type')
     - Tests a compatible format for every sample type
     - Tests an incompatible format for every sample type`
   )
-  .cases(poptions('sampleType', ['float', 'sint', 'uint'] as const))
+  .params(u => u.combine('sampleType', ['float', 'sint', 'uint'] as const))
   .fn(async t => {
     const { sampleType } = t.params;
 
@@ -235,8 +234,12 @@ g.test('texture_must_have_correct_dimension')
     Test that bound texture views match the dimensions supplied in the BindGroupLayout
     - Test for every GPUTextureViewDimension`
   )
-  .cases(poptions('viewDimension', kTextureViewDimensions))
-  .subcases(() => poptions('dimension', kTextureViewDimensions))
+  .params(u =>
+    u
+      .combine('viewDimension', kTextureViewDimensions)
+      .beginSubcases()
+      .combine('dimension', kTextureViewDimensions)
+  )
   .fn(async t => {
     const { viewDimension, dimension } = t.params;
     const bindGroupLayout = t.device.createBindGroupLayout({
@@ -274,7 +277,7 @@ g.test('buffer_offset_and_size_for_bind_groups_match')
     - Test for various offsets and sizes
     - TODO(#234): disallow zero-sized bindings`
   )
-  .subcases(() => [
+  .paramsSubcasesOnly([
     { offset: 0, size: 512, _success: true }, // offset 0 is valid
     { offset: 256, size: 256, _success: true }, // offset 256 (aligned) is valid
 
@@ -336,16 +339,13 @@ g.test('buffer_offset_and_size_for_bind_groups_match')
 
 g.test('minBindingSize')
   .desc('Tests that minBindingSize is correctly enforced.')
-  .subcases(() =>
-    params()
-      .combine(poptions('minBindingSize', [undefined, 4, 256]))
-      .expand(({ minBindingSize }) =>
-        poptions(
-          'size',
-          minBindingSize !== undefined
-            ? [minBindingSize - 1, minBindingSize, minBindingSize + 1]
-            : [4, 256]
-        )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('minBindingSize', [undefined, 4, 256])
+      .expand('size', ({ minBindingSize }) =>
+        minBindingSize !== undefined
+          ? [minBindingSize - 1, minBindingSize, minBindingSize + 1]
+          : [4, 256]
       )
   )
   .fn(t => {

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -4,7 +4,7 @@ createBindGroupLayout validation tests.
 TODO: make sure tests are complete.
 `;
 
-import { poptions, params } from '../../../common/framework/params_builder.js';
+import { kUnitCaseParamsBuilder } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
   kMaxBindingsPerBindGroup,
@@ -28,7 +28,7 @@ export const g = makeTestGroup(ValidationTest);
 
 g.test('duplicate_bindings')
   .desc('Test that uniqueness of binding numbers across entries is enforced.')
-  .subcases(() => [
+  .paramsSubcasesOnly([
     { bindings: [0, 1], _valid: true },
     { bindings: [0, 0], _valid: false },
   ])
@@ -58,8 +58,12 @@ g.test('visibility')
     - Test each possible combination of shader stage visibilities.
     - Test each type of bind group resource.`
   )
-  .cases(poptions('visibility', kShaderStageCombinations))
-  .subcases(() => poptions('entry', allBindingEntries(false)))
+  .params(u =>
+    u
+      .combine('visibility', kShaderStageCombinations)
+      .beginSubcases()
+      .combine('entry', allBindingEntries(false))
+  )
   .fn(async t => {
     const { visibility, entry } = t.params;
     const info = bindingTypeInfo(entry);
@@ -75,7 +79,10 @@ g.test('visibility')
 
 g.test('multisampled_validation')
   .desc('Test that multisampling is only allowed with "2d" view dimensions.')
-  .subcases(() => poptions('viewDimension', [undefined, ...kTextureViewDimensions]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('viewDimension', [undefined, ...kTextureViewDimensions])
+  )
   .fn(async t => {
     const { viewDimension } = t.params;
 
@@ -102,11 +109,12 @@ g.test('max_dynamic_buffers')
     - Test creation of a bind group layout using the maximum number of dynamic buffers + 1 fails.
     - TODO(#230): Update to enforce per-stage and per-pipeline-layout limits on BGLs as well.`
   )
-  .cases(poptions('type', kBufferBindingTypes))
-  .subcases(() =>
-    params()
-      .combine(poptions('extraDynamicBuffers', [0, 1]))
-      .combine(poptions('staticBuffers', [0, 1]))
+  .params(u =>
+    u
+      .combine('type', kBufferBindingTypes)
+      .beginSubcases()
+      .combine('extraDynamicBuffers', [0, 1])
+      .combine('staticBuffers', [0, 1])
   )
   .fn(async t => {
     const { type, extraDynamicBuffers, staticBuffers } = t.params;
@@ -149,10 +157,7 @@ g.test('max_dynamic_buffers')
  *     (i.e. 'storage-buffer' <-> 'readonly-storage-buffer').
  *   - Otherwise, an arbitrary other type.
  */
-function* pickExtraBindingTypesForPerStage(
-  entry: BGLEntry,
-  extraTypeSame: boolean
-): IterableIterator<BGLEntry> {
+function* pickExtraBindingTypesForPerStage(entry: BGLEntry, extraTypeSame: boolean) {
   if (extraTypeSame) {
     const info = bindingTypeInfo(entry);
     for (const extra of allBindingEntries(false)) {
@@ -162,21 +167,21 @@ function* pickExtraBindingTypesForPerStage(
       }
     }
   } else {
-    return entry.sampler ? { texture: {} } : { sampler: {} };
+    yield entry.sampler ? { texture: {} } : { sampler: {} };
   }
 }
 
-function subcasesForMaxResourcesPerStageTests(caseParams: { maxedEntry: BGLEntry }) {
-  return params()
-    .combine(poptions('maxedVisibility', kShaderStages))
-    .filter(p => (bindingTypeInfo(caseParams.maxedEntry).validStages & p.maxedVisibility) !== 0)
-    .expand(function* () {
-      yield* poptions('extraEntry', pickExtraBindingTypesForPerStage(caseParams.maxedEntry, true));
-      yield* poptions('extraEntry', pickExtraBindingTypesForPerStage(caseParams.maxedEntry, false));
-    })
-    .combine(poptions('extraVisibility', kShaderStages))
-    .filter(p => (bindingTypeInfo(p.extraEntry).validStages & p.extraVisibility) !== 0);
-}
+const kMaxResourcesCases = kUnitCaseParamsBuilder
+  .combine('maxedEntry', allBindingEntries(false))
+  .beginSubcases()
+  .combine('maxedVisibility', kShaderStages)
+  .filter(p => (bindingTypeInfo(p.maxedEntry).validStages & p.maxedVisibility) !== 0)
+  .expand('extraEntry', p => [
+    ...pickExtraBindingTypesForPerStage(p.maxedEntry, true),
+    ...pickExtraBindingTypesForPerStage(p.maxedEntry, false),
+  ])
+  .combine('extraVisibility', kShaderStages)
+  .filter(p => (bindingTypeInfo(p.extraEntry).validStages & p.extraVisibility) !== 0);
 
 // Should never fail unless kMaxBindingsPerBindGroup is exceeded, because the validation for
 // resources-of-type-per-stage is in pipeline layout creation.
@@ -190,8 +195,7 @@ g.test('max_resources_per_stage,in_bind_group_layout')
     - Test that creation of a bind group layout using the maximum number of bindings + 1 fails.
     - TODO(#230): Update to enforce per-stage and per-pipeline-layout limits on BGLs as well.`
   )
-  .cases(poptions('maxedEntry', allBindingEntries(false)))
-  .subcases(cp => subcasesForMaxResourcesPerStageTests(cp))
+  .params(kMaxResourcesCases)
   .fn(async t => {
     const { maxedEntry, extraEntry, maxedVisibility, extraVisibility } = t.params;
     const maxedTypeInfo = bindingTypeInfo(maxedEntry);
@@ -238,8 +242,7 @@ g.test('max_resources_per_stage,in_pipeline_layout')
     - Test that creation of a pipeline using the maximum number of bindings + 1 fails.
   `
   )
-  .cases(poptions('maxedEntry', allBindingEntries(false)))
-  .subcases(cp => subcasesForMaxResourcesPerStageTests(cp))
+  .params(kMaxResourcesCases)
   .fn(async t => {
     const { maxedEntry, extraEntry, maxedVisibility, extraVisibility } = t.params;
     const maxedTypeInfo = bindingTypeInfo(maxedEntry);

--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 createComputePipeline and createComputePipelineAsync validation tests.
 `;
 
-import { params, poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 // import { kAllTextureFormats, kAllTextureFormatInfo } from '../../capability_info.js';
@@ -84,7 +83,7 @@ Control case for createComputePipeline and createComputePipelineAsync.
 Call the API with valid compute shader and matching valid entryPoint, making sure that the test function working well.
 `
   )
-  .cases(poptions('isAsync', [true, false]))
+  .params(u => u.combine('isAsync', [true, false]))
   .fn(async t => {
     const { isAsync } = t.params;
     t.doCreateComputePipelineTest(isAsync, true, {
@@ -98,7 +97,7 @@ g.test('shader_module_must_be_valid')
 Tests calling createComputePipeline(Async) with a invalid compute shader, and check that the APIs catch this error.
 `
   )
-  .cases(poptions('isAsync', [true, false]))
+  .params(u => u.combine('isAsync', [true, false]))
   .fn(async t => {
     const { isAsync } = t.params;
     t.doCreateComputePipelineTest(isAsync, false, {
@@ -116,10 +115,10 @@ Tests calling createComputePipeline(Async) with valid but different stage shader
 and check that the APIs only accept compute shader.
 `
   )
-  .cases(
-    params()
-      .combine(poptions('isAsync', [true, false]))
-      .combine(poptions('shaderModuleStage', ['compute', 'vertex', 'fragment'] as TShaderStage[]))
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combine('shaderModuleStage', ['compute', 'vertex', 'fragment'] as TShaderStage[])
   )
   .fn(async t => {
     const { isAsync, shaderModuleStage } = t.params;
@@ -146,26 +145,24 @@ The entryPoint assigned in descriptor include:
 - Containing invalid char, including space and control codes (Null character)
 `
   )
-  .cases(
-    params()
-      .combine(poptions('isAsync', [true, false]))
-      .combine([
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main' },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: '' },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0' },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0a' },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'mian' },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main ' },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'ma in' },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\n' },
-        { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'mian' },
-        { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'main' },
-        { shaderModuleEntryPoint: 'mainmain', stageEntryPoint: 'mainmain' },
-        { shaderModuleEntryPoint: 'mainmain', stageEntryPoint: 'foo' },
-        { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: 'main_t12V3' },
-        { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: 'main_t12V5' },
-        { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: '_main_t12V3' },
-      ])
+  .params(u =>
+    u.combine('isAsync', [true, false]).combineWithParams([
+      { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main' },
+      { shaderModuleEntryPoint: 'main', stageEntryPoint: '' },
+      { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0' },
+      { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0a' },
+      { shaderModuleEntryPoint: 'main', stageEntryPoint: 'mian' },
+      { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main ' },
+      { shaderModuleEntryPoint: 'main', stageEntryPoint: 'ma in' },
+      { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\n' },
+      { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'mian' },
+      { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'main' },
+      { shaderModuleEntryPoint: 'mainmain', stageEntryPoint: 'mainmain' },
+      { shaderModuleEntryPoint: 'mainmain', stageEntryPoint: 'foo' },
+      { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: 'main_t12V3' },
+      { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: 'main_t12V5' },
+      { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: '_main_t12V3' },
+    ])
   )
   .fn(async t => {
     const { isAsync, shaderModuleEntryPoint, stageEntryPoint } = t.params;

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -4,7 +4,6 @@ createPipelineLayout validation tests.
 TODO: review existing tests, write descriptions, and make sure tests are complete.
 `;
 
-import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { bufferBindingTypeInfo, kBufferBindingTypes } from '../../capability_info.js';
 
@@ -22,10 +21,10 @@ g.test('number_of_dynamic_buffers_exceeds_the_maximum_value')
 
 TODO(#230): Update to enforce per-stage and per-pipeline-layout limits on BGLs as well.`
   )
-  .params(
-    params()
-      .combine(poptions('visibility', [0, 2, 4, 6]))
-      .combine(poptions('type', kBufferBindingTypes))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('visibility', [0, 2, 4, 6])
+      .combine('type', kBufferBindingTypes)
   )
   .fn(async t => {
     const { type, visibility } = t.params;

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -23,7 +23,6 @@ TODO: review existing tests, write descriptions, and make sure tests are complet
 
 `;
 
-import { poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { kAllTextureFormats, kAllTextureFormatInfo } from '../../capability_info.js';
 
@@ -131,7 +130,7 @@ g.test('at_least_one_color_state_is_required').fn(async t => {
 });
 
 g.test('color_formats_must_be_renderable')
-  .params(poptions('format', kAllTextureFormats))
+  .params(u => u.combine('format', kAllTextureFormats))
   .fn(async t => {
     const format: GPUTextureFormat = t.params.format;
     const info = kAllTextureFormatInfo[format];
@@ -151,7 +150,7 @@ g.test('color_formats_must_be_renderable')
   });
 
 g.test('sample_count_must_be_valid')
-  .params([
+  .paramsSimple([
     { sampleCount: 0, _success: false },
     { sampleCount: 1, _success: true },
     { sampleCount: 2, _success: false },
@@ -177,7 +176,7 @@ g.test('sample_count_must_be_valid')
   });
 
 g.test('sample_count_must_be_equal_to_the_one_of_every_attachment_in_the_render_pass')
-  .params([
+  .paramsSimple([
     { attachmentSamples: 4, pipelineSamples: 4, _success: true }, // It is allowed to use multisampled render pass and multisampled render pipeline.
     { attachmentSamples: 4, pipelineSamples: 1, _success: false }, // It is not allowed to use multisampled render pass and non-multisampled render pipeline.
     { attachmentSamples: 1, pipelineSamples: 4, _success: false }, // It is not allowed to use non-multisampled render pass and multisampled render pipeline.

--- a/src/webgpu/api/validation/createSampler.spec.ts
+++ b/src/webgpu/api/validation/createSampler.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 createSampler validation tests.
 `;
 
-import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 import { ValidationTest } from './validation_test.js';
@@ -11,10 +10,10 @@ export const g = makeTestGroup(ValidationTest);
 
 g.test('lodMinAndMaxClamp')
   .desc('test different combinations of min and max clamp values')
-  .params(
-    params()
-      .combine(poptions('lodMinClamp', [-4e-30, -1, 0, 0.5, 1, 10, 4e30]))
-      .combine(poptions('lodMaxClamp', [-4e-30, -1, 0, 0.5, 1, 10, 4e30]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('lodMinClamp', [-4e-30, -1, 0, 0.5, 1, 10, 4e30])
+      .combine('lodMaxClamp', [-4e-30, -1, 0, 0.5, 1, 10, 4e30])
   )
   .fn(async t => {
     t.expectValidationError(() => {
@@ -27,12 +26,16 @@ g.test('lodMinAndMaxClamp')
 
 g.test('maxAnisotropy')
   .desc('test different maxAnisotropy values and combinations with min/mag/mipmapFilter')
-  .params([
-    ...poptions('maxAnisotropy', [-1, undefined, 0, 1, 2, 4, 7, 16, 32, 33, 1024]),
-    { minFilter: 'nearest' as const },
-    { magFilter: 'nearest' as const },
-    { mipmapFilter: 'nearest' as const },
-  ])
+  .params(u =>
+    u //
+      .beginSubcases()
+      .combineWithParams([
+        ...u.combine('maxAnisotropy', [-1, undefined, 0, 1, 2, 4, 7, 16, 32, 33, 1024]),
+        { minFilter: 'nearest' as const },
+        { magFilter: 'nearest' as const },
+        { mipmapFilter: 'nearest' as const },
+      ])
+  )
   .fn(async t => {
     const {
       maxAnisotropy = 1,

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -1,6 +1,5 @@
 export const description = `createTexture validation tests.`;
 
-import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { assert } from '../../../common/framework/util/util.js';
 import {
@@ -26,28 +25,25 @@ g.test('zero_size')
     `Test texture creation with zero or nonzero size of
     width, height, depthOrArrayLayers and mipLevelCount for every dimension, and representative formats.`
   )
-  .cases(poptions('dimension', [undefined, ...kTextureDimensions]))
-  .subcases(({ dimension }) =>
-    params()
-      .combine(
-        poptions('zeroArgument', [
-          'none',
-          'width',
-          'height',
-          'depthOrArrayLayers',
-          'mipLevelCount',
-        ] as const)
-      )
-      .combine(
-        poptions('format', [
-          'rgba8unorm',
-          'rgb10a2unorm',
-          'bc1-rgba-unorm',
-          'depth24plus-stencil8',
-        ] as const)
-      )
+  .params(u =>
+    u
+      .combine('dimension', [undefined, ...kTextureDimensions])
+      .beginSubcases()
+      .combine('zeroArgument', [
+        'none',
+        'width',
+        'height',
+        'depthOrArrayLayers',
+        'mipLevelCount',
+      ] as const)
+      .combine('format', [
+        'rgba8unorm',
+        'rgb10a2unorm',
+        'bc1-rgba-unorm',
+        'depth24plus-stencil8',
+      ] as const)
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
   )
   .fn(async t => {
     const { dimension, zeroArgument, format } = t.params;
@@ -93,8 +89,12 @@ g.test('dimension_type_and_format_compatibility')
   .desc(
     `Test every dimension type on every format. Note that compressed formats and depth/stencil formats are not valid for 1D/3D dimension types.`
   )
-  .cases(poptions('dimension', [undefined, ...kTextureDimensions]))
-  .subcases(() => params().combine(poptions('format', kAllTextureFormats)))
+  .params(u =>
+    u
+      .combine('dimension', [undefined, ...kTextureDimensions])
+      .beginSubcases()
+      .combine('format', kAllTextureFormats)
+  )
   .fn(async t => {
     const { dimension, format } = t.params;
     const info = kAllTextureFormatInfo[format];
@@ -117,13 +117,14 @@ g.test('mipLevelCount,format')
     `Test texture creation with no mipmap chain, partial mipmap chain, full mipmap chain, out-of-bounds mipmap chain
     for every format with different texture dimension types.`
   )
-  .cases(poptions('dimension', [undefined, ...kTextureDimensions]))
-  .subcases(({ dimension }) =>
-    params()
-      .combine(poptions('format', kAllTextureFormats))
-      .combine(poptions('mipLevelCount', [1, 3, 6, 7]))
+  .params(u =>
+    u
+      .combine('dimension', [undefined, ...kTextureDimensions])
+      .beginSubcases()
+      .combine('format', kAllTextureFormats)
+      .combine('mipLevelCount', [1, 3, 6, 7])
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
   )
   .fn(async t => {
     const { dimension, format, mipLevelCount } = t.params;
@@ -155,10 +156,10 @@ g.test('mipLevelCount,bound_check')
     `Test mip level count bound check upon different texture size and different texture dimension types.
     The cases below test: 1) there must be no mip levels after a 1 level (1D texture), or 1x1 level (2D texture), or 1x1x1 level (3D texture), 2) array layers are not mip-mapped, 3) power-of-two, non-power-of-two, and non-square sizes.`
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('format', ['rgba8unorm', 'bc1-rgba-unorm'] as const))
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('format', ['rgba8unorm', 'bc1-rgba-unorm'] as const)
+      .combineWithParams([
         { size: [32, 32] }, // Mip level sizes: 32x32, 16x16, 8x8, 4x4, 2x2, 1x1
         { size: [31, 32] }, // Mip level sizes: 31x32, 15x16, 7x8, 3x4, 1x2, 1x1
         { size: [28, 32] }, // Mip level sizes: 28x32, 14x16, 7x8, 3x4, 1x2, 1x1
@@ -226,11 +227,12 @@ g.test('sampleCount,various_sampleCount_with_all_formats')
   .desc(
     `Test texture creation with various (valid or invalid) sample count and all formats. Note that 1D and 3D textures can't support multisample.`
   )
-  .cases(poptions('dimension', [undefined, '2d'] as const))
-  .subcases(() =>
-    params()
-      .combine(poptions('sampleCount', [0, 1, 2, 4, 8, 16, 32, 256]))
-      .combine(poptions('format', kAllTextureFormats))
+  .params(u =>
+    u
+      .combine('dimension', [undefined, '2d'] as const)
+      .beginSubcases()
+      .combine('sampleCount', [0, 1, 2, 4, 8, 16, 32, 256])
+      .combine('format', kAllTextureFormats)
   )
   .fn(async t => {
     const { dimension, sampleCount, format } = t.params;
@@ -258,20 +260,21 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
      Texture can be single sample (sampleCount is 1) or multi-sample (sampleCount is 4).
      Multisample texture requires that 1) its dimension is 2d or undefined, 2) its format supports multisample, 3) its mipLevelCount and arrayLayerCount are 1, 4) its usage doesn't include STORAGE.`
   )
-  .cases(poptions('dimension', [undefined, ...kTextureDimensions]))
-  .subcases(({ dimension }) =>
-    params()
-      .combine(poptions('sampleCount', [1, 4]))
-      .combine(poptions('arrayLayerCount', [1, 2]))
+  .params(u =>
+    u
+      .combine('dimension', [undefined, ...kTextureDimensions])
+      .beginSubcases()
+      .combine('sampleCount', [1, 4])
+      .combine('arrayLayerCount', [1, 2])
       .unless(
-        ({ arrayLayerCount }) =>
+        ({ dimension, arrayLayerCount }) =>
           arrayLayerCount === 2 && dimension !== '2d' && dimension !== undefined
       )
-      .combine(poptions('mipLevelCount', [1, 2]))
-      .combine(poptions('format', kAllTextureFormats))
-      .combine(poptions('usage', kTextureUsages))
+      .combine('mipLevelCount', [1, 2])
+      .combine('format', kAllTextureFormats)
+      .combine('usage', kTextureUsages)
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
       .unless(({ usage, format }) => {
         const info = kAllTextureFormatInfo[format];
         return (
@@ -318,13 +321,14 @@ g.test('texture_size,default_value_and_smallest_size,uncompressed_format')
     `Test default values for height and depthOrArrayLayers for every dimension type and every uncompressed format.
 	  It also tests smallest size (lower bound) for every dimension type and every uncompressed format, while other texture_size tests are testing the upper bound.`
   )
-  .cases(poptions('dimension', [undefined, ...kTextureDimensions]))
-  .subcases(({ dimension }) =>
-    params()
-      .combine(poptions('format', kUncompressedTextureFormats))
-      .combine(poptions('size', [[1], [1, 1], [1, 1, 1]]))
+  .params(u =>
+    u
+      .combine('dimension', [undefined, ...kTextureDimensions])
+      .beginSubcases()
+      .combine('format', kUncompressedTextureFormats)
+      .combine('size', [[1], [1, 1], [1, 1, 1]])
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
   )
   .fn(async t => {
     const { dimension, format, size } = t.params;
@@ -345,12 +349,13 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
     `Test default values for height and depthOrArrayLayers for every dimension type and every compressed format.
 	  It also tests smallest size (lower bound) for every dimension type and every compressed format, while other texture_size tests are testing the upper bound.`
   )
-  // Compressed formats are invalid for 1D and 3D.
-  .cases(poptions('dimension', [undefined, '2d'] as const))
-  .subcases(() =>
-    params()
-      .combine(poptions('format', kCompressedTextureFormats))
-      .expand(p => {
+  .params(u =>
+    u
+      // Compressed formats are invalid for 1D and 3D.
+      .combine('dimension', [undefined, '2d'] as const)
+      .beginSubcases()
+      .combine('format', kCompressedTextureFormats)
+      .expandWithParams(p => {
         const { blockWidth, blockHeight } = kAllTextureFormatInfo[p.format];
         return [
           { size: [1], _success: false },
@@ -381,19 +386,17 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
 
 g.test('texture_size,1d_texture')
   .desc(`Test texture size requirement for 1D texture`)
-  .subcases(() =>
-    params()
+  .paramsSubcasesOnly(u =>
+    u //
       // Compressed textures are invalid for 1D.
-      .combine(poptions('format', kUncompressedTextureFormats))
-      .combine(
-        poptions('width', [
-          DefaultLimits.maxTextureDimension1D - 1,
-          DefaultLimits.maxTextureDimension1D,
-          DefaultLimits.maxTextureDimension1D + 1,
-        ])
-      )
-      .combine(poptions('height', [1, 2]))
-      .combine(poptions('depthOrArrayLayers', [1, 2]))
+      .combine('format', kUncompressedTextureFormats)
+      .combine('width', [
+        DefaultLimits.maxTextureDimension1D - 1,
+        DefaultLimits.maxTextureDimension1D,
+        DefaultLimits.maxTextureDimension1D + 1,
+      ])
+      .combine('height', [1, 2])
+      .combine('depthOrArrayLayers', [1, 2])
   )
   .fn(async t => {
     const { format, width, height, depthOrArrayLayers } = t.params;
@@ -416,26 +419,24 @@ g.test('texture_size,1d_texture')
 
 g.test('texture_size,2d_texture,uncompressed_format')
   .desc(`Test texture size requirement for 2D texture with uncompressed format.`)
-  .cases(poptions('dimension', [undefined, '2d'] as const))
-  .subcases(() =>
-    params()
-      .combine(poptions('format', kUncompressedTextureFormats))
-      .combine(
-        poptions('size', [
-          // Test the bound of width
-          [DefaultLimits.maxTextureDimension2D - 1, 1, 1],
-          [DefaultLimits.maxTextureDimension2D, 1, 1],
-          [DefaultLimits.maxTextureDimension2D + 1, 1, 1],
-          // Test the bound of height
-          [1, DefaultLimits.maxTextureDimension2D - 1, 1],
-          [1, DefaultLimits.maxTextureDimension2D, 1],
-          [1, DefaultLimits.maxTextureDimension2D + 1, 1],
-          // Test the bound of array layers
-          [1, 1, DefaultLimits.maxTextureArrayLayers - 1],
-          [1, 1, DefaultLimits.maxTextureArrayLayers],
-          [1, 1, DefaultLimits.maxTextureArrayLayers + 1],
-        ])
-      )
+  .params(u =>
+    u
+      .combine('dimension', [undefined, '2d'] as const)
+      .combine('format', kUncompressedTextureFormats)
+      .combine('size', [
+        // Test the bound of width
+        [DefaultLimits.maxTextureDimension2D - 1, 1, 1],
+        [DefaultLimits.maxTextureDimension2D, 1, 1],
+        [DefaultLimits.maxTextureDimension2D + 1, 1, 1],
+        // Test the bound of height
+        [1, DefaultLimits.maxTextureDimension2D - 1, 1],
+        [1, DefaultLimits.maxTextureDimension2D, 1],
+        [1, DefaultLimits.maxTextureDimension2D + 1, 1],
+        // Test the bound of array layers
+        [1, 1, DefaultLimits.maxTextureArrayLayers - 1],
+        [1, 1, DefaultLimits.maxTextureArrayLayers],
+        [1, 1, DefaultLimits.maxTextureArrayLayers + 1],
+      ])
   )
   .fn(async t => {
     const { dimension, format, size } = t.params;
@@ -460,13 +461,13 @@ g.test('texture_size,2d_texture,uncompressed_format')
 
 g.test('texture_size,2d_texture,compressed_format')
   .desc(`Test texture size requirement for 2D texture with compressed format.`)
-  .cases(poptions('dimension', [undefined, '2d'] as const))
-  .subcases(() =>
-    params()
-      .combine(poptions('format', kCompressedTextureFormats))
-      .expand(p => {
+  .params(u =>
+    u
+      .combine('dimension', [undefined, '2d'] as const)
+      .combine('format', kCompressedTextureFormats)
+      .expand('size', p => {
         const { blockWidth, blockHeight } = kAllTextureFormatInfo[p.format];
-        return poptions('size', [
+        return [
           // Test the bound of width
           [DefaultLimits.maxTextureDimension2D - 1, 1, 1],
           [DefaultLimits.maxTextureDimension2D - blockWidth, 1, 1],
@@ -498,7 +499,7 @@ g.test('texture_size,2d_texture,compressed_format')
           [blockWidth, 1, DefaultLimits.maxTextureArrayLayers + 1],
           [1, blockHeight, DefaultLimits.maxTextureArrayLayers + 1],
           [blockWidth, blockHeight, DefaultLimits.maxTextureArrayLayers + 1],
-        ]);
+        ];
       })
   )
   .fn(async t => {
@@ -532,25 +533,23 @@ g.test('texture_size,2d_texture,compressed_format')
 
 g.test('texture_size,3d_texture,uncompressed_format')
   .desc(`Test texture size requirement for 3D texture with uncompressed format.`)
-  .subcases(() =>
-    params()
-      .combine(poptions('format', kUncompressedTextureFormats))
-      .combine(
-        poptions('size', [
-          // Test the bound of width
-          [DefaultLimits.maxTextureDimension3D - 1, 1, 1],
-          [DefaultLimits.maxTextureDimension3D, 1, 1],
-          [DefaultLimits.maxTextureDimension3D + 1, 1, 1],
-          // Test the bound of height
-          [1, DefaultLimits.maxTextureDimension3D - 1, 1],
-          [1, DefaultLimits.maxTextureDimension3D, 1],
-          [1, DefaultLimits.maxTextureDimension3D + 1, 1],
-          // Test the bound of depth
-          [1, 1, DefaultLimits.maxTextureDimension3D - 1],
-          [1, 1, DefaultLimits.maxTextureDimension3D],
-          [1, 1, DefaultLimits.maxTextureDimension3D + 1],
-        ])
-      )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('format', kUncompressedTextureFormats)
+      .combine('size', [
+        // Test the bound of width
+        [DefaultLimits.maxTextureDimension3D - 1, 1, 1],
+        [DefaultLimits.maxTextureDimension3D, 1, 1],
+        [DefaultLimits.maxTextureDimension3D + 1, 1, 1],
+        // Test the bound of height
+        [1, DefaultLimits.maxTextureDimension3D - 1, 1],
+        [1, DefaultLimits.maxTextureDimension3D, 1],
+        [1, DefaultLimits.maxTextureDimension3D + 1, 1],
+        // Test the bound of depth
+        [1, 1, DefaultLimits.maxTextureDimension3D - 1],
+        [1, 1, DefaultLimits.maxTextureDimension3D],
+        [1, 1, DefaultLimits.maxTextureDimension3D + 1],
+      ])
   )
   .fn(async t => {
     const { format, size } = t.params;
@@ -575,12 +574,12 @@ g.test('texture_size,3d_texture,uncompressed_format')
 
 g.test('texture_size,3d_texture,compressed_format')
   .desc(`Test texture size requirement for 3D texture with compressed format.`)
-  .subcases(() =>
-    params()
-      .combine(poptions('format', kCompressedTextureFormats))
-      .expand(p => {
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('format', kCompressedTextureFormats)
+      .expand('size', p => {
         const { blockWidth, blockHeight } = kAllTextureFormatInfo[p.format];
-        return poptions('size', [
+        return [
           // Test the bound of width
           [DefaultLimits.maxTextureDimension3D - 1, 1, 1],
           [DefaultLimits.maxTextureDimension3D - blockWidth, 1, 1],
@@ -612,7 +611,7 @@ g.test('texture_size,3d_texture,compressed_format')
           [blockWidth, 1, DefaultLimits.maxTextureDimension3D + 1],
           [1, blockHeight, DefaultLimits.maxTextureDimension3D + 1],
           [blockWidth, blockHeight, DefaultLimits.maxTextureDimension3D + 1],
-        ]);
+        ];
       })
   )
   .fn(async t => {
@@ -652,15 +651,16 @@ g.test('texture_usage')
   .desc(
     `Test texture usage (single usage or combined usages) for every texture format and every dimension type`
   )
-  .cases(poptions('dimension', [undefined, ...kTextureDimensions]))
-  .subcases(({ dimension }) =>
-    params()
-      .combine(poptions('format', kAllTextureFormats))
+  .params(u =>
+    u
+      .combine('dimension', [undefined, ...kTextureDimensions])
+      .beginSubcases()
+      .combine('format', kAllTextureFormats)
       // If usage0 and usage1 are the same, then the usage being test is a single usage. Otherwise, it is a combined usage.
-      .combine(poptions('usage0', kTextureUsages))
-      .combine(poptions('usage1', kTextureUsages))
+      .combine('usage0', kTextureUsages)
+      .combine('usage1', kTextureUsages)
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
   )
   .fn(async t => {
     const { dimension, format, usage0, usage1 } = t.params;

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -93,7 +93,7 @@ g.test('creating_texture_view_on_a_2D_non_array_texture')
 
   TODO: mipLevelCount == 0 should mean 0, not "auto". "undefined" means "auto".`
   )
-  .params([
+  .paramsSimple([
     { _success: true }, // default view works
     { arrayLayerCount: 1, _success: true }, // it is OK to create a 2D texture view on a 2D texture
     { arrayLayerCount: 2, _success: false }, // it is an error to view a layer past the end of the texture
@@ -135,7 +135,7 @@ g.test('creating_texture_view_on_a_2D_array_texture')
 
   TODO: arrayLayerCount == 0 should mean 0, not "auto". "undefined" means "auto".`
   )
-  .params([
+  .paramsSimple([
     { _success: true }, // default view works
     { dimension: '2d' as const, arrayLayerCount: 1, _success: true }, // it is OK to create a 2D texture view on a 2D array texture
     { arrayLayerCount: ARRAY_LAYER_COUNT_2D, _success: true }, // it is OK to create a 2D array texture view on a 2D array texture
@@ -167,7 +167,7 @@ g.test('creating_texture_view_on_a_2D_array_texture')
   });
 
 g.test('Using_defaults_validates_the_same_as_setting_values_for_more_than_1_array_layer')
-  .params([
+  .paramsSimple([
     { _success: true },
     { format: 'rgba8unorm', _success: true },
     { format: 'r8unorm', _success: false },
@@ -195,7 +195,7 @@ g.test('Using_defaults_validates_the_same_as_setting_values_for_more_than_1_arra
   });
 
 g.test('Using_defaults_validates_the_same_as_setting_values_for_only_1_array_layer')
-  .params([
+  .paramsSimple([
     { _success: true },
     { format: 'rgba8unorm', _success: true },
     { format: 'r8unorm', _success: false },
@@ -220,7 +220,7 @@ g.test('Using_defaults_validates_the_same_as_setting_values_for_only_1_array_lay
   });
 
 g.test('creating_cube_map_texture_view')
-  .params([
+  .paramsSimple([
     { dimension: 'cube', arrayLayerCount: 6, _success: true }, // it is OK to create a cube map texture view with arrayLayerCount == 6
     // it is an error to create a cube map texture view with arrayLayerCount != 6
     { dimension: 'cube', arrayLayerCount: 3, _success: false },
@@ -248,7 +248,7 @@ g.test('creating_cube_map_texture_view')
   });
 
 g.test('creating_cube_map_texture_view_with_a_non_square_texture')
-  .params([
+  .paramsSimple([
     { dimension: 'cube', arrayLayerCount: 6 }, // it is an error to create a cube map texture view with width != height.
     { dimension: 'cube-array', arrayLayerCount: 12 }, // it is an error to create a cube map array texture view with width != height.
   ] as const)

--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -6,7 +6,6 @@ TODO:
 - Move all the tests here to image_copy/ and test writeTexture() with depth/stencil formats.
 `;
 
-import { poptions, params } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { assert } from '../../../../../common/framework/util/util.js';
 import {
@@ -55,9 +54,11 @@ g.test('depth_stencil_format,copy_usage_and_aspect')
   and copyTextureToBuffer. See https://gpuweb.github.io/gpuweb/#depth-formats for more details.
 `
   )
-  .cases(params().combine(poptions('format', kDepthStencilFormats)))
-  .subcases(() =>
-    params().combine(poptions('aspect', ['all', 'depth-only', 'stencil-only'] as const))
+  .params(u =>
+    u //
+      .combine('format', kDepthStencilFormats)
+      .beginSubcases()
+      .combine('aspect', ['all', 'depth-only', 'stencil-only'] as const)
   )
   .fn(async t => {
     const { format, aspect } = t.params;
@@ -99,23 +100,20 @@ g.test('depth_stencil_format,copy_buffer_size')
   required buffer size.
 `
   )
-  .cases(
-    params()
-      .combine(poptions('format', kDepthStencilFormats))
-      .combine(poptions('aspect', ['depth-only', 'stencil-only'] as const))
-      .combine(poptions('copyType', ['CopyB2T', 'CopyT2B'] as const))
+  .params(u =>
+    u
+      .combine('format', kDepthStencilFormats)
+      .combine('aspect', ['depth-only', 'stencil-only'] as const)
+      .combine('copyType', ['CopyB2T', 'CopyT2B'] as const)
       .filter(param =>
         depthStencilBufferTextureCopySupported(param.copyType, param.format, param.aspect)
       )
-  )
-  .subcases(() =>
-    params().combine(
-      poptions('copySize', [
+      .beginSubcases()
+      .combine('copySize', [
         { width: 8, height: 1, depthOrArrayLayers: 1 },
         { width: 4, height: 4, depthOrArrayLayers: 1 },
         { width: 4, height: 4, depthOrArrayLayers: 3 },
       ])
-    )
   )
   .fn(async t => {
     const { format, aspect, copyType, copySize } = t.params;
@@ -183,16 +181,17 @@ g.test('depth_stencil_format,copy_buffer_offset')
     copyBufferToTexture() and copyTextureToBuffer().
     `
   )
-  .cases(
-    params()
-      .combine(poptions('format', kDepthStencilFormats))
-      .combine(poptions('aspect', ['depth-only', 'stencil-only'] as const))
-      .combine(poptions('copyType', ['CopyB2T', 'CopyT2B'] as const))
+  .params(u =>
+    u
+      .combine('format', kDepthStencilFormats)
+      .combine('aspect', ['depth-only', 'stencil-only'] as const)
+      .combine('copyType', ['CopyB2T', 'CopyT2B'] as const)
       .filter(param =>
         depthStencilBufferTextureCopySupported(param.copyType, param.format, param.aspect)
       )
+      .beginSubcases()
+      .combine('offset', [1, 2, 4, 6, 8])
   )
-  .subcases(() => poptions('offset', [1, 2, 4, 6, 8]))
   .fn(async t => {
     const { format, aspect, copyType, offset } = t.params;
     await t.selectDeviceForTextureFormatOrSkipTestCase(format);

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -4,7 +4,6 @@ API validation test for compute pass
 Does **not** test usage scopes (resource_usages/) or programmable pass stuff (programmable_pass).
 `;
 
-import { params, poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
@@ -51,7 +50,7 @@ g.test('set_pipeline')
 setPipeline should generate an error iff using an 'invalid' pipeline.
 `
   )
-  .params(poptions('state', ['valid', 'invalid'] as const))
+  .params(u => u.beginSubcases().combine('state', ['valid', 'invalid'] as const))
   .fn(t => {
     const pipeline = t.createComputePipeline(t.params.state);
     const { encoder, finish } = t.createEncoder('compute pass');
@@ -70,15 +69,14 @@ Test 'direct' and 'indirect' dispatch with various sizes.
     - invalid, TODO: workSizes {x,y,z} just under and above limit, once limit is established.
 `
   )
-  .params(
-    params()
-      .combine(poptions('dispatchType', ['direct', 'indirect'] as const))
-      .combine(
-        poptions('workSizes', [
-          [0, 0, 0],
-          [1, 1, 1],
-        ] as const)
-      )
+  .params(u =>
+    u
+      .combine('dispatchType', ['direct', 'indirect'] as const)
+      .beginSubcases()
+      .combine('workSizes', [
+        [0, 0, 0],
+        [1, 1, 1],
+      ] as const)
   )
   .fn(t => {
     const pipeline = t.createNoOpComputePipeline();
@@ -109,21 +107,19 @@ TODO: test specifically which call the validation error occurs in.
       (Should be finish() for invalid, but submit() for destroyed.)
 `
   )
-  .params(
-    params()
-      .combine(poptions('state', ['valid', 'invalid', 'destroyed'] as const))
-      .combine(
-        poptions('offset', [
-          // valid (for 'valid' buffers)
-          0,
-          Uint32Array.BYTES_PER_ELEMENT,
-          kBufferData.byteLength - 3 * Uint32Array.BYTES_PER_ELEMENT,
-          // invalid, non-multiple of 4 offset
-          1,
-          // invalid, last element outside buffer
-          kBufferData.byteLength - 2 * Uint32Array.BYTES_PER_ELEMENT,
-        ])
-      )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('state', ['valid', 'invalid', 'destroyed'] as const)
+      .combine('offset', [
+        // valid (for 'valid' buffers)
+        0,
+        Uint32Array.BYTES_PER_ELEMENT,
+        kBufferData.byteLength - 3 * Uint32Array.BYTES_PER_ELEMENT,
+        // invalid, non-multiple of 4 offset
+        1,
+        // invalid, last element outside buffer
+        kBufferData.byteLength - 2 * Uint32Array.BYTES_PER_ELEMENT,
+      ])
   )
   .fn(t => {
     const { state, offset } = t.params;

--- a/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
@@ -23,7 +23,6 @@ Test Plan:
 * Source buffer and destination buffer are the same buffer
 `;
 
-import { poptions, params } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kBufferUsages } from '../../../../capability_info.js';
 import { kMaxSafeMultipleOf8 } from '../../../../util/math.js';
@@ -79,10 +78,10 @@ g.test('copy_with_invalid_buffer').fn(async t => {
 });
 
 g.test('buffer_usage')
-  .params(
-    params()
-      .combine(poptions('srcUsage', kBufferUsages))
-      .combine(poptions('dstUsage', kBufferUsages))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('srcUsage', kBufferUsages)
+      .combine('dstUsage', kBufferUsages)
   )
   .fn(async t => {
     const { srcUsage, dstUsage } = t.params;
@@ -109,7 +108,7 @@ g.test('buffer_usage')
   });
 
 g.test('copy_size_alignment')
-  .params([
+  .paramsSubcasesOnly([
     { copySize: 0, _isSuccess: true },
     { copySize: 2, _isSuccess: false },
     { copySize: 4, _isSuccess: true },
@@ -139,7 +138,7 @@ g.test('copy_size_alignment')
   });
 
 g.test('copy_offset_alignment')
-  .params([
+  .paramsSubcasesOnly([
     { srcOffset: 0, dstOffset: 0, _isSuccess: true },
     { srcOffset: 2, dstOffset: 0, _isSuccess: false },
     { srcOffset: 4, dstOffset: 0, _isSuccess: true },
@@ -174,7 +173,7 @@ g.test('copy_offset_alignment')
   });
 
 g.test('copy_overflow')
-  .params([
+  .paramsSubcasesOnly([
     { srcOffset: 0, dstOffset: 0, copySize: kMaxSafeMultipleOf8 },
     { srcOffset: 16, dstOffset: 0, copySize: kMaxSafeMultipleOf8 },
     { srcOffset: 0, dstOffset: 16, copySize: kMaxSafeMultipleOf8 },
@@ -211,7 +210,7 @@ g.test('copy_overflow')
   });
 
 g.test('copy_out_of_bounds')
-  .params([
+  .paramsSubcasesOnly([
     { srcOffset: 0, dstOffset: 0, copySize: 32, _isSuccess: true },
     { srcOffset: 0, dstOffset: 0, copySize: 36 },
     { srcOffset: 36, dstOffset: 0, copySize: 4 },
@@ -246,7 +245,7 @@ g.test('copy_out_of_bounds')
   });
 
 g.test('copy_within_same_buffer')
-  .params([
+  .paramsSubcasesOnly([
     { srcOffset: 0, dstOffset: 8, copySize: 4 },
     { srcOffset: 8, dstOffset: 0, copySize: 4 },
     { srcOffset: 0, dstOffset: 4, copySize: 8 },

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -36,7 +36,6 @@ Test Plan: (TODO(jiawei.shao@intel.com): add tests on 1D/3D textures)
     texture subresources.
 `;
 
-import { poptions, params } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import {
   kAllTextureFormatInfo,
@@ -112,19 +111,17 @@ g.test('copy_with_invalid_texture').fn(async t => {
 });
 
 g.test('mipmap_level')
-  .subcases(
-    () =>
-      [
-        { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 0 },
-        { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 1, dstCopyLevel: 0 },
-        { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 1 },
-        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 0 },
-        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 2, dstCopyLevel: 0 },
-        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 3, dstCopyLevel: 0 },
-        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 2 },
-        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 3 },
-      ] as const
-  )
+  .paramsSubcasesOnly([
+    { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 0 },
+    { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 1, dstCopyLevel: 0 },
+    { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 1 },
+    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 0 },
+    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 2, dstCopyLevel: 0 },
+    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 3, dstCopyLevel: 0 },
+    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 2 },
+    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 3 },
+  ] as const)
+
   .fn(async t => {
     const { srcLevelCount, dstLevelCount, srcCopyLevel, dstCopyLevel } = t.params;
 
@@ -151,10 +148,10 @@ g.test('mipmap_level')
   });
 
 g.test('texture_usage')
-  .params(
-    params()
-      .combine(poptions('srcUsage', kTextureUsages))
-      .combine(poptions('dstUsage', kTextureUsages))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('srcUsage', kTextureUsages)
+      .combine('dstUsage', kTextureUsages)
   )
   .fn(async t => {
     const { srcUsage, dstUsage } = t.params;
@@ -182,10 +179,10 @@ g.test('texture_usage')
   });
 
 g.test('sample_count')
-  .params(
-    params()
-      .combine(poptions('srcSampleCount', [1, 4]))
-      .combine(poptions('dstSampleCount', [1, 4]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('srcSampleCount', [1, 4])
+      .combine('dstSampleCount', [1, 4])
   )
   .fn(async t => {
     const { srcSampleCount, dstSampleCount } = t.params;
@@ -213,26 +210,22 @@ g.test('sample_count')
   });
 
 g.test('multisampled_copy_restrictions')
-  .subcases(() =>
-    params()
-      .combine(
-        poptions('srcCopyOrigin', [
-          { x: 0, y: 0, z: 0 },
-          { x: 1, y: 0, z: 0 },
-          { x: 0, y: 1, z: 0 },
-          { x: 1, y: 1, z: 0 },
-        ])
-      )
-      .combine(
-        poptions('dstCopyOrigin', [
-          { x: 0, y: 0, z: 0 },
-          { x: 1, y: 0, z: 0 },
-          { x: 0, y: 1, z: 0 },
-          { x: 1, y: 1, z: 0 },
-        ])
-      )
-      .expand(p => poptions('copyWidth', [32 - Math.max(p.srcCopyOrigin.x, p.dstCopyOrigin.x), 16]))
-      .expand(p => poptions('copyHeight', [16 - Math.max(p.srcCopyOrigin.y, p.dstCopyOrigin.y), 8]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('srcCopyOrigin', [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+        { x: 0, y: 1, z: 0 },
+        { x: 1, y: 1, z: 0 },
+      ])
+      .combine('dstCopyOrigin', [
+        { x: 0, y: 0, z: 0 },
+        { x: 1, y: 0, z: 0 },
+        { x: 0, y: 1, z: 0 },
+        { x: 1, y: 1, z: 0 },
+      ])
+      .expand('copyWidth', p => [32 - Math.max(p.srcCopyOrigin.x, p.dstCopyOrigin.x), 16])
+      .expand('copyHeight', p => [16 - Math.max(p.srcCopyOrigin.y, p.dstCopyOrigin.y), 8])
   )
   .fn(async t => {
     const { srcCopyOrigin, dstCopyOrigin, copyWidth, copyHeight } = t.params;
@@ -265,10 +258,10 @@ g.test('multisampled_copy_restrictions')
   });
 
 g.test('texture_format_equality')
-  .subcases(() =>
-    params()
-      .combine(poptions('srcFormat', kAllTextureFormats))
-      .combine(poptions('dstFormat', kAllTextureFormats))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('srcFormat', kAllTextureFormats)
+      .combine('dstFormat', kAllTextureFormats)
   )
   .fn(async t => {
     const { srcFormat, dstFormat } = t.params;
@@ -300,34 +293,29 @@ g.test('texture_format_equality')
   });
 
 g.test('depth_stencil_copy_restrictions')
-  .cases(poptions('format', kDepthStencilFormats))
-  .subcases(() =>
-    params()
-      .combine(
-        poptions('copyBoxOffsets', [
-          { x: 0, y: 0, width: 0, height: 0 },
-          { x: 1, y: 0, width: 0, height: 0 },
-          { x: 0, y: 1, width: 0, height: 0 },
-          { x: 0, y: 0, width: -1, height: 0 },
-          { x: 0, y: 0, width: 0, height: -1 },
-        ])
-      )
-      .combine(
-        poptions('srcTextureSize', [
-          { width: 64, height: 64, depthOrArrayLayers: 1 },
-          { width: 64, height: 32, depthOrArrayLayers: 1 },
-          { width: 32, height: 32, depthOrArrayLayers: 1 },
-        ])
-      )
-      .combine(
-        poptions('dstTextureSize', [
-          { width: 64, height: 64, depthOrArrayLayers: 1 },
-          { width: 64, height: 32, depthOrArrayLayers: 1 },
-          { width: 32, height: 32, depthOrArrayLayers: 1 },
-        ])
-      )
-      .combine(poptions('srcCopyLevel', [1, 2]))
-      .combine(poptions('dstCopyLevel', [0, 1]))
+  .params(u =>
+    u
+      .combine('format', kDepthStencilFormats)
+      .beginSubcases()
+      .combine('copyBoxOffsets', [
+        { x: 0, y: 0, width: 0, height: 0 },
+        { x: 1, y: 0, width: 0, height: 0 },
+        { x: 0, y: 1, width: 0, height: 0 },
+        { x: 0, y: 0, width: -1, height: 0 },
+        { x: 0, y: 0, width: 0, height: -1 },
+      ])
+      .combine('srcTextureSize', [
+        { width: 64, height: 64, depthOrArrayLayers: 1 },
+        { width: 64, height: 32, depthOrArrayLayers: 1 },
+        { width: 32, height: 32, depthOrArrayLayers: 1 },
+      ])
+      .combine('dstTextureSize', [
+        { width: 64, height: 64, depthOrArrayLayers: 1 },
+        { width: 64, height: 32, depthOrArrayLayers: 1 },
+        { width: 32, height: 32, depthOrArrayLayers: 1 },
+      ])
+      .combine('srcCopyLevel', [1, 2])
+      .combine('dstCopyLevel', [0, 1])
   )
   .fn(async t => {
     const {
@@ -388,27 +376,25 @@ g.test('depth_stencil_copy_restrictions')
   });
 
 g.test('copy_ranges')
-  .subcases(() =>
-    params()
-      .combine(
-        poptions('copyBoxOffsets', [
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
-          { x: 1, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
-          { x: 1, y: 0, z: 0, width: -1, height: 0, depthOrArrayLayers: -2 },
-          { x: 0, y: 1, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
-          { x: 0, y: 1, z: 0, width: 0, height: -1, depthOrArrayLayers: -2 },
-          { x: 0, y: 0, z: 1, width: 0, height: 1, depthOrArrayLayers: -2 },
-          { x: 0, y: 0, z: 2, width: 0, height: 1, depthOrArrayLayers: 0 },
-          { x: 0, y: 0, z: 0, width: 1, height: 0, depthOrArrayLayers: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: 1, depthOrArrayLayers: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: 1 },
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: 0 },
-          { x: 0, y: 0, z: 1, width: 0, height: 0, depthOrArrayLayers: -1 },
-          { x: 0, y: 0, z: 2, width: 0, height: 0, depthOrArrayLayers: -1 },
-        ])
-      )
-      .combine(poptions('srcCopyLevel', [0, 1, 3]))
-      .combine(poptions('dstCopyLevel', [0, 1, 3]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('copyBoxOffsets', [
+        { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+        { x: 1, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+        { x: 1, y: 0, z: 0, width: -1, height: 0, depthOrArrayLayers: -2 },
+        { x: 0, y: 1, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+        { x: 0, y: 1, z: 0, width: 0, height: -1, depthOrArrayLayers: -2 },
+        { x: 0, y: 0, z: 1, width: 0, height: 1, depthOrArrayLayers: -2 },
+        { x: 0, y: 0, z: 2, width: 0, height: 1, depthOrArrayLayers: 0 },
+        { x: 0, y: 0, z: 0, width: 1, height: 0, depthOrArrayLayers: -2 },
+        { x: 0, y: 0, z: 0, width: 0, height: 1, depthOrArrayLayers: -2 },
+        { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: 1 },
+        { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: 0 },
+        { x: 0, y: 0, z: 1, width: 0, height: 0, depthOrArrayLayers: -1 },
+        { x: 0, y: 0, z: 2, width: 0, height: 0, depthOrArrayLayers: -1 },
+      ])
+      .combine('srcCopyLevel', [0, 1, 3])
+      .combine('dstCopyLevel', [0, 1, 3])
   )
   .fn(async t => {
     const { copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
@@ -480,11 +466,11 @@ g.test('copy_ranges')
   });
 
 g.test('copy_within_same_texture')
-  .subcases(() =>
-    params()
-      .combine(poptions('srcCopyOriginZ', [0, 2, 4]))
-      .combine(poptions('dstCopyOriginZ', [0, 2, 4]))
-      .combine(poptions('copyExtentDepth', [1, 2, 3]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('srcCopyOriginZ', [0, 2, 4])
+      .combine('dstCopyOriginZ', [0, 2, 4])
+      .combine('copyExtentDepth', [1, 2, 3])
   )
   .fn(async t => {
     const { srcCopyOriginZ, dstCopyOriginZ, copyExtentDepth } = t.params;
@@ -517,11 +503,12 @@ Test the validations on the member 'aspect' of GPUImageCopyTexture in CopyTextur
 - for all the stencil-only formats: the texture copy aspects must be either 'all' or 'stencil-only'.
 `
   )
-  .cases(poptions('format', ['rgba8unorm', ...kDepthStencilFormats] as const))
-  .subcases(() =>
-    params()
-      .combine(poptions('sourceAspect', ['all', 'depth-only', 'stencil-only'] as const))
-      .combine(poptions('destinationAspect', ['all', 'depth-only', 'stencil-only'] as const))
+  .params(u =>
+    u
+      .combine('format', ['rgba8unorm', ...kDepthStencilFormats] as const)
+      .beginSubcases()
+      .combine('sourceAspect', ['all', 'depth-only', 'stencil-only'] as const)
+      .combine('destinationAspect', ['all', 'depth-only', 'stencil-only'] as const)
   )
   .fn(async t => {
     const { format, sourceAspect, destinationAspect } = t.params;
@@ -568,26 +555,25 @@ Test the validations on the member 'aspect' of GPUImageCopyTexture in CopyTextur
   });
 
 g.test('copy_ranges_with_compressed_texture_formats')
-  .cases(poptions('format', kCompressedTextureFormats))
-  .subcases(() =>
-    params()
-      .combine(
-        poptions('copyBoxOffsets', [
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
-          { x: 1, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
-          { x: 4, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
-          { x: 0, y: 0, z: 0, width: -1, height: 0, depthOrArrayLayers: -2 },
-          { x: 0, y: 0, z: 0, width: -4, height: 0, depthOrArrayLayers: -2 },
-          { x: 0, y: 1, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
-          { x: 0, y: 4, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: -1, depthOrArrayLayers: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: -4, depthOrArrayLayers: -2 },
-          { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: 0 },
-          { x: 0, y: 0, z: 1, width: 0, height: 0, depthOrArrayLayers: -1 },
-        ])
-      )
-      .combine(poptions('srcCopyLevel', [0, 1, 2]))
-      .combine(poptions('dstCopyLevel', [0, 1, 2]))
+  .params(u =>
+    u
+      .combine('format', kCompressedTextureFormats)
+      .beginSubcases()
+      .combine('copyBoxOffsets', [
+        { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+        { x: 1, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+        { x: 4, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+        { x: 0, y: 0, z: 0, width: -1, height: 0, depthOrArrayLayers: -2 },
+        { x: 0, y: 0, z: 0, width: -4, height: 0, depthOrArrayLayers: -2 },
+        { x: 0, y: 1, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+        { x: 0, y: 4, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
+        { x: 0, y: 0, z: 0, width: 0, height: -1, depthOrArrayLayers: -2 },
+        { x: 0, y: 0, z: 0, width: 0, height: -4, depthOrArrayLayers: -2 },
+        { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: 0 },
+        { x: 0, y: 0, z: 1, width: 0, height: 0, depthOrArrayLayers: -1 },
+      ])
+      .combine('srcCopyLevel', [0, 1, 2])
+      .combine('dstCopyLevel', [0, 1, 2])
   )
   .fn(async t => {
     const { format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;

--- a/src/webgpu/api/validation/encoding/cmds/debug.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/debug.spec.ts
@@ -11,18 +11,18 @@ Test Coverage:
     - Test inserting a debug marker with empty and non-empty strings.
 `;
 
-import { poptions, params } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest, kEncoderTypes } from '../../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
 
 g.test('debug_group_balanced')
-  .params(
-    params()
-      .combine(poptions('encoderType', kEncoderTypes))
-      .combine(poptions('pushCount', [0, 1, 2]))
-      .combine(poptions('popCount', [0, 1, 2]))
+  .params(u =>
+    u
+      .combine('encoderType', kEncoderTypes)
+      .beginSubcases()
+      .combine('pushCount', [0, 1, 2])
+      .combine('popCount', [0, 1, 2])
   )
   .fn(t => {
     const { encoder, finish } = t.createEncoder(t.params.encoderType);
@@ -40,10 +40,11 @@ g.test('debug_group_balanced')
   });
 
 g.test('debug_group')
-  .params(
-    params()
-      .combine(poptions('encoderType', kEncoderTypes))
-      .combine(poptions('label', ['', 'group']))
+  .params(u =>
+    u //
+      .combine('encoderType', kEncoderTypes)
+      .beginSubcases()
+      .combine('label', ['', 'group'])
   )
   .fn(t => {
     const { encoder, finish } = t.createEncoder(t.params.encoderType);
@@ -54,10 +55,11 @@ g.test('debug_group')
   });
 
 g.test('debug_marker')
-  .params(
-    params()
-      .combine(poptions('encoderType', kEncoderTypes))
-      .combine(poptions('label', ['', 'marker']))
+  .params(u =>
+    u //
+      .combine('encoderType', kEncoderTypes)
+      .beginSubcases()
+      .combine('label', ['', 'marker'])
   )
   .fn(t => {
     const maker = t.createEncoder(t.params.encoderType);

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -13,7 +13,6 @@ TODO: Since there are no errors here, these should be "robustness" operation tes
 valid results).
 `;
 
-import { params, poptions, pbool } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
@@ -137,11 +136,12 @@ g.test('out_of_bounds')
     - max uint32 firstIndex and small indexCount
     Together with normal and large instanceCount`
   )
-  .cases(pbool('indirect'))
-  .subcases(
-    () =>
-      params()
-        .combine([
+  .params(
+    u =>
+      u
+        .combine('indirect', [false, true])
+        .beginSubcases()
+        .combineWithParams([
           { indexCount: 6, firstIndex: 1 }, // indexCount + firstIndex out of bound
           { indexCount: 0, firstIndex: 6 }, // indexCount is 0 but firstIndex out of bound
           { indexCount: 6, firstIndex: 6 }, // only firstIndex out of bound
@@ -152,7 +152,7 @@ g.test('out_of_bounds')
           { indexCount: 0xffffffff, firstIndex: 2 }, // max uint32 indexCount and small firstIndex
           { indexCount: 2, firstIndex: 0xffffffff }, // small indexCount and max uint32 firstIndex
         ] as const)
-        .combine(poptions('instanceCount', [1, 10000])) // normal and large instanceCount
+        .combine('instanceCount', [1, 10000]) // normal and large instanceCount
   )
   .fn(t => {
     const { indirect, indexCount, firstIndex, instanceCount } = t.params;
@@ -180,17 +180,17 @@ g.test('out_of_bounds_zero_sized_index_buffer')
     - both are 0s (not out of bound) but index buffer size is 0
     Together with normal and large instanceCount`
   )
-  .cases(pbool('indirect'))
-  .subcases(
-    () =>
-      params()
-        .combine([
+  .params(
+    u =>
+      u
+        .combine('indirect', [false, true])
+        .combineWithParams([
           { indexCount: 3, firstIndex: 1 }, // indexCount + firstIndex out of bound
           { indexCount: 0, firstIndex: 1 }, // indexCount is 0 but firstIndex out of bound
           { indexCount: 3, firstIndex: 0 }, // only indexCount out of bound
           { indexCount: 0, firstIndex: 0 }, // just zeros
         ] as const)
-        .combine(poptions('instanceCount', [1, 10000])) // normal and large instanceCount
+        .combine('instanceCount', [1, 10000]) // normal and large instanceCount
   )
   .fn(t => {
     const { indirect, indexCount, firstIndex, instanceCount } = t.params;

--- a/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
@@ -22,7 +22,6 @@ TODO: ensure existing tests cover these notes. Note many of these may be operati
 >     - used with a simple pipeline that {does, doesn't} use it
 `;
 
-import { params } from '../../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../../validation_test.js';
 
@@ -133,7 +132,7 @@ export const g = makeTestGroup(F);
 
 g.test('setViewport,x_y_width_height_nonnegative')
   .desc('Test that the parameters of setViewport to define the box must be non-negative.')
-  .params([
+  .paramsSubcasesOnly([
     // Control case: everything to 0 is ok, covers the empty viewport case.
     { x: 0, y: 0, w: 0, h: 0 },
 
@@ -156,15 +155,15 @@ g.test('setViewport,xy_rect_contained_in_attachment')
   .desc(
     'Test that the rectangle defined by x, y, width, height must be contained in the attachments'
   )
-  .params(
-    params()
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u
+      .combineWithParams([
         { attachmentWidth: 3, attachmentHeight: 5 },
         { attachmentWidth: 5, attachmentHeight: 3 },
         { attachmentWidth: 1024, attachmentHeight: 1 },
         { attachmentWidth: 1, attachmentHeight: 1024 },
       ])
-      .combine([
+      .combineWithParams([
         // Control case: a full viewport is valid.
         { dx: 0, dy: 0, dw: 0, dh: 0 },
 
@@ -198,7 +197,7 @@ g.test('setViewport,xy_rect_contained_in_attachment')
 
 g.test('setViewport,depth_rangeAndOrder')
   .desc('Test that 0 <= minDepth <= maxDepth <= 1')
-  .params([
+  .paramsSubcasesOnly([
     // Success cases
     { minDepth: 0, maxDepth: 1 },
     { minDepth: -0, maxDepth: -0 },
@@ -223,7 +222,7 @@ g.test('setScissorRect,x_y_width_height_nonnegative')
   .desc(
     'Test that the parameters of setScissorRect to define the box must be non-negative or a TypeError is thrown.'
   )
-  .params([
+  .paramsSubcasesOnly([
     // Control case: everything to 0 is ok, covers the empty scissor case.
     { x: 0, y: 0, w: 0, h: 0 },
 
@@ -246,15 +245,15 @@ g.test('setScissorRect,xy_rect_contained_in_attachment')
   .desc(
     'Test that the rectangle defined by x, y, width, height must be contained in the attachments'
   )
-  .params(
-    params()
-      .combine([
+  .paramsSubcasesOnly(u =>
+    u
+      .combineWithParams([
         { attachmentWidth: 3, attachmentHeight: 5 },
         { attachmentWidth: 5, attachmentHeight: 3 },
         { attachmentWidth: 1024, attachmentHeight: 1 },
         { attachmentWidth: 1, attachmentHeight: 1024 },
       ])
-      .combine([
+      .combineWithParams([
         // Control case: a full scissor is valid.
         { dx: 0, dy: 0, dw: 0, dh: 0 },
 
@@ -288,7 +287,7 @@ g.test('setScissorRect,xy_rect_contained_in_attachment')
 
 g.test('setBlendConstant')
   .desc('Test that almost any color value is valid for setBlendConstant')
-  .params([
+  .paramsSubcasesOnly([
     { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
     { r: -1.0, g: -1.0, b: -1.0, a: -1.0 },
     { r: Number.MAX_SAFE_INTEGER, g: Number.MIN_SAFE_INTEGER, b: -0, a: 100000 },
@@ -303,7 +302,7 @@ g.test('setBlendConstant')
 
 g.test('setStencilReference')
   .desc('Test that almost any stencil reference value is valid for setStencilReference')
-  .params([
+  .paramsSubcasesOnly([
     { value: 1 }, //
     { value: 0 },
     { value: 1000 },

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -10,7 +10,6 @@ TODO: merge these notes and implement.
 >     - setBindGroup in different orders (e.g. 0,1,2 vs 2,0,1)
 `;
 
-import { poptions, params, pbool } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { range, unreachable } from '../../../../../common/framework/util/util.js';
 import { kMinDynamicBufferOffsetAlignment } from '../../../../capability_info.js';
@@ -98,11 +97,11 @@ export const g = makeTestGroup(F);
 
 g.test('state_and_binding_index')
   .desc('Tests that setBindGroup correctly handles {valid, invalid} bindGroups.')
-  .cases(
-    params()
-      .combine(poptions('encoderType', kProgrammableEncoderTypes))
-      .combine(poptions('state', ['valid', 'invalid', 'destroyed'] as const))
-      .combine(poptions('resourceType', ['buffer', 'texture'] as const))
+  .params(u =>
+    u
+      .combine('encoderType', kProgrammableEncoderTypes)
+      .combine('state', ['valid', 'invalid', 'destroyed'] as const)
+      .combine('resourceType', ['buffer', 'texture'] as const)
   )
   .fn(async t => {
     const { encoderType, state, resourceType } = t.params;
@@ -139,7 +138,7 @@ g.test('state_and_binding_index')
 
 g.test('dynamic_offsets_passed_but_not_expected')
   .desc('Tests that setBindGroup correctly errors on unexpected dynamicOffsets.')
-  .cases(poptions('encoderType', kProgrammableEncoderTypes))
+  .params(u => u.combine('encoderType', kProgrammableEncoderTypes))
   .fn(async t => {
     const { encoderType } = t.params;
     const bindGroup = t.createBindGroup('valid', 'buffer', encoderType, []);
@@ -155,10 +154,10 @@ g.test('dynamic_offsets_passed_but_not_expected')
 
 g.test('dynamic_offsets_match_expectations_in_pass_encoder')
   .desc('Tests that given dynamicOffsets match the specified bindGroup.')
-  .cases(
-    params()
-      .combine(poptions('encoderType', kProgrammableEncoderTypes))
-      .combine([
+  .params(u =>
+    u
+      .combine('encoderType', kProgrammableEncoderTypes)
+      .combineWithParams([
         { dynamicOffsets: [256, 0], _success: true }, // Dynamic offsets aligned
         { dynamicOffsets: [1, 2], _success: false }, // Dynamic offsets not aligned
 
@@ -177,7 +176,7 @@ g.test('dynamic_offsets_match_expectations_in_pass_encoder')
         { dynamicOffsets: [0, 1024], _success: false },
         { dynamicOffsets: [0, 0xffffffff], _success: false },
       ])
-      .combine(pbool('useU32array'))
+      .combine('useU32array', [false, true])
   )
   .fn(async t => {
     const kBindingSize = 9;
@@ -249,7 +248,7 @@ g.test('dynamic_offsets_match_expectations_in_pass_encoder')
 
 g.test('u32array_start_and_length')
   .desc('Tests that dynamicOffsetsData(Start|Length) apply to the given Uint32Array.')
-  .subcases(() => [
+  .paramsSubcasesOnly([
     // dynamicOffsetsDataLength > offsets.length
     {
       offsets: [0] as const,

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -89,7 +89,7 @@ class F extends ValidationTest {
 export const g = makeTestGroup(F);
 
 g.test('it_is_invalid_to_draw_in_a_render_pass_with_missing_bind_groups')
-  .params([
+  .paramsSubcasesOnly([
     { setBindGroup1: true, setBindGroup2: true, _success: true },
     { setBindGroup1: true, setBindGroup2: false, _success: false },
     { setBindGroup1: false, setBindGroup2: true, _success: false },

--- a/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
@@ -14,7 +14,6 @@ TODO: tests for pipeline statistics queries:
         - }
 `;
 
-import { pbool } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
@@ -33,16 +32,13 @@ Tests that begin/end occlusion queries mismatch on render pass:
 - begin n queries, then end m queries, for various n and m.
   `
   )
-  .subcases(
-    () =>
-      [
-        { begin: 0, end: 1 },
-        { begin: 1, end: 0 },
-        { begin: 1, end: 1 }, // control case
-        { begin: 1, end: 2 },
-        { begin: 2, end: 1 },
-      ] as const
-  )
+  .paramsSubcasesOnly([
+    { begin: 0, end: 1 },
+    { begin: 1, end: 0 },
+    { begin: 1, end: 1 }, // control case
+    { begin: 1, end: 2 },
+    { begin: 2, end: 1 },
+  ] as const)
   .fn(async t => {
     const { begin, end } = t.params;
     const querySet = createQuerySetWithType(t, 'occlusion', 2);
@@ -69,14 +65,11 @@ Tests the invalid nesting of begin/end occlusion queries:
 - begin index 0, begin index 1, end, end
   `
   )
-  .subcases(
-    () =>
-      [
-        { calls: [0, 'end', 1, 'end'], _valid: true }, // control case
-        { calls: [0, 0, 'end', 'end'], _valid: false },
-        { calls: [0, 1, 'end', 'end'], _valid: false },
-      ] as const
-  )
+  .paramsSubcasesOnly([
+    { calls: [0, 'end', 1, 'end'], _valid: true }, // control case
+    { calls: [0, 0, 'end', 'end'], _valid: false },
+    { calls: [0, 1, 'end', 'end'], _valid: false },
+  ] as const)
   .fn(async t => {
     const querySet = createQuerySetWithType(t, 'occlusion', 2);
 
@@ -103,7 +96,7 @@ Tests that two disjoint occlusion queries cannot be begun with same query index 
 - call on {same (invalid), different (control case)} render pass
   `
   )
-  .subcases(() => pbool('isOnSameRenderPass'))
+  .paramsSubcasesOnly(u => u.combine('isOnSameRenderPass', [false, true]))
   .fn(async t => {
     const querySet = createQuerySetWithType(t, 'occlusion', 1);
 
@@ -136,44 +129,41 @@ Tests that whether it's allowed to nest various types of queries:
 - call {occlusion, pipeline-statistics, timestamp} query in same type or other type.
   `
   )
-  .subcases(
-    () =>
-      [
-        { begin: 'occlusion', nest: 'timestamp', end: 'occlusion', _valid: true },
-        { begin: 'occlusion', nest: 'occlusion', end: 'occlusion', _valid: false },
-        { begin: 'occlusion', nest: 'pipeline-statistics', end: 'occlusion', _valid: true },
-        {
-          begin: 'occlusion',
-          nest: 'pipeline-statistics',
-          end: 'pipeline-statistics',
-          _valid: true,
-        },
-        {
-          begin: 'pipeline-statistics',
-          nest: 'timestamp',
-          end: 'pipeline-statistics',
-          _valid: true,
-        },
-        {
-          begin: 'pipeline-statistics',
-          nest: 'pipeline-statistics',
-          end: 'pipeline-statistics',
-          _valid: false,
-        },
-        {
-          begin: 'pipeline-statistics',
-          nest: 'occlusion',
-          end: 'pipeline-statistics',
-          _valid: true,
-        },
-        { begin: 'pipeline-statistics', nest: 'occlusion', end: 'occlusion', _valid: true },
-        { begin: 'timestamp', nest: 'occlusion', end: 'occlusion', _valid: true },
-        {
-          begin: 'timestamp',
-          nest: 'pipeline-statistics',
-          end: 'pipeline-statistics',
-          _valid: true,
-        },
-      ] as const
-  )
+  .paramsSubcasesOnly([
+    { begin: 'occlusion', nest: 'timestamp', end: 'occlusion', _valid: true },
+    { begin: 'occlusion', nest: 'occlusion', end: 'occlusion', _valid: false },
+    { begin: 'occlusion', nest: 'pipeline-statistics', end: 'occlusion', _valid: true },
+    {
+      begin: 'occlusion',
+      nest: 'pipeline-statistics',
+      end: 'pipeline-statistics',
+      _valid: true,
+    },
+    {
+      begin: 'pipeline-statistics',
+      nest: 'timestamp',
+      end: 'pipeline-statistics',
+      _valid: true,
+    },
+    {
+      begin: 'pipeline-statistics',
+      nest: 'pipeline-statistics',
+      end: 'pipeline-statistics',
+      _valid: false,
+    },
+    {
+      begin: 'pipeline-statistics',
+      nest: 'occlusion',
+      end: 'pipeline-statistics',
+      _valid: true,
+    },
+    { begin: 'pipeline-statistics', nest: 'occlusion', end: 'occlusion', _valid: true },
+    { begin: 'timestamp', nest: 'occlusion', end: 'occlusion', _valid: true },
+    {
+      begin: 'timestamp',
+      nest: 'pipeline-statistics',
+      end: 'pipeline-statistics',
+      _valid: true,
+    },
+  ] as const)
   .unimplemented();

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -7,7 +7,6 @@ TODO:
     - x ={render pass, compute pass} encoder
 `;
 
-import { params, poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kQueryTypes } from '../../../../capability_info.js';
 import { ValidationTest } from '../../validation_test.js';
@@ -24,7 +23,7 @@ Tests that set occlusion query set with all types in render pass descriptor:
 - {undefined} for occlusion query set in render pass descriptor
   `
   )
-  .subcases(() => poptions('type', [undefined, ...kQueryTypes]))
+  .paramsSubcasesOnly(u => u.combine('type', [undefined, ...kQueryTypes]))
   .fn(async t => {
     const type = t.params.type;
 
@@ -49,7 +48,7 @@ g.test('occlusion_query,invalid_query_set')
 Tests that begin occlusion query with a invalid query set that failed during creation.
   `
   )
-  .subcases(() => poptions('querySetState', ['valid', 'invalid'] as const))
+  .paramsSubcasesOnly(u => u.combine('querySetState', ['valid', 'invalid'] as const))
   .fn(t => {
     const querySet = t.createQuerySetWithState(t.params.querySetState);
 
@@ -69,7 +68,7 @@ Tests that begin occlusion query with query index:
 - queryIndex {in, out of} range for GPUQuerySet
   `
   )
-  .subcases(() => poptions('queryIndex', [0, 2]))
+  .paramsSubcasesOnly(u => u.combine('queryIndex', [0, 2]))
   .fn(t => {
     const querySet = createQuerySetWithType(t, 'occlusion', 2);
 
@@ -91,12 +90,13 @@ Tests that write timestamp to all types of query set on all possible encoders:
 - x= {non-pass, compute, render} encoder
   `
   )
-  .cases(
-    params()
-      .combine(poptions('encoderType', ['non-pass', 'compute pass', 'render pass'] as const))
-      .combine(poptions('type', kQueryTypes))
+  .params(u =>
+    u
+      .combine('encoderType', ['non-pass', 'compute pass', 'render pass'] as const)
+      .combine('type', kQueryTypes)
+      .beginSubcases()
+      .expand('queryIndex', p => (p.type === 'timestamp' ? [0, 2] : [0]))
   )
-  .subcases(({ type }) => poptions('queryIndex', type === 'timestamp' ? [0, 2] : [0]))
   .fn(async t => {
     const { encoderType, type, queryIndex } = t.params;
 
@@ -120,7 +120,9 @@ Tests that write timestamp to a invalid query set that failed during creation:
 - x= {non-pass, compute, render} enconder
   `
   )
-  .subcases(() => poptions('encoderType', ['non-pass', 'compute pass', 'render pass'] as const))
+  .paramsSubcasesOnly(u =>
+    u.combine('encoderType', ['non-pass', 'compute pass', 'render pass'] as const)
+  )
   .fn(async t => {
     const querySet = t.createQuerySetWithState('invalid');
 

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -1,7 +1,6 @@
 export const description = `
 Validation tests for resolveQuerySet.
 `;
-import { poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUConst } from '../../../../constants.js';
 import { ValidationTest } from '../../validation_test.js';
@@ -18,14 +17,11 @@ Tests that resolve query set with invalid object.
 - invalid destination buffer that failed during creation.
   `
   )
-  .subcases(
-    () =>
-      [
-        { querySetState: 'valid', destinationState: 'valid' }, // control case
-        { querySetState: 'invalid', destinationState: 'valid' },
-        { querySetState: 'valid', destinationState: 'invalid' },
-      ] as const
-  )
+  .paramsSubcasesOnly([
+    { querySetState: 'valid', destinationState: 'valid' }, // control case
+    { querySetState: 'invalid', destinationState: 'valid' },
+    { querySetState: 'valid', destinationState: 'invalid' },
+  ] as const)
   .fn(async t => {
     const { querySetState, destinationState } = t.params;
 
@@ -51,7 +47,7 @@ Tests that resolve query set with invalid firstQuery and queryCount:
 - firstQuery and/or queryCount out of range
   `
   )
-  .subcases(() => [
+  .paramsSubcasesOnly([
     { firstQuery: 0, queryCount: kQueryCount }, // control case
     { firstQuery: 0, queryCount: kQueryCount + 1 },
     { firstQuery: 1, queryCount: kQueryCount },
@@ -81,11 +77,12 @@ Tests that resolve query set with invalid destinationBuffer:
 - Buffer usage {with, without} QUERY_RESOLVE
   `
   )
-  .subcases(() =>
-    poptions('bufferUsage', [
-      GPUConst.BufferUsage.STORAGE,
-      GPUConst.BufferUsage.QUERY_RESOLVE, // control case
-    ] as const)
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('bufferUsage', [
+        GPUConst.BufferUsage.STORAGE,
+        GPUConst.BufferUsage.QUERY_RESOLVE, // control case
+      ] as const)
   )
   .fn(async t => {
     const querySet = t.device.createQuerySet({ type: 'occlusion', count: kQueryCount });
@@ -111,7 +108,7 @@ Tests that resolve query set with invalid destinationOffset:
 - destinationOffset out of range
   `
   )
-  .subcases(() => poptions('destinationOffset', [0, 6, 8, 16]))
+  .paramsSubcasesOnly(u => u.combine('destinationOffset', [0, 6, 8, 16]))
   .fn(async t => {
     const querySet = t.device.createQuerySet({ type: 'occlusion', count: kQueryCount });
     const destination = t.device.createBuffer({

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -1,4 +1,3 @@
-import { poptions } from '../../../../common/framework/params_builder.js';
 import { kSizedTextureFormatInfo, SizedTextureFormat } from '../../../capability_info.js';
 import { ImageCopyType } from '../../../util/texture/image_copy.js';
 import { ValidationTest } from '../validation_test.js';
@@ -123,18 +122,12 @@ interface WithFormatAndMethod extends WithFormat {
 
 // This is a helper function used for expanding test parameters for texel block alignment tests on offset
 export function texelBlockAlignmentTestExpanderForOffset({ format }: WithFormat) {
-  return poptions(
-    'offset',
-    valuesToTestDivisibilityBy(kSizedTextureFormatInfo[format].bytesPerBlock)
-  );
+  return valuesToTestDivisibilityBy(kSizedTextureFormatInfo[format].bytesPerBlock);
 }
 
 // This is a helper function used for expanding test parameters for texel block alignment tests on rowsPerImage
 export function texelBlockAlignmentTestExpanderForRowsPerImage({ format }: WithFormat) {
-  return poptions(
-    'rowsPerImage',
-    valuesToTestDivisibilityBy(kSizedTextureFormatInfo[format].blockHeight)
-  );
+  return valuesToTestDivisibilityBy(kSizedTextureFormatInfo[format].blockHeight);
 }
 
 // This is a helper function used for expanding test parameters for texel block alignment tests on origin and size
@@ -145,21 +138,15 @@ export function texelBlockAlignmentTestExpanderForValueToCoordinate({
   switch (coordinateToTest) {
     case 'x':
     case 'width':
-      return poptions(
-        'valueToCoordinate',
-        valuesToTestDivisibilityBy(kSizedTextureFormatInfo[format].blockWidth!)
-      );
+      return valuesToTestDivisibilityBy(kSizedTextureFormatInfo[format].blockWidth!);
 
     case 'y':
     case 'height':
-      return poptions(
-        'valueToCoordinate',
-        valuesToTestDivisibilityBy(kSizedTextureFormatInfo[format].blockHeight!)
-      );
+      return valuesToTestDivisibilityBy(kSizedTextureFormatInfo[format].blockHeight!);
 
     case 'z':
     case 'depthOrArrayLayers':
-      return poptions('valueToCoordinate', valuesToTestDivisibilityBy(1));
+      return valuesToTestDivisibilityBy(1);
   }
 }
 

--- a/src/webgpu/api/validation/query_set/create.spec.ts
+++ b/src/webgpu/api/validation/query_set/create.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Tests for validation in createQuerySet.
 `;
 
-import { poptions } from '../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { kQueryTypes, kMaxQueryCount } from '../../../capability_info.js';
 import { ValidationTest } from '../validation_test.js';
@@ -17,8 +16,12 @@ Tests that create query set with the count for all query types:
 - x= {occlusion, pipeline-statistics, timestamp} query
   `
   )
-  .cases(poptions('type', kQueryTypes))
-  .subcases(() => poptions('count', [0, kMaxQueryCount, kMaxQueryCount + 1]))
+  .params(u =>
+    u
+      .combine('type', kQueryTypes)
+      .beginSubcases()
+      .combine('count', [0, kMaxQueryCount, kMaxQueryCount + 1])
+  )
   .fn(async t => {
     const { type, count } = t.params;
 
@@ -41,9 +44,11 @@ Tests that create query set with the GPUPipelineStatisticName for all query type
 - x= {occlusion, pipeline-statistics, timestamp} query
   `
   )
-  .cases(poptions('type', kQueryTypes))
-  .subcases(() =>
-    poptions('pipelineStatistics', [undefined, [] as const, ['clipper-invocations'] as const])
+  .params(u =>
+    u
+      .combine('type', kQueryTypes)
+      .beginSubcases()
+      .combine('pipelineStatistics', [undefined, [] as const, ['clipper-invocations'] as const])
   )
   .fn(async t => {
     const { type, pipelineStatistics } = t.params;
@@ -69,17 +74,18 @@ g.test('pipelineStatistics,duplicates_and_all')
 Tests that create query set with the duplicate values and all values of GPUPipelineStatisticName for pipeline-statistics query.
   `
   )
-  .subcases(() =>
-    poptions('pipelineStatistics', [
-      ['clipper-invocations', 'clipper-invocations'] as const,
-      [
-        'clipper-invocations',
-        'clipper-primitives-out',
-        'compute-shader-invocations',
-        'fragment-shader-invocations',
-        'vertex-shader-invocations',
-      ] as const,
-    ])
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('pipelineStatistics', [
+        ['clipper-invocations', 'clipper-invocations'] as const,
+        [
+          'clipper-invocations',
+          'clipper-primitives-out',
+          'compute-shader-invocations',
+          'fragment-shader-invocations',
+          'vertex-shader-invocations',
+        ] as const,
+      ])
   )
   .fn(async t => {
     const type = 'pipeline-statistics';

--- a/src/webgpu/api/validation/queue/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/ImageBitmap.spec.ts
@@ -25,7 +25,6 @@ Test Plan:
 TODO: copying into slices of 2d array textures. 1d and 3d as well if they're not invalid.
 `;
 
-import { poptions, params, pbool } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import {
   kAllTextureFormatInfo,
@@ -60,7 +59,7 @@ interface WithDstOriginMipLevel extends WithMipLevel {
 function generateCopySizeForSrcOOB({ srcOrigin }: { srcOrigin: Required<GPUOrigin2DDict> }) {
   // OOB origin fails even with no-op copy.
   if (srcOrigin.x > kDefaultWidth || srcOrigin.y > kDefaultHeight) {
-    return poptions('copySize', [{ width: 0, height: 0, depthOrArrayLayers: 0 }]);
+    return [{ width: 0, height: 0, depthOrArrayLayers: 0 }];
   }
 
   const justFitCopySize = {
@@ -69,19 +68,19 @@ function generateCopySizeForSrcOOB({ srcOrigin }: { srcOrigin: Required<GPUOrigi
     depthOrArrayLayers: 1,
   };
 
-  return poptions('copySize', [
+  return [
     justFitCopySize, // correct size, maybe no-op copy.
     { width: justFitCopySize.width + 1, height: justFitCopySize.height, depthOrArrayLayers: 1 }, // OOB in width
     { width: justFitCopySize.width, height: justFitCopySize.height + 1, depthOrArrayLayers: 1 }, // OOB in height
     { width: justFitCopySize.width, height: justFitCopySize.height, depthOrArrayLayers: 2 }, // OOB in depthOrArrayLayers
-  ]);
+  ];
 }
 
 // Helper function to generate dst origin value based on mipLevel.
 function generateDstOriginValue({ mipLevel }: WithMipLevel) {
   const origin = computeMipMapSize(kDefaultWidth, kDefaultHeight, mipLevel);
 
-  return poptions('dstOrigin', [
+  return [
     { x: 0, y: 0, z: 0 },
     { x: origin.mipWidth - 1, y: 0, z: 0 },
     { x: 0, y: origin.mipHeight - 1, z: 0 },
@@ -91,7 +90,7 @@ function generateDstOriginValue({ mipLevel }: WithMipLevel) {
     { x: origin.mipWidth + 1, y: 0, z: 0 },
     { x: 0, y: origin.mipHeight + 1, z: 0 },
     { x: 0, y: 0, z: kDefaultDepth + 1 },
-  ]);
+  ];
 }
 
 // Helper function to generate copySize for dst OOB test
@@ -104,7 +103,7 @@ function generateCopySizeForDstOOB({ mipLevel, dstOrigin }: WithDstOriginMipLeve
     dstOrigin.y > dstMipMapSize.mipHeight ||
     dstOrigin.z > kDefaultDepth
   ) {
-    return poptions('copySize', [{ width: 0, height: 0, depthOrArrayLayers: 0 }]);
+    return [{ width: 0, height: 0, depthOrArrayLayers: 0 }];
   }
 
   const justFitCopySize = {
@@ -113,7 +112,7 @@ function generateCopySizeForDstOOB({ mipLevel, dstOrigin }: WithDstOriginMipLeve
     depthOrArrayLayers: kDefaultDepth - dstOrigin.z,
   };
 
-  return poptions('copySize', [
+  return [
     justFitCopySize,
     {
       width: justFitCopySize.width + 1,
@@ -130,7 +129,7 @@ function generateCopySizeForDstOOB({ mipLevel, dstOrigin }: WithDstOriginMipLeve
       height: justFitCopySize.height,
       depthOrArrayLayers: justFitCopySize.depthOrArrayLayers + 1,
     }, // OOB in depthOrArrayLayers
-  ]);
+  ];
 }
 
 class CopyImageBitmapToTextureTest extends ValidationTest {
@@ -164,15 +163,14 @@ class CopyImageBitmapToTextureTest extends ValidationTest {
 export const g = makeTestGroup(CopyImageBitmapToTextureTest);
 
 g.test('source_imageBitmap,state')
-  .params(
-    params()
-      .combine(pbool('closed'))
-      .combine(
-        poptions('copySize', [
-          { width: 0, height: 0, depthOrArrayLayers: 0 },
-          { width: 1, height: 1, depthOrArrayLayers: 1 },
-        ])
-      )
+  .params(u =>
+    u //
+      .combine('closed', [false, true])
+      .beginSubcases()
+      .combine('copySize', [
+        { width: 0, height: 0, depthOrArrayLayers: 0 },
+        { width: 1, height: 1, depthOrArrayLayers: 1 },
+      ])
   )
   .fn(async t => {
     const { closed, copySize } = t.params;
@@ -195,15 +193,14 @@ g.test('source_imageBitmap,state')
   });
 
 g.test('destination_texture,state')
-  .params(
-    params()
-      .combine(poptions('state', ['valid', 'invalid', 'destroyed'] as const))
-      .combine(
-        poptions('copySize', [
-          { width: 0, height: 0, depthOrArrayLayers: 0 },
-          { width: 1, height: 1, depthOrArrayLayers: 1 },
-        ])
-      )
+  .params(u =>
+    u //
+      .combine('state', ['valid', 'invalid', 'destroyed'] as const)
+      .beginSubcases()
+      .combine('copySize', [
+        { width: 0, height: 0, depthOrArrayLayers: 0 },
+        { width: 1, height: 1, depthOrArrayLayers: 1 },
+      ])
   )
   .fn(async t => {
     const { state, copySize } = t.params;
@@ -214,15 +211,14 @@ g.test('destination_texture,state')
   });
 
 g.test('destination_texture,usage')
-  .params(
-    params()
-      .combine(poptions('usage', kTextureUsages))
-      .combine(
-        poptions('copySize', [
-          { width: 0, height: 0, depthOrArrayLayers: 0 },
-          { width: 1, height: 1, depthOrArrayLayers: 1 },
-        ])
-      )
+  .params(u =>
+    u //
+      .combine('usage', kTextureUsages)
+      .beginSubcases()
+      .combine('copySize', [
+        { width: 0, height: 0, depthOrArrayLayers: 0 },
+        { width: 1, height: 1, depthOrArrayLayers: 1 },
+      ])
   )
   .fn(async t => {
     const { usage, copySize } = t.params;
@@ -242,15 +238,14 @@ g.test('destination_texture,usage')
   });
 
 g.test('destination_texture,sample_count')
-  .params(
-    params()
-      .combine(poptions('sampleCount', [1, 4]))
-      .combine(
-        poptions('copySize', [
-          { width: 0, height: 0, depthOrArrayLayers: 0 },
-          { width: 1, height: 1, depthOrArrayLayers: 1 },
-        ])
-      )
+  .params(u =>
+    u //
+      .combine('sampleCount', [1, 4])
+      .beginSubcases()
+      .combine('copySize', [
+        { width: 0, height: 0, depthOrArrayLayers: 0 },
+        { width: 1, height: 1, depthOrArrayLayers: 1 },
+      ])
   )
   .fn(async t => {
     const { sampleCount, copySize } = t.params;
@@ -266,15 +261,14 @@ g.test('destination_texture,sample_count')
   });
 
 g.test('destination_texture,mipLevel')
-  .params(
-    params()
-      .combine(poptions('mipLevel', [0, kDefaultMipLevelCount - 1, kDefaultMipLevelCount]))
-      .combine(
-        poptions('copySize', [
-          { width: 0, height: 0, depthOrArrayLayers: 0 },
-          { width: 1, height: 1, depthOrArrayLayers: 1 },
-        ])
-      )
+  .params(u =>
+    u //
+      .combine('mipLevel', [0, kDefaultMipLevelCount - 1, kDefaultMipLevelCount])
+      .beginSubcases()
+      .combine('copySize', [
+        { width: 0, height: 0, depthOrArrayLayers: 0 },
+        { width: 1, height: 1, depthOrArrayLayers: 1 },
+      ])
   )
   .fn(async t => {
     const { mipLevel, copySize } = t.params;
@@ -295,15 +289,14 @@ g.test('destination_texture,mipLevel')
   });
 
 g.test('destination_texture,format')
-  .params(
-    params()
-      .combine(poptions('format', kAllTextureFormats))
-      .combine(
-        poptions('copySize', [
-          { width: 0, height: 0, depthOrArrayLayers: 0 },
-          { width: 1, height: 1, depthOrArrayLayers: 1 },
-        ])
-      )
+  .params(u =>
+    u
+      .combine('format', kAllTextureFormats)
+      .beginSubcases()
+      .combine('copySize', [
+        { width: 0, height: 0, depthOrArrayLayers: 0 },
+        { width: 1, height: 1, depthOrArrayLayers: 1 },
+      ])
   )
   .fn(async t => {
     const { format, copySize } = t.params;
@@ -327,19 +320,17 @@ g.test('destination_texture,format')
   });
 
 g.test('OOB,source')
-  .params(
-    params()
-      .combine(
-        poptions('srcOrigin', [
-          { x: 0, y: 0 }, // origin is on top-left
-          { x: kDefaultWidth - 1, y: 0 }, // x near the border
-          { x: 0, y: kDefaultHeight - 1 }, // y is near the border
-          { x: kDefaultWidth, y: kDefaultHeight }, // origin is on bottom-right
-          { x: kDefaultWidth + 1, y: 0 }, // x is too large
-          { x: 0, y: kDefaultHeight + 1 }, // y is too large
-        ])
-      )
-      .expand(generateCopySizeForSrcOOB)
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('srcOrigin', [
+        { x: 0, y: 0 }, // origin is on top-left
+        { x: kDefaultWidth - 1, y: 0 }, // x near the border
+        { x: 0, y: kDefaultHeight - 1 }, // y is near the border
+        { x: kDefaultWidth, y: kDefaultHeight }, // origin is on bottom-right
+        { x: kDefaultWidth + 1, y: 0 }, // x is too large
+        { x: 0, y: kDefaultHeight + 1 }, // y is too large
+      ])
+      .expand('copySize', generateCopySizeForSrcOOB)
   )
   .fn(async t => {
     const { srcOrigin, copySize } = t.params;
@@ -375,11 +366,11 @@ g.test('OOB,source')
   });
 
 g.test('OOB,destination')
-  .params(
-    params()
-      .combine(poptions('mipLevel', [0, 1, kDefaultMipLevelCount - 2]))
-      .expand(generateDstOriginValue)
-      .expand(generateCopySizeForDstOOB)
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('mipLevel', [0, 1, kDefaultMipLevelCount - 2])
+      .expand('dstOrigin', generateDstOriginValue)
+      .expand('copySize', generateCopySizeForDstOOB)
   )
   .fn(async t => {
     const { mipLevel, dstOrigin, copySize } = t.params;

--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -4,7 +4,6 @@ Tests using a destroyed query set on a queue.
 TODO: Test with pipeline statistics queries on {compute, render} as well.
 `;
 
-import { poptions } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { createRenderEncoderWithQuerySet } from '../../encoding/queries/common.js';
 import { ValidationTest } from '../../validation_test.js';
@@ -18,7 +17,7 @@ Tests that use a destroyed query set in occlusion query on render pass encoder.
 - x= {destroyed, not destroyed (control case)}
   `
   )
-  .subcases(() => poptions('querySetState', ['valid', 'destroyed'] as const))
+  .paramsSubcasesOnly(u => u.combine('querySetState', ['valid', 'destroyed'] as const))
   .fn(t => {
     const querySet = t.createQuerySetWithState(t.params.querySetState);
 
@@ -38,8 +37,12 @@ Tests that use a destroyed query set in writeTimestamp on {non-pass, compute, re
 - x= {destroyed, not destroyed (control case)}
   `
   )
-  .cases(poptions('encoderType', ['non-pass', 'compute pass', 'render pass'] as const))
-  .subcases(() => poptions('querySetState', ['valid', 'destroyed'] as const))
+  .params(u =>
+    u
+      .combine('encoderType', ['non-pass', 'compute pass', 'render pass'] as const)
+      .beginSubcases()
+      .combine('querySetState', ['valid', 'destroyed'] as const)
+  )
   .fn(async t => {
     await t.selectDeviceOrSkipTestCase('timestamp-query');
 
@@ -63,7 +66,7 @@ Tests that use a destroyed query set in resolveQuerySet.
 - x= {destroyed, not destroyed (control case)}
   `
   )
-  .subcases(() => poptions('querySetState', ['valid', 'destroyed'] as const))
+  .paramsSubcasesOnly(u => u.combine('querySetState', ['valid', 'destroyed'] as const))
   .fn(async t => {
     const querySet = t.createQuerySetWithState(t.params.querySetState);
 

--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -30,7 +30,7 @@ Test various validation behaviors when a resolveTarget is provided.
 - resolve source and target have different sizes.
 `
   )
-  .params([
+  .paramsSimple([
     // control case should be valid
     { _valid: true },
     // a single sampled resolve source should cause a validation error.

--- a/src/webgpu/api/validation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/validation/render_pass/storeOp.spec.ts
@@ -22,7 +22,7 @@ import { ValidationTest } from '../validation_test.js';
 export const g = makeTestGroup(ValidationTest);
 
 g.test('store_op_and_read_only')
-  .params([
+  .paramsSimple([
     { readonly: true, _valid: true },
     // Using depthReadOnly=true and depthStoreOp='clear' should cause a validation error.
     { readonly: true, depthStoreOp: 'clear', _valid: false },

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -101,7 +101,7 @@ g.test('a_render_pass_with_only_one_depth_attachment_is_ok').fn(t => {
 });
 
 g.test('OOB_color_attachment_indices_are_handled')
-  .params([
+  .paramsSimple([
     { colorAttachmentsCount: 4, _success: true }, // Control case
     { colorAttachmentsCount: 5, _success: false }, // Out of bounds
   ])
@@ -193,7 +193,7 @@ g.test('attachments_must_match_whether_they_are_used_for_color_or_depth_stencil'
 });
 
 g.test('check_layer_count_for_color_or_depth_stencil')
-  .params([
+  .paramsSimple([
     { arrayLayerCount: 5, baseArrayLayer: 0, _success: false }, // using 2D array texture view with arrayLayerCount > 1 is not allowed
     { arrayLayerCount: 1, baseArrayLayer: 0, _success: true }, // using 2D array texture view that covers the first layer of the texture is OK
     { arrayLayerCount: 1, baseArrayLayer: 9, _success: true }, // using 2D array texture view that covers the last layer is OK for depth stencil
@@ -262,7 +262,7 @@ g.test('check_layer_count_for_color_or_depth_stencil')
   });
 
 g.test('check_mip_level_count_for_color_or_depth_stencil')
-  .params([
+  .paramsSimple([
     { mipLevelCount: 2, baseMipLevel: 0, _success: false }, // using 2D texture view with mipLevelCount > 1 is not allowed
     { mipLevelCount: 1, baseMipLevel: 0, _success: true }, // using 2D texture view that covers the first level of the texture is OK
     { mipLevelCount: 1, baseMipLevel: 3, _success: true }, // using 2D texture view that covers the last level of the texture is OK

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -42,7 +42,6 @@ Test Coverage:
       dispatch call in compute.
 `;
 
-import { pbool, poptions, params } from '../../../../../common/framework/params_builder.js';
 import { pp } from '../../../../../common/framework/preprocessor.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { assert } from '../../../../../common/framework/util/util.js';
@@ -231,12 +230,38 @@ const SLICE_COUNT = 2;
 
 // For all tests below, we test compute pass if 'compute' is true, and test render pass otherwise.
 g.test('subresources_and_binding_types_combination_for_color')
-  .params(
-    params()
-      .combine(pbool('compute'))
-      .combine(pbool('binding0InBundle'))
-      .combine(pbool('binding1InBundle'))
-      .combine([
+  .params(u =>
+    u
+      .combine('compute', [false, true])
+      .combineWithParams([
+        { _usageOK: true, type0: 'sampled-texture', type1: 'sampled-texture' },
+        { _usageOK: true, type0: 'sampled-texture', type1: 'readonly-storage-texture' },
+        { _usageOK: false, type0: 'sampled-texture', type1: 'writeonly-storage-texture' },
+        { _usageOK: false, type0: 'sampled-texture', type1: 'render-target' },
+        { _usageOK: true, type0: 'readonly-storage-texture', type1: 'readonly-storage-texture' },
+        { _usageOK: false, type0: 'readonly-storage-texture', type1: 'writeonly-storage-texture' },
+        { _usageOK: false, type0: 'readonly-storage-texture', type1: 'render-target' },
+        // Race condition upon multiple writable storage texture is valid.
+        { _usageOK: true, type0: 'writeonly-storage-texture', type1: 'writeonly-storage-texture' },
+        { _usageOK: false, type0: 'writeonly-storage-texture', type1: 'render-target' },
+        { _usageOK: false, type0: 'render-target', type1: 'render-target' },
+      ] as const)
+      .beginSubcases()
+      .combine('binding0InBundle', [false, true])
+      .combine('binding1InBundle', [false, true])
+      .unless(
+        p =>
+          // We can't set 'render-target' in bundle, so we need to exclude it from bundle.
+          (p.binding0InBundle && p.type0 === 'render-target') ||
+          (p.binding1InBundle && p.type1 === 'render-target') ||
+          // We can't set 'render-target' or bundle in compute.
+          (p.compute &&
+            (p.binding0InBundle ||
+              p.binding1InBundle ||
+              p.type0 === 'render-target' ||
+              p.type1 === 'render-target'))
+      )
+      .combineWithParams([
         // Two texture usages are binding to the same texture subresource.
         {
           levelCount0: 1,
@@ -369,44 +394,15 @@ g.test('subresources_and_binding_types_combination_for_color')
           _resourceSuccess: false,
         },
       ])
-      .combine([
-        { _usageOK: true, type0: 'sampled-texture', type1: 'sampled-texture' },
-        { _usageOK: true, type0: 'sampled-texture', type1: 'readonly-storage-texture' },
-        { _usageOK: false, type0: 'sampled-texture', type1: 'writeonly-storage-texture' },
-        { _usageOK: false, type0: 'sampled-texture', type1: 'render-target' },
-        { _usageOK: true, type0: 'readonly-storage-texture', type1: 'readonly-storage-texture' },
-        { _usageOK: false, type0: 'readonly-storage-texture', type1: 'writeonly-storage-texture' },
-        { _usageOK: false, type0: 'readonly-storage-texture', type1: 'render-target' },
-        // Race condition upon multiple writable storage texture is valid.
-        { _usageOK: true, type0: 'writeonly-storage-texture', type1: 'writeonly-storage-texture' },
-        { _usageOK: false, type0: 'writeonly-storage-texture', type1: 'render-target' },
-        { _usageOK: false, type0: 'render-target', type1: 'render-target' },
-      ] as const)
-      // Every color attachment can use only one single subresource.
       .unless(
         p =>
+          // Every color attachment can use only one single subresource.
           (p.type0 === 'render-target' && (p.levelCount0 !== 1 || p.layerCount0 !== 1)) ||
-          (p.type1 === 'render-target' && (p.levelCount1 !== 1 || p.layerCount1 !== 1))
-      )
-      // All color attachments' size should be the same.
-      .unless(
-        p =>
-          p.type0 === 'render-target' && p.type1 === 'render-target' && p.baseLevel1 !== BASE_LEVEL
-      )
-      .unless(
-        p =>
-          // We can't set 'render-target' in bundle, so we need to exclude it from bundle.
-          (p.binding0InBundle && p.type0 === 'render-target') ||
-          (p.binding1InBundle && p.type1 === 'render-target')
-      )
-      .unless(
-        p =>
-          // We can't set 'render-target' or bundle in compute.
-          p.compute &&
-          (p.binding0InBundle ||
-            p.binding1InBundle ||
-            p.type0 === 'render-target' ||
-            p.type1 === 'render-target')
+          (p.type1 === 'render-target' && (p.levelCount1 !== 1 || p.layerCount1 !== 1)) ||
+          // All color attachments' size should be the same.
+          (p.type0 === 'render-target' &&
+            p.type1 === 'render-target' &&
+            p.baseLevel1 !== BASE_LEVEL)
       )
   )
   .fn(async t => {
@@ -507,13 +503,14 @@ g.test('subresources_and_binding_types_combination_for_color')
   });
 
 g.test('subresources_and_binding_types_combination_for_aspect')
-  .params(
-    params()
-      .combine(pbool('compute'))
-      .combine(pbool('binding0InBundle'))
-      .combine(pbool('binding1InBundle'))
-      .combine(poptions('format', kDepthStencilFormats))
-      .combine([
+  .params(u =>
+    u
+      .combine('compute', [false, true])
+      .combine('binding0InBundle', [false, true])
+      .combine('binding1InBundle', [false, true])
+      .combine('format', kDepthStencilFormats)
+      .beginSubcases()
+      .combineWithParams([
         {
           baseLevel: BASE_LEVEL,
           baseLayer: BASE_LAYER,
@@ -530,8 +527,8 @@ g.test('subresources_and_binding_types_combination_for_aspect')
           _resourceSuccess: true,
         },
       ])
-      .combine(poptions('aspect0', ['all', 'depth-only', 'stencil-only'] as const))
-      .combine(poptions('aspect1', ['all', 'depth-only', 'stencil-only'] as const))
+      .combine('aspect0', ['all', 'depth-only', 'stencil-only'] as const)
+      .combine('aspect1', ['all', 'depth-only', 'stencil-only'] as const)
       .unless(
         p =>
           (p.aspect0 === 'stencil-only' && !kDepthStencilFormatInfo[p.format].stencil) ||
@@ -542,7 +539,7 @@ g.test('subresources_and_binding_types_combination_for_aspect')
           (p.aspect0 === 'depth-only' && !kDepthStencilFormatInfo[p.format].depth) ||
           (p.aspect1 === 'depth-only' && !kDepthStencilFormatInfo[p.format].depth)
       )
-      .combine([
+      .combineWithParams([
         {
           type0: 'sampled-texture',
           type1: 'sampled-texture',
@@ -665,11 +662,11 @@ g.test('subresources_and_binding_types_combination_for_aspect')
   });
 
 g.test('shader_stages_and_visibility')
-  .params(
-    params()
-      .combine(pbool('compute'))
-      .combine(poptions('readVisibility', [0, ...kShaderStages]))
-      .combine(poptions('writeVisibility', [0, ...kShaderStages]))
+  .params(u =>
+    u
+      .combine('compute', [false, true])
+      .combine('readVisibility', [0, ...kShaderStages])
+      .combine('writeVisibility', [0, ...kShaderStages])
       .unless(
         p =>
           // Writeonly-storage-texture binding type is not supported in vertex stage. But it is the
@@ -731,18 +728,16 @@ g.test('shader_stages_and_visibility')
 // call site upon the same index in the same render pass. However, replaced bindings in compute
 // should not be validated.
 g.test('replaced_binding')
-  .cases(
-    params()
-      .combine(pbool('compute'))
-      .combine(pbool('callDrawOrDispatch'))
-      .combine(
-        poptions('entry', [
-          { texture: {} },
-          { texture: { multisampled: true } },
-          { storageTexture: { access: 'read-only', format: 'rgba8unorm' } },
-          { storageTexture: { access: 'write-only', format: 'rgba8unorm' } },
-        ] as const)
-      )
+  .params(u =>
+    u
+      .combine('compute', [false, true])
+      .combine('callDrawOrDispatch', [false, true])
+      .combine('entry', [
+        { texture: {} },
+        { texture: { multisampled: true } },
+        { storageTexture: { access: 'read-only', format: 'rgba8unorm' } },
+        { storageTexture: { access: 'write-only', format: 'rgba8unorm' } },
+      ] as const)
   )
   .fn(async t => {
     const { compute, callDrawOrDispatch, entry } = t.params;
@@ -803,12 +798,13 @@ g.test('replaced_binding')
   });
 
 g.test('bindings_in_bundle')
-  .params(
-    params()
-      .combine(pbool('binding0InBundle'))
-      .combine(pbool('binding1InBundle'))
-      .combine(poptions('type0', ['render-target', ...kTextureBindingTypes] as const))
-      .combine(poptions('type1', ['render-target', ...kTextureBindingTypes] as const))
+  .params(u =>
+    u
+      .combine('type0', ['render-target', ...kTextureBindingTypes] as const)
+      .combine('type1', ['render-target', ...kTextureBindingTypes] as const)
+      .beginSubcases()
+      .combine('binding0InBundle', [false, true])
+      .combine('binding1InBundle', [false, true])
       .unless(
         p =>
           // We can't set 'render-target' in bundle, so we need to exclude it from bundle.
@@ -886,14 +882,14 @@ g.test('bindings_in_bundle')
   });
 
 g.test('unused_bindings_in_pipeline')
-  .params(
-    params()
-      .combine(pbool('compute'))
-      .combine(pbool('useBindGroup0'))
-      .combine(pbool('useBindGroup1'))
-      .combine(poptions('setBindGroupsOrder', ['common', 'reversed'] as const))
-      .combine(poptions('setPipeline', ['before', 'middle', 'after', 'none'] as const))
-      .combine(pbool('callDrawOrDispatch'))
+  .params(u =>
+    u
+      .combine('compute', [false, true])
+      .combine('useBindGroup0', [false, true])
+      .combine('useBindGroup1', [false, true])
+      .combine('setBindGroupsOrder', ['common', 'reversed'] as const)
+      .combine('setPipeline', ['before', 'middle', 'after', 'none'] as const)
+      .combine('callDrawOrDispatch', [false, true])
   )
   .fn(async t => {
     const {
@@ -989,7 +985,7 @@ g.test('unused_bindings_in_pipeline')
   });
 
 g.test('validation_scope,no_draw_or_dispatch')
-  .params(pbool('compute'))
+  .params(u => u.combine('compute', [false, true]))
   .fn(async t => {
     const { compute } = t.params;
 
@@ -1007,7 +1003,7 @@ g.test('validation_scope,no_draw_or_dispatch')
   });
 
 g.test('validation_scope,same_draw_or_dispatch')
-  .params(pbool('compute'))
+  .params(u => u.combine('compute', [false, true]))
   .fn(async t => {
     const { compute } = t.params;
 
@@ -1024,7 +1020,7 @@ g.test('validation_scope,same_draw_or_dispatch')
   });
 
 g.test('validation_scope,different_draws_or_dispatches')
-  .params(pbool('compute'))
+  .params(u => u.combine('compute', [false, true]))
   .fn(async t => {
     const { compute } = t.params;
     const { bindGroup0, bindGroup1, encoder, pass, pipeline } = t.testValidationScope(compute);
@@ -1045,7 +1041,7 @@ g.test('validation_scope,different_draws_or_dispatches')
   });
 
 g.test('validation_scope,different_passes')
-  .params(pbool('compute'))
+  .params(u => u.combine('compute', [false, true]))
   .fn(async t => {
     const { compute } = t.params;
     const { bindGroup0, bindGroup1, encoder, pass, pipeline } = t.testValidationScope(compute);

--- a/src/webgpu/api/validation/texture/destroy.spec.ts
+++ b/src/webgpu/api/validation/texture/destroy.spec.ts
@@ -26,7 +26,7 @@ g.test('submit_a_destroyed_texture')
   .desc(
     `Test that it is invalid to submit with a texture that was destroyed {before, after} encoding finishes.`
   )
-  .params([
+  .paramsSimple([
     { destroyBeforeEncode: false, destroyAfterEncode: false, _success: true },
     { destroyBeforeEncode: true, destroyAfterEncode: false, _success: false },
     { destroyBeforeEncode: false, destroyAfterEncode: true, _success: false },

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -1,6 +1,5 @@
 export const description = `vertexState validation tests.`;
 
-import { params, pbool, poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
   kMaxVertexAttributes,
@@ -145,10 +144,10 @@ g.test('max_vertex_buffer_limit')
    - Tests with the last buffer having an attribute or not.
   This also happens to test that vertex buffers with no attributes are allowed and that a vertex state with no buffers is allowed.`
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('count', [0, 1, kMaxVertexBuffers, kMaxVertexBuffers + 1]))
-      .combine(pbool('lastEmpty'))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('count', [0, 1, kMaxVertexBuffers, kMaxVertexBuffers + 1])
+      .combine('lastEmpty', [false, true])
   )
   .fn(t => {
     const { count, lastEmpty } = t.params;
@@ -175,10 +174,10 @@ g.test('max_vertex_attribute_limit')
    - Tests with 0, 1, limit, limits + 1 vertex attribute.
    - Tests with 0, 1, 4 attributes per buffer (with remaining attributes in the last buffer).`
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('attribCount', [0, 1, kMaxVertexAttributes, kMaxVertexAttributes + 1]))
-      .combine(poptions('attribsPerBuffer', [0, 1, 4]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('attribCount', [0, 1, kMaxVertexAttributes, kMaxVertexAttributes + 1])
+      .combine('attribsPerBuffer', [0, 1, 4])
   )
   .fn(t => {
     const { attribCount, attribsPerBuffer } = t.params;
@@ -212,19 +211,17 @@ g.test('max_vertex_buffer_array_stride_limit')
    - Test for various vertex buffer indices
    - Test for array strides 0, 4, 256, limit - 4, limit, limit + 4`
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1]))
-      .combine(
-        poptions('arrayStride', [
-          0,
-          4,
-          256,
-          kMaxVertexBufferArrayStride - 4,
-          kMaxVertexBufferArrayStride,
-          kMaxVertexBufferArrayStride + 4,
-        ])
-      )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1])
+      .combine('arrayStride', [
+        0,
+        4,
+        256,
+        kMaxVertexBufferArrayStride - 4,
+        kMaxVertexBufferArrayStride,
+        kMaxVertexBufferArrayStride + 4,
+      ])
   )
   .fn(t => {
     const { vertexBufferIndex, arrayStride } = t.params;
@@ -242,20 +239,18 @@ g.test('vertex_buffer_array_stride_limit_alignment')
    - Test for various vertex buffer indices
    - Test for array strides 0, 1, 2, 4, limit - 4, limit - 2, limit`
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1]))
-      .combine(
-        poptions('arrayStride', [
-          0,
-          1,
-          2,
-          4,
-          kMaxVertexBufferArrayStride - 4,
-          kMaxVertexBufferArrayStride - 2,
-          kMaxVertexBufferArrayStride,
-        ])
-      )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1])
+      .combine('arrayStride', [
+        0,
+        1,
+        2,
+        4,
+        kMaxVertexBufferArrayStride - 4,
+        kMaxVertexBufferArrayStride - 2,
+        kMaxVertexBufferArrayStride,
+      ])
   )
   .fn(t => {
     const { vertexBufferIndex, arrayStride } = t.params;
@@ -274,14 +269,12 @@ g.test('vertex_attribute_shaderLocation_limit')
    - Test for various amounts of attributes in that vertex buffer
    - Test for shaderLocation 0, 1, limit - 1, limit`
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1]))
-      .combine(poptions('extraAttributeCount', [0, 1, kMaxVertexAttributes - 1]))
-      .combine(pbool('testAttributeAtStart'))
-      .combine(
-        poptions('testShaderLocation', [0, 1, kMaxVertexAttributes - 1, kMaxVertexAttributes])
-      )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1])
+      .combine('extraAttributeCount', [0, 1, kMaxVertexAttributes - 1])
+      .combine('testAttributeAtStart', [false, true])
+      .combine('testShaderLocation', [0, 1, kMaxVertexAttributes - 1, kMaxVertexAttributes])
   )
   .fn(t => {
     const {
@@ -313,15 +306,15 @@ g.test('vertex_attribute_shaderLocation_unique')
    - Test for the potentially conflicting attributes in various places in the buffers (with dummy attributes)
    - Test for various shaderLocations that conflict or not`
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('vertexBufferIndexA', [0, 1, kMaxVertexBuffers - 1]))
-      .combine(poptions('vertexBufferIndexB', [0, 1, kMaxVertexBuffers - 1]))
-      .combine(pbool('testAttributeAtStartA'))
-      .combine(pbool('testAttributeAtStartB'))
-      .combine(poptions('shaderLocationA', [0, 1, 7, kMaxVertexAttributes - 1]))
-      .combine(poptions('shaderLocationB', [0, 1, 7, kMaxVertexAttributes - 1]))
-      .combine(poptions('extraAttributeCount', [0, 4]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('vertexBufferIndexA', [0, 1, kMaxVertexBuffers - 1])
+      .combine('vertexBufferIndexB', [0, 1, kMaxVertexBuffers - 1])
+      .combine('testAttributeAtStartA', [false, true])
+      .combine('testAttributeAtStartB', [false, true])
+      .combine('shaderLocationA', [0, 1, 7, kMaxVertexAttributes - 1])
+      .combine('shaderLocationB', [0, 1, 7, kMaxVertexAttributes - 1])
+      .combine('extraAttributeCount', [0, 4])
   )
   .fn(t => {
     const {
@@ -376,10 +369,9 @@ g.test('vertex_shader_input_location_limit')
     `Test that vertex shader's input's location decoration must be less than maxVertexAttributes.
    - Test for shaderLocation 0, 1, limit - 1, limit`
   )
-  .subcases(() =>
-    params().combine(
-      poptions('testLocation', [0, 1, kMaxVertexAttributes - 1, kMaxVertexAttributes, -1, 2 ** 32])
-    )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('testLocation', [0, 1, kMaxVertexAttributes - 1, kMaxVertexAttributes, -1, 2 ** 32])
   )
   .fn(t => {
     const { testLocation } = t.params;
@@ -414,12 +406,12 @@ g.test('vertex_shader_input_location_in_vertex_state')
        - Test for various input locations.
        - Test for the attribute in various places in the list of vertex buffer and various places inside the vertex buffer descriptor`
   )
-  .subcases(() =>
-    params()
-      .combine(poptions('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1]))
-      .combine(poptions('extraAttributeCount', [0, 1, kMaxVertexAttributes - 1]))
-      .combine(pbool('testAttributeAtStart'))
-      .combine(poptions('testShaderLocation', [0, 1, 4, 7, kMaxVertexAttributes - 1]))
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1])
+      .combine('extraAttributeCount', [0, 1, kMaxVertexAttributes - 1])
+      .combine('testAttributeAtStart', [false, true])
+      .combine('testShaderLocation', [0, 1, 4, 7, kMaxVertexAttributes - 1])
   )
   .fn(t => {
     const {
@@ -463,18 +455,17 @@ g.test('vertex_shader_type_matches_attribute_format')
      - Test for all formats.
      - Test for all combinations of u/i/f32 with and without vectors.`
   )
-  .cases(poptions('format', kVertexFormats))
-  .subcases(() =>
-    params()
-      .combine(poptions('shaderBaseType', ['u32', 'i32', 'f32']))
-      .expand(p => {
-        return poptions('shaderType', [
-          p.shaderBaseType,
-          `vec2<${p.shaderBaseType}>`,
-          `vec3<${p.shaderBaseType}>`,
-          `vec4<${p.shaderBaseType}>`,
-        ]);
-      })
+  .params(u =>
+    u
+      .combine('format', kVertexFormats)
+      .beginSubcases()
+      .combine('shaderBaseType', ['u32', 'i32', 'f32'])
+      .expand('shaderType', p => [
+        p.shaderBaseType,
+        `vec2<${p.shaderBaseType}>`,
+        `vec3<${p.shaderBaseType}>`,
+        `vec4<${p.shaderBaseType}>`,
+      ])
   )
   .fn(t => {
     const { format, shaderBaseType, shaderType } = t.params;
@@ -515,32 +506,27 @@ g.test('vertex_attribute_offset_alignment')
     - Test for various vertex buffer indices
     - Test for various amounts of attributes in that vertex buffer`
   )
-  .cases(
-    params()
-      .combine(poptions('format', kVertexFormats))
-      .combine(poptions('arrayStride', [256, kMaxVertexBufferArrayStride]))
-      .expand(p => {
+  .params(u =>
+    u
+      .combine('format', kVertexFormats)
+      .combine('arrayStride', [256, kMaxVertexBufferArrayStride])
+      .expand('offset', p => {
         const { bytesPerComponent, componentCount } = kVertexFormatInfo[p.format];
         const formatSize = bytesPerComponent * componentCount;
         const halfAlignment = Math.floor(bytesPerComponent / 2);
 
-        return poptions(
-          'offset',
-          new Set([
-            0,
-            halfAlignment,
-            bytesPerComponent,
-            p.arrayStride - formatSize,
-            p.arrayStride - formatSize - halfAlignment,
-          ])
-        );
+        return new Set([
+          0,
+          halfAlignment,
+          bytesPerComponent,
+          p.arrayStride - formatSize,
+          p.arrayStride - formatSize - halfAlignment,
+        ]);
       })
-  )
-  .subcases(() =>
-    params()
-      .combine(poptions('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1]))
-      .combine(poptions('extraAttributeCount', [0, 1, kMaxVertexAttributes - 1]))
-      .combine(pbool('testAttributeAtStart'))
+      .beginSubcases()
+      .combine('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1])
+      .combine('extraAttributeCount', [0, 1, kMaxVertexAttributes - 1])
+      .combine('testAttributeAtStart', [false, true])
   )
   .fn(t => {
     const {
@@ -576,39 +562,37 @@ g.test('vertex_attribute_contained_in_stride')
     - Test for various vertex buffer indices
     - Test for various amounts of attributes in that vertex buffer`
   )
-  .cases(poptions('format', kVertexFormats))
-  .subcases(({ format }) =>
-    params()
-      .combine(
-        poptions('arrayStride', [
-          0,
-          256,
-          kMaxVertexBufferArrayStride - 4,
-          kMaxVertexBufferArrayStride,
-        ])
-      )
-      .expand(p => {
+  .params(u =>
+    u
+      .combine('format', kVertexFormats)
+      .beginSubcases()
+      .combine('arrayStride', [
+        0,
+        256,
+        kMaxVertexBufferArrayStride - 4,
+        kMaxVertexBufferArrayStride,
+      ])
+      .expand('offset', function* (p) {
         // Compute a bunch of test offsets to test.
-        const { bytesPerComponent, componentCount } = kVertexFormatInfo[format];
+        const { bytesPerComponent, componentCount } = kVertexFormatInfo[p.format];
         const formatSize = bytesPerComponent * componentCount;
-        const offsetsToTest = [0, bytesPerComponent];
+        yield 0;
+        yield bytesPerComponent;
 
         // arrayStride = 0 is a special case because for the offset validation it acts the same
         // as arrayStride = kMaxVertexBufferArrayStride. We branch so as to avoid adding negative
         // offsets that would cause an IDL exception to be thrown instead of a validation error.
         if (p.arrayStride === 0) {
-          offsetsToTest.push(kMaxVertexBufferArrayStride - formatSize);
-          offsetsToTest.push(kMaxVertexBufferArrayStride - formatSize + bytesPerComponent);
+          yield kMaxVertexBufferArrayStride - formatSize;
+          yield kMaxVertexBufferArrayStride - formatSize + bytesPerComponent;
         } else {
-          offsetsToTest.push(p.arrayStride - formatSize);
-          offsetsToTest.push(p.arrayStride - formatSize + bytesPerComponent);
+          yield p.arrayStride - formatSize;
+          yield p.arrayStride - formatSize + bytesPerComponent;
         }
-
-        return poptions('offset', offsetsToTest);
       })
-      .combine(poptions('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1]))
-      .combine(poptions('extraAttributeCount', [0, 1, kMaxVertexAttributes - 1]))
-      .combine(pbool('testAttributeAtStart'))
+      .combine('vertexBufferIndex', [0, 1, kMaxVertexBuffers - 1])
+      .combine('extraAttributeCount', [0, 1, kMaxVertexAttributes - 1])
+      .combine('testAttributeAtStart', [false, true])
   )
   .fn(t => {
     const {

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -4,13 +4,12 @@ Examples of writing CTS tests with various features.
 Start here when looking for examples of basic framework usage.
 `;
 
-import { params, pbool, poptions } from '../common/framework/params_builder.js';
 import { makeTestGroup } from '../common/framework/test_group.js';
 
 import { GPUTest } from './gpu_test.js';
 
 // To run these tests in the standalone runner, run `npm start` then open:
-// - http://localhost:XXXX/standalone/?runnow=1&q=webgpu:examples:
+// - http://localhost:XXXX/standalone/?runnow=1&q=webgpu:examples:*
 // To run in WPT, copy/symlink the out-wpt/ directory as the webgpu/ directory in WPT, then open:
 // - (wpt server url)/webgpu/cts.html?q=webgpu:examples:
 //
@@ -74,21 +73,43 @@ g.test('basic,async').fn(async t => {
   );
 });
 
-// A test can be parameterized with a simple array of objects using .cases().
-// Each such instance of the test is a "case".
-//
-// Parameters can be public (x, y) which means they're part of the case name.
-// They can also be private by starting with an underscore (_result), which passes
-// them into the test but does not make them part of the case name:
-//
-// In this example, the following cases are generated (identified by their "query string"):
-//   - webgpu:examples:basic,cases:x=2;y=4     runs once, with t.params set to:
-//       - { x:   2, y:  4, _result: 6 }
-//   - webgpu:examples:basic,cases:x=-10;y=18  runs once, with t.params set to:
-//       - { x: -10, y: 18, _result: 8 }
+g.test('basic,plain_cases')
+  .desc(
+    `
+A test can be parameterized with a simple array of objects using .paramsSimple([ ... ]).
+Each such instance of the test is a "case".
 
-g.test('basic,cases')
-  .cases([
+In this example, the following cases are generated (identified by their "query string"),
+each with just one subcase:
+  - webgpu:examples:basic,cases:x=2;y=2      runs 1 subcase, with t.params set to:
+      - { x:   2, y:   2 }
+  - webgpu:examples:basic,cases:x=-10;y=-10  runs 1 subcase, with t.params set to:
+      - { x: -10, y: -10 }
+  `
+  )
+  .paramsSimple([
+    { x: 2, y: 2 }, //
+    { x: -10, y: -10 },
+  ])
+  .fn(t => {
+    t.expect(t.params.x === t.params.y);
+  });
+
+g.test('basic,plain_cases_private')
+  .desc(
+    `
+Parameters can be public ("x", "y") which means they're part of the case name.
+They can also be private by starting with an underscore ("_result"), which passes
+them into the test but does not make them part of the case name:
+
+In this example, the following cases are generated, each with just one subcase:
+  - webgpu:examples:basic,cases:x=2;y=4     runs 1 subcase, with t.params set to:
+      - { x:   2, y:  4, _result: 6 }
+  - webgpu:examples:basic,cases:x=-10;y=18  runs 1 subcase, with t.params set to:
+      - { x: -10, y: 18, _result: 8 }
+  `
+  )
+  .paramsSimple([
     { x: 2, y: 4, _result: 6 }, //
     { x: -10, y: 18, _result: 8 },
   ])
@@ -97,38 +118,91 @@ g.test('basic,cases')
   });
 // (note the blank comment above to enforce newlines on autoformat)
 
-// Each case can be further parameterized using .subcases().
-// Each such instance of the test is a "subcase", which cannot be run independently of other
-// subcases. It is analogous to wrapping the entire fn body in a for-loop.
-//
-// In this example, the following cases are generated (identified by their "query string"):
-//   - webgpu:examples:basic,cases:x=1  runs twice, with t.params set to each of:
-//       - { x: 1, a: 2 }
-//       - { x: 1, b: 2 }
-//   - webgpu:examples:basic,cases:x=2  runs twice, with t.params set to each of:
-//       - { x: 2, a: 3 }
-//       - { x: 2, b: 2 }
+g.test('basic,builder_cases')
+  .desc(
+    `
+A "CaseParamsBuilder" or "SubcaseParamsBuilder" can be passed to .params() instead.
+The params builder provides facilities for generating tests combinatorially (by cartesian
+product). For convenience, the "unit" CaseParamsBuilder is passed as an argument ("u" below).
 
-g.test('basic,subcases')
-  .cases([{ x: 1 }, { x: 2 }])
-  .subcases(p => [{ a: p.x + 1 }, { b: 2 }])
-  .fn(t => {
-    t.expect(
-      ((t.params.a === 2 || t.params.a === 3) && t.params.b === undefined) ||
-        (t.params.a === undefined && t.params.b === 2)
-    );
-  });
+In this example, the following cases are generated, each with just one subcase:
+  - webgpu:examples:basic,cases:x=1,y=1  runs 1 subcase, with t.params set to:
+      - { x: 1, y: 1 }
+  - webgpu:examples:basic,cases:x=1,y=2  runs 1 subcase, with t.params set to:
+      - { x: 1, y: 2 }
+  - webgpu:examples:basic,cases:x=2,y=1  runs 1 subcase, with t.params set to:
+      - { x: 2, y: 1 }
+  - webgpu:examples:basic,cases:x=2,y=2  runs 1 subcase, with t.params set to:
+      - { x: 2, y: 2 }
+  `
+  )
+  .params(u =>
+    u //
+      .combineWithParams([{ x: 1 }, { x: 2 }])
+      .combineWithParams([{ y: 1 }, { y: 2 }])
+  )
+  .fn(() => {});
 
-// Runs the following cases:
-// { x: 2, y: 2 }
-// { x: 2, z: 3 }
-// { x: 3, y: 2 }
-// { x: 3, z: 3 }
-g.test('basic,params_builder')
-  .cases(
-    params()
-      .combine(poptions('x', [2, 3]))
-      .combine([{ y: 2 }, { z: 3 }])
+g.test('basic,builder_cases_subcases')
+  .desc(
+    `
+Each case sub-parameterized using .beginSubcases().
+Each such instance of the test is a "subcase", which cannot be run independently of other
+subcases. It is somewhat like wrapping the entire fn body in a for-loop.
+
+In this example, the following cases are generated:
+  - webgpu:examples:basic,cases:x=1      runs 2 subcases, with t.params set to:
+      - { x: 1, y: 1 }
+      - { x: 1, y: 2 }
+  - webgpu:examples:basic,cases:x=2      runs 2 subcases, with t.params set to:
+      - { x: 2, y: 1 }
+      - { x: 2, y: 2 }
+  `
+  )
+  .params(u =>
+    u //
+      .combineWithParams([{ x: 1 }, { x: 2 }])
+      .beginSubcases()
+      .combineWithParams([{ y: 1 }, { y: 2 }])
+  )
+  .fn(() => {});
+
+g.test('basic,builder_subcases')
+  .desc(
+    `
+In this example, the following single case is generated:
+  - webgpu:examples:basic,cases:         runs 4 subcases, with t.params set to:
+      - { x: 1, y: 1 }
+      - { x: 1, y: 2 }
+      - { x: 2, y: 1 }
+      - { x: 2, y: 2 }
+  `
+  )
+  .params(u =>
+    u //
+      .beginSubcases()
+      .combineWithParams([{ x: 1 }, { x: 2 }])
+      .combineWithParams([{ y: 1 }, { y: 2 }])
+  )
+  .fn(() => {});
+
+g.test('basic,builder_subcases_short')
+  .desc(
+    `
+As a shorthand, .paramsSubcasesOnly() can be used.
+
+In this example, the following single case is generated:
+  - webgpu:examples:basic,cases:         runs 4 subcases, with t.params set to:
+      - { x: 1, y: 1 }
+      - { x: 1, y: 2 }
+      - { x: 2, y: 1 }
+      - { x: 2, y: 2 }
+  `
+  )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combineWithParams([{ x: 1 }, { x: 2 }])
+      .combineWithParams([{ y: 1 }, { y: 2 }])
   )
   .fn(() => {});
 
@@ -159,7 +233,7 @@ g.test('gpu,with_texture_compression,bc')
     `Example of a test using a device descriptor.
 Tests that a BC format passes validation iff the feature is enabled.`
   )
-  .cases(pbool('textureCompressionBC'))
+  .params(u => u.combine('textureCompressionBC', [false, true]))
   .fn(async t => {
     const { textureCompressionBC } = t.params;
 
@@ -187,7 +261,7 @@ g.test('gpu,with_texture_compression,etc')
 
 TODO: Test that an ETC format passes validation iff the feature is enabled.`
   )
-  .cases(pbool('textureCompressionETC'))
+  .params(u => u.combine('textureCompressionETC', [false, true]))
   .fn(async t => {
     const { textureCompressionETC } = t.params;
 

--- a/src/webgpu/idl/constants/flags.spec.ts
+++ b/src/webgpu/idl/constants/flags.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Test the values of flags interfaces (e.g. GPUTextureUsage).
 `;
 
-import { poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { IDLTest } from '../idl_test.js';
 
@@ -24,7 +23,7 @@ g.test('BufferUsage,count').fn(t => {
   t.assertMemberCount(GPUBufferUsage, kBufferUsageExp);
 });
 g.test('BufferUsage,values')
-  .params(poptions('key', Object.keys(kBufferUsageExp)))
+  .params(u => u.combine('key', Object.keys(kBufferUsageExp)))
   .fn(t => {
     const { key } = t.params;
     t.assertMember(GPUBufferUsage, kBufferUsageExp, key);
@@ -41,7 +40,7 @@ g.test('TextureUsage,count').fn(t => {
   t.assertMemberCount(GPUTextureUsage, kTextureUsageExp);
 });
 g.test('TextureUsage,values')
-  .params(poptions('key', Object.keys(kTextureUsageExp)))
+  .params(u => u.combine('key', Object.keys(kTextureUsageExp)))
   .fn(t => {
     const { key } = t.params;
     t.assertMember(GPUTextureUsage, kTextureUsageExp, key);
@@ -58,7 +57,7 @@ g.test('ColorWrite,count').fn(t => {
   t.assertMemberCount(GPUColorWrite, kColorWriteExp);
 });
 g.test('ColorWrite,values')
-  .params(poptions('key', Object.keys(kColorWriteExp)))
+  .params(u => u.combine('key', Object.keys(kColorWriteExp)))
   .fn(t => {
     const { key } = t.params;
     t.assertMember(GPUColorWrite, kColorWriteExp, key);
@@ -73,7 +72,7 @@ g.test('ShaderStage,count').fn(t => {
   t.assertMemberCount(GPUShaderStage, kShaderStageExp);
 });
 g.test('ShaderStage,values')
-  .params(poptions('key', Object.keys(kShaderStageExp)))
+  .params(u => u.combine('key', Object.keys(kShaderStageExp)))
   .fn(t => {
     const { key } = t.params;
     t.assertMember(GPUShaderStage, kShaderStageExp, key);

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -44,7 +44,6 @@ Vertex buffer contents could be randomized to prevent the case where a previous 
 a similar buffer to ours and the OOB-read seems valid. This should be deterministic, which adds
 more complexity that we may not need.`;
 
-import { params, pbool, poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { GPUTest } from '../../gpu_test.js';
 
@@ -252,29 +251,21 @@ const typeInfoMap: { [k: string]: VertexInfo } = {
 };
 
 g.test('vertexAccess')
-  .params(
-    params()
-      .combine(pbool('indexed'))
-      .combine(pbool('indirect'))
-      .expand(p =>
-        poptions(
-          'drawCallTestParameter',
-          p.indexed
-            ? ([
-                'indexCount',
-                'instanceCount',
-                'firstIndex',
-                'baseVertex',
-                'firstInstance',
-              ] as const)
-            : (['vertexCount', 'instanceCount', 'firstVertex', 'firstInstance'] as const)
-        )
+  .params(u =>
+    u
+      .combine('indexed', [false, true])
+      .combine('indirect', [false, true])
+      .expand('drawCallTestParameter', p =>
+        p.indexed
+          ? (['indexCount', 'instanceCount', 'firstIndex', 'baseVertex', 'firstInstance'] as const)
+          : (['vertexCount', 'instanceCount', 'firstVertex', 'firstInstance'] as const)
       )
-      .combine(poptions('type', Object.keys(typeInfoMap)))
-      .combine(poptions('additionalBuffers', [0, 4]))
-      .combine(pbool('partialLastNumber'))
-      .combine(pbool('offsetVertexBuffer'))
-      .combine(poptions('errorScale', [1, 4, 10 ** 2, 10 ** 4, 10 ** 6]))
+      .beginSubcases()
+      .combine('type', Object.keys(typeInfoMap))
+      .combine('additionalBuffers', [0, 4])
+      .combine('partialLastNumber', [false, true])
+      .combine('offsetVertexBuffer', [false, true])
+      .combine('errorScale', [1, 4, 10 ** 2, 10 ** 4, 10 ** 6])
   )
   .fn(async t => {
     const p = t.params;

--- a/src/webgpu/shader/validation/variable_and_const.spec.ts
+++ b/src/webgpu/shader/validation/variable_and_const.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Positive and negative validation tests for variable and const.
 `;
 
-import { params, poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 import { ShaderValidationTest } from './shader_validation_test.js';
@@ -72,13 +71,13 @@ g.test('v_0033')
   TODO: add test for: structs - arrays of vectors and matrices - arrays of different length
 `
   )
-  .params(
-    params()
-      .combine(poptions('variableOrConstant', ['var', 'const']))
-      .combine(poptions('lhsContainerType', kContainerTypes))
-      .combine(poptions('lhsScalarType', kScalarType))
-      .combine(poptions('rhsContainerType', kContainerTypes))
-      .combine(poptions('rhsScalarType', kScalarType))
+  .params(u =>
+    u
+      .combine('variableOrConstant', ['var', 'const'])
+      .combine('lhsContainerType', kContainerTypes)
+      .combine('lhsScalarType', kScalarType)
+      .combine('rhsContainerType', kContainerTypes)
+      .combine('rhsScalarType', kScalarType)
   )
   .fn(t => {
     const {
@@ -127,11 +126,11 @@ g.test('v_0038')
   becomes invalid and nothing else is wrong.
   TODO: add test for: struct - struct with bool component - struct with runtime array`
   )
-  .params(
-    params()
-      .combine(poptions('storageClass', ['in', 'out', 'private']))
-      .combine(poptions('containerType', kContainerTypes))
-      .combine(poptions('scalarType', kScalarType))
+  .params(u =>
+    u
+      .combine('storageClass', ['in', 'out', 'private'])
+      .combine('containerType', kContainerTypes)
+      .combine('scalarType', kScalarType)
   )
   .fn(t => {
     const { storageClass, containerType, scalarType } = t.params;

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -1,6 +1,5 @@
 export const description = 'Test helpers for texel data produce the expected data in the shader';
 
-import { params, poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { assert } from '../../../common/framework/util/util.js';
 import {
@@ -22,18 +21,17 @@ function doTest(
   t: GPUTest & {
     params: {
       format: EncodableTextureFormat;
-      R?: number;
-      G?: number;
-      B?: number;
-      A?: number;
+      componentData: {
+        R?: number;
+        G?: number;
+        B?: number;
+        A?: number;
+      };
     };
   }
 ) {
   const { format } = t.params;
-  const componentData = (() => {
-    const { R, G, B, A } = t.params;
-    return { R, G, B, A };
-  })();
+  const componentData = t.params.componentData;
 
   const rep = kTexelRepresentationInfo[format];
   const texelData = rep.pack(componentData);
@@ -137,9 +135,9 @@ function makeParam(
 }
 
 g.test('unorm_texel_data_in_shader')
-  .params(
-    params()
-      .combine(poptions('format', kEncodableTextureFormats))
+  .params(u =>
+    u
+      .combine('format', kEncodableTextureFormats)
       .filter(({ format }) => {
         return (
           kEncodableTextureFormatInfo[format].copyDst &&
@@ -147,7 +145,8 @@ g.test('unorm_texel_data_in_shader')
           getSingleDataType(format) === 'unorm'
         );
       })
-      .expand(({ format }) => {
+      .beginSubcases()
+      .expand('componentData', ({ format }) => {
         const max = (bitLength: number) => Math.pow(2, bitLength) - 1;
         return [
           // Test extrema
@@ -168,9 +167,9 @@ g.test('unorm_texel_data_in_shader')
   .fn(doTest);
 
 g.test('snorm_texel_data_in_shader')
-  .params(
-    params()
-      .combine(poptions('format', kEncodableTextureFormats))
+  .params(u =>
+    u
+      .combine('format', kEncodableTextureFormats)
       .filter(({ format }) => {
         return (
           kEncodableTextureFormatInfo[format].copyDst &&
@@ -178,7 +177,8 @@ g.test('snorm_texel_data_in_shader')
           getSingleDataType(format) === 'snorm'
         );
       })
-      .expand(({ format }) => {
+      .beginSubcases()
+      .expand('componentData', ({ format }) => {
         const max = (bitLength: number) => Math.pow(2, bitLength - 1) - 1;
         return [
           // Test extrema
@@ -202,9 +202,9 @@ g.test('snorm_texel_data_in_shader')
   .fn(doTest);
 
 g.test('uint_texel_data_in_shader')
-  .params(
-    params()
-      .combine(poptions('format', kEncodableTextureFormats))
+  .params(u =>
+    u
+      .combine('format', kEncodableTextureFormats)
       .filter(({ format }) => {
         return (
           kEncodableTextureFormatInfo[format].copyDst &&
@@ -212,7 +212,8 @@ g.test('uint_texel_data_in_shader')
           getSingleDataType(format) === 'uint'
         );
       })
-      .expand(({ format }) => {
+      .beginSubcases()
+      .expand('componentData', ({ format }) => {
         const max = (bitLength: number) => Math.pow(2, bitLength) - 1;
         return [
           // Test extrema
@@ -233,9 +234,9 @@ g.test('uint_texel_data_in_shader')
   .fn(doTest);
 
 g.test('sint_texel_data_in_shader')
-  .params(
-    params()
-      .combine(poptions('format', kEncodableTextureFormats))
+  .params(u =>
+    u
+      .combine('format', kEncodableTextureFormats)
       .filter(({ format }) => {
         return (
           kEncodableTextureFormatInfo[format].copyDst &&
@@ -243,7 +244,8 @@ g.test('sint_texel_data_in_shader')
           getSingleDataType(format) === 'sint'
         );
       })
-      .expand(({ format }) => {
+      .beginSubcases()
+      .expand('componentData', ({ format }) => {
         const max = (bitLength: number) => Math.pow(2, bitLength - 1) - 1;
         return [
           // Test extrema
@@ -266,9 +268,9 @@ g.test('sint_texel_data_in_shader')
   .fn(doTest);
 
 g.test('float_texel_data_in_shader')
-  .params(
-    params()
-      .combine(poptions('format', kEncodableTextureFormats))
+  .params(u =>
+    u
+      .combine('format', kEncodableTextureFormats)
       .filter(({ format }) => {
         return (
           kEncodableTextureFormatInfo[format].copyDst &&
@@ -276,7 +278,8 @@ g.test('float_texel_data_in_shader')
           getSingleDataType(format) === 'float'
         );
       })
-      .expand(({ format }) => {
+      .beginSubcases()
+      .expand('componentData', ({ format }) => {
         return [
           // Test extrema
           makeParam(format, () => 0),
@@ -301,9 +304,9 @@ g.test('float_texel_data_in_shader')
   .fn(doTest);
 
 g.test('ufloat_texel_data_in_shader')
-  .params(
-    params()
-      .combine(poptions('format', kEncodableTextureFormats))
+  .params(u =>
+    u
+      .combine('format', kEncodableTextureFormats)
       .filter(({ format }) => {
         return (
           kEncodableTextureFormatInfo[format].copyDst &&
@@ -311,7 +314,8 @@ g.test('ufloat_texel_data_in_shader')
           getSingleDataType(format) === 'ufloat'
         );
       })
-      .expand(({ format }) => {
+      .beginSubcases()
+      .expand('componentData', ({ format }) => {
         return [
           // Test extrema
           makeParam(format, () => 0),

--- a/src/webgpu/web_platform/canvas/context_creation.spec.ts
+++ b/src/webgpu/web_platform/canvas/context_creation.spec.ts
@@ -6,7 +6,6 @@ Options are configured in configureSwapChain instead.
 `;
 
 import { Fixture } from '../../../common/framework/fixture.js';
-import { pbool, poptions } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 export const g = makeTestGroup(Fixture);
@@ -17,8 +16,12 @@ g.test('return_type')
 
     TODO: Test OffscreenCanvas made from transferControlToOffscreen.`
   )
-  .cases(pbool('offscreen'))
-  .subcases(() => poptions('attributes', [undefined, {}]))
+  .params(u =>
+    u //
+      .combine('offscreen', [false, true])
+      .beginSubcases()
+      .combine('attributes', [undefined, {}])
+  )
   .fn(async t => {
     let canvas: HTMLCanvasElement | OffscreenCanvas;
     if (t.params.offscreen) {

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -10,7 +10,6 @@ TODO: Test ImageBitmap generated from all possible ImageBitmapSource, relevant I
 TODO: Test zero-sized copies from all sources (just make sure params cover it) (e.g. 0x0, 0x4, 4x0).
 `;
 
-import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { unreachable } from '../../../common/framework/util/util.js';
 import {
@@ -253,16 +252,14 @@ g.test('from_ImageData')
   in CPU back resource.
   `
   )
-  .cases(
-    params()
-      .combine(poptions('alpha', ['none', 'premultiply'] as const))
-      .combine(poptions('orientation', ['none', 'flipY'] as const))
-      .combine(poptions('dstColorFormat', kValidTextureFormatsForCopyIB2T))
-  )
-  .subcases(() =>
-    params()
-      .combine(poptions('width', [1, 2, 4, 15, 255, 256]))
-      .combine(poptions('height', [1, 2, 4, 15, 255, 256]))
+  .params(u =>
+    u
+      .combine('alpha', ['none', 'premultiply'] as const)
+      .combine('orientation', ['none', 'flipY'] as const)
+      .combine('dstColorFormat', kValidTextureFormatsForCopyIB2T)
+      .beginSubcases()
+      .combine('width', [1, 2, 4, 15, 255, 256])
+      .combine('height', [1, 2, 4, 15, 255, 256])
   )
   .fn(async t => {
     const { width, height, alpha, orientation, dstColorFormat } = t.params;
@@ -321,15 +318,13 @@ g.test('from_canvas')
   texture correctly. These imageBitmaps are highly possible living in GPU back resource.
   `
   )
-  .cases(
-    params()
-      .combine(poptions('orientation', ['none', 'flipY'] as const))
-      .combine(poptions('dstColorFormat', kValidTextureFormatsForCopyIB2T))
-  )
-  .subcases(() =>
-    params()
-      .combine(poptions('width', [1, 2, 4, 15, 255, 256]))
-      .combine(poptions('height', [1, 2, 4, 15, 255, 256]))
+  .params(u =>
+    u
+      .combine('orientation', ['none', 'flipY'] as const)
+      .combine('dstColorFormat', kValidTextureFormatsForCopyIB2T)
+      .beginSubcases()
+      .combine('width', [1, 2, 4, 15, 255, 256])
+      .combine('height', [1, 2, 4, 15, 255, 256])
   )
   .fn(async t => {
     const { width, height, orientation, dstColorFormat } = t.params;


### PR DESCRIPTION
Baking the split between cases and subcases into the params builder
should make it more ergonomic to use: especially in cases where the
cases/subcases are not defined inline, this means the cases and subcases
don't have to be defined as two separate things (an iterable and a
function), and instead can be defined as a single SubcaseParamsBuilder.

It also makes it easy to change whether a parameter is a case or subcase parameter.

<hr>

**Author checklist for test code/plans:**

- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    https://chromium-review.googlesource.com/c/chromium/src/+/2938946
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
