### PR TITLE
wgsl: add workgroup_size to all stage(compute)

### DIFF
--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -35,7 +35,7 @@ g.test('memcpy').fn(async t => {
           [[group(0), binding(0)]] var<storage, read> src : Data;
           [[group(0), binding(1)]] var<storage, read_write> dst : Data;
 
-          [[stage(compute)]] fn main() {
+          [[stage(compute), workgroup_size(1)]] fn main() {
             dst.value = src.value;
             return;
           }

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -58,7 +58,7 @@ export class BufferSyncTest extends GPUTest {
       };
 
       [[group(0), binding(0)]] var<storage, read_write> data : Data;
-      [[stage(compute)]] fn main() {
+      [[stage(compute), workgroup_size(1)]] fn main() {
         data.a = ${value};
         return;
       }

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -67,7 +67,7 @@ export const checkContentsBySampling: CheckContents = (
             };
             [[group(0), binding(3)]] var<storage, read_write> result : Result;
 
-            [[stage(compute)]]
+            [[stage(compute), workgroup_size(1)]]
             fn main([[builtin(global_invocation_id)]] GlobalInvocationID : vec3<u32>) {
               let flatIndex : u32 = ${componentCount}u * (
                 ${width}u * ${height}u * GlobalInvocationID.z +

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -926,7 +926,7 @@ g.test('unused_bindings_in_pipeline')
       ${pp._if(useBindGroup1)}
       [[group(1), binding(0)]] var<image> image1 : texture_storage_2d<rgba8unorm, read>;
       ${pp._endif}
-      [[stage(compute)]] fn main() {}
+      [[stage(compute), workgroup_size(1)]] fn main() {}
     `;
 
     const pipeline = compute

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -257,7 +257,7 @@ export class ValidationTest extends GPUTest {
     return this.device.createComputePipeline({
       compute: {
         module: this.device.createShaderModule({
-          code: '[[stage(compute)]] fn main() {}',
+          code: '[[stage(compute), workgroup_size(1)]] fn main() {}',
         }),
         entryPoint: 'main',
       },

--- a/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/global-vars-must-be-unique.fail.wgsl
@@ -3,7 +3,7 @@
 let a : vec2<f32> = vec2<f32>(0.1, 1.0);
 var<private> a : vec4<f32>;
 
-[[stage(compute)]]
+[[stage(compute), workgroup_size(1)]]
 fn main() {
   return;
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-f32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-f32.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> flag : bool  = 0.0;
 
-[[stage(compute)]]
+[[stage(compute), workgroup_size(1)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-i32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-i32.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> flag : bool  = 0;
 
-[[stage(compute)]]
+[[stage(compute), workgroup_size(1)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-u32.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool-u32.fail.wgsl
@@ -2,6 +2,6 @@
 
 var<private> flag : bool  = 1u;
 
-[[stage(compute)]]
+[[stage(compute), workgroup_size(1)]]
 fn main() {
 }

--- a/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-initializer-mismatch-bool.pass.wgsl
@@ -2,6 +2,6 @@
 
 var<private> flag : bool  = true;
 
-[[stage(compute)]]
+[[stage(compute), workgroup_size(1)]]
 fn main() {
 }

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -60,7 +60,7 @@ function doTest(
   };
   [[group(0), binding(1)]] var<storage, read_write> output : Output;
 
-  [[stage(compute)]]
+  [[stage(compute), workgroup_size(1)]]
   fn main() {
       var texel : vec4<${shaderType}> = textureLoad(tex, vec2<i32>(0, 0), 0);
       ${rep.componentOrder.map(C => `output.result${C} = texel.${C.toLowerCase()};`).join('\n')}


### PR DESCRIPTION
The WebGPU spec now requires that this decoration be always present for
compute stage.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
