### PR TITLE
CopyToTexture,canvas basic tests : Add premultiplied alpha tests

### DIFF
--- a/src/webgpu/util/copyToTexture.ts
+++ b/src/webgpu/util/copyToTexture.ts
@@ -57,7 +57,7 @@ export class CopyToTextureUtils extends GPUTest {
 
   doTestAndCheckResult(
     imageCopyExternalImage: GPUImageCopyExternalImage,
-    dstTextureCopyView: GPUImageCopyTexture,
+    dstTextureCopyView: GPUImageCopyTextureTagged,
     copySize: GPUExtent3DDict,
     bytesPerPixel: number,
     expectedData: Uint8ClampedArray

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -15,24 +15,11 @@ import { CopyToTextureUtils } from '../../util/copyToTexture.js';
 import { kTexelRepresentationInfo } from '../../util/texture/texel_data.js';
 
 class F extends CopyToTextureUtils {
-  initCanvasContent({
-    canvasType,
-    contextName,
-    width,
-    height,
-  }: {
-    canvasType: 'onscreen' | 'offscreen';
-    contextName: '2d' | 'webgl' | 'webgl2';
-    width: number;
-    height: number;
-  }): {
-    canvas: HTMLCanvasElement | OffscreenCanvas;
-    canvasContext:
-      | WebGLRenderingContext
-      | WebGL2RenderingContext
-      | CanvasRenderingContext2D
-      | OffscreenCanvasRenderingContext2D;
-  } {
+  createCanvas(
+    canvasType: 'onscreen' | 'offscreen',
+    width: number,
+    height: number
+  ): HTMLCanvasElement | OffscreenCanvas | null {
     let canvas: HTMLCanvasElement | OffscreenCanvas | null = null;
     if (canvasType === 'onscreen') {
       if (typeof document !== 'undefined') {
@@ -51,53 +38,137 @@ class F extends CopyToTextureUtils {
       unreachable();
     }
 
+    return canvas;
+  }
+
+  init2DCanvasContent({
+    canvasType,
+    width,
+    height,
+    isLosePrecisionDstFormat,
+  }: {
+    canvasType: 'onscreen' | 'offscreen';
+    width: number;
+    height: number;
+    isLosePrecisionDstFormat: boolean;
+  }): {
+    canvas: HTMLCanvasElement | OffscreenCanvas;
+    canvasContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+  } {
+    const canvas = this.createCanvas(canvasType, width, height);
     if (canvas === null) {
       this.skip('Cannot create canvas');
     }
 
-    const canvasContext = canvas.getContext(contextName) as
-      | WebGLRenderingContext
-      | WebGL2RenderingContext
+    let canvasContext = null;
+    canvasContext = canvas.getContext('2d') as
       | CanvasRenderingContext2D
       | OffscreenCanvasRenderingContext2D
       | null;
+
     if (canvasContext === null) {
       this.skip(canvasType + ' canvas context not available');
     }
 
-    const contextType: '2d' | 'gl' = contextName === '2d' ? '2d' : 'gl';
+    const rectWidth = Math.floor(width / 2);
+    const rectHeight = Math.floor(height / 2);
+
+    // The rgb10a2unorm dst texture will have tiny errors when we compare actual and expectation.
+    // This is due to the convert from 8-bit to 10-bit combined with alpha value ops. So for
+    // rgb10a2unorm dst textures, we'll set alphaValue to 1.0 to test.
+    const alphaValue = isLosePrecisionDstFormat ? 1.0 : 0.6;
+    const ctx = canvasContext as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    // Red
+    ctx.fillStyle = 'rgba(255, 0, 0,' + alphaValue + ')';
+    ctx.fillRect(0, 0, rectWidth, rectHeight);
+    // Lime
+    ctx.fillStyle = 'rgba(0, 255, 0,' + alphaValue + ')';
+    ctx.fillRect(rectWidth, 0, width - rectWidth, rectHeight);
+    // Blue
+    ctx.fillStyle = 'rgba(0, 0, 255,' + alphaValue + ')';
+    ctx.fillRect(0, rectHeight, rectWidth, height - rectHeight);
+    // Black
+    if (isLosePrecisionDstFormat) {
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.0)';
+    } else {
+      ctx.fillStyle = 'rgba(0, 0, 0,' + alphaValue + ')';
+    }
+    ctx.fillRect(rectWidth, rectHeight, width - rectWidth, height - rectHeight);
+
+    return { canvas, canvasContext };
+  }
+
+  initGLCanvasContent({
+    canvasType,
+    contextName,
+    width,
+    height,
+    premultiplied,
+    isLosePrecisionDstFormat,
+  }: {
+    canvasType: 'onscreen' | 'offscreen';
+    contextName: 'webgl' | 'webgl2';
+    width: number;
+    height: number;
+    premultiplied: boolean;
+    isLosePrecisionDstFormat: boolean;
+  }): {
+    canvas: HTMLCanvasElement | OffscreenCanvas;
+    canvasContext: WebGLRenderingContext | WebGL2RenderingContext;
+  } {
+    const canvas = this.createCanvas(canvasType, width, height);
+    if (canvas === null) {
+      this.skip('Cannot create canvas');
+    }
+
+    let canvasContext = null;
+    canvasContext = canvas.getContext(contextName, { premultipliedAlpha: premultiplied }) as
+      | WebGLRenderingContext
+      | WebGL2RenderingContext
+      | null;
+
+    if (canvasContext === null) {
+      this.skip(canvasType + ' canvas context not available');
+    }
 
     const rectWidth = Math.floor(width / 2);
     const rectHeight = Math.floor(height / 2);
-    if (contextType === '2d') {
-      const ctx = canvasContext as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
-      ctx.fillStyle = '#ff0000'; // red
-      ctx.fillRect(0, 0, rectWidth, rectHeight);
-      ctx.fillStyle = '#00ff00'; // lime
-      ctx.fillRect(rectWidth, 0, width - rectWidth, rectHeight);
-      ctx.fillStyle = '#0000ff'; // blue
-      ctx.fillRect(0, rectHeight, rectWidth, height - rectHeight);
-      ctx.fillStyle = '#000000'; // black
-      ctx.fillRect(rectWidth, rectHeight, width - rectWidth, height - rectHeight);
-    } else if (contextType === 'gl') {
-      const gl = canvasContext as WebGLRenderingContext | WebGL2RenderingContext;
-      gl.enable(gl.SCISSOR_TEST);
-      gl.scissor(0, 0, rectWidth, rectHeight);
-      gl.clearColor(1.0, 0.0, 0.0, 1.0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
 
-      gl.scissor(rectWidth, 0, width - rectWidth, rectHeight);
-      gl.clearColor(0.0, 1.0, 0.0, 1.0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
+    const gl = canvasContext as WebGLRenderingContext | WebGL2RenderingContext;
 
-      gl.scissor(0, rectHeight, rectWidth, height - rectHeight);
-      gl.clearColor(0.0, 0.0, 1.0, 1.0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
+    // The rgb10a2unorm dst texture will have tiny errors when we compare actual and expectation.
+    // This is due to the convert from 8-bit to 10-bit combined with alpha value ops. So for
+    // rgb10a2unorm dst textures, we'll set alphaValue to 0.0 to test.
+    const alphaValue = isLosePrecisionDstFormat ? 1.0 : 0.6;
 
-      gl.scissor(rectWidth, rectHeight, width - rectWidth, height - rectHeight);
-      gl.clearColor(0.0, 0.0, 0.0, 1.0);
-      gl.clear(gl.COLOR_BUFFER_BIT);
-    }
+    // For webgl/webgl2 context canvas, if the context created with premultipliedAlpha attributes,
+    // it means that the value in drawing buffer is premultiplied or not. So we should set
+    // premultipliedAlpha value for premultipliedAlpha true gl context and unpremultipliedAlpha value
+    // for the premulitpliedAlpha false gl context.
+    gl.enable(gl.SCISSOR_TEST);
+    gl.scissor(0, 0, rectWidth, rectHeight);
+    premultiplied
+      ? gl.clearColor(alphaValue, 0.0, 0.0, alphaValue)
+      : gl.clearColor(1.0, 0.0, 0.0, alphaValue);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    gl.scissor(rectWidth, 0, width - rectWidth, rectHeight);
+    premultiplied
+      ? gl.clearColor(0.0, alphaValue, 0.0, alphaValue)
+      : gl.clearColor(0.0, 1.0, 0.0, alphaValue);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    gl.scissor(0, rectHeight, rectWidth, height - rectHeight);
+    premultiplied
+      ? gl.clearColor(0.0, 0.0, alphaValue, alphaValue)
+      : gl.clearColor(0.0, 0.0, 1.0, alphaValue);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    gl.scissor(rectWidth, rectHeight, width - rectWidth, height - rectHeight);
+    premultiplied
+      ? gl.clearColor(alphaValue, alphaValue, alphaValue, alphaValue)
+      : gl.clearColor(1.0, 1.0, 1.0, alphaValue);
+    gl.clear(gl.COLOR_BUFFER_BIT);
 
     return { canvas, canvasContext };
   }
@@ -108,6 +179,8 @@ class F extends CopyToTextureUtils {
     height,
     format,
     contextType,
+    srcPremultiplied,
+    dstPremultiplied,
   }: {
     context:
       | CanvasRenderingContext2D
@@ -118,6 +191,8 @@ class F extends CopyToTextureUtils {
     height: number;
     format: RegularTextureFormat;
     contextType: '2d' | 'gl';
+    srcPremultiplied: boolean;
+    dstPremultiplied: boolean;
   }): Uint8ClampedArray {
     const bytesPerPixel = kTextureFormatInfo[format].bytesPerBlock;
 
@@ -135,18 +210,44 @@ class F extends CopyToTextureUtils {
     }
 
     // Generate expectedPixels
+    // Use getImageData and readPixels to get canvas contents.
     const rep = kTexelRepresentationInfo[format];
     const divide = 255.0;
+    let rgba: { R: number; G: number; B: number; A: number };
     for (let i = 0; i < height; ++i) {
       for (let j = 0; j < width; ++j) {
         const pixelPos = i * width + j;
+
+        rgba = {
+          R: sourcePixels[pixelPos * 4] / divide,
+          G: sourcePixels[pixelPos * 4 + 1] / divide,
+          B: sourcePixels[pixelPos * 4 + 2] / divide,
+          A: sourcePixels[pixelPos * 4 + 3] / divide,
+        };
+
+        if (!srcPremultiplied) {
+          if (dstPremultiplied) {
+            rgba.R *= rgba.A;
+            rgba.G *= rgba.A;
+            rgba.B *= rgba.A;
+          }
+        }
+
+        if (srcPremultiplied && !dstPremultiplied) {
+          if (rgba.A !== 0) {
+            rgba.R /= rgba.A;
+            rgba.G /= rgba.A;
+            rgba.B /= rgba.A;
+          }
+        }
+
         const pixelData = new Uint8Array(
           rep.pack(
             rep.encode({
-              R: sourcePixels[pixelPos * 4] / divide,
-              G: sourcePixels[pixelPos * 4 + 1] / divide,
-              B: sourcePixels[pixelPos * 4 + 2] / divide,
-              A: sourcePixels[pixelPos * 4 + 3] / divide,
+              R: rgba.R,
+              G: rgba.G,
+              B: rgba.B,
+              A: rgba.A,
             })
           )
         );
@@ -160,13 +261,13 @@ class F extends CopyToTextureUtils {
 
 export const g = makeTestGroup(F);
 
-g.test('copy_contents_from_canvas')
+g.test('copy_contents_from_2d_context_canvas')
   .desc(
     `
-  Test HTMLCanvasElement and OffscreenCanvas with 2d/webgl/webgl2 context
+  Test HTMLCanvasElement and OffscreenCanvas with 2d context
   can be copied to WebGPU texture correctly.
 
-  It creates HTMLCanvasElement/OffscreenCanvas with '2d'/'webgl'/'webgl2'.
+  It creates HTMLCanvasElement/OffscreenCanvas with '2d'.
   Use fillRect(2d context) or stencil + clear (gl context) to rendering
   red rect for top-left, green rect for top-right, blue rect for bottom-left
   and black for bottom-right.
@@ -175,8 +276,7 @@ g.test('copy_contents_from_canvas')
 
   The tests covers:
   - Valid canvas type
-  - Valid context type
-  - TODO: premultiplied alpha tests need to be added.
+  - Valid 2d context type
   - TODO: color space tests need to be added
 
   And the expected results are all passed.
@@ -185,20 +285,23 @@ g.test('copy_contents_from_canvas')
   .params(u =>
     u
       .combine('canvasType', ['onscreen', 'offscreen'] as const)
-      .combine('contextName', ['2d', 'webgl', 'webgl2'] as const)
       .combine('dstColorFormat', kValidTextureFormatsForCopyIB2T)
+      .combine('premultipliedAlpha', [true, false])
       .beginSubcases()
       .combine('width', [1, 2, 4, 15, 255, 256])
       .combine('height', [1, 2, 4, 15, 255, 256])
   )
   .fn(async t => {
-    const { width, height, canvasType, contextName, dstColorFormat } = t.params;
+    const { width, height, canvasType, dstColorFormat, premultipliedAlpha } = t.params;
 
-    const { canvas, canvasContext } = t.initCanvasContent({
+    // The rgb10a2unorm dst texture will have tiny errors when we compare actual and expectation.
+    // This is due to the convert from 8-bit to 10-bit combined with alpha value ops. So for
+    // rgb10a2unorm dst textures, we'll set alphaValue to 0.0 to test.
+    const { canvas, canvasContext } = t.init2DCanvasContent({
       canvasType,
-      contextName,
       width,
       height,
+      isLosePrecisionDstFormat: dstColorFormat === 'rgb10a2unorm',
     });
 
     const dst = t.device.createTexture({
@@ -214,17 +317,131 @@ g.test('copy_contents_from_canvas')
 
     // Construct expected value for different dst color format
     const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
+    const format: RegularTextureFormat =
+      dstColorFormat === 'rgba8unorm-srgb' || dstColorFormat === 'bgra8unorm-srgb'
+        ? dstColorFormat === 'rgba8unorm-srgb'
+          ? 'rgba8unorm'
+          : 'bgra8unorm'
+        : dstColorFormat;
+    dstColorFormat;
+
+    // For 2d canvas, get expected pixels with getImageData(), which returns origin
+    // values(not applied premultipy alpha) always.
     const expectedPixels = t.getExpectedPixels({
       context: canvasContext,
       width,
       height,
-      format: dstColorFormat,
-      contextType: contextName === '2d' ? '2d' : 'gl',
+      format,
+      contextType: '2d',
+      srcPremultiplied: false,
+      dstPremultiplied: premultipliedAlpha,
     });
 
     t.doTestAndCheckResult(
       { source: canvas, origin: { x: 0, y: 0 } },
-      { texture: dst },
+      {
+        texture: dst,
+        origin: { x: 0, y: 0 },
+        colorSpace: 'srgb',
+        premultipliedAlpha,
+      },
+      { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
+      dstBytesPerPixel,
+      expectedPixels
+    );
+  });
+
+g.test('copy_contents_from_gl_context_canvas')
+  .desc(
+    `
+  Test HTMLCanvasElement and OffscreenCanvas with webgl/webgl2 context
+  can be copied to WebGPU texture correctly.
+
+  It creates HTMLCanvasElement/OffscreenCanvas with webgl'/'webgl2'.
+  Use fillRect(2d context) or stencil + clear (gl context) to rendering
+  red rect for top-left, green rect for top-right, blue rect for bottom-left
+  and black for bottom-right.
+  Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
+  of dst texture, and read the contents out to compare with the canvas contents.
+
+  The tests covers:
+  - Valid canvas type
+  - Valid webgl/webgl2 context type
+  - TODO: color space tests need to be added
+
+  And the expected results are all passed.
+  `
+  )
+  .params(u =>
+    u
+      .combine('canvasType', ['onscreen', 'offscreen'] as const)
+      .combine('contextName', ['webgl', 'webgl2'] as const)
+      .combine('dstColorFormat', kValidTextureFormatsForCopyIB2T)
+      .combine('webglCanvasPremultipliedAlpha', [true, false])
+      .combine('premultipliedAlpha', [true, false])
+      .beginSubcases()
+      .combine('width', [1, 2, 4, 15, 255, 256])
+      .combine('height', [1, 2, 4, 15, 255, 256])
+  )
+  .fn(async t => {
+    const {
+      width,
+      height,
+      canvasType,
+      contextName,
+      dstColorFormat,
+      webglCanvasPremultipliedAlpha,
+      premultipliedAlpha,
+    } = t.params;
+
+    const { canvas, canvasContext } = t.initGLCanvasContent({
+      canvasType,
+      contextName,
+      width,
+      height,
+      premultiplied: webglCanvasPremultipliedAlpha,
+      isLosePrecisionDstFormat: dstColorFormat === 'rgb10a2unorm',
+    });
+
+    const dst = t.device.createTexture({
+      size: {
+        width,
+        height,
+        depthOrArrayLayers: 1,
+      },
+      format: dstColorFormat,
+      usage:
+        GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    // Construct expected value for different dst color format
+    const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
+    const format: RegularTextureFormat =
+      dstColorFormat === 'rgba8unorm-srgb' || dstColorFormat === 'bgra8unorm-srgb'
+        ? dstColorFormat === 'rgba8unorm-srgb'
+          ? 'rgba8unorm'
+          : 'bgra8unorm'
+        : dstColorFormat;
+    dstColorFormat;
+
+    const expectedPixels = t.getExpectedPixels({
+      context: canvasContext,
+      width,
+      height,
+      format,
+      contextType: 'gl',
+      srcPremultiplied: webglCanvasPremultipliedAlpha,
+      dstPremultiplied: premultipliedAlpha,
+    });
+
+    t.doTestAndCheckResult(
+      { source: canvas, origin: { x: 0, y: 0 } },
+      {
+        texture: dst,
+        origin: { x: 0, y: 0 },
+        colorSpace: 'srgb',
+        premultipliedAlpha,
+      },
       { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
       dstBytesPerPixel,
       expectedPixels

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -53,6 +53,7 @@ class F extends CopyToTextureUtils {
     return canvas;
   }
 
+  // TODO: Cache the generated canvas to avoid duplicated initialization. 
   init2DCanvasContent({
     canvasType,
     width,
@@ -91,21 +92,22 @@ class F extends CopyToTextureUtils {
     const alphaValue = paintOpaqueRects ? 1.0 : 0.6;
     const ctx = canvasContext as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
     // Red
-    ctx.fillStyle = 'rgba(255, 0, 0,' + alphaValue + ')';
+    ctx.fillStyle = `rgba(255, 0, 0, ${alphaValue})`;
     ctx.fillRect(0, 0, rectWidth, rectHeight);
     // Lime
-    ctx.fillStyle = 'rgba(0, 255, 0,' + alphaValue + ')';
+    ctx.fillStyle = `rgba(0, 255, 0, ${alphaValue})`;
     ctx.fillRect(rectWidth, 0, width - rectWidth, rectHeight);
     // Blue
-    ctx.fillStyle = 'rgba(0, 0, 255,' + alphaValue + ')';
+    ctx.fillStyle = `rgba(0, 0, 255, ${alphaValue})`;
     ctx.fillRect(0, rectHeight, rectWidth, height - rectHeight);
     // White
-    ctx.fillStyle = 'rgba(255, 255, 255,' + alphaValue + ')';
+    ctx.fillStyle = `rgba(255, 255, 255, ${alphaValue})`;
     ctx.fillRect(rectWidth, rectHeight, width - rectWidth, height - rectHeight);
 
     return { canvas, canvasContext };
   }
 
+  // TODO: Cache the generated canvas to avoid duplicated initialization. 
   initGLCanvasContent({
     canvasType,
     contextName,

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -53,7 +53,7 @@ class F extends CopyToTextureUtils {
     return canvas;
   }
 
-  // TODO: Cache the generated canvas to avoid duplicated initialization. 
+  // TODO: Cache the generated canvas to avoid duplicated initialization.
   init2DCanvasContent({
     canvasType,
     width,
@@ -107,7 +107,7 @@ class F extends CopyToTextureUtils {
     return { canvas, canvasContext };
   }
 
-  // TODO: Cache the generated canvas to avoid duplicated initialization. 
+  // TODO: Cache the generated canvas to avoid duplicated initialization.
   initGLCanvasContent({
     canvasType,
     contextName,

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -136,7 +136,7 @@ class F extends CopyToTextureUtils {
       | null;
 
     if (gl === null) {
-      this.skip(canvasType + ' canvas ' +  contextName + ' context not available');
+      this.skip(canvasType + ' canvas ' + contextName + ' context not available');
     }
 
     const rectWidth = Math.floor(width / 2);


### PR DESCRIPTION
This PR add premultiplied alpha tests to test 2d/webgl/webgl2
canvas/offscreenCanvas.

The tests covers webgl/webgl2 context created with premultipliedAlpha
attribute values and the CopyExternalImageToTexture with different
premultipliedAlpha config value





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
