### PR TITLE
Add validation for creating compute pipeline

### DIFF
--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -1,16 +1,5 @@
 export const description = `
 createComputePipeline and createComputePipelineAsync validation tests.
-
-For createComputePipeline and its async version createComputePipelineAsync,
-each start with a valid descriptor, than for the only one compute stage, make
-following errors:
-- compute stage's module is an invalid object
-- compute stage's module is of other stage, i.e., vertex or gragment
-- stage's entryPoint doesn't exist, including following situation:
-  - the entryPoint in module is / isn't 'main'
-  - the assigned name is different from module's name
-  - the assigned name is empty string
-  - the assigned name contain illegal character
 `;
 
 import { params, poptions } from '../../../common/framework/params_builder.js';

--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -1,4 +1,5 @@
 export const description = `
+createComputePipeline and createComputePipelineAsync validation tests.
 
 TODO:
 For createComputePipeline and its async version createComputePipelineAsync,
@@ -115,30 +116,23 @@ g.test('shader_module_stage_must_be_compute')
   .cases(
     params()
       .combine(poptions('isAsync', [true, false]))
-      .combine([
-        {
-          shaderModuleStage: 'compute' as TShaderStage,
-          _success: true,
-        },
-        {
-          shaderModuleStage: 'vertex' as TShaderStage,
-          _success: false,
-        },
-        {
-          shaderModuleStage: 'fragment' as TShaderStage,
-          _success: false,
-        },
-      ])
+      .combine(
+        poptions('shaderModuleStage', [
+          'compute' as TShaderStage,
+          'vertex' as TShaderStage,
+          'fragment' as TShaderStage,
+        ])
+      )
   )
   .fn(async t => {
-    const { isAsync, shaderModuleStage, _success } = t.params;
+    const { isAsync, shaderModuleStage } = t.params;
     const descriptor = {
       compute: {
         module: t.getShaderModule(shaderModuleStage, 'main'),
         entryPoint: 'main',
       },
     };
-    t.doCreateComputePipelineTest(isAsync, _success, descriptor);
+    t.doCreateComputePipelineTest(isAsync, shaderModuleStage === 'compute', descriptor);
   });
 
 g.test('enrty_point_name_must_match')
@@ -146,24 +140,25 @@ g.test('enrty_point_name_must_match')
     params()
       .combine(poptions('isAsync', [true, false]))
       .combine([
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main', _success: true },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: '', _success: false },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0', _success: false },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0a', _success: false },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'mian', _success: false },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main ', _success: false },
-        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\n', _success: false },
-        { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'mian', _success: true },
-        { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'main', _success: false },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main' },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: '' },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0' },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0a' },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'mian' },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main ' },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\n' },
+        { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'mian' },
+        { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'main' },
       ])
   )
   .fn(async t => {
-    const { isAsync, shaderModuleEntryPoint, stageEntryPoint, _success } = t.params;
+    const { isAsync, shaderModuleEntryPoint, stageEntryPoint } = t.params;
     const descriptor = {
       compute: {
         module: t.getShaderModule('compute', shaderModuleEntryPoint),
         entryPoint: stageEntryPoint,
       },
     };
+    const _success = shaderModuleEntryPoint === stageEntryPoint;
     t.doCreateComputePipelineTest(isAsync, _success, descriptor);
   });

--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -1,0 +1,169 @@
+export const description = `
+
+TODO:
+For createComputePipeline and its async version createComputePipelineAsync,
+each start with a valid descriptor, than for the only one compute stage, make
+following errors:
+- compute stage's module is an invalid object
+- compute stage's module is of other stage, i.e., vertex or gragment
+- stage's entryPoint doesn't exist, including following situation:
+  - the entryPoint in module is / isn't 'main'
+  - the assigned name is different from module's name
+  - the assigned name is empty string
+  - the assigned name contain illegal character
+`;
+
+import { params, poptions } from '../../../common/framework/params_builder.js';
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+
+// import { kAllTextureFormats, kAllTextureFormatInfo } from '../../capability_info.js';
+import { ValidationTest } from './validation_test.js';
+
+type TShaderStage = 'compute' | 'vertex' | 'fragment' | 'empty';
+
+class F extends ValidationTest {
+  getShaderModule(
+    shaderStage: TShaderStage = 'compute',
+    entryPoint: string = 'main'
+  ): GPUShaderModule {
+    let code;
+    switch (shaderStage) {
+      case 'compute': {
+        code = `[[stage(compute)]] fn ${entryPoint}() {}`;
+        break;
+      }
+      case 'vertex': {
+        code = `
+        [[stage(vertex)]] fn ${entryPoint}() -> [[builtin(position)]] vec4<f32> {
+          return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }`;
+        break;
+      }
+      case 'fragment': {
+        const fragColorType = 'i32';
+        const suffix = '';
+        code = `
+        [[stage(fragment)]] fn ${entryPoint}() -> [[location(0)]] vec4<${fragColorType}> {
+          return vec4<${fragColorType}>(0${suffix}, 1${suffix}, 0${suffix}, 1${suffix});
+        }`;
+        break;
+      }
+      case 'empty':
+      default: {
+        code = '';
+        break;
+      }
+    }
+    return this.device.createShaderModule({ code });
+  }
+
+  getInvalidShaderModule(): GPUShaderModule {
+    this.device.pushErrorScope('validation');
+    const code = 'deadbeaf'; // Something make nonsense
+    const shaderModule = this.device.createShaderModule({ code });
+    this.device.popErrorScope();
+    return shaderModule;
+  }
+
+  doCreateComputePipelineTest(
+    isAsync: boolean,
+    _success: boolean,
+    descriptor: GPUComputePipelineDescriptor
+  ) {
+    if (isAsync) {
+      if (_success) {
+        this.shouldResolve(this.device.createComputePipelineAsync(descriptor));
+      } else {
+        this.shouldReject('OperationError', this.device.createComputePipelineAsync(descriptor));
+      }
+    } else {
+      if (_success) {
+        this.device.createComputePipeline(descriptor);
+      } else {
+        this.expectValidationError(() => {
+          this.device.createComputePipeline(descriptor);
+        });
+      }
+    }
+  }
+}
+
+export const g = makeTestGroup(F);
+
+g.test('basic_use_of_createComputePipeline')
+  .cases(poptions('isAsync', [true, false]))
+  .fn(async t => {
+    const { isAsync } = t.params;
+    t.doCreateComputePipelineTest(isAsync, true, {
+      compute: { module: t.getShaderModule('compute', 'main'), entryPoint: 'main' },
+    });
+  });
+
+g.test('shader_module_must_be_valid')
+  .cases(poptions('isAsync', [true, false]))
+  .fn(async t => {
+    const { isAsync } = t.params;
+    t.doCreateComputePipelineTest(isAsync, false, {
+      compute: {
+        module: t.getInvalidShaderModule(),
+        entryPoint: 'main',
+      },
+    });
+  });
+
+g.test('shader_module_stage_must_be_compute')
+  .cases(
+    params()
+      .combine(poptions('isAsync', [true, false]))
+      .combine([
+        {
+          shaderModuleStage: 'compute' as TShaderStage,
+          _success: true,
+        },
+        {
+          shaderModuleStage: 'vertex' as TShaderStage,
+          _success: false,
+        },
+        {
+          shaderModuleStage: 'fragment' as TShaderStage,
+          _success: false,
+        },
+      ])
+  )
+  .fn(async t => {
+    const { isAsync, shaderModuleStage, _success } = t.params;
+    const descriptor = {
+      compute: {
+        module: t.getShaderModule(shaderModuleStage, 'main'),
+        entryPoint: 'main',
+      },
+    };
+    t.doCreateComputePipelineTest(isAsync, _success, descriptor);
+  });
+
+g.test('enrty_point_name_must_match')
+  .cases(
+    params()
+      .combine(poptions('isAsync', [true, false]))
+      .combine([
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main', _success: true },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: '', _success: false },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0', _success: false },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0a', _success: false },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'mian', _success: false },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main ', _success: false },
+        { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\n', _success: false },
+        { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'mian', _success: true },
+        { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'main', _success: false },
+      ])
+  )
+  .fn(async t => {
+    const { isAsync, shaderModuleEntryPoint, stageEntryPoint, _success } = t.params;
+    const descriptor = {
+      compute: {
+        module: t.getShaderModule('compute', shaderModuleEntryPoint),
+        entryPoint: stageEntryPoint,
+      },
+    };
+    t.doCreateComputePipelineTest(isAsync, _success, descriptor);
+  });


### PR DESCRIPTION
Add validation test for both createComputePipeline and createComputePipelieAsync.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
