### PR TITLE
vertex_state correctness: test more attrib.offset

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -657,7 +657,11 @@ g.test('setVertexBufferOffset_and_attributeOffset')
         return [
           0,
           componentSize,
+          componentSize * 2,
+          componentSize * 3,
           p.arrayStride / 2,
+          p.arrayStride - formatSize - componentSize * 3,
+          p.arrayStride - formatSize - componentSize * 2,
           p.arrayStride - formatSize - componentSize,
           p.arrayStride - formatSize,
         ];


### PR DESCRIPTION
This provides missing coverage for the programmable vertex pulling code
transform in Tint for 8bit formats with offset aligned to 3 (mod 4).





<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
