### PR TITLE
Update validation tests of copyImageBitmapToTexture

### DIFF
--- a/src/webgpu/api/validation/queue/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/ImageBitmap.spec.ts
@@ -321,7 +321,7 @@ g.test('destination_texture,format')
     });
     t.device.popErrorScope();
 
-    const success = ([...kValidTextureFormatsForCopyIB2T] as string[]).includes(format);
+    const success = (kValidTextureFormatsForCopyIB2T as readonly string[]).includes(format);
 
     t.runTest({ imageBitmap }, { texture: dstTexture }, copySize, success);
   });

--- a/src/webgpu/api/validation/queue/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/ImageBitmap.spec.ts
@@ -31,6 +31,7 @@ import {
   kAllTextureFormatInfo,
   kAllTextureFormats,
   kTextureUsages,
+  kValidTextureFormatsForCopyIB2T,
 } from '../../../../capability_info.js';
 import { ValidationTest } from '../../validation_test.js';
 
@@ -39,16 +40,6 @@ const kDefaultWidth = 32;
 const kDefaultHeight = 32;
 const kDefaultDepth = 1;
 const kDefaultMipLevelCount = 6;
-
-// From spec
-const kValidTextureFormatsForCopyIB2T = [
-  'rgba8unorm',
-  'rgba8unorm-srgb',
-  'bgra8unorm',
-  'bgra8unorm-srgb',
-  'rgb10a2unorm',
-  'rg8unorm',
-];
 
 function computeMipMapSize(width: number, height: number, mipLevel: number) {
   return {
@@ -330,7 +321,7 @@ g.test('destination_texture,format')
     });
     t.device.popErrorScope();
 
-    const success = kValidTextureFormatsForCopyIB2T.includes(format);
+    const success = ([...kValidTextureFormatsForCopyIB2T] as string[]).includes(format);
 
     t.runTest({ imageBitmap }, { texture: dstTexture }, copySize, success);
   });

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -220,6 +220,16 @@ export const kAllTextureFormats = keysOf(kAllTextureFormatInfo);
 // Assert every GPUTextureFormat is covered by one of the tables.
 ((x: { readonly [k in GPUTextureFormat]: {} }) => x)(kAllTextureFormatInfo);
 
+// From spec
+export const kValidTextureFormatsForCopyIB2T = [
+  'rgba8unorm',
+  'rgba8unorm-srgb',
+  'bgra8unorm',
+  'bgra8unorm-srgb',
+  'rgb10a2unorm',
+  'rg8unorm',
+] as const;
+
 export const kTextureDimensionInfo: {
   readonly [k in GPUTextureDimension]: {
     // Add fields as needed

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -13,7 +13,11 @@ TODO: Test zero-sized copies from all sources (just make sure params cover it) (
 import { poptions, params } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { unreachable } from '../../../common/framework/util/util.js';
-import { RegularTextureFormat, kRegularTextureFormatInfo } from '../../capability_info.js';
+import {
+  RegularTextureFormat,
+  kRegularTextureFormatInfo,
+  kValidTextureFormatsForCopyIB2T,
+} from '../../capability_info.js';
 import { GPUTest } from '../../gpu_test.js';
 import { kTexelRepresentationInfo } from '../../util/texture/texel_data.js';
 
@@ -253,16 +257,7 @@ g.test('from_ImageData')
     params()
       .combine(poptions('alpha', ['none', 'premultiply'] as const))
       .combine(poptions('orientation', ['none', 'flipY'] as const))
-      .combine(
-        poptions('dstColorFormat', [
-          'rgba8unorm',
-          'bgra8unorm',
-          'rgba8unorm-srgb',
-          'bgra8unorm-srgb',
-          'rgb10a2unorm',
-          'rg8unorm',
-        ] as const)
-      )
+      .combine(poptions('dstColorFormat', kValidTextureFormatsForCopyIB2T))
   )
   .subcases(() =>
     params()
@@ -329,16 +324,7 @@ g.test('from_canvas')
   .cases(
     params()
       .combine(poptions('orientation', ['none', 'flipY'] as const))
-      .combine(
-        poptions('dstColorFormat', [
-          'rgba8unorm',
-          'bgra8unorm',
-          'rgba8unorm-srgb',
-          'bgra8unorm-srgb',
-          'rgb10a2unorm',
-          'rg8unorm',
-        ] as const)
-      )
+      .combine(poptions('dstColorFormat', kValidTextureFormatsForCopyIB2T))
   )
   .subcases(() =>
     params()

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -260,10 +260,7 @@ g.test('from_ImageData')
           'rgba8unorm-srgb',
           'bgra8unorm-srgb',
           'rgb10a2unorm',
-          'rgba16float',
-          'rgba32float',
           'rg8unorm',
-          'rg16float',
         ] as const)
       )
   )
@@ -339,10 +336,7 @@ g.test('from_canvas')
           'rgba8unorm-srgb',
           'bgra8unorm-srgb',
           'rgb10a2unorm',
-          'rgba16float',
-          'rgba32float',
           'rg8unorm',
-          'rg16float',
         ] as const)
       )
   )


### PR DESCRIPTION
Update copyImageBitmapToTexture validation rules based on the new
CL (https://github.com/gpuweb/gpuweb/pull/1737)





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
