### PR TITLE
Remove last WGSL `const` and `-> void` usages

### DIFF
--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -58,7 +58,7 @@ class IndexFormatTest extends GPUTest {
       // TODO?: These positions will create triangles that cut right through pixel centers. If this
       // results in different rasterization results on different hardware, tweak to avoid this.
       code: `
-        const pos: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
+        let pos: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
           vec2<f32>(0.01,  0.98),
           vec2<f32>(0.99, -0.98),
           vec2<f32>(0.99,  0.98),

--- a/src/webgpu/shader/validation/wgsl/duplicate-name-between-global-and-func-vars.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-name-between-global-and-func-vars.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0013 - This fails because of the duplicated `a` variable.
 
-const a : vec2<f32> = vec2<f32>(0.1, 1.0);
+let a : vec2<f32> = vec2<f32>(0.1, 1.0);
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
@@ -5,7 +5,7 @@ struct Foo {
   b : f32;
 };
 
-fn Foo() ->void {
+fn Foo() {
   return;
 }
 

--- a/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v2.fail.wgsl
@@ -1,8 +1,8 @@
 // v-0011 - This fails because of the duplicate name `a`.
 
-const a : vec2<f32> = vec2<f32>(0.1, 1.0);
+let a : vec2<f32> = vec2<f32>(0.1, 1.0);
 
-fn a()->void {
+fn a() {
   return;
 }
 

--- a/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v3.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0011 - This fails because of the duplicated `a` variable.
 
-const a : vec2<f32> = vec2<f32>(0.1, 1.0);
+let a : vec2<f32> = vec2<f32>(0.1, 1.0);
 
 [[stage(vertex)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/reassign-const.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/reassign-const.fail.wgsl
@@ -2,7 +2,7 @@
 
 [[stage(vertex)]]
 fn main() {
-  const c : f32 = 0.1;
+  let c : f32 = 0.1;
   c = 0.2;
   return;
 }


### PR DESCRIPTION
Some of these tests have other issues (e.g. vertex shaders not returning positions), but they'll take more work to address across the whole codebase.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
