### PR TITLE
Review api,operation,buffers,map_detach:*

### DIFF
--- a/src/webgpu/api/operation/buffers/map_detach.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_detach.spec.ts
@@ -7,21 +7,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUConst } from '../../../constants.js';
 import { GPUTest } from '../../../gpu_test.js';
 
-class F extends GPUTest {
-  checkDetach(buffer: GPUBuffer, arrayBuffer: ArrayBuffer, unmap: boolean, destroy: boolean): void {
-    const view = new Uint8Array(arrayBuffer);
-    this.expect(arrayBuffer.byteLength === 4);
-    this.expect(view.length === 4);
-
-    if (unmap) buffer.unmap();
-    if (destroy) buffer.destroy();
-
-    this.expect(arrayBuffer.byteLength === 0, 'ArrayBuffer should be detached');
-    this.expect(view.byteLength === 0, 'ArrayBufferView should be detached');
-  }
-}
-
-export const g = makeTestGroup(F);
+export const g = makeTestGroup(GPUTest);
 
 g.test('while_mapped')
   .desc(
@@ -69,5 +55,13 @@ g.test('while_mapped')
     }
 
     const arrayBuffer = buffer.getMappedRange();
-    t.checkDetach(buffer, arrayBuffer, unmap, destroy);
+    const view = new Uint8Array(arrayBuffer);
+    t.expect(arrayBuffer.byteLength === 4);
+    t.expect(view.length === 4);
+
+    if (unmap) buffer.unmap();
+    if (destroy) buffer.destroy();
+
+    t.expect(arrayBuffer.byteLength === 0, 'ArrayBuffer should be detached');
+    t.expect(view.byteLength === 0, 'ArrayBufferView should be detached');
   });

--- a/src/webgpu/api/operation/buffers/map_detach.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_detach.spec.ts
@@ -1,6 +1,10 @@
-export const description = '';
+export const description = `
+  Tests that TypedArrays created when mapping a GPUBuffer are detached when the
+  buffer is unmapped or destroyed.
+`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUConst } from '../../../constants.js';
 import { GPUTest } from '../../../gpu_test.js';
 
 class F extends GPUTest {
@@ -19,53 +23,51 @@ class F extends GPUTest {
 
 export const g = makeTestGroup(F);
 
-g.test('mapAsync,write')
-  .paramsSimple([
-    { unmap: true, destroy: false }, //
-    { unmap: false, destroy: true },
-    { unmap: true, destroy: true },
-  ])
+g.test('while_mapped')
+  .desc(
+    `
+    Test that a mapped buffers are able to properly detach.
+    - Tests {mappable, unmappable mapAtCreation, mappable mapAtCreation}
+    - Tests while {mapped, mapped at creation, mapped at creation then unmapped and mapped again}`
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('mappedAtCreation', [false, true])
+      .combineWithParams([
+        { usage: GPUConst.BufferUsage.COPY_SRC },
+        { usage: GPUConst.BufferUsage.MAP_WRITE | GPUConst.BufferUsage.COPY_SRC },
+        { usage: GPUConst.BufferUsage.COPY_DST | GPUConst.BufferUsage.MAP_READ },
+        {
+          usage: GPUConst.BufferUsage.MAP_WRITE | GPUConst.BufferUsage.COPY_SRC,
+          mapMode: GPUConst.MapMode.WRITE,
+        },
+        {
+          usage: GPUConst.BufferUsage.COPY_DST | GPUConst.BufferUsage.MAP_READ,
+          mapMode: GPUConst.MapMode.READ,
+        },
+      ])
+      .combineWithParams([
+        { unmap: true, destroy: false },
+        { unmap: false, destroy: true },
+        { unmap: true, destroy: true },
+      ])
+      .unless(p => p.mappedAtCreation === false && p.mapMode === undefined)
+  )
   .fn(async t => {
-    const buffer = t.device.createBuffer({ size: 4, usage: GPUBufferUsage.MAP_WRITE });
-    await buffer.mapAsync(GPUMapMode.WRITE);
-    const arrayBuffer = buffer.getMappedRange();
-    t.checkDetach(buffer, arrayBuffer, t.params.unmap, t.params.destroy);
-  });
-
-g.test('mapAsync,read')
-  .paramsSimple([
-    { unmap: true, destroy: false }, //
-    { unmap: false, destroy: true },
-    { unmap: true, destroy: true },
-  ])
-  .fn(async t => {
-    const buffer = t.device.createBuffer({ size: 4, usage: GPUBufferUsage.MAP_READ });
-    await buffer.mapAsync(GPUMapMode.READ);
-    const arrayBuffer = buffer.getMappedRange();
-    t.checkDetach(buffer, arrayBuffer, t.params.unmap, t.params.destroy);
-  });
-
-g.test('create_mapped')
-  .paramsSimple([
-    { unmap: true, destroy: false },
-    { unmap: false, destroy: true },
-    { unmap: true, destroy: true },
-  ])
-  .fn(async t => {
-    const desc = {
-      mappedAtCreation: true,
+    const { usage, mapMode, mappedAtCreation, unmap, destroy } = t.params;
+    const buffer = t.device.createBuffer({
       size: 4,
-      usage: GPUBufferUsage.MAP_WRITE,
-    };
-    const buffer = t.device.createBuffer(desc);
+      usage,
+      mappedAtCreation,
+    });
+
+    if (mapMode !== undefined) {
+      if (mappedAtCreation) {
+        buffer.unmap();
+      }
+      await buffer.mapAsync(mapMode);
+    }
+
     const arrayBuffer = buffer.getMappedRange();
-
-    const view = new Uint8Array(arrayBuffer);
-    t.expect(arrayBuffer.byteLength === 4);
-    t.expect(view.length === 4);
-
-    if (t.params.unmap) buffer.unmap();
-    if (t.params.destroy) buffer.destroy();
-    t.expect(arrayBuffer.byteLength === 0, 'ArrayBuffer should be detached');
-    t.expect(view.byteLength === 0, 'ArrayBufferView should be detached');
+    t.checkDetach(buffer, arrayBuffer, unmap, destroy);
   });


### PR DESCRIPTION
Reviews api,operation,buffers,map_detach:* and condenses it down into a single test who's subcases should hit every interesting variant of this behavior. Modeled after recent update to api,validation,buffer,destroy:*

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
