### PR TITLE
Add test plan for the operation tests about stencil aspect

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -597,3 +597,20 @@ g.test('zero_sized')
       dstCopyLevel
     );
   });
+
+g.test('copy_stencil_aspect')
+  .desc(
+    `
+  Validate the correctness of copyTextureToTexture() with stencil aspect.
+
+  For all the texture formats with stencil aspect:
+  - Upload the expected data into a staging buffer
+  - Copy the data of the staging buffer into the stencil aspect of the source texture
+  - Copy the stencil aspect from the source texture into the destination texture
+  - Copy the stencil aspect of the destination texture into another staging buffer and check its
+    content
+  - Test the copies from / into zero / non-zero array layer / mipmap levels
+  - Test copying multiple array layers
+  `
+  )
+  .unimplemented();

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1114,3 +1114,35 @@ g.test('undefined_params')
       changeBeforePass: 'undefined',
     });
   });
+
+g.test('copy_from_stencil_aspect')
+  .desc(
+    `
+  Validate the correctness of copyTextureToBuffer() with stencil aspect.
+
+  For all the texture formats with stencil aspect:
+  - Initialize the source texture with the stencil comparison function "always" and the stencil
+    operation "replace" in a render pass encoder
+  - Copy the stencil aspect of the source texture into the destination buffer
+  - Check if the data in the destination buffer is expected
+  - Test the copies from / into zero / non-zero array layer / mipmap levels
+  - Test copying multiple array layers
+  `
+  )
+  .unimplemented();
+
+g.test('copy_into_stencil_aspect')
+  .desc(
+    `
+  Validate the correctness of copyBufferToTexture() with stencil aspect.
+
+  For all the texture formats with stencil aspect:
+  - Initialize the source buffer with the expected data
+  - Copy the data in the source buffer into the stencil aspect of the destination texture
+  - Check if the data in the stencil aspect of the destination texture is expected with the stencil
+    comparison function "equal" and the stencil operation "keep" in a render pass encoder
+  - Test the copies from / into zero / non-zero array layer / mipmap levels
+  - Test copying multiple array layers
+  `
+  )
+  .unimplemented();


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented in `helper_index.md`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)
    
**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
