### PR TITLE
Fix byte vs element units bug; allow buffer checking by mapping

### DIFF
--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -45,16 +45,10 @@ class F extends GPUTest {
     bufferUsage: GPUBufferUsageFlags,
     expectedData: Uint8Array
   ): Promise<void> {
-    // We can only check the buffer contents with t.expectGPUBufferValuesEqual() when the buffer
-    // usage contains COPY_SRC.
-    if (bufferUsage & GPUBufferUsage.MAP_READ) {
-      await buffer.mapAsync(GPUMapMode.READ);
-      this.expectOK(checkElementsEqual(new Uint8Array(buffer.getMappedRange()), expectedData));
-      buffer.unmap();
-    } else {
-      assert((bufferUsage & GPUBufferUsage.COPY_SRC) !== 0);
-      this.expectGPUBufferValuesEqual(buffer, expectedData);
-    }
+    const isMappable = bufferUsage & GPUBufferUsage.MAP_READ;
+    this.expectGPUBufferValuesEqual(buffer, expectedData, 0, {
+      method: isMappable ? 'map' : undefined,
+    });
   }
 }
 

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -1,8 +1,7 @@
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { assert, unreachable } from '../../../../common/util/util.js';
+import { unreachable } from '../../../../common/util/util.js';
 import { GPUConst } from '../../../constants.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { checkElementsEqual } from '../../../util/check_contents.js';
 import { getTextureCopyLayout } from '../../../util/texture/layout.js';
 
 export const description = `
@@ -45,10 +44,8 @@ class F extends GPUTest {
     bufferUsage: GPUBufferUsageFlags,
     expectedData: Uint8Array
   ): Promise<void> {
-    const isMappable = bufferUsage & GPUBufferUsage.MAP_READ;
-    this.expectGPUBufferValuesEqual(buffer, expectedData, 0, {
-      method: isMappable ? 'map' : undefined,
-    });
+    const mappable = bufferUsage & GPUBufferUsage.MAP_READ;
+    this.expectGPUBufferValuesEqual(buffer, expectedData, 0, { method: mappable ? 'map' : 'copy' });
   }
 }
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -4,6 +4,7 @@ import {
   assert,
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
+  unreachable,
 } from '../common/util/util.js';
 
 import {
@@ -20,7 +21,7 @@ import {
   TestOOMedShouldAttemptGC,
   UncanonicalizedDeviceDescriptor,
 } from './util/device_pool.js';
-import { align } from './util/math.js';
+import { align, roundDown } from './util/math.js';
 import {
   fillTextureDataWithTexelValue,
   getTextureCopyLayout,
@@ -162,7 +163,7 @@ export class GPUTest extends Fixture {
   }
 
   /** Snapshot a GPUBuffer's contents, returning a new GPUBuffer with the `MAP_READ` usage. */
-  createCopyForMapRead(src: GPUBuffer, srcOffset: number, size: number): GPUBuffer {
+  private createCopyForMapRead(src: GPUBuffer, srcOffset: number, size: number): GPUBuffer {
     assert(srcOffset % 4 === 0);
     assert(size % 4 === 0);
 
@@ -173,7 +174,6 @@ export class GPUTest extends Fixture {
 
     const c = this.device.createCommandEncoder();
     c.copyBufferToBuffer(src, srcOffset, dst, 0, size);
-
     this.queue.submit([c.finish()]);
 
     return dst;
@@ -186,16 +186,74 @@ export class GPUTest extends Fixture {
    * we initially wanted to map.
    * The copy will not cause an OOB error because the buffer size must be 4-aligned.
    */
-  createAlignedCopyForMapRead(
+  private createAlignedCopyForMapRead(
     src: GPUBuffer,
     size: number,
     offset: number
-  ): { dst: GPUBuffer; begin: number; end: number } {
-    const alignedOffset = Math.floor(offset / 4) * 4;
-    const offsetDifference = offset - alignedOffset;
-    const alignedSize = align(size + offsetDifference, 4);
-    const dst = this.createCopyForMapRead(src, alignedOffset, alignedSize);
-    return { dst, begin: offsetDifference, end: offsetDifference + size };
+  ): { mappable: GPUBuffer; subarrayByteStart: number } {
+    const alignedOffset = roundDown(offset, 4);
+    const subarrayByteStart = offset - alignedOffset;
+    const alignedSize = align(size + subarrayByteStart, 4);
+    const mappable = this.createCopyForMapRead(src, alignedOffset, alignedSize);
+    return { mappable, subarrayByteStart };
+  }
+
+  /**
+   * Snapshot the current contents of a range of a GPUBuffer, and return them as a TypedArray.
+   * Also provides a cleanup() function to unmap and destroy the staging buffer.
+   */
+  async readGPUBufferRangeTyped<T extends TypedArrayBufferView>(
+    src: GPUBuffer,
+    {
+      srcByteOffset = 0,
+      method = 'copy',
+      type,
+      typedLength,
+    }: {
+      srcByteOffset?: number;
+      method?: 'copy' | 'map';
+      type: TypedArrayBufferViewConstructor<T>;
+      typedLength: number;
+    }
+  ): Promise<{ data: T; cleanup(): void }> {
+    assert(
+      srcByteOffset % type.BYTES_PER_ELEMENT === 0,
+      'srcByteOffset must be a multiple of BYTES_PER_ELEMENT'
+    );
+
+    const byteLength = typedLength * type.BYTES_PER_ELEMENT;
+    let mappable: GPUBuffer;
+    let mapOffset: number | undefined, mapSize: number | undefined, subarrayByteStart: number;
+    if (method === 'copy') {
+      ({ mappable, subarrayByteStart } = this.createAlignedCopyForMapRead(
+        src,
+        byteLength,
+        srcByteOffset
+      ));
+    } else if (method === 'map') {
+      mappable = src;
+      mapOffset = roundDown(srcByteOffset, 8);
+      mapSize = align(byteLength, 4);
+      subarrayByteStart = srcByteOffset - mapOffset;
+    } else {
+      unreachable();
+    }
+
+    assert(subarrayByteStart % type.BYTES_PER_ELEMENT === 0);
+    const subarrayStart = subarrayByteStart / type.BYTES_PER_ELEMENT;
+
+    // 2. Map the staging buffer, and create the TypedArray from it.
+    await mappable.mapAsync(GPUMapMode.READ, mapOffset, mapSize);
+    const mapped = new type(mappable.getMappedRange(mapOffset, mapSize));
+    const data = mapped.subarray(subarrayStart, typedLength) as T;
+
+    return {
+      data,
+      cleanup() {
+        mappable.unmap();
+        mappable.destroy();
+      },
+    };
   }
 
   /**
@@ -208,24 +266,26 @@ export class GPUTest extends Fixture {
       srcByteOffset = 0,
       type,
       typedLength,
+      method = 'copy',
       mode = 'fail',
     }: {
       srcByteOffset?: number;
       type: TypedArrayBufferViewConstructor<T>;
       typedLength: number;
+      method?: 'copy' | 'map';
       mode?: 'fail' | 'warn';
     }
   ) {
-    const byteLength = typedLength * type.BYTES_PER_ELEMENT;
-    const { dst, begin, end } = this.createAlignedCopyForMapRead(src, byteLength, srcByteOffset);
-
+    const readbackPromise = this.readGPUBufferRangeTyped(src, {
+      srcByteOffset,
+      type,
+      typedLength,
+      method,
+    });
     this.eventualAsyncExpectation(async niceStack => {
-      await dst.mapAsync(GPUMapMode.READ);
-      // TODO: begin and end are byte offsets, but used here as array offsets.
-      const mapped: T = new type(dst.getMappedRange());
-      const actual = mapped.subarray(begin, end) as T;
-      this.expectOK(check(actual), { mode, niceStack });
-      dst.destroy();
+      const readback = await readbackPromise;
+      this.expectOK(check(readback.data), { mode, niceStack });
+      readback.cleanup();
     });
   }
 
@@ -236,12 +296,13 @@ export class GPUTest extends Fixture {
     src: GPUBuffer,
     expected: TypedArrayBufferView,
     srcByteOffset: number = 0,
-    { mode = 'fail' }: { mode?: 'fail' | 'warn' } = {}
+    { method = 'copy', mode = 'fail' }: { method?: 'copy' | 'map'; mode?: 'fail' | 'warn' } = {}
   ): void {
     this.expectGPUBufferValuesPassCheck(src, a => checkElementsEqual(a, expected), {
       srcByteOffset,
       type: expected.constructor as TypedArrayBufferViewConstructor,
       typedLength: expected.length,
+      method,
       mode,
     });
   }

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -9,11 +9,19 @@ import { assert } from '../../common/util/util.js';
  */
 export const kMaxSafeMultipleOf8 = Number.MAX_SAFE_INTEGER - 7;
 
-/** Round `n` up to the next multiple of `alignment`. */
+/** Round `n` up to the next multiple of `alignment` (inclusive). */
+// TODO: Rename to `roundUp`
 export function align(n: number, alignment: number): number {
   assert(Number.isInteger(n) && n >= 0, 'n must be a non-negative integer');
   assert(Number.isInteger(alignment) && alignment > 0, 'alignment must be a positive integer');
   return Math.ceil(n / alignment) * alignment;
+}
+
+/** Round `n` down to the next multiple of `alignment` (inclusive). */
+export function roundDown(n: number, alignment: number): number {
+  assert(Number.isInteger(n) && n >= 0, 'n must be a non-negative integer');
+  assert(Number.isInteger(alignment) && alignment > 0, 'alignment must be a positive integer');
+  return Math.floor(n / alignment) * alignment;
 }
 
 /** Clamp a number to the provided range. */


### PR DESCRIPTION
So, I guess replacing usages of `createAlignedCopyForMapRead` with `readGPUBufferRangeTyped` mostly didn't end up in net simplifications (especially since most of them just use `Uint8Array`), but I still think it's a bit easier to reason about? And it makes it easier for tests to test both read-by-copy and read-by-map (but does it matter?)

WDYT?

Tested `webgpu:api,operation,resource_init,buffer:*` locally and still passes.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
