### PR TITLE
Remove expected error codes from WGSL validation tests

### DIFF
--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -13,7 +13,7 @@ export class ShaderValidationTest extends GPUTest {
    * ```ts
    * t.expectCompileResult(true, `wgsl code`); // Expect success
    * t.expectCompileResult(false, `wgsl code`); // Expect validation error with any error string
-   * t.expectCompileResult('v-0000', `wgsl code`); // Expect validation error containing 'v-0000'
+   * t.expectCompileResult('substr', `wgsl code`); // Expect validation error containing 'substr'
    * ```
    */
   expectCompileResult(result: boolean | string, code: string) {

--- a/src/webgpu/shader/validation/variable_and_const.spec.ts
+++ b/src/webgpu/shader/validation/variable_and_const.spec.ts
@@ -63,9 +63,9 @@ function getType(scalarType: ScalarType, containerType: ContainerType) {
   return type;
 }
 
-g.test('v_0033')
+g.test('initializer_type')
   .desc(
-    `Tests for validation rule v-0033:
+    `
   If present, the initializer's type must match the store type of the variable.
   Testing scalars, vectors, and matrices of every dimension and type.
   TODO: add test for: structs - arrays of vectors and matrices - arrays of different length
@@ -98,14 +98,13 @@ g.test('v_0033')
       }
     `;
 
-    const expectation =
-      (lhsScalarType === rhsScalarType && lhsContainerType === rhsContainerType) || 'v-0033';
+    const expectation = lhsScalarType === rhsScalarType && lhsContainerType === rhsContainerType;
     t.expectCompileResult(expectation, code);
   });
 
-g.test('v_0038')
+g.test('io_shareable_type')
   .desc(
-    `Tests for validation rule v-0038:
+    `
   The following types are IO-shareable:
   - numeric scalar types
   - numeric vector types
@@ -168,6 +167,6 @@ g.test('v_0038')
       `;
     }
 
-    const expectation = storageClass === 'private' || scalarType !== 'bool' || 'v-0038';
+    const expectation = storageClass === 'private' || scalarType !== 'bool';
     t.expectCompileResult(expectation, code);
   });

--- a/src/webgpu/shader/validation/wgsl/basic.spec.ts
+++ b/src/webgpu/shader/validation/wgsl/basic.spec.ts
@@ -11,7 +11,7 @@ g.test('trivial')
   .desc(`A trivial correct and incorrect shader.`)
   .fn(t => {
     t.expectCompileResult(true, `[[stage(vertex)]] fn main() {}`);
-    t.expectCompileResult('v-0020', `[[stage(vertex), stage(fragment)]] fn main() {}`);
+    t.expectCompileResult(false, `[[stage(vertex), stage(fragment)]] fn main() {}`);
   });
 
 g.test('nonsense')


### PR DESCRIPTION
These have been removed from the WGSL specification. The code for
checking for a specific error substring has been left in for now, in
case we decide to revisit standardized error codes in the future.

Let me know if you'd rather I just remove that code from `expectCompileResult`.

<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
