### PR TITLE
Test that buffer writes are preserved after another range is mapped.

### DIFF
--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -10,8 +10,6 @@ mapRegionBoundModes is used to get mapRegion from range:
  - default-expand: expand mapRegion to buffer bound by setting offset/size to undefined
  - explicit-expand: expand mapRegion to buffer bound by explicitly calculating offset/size
  - minimal: make mapRegion to be the same as range which is the minimal range to make getMappedRange input valid
-
-TODO: Test that ranges not written preserve previous contents.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -96,6 +94,73 @@ g.test('mapAsync,write')
     await buffer.mapAsync(GPUMapMode.WRITE, ...mapRegion);
     const arrayBuffer = buffer.getMappedRange(...range);
     t.checkMapWrite(buffer, rangeOffset, arrayBuffer, rangeSize);
+  });
+
+g.test('mapAsync,write,unchanged_ranges_preserved')
+  .desc(
+    `Use mappedAtCreation or mapAsync to write to various ranges of variously-sized buffers, then
+use mapAsync to map a different range and zero it out. Finally use expectGPUBufferValuesEqual
+(which does copyBufferToBuffer + map-read) to verify that contents originally written outside the
+second mapped range were not altered.`
+  )
+  .params(u =>
+    u
+      .beginSubcases()
+      .combine('mappedAtCreation', [false, true])
+      .combineWithParams([
+        { size: 12, range1: [], range2: [8], verify: [0, 8] },
+        { size: 12, range1: [], range2: [0, 8], verify: [8] },
+        { size: 12, range1: [0, 8], range2: [8], verify: [0, 8] },
+        { size: 12, range1: [8], range2: [0, 8], verify: [8] },
+        { size: 28, range1: [], range2: [8, 8], verify: [0, 8] },
+        { size: 28, range1: [], range2: [8, 8], verify: [16] },
+        { size: 28, range1: [8, 16], range2: [16, 8], verify: [8, 8] },
+        { size: 32, range1: [16, 12], range2: [8, 16], verify: [24, 4] },
+        { size: 32, range1: [8, 8], range2: [24, 4], verify: [8, 8] },
+      ] as const)
+  )
+  .fn(async t => {
+    const { size, range1, range2, verify, mappedAtCreation } = t.params;
+    const [rangeOffset1, rangeSize1] = reifyMapRange(size, range1);
+    const [, rangeSize2] = reifyMapRange(size, range2);
+    const [verifyOffset, verifySize] = reifyMapRange(size, verify);
+
+    const buffer = t.device.createBuffer({
+      mappedAtCreation,
+      size,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+    });
+
+    // If the buffer is not mappedAtCreation map it now.
+    if (!mappedAtCreation) {
+      await buffer.mapAsync(GPUMapMode.WRITE);
+    }
+
+    // Set the initial contents of the buffer.
+    const init = buffer.getMappedRange(...range1);
+
+    assert(init.byteLength === rangeSize1);
+    const written = new Uint32Array(new ArrayBuffer(rangeSize1));
+    const data = new Uint32Array(init);
+    for (let i = 0; i < data.length; ++i) {
+      data[i] = written[i] = i + 1;
+    }
+    buffer.unmap();
+
+    // Write to a second range of the buffer
+    await buffer.mapAsync(GPUMapMode.WRITE, ...range2);
+    const init2 = buffer.getMappedRange(...range2);
+
+    assert(init2.byteLength === rangeSize2);
+    const data2 = new Uint32Array(init2);
+    for (let i = 0; i < data2.length; ++i) {
+      data2[i] = 0;
+    }
+    buffer.unmap();
+
+    // Verify that the range of the buffer which was not overwritten was preserved.
+    const expected = new Uint8Array(written.buffer, verifyOffset - rangeOffset1, verifySize);
+    t.expectGPUBufferValuesEqual(buffer, expected, verifyOffset);
   });
 
 g.test('mapAsync,read')


### PR DESCRIPTION
Completes a TODO in api,operation,buffers,map:*

Uses `mappedAtCreation` or `mapAsync` to write to various ranges of variously-sized buffers, then uses `mapAsync` to map a different range and zero it out. Finally uses `expectGPUBufferValuesEqual` to verify that contents originally written outside the
second mapped range were not altered.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
