### PR TITLE
Validation tests for queue.writeBuffer

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -157,6 +157,7 @@ export function* iterRange<T>(n: number, fn: (i: number) => T): Iterable<T> {
 
 export type TypedArrayBufferView =
   | Uint8Array
+  | Uint8ClampedArray
   | Uint16Array
   | Uint32Array
   | Int8Array

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -1,18 +1,8 @@
 export const description = `
 Tests writeBuffer validation.
 
-- buffer missing usage flag
-- bufferOffset {ok, unaligned, too large for buffer}
-- dataOffset {ok, too large for data}
-- buffer size {ok, too small for copy}
-- data size {ok, too small for copy}
-- size {aligned, unaligned}
-- size unspecified; default {ok, too large for buffer}
-
 Note: destroyed buffer is tested in destroyed/.
-
-TODO: implement usage flag validation.
-TODO: validate large write sizes that may overflow.
+Note: buffer map state is tested in ./buffer_mapped.spec.ts.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -20,6 +10,7 @@ import {
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
 } from '../../../../common/util/util.js';
+import { GPUConst } from '../../../constants.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
@@ -36,7 +27,7 @@ interpreted correctly for both.
 
 Also verifies that the specified data range:
 
-  - Describes a valid range of the source buffer.
+  - Describes a valid range of the destination buffer and source buffer.
   - Fits fully within the destination buffer.
   - Has a byte size which is a multiple of 4.
 `
@@ -112,8 +103,14 @@ Also verifies that the specified data range:
       // Writing zero bytes at the end of the buffer
       queue.writeBuffer(buffer, bufferSize, arraySm, 0, 0);
 
+      // Writing with a buffer offset that is out of range of buffer size
+      t.expectValidationError(() => queue.writeBuffer(buffer, bufferSize + 4, arraySm, 0, 0));
+
       // Writing zero bytes from the end of the data
       queue.writeBuffer(buffer, 0, arraySm, 8, 0);
+
+      // Writing with a data offset that is out of range of data size
+      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, 9, 0));
 
       // A data offset of undefined should be treated as 0
       queue.writeBuffer(buffer, 0, arraySm, undefined, 8);
@@ -121,7 +118,6 @@ Also verifies that the specified data range:
     }
 
     const arrayTypes = [
-      Uint8Array,
       Uint8Array,
       Int8Array,
       Uint16Array,
@@ -137,4 +133,27 @@ Also verifies that the specified data range:
     for (const arrayType of arrayTypes) {
       runTest(arrayType, false);
     }
+  });
+
+g.test('usages')
+  .desc(
+    `
+Tests calling writeBuffer with the buffer missed COPY_DST usage.
+- buffer {with, without} COPY DST usage
+`
+  )
+  .paramsSubcasesOnly([
+    { usage: GPUConst.BufferUsage.COPY_DST, _valid: true }, // control case
+    { usage: GPUConst.BufferUsage.STORAGE, _valid: false }, // wihtout COPY_DST usage
+    { usage: GPUConst.BufferUsage.STORAGE | GPUConst.BufferUsage.COPY_SRC, _valid: false }, // with other usage
+    { usage: GPUConst.BufferUsage.STORAGE | GPUConst.BufferUsage.COPY_DST, _valid: true }, // with COPY_DST usage
+  ])
+  .fn(async t => {
+    const { usage, _valid } = t.params;
+    const buffer = t.device.createBuffer({ size: 16, usage });
+    const data = new Uint8Array(16);
+
+    t.expectValidationError(() => {
+      t.device.queue.writeBuffer(buffer, 0, data, 0, data.length);
+    }, !_valid);
   });

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -136,35 +136,6 @@ Also verifies that the specified data range:
     }
   });
 
-g.test('write_sizes_overflow')
-  .desc(
-    `
-Tests writing large sizes that may overflow a 64-bit integer.
-- dataOffset + size overflow
-`
-  )
-  .paramsSubcasesOnly([
-    { dataOffset: 0, size: 0x1008, _valid: true }, // control case
-    { dataOffset: 0x800, size: 0xfffffffffffff800, _valid: false }, // dataOffset + size overflow to zero
-    { dataOffset: 0xfffffffffffff800, size: 0x800, _valid: false }, // dataOffset + size overflow to zero
-    { dataOffset: 0x1008, size: 0xfffffffffffff800, _valid: false }, // dataOffset + size overflow to non-zero
-    { dataOffset: 0xfffffffffffff800, size: 0x1008, _valid: false }, // dataOffset + size overflow to non-zero
-  ])
-  .fn(async t => {
-    const { dataOffset, size, _valid } = t.params;
-    const dataSize = 4104; // Large enough to write the sizes after overflow
-    const buffer = t.device.createBuffer({ size: dataSize, usage: GPUBufferUsage.COPY_DST });
-    const data = new Uint8Array(dataSize);
-
-    if (_valid) {
-      t.device.queue.writeBuffer(buffer, 0, data, dataOffset, size);
-    } else {
-      t.shouldThrow('OperationError', () =>
-        t.device.queue.writeBuffer(buffer, 0, data, dataOffset, size)
-      );
-    }
-  });
-
 g.test('usages')
   .desc(
     `


### PR DESCRIPTION
- The ranges tests have covered these validations:
  - the write size is  too large for the destination buffer,
  - the write size extends the source buffer size.
- Add tests for buffer offset and data offset out of range.
- Add tests for the buffer missed COPY_DST usage.
- Cleanup TODOs.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
