### PR TITLE
Fix unintended compilation and validation failures

### DIFF
--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -28,7 +28,7 @@ g.test('memcpy').fn(async t => {
       module: t.device.createShaderModule({
         code: `
           [[block]] struct Data {
-              [[offset(0)]] value : u32;
+              value : u32;
           };
 
           [[group(0), binding(0)]] var<storage, read> src : Data;

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -54,7 +54,7 @@ export class BufferSyncTest extends GPUTest {
   createStorageWriteComputePipeline(value: number): GPUComputePipeline {
     const wgslCompute = `
       [[block]] struct Data {
-        [[offset(0)]] a : i32;
+        a : i32;
       };
 
       [[group(0), binding(0)]] var<storage, read_write> data : Data;
@@ -85,7 +85,7 @@ export class BufferSyncTest extends GPUTest {
 
       fragment: `
       [[block]] struct Data {
-        [[offset(0)]] a : i32;
+        a : i32;
       };
 
       [[group(0), binding(0)]] var<storage, read_write> data : Data;

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -30,7 +30,7 @@ class F extends ValidationTest {
         module: this.device.createShaderModule({
           code: `
             [[block]] struct VertexUniforms {
-              [[offset(0)]] transform : mat2x2<f32> ;
+              transform : mat2x2<f32> ;
             };
             [[group(0), binding(0)]] var<uniform> uniforms : VertexUniforms;
 
@@ -51,7 +51,7 @@ class F extends ValidationTest {
         module: this.device.createShaderModule({
           code: `
             [[block]] struct FragmentUniforms {
-              [[offset(0)]] color : vec4<f32>;
+              color : vec4<f32>;
             };
             [[group(1), binding(0)]] var<uniform> uniforms : FragmentUniforms;
 

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -904,7 +904,9 @@ g.test('unused_bindings_in_pipeline')
     const bindGroup0 = t.createBindGroup(0, view, 'readonly-storage-texture', '2d', 'rgba8unorm');
     const bindGroup1 = t.createBindGroup(0, view, 'writeonly-storage-texture', '2d', 'rgba8unorm');
 
-    const wgslVertex = '[[stage(vertex)]] fn main() {}';
+    const wgslVertex = `[[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+  return vec4<f32>();
+}`;
     // TODO: revisit the shader code once 'image' can be supported in wgsl.
     const wgslFragment = pp`
       ${pp._if(useBindGroup0)}

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -209,7 +209,9 @@ export class ValidationTest extends GPUTest {
     return this.device.createRenderPipeline({
       vertex: {
         module: this.device.createShaderModule({
-          code: '[[stage(vertex)]] fn main() {}',
+          code: `[[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+  return vec4<f32>();
+}`,
         }),
         entryPoint: 'main',
       },

--- a/src/webgpu/shader/validation/variable_and_const.spec.ts
+++ b/src/webgpu/shader/validation/variable_and_const.spec.ts
@@ -92,7 +92,7 @@ g.test('initializer_type')
     const rhsType = getType(rhsScalarType, rhsContainerType);
 
     const code = `
-      [[stage(vertex)]]
+      [[stage(fragment)]]
       fn main() {
         ${variableOrConstant} a : ${lhsType} = ${rhsType}();
       }

--- a/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
@@ -8,5 +8,6 @@ struct Particles {
 [[group(0), binding(1)]] var<storage> particles : Particles;
 
 [[stage(vertex)]]
-fn main() {
+fn main() -> [[builtin(position)]] vec4<f32> {
+  return vec4<f32>();
 }

--- a/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
@@ -2,7 +2,7 @@
 
 [[block]]
 struct Particles {
-  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;
+  particles : [[stride(16)]] array<f32, 4>;
 };
 
 [[group(0), binding(1)]] var<storage> particles : Particles;

--- a/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
@@ -9,5 +9,6 @@ struct Particles {
 [[group(1), binding(0)]] var<storage, read_write> particles : Particles;
 
 [[stage(vertex)]]
-fn main() {
+fn main() -> [[builtin(position)]] vec4<f32> {
+  return vec4<f32>();
 }

--- a/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
@@ -3,7 +3,7 @@
 
 [[block]]
 struct Particles {
-  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;
+  particles : [[stride(16)]] array<f32, 4>;
 };
 
 [[group(1), binding(0)]] var<storage, read_write> particles : Particles;

--- a/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
@@ -9,5 +9,6 @@ struct Particles {
 [[group(0), binding(0)]] var<uniform, read_write> particles : Particles;
 
 [[stage(vertex)]]
-fn main() {
+fn main() -> [[builtin(position)]] vec4<f32> {
+  return vec4<f32>();
 }

--- a/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
@@ -3,7 +3,7 @@
 
 [[block]]
 struct Particles {
-  [[offset(0)]] particles : [[stride(16)]] array<f32, 4>;
+  particles : [[stride(16)]] array<f32, 4>;
 };
 
 [[group(0), binding(0)]] var<uniform, read_write> particles : Particles;

--- a/src/webgpu/shader/validation/wgsl/basic.spec.ts
+++ b/src/webgpu/shader/validation/wgsl/basic.spec.ts
@@ -10,7 +10,12 @@ export const g = makeTestGroup(ShaderValidationTest);
 g.test('trivial')
   .desc(`A trivial correct and incorrect shader.`)
   .fn(t => {
-    t.expectCompileResult(true, `[[stage(vertex)]] fn main() {}`);
+    t.expectCompileResult(
+      true,
+      `[[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+  return vec4<f32>();
+}`
+    );
     t.expectCompileResult(false, `[[stage(vertex), stage(fragment)]] fn main() {}`);
   });
 

--- a/src/webgpu/shader/validation/wgsl/break-outside-for-or-switch.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/break-outside-for-or-switch.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0009 - This fails because the break is used outside a for or switch block.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   if (true) {
     break;

--- a/src/webgpu/shader/validation/wgsl/continue-outside-for.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/continue-outside-for.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0010 - This fails because the continue is used outside of a for block.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   continue;
   return;

--- a/src/webgpu/shader/validation/wgsl/duplicate-func-name.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-func-name.fail.wgsl
@@ -8,7 +8,7 @@ fn my_func() {
   return;
 }
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/duplicate-name-between-global-and-func-vars.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-name-between-global-and-func-vars.fail.wgsl
@@ -2,7 +2,7 @@
 
 let a : vec2<f32> = vec2<f32>(0.1, 1.0);
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a : f32;
 

--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
@@ -9,7 +9,7 @@ fn Foo() {
   return;
 }
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var Foo : f32;
   var f : Foo;

--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
@@ -8,7 +8,7 @@ struct foo {
   b : f32;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
@@ -1,11 +1,11 @@
 // v-0012 - This fails because of the duplicated `foo` structure.
 
 struct foo {
-  [[offset (0)]] a : i32;
+  a : i32;
 };
 
 struct foo {
-  [[offset (0)]] b : f32;
+  b : f32;
 };
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/duplicate-var-name-sibling.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-name-sibling.pass.wgsl
@@ -1,6 +1,6 @@
 // v-0014 - This passes because variable `a` is redeclared in a sibling scope.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   if (true) {
     var a : i32 = -1;

--- a/src/webgpu/shader/validation/wgsl/duplicate-var-name-within-func.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-name-within-func.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0014 - This fails because variable `a` is redeclared.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a : u32 = 1u;
   if (true) {

--- a/src/webgpu/shader/validation/wgsl/fn-use-before-def.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/fn-use-before-def.fail.wgsl
@@ -12,7 +12,7 @@ fn c() -> i32 {
   return a();
 }
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/function-return-missing-return-empty-body.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/function-return-missing-return-empty-body.fail.wgsl
@@ -4,6 +4,6 @@
 fn func() -> i32 {
 }
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/function-return-missing-return.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/function-return-missing-return.fail.wgsl
@@ -5,7 +5,7 @@ fn func() -> i32 {
   var a : i32 = 0;
 }
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   func();
 }

--- a/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v2.fail.wgsl
@@ -6,7 +6,7 @@ fn a() {
   return;
 }
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique-v3.fail.wgsl
@@ -2,7 +2,7 @@
 
 let a : vec2<f32> = vec2<f32>(0.1, 1.0);
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a: u32;
   return;

--- a/src/webgpu/shader/validation/wgsl/module-scope-variable-function-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/module-scope-variable-function-storage-class.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<function> f : vec2<f32>;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/module-scope-variable-no-explicit-storage-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/module-scope-variable-no-explicit-storage-decoration.fail.wgsl
@@ -3,6 +3,6 @@
 
 var f : vec2<f32>;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/reassign-const.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/reassign-const.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0021 - Fails because `c` is a const and can not be re-assigned.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   let c : f32 = 0.1;
   c = 0.2;

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
@@ -5,7 +5,7 @@ struct S{
   data : RTArr;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var <storage> x : S;
   var y : array<i32,2>;

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
@@ -2,7 +2,7 @@
 
 type RTArr = [[stride (16)]] array<i32>;
 struct S{
-  [[offset(0)]] data : RTArr;
+  data : RTArr;
 };
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
@@ -3,7 +3,7 @@
 type RTArr = [[stride(4)]] array<f32>;
 [[group(0), binding(1)]] var<storage> x : RTArr;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
@@ -6,7 +6,7 @@ struct SArr{
   data : RTArr;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var s : SArr;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
@@ -3,7 +3,7 @@
 type RTArr = [[stride (16)]] array<vec4<f32>>;
 [[block]]
 struct SArr{
-  [[offset(0)]] data : RTArr;
+  data : RTArr;
 };
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
@@ -5,7 +5,6 @@ struct S{
   data : RTArr;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
-  var <storage> x : S;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
@@ -2,7 +2,7 @@
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
 struct S{
-  [[offset(0)]] data : RTArr;
+  data : RTArr;
 };
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
@@ -7,6 +7,6 @@ struct S {
   b : f32;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
@@ -3,8 +3,8 @@
 type RTArr = [[stride (16)]] array<vec4<f32>>;
 [[block]]
 struct S {
-  [[offset(0)]] data : RTArr;
-  [[offset(4)]] b : f32;
+  data : RTArr;
+  b : f32;
 };
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
@@ -2,7 +2,6 @@
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
-  var<storage> rt : RTArr;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
@@ -6,7 +6,7 @@ struct Foo {
   b : f32;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
@@ -2,8 +2,8 @@
 
 [[block]]
 struct Foo {
-  [[offset (0)]] a : [[stride (16)]] array<f32>;
-  [[offset (8)]] b : f32;
+  a : [[stride (16)]] array<f32>;
+  b : f32;
 };
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
@@ -5,7 +5,7 @@ struct Foo {
   a : array<f32>;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
@@ -2,7 +2,7 @@
 
 [[block]]
 struct Foo {
-  [[offset (0)]] a : array<f32>;
+  a : array<f32>;
 };
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/self-recursion-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/self-recursion-v2.fail.wgsl
@@ -16,7 +16,7 @@ fn a() -> i32 {
   return b();
 }
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var v : i32 = a();
   return;

--- a/src/webgpu/shader/validation/wgsl/self-recursion.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/self-recursion.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0004 - Self recursion is dis-allowed and `other` calls itself.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn other() -> i32 {
   return other();
 }

--- a/src/webgpu/shader/validation/wgsl/struct-def-before-use.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-def-before-use.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0007 - fails because 'f' is not a struct.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var f : f32;
   f.a = 4.0;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
@@ -12,7 +12,7 @@ struct foo {
   x : goo;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var f : foo;
   f.x.y.t = 2.0;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
@@ -12,7 +12,7 @@ fn Foo() -> goo {
   return a;
 }
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var r : i32 = Foo().s.z;
   return;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
@@ -6,7 +6,7 @@ struct foo {
   a : array<f32>;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var f : foo;
   f.c = 2;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
@@ -2,8 +2,8 @@
 // is used.
 
 struct foo {
-  [[offset (0)]] b : f32;
-  [[offset (8)]] a : array<f32>;
+  b : f32;
+  a : array<f32>;
 };
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
@@ -9,7 +9,7 @@ struct foo {
   a : f32;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var f : foo;
   f.a = 2.0;

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0007 - Fails because 'f' is not a struct.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var f : f32;
   f.a = 4.0;

--- a/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
@@ -6,7 +6,7 @@ struct Foo {
   a : i32;
 };
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
@@ -3,7 +3,7 @@
 const a : Foo;
 
 struct Foo {
-  [[offset 0]] a : i32;
+  a : i32;
 };
 
 [[stage(vertex)]]

--- a/src/webgpu/shader/validation/wgsl/switch-case-selector-must-have-the-same-type-as-the-selector-expression-2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-case-selector-must-have-the-same-type-as-the-selector-expression-2.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0026: line 7: the case selector values must have the same type as the selector expression
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a: i32 = -2;
   switch (a) {

--- a/src/webgpu/shader/validation/wgsl/switch-case-selector-must-have-the-same-type-as-the-selector-expression.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-case-selector-must-have-the-same-type-as-the-selector-expression.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0026: line 7: the case selector values must have the same type as the selector expression
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a: u32 = 2;
   switch (a) {

--- a/src/webgpu/shader/validation/wgsl/switch-case-selector-value-must-be-unique.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-case-selector-value-must-be-unique.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0027: line 9: a literal value must not appear more than once in the case selectors for a
 // switch statement: '0'
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a: u32 = 2;
   switch (a) {

--- a/src/webgpu/shader/validation/wgsl/switch-case.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-case.pass.wgsl
@@ -1,6 +1,6 @@
 // correct use of switch statement
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a: i32 = 2;
   switch (a) {

--- a/src/webgpu/shader/validation/wgsl/switch-fallthrough-must-not-be-last-stmt-of-last-clause.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-fallthrough-must-not-be-last-stmt-of-last-clause.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0028: line 9: a fallthrough statement must not appear as the last statement in last clause
 // of a switch
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a: i32 = -2;
   switch (a) {

--- a/src/webgpu/shader/validation/wgsl/switch-must-have-exactly-one-default-clause-2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-must-have-exactly-one-default-clause-2.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0008: line 6: switch statement must have exactly one default clause
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a: i32 = 2;
   switch (a) {

--- a/src/webgpu/shader/validation/wgsl/switch-must-have-exactly-one-default-clause.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-must-have-exactly-one-default-clause.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0008: line 6: switch statement must have exactly one default clause
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a: i32 = 2;
   switch (a) {

--- a/src/webgpu/shader/validation/wgsl/switch-selector-expression-must-be-scalar-integer-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/switch-selector-expression-must-be-scalar-integer-type.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0025: line 6: switch statement selector expression must be of a scalar integer type
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var a: f32 = 3.14;
   switch (a) {

--- a/src/webgpu/shader/validation/wgsl/var-def-before-use.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/var-def-before-use.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0006 - Fails because 'a' is not defined.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var b : f32 = 1.0;
   a = 4;

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-bool.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> f : f32  = true;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-i32.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> f : f32  = 0;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32-u32.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> f : f32  = 0u;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-f32.pass.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : f32  = 0.0;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-function.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-function.wgsl
@@ -1,6 +1,6 @@
 // v-0033: variable 'a' store type is 'f32', however its initializer type is 'i32'.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var<function> a : f32  = 1;
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-bool.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : i32  = true;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-f32.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : i32  = 123.0;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32-u32.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : i32  = 1u;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-i32.pass.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : i32  = 0;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-out.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-out.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : i32  = 1.0;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-private.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-private.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : i32  = 1.0;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-bool.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-bool.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> u : u32  = true;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-f32.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> f : u32  = 0.0;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32-i32.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> f : u32  = 0;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-u32.pass.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : u32  = 0u;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
@@ -3,11 +3,11 @@
 
 [[block]]
 struct PositionBuffer {
-  pos: vec2<f32>; 
+  pos: vec2<f32>;
 };
 
 var<storage> s : PositionBuffer;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
@@ -3,7 +3,7 @@
 
 [[block]]
 struct PositionBuffer {
-  [[offset(0)]] pos: vec2<f32>; 
+  pos: vec2<f32>; 
 };
 
 var<storage> s : PositionBuffer;

--- a/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
@@ -1,5 +1,5 @@
 # v-0040: variable 'u' is in uniform storage class so it must be declared with group and binding
-# decoration. 
+# decoration.
 
 [[block]]
 struct Params {
@@ -8,6 +8,6 @@ struct Params {
 
 var<uniform> u : Params;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
@@ -3,7 +3,7 @@
 
 [[block]]
 struct Params {
-  [[offset(0)]] count: i32;
+  count: i32;
 };
 
 var<uniform> u : Params;

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-function.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-function.pass.wgsl
@@ -1,6 +1,6 @@
 // pass v-0032: variable 'a' has an initializer and its storage class is 'function'.
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
   var<function> a : i32  = 1;
 }

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-out.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-out.pass.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : i32  = 1;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-private.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-private.pass.wgsl
@@ -2,6 +2,6 @@
 
 var<private> a : i32  = 1;
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
@@ -8,6 +8,6 @@ struct PositionBuffer {
 [[group(0), binding(0)]]
 var<storage> s : PositionBuffer = PositionBuffer(vec2<f32>(0.0, 0.0));
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
@@ -2,7 +2,7 @@
 
 [[block]]
 struct PositionBuffer {
-  [[offset(0)]] pos: vec2<f32>;
+  pos: vec2<f32>;
 };
 
 [[group(0), binding(0)]]

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
@@ -8,6 +8,6 @@ struct Params {
 [[group(0), binding(0)]]
 var<uniform> u : Params = Params(1);
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
@@ -2,7 +2,7 @@
 
 [[block]]
 struct Params {
-  [[offset(0)]] count: i32;
+  count: i32;
 };
 
 [[group(0), binding(0)]]

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup-array.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup-array.fail.wgsl
@@ -2,7 +2,7 @@
 
 var<workgroup> w : array<i32, 4> = array<i32, 4>(0, 1, 0, 1);
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }
 

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-workgroup.fail.wgsl
@@ -2,7 +2,7 @@
 
 var<workgroup> w : vec3<i32> = vec3<i32>(0, 1, 0);
 
-[[stage(vertex)]]
+[[stage(fragment)]]
 fn main() {
 }
 

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -56,9 +56,7 @@ function doTest(
   [[group(0), binding(0)]] var tex : texture_2d<${shaderType}>;
 
   [[block]] struct Output {
-    ${rep.componentOrder
-      .map((C, i) => `result${C} : ${shaderType};`)
-      .join('\n')}
+    ${rep.componentOrder.map(C => `result${C} : ${shaderType};`).join('\n')}
   };
   [[group(0), binding(1)]] var<storage, read_write> output : Output;
 

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -57,7 +57,7 @@ function doTest(
 
   [[block]] struct Output {
     ${rep.componentOrder
-      .map((C, i) => `[[offset(${i * 4})]] result${C} : ${shaderType};`)
+      .map((C, i) => `result${C} : ${shaderType};`)
       .join('\n')}
   };
   [[group(0), binding(1)]] var<storage, read_write> output : Output;


### PR DESCRIPTION
A number of fixes for updating WGSL to match new spec changes.

The `[[offset]]` decoration has been removed for `[[size]]` and `[[align]]` decorations. See https://github.com/gpuweb/gpuweb/pull/1447.

Vertex stage entry points must now return a `[[builtin(position)]]` value.

Most of this is done without testing, as there's many so many pre-existing failing tests, I simply couldn't use the test runner.
