### PR TITLE
Add operation tests about buffer zero initialization - Part I

### DIFF
--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -1,25 +1,68 @@
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { assert, unreachable } from '../../../../common/util/util.js';
+import { GPUConst } from '../../../constants.js';
 import { GPUTest } from '../../../gpu_test.js';
 
 export const description = `
 Test uninitialized buffers are initialized to zero when read
 (or read-written, e.g. with depth write or atomics).
 
-Here lists all the buffer usages to test:
-- in writeBuffer()
-- in map async (read and partial write)
-- created with mappedAtCreation === true
-- as copy source (TODO)
-- as copy destination in a partial copy (TODO)
-- in ResolveQuerySet() (TODO)
-- as uniform / read-only storage / storage buffer (TODO)
-- as vertex / index buffe (TODO)
-- as indirect buffer (TODO)
+Here lists all the buffer usages to test in future patches:
+- as copy source
+- as copy destination in a partial copy
+- in ResolveQuerySet()
+- as uniform / read-only storage / storage buffer
+- as vertex / index buffer
+- as indirect buffer
 `;
 
-export const g = makeTestGroup(GPUTest);
+const kMapModeOptions = [GPUConst.MapMode.READ, GPUConst.MapMode.WRITE];
+const kBufferUsagesInBufferMappingTests = [
+  GPUConst.BufferUsage.COPY_DST | GPUConst.BufferUsage.MAP_READ,
+  GPUConst.BufferUsage.COPY_SRC | GPUConst.BufferUsage.MAP_WRITE,
+  GPUConst.BufferUsage.COPY_SRC,
+];
+
+class F extends GPUTest {
+  GetBufferUsageFromMapMode(mapMode: GPUMapModeFlags): number {
+    switch (mapMode) {
+      case GPUMapMode.READ:
+        return GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
+      case GPUMapMode.WRITE:
+        return GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE;
+      default:
+        unreachable();
+        return 0;
+    }
+  }
+
+  async CheckGPUBufferContent(
+    buffer: GPUBuffer,
+    bufferUsage: GPUBufferUsageFlags,
+    expectedData: Uint8Array
+  ): Promise<void> {
+    // We can only check the buffer contents with t.expectContents() when the buffer usage contains
+    // COPY_SRC.
+    if (bufferUsage & GPUBufferUsage.MAP_READ) {
+      await buffer.mapAsync(GPUMapMode.READ);
+      this.expectBuffer(new Uint8Array(buffer.getMappedRange()), expectedData);
+      buffer.unmap();
+    } else {
+      assert((bufferUsage & GPUBufferUsage.COPY_SRC) !== 0);
+      this.expectContents(buffer, expectedData);
+    }
+  }
+}
+
+export const g = makeTestGroup(F);
 
 g.test('partial_write_buffer')
+  .desc(
+    `
+  Verify when we upload data to a part of a buffer with writeBuffer() just after the creation of the
+  buffer, the remaining part of that buffer will be initialized to 0.
+  `
+  )
   .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -12]))
   .fn(async t => {
     const { offset } = t.params;
@@ -42,239 +85,147 @@ g.test('partial_write_buffer')
     t.expectContents(buffer, expectedData);
   });
 
