### PR TITLE
Port and refactor robust access tests

### DIFF
--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -59,6 +59,7 @@ Whenever a new generally-useful helper is added, it should be indexed here.
     (like in copyBufferToTexture, copyTextureToBuffer, writeTexture).
 - {@link webgpu/util/texture/subresource}: Helpers for working with texture subresource ranges.
 - {@link webgpu/util/texture/texel_data}: Helpers encoding/decoding texel formats.
+- {@link webgpu/shader/types}: Helpers for WGSL data types.
 
 ### General Helpers
 

--- a/src/common/internal/logging/log_message.ts
+++ b/src/common/internal/logging/log_message.ts
@@ -19,7 +19,7 @@ export class LogMessageWithStack extends Error {
 
   /** Set a flag so the stack is not printed in toJSON(). */
   setStackHidden(stackHiddenMessage: string) {
-    this.stackHiddenMessage = stackHiddenMessage;
+    this.stackHiddenMessage ??= stackHiddenMessage;
   }
 
   /** Increment the "seen x times" counter. */

--- a/src/common/util/data_tables.ts
+++ b/src/common/util/data_tables.ts
@@ -1,0 +1,39 @@
+import { ResolveType, ZipKeysWithValues } from './types.js';
+
+export type valueof<K> = K[keyof K];
+
+export function keysOf<T extends string>(obj: { [k in T]: unknown }): readonly T[] {
+  return (Object.keys(obj) as unknown[]) as T[];
+}
+
+export function numericKeysOf<T>(obj: object): readonly T[] {
+  return (Object.keys(obj).map(n => Number(n)) as unknown[]) as T[];
+}
+
+/**
+ * Creates an info lookup object from a more nicely-formatted table. See below for examples.
+ *
+ * Note: Using `as const` on the arguments to this function is necessary to infer the correct type.
+ */
+export function makeTable<
+  Members extends readonly string[],
+  Defaults extends readonly unknown[],
+  Table extends { readonly [k: string]: readonly unknown[] }
+>(
+  members: Members,
+  defaults: Defaults,
+  table: Table
+): {
+  readonly [k in keyof Table]: ResolveType<ZipKeysWithValues<Members, Table[k], Defaults>>;
+} {
+  const result: { [k: string]: { [m: string]: unknown } } = {};
+  for (const [k, v] of Object.entries<readonly unknown[]>(table)) {
+    const item: { [m: string]: unknown } = {};
+    for (let i = 0; i < members.length; ++i) {
+      item[members[i]] = v[i] ?? defaults[i];
+    }
+    result[k] = item;
+  }
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  return result as any;
+}

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -3,48 +3,11 @@
 
 /* eslint-disable no-sparse-arrays */
 
-import { assertTypeTrue, ResolveType, TypeEqual, ZipKeysWithValues } from '../common/util/types.js';
+import { keysOf, makeTable, numericKeysOf, valueof } from '../common/util/data_tables.js';
+import { assertTypeTrue, TypeEqual } from '../common/util/types.js';
 import { assert, unreachable } from '../common/util/util.js';
 
 import { GPUConst } from './constants.js';
-
-type valueof<K> = K[keyof K];
-
-function keysOf<T extends string>(obj: { [k in T]: unknown }): readonly T[] {
-  return (Object.keys(obj) as unknown[]) as T[];
-}
-
-function numericKeysOf<T>(obj: object): readonly T[] {
-  return (Object.keys(obj).map(n => Number(n)) as unknown[]) as T[];
-}
-
-/**
- * Creates an info lookup object from a more nicely-formatted table. See below for examples.
- *
- * Note: Using `as const` on the arguments to this function is necessary to infer the correct type.
- */
-function makeTable<
-  Members extends readonly string[],
-  Defaults extends readonly unknown[],
-  Table extends { readonly [k: string]: readonly unknown[] }
->(
-  members: Members,
-  defaults: Defaults,
-  table: Table
-): {
-  readonly [k in keyof Table]: ResolveType<ZipKeysWithValues<Members, Table[k], Defaults>>;
-} {
-  const result: { [k: string]: { [m: string]: unknown } } = {};
-  for (const [k, v] of Object.entries<readonly unknown[]>(table)) {
-    const item: { [m: string]: unknown } = {};
-    for (let i = 0; i < members.length; ++i) {
-      item[members[i]] = v[i] ?? defaults[i];
-    }
-    result[k] = item;
-  }
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  return result as any;
-}
 
 // Queries
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -489,6 +489,8 @@ export class GPUTest extends Fixture {
 
   /**
    * Create a GPUBuffer with the specified contents and usage.
+   *
+   * TODO: Several call sites would be simplified if this took ArrayBuffer as well.
    */
   makeBufferWithContents(dataArray: TypedArrayBufferView, usage: GPUBufferUsageFlags): GPUBuffer {
     return makeBufferWithContents(this.device, dataArray, usage);

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -1,0 +1,442 @@
+export const description = `
+Tests to check datatype clamping in shaders is correctly implemented for all indexable types
+(vectors, matrices, sized/unsized arrays) visible to shaders in various ways.
+
+TODO: add tests to check that textureLoad operations stay in-bounds.
+`;
+
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { assert } from '../../../common/util/util.js';
+import { GPUTest } from '../../gpu_test.js';
+import { align } from '../../util/math.js';
+import {
+  ScalarType,
+  kScalarTypeInfo,
+  kVectorContainerTypes,
+  kVectorContainerTypeInfo,
+  kMatrixContainerTypes,
+  kMatrixContainerTypeInfo,
+  kScalarTypes,
+} from '../types.js';
+
+export const g = makeTestGroup(GPUTest);
+
+const kMaxU32 = 0xffff_ffff;
+const kMaxI32 = 0x7fff_ffff;
+const kMinI32 = -0x8000_0000;
+
+/**
+ * Wraps the provided source into a harness that checks calling `runTest()` returns 0.
+ *
+ * Non-test bindings are in bind group 1, including:
+ * - `constants.zero`: a dynamically-uniform `0u` value.
+ */
+function runShaderTest(
+  t: GPUTest,
+  stage: GPUShaderStageFlags,
+  testSource: string,
+  testBindings: GPUBindGroupEntry[]
+): void {
+  assert(stage === GPUShaderStage.COMPUTE, 'Only know how to deal with compute for now');
+
+  // Contains just zero (for now).
+  const constantsBuffer = t.device.createBuffer({ size: 4, usage: GPUBufferUsage.UNIFORM });
+
+  const resultBuffer = t.device.createBuffer({
+    size: 4,
+    usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+  });
+
+  const source = `
+    [[block]] struct Constants {
+      zero: u32;
+    };
+    [[group(1), binding(0)]] var<uniform> constants: Constants;
+
+    [[block]] struct Result {
+      value: u32;
+    };
+    [[group(1), binding(1)]] var<storage, write> result: Result;
+
+    ${testSource}
+
+    [[stage(compute), workgroup_size(1)]]
+    fn main() {
+      ignore(constants.zero); // Ensure constants buffer is statically-accessed
+      result.value = runTest();
+    }`;
+
+  t.debug(source);
+  const module = t.device.createShaderModule({ code: source });
+  const pipeline = t.device.createComputePipeline({
+    compute: { module, entryPoint: 'main' },
+  });
+
+  const group = t.device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(1),
+    entries: [
+      { binding: 0, resource: { buffer: constantsBuffer } },
+      { binding: 1, resource: { buffer: resultBuffer } },
+    ],
+  });
+
+  const testGroup = t.device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: testBindings,
+  });
+
+  const encoder = t.device.createCommandEncoder();
+  const pass = encoder.beginComputePass();
+  pass.setPipeline(pipeline);
+  pass.setBindGroup(0, testGroup);
+  pass.setBindGroup(1, group);
+  pass.dispatch(1);
+  pass.endPass();
+
+  t.queue.submit([encoder.finish()]);
+
+  t.expectGPUBufferValuesEqual(resultBuffer, new Uint32Array([0]));
+}
+
+/** Fill an ArrayBuffer with sentinel values, except clear a region to zero. */
+function testFillArrayBuffer(
+  array: ArrayBuffer,
+  type: 'u32' | 'i32' | 'f32',
+  { zeroByteStart, zeroByteCount }: { zeroByteStart: number; zeroByteCount: number }
+) {
+  const constructor = { u32: Uint32Array, i32: Int32Array, f32: Float32Array }[type];
+  assert(zeroByteCount % constructor.BYTES_PER_ELEMENT === 0);
+  new constructor(array).fill(42);
+  new constructor(array, zeroByteStart, zeroByteCount / constructor.BYTES_PER_ELEMENT).fill(0);
+}
+
+const kArrayLength = 3;
+
+/**
+ * Generate a bunch of indexable types (vec, mat, sized/unsized array) for testing.
+ */
+function* generateIndexableTypes({
+  storageClass,
+  baseType,
+  atomic = false,
+}: {
+  /** Unsized array will only be generated for storageClass "storage". */
+  storageClass: string;
+  /** Base scalar type (i32/u32/f32/bool). */
+  baseType: ScalarType;
+  /** Whether to wrap the baseType in `atomic<>`. */
+  atomic?: boolean;
+}) {
+  const scalarInfo = kScalarTypeInfo[baseType];
+  if (atomic) assert(scalarInfo.supportsAtomics, 'type does not support atomics');
+  const scalarType = atomic ? `atomic<${baseType}>` : baseType;
+
+  // Don't generate vec2<atomic<i32>> etc.
+  if (!atomic) {
+    // Vector types
+    for (const vectorType of kVectorContainerTypes) {
+      yield {
+        type: `${vectorType}<${scalarType}>`,
+        _typeInfo: { elementBaseType: baseType, ...kVectorContainerTypeInfo[vectorType] },
+      };
+    }
+
+    // Matrices can only be f32.
+    if (baseType === 'f32') {
+      for (const matrixType of kMatrixContainerTypes) {
+        const matrixInfo = kMatrixContainerTypeInfo[matrixType];
+        yield {
+          type: `${matrixType}<${scalarType}>`,
+          _typeInfo: {
+            elementBaseType: `vec${matrixInfo.innerLength}<${scalarType}>`,
+            ...matrixInfo,
+          },
+        };
+      }
+    }
+  }
+
+  const arrayTypeInfo = {
+    elementBaseType: baseType,
+    arrayLength: kArrayLength,
+    layout: scalarInfo.layout
+      ? {
+          alignment: scalarInfo.layout.alignment,
+          size: kArrayLength * arrayStride(scalarInfo.layout),
+        }
+      : undefined,
+  };
+  // Sized array
+  yield { type: `array<${scalarType},${kArrayLength}>`, _typeInfo: arrayTypeInfo };
+  // Unsized array
+  if (storageClass === 'storage') {
+    yield { type: `array<${scalarType}>`, _typeInfo: arrayTypeInfo };
+  }
+}
+
+function arrayStride(elementLayout: { size: number; alignment: number }) {
+  return align(elementLayout.size, elementLayout.alignment);
+}
+
+/** Generates scalarTypes (i32/u32/f32/bool) that support the specified usage. */
+function* supportedScalarTypes(p: { atomic: boolean; storageClass: string }) {
+  for (const scalarType of kScalarTypes) {
+    const info = kScalarTypeInfo[scalarType];
+
+    // Test atomics only on supported scalar types.
+    if (p.atomic && !info.supportsAtomics) continue;
+
+    // Storage and uniform require host-sharable types.
+    const isHostShared = p.storageClass === 'storage' || p.storageClass === 'uniform';
+    if (isHostShared && info.layout === undefined) continue;
+
+    yield scalarType;
+  }
+}
+
+/** Atomic access requires atomic type and storage/workgroup memory. */
+function supportsAtomics(p: { storageClass: string; storageMode: string | undefined }) {
+  return (
+    (p.storageClass === 'storage' && p.storageMode === 'read_write') ||
+    p.storageClass === 'workgroup'
+  );
+}
+
+g.test('linear_memory')
+  .desc(
+    `For each indexable data type (vec, mat, sized/unsized array, of various scalar types), attempts
+    to access (read, write, atomic load/store) a region of memory (buffer or internal) at various
+    (signed/unsigned) indices. Checks that the accesses conform to robust access (OOB reads only
+    return bound memory, OOB writes don't write OOB).
+
+    TODO: Test in/out storage classes.
+    TODO: Test vertex and fragment stages.
+    TODO: Test using a dynamic offset instead of a static offset into uniform/storage bindings.
+    TODO: Test types like vec2<atomic<i32>>, if that's allowed.
+    TODO: Test exprIndexAddon as constexpr.
+    TODO: Test exprIndexAddon as pipeline-overridable constant expression.
+  `
+  )
+  .params(u =>
+    u
+      .combineWithParams([
+        { storageClass: 'storage', storageMode: 'read', access: 'read' },
+        { storageClass: 'storage', storageMode: 'write', access: 'write' },
+        { storageClass: 'storage', storageMode: 'read_write', access: 'read' },
+        { storageClass: 'storage', storageMode: 'read_write', access: 'write' },
+        { storageClass: 'uniform', access: 'read' },
+        { storageClass: 'private', access: 'read' },
+        { storageClass: 'private', access: 'write' },
+        { storageClass: 'function', access: 'read' },
+        { storageClass: 'function', access: 'write' },
+        { storageClass: 'workgroup', access: 'read' },
+        { storageClass: 'workgroup', access: 'write' },
+      ] as const)
+      .expand('atomic', p => (supportsAtomics(p) ? [false, true] : [false]))
+      .expand('baseType', supportedScalarTypes)
+      .beginSubcases()
+      .expandWithParams(generateIndexableTypes)
+  )
+  .fn(async t => {
+    const { storageClass, storageMode, access, atomic, baseType, type, _typeInfo } = t.params;
+
+    let usesCanary = false;
+    let globalSource = '';
+    let testFunctionSource = '';
+    const testBufferSize = 512;
+    const bufferBindingOffset = 256;
+    /** Undefined if no buffer binding is needed */
+    let bufferBindingSize: number | undefined = undefined;
+
+    // Declare the data that will be accessed to check robust access, as a buffer or a struct
+    // in the global scope or inside the test function itself.
+    const structDecl = `
+      struct S {
+        startCanary: array<u32, 10>;
+        data: ${type};
+        endCanary: array<u32, 10>;
+      };`;
+
+    switch (storageClass) {
+      case 'uniform':
+      case 'storage':
+        {
+          assert(_typeInfo.layout !== undefined);
+          const layout = _typeInfo.layout;
+          bufferBindingSize = layout.size;
+          const qualifiers = storageClass === 'storage' ? `storage, ${storageMode}` : storageClass;
+          globalSource += `
+          [[block]] struct TestData {
+            data: ${type};
+          };
+          [[group(0), binding(0)]] var<${qualifiers}> s: TestData;`;
+        }
+        break;
+
+      case 'private':
+      case 'workgroup':
+        usesCanary = true;
+        globalSource += structDecl;
+        globalSource += `var<${storageClass}> s: S;`;
+        break;
+
+      case 'function':
+        usesCanary = true;
+        globalSource += structDecl;
+        testFunctionSource += 'var s: S;';
+        break;
+    }
+
+    // Build the test function that will do the tests.
+
+    // If we use a local canary declared in the shader, initialize it.
+    if (usesCanary) {
+      testFunctionSource += `
+        for (var i = 0u; i < 10u; i = i + 1u) {
+          s.startCanary[i] = 0xFFFFFFFFu;
+          s.endCanary[i] = 0xFFFFFFFFu;
+        }`;
+    }
+
+    /** Returns a different number each time, kind of like a `__LINE__` to ID the failing check. */
+    const nextErrorReturnValue = (() => {
+      let errorReturnValue = 0x1000;
+      return () => {
+        ++errorReturnValue;
+        return `0x${errorReturnValue.toString(16)}u`;
+      };
+    })();
+
+    // This is here, instead of in subcases, so only a single shader is needed to test many modes.
+    for (const indexSigned of [false, true]) {
+      const indicesToTest = indexSigned
+        ? [
+            // Exactly in bounds (should be OK)
+            '0',
+            `${_typeInfo.arrayLength} - 1`,
+            // Exactly out of bounds
+            '-1',
+            `${_typeInfo.arrayLength}`,
+            // Far out of bounds
+            '-1000000',
+            '1000000',
+            `${kMinI32}`,
+            `${kMaxI32}`,
+          ]
+        : [
+            // Exactly in bounds (should be OK)
+            '0u',
+            `${_typeInfo.arrayLength}u - 1u`,
+            // Exactly out of bounds
+            `${_typeInfo.arrayLength}u`,
+            // Far out of bounds
+            '1000000u',
+            `${kMaxU32}u`,
+            `${kMaxI32}u`,
+          ];
+
+      const indexTypeLiteral = indexSigned ? '0' : '0u';
+      const indexTypeCast = indexSigned ? 'i32' : 'u32';
+      for (const exprIndexAddon of [
+        '', // No addon
+        ` + ${indexTypeLiteral}`, // Add a literal 0
+        ` + ${indexTypeCast}(constants.zero)`, // Add a uniform 0
+      ]) {
+        // Produce the accesses to the variable.
+        for (const indexToTest of indicesToTest) {
+          const exprIndex = `(${indexToTest})${exprIndexAddon}`;
+          const exprZeroElement = `${_typeInfo.elementBaseType}()`;
+          const exprElement = `s.data[${exprIndex}]`;
+
+          switch (access) {
+            case 'read':
+              {
+                const exprLoadElement = atomic ? `atomicLoad(&${exprElement})` : exprElement;
+                let condition = `${exprLoadElement} != ${exprZeroElement}`;
+                if ('innerLength' in _typeInfo) condition = `any(${condition})`;
+                testFunctionSource += `
+                  if (${condition}) { return ${nextErrorReturnValue()}; }`;
+              }
+              break;
+
+            case 'write':
+              if (atomic) {
+                testFunctionSource += `
+                  atomicStore(&s.data[${exprIndex}], ${exprZeroElement});`;
+              } else {
+                testFunctionSource += `
+                  s.data[${exprIndex}] = ${exprZeroElement};`;
+              }
+              break;
+          }
+        }
+        testFunctionSource += '\n';
+      }
+    }
+
+    // Check that the canaries haven't been modified
+    if (usesCanary) {
+      testFunctionSource += `
+        for (var i = 0u; i < 10u; i = i + 1u) {
+          if (s.startCanary[i] != 0xFFFFFFFFu) {
+            return ${nextErrorReturnValue()};
+          }
+          if (s.endCanary[i] != 0xFFFFFFFFu) {
+            return ${nextErrorReturnValue()};
+          }
+        }`;
+    }
+
+    // Run the test
+
+    // First aggregate the test source
+    const testSource = `
+      ${globalSource}
+
+      fn runTest() -> u32 {
+        ${testFunctionSource}
+        return 0u;
+      }`;
+
+    // Run it.
+    if (bufferBindingSize !== undefined) {
+      assert(baseType !== 'bool', 'case should have been filtered out');
+
+      const expectedData = new ArrayBuffer(testBufferSize);
+      const bufferBindingEnd = bufferBindingOffset + bufferBindingSize;
+      testFillArrayBuffer(expectedData, baseType, {
+        zeroByteStart: bufferBindingOffset,
+        zeroByteCount: bufferBindingSize,
+      });
+
+      // Create a buffer that contains zeroes in the allowed access area, and 42s everywhere else.
+      const testBuffer = t.makeBufferWithContents(
+        new Uint8Array(expectedData),
+        GPUBufferUsage.COPY_SRC |
+          GPUBufferUsage.UNIFORM |
+          GPUBufferUsage.STORAGE |
+          GPUBufferUsage.COPY_DST
+      );
+
+      // Run the shader, accessing the buffer.
+      runShaderTest(t, GPUShaderStage.COMPUTE, testSource, [
+        {
+          binding: 0,
+          resource: { buffer: testBuffer, offset: bufferBindingOffset, size: bufferBindingSize },
+        },
+      ]);
+
+      // Check that content of the buffer outside of the allowed area didn't change.
+      const expectedBytes = new Uint8Array(expectedData);
+      t.expectGPUBufferValuesEqual(testBuffer, expectedBytes.subarray(0, bufferBindingOffset), 0);
+      t.expectGPUBufferValuesEqual(
+        testBuffer,
+        expectedBytes.subarray(bufferBindingEnd, testBufferSize),
+        bufferBindingEnd
+      );
+
+      testBuffer.destroy();
+    } else {
+      runShaderTest(t, GPUShaderStage.COMPUTE, testSource, []);
+    }
+  });

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -1,0 +1,38 @@
+import { keysOf } from '../../common/util/data_tables.js';
+
+/** WGSL plain scalar type names. */
+export type ScalarType = 'i32' | 'u32' | 'f32' | 'bool';
+
+/** Info for each plain scalar type. */
+export const kScalarTypeInfo = /* prettier-ignore */ {
+  'i32':    { layout: { alignment:  4, size:  4 }, supportsAtomics:  true },
+  'u32':    { layout: { alignment:  4, size:  4 }, supportsAtomics:  true },
+  'f32':    { layout: { alignment:  4, size:  4 }, supportsAtomics: false },
+  'bool':   { layout:                   undefined, supportsAtomics: false },
+} as const;
+/** List of all plain scalar types. */
+export const kScalarTypes = keysOf(kScalarTypeInfo);
+
+/** Info for each vecN<> container type. */
+export const kVectorContainerTypeInfo = /* prettier-ignore */ {
+  'vec2':   { layout: { alignment:  8, size:  8 }, arrayLength: 2 },
+  'vec3':   { layout: { alignment: 16, size: 12 }, arrayLength: 3 },
+  'vec4':   { layout: { alignment: 16, size: 16 }, arrayLength: 4 },
+} as const;
+/** List of all vecN<> container types. */
+export const kVectorContainerTypes = keysOf(kVectorContainerTypeInfo);
+
+/** Info for each matNxN<> container type. */
+export const kMatrixContainerTypeInfo = /* prettier-ignore */ {
+  'mat2x2': { layout: { alignment:  8, size: 16 }, arrayLength: 2, innerLength: 2 },
+  'mat3x2': { layout: { alignment:  8, size: 24 }, arrayLength: 3, innerLength: 2 },
+  'mat4x2': { layout: { alignment:  8, size: 32 }, arrayLength: 4, innerLength: 2 },
+  'mat2x3': { layout: { alignment: 16, size: 32 }, arrayLength: 2, innerLength: 3 },
+  'mat3x3': { layout: { alignment: 16, size: 48 }, arrayLength: 3, innerLength: 3 },
+  'mat4x3': { layout: { alignment: 16, size: 64 }, arrayLength: 4, innerLength: 3 },
+  'mat2x4': { layout: { alignment: 16, size: 32 }, arrayLength: 2, innerLength: 4 },
+  'mat3x4': { layout: { alignment: 16, size: 48 }, arrayLength: 3, innerLength: 4 },
+  'mat4x4': { layout: { alignment: 16, size: 64 }, arrayLength: 4, innerLength: 4 },
+} as const;
+/** List of all matNxN<> container types. */
+export const kMatrixContainerTypes = keysOf(kMatrixContainerTypeInfo);


### PR DESCRIPTION
Commits can be viewed separately (though you may want to view commits 3/4/5 together).

Passes in Chrome Canary except for ~https://crbug.com/tint/953 and~ https://crbug.com/tint/938

Replaces #380

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
