### PR TITLE
add ErrorWithExtra for extra debug data

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -1,6 +1,6 @@
 import { TestCaseRecorder } from '../internal/logging/test_case_recorder.js';
 import { JSONWithUndefined } from '../internal/params_utils.js';
-import { assert } from '../util/util.js';
+import { assert, unreachable } from '../util/util.js';
 
 export class SkipTestCase extends Error {}
 export class UnexpectedPassError extends Error {}
@@ -186,5 +186,24 @@ export class Fixture {
       this.rec.expectationFailed(new Error(msg));
     }
     return cond;
+  }
+
+  /** If the argument is an Error, fail (or warn). Otherwise, no-op. */
+  expectOK(
+    error: Error | unknown,
+    { mode = 'fail', niceStack }: { mode?: 'fail' | 'warn'; niceStack?: Error } = {}
+  ): void {
+    if (error instanceof Error) {
+      if (niceStack) {
+        error.stack = niceStack.stack;
+      }
+      if (mode === 'fail') {
+        this.rec.expectationFailed(error);
+      } else if (mode === 'warn') {
+        this.rec.warn(error);
+      } else {
+        unreachable();
+      }
+    }
   }
 }

--- a/src/common/internal/logging/log_message.ts
+++ b/src/common/internal/logging/log_message.ts
@@ -1,14 +1,20 @@
+import { ErrorWithExtra } from '../../util/util.js';
 import { extractImportantStackTrace } from '../stack.js';
 
 export class LogMessageWithStack extends Error {
+  readonly extra: unknown;
+
   private stackHiddenMessage: string | undefined = undefined;
   private timesSeen: number = 1;
 
-  constructor(name: string, ex: Error) {
+  constructor(name: string, ex: Error | ErrorWithExtra) {
     super(ex.message);
 
     this.name = name;
     this.stack = ex.stack;
+    if ('extra' in ex) {
+      this.extra = ex.extra;
+    }
   }
 
   /** Set a flag so the stack is not printed in toJSON(). */

--- a/src/common/internal/logging/logger.ts
+++ b/src/common/internal/logging/logger.ts
@@ -6,17 +6,22 @@ import { TestCaseRecorder } from './test_case_recorder.js';
 export type LogResults = Map<string, LiveTestCaseResult>;
 
 export class Logger {
-  readonly debug: boolean;
+  static globalDebugMode: boolean = false;
+
+  readonly overriddenDebugMode: boolean | undefined;
   readonly results: LogResults = new Map();
 
-  constructor(debug: boolean) {
-    this.debug = debug;
+  constructor({ overrideDebugMode }: { overrideDebugMode?: boolean } = {}) {
+    this.overriddenDebugMode = overrideDebugMode;
   }
 
   record(name: string): [TestCaseRecorder, LiveTestCaseResult] {
     const result: LiveTestCaseResult = { status: 'running', timems: -1 };
     this.results.set(name, result);
-    return [new TestCaseRecorder(result, this.debug), result];
+    return [
+      new TestCaseRecorder(result, this.overriddenDebugMode ?? Logger.globalDebugMode),
+      result,
+    ];
   }
 
   asJSON(space?: number): string {

--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -70,7 +70,8 @@ if (queries.length === 0) {
     filterQuery
   );
 
-  const log = new Logger(debug);
+  Logger.globalDebugMode = debug;
+  const log = new Logger();
 
   const failed: Array<[string, LiveTestCaseResult]> = [];
   const warned: Array<[string, LiveTestCaseResult]> = [];

--- a/src/common/runtime/helper/test_worker-worker.ts
+++ b/src/common/runtime/helper/test_worker-worker.ts
@@ -15,7 +15,8 @@ self.onmessage = async (ev: MessageEvent) => {
   const expectations: TestQueryWithExpectation[] = ev.data.expectations;
   const debug: boolean = ev.data.debug;
 
-  const log = new Logger(debug);
+  Logger.globalDebugMode = debug;
+  const log = new Logger();
 
   const testcases = Array.from(await loader.loadCases(parseQuery(query)));
   assert(testcases.length === 1, 'worker query resulted in != 1 cases');

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -6,7 +6,7 @@ import { LiveTestCaseResult } from '../internal/logging/result.js';
 import { parseQuery } from '../internal/query/parseQuery.js';
 import { TestQueryLevel } from '../internal/query/query.js';
 import { TestTreeNode, TestSubtree, TestTreeLeaf } from '../internal/tree.js';
-import { assert } from '../util/util.js';
+import { assert, ErrorWithExtra } from '../util/util.js';
 
 import { optionEnabled } from './helper/options.js';
 import { TestWorker } from './helper/test_worker.js';
@@ -21,7 +21,8 @@ let haveSomeResults = false;
 const runnow = optionEnabled('runnow');
 const debug = optionEnabled('debug');
 
-const logger = new Logger(debug);
+Logger.globalDebugMode = debug;
+const logger = new Logger();
 
 const worker = optionEnabled('worker') ? new TestWorker(debug) : undefined;
 
@@ -112,8 +113,7 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
               .attr('title', 'Log stack to console')
               .appendTo(caselog)
               .on('click', () => {
-                /* eslint-disable-next-line no-console */
-                console.log(l);
+                consoleLogError(l);
               });
             $('<pre>').addClass('testcaselogtext').appendTo(caselog).text(l.toJSON());
           }
@@ -192,6 +192,18 @@ function makeSubtreeChildrenHTML(
   return { runSubtree: runMySubtree, generateSubtreeHTML: generateMyHTML };
 }
 
+function consoleLogError(e: Error | ErrorWithExtra | undefined) {
+  if (e === undefined) return;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  (globalThis as any)._stack = e;
+  /* eslint-disable-next-line no-console */
+  console.log('_stack =', e);
+  if ('extra' in e && e.extra !== undefined) {
+    /* eslint-disable-next-line no-console */
+    console.log('_stack.extra =', e.extra);
+  }
+}
+
 function makeTreeNodeHeaderHTML(
   n: TestTreeNode,
   runSubtree: RunSubtree,
@@ -242,8 +254,7 @@ function makeTreeNodeHeaderHTML(
       .attr('title', 'Log test creation stack to console')
       .appendTo(header)
       .on('click', () => {
-        /* eslint-disable-next-line no-console */
-        console.log(n.testCreationStack);
+        consoleLogError(n.testCreationStack);
       });
   }
   const nodetitle = $('<div>').addClass('nodetitle').appendTo(header);

--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -47,7 +47,7 @@ setup({
         )
       : [];
 
-  const log = new Logger(false);
+  const log = new Logger();
 
   for (const testcase of testcases) {
     const name = testcase.query.toString();

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -9,10 +9,20 @@ import { timeout } from './timeout.js';
 export class ErrorWithExtra extends Error {
   readonly extra: {};
 
-  /** `extra` function is only called if in debug mode. */
-  constructor(message: string, extra: () => {}) {
+  /**
+   * `extra` function is only called if in debug mode.
+   * If an `ErrorWithExtra` is passed, its message is used and its extras are passed through.
+   */
+  constructor(message: string, extra: () => {});
+  constructor(base: ErrorWithExtra, newExtra: () => {});
+  constructor(baseOrMessage: string | ErrorWithExtra, newExtra: () => {}) {
+    const message = typeof baseOrMessage === 'string' ? baseOrMessage : baseOrMessage.message;
     super(message);
-    this.extra = Logger.globalDebugMode ? extra() : { omitted: 'must ?debug=1' };
+
+    const oldExtras = baseOrMessage instanceof ErrorWithExtra ? baseOrMessage.extra : {};
+    this.extra = Logger.globalDebugMode
+      ? { ...oldExtras, ...newExtra() }
+      : { omitted: 'pass ?debug=1' };
   }
 }
 

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -1,4 +1,20 @@
+import { Logger } from '../internal/logging/logger.js';
+
 import { timeout } from './timeout.js';
+
+/**
+ * Error with arbitrary `extra` data attached, for debugging.
+ * The extra data is omitted if not running the test in debug mode (`?debug=1`).
+ */
+export class ErrorWithExtra extends Error {
+  readonly extra: {};
+
+  /** `extra` function is only called if in debug mode. */
+  constructor(message: string, extra: () => {}) {
+    super(message);
+    this.extra = Logger.globalDebugMode ? extra() : { omitted: 'must ?debug=1' };
+  }
+}
 
 /**
  * Asserts `condition` is true. Otherwise, throws an `Error` with the provided message.
@@ -7,6 +23,14 @@ export function assert(condition: boolean, msg?: string | (() => string)): asser
   if (!condition) {
     throw new Error(msg && (typeof msg === 'string' ? msg : msg()));
   }
+}
+
+/** If the argument is an Error, throw it. Otherwise, pass it back. */
+export function assertOK<T>(value: Error | T): T {
+  if (value instanceof Error) {
+    throw value;
+  }
+  return value;
 }
 
 /**

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -228,7 +228,7 @@ g.test('end2end').fn(async t => {
   const l = await t.load('suite2:foof:*');
   assert(l.length === 3, 'listing length');
 
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
 
   await runTestcase(
     t,
@@ -266,7 +266,7 @@ g.test('end2end').fn(async t => {
 });
 
 g.test('expectations,single_case').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const zedCases = await t.load('suite1:baz:zed:*');
 
   // Single-case. Covers one case.
@@ -301,7 +301,7 @@ g.test('expectations,single_case').fn(async t => {
 });
 
 g.test('expectations,single_case,none').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const zedCases = await t.load('suite1:baz:zed:*');
   // Single-case. Doesn't cover any cases.
   const zedExpectationsSkipA1B0 = [
@@ -335,7 +335,7 @@ g.test('expectations,single_case,none').fn(async t => {
 });
 
 g.test('expectations,multi_case').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const zedCases = await t.load('suite1:baz:zed:*');
   // Multi-case, not all cases covered.
   const zedExpectationsSkipB3 = [
@@ -369,7 +369,7 @@ g.test('expectations,multi_case').fn(async t => {
 });
 
 g.test('expectations,multi_case_all').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const zedCases = await t.load('suite1:baz:zed:*');
   // Multi-case, all cases covered.
   const zedExpectationsSkipA1 = [
@@ -403,7 +403,7 @@ g.test('expectations,multi_case_all').fn(async t => {
 });
 
 g.test('expectations,multi_case_none').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const zedCases = await t.load('suite1:baz:zed:*');
   // Multi-case, no params, all cases covered.
   const zedExpectationsSkipZed = [
@@ -437,7 +437,7 @@ g.test('expectations,multi_case_none').fn(async t => {
 });
 
 g.test('expectations,multi_test').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const suite1Cases = await t.load('suite1:*');
 
   // Multi-test, all cases covered.
@@ -472,7 +472,7 @@ g.test('expectations,multi_test').fn(async t => {
 });
 
 g.test('expectations,multi_test,none').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const suite1Cases = await t.load('suite1:*');
 
   // Multi-test, no cases covered.
@@ -507,7 +507,7 @@ g.test('expectations,multi_test,none').fn(async t => {
 });
 
 g.test('expectations,multi_file').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const suite1Cases = await t.load('suite1:*');
 
   // Multi-file
@@ -542,7 +542,7 @@ g.test('expectations,multi_file').fn(async t => {
 });
 
 g.test('expectations,catches_failure').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const suite2Cases = await t.load('suite2:*');
 
   // Catches failure
@@ -578,7 +578,7 @@ g.test('expectations,catches_failure').fn(async t => {
 });
 
 g.test('expectations,skip_dominates_failure').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const suite2Cases = await t.load('suite2:*');
 
   const expectedFailures = [
@@ -605,7 +605,7 @@ g.test('expectations,skip_dominates_failure').fn(async t => {
 });
 
 g.test('expectations,skip_inside_failure').fn(async t => {
-  const log = new Logger(true);
+  const log = new Logger({ overrideDebugMode: true });
   const suite2Cases = await t.load('suite2:*');
 
   const expectedFailures = [

--- a/src/unittests/logger.spec.ts
+++ b/src/unittests/logger.spec.ts
@@ -14,7 +14,7 @@ import { UnitTest } from './unit_test.js';
 export const g = makeTestGroup(UnitTest);
 
 g.test('construct').fn(t => {
-  const mylog = new Logger(true);
+  const mylog = new Logger({ overrideDebugMode: true });
   const [, res1] = mylog.record('one');
   const [, res2] = mylog.record('two');
 
@@ -29,7 +29,7 @@ g.test('construct').fn(t => {
 });
 
 g.test('empty').fn(t => {
-  const mylog = new Logger(true);
+  const mylog = new Logger({ overrideDebugMode: true });
   const [rec, res] = mylog.record('one');
 
   rec.start();
@@ -41,7 +41,7 @@ g.test('empty').fn(t => {
 });
 
 g.test('pass').fn(t => {
-  const mylog = new Logger(true);
+  const mylog = new Logger({ overrideDebugMode: true });
   const [rec, res] = mylog.record('one');
 
   rec.start();
@@ -54,7 +54,7 @@ g.test('pass').fn(t => {
 });
 
 g.test('skip').fn(t => {
-  const mylog = new Logger(true);
+  const mylog = new Logger({ overrideDebugMode: true });
   const [rec, res] = mylog.record('one');
 
   rec.start();
@@ -67,7 +67,7 @@ g.test('skip').fn(t => {
 });
 
 g.test('warn').fn(t => {
-  const mylog = new Logger(true);
+  const mylog = new Logger({ overrideDebugMode: true });
   const [rec, res] = mylog.record('one');
 
   rec.start();
@@ -80,7 +80,7 @@ g.test('warn').fn(t => {
 });
 
 g.test('fail,expectationFailed').fn(t => {
-  const mylog = new Logger(true);
+  const mylog = new Logger({ overrideDebugMode: true });
   const [rec, res] = mylog.record('one');
 
   rec.start();
@@ -94,7 +94,7 @@ g.test('fail,expectationFailed').fn(t => {
 });
 
 g.test('fail,validationFailed').fn(t => {
-  const mylog = new Logger(true);
+  const mylog = new Logger({ overrideDebugMode: true });
   const [rec, res] = mylog.record('one');
 
   rec.start();
@@ -108,7 +108,7 @@ g.test('fail,validationFailed').fn(t => {
 });
 
 g.test('fail,threw').fn(t => {
-  const mylog = new Logger(true);
+  const mylog = new Logger({ overrideDebugMode: true });
   const [rec, res] = mylog.record('one');
 
   rec.start();
@@ -129,7 +129,7 @@ g.test('debug')
   .fn(t => {
     const { debug, _logsCount } = t.params;
 
-    const mylog = new Logger(debug);
+    const mylog = new Logger({ overrideDebugMode: debug });
     const [rec, res] = mylog.record('one');
 
     rec.start();

--- a/src/unittests/test_group_test.ts
+++ b/src/unittests/test_group_test.ts
@@ -7,7 +7,7 @@ import { UnitTest } from './unit_test.js';
 
 export class TestGroupTest extends UnitTest {
   async run(g: IterableTestGroup): Promise<LogResults> {
-    const logger = new Logger(true);
+    const logger = new Logger({ overrideDebugMode: true });
     for (const t of g.iterate()) {
       for (const rc of t.iterate()) {
         const query = new TestQuerySingleCase('xx', ['yy'], rc.id.test, rc.id.params);


### PR DESCRIPTION
- Make the "debug mode" logging a global state so we can use it to determine whether to actually save off the extra data or not
- Add an `expectOK` in prep to add helpers which **return** (not throw) `ErrorWithExtra | undefined`, depending on whether they fail.

In service of #592

<hr>

**Author checklist for test code/plans:**

- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
