### PR TITLE
wgsl: Fixes for new validation failures

### DIFF
--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -55,7 +55,7 @@ g.test('render_pass_resolve')
             [[stage(vertex)]] fn main(
               [[builtin(vertex_index)]] VertexIndex : i32
               ) -> [[builtin(position)]] vec4<f32> {
-              let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+              var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                   vec2<f32>(-1.0, -1.0),
                   vec2<f32>(-1.0,  1.0),
                   vec2<f32>( 1.0,  1.0));

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -29,7 +29,7 @@ g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
             [[stage(vertex)]] fn main(
               [[builtin(vertex_index)]] VertexIndex : i32
               ) -> [[builtin(position)]] vec4<f32> {
-              let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+              var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                   vec2<f32>( 1.0, -1.0),
                   vec2<f32>( 1.0,  1.0),
                   vec2<f32>(-1.0,  1.0));

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -103,7 +103,7 @@ g.test('culling')
               [[stage(vertex)]] fn main(
                 [[builtin(vertex_index)]] VertexIndex : i32
                 ) -> [[builtin(position)]] vec4<f32> {
-                let pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+                var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
                     vec2<f32>(-1.0,  1.0),
                     vec2<f32>(-1.0,  0.0),
                     vec2<f32>( 0.0,  1.0),

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -61,7 +61,7 @@ g.test('fullscreen_quad').fn(async t => {
         [[stage(vertex)]] fn main(
           [[builtin(vertex_index)]] VertexIndex : i32
           ) -> [[builtin(position)]] vec4<f32> {
-            let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+            var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
                 vec2<f32>(-1.0, -3.0),
                 vec2<f32>(3.0, 1.0),
                 vec2<f32>(-1.0, 1.0));

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -186,7 +186,7 @@ g.test('reverse_depth')
               [[builtin(vertex_index)]] VertexIndex : u32,
               [[builtin(instance_index)]] InstanceIndex : u32) -> Output {
               // TODO: remove workaround for Tint unary array access broke
-              let zv : array<vec2<f32>, 4> = array<vec2<f32>, 4>(
+              var zv : array<vec2<f32>, 4> = array<vec2<f32>, 4>(
                   vec2<f32>(0.2, 0.2),
                   vec2<f32>(0.3, 0.3),
                   vec2<f32>(-0.1, -0.1),
@@ -195,7 +195,7 @@ g.test('reverse_depth')
 
               var output : Output;
               output.Position = vec4<f32>(0.5, 0.5, z, 1.0);
-              let colors : array<vec4<f32>, 4> = array<vec4<f32>, 4>(
+              var colors : array<vec4<f32>, 4> = array<vec4<f32>, 4>(
                   vec4<f32>(1.0, 0.0, 0.0, 1.0),
                   vec4<f32>(0.0, 1.0, 0.0, 1.0),
                   vec4<f32>(0.0, 0.0, 1.0, 1.0),

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -9,7 +9,7 @@ function makeFullscreenVertexModule(device: GPUDevice) {
     [[stage(vertex)]]
     fn main([[builtin(vertex_index)]] VertexIndex : i32)
          -> [[builtin(position)]] vec4<f32> {
-      let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+      var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
         vec2<f32>(-1.0, -3.0),
         vec2<f32>( 3.0,  1.0),
         vec2<f32>(-1.0,  1.0));

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -64,7 +64,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
 
             [[stage(vertex)]] fn main(
               [[builtin(vertex_index)]] VertexIndex : i32) -> Outputs {
-              let position : array<vec3<f32>, 6> = array<vec3<f32>, 6>(
+              var position : array<vec3<f32>, 6> = array<vec3<f32>, 6>(
                 vec3<f32>(-0.5, 0.5, -0.5),
                 vec3<f32>(0.5, 0.5, -0.5),
                 vec3<f32>(-0.5, 0.5, 0.5),
@@ -72,7 +72,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
                 vec3<f32>(0.5, 0.5, -0.5),
                 vec3<f32>(0.5, 0.5, 0.5));
               // uv is pre-scaled to mimic repeating tiled texture
-              let uv : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+              var uv : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
                 vec2<f32>(0.0, 0.0),
                 vec2<f32>(1.0, 0.0),
                 vec2<f32>(0.0, 50.0),


### PR DESCRIPTION
Values of array and matrix can now only be indexed by a constant value.
Dynamic indexing requires the value to be held in memory.

See: https://github.com/gpuweb/gpuweb/issues/1782
