### PR TITLE
Add operation tests about buffer zero initialization - Part IV

### DIFF
--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -57,29 +57,6 @@ class F extends GPUTest {
     }
   }
 
-  RecordInitializeTextureAsRenderAttachment(
-    encoder: GPUCommandEncoder,
-    texture: GPUTexture,
-    color: GPUColor,
-    baseArrayLayer = 0,
-    baseMipLevel = 0
-  ): void {
-    const renderPass = encoder.beginRenderPass({
-      colorAttachments: [
-        {
-          view: texture.createView({
-            baseArrayLayer,
-            arrayLayerCount: 1,
-            baseMipLevel,
-          }),
-          loadValue: color,
-          storeOp: 'store',
-        },
-      ],
-    });
-    renderPass.endPass();
-  }
-
   TestBufferZeroInitInBindGroup(
     computeShaderModule: GPUShaderModule,
     buffer: GPUBuffer,
@@ -433,13 +410,20 @@ remaining part of it will be initialized to 0.`
 
     // Initialize srcTexture
     for (let layer = 0; layer < arrayLayerCount; ++layer) {
-      t.RecordInitializeTextureAsRenderAttachment(
-        encoder,
-        srcTexture,
-        { r: layer + 1, g: 0, b: 0, a: 0 },
-        layer,
-        copyMipLevel
-      );
+      const renderPass = encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: srcTexture.createView({
+              baseArrayLayer: layer,
+              arrayLayerCount: 1,
+              baseMipLevel: copyMipLevel,
+            }),
+            loadValue: { r: layer + 1, g: 0, b: 0, a: 0 },
+            storeOp: 'store',
+          },
+        ],
+      });
+      renderPass.endPass();
     }
 
     // Do texture-to-buffer copy

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -15,7 +15,6 @@ Note that:
 
 TODO:
 Test the buffers whose first usage is being used:
-- as uniform / read-only storage / storage buffer
 - as vertex / index buffer
 - as indirect buffer
 `;


### PR DESCRIPTION
This patch adds the 4th part of the operation tests about buffer zero
initialization, including the tests on the buffers used as uniform
buffers, read-only storage buffers and storage buffer.

<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
