### PR TITLE
Roll @webgpu/types to 0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/node": "^14.11.10",
         "@types/offscreencanvas": "^2019.6.2",
         "@typescript-eslint/parser": "^4.22.0",
-        "@webgpu/types": "^0.1.3",
+        "@webgpu/types": "^0.1.4",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.0.1",
         "chokidar": "^3.4.3",
@@ -1360,9 +1360,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.3.tgz",
-      "integrity": "sha512-rvqmSxoSMqwIjtvMHOvdvgCtJaz8PS4okXTL47Jyf/X5rDTiRoKEW1U3+XPsWcfY9Hp5gir3A0ksi+Eh81bbyg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.4.tgz",
+      "integrity": "sha512-nR0L4xBKUSksLKdFVxcshBL2M9ofAWneYYmK5/5iQJukY4q8a9hcXJwvH7QKQemiK3jxXuCMPkDzFCu/1+5Xvg==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10795,9 +10795,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.3.tgz",
-      "integrity": "sha512-rvqmSxoSMqwIjtvMHOvdvgCtJaz8PS4okXTL47Jyf/X5rDTiRoKEW1U3+XPsWcfY9Hp5gir3A0ksi+Eh81bbyg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.4.tgz",
+      "integrity": "sha512-nR0L4xBKUSksLKdFVxcshBL2M9ofAWneYYmK5/5iQJukY4q8a9hcXJwvH7QKQemiK3jxXuCMPkDzFCu/1+5Xvg==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "^0.1.3",
+    "@webgpu/types": "^0.1.4",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",
     "chokidar": "^3.4.3",

--- a/src/webgpu/api/validation/encoding/queries/common.ts
+++ b/src/webgpu/api/validation/encoding/queries/common.ts
@@ -19,7 +19,7 @@ export function beginRenderPassWithQuerySet(
   encoder: GPUCommandEncoder,
   querySet?: GPUQuerySet
 ): GPURenderPassEncoder {
-  const attachment = t.device
+  const view = t.device
     .createTexture({
       format: 'rgba8unorm' as const,
       size: { width: 16, height: 16, depthOrArrayLayers: 1 },
@@ -29,8 +29,9 @@ export function beginRenderPassWithQuerySet(
   return encoder.beginRenderPass({
     colorAttachments: [
       {
-        attachment,
+        view,
         loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        storeOp: 'store',
       },
     ],
     occlusionQuerySet: querySet,

--- a/src/webgpu/constants.ts
+++ b/src/webgpu/constants.ts
@@ -56,7 +56,7 @@ export const GPUConst = {
   MapMode,
 } as const;
 
-type Limits = Omit<GPUAdapterLimits, '__brand'>;
+type Limits = Omit<GPUSupportedLimits, '__brand'>;
 export const DefaultLimits: Limits = {
   maxTextureDimension1D: 8192,
   maxTextureDimension2D: 8192,

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -199,6 +199,8 @@ function canonicalizeDescriptor(
 
   // Type ensures every field is carried through.
   const descriptorCanonicalized: CanonicalDeviceDescriptor = {
+    requiredFeatures: featuresCanonicalized,
+    requiredLimits: limitsCanonicalized,
     nonGuaranteedFeatures: featuresCanonicalized,
     nonGuaranteedLimits: limitsCanonicalized,
   };


### PR DESCRIPTION
With minimal changes necessary to allow `npm run check` to pass cleanly.