### PR TITLE
Review and expand api,validation,buffer,destroy:*

### DIFF
--- a/src/webgpu/api/validation/buffer/destroy.spec.ts
+++ b/src/webgpu/api/validation/buffer/destroy.spec.ts
@@ -1,15 +1,43 @@
 export const description = `
-Destroying a buffer more than once is allowed.
+Validation tests for GPUBuffer.destroy.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { kBufferUsages } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
 
+g.test('all_usages')
+  .desc('Test destroying buffers of every usage type.')
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('usage', kBufferUsages)
+  )
+  .fn(async t => {
+    const { usage } = t.params;
+    const buf = t.device.createBuffer({
+      size: 4,
+      usage,
+    });
+
+    buf.destroy();
+  });
+
+g.test('error_buffer')
+  .desc('Test that error buffers may be destroyed without generating validation errors.')
+  .fn(async t => {
+    const buf = t.getErrorBuffer();
+    buf.destroy();
+  });
+
 g.test('twice')
-  .desc('Tests various mapping-related descripton options that could affect how state is tracked.')
+  .desc(
+    `Test that destroying a buffer more than once is allowed.
+      - Tests buffers which are mapped at creation or not
+      - Tests buffers with various usages`
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('mappedAtCreation', [false, true])
@@ -28,7 +56,37 @@ g.test('twice')
 
 g.test('while_mapped')
   .desc(
-    `Test destroying a {mappable, unmappable mapAtCreation, mappable mapAtCreation} buffer while it
-is {mapped, mapped at creation}`
+    `Test destroying buffers while mapped.
+      - Tests {mappable, unmappable mapAtCreation, mappable mapAtCreation}
+      - Tests while {mapped, mapped at creation}`
   )
-  .unimplemented();
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('mappedAtCreation', [false, true])
+      .combineWithParams([
+        { usage: GPUConst.BufferUsage.COPY_SRC },
+        {
+          usage: GPUConst.BufferUsage.MAP_WRITE | GPUConst.BufferUsage.COPY_SRC,
+          mapMode: GPUConst.MapMode.WRITE,
+        },
+        {
+          usage: GPUConst.BufferUsage.COPY_DST | GPUConst.BufferUsage.MAP_READ,
+          mapMode: GPUConst.MapMode.READ,
+        },
+      ])
+      .filter(p => p.mappedAtCreation === false && p.mapMode === undefined)
+  )
+  .fn(async t => {
+    const { usage, mapMode, mappedAtCreation } = t.params;
+    const buf = t.device.createBuffer({
+      size: 4,
+      usage,
+      mappedAtCreation,
+    });
+
+    if (!mappedAtCreation && mapMode !== undefined) {
+      await buf.mapAsync(mapMode);
+    }
+
+    buf.destroy();
+  });


### PR DESCRIPTION
Adds tests for destroying buffers that:
 - have all usages
 - are error buffers
 - are mapped

Error buffer test does not currently pass in Chrome, but the behavior is simple enough that we can confidently add the test now.

<hr>

**Author checklist for test code/plans:**

- [ ] **N/A** All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] **N/A** New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