-g.test('map_read_whole_buffer').fn(async t => {
-  const bufferSize = 32;
-
-  const buffer = t.device.createBuffer({
-    size: bufferSize,
-    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
-  });
-
-  await buffer.mapAsync(GPUMapMode.READ);
-  const readData = new Uint8Array(buffer.getMappedRange());
-  for (let i = 0; i < readData.length; ++i) {
-    t.expect(readData[i] === 0);
-  }
-  buffer.unmap();
-});
-
-g.test('map_read_partial_buffer')
-  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
+g.test('map_whole_buffer')
+  .desc(
+    `
+  Verify when we map the whole range of a mappable GPUBuffer to a typed array buffer just after
+  creating the GPUBuffer, the contents of both the typed array buffer and the GPUBuffer itself have
+  already been initialized to 0.
+  `
+  )
+  .params(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
-    const { offset } = t.params;
-    const bufferSize = 32;
-    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
+    const { mapMode } = t.params;
 
+    const bufferSize = 32;
+    const bufferUsage = t.GetBufferUsageFromMapMode(mapMode);
     const buffer = t.device.createBuffer({
       size: bufferSize,
-      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+      usage: bufferUsage,
     });
 
-    {
-      const mapSize = 16;
-      await buffer.mapAsync(GPUMapMode.READ, appliedOffset, mapSize);
-      const readData = new Uint8Array(buffer.getMappedRange(appliedOffset, mapSize));
-      for (let i = 0; i < mapSize; ++i) {
-        t.expect(readData[i] === 0);
-      }
-      buffer.unmap();
+    await buffer.mapAsync(mapMode);
+    const readData = new Uint8Array(buffer.getMappedRange());
+    for (let i = 0; i < bufferSize; ++i) {
+      t.expect(readData[i] === 0);
     }
+    buffer.unmap();
 
-    {
-      await buffer.mapAsync(GPUMapMode.READ);
-      const readData = new Uint8Array(buffer.getMappedRange());
-      for (let i = 0; i < bufferSize; ++i) {
-        t.expect(readData[i] === 0);
-      }
-      buffer.unmap();
-    }
-  });
-
-g.test('map_write_whole_buffer').fn(async t => {
-  const bufferSize = 32;
-  const buffer = t.device.createBuffer({
-    size: bufferSize,
-    usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
-  });
-
-  await buffer.mapAsync(GPUMapMode.WRITE);
-  const writeData = new Uint8Array(buffer.getMappedRange());
-  for (let i = 0; i < bufferSize; ++i) {
-    t.expect(writeData[i] === 0);
-  }
-  buffer.unmap();
-});
-
-g.test('map_write_partial_buffer')
-  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
-  .fn(async t => {
-    const { offset } = t.params;
-    const bufferSize = 32;
-    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
-
-    const buffer = t.device.createBuffer({
-      size: bufferSize,
-      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
-    });
-
-    {
-      const mappedSize = 12;
-      await buffer.mapAsync(GPUMapMode.WRITE, appliedOffset, mappedSize);
-      const writeData = new Uint8Array(buffer.getMappedRange(appliedOffset, mappedSize));
-      for (let i = 0; i < mappedSize; ++i) {
-        t.expect(writeData[i] === 0);
-      }
-      buffer.unmap();
-    }
-
-    {
+    // We can only check the buffer contents with t.expectContents() when the buffer usage contains
+    // COPY_SRC.
+    if (bufferUsage & GPUBufferUsage.COPY_SRC) {
       const expectedData = new Uint8Array(bufferSize);
       t.expectContents(buffer, expectedData);
     }
   });
 
-g.test('mapped_at_creation_map_readable_whole_buffer').fn(async t => {
-  const bufferSize = 32;
-  const buffer = t.device.createBuffer({
-    mappedAtCreation: true,
-    size: bufferSize,
-    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+g.test('map_partial_buffer')
+  .desc(
+    `
+  Verify when we map a subrange of a mappable GPUBuffer to a typed array buffer just after the
+  creation of the GPUBuffer, the contents of both the typed array buffer and the GPUBuffer have
+  already been initialized to 0.
+  `
+  )
+  .params(u => u.combine('mapMode', kMapModeOptions).beginSubcases().combine('offset', [0, 8, -16]))
+  .fn(async t => {
+    const { mapMode, offset } = t.params;
+    const bufferSize = 32;
+    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
+
+    const bufferUsage = t.GetBufferUsageFromMapMode(mapMode);
+    const buffer = t.device.createBuffer({
+      size: bufferSize,
+      usage: bufferUsage,
+    });
+
+    const expectedData = new Uint8Array(bufferSize);
+    {
+      const mapSize = 16;
+      await buffer.mapAsync(mapMode, appliedOffset, mapSize);
+      const mappedData = new Uint8Array(buffer.getMappedRange(appliedOffset, mapSize));
+      for (let i = 0; i < mapSize; ++i) {
+        t.expect(mappedData[i] === 0);
+        if (mapMode === GPUMapMode.WRITE) {
+          mappedData[i] = expectedData[appliedOffset + i] = i + 1;
+        }
+      }
+      buffer.unmap();
+    }
+
+    await t.CheckGPUBufferContent(buffer, bufferUsage, expectedData);
   });
 
-  const mapped = new Uint8Array(buffer.getMappedRange());
-  for (let i = 0; i < bufferSize; ++i) {
-    t.expect(mapped[i] === 0);
-  }
-  buffer.unmap();
-});
-
-g.test('mapped_at_creation_map_readable_partial_buffer')
-  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
+g.test('mapped_at_creation_whole_buffer')
+  .desc(
+    `
+  Verify when we call getMappedRange() at the whole range of a GPUBuffer created with
+  mappedAtCreation === true just after its creation, the contents of both the returned typed array
+  buffer of getMappedRange() and the GPUBuffer itself have all been initialized to 0.
+  `
+  )
+  .params(u => u.combine('bufferUsage', kBufferUsagesInBufferMappingTests))
   .fn(async t => {
-    const { offset } = t.params;
+    const { bufferUsage } = t.params;
+
+    const bufferSize = 32;
+    const buffer = t.device.createBuffer({
+      mappedAtCreation: true,
+      size: bufferSize,
+      usage: bufferUsage,
+    });
+
+    const mapped = new Uint8Array(buffer.getMappedRange());
+    for (let i = 0; i < bufferSize; ++i) {
+      t.expect(mapped[i] === 0);
+    }
+    buffer.unmap();
+
+    // We can only check the buffer contents with t.expectContents() when the buffer usage contains
+    // COPY_SRC.
+    if (bufferUsage & GPUBufferUsage.COPY_SRC) {
+      const expectedData = new Uint8Array(bufferSize);
+      t.expectContents(buffer, expectedData);
+    }
+  });
+
+g.test('mapped_at_creation_partial_buffer')
+  .desc(
+    `
+  Verify when we call getMappedRange() at a subrange of a GPUBuffer created with
+  mappedAtCreation === true just after its creation, the contents of both the returned typed array
+  buffer of getMappedRange() and the GPUBuffer itself have all been initialized to 0.
+  `
+  )
+  .params(u =>
+    u
+      .combine('bufferUsage', kBufferUsagesInBufferMappingTests)
+      .beginSubcases()
+      .combine('offset', [0, 8, -16])
+  )
+  .fn(async t => {
+    const { bufferUsage, offset } = t.params;
     const bufferSize = 32;
     const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
 
     const buffer = t.device.createBuffer({
       mappedAtCreation: true,
       size: bufferSize,
-      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+      usage: bufferUsage,
     });
 
+    const expectedData = new Uint8Array(bufferSize);
     {
       const mappedSize = 12;
       const mapped = new Uint8Array(buffer.getMappedRange(appliedOffset, mappedSize));
       for (let i = 0; i < mappedSize; ++i) {
         t.expect(mapped[i] === 0);
+        if (!(bufferUsage & GPUBufferUsage.MAP_READ)) {
+          mapped[i] = expectedData[appliedOffset + i] = i + 1;
+        }
       }
       buffer.unmap();
     }
 
-    {
-      await buffer.mapAsync(GPUMapMode.READ);
-      const readData = new Uint8Array(buffer.getMappedRange());
-      const expectedData = new Uint8Array(bufferSize);
-      t.expectBuffer(readData, expectedData);
-      buffer.unmap();
-    }
-  });
-
-g.test('mapped_at_creation_map_writable_whole_buffer').fn(async t => {
-  const bufferSize = 32;
-  const buffer = t.device.createBuffer({
-    mappedAtCreation: true,
-    size: bufferSize,
-    usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
-  });
-
-  {
-    const writeData = new Uint8Array(buffer.getMappedRange());
-    for (let i = 0; i < bufferSize; ++i) {
-      t.expect(writeData[i] === 0);
-    }
-    buffer.unmap();
-  }
-
-  {
-    const expectedData = new Uint8Array(bufferSize);
-    t.expectContents(buffer, expectedData);
-  }
-});
-
-g.test('mapped_at_creation_map_writable_partial_buffer')
-  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
-  .fn(async t => {
-    const { offset } = t.params;
-    const bufferSize = 32;
-    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
-
-    const buffer = t.device.createBuffer({
-      mappedAtCreation: true,
-      size: bufferSize,
-      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
-    });
-
-    {
-      const mappedSize = 12;
-      const writeData = new Uint8Array(buffer.getMappedRange(appliedOffset, mappedSize));
-      for (let i = 0; i < mappedSize; ++i) {
-        t.expect(writeData[i] === 0);
-      }
-      buffer.unmap();
-    }
-
-    {
-      const expectedData = new Uint8Array(bufferSize);
-      t.expectContents(buffer, expectedData);
-    }
-  });
-
-g.test('mapped_at_creation_no_map_usage_whole_buffer').fn(async t => {
-  const bufferSize = 32;
-  const buffer = t.device.createBuffer({
-    mappedAtCreation: true,
-    size: bufferSize,
-    usage: GPUBufferUsage.COPY_SRC,
-  });
-
-  {
-    const writeData = new Uint8Array(buffer.getMappedRange());
-    for (let i = 0; i < bufferSize; ++i) {
-      t.expect(writeData[i] === 0);
-    }
-    buffer.unmap();
-  }
-
-  {
-    const expectedData = new Uint8Array(bufferSize);
-    t.expectContents(buffer, expectedData);
-  }
-});
-
-g.test('mapped_at_creation_no_map_usage_partial_buffer')
-  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
-  .fn(async t => {
-    const { offset } = t.params;
-    const bufferSize = 32;
-    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
-
-    const buffer = t.device.createBuffer({
-      mappedAtCreation: true,
-      size: bufferSize,
-      usage: GPUBufferUsage.COPY_SRC,
-    });
-
-    {
-      const mappedSize = 12;
-      const writeData = new Uint8Array(buffer.getMappedRange(appliedOffset, mappedSize));
-      for (let i = 0; i < mappedSize; ++i) {
-        t.expect(writeData[i] === 0);
-      }
-      buffer.unmap();
-    }
-
-    {
-      const expectedData = new Uint8Array(bufferSize);
-      t.expectContents(buffer, expectedData);
-    }
+    await t.CheckGPUBufferContent(buffer, bufferUsage, expectedData);
   });

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -5,7 +5,276 @@ export const description = `
 Test uninitialized buffers are initialized to zero when read
 (or read-written, e.g. with depth write or atomics).
 
-TODO
+Here lists all the buffer usages to test:
+- in writeBuffer()
+- in map async (read and partial write)
+- created with mappedAtCreation === true
+- as copy source (TODO)
+- as copy destination in a partial copy (TODO)
+- in ResolveQuerySet() (TODO)
+- as uniform / read-only storage / storage buffer (TODO)
+- as vertex / index buffe (TODO)
+- as indirect buffer (TODO)
 `;
 
 export const g = makeTestGroup(GPUTest);
+
+g.test('partial_write_buffer')
+  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -12]))
+  .fn(async t => {
+    const { offset } = t.params;
+    const bufferSize = 32;
+    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
+
+    const buffer = t.device.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+
+    const copySize = 12;
+    const writeData = new Uint8Array(copySize);
+    const expectedData = new Uint8Array(bufferSize);
+    for (let i = 0; i < copySize; ++i) {
+      expectedData[appliedOffset + i] = writeData[i] = i + 1;
+    }
+    t.queue.writeBuffer(buffer, appliedOffset, writeData, 0);
+
+    t.expectContents(buffer, expectedData);
+  });
+
+g.test('map_read_whole_buffer').fn(async t => {
+  const bufferSize = 32;
+
+  const buffer = t.device.createBuffer({
+    size: bufferSize,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  await buffer.mapAsync(GPUMapMode.READ);
+  const readData = new Uint8Array(buffer.getMappedRange());
+  for (let i = 0; i < readData.length; ++i) {
+    t.expect(readData[i] === 0);
+  }
+  buffer.unmap();
+});
+
+g.test('map_read_partial_buffer')
+  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
+  .fn(async t => {
+    const { offset } = t.params;
+    const bufferSize = 32;
+    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
+
+    const buffer = t.device.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    });
+
+    {
+      const mapSize = 16;
+      await buffer.mapAsync(GPUMapMode.READ, appliedOffset, mapSize);
+      const readData = new Uint8Array(buffer.getMappedRange(appliedOffset, mapSize));
+      for (let i = 0; i < mapSize; ++i) {
+        t.expect(readData[i] === 0);
+      }
+      buffer.unmap();
+    }
+
+    {
+      await buffer.mapAsync(GPUMapMode.READ);
+      const readData = new Uint8Array(buffer.getMappedRange());
+      for (let i = 0; i < bufferSize; ++i) {
+        t.expect(readData[i] === 0);
+      }
+      buffer.unmap();
+    }
+  });
+
+g.test('map_write_whole_buffer').fn(async t => {
+  const bufferSize = 32;
+  const buffer = t.device.createBuffer({
+    size: bufferSize,
+    usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  });
+
+  await buffer.mapAsync(GPUMapMode.WRITE);
+  const writeData = new Uint8Array(buffer.getMappedRange());
+  for (let i = 0; i < bufferSize; ++i) {
+    t.expect(writeData[i] === 0);
+  }
+  buffer.unmap();
+});
+
+g.test('map_write_partial_buffer')
+  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
+  .fn(async t => {
+    const { offset } = t.params;
+    const bufferSize = 32;
+    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
+
+    const buffer = t.device.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+    });
+
+    {
+      const mappedSize = 12;
+      await buffer.mapAsync(GPUMapMode.WRITE, appliedOffset, mappedSize);
+      const writeData = new Uint8Array(buffer.getMappedRange(appliedOffset, mappedSize));
+      for (let i = 0; i < mappedSize; ++i) {
+        t.expect(writeData[i] === 0);
+      }
+      buffer.unmap();
+    }
+
+    {
+      const expectedData = new Uint8Array(bufferSize);
+      t.expectContents(buffer, expectedData);
+    }
+  });
+
+g.test('mapped_at_creation_map_readable_whole_buffer').fn(async t => {
+  const bufferSize = 32;
+  const buffer = t.device.createBuffer({
+    mappedAtCreation: true,
+    size: bufferSize,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  const mapped = new Uint8Array(buffer.getMappedRange());
+  for (let i = 0; i < bufferSize; ++i) {
+    t.expect(mapped[i] === 0);
+  }
+  buffer.unmap();
+});
+
+g.test('mapped_at_creation_map_readable_partial_buffer')
+  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
+  .fn(async t => {
+    const { offset } = t.params;
+    const bufferSize = 32;
+    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
+
+    const buffer = t.device.createBuffer({
+      mappedAtCreation: true,
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    });
+
+    {
+      const mappedSize = 12;
+      const mapped = new Uint8Array(buffer.getMappedRange(appliedOffset, mappedSize));
+      for (let i = 0; i < mappedSize; ++i) {
+        t.expect(mapped[i] === 0);
+      }
+      buffer.unmap();
+    }
+
+    {
+      await buffer.mapAsync(GPUMapMode.READ);
+      const readData = new Uint8Array(buffer.getMappedRange());
+      const expectedData = new Uint8Array(bufferSize);
+      t.expectBuffer(readData, expectedData);
+      buffer.unmap();
+    }
+  });
+
+g.test('mapped_at_creation_map_writable_whole_buffer').fn(async t => {
+  const bufferSize = 32;
+  const buffer = t.device.createBuffer({
+    mappedAtCreation: true,
+    size: bufferSize,
+    usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+  });
+
+  {
+    const writeData = new Uint8Array(buffer.getMappedRange());
+    for (let i = 0; i < bufferSize; ++i) {
+      t.expect(writeData[i] === 0);
+    }
+    buffer.unmap();
+  }
+
+  {
+    const expectedData = new Uint8Array(bufferSize);
+    t.expectContents(buffer, expectedData);
+  }
+});
+
+g.test('mapped_at_creation_map_writable_partial_buffer')
+  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
+  .fn(async t => {
+    const { offset } = t.params;
+    const bufferSize = 32;
+    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
+
+    const buffer = t.device.createBuffer({
+      mappedAtCreation: true,
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+    });
+
+    {
+      const mappedSize = 12;
+      const writeData = new Uint8Array(buffer.getMappedRange(appliedOffset, mappedSize));
+      for (let i = 0; i < mappedSize; ++i) {
+        t.expect(writeData[i] === 0);
+      }
+      buffer.unmap();
+    }
+
+    {
+      const expectedData = new Uint8Array(bufferSize);
+      t.expectContents(buffer, expectedData);
+    }
+  });
+
+g.test('mapped_at_creation_no_map_usage_whole_buffer').fn(async t => {
+  const bufferSize = 32;
+  const buffer = t.device.createBuffer({
+    mappedAtCreation: true,
+    size: bufferSize,
+    usage: GPUBufferUsage.COPY_SRC,
+  });
+
+  {
+    const writeData = new Uint8Array(buffer.getMappedRange());
+    for (let i = 0; i < bufferSize; ++i) {
+      t.expect(writeData[i] === 0);
+    }
+    buffer.unmap();
+  }
+
+  {
+    const expectedData = new Uint8Array(bufferSize);
+    t.expectContents(buffer, expectedData);
+  }
+});
+
+g.test('mapped_at_creation_no_map_usage_partial_buffer')
+  .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -16]))
+  .fn(async t => {
+    const { offset } = t.params;
+    const bufferSize = 32;
+    const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
+
+    const buffer = t.device.createBuffer({
+      mappedAtCreation: true,
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_SRC,
+    });
+
+    {
+      const mappedSize = 12;
+      const writeData = new Uint8Array(buffer.getMappedRange(appliedOffset, mappedSize));
+      for (let i = 0; i < mappedSize; ++i) {
+        t.expect(writeData[i] === 0);
+      }
+      buffer.unmap();
+    }
+
+    {
+      const expectedData = new Uint8Array(bufferSize);
+      t.expectContents(buffer, expectedData);
+    }
+  });

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -7,7 +7,8 @@ export const description = `
 Test uninitialized buffers are initialized to zero when read
 (or read-written, e.g. with depth write or atomics).
 
-Here lists all the buffer usages to test in future patches:
+TODO:
+Test the buffers whose first usage is being used:
 - as copy source
 - as copy destination in a partial copy
 - in ResolveQuerySet()
@@ -58,10 +59,8 @@ export const g = makeTestGroup(F);
 
 g.test('partial_write_buffer')
   .desc(
-    `
-  Verify when we upload data to a part of a buffer with writeBuffer() just after the creation of the
-  buffer, the remaining part of that buffer will be initialized to 0.
-  `
+    `Verify when we upload data to a part of a buffer with writeBuffer() just after the creation of
+the buffer, the remaining part of that buffer will be initialized to 0.`
   )
   .paramsSubcasesOnly(u => u.combine('offset', [0, 8, -12]))
   .fn(async t => {
@@ -87,11 +86,9 @@ g.test('partial_write_buffer')
 
 g.test('map_whole_buffer')
   .desc(
-    `
-  Verify when we map the whole range of a mappable GPUBuffer to a typed array buffer just after
-  creating the GPUBuffer, the contents of both the typed array buffer and the GPUBuffer itself have
-  already been initialized to 0.
-  `
+    `Verify when we map the whole range of a mappable GPUBuffer to a typed array buffer just after
+creating the GPUBuffer, the contents of both the typed array buffer and the GPUBuffer itself
+have already been initialized to 0.`
   )
   .params(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
@@ -111,21 +108,15 @@ g.test('map_whole_buffer')
     }
     buffer.unmap();
 
-    // We can only check the buffer contents with t.expectContents() when the buffer usage contains
-    // COPY_SRC.
-    if (bufferUsage & GPUBufferUsage.COPY_SRC) {
-      const expectedData = new Uint8Array(bufferSize);
-      t.expectContents(buffer, expectedData);
-    }
+    const expectedData = new Uint8Array(bufferSize);
+    await t.CheckGPUBufferContent(buffer, bufferUsage, expectedData);
   });
 
 g.test('map_partial_buffer')
   .desc(
-    `
-  Verify when we map a subrange of a mappable GPUBuffer to a typed array buffer just after the
-  creation of the GPUBuffer, the contents of both the typed array buffer and the GPUBuffer have
-  already been initialized to 0.
-  `
+    `Verify when we map a subrange of a mappable GPUBuffer to a typed array buffer just after the
+creation of the GPUBuffer, the contents of both the typed array buffer and the GPUBuffer have
+already been initialized to 0.`
   )
   .params(u => u.combine('mapMode', kMapModeOptions).beginSubcases().combine('offset', [0, 8, -16]))
   .fn(async t => {
@@ -158,11 +149,9 @@ g.test('map_partial_buffer')
 
 g.test('mapped_at_creation_whole_buffer')
   .desc(
-    `
-  Verify when we call getMappedRange() at the whole range of a GPUBuffer created with
-  mappedAtCreation === true just after its creation, the contents of both the returned typed array
-  buffer of getMappedRange() and the GPUBuffer itself have all been initialized to 0.
-  `
+    `Verify when we call getMappedRange() at the whole range of a GPUBuffer created with
+mappedAtCreation === true just after its creation, the contents of both the returned typed
+array buffer of getMappedRange() and the GPUBuffer itself have all been initialized to 0.`
   )
   .params(u => u.combine('bufferUsage', kBufferUsagesInBufferMappingTests))
   .fn(async t => {
@@ -181,21 +170,15 @@ g.test('mapped_at_creation_whole_buffer')
     }
     buffer.unmap();
 
-    // We can only check the buffer contents with t.expectContents() when the buffer usage contains
-    // COPY_SRC.
-    if (bufferUsage & GPUBufferUsage.COPY_SRC) {
-      const expectedData = new Uint8Array(bufferSize);
-      t.expectContents(buffer, expectedData);
-    }
+    const expectedData = new Uint8Array(bufferSize);
+    await t.CheckGPUBufferContent(buffer, bufferUsage, expectedData);
   });
 
 g.test('mapped_at_creation_partial_buffer')
   .desc(
-    `
-  Verify when we call getMappedRange() at a subrange of a GPUBuffer created with
-  mappedAtCreation === true just after its creation, the contents of both the returned typed array
-  buffer of getMappedRange() and the GPUBuffer itself have all been initialized to 0.
-  `
+    `Verify when we call getMappedRange() at a subrange of a GPUBuffer created with
+mappedAtCreation === true just after its creation, the contents of both the returned typed
+array buffer of getMappedRange() and the GPUBuffer itself have all been initialized to 0.`
   )
   .params(u =>
     u

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -18,7 +18,7 @@ Test the buffers whose first usage is being used:
 `;
 
 const kMapModeOptions = [GPUConst.MapMode.READ, GPUConst.MapMode.WRITE];
-const kBufferUsagesInBufferMappingTests = [
+const kBufferUsagesForMappedAtCreationTests = [
   GPUConst.BufferUsage.COPY_DST | GPUConst.BufferUsage.MAP_READ,
   GPUConst.BufferUsage.COPY_SRC | GPUConst.BufferUsage.MAP_WRITE,
   GPUConst.BufferUsage.COPY_SRC,
@@ -153,7 +153,7 @@ g.test('mapped_at_creation_whole_buffer')
 mappedAtCreation === true just after its creation, the contents of both the returned typed
 array buffer of getMappedRange() and the GPUBuffer itself have all been initialized to 0.`
   )
-  .params(u => u.combine('bufferUsage', kBufferUsagesInBufferMappingTests))
+  .params(u => u.combine('bufferUsage', kBufferUsagesForMappedAtCreationTests))
   .fn(async t => {
     const { bufferUsage } = t.params;
 
@@ -182,7 +182,7 @@ array buffer of getMappedRange() and the GPUBuffer itself have all been initiali
   )
   .params(u =>
     u
-      .combine('bufferUsage', kBufferUsagesInBufferMappingTests)
+      .combine('bufferUsage', kBufferUsagesForMappedAtCreationTests)
       .beginSubcases()
       .combine('offset', [0, 8, -16])
   )


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
