### PR TITLE
operation/vertex_state: split runTest into smaller functions

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -510,26 +510,35 @@ struct VSOutputs {
     }
   }
 
-  runTest(
-    buffers: VertexState<
+  createPipelineAndTestData<V, A>(
+    state: VertexState<
       {
         stepMode: GPUInputStepMode;
         arrayStride: number;
-        vbOffset?: number;
-      },
+      } & V,
       {
         offset: number;
         format: GPUVertexFormat;
-        shaderComponentCount?: number;
-      }
+      } & A
     >,
-    // Default to using 20 vertices and 20 instances so that we cover each of the test data at least
-    // once (at the time of writing the largest testData has 16 values).
-    vertexCount: number = 20,
-    instanceCount: number = 20
-  ) {
+    vertexCount: number,
+    instanceCount: number
+  ): {
+    pipeline: GPURenderPipeline;
+    testData: VertexState<
+      {
+        stepMode: GPUInputStepMode;
+        arrayStride: number;
+      } & V,
+      {
+        offset: number;
+        format: GPUVertexFormat;
+      } & A &
+        TestData
+    >;
+  } {
     // Gather the test data and some additional test state for attribs.
-    const pipelineAndTestState = mapStateAttribs(buffers, (buffer, attrib) => {
+    const pipelineAndTestState = mapStateAttribs(state, (buffer, attrib) => {
       const maxCount = buffer.stepMode === 'instance' ? instanceCount : vertexCount;
       const formatInfo = kVertexFormatInfo[attrib.format];
 
@@ -544,12 +553,17 @@ struct VSOutputs {
     });
 
     // Create the pipeline from the test data.
-    const pipeline = this.makeTestPipeline(pipelineAndTestState, vertexCount, instanceCount);
+    return {
+      testData: pipelineAndTestState,
+      pipeline: this.makeTestPipeline(pipelineAndTestState, vertexCount, instanceCount),
+    };
+  }
 
+  createExpectedBG(state: VertexState<{}, TestData>, pipeline: GPURenderPipeline): GPUBindGroup {
     // Create the bindgroups from that test data
     const bgEntries: GPUBindGroupEntry[] = [];
 
-    for (const buffer of pipelineAndTestState) {
+    for (const buffer of state) {
       for (const attrib of buffer.attributes) {
         const expectedDataBuffer = this.makeBufferWithContents(
           new Uint8Array(attrib.expectedData),
@@ -562,15 +576,31 @@ struct VSOutputs {
       }
     }
 
-    const expectedDataBG = this.device.createBindGroup({
+    return this.device.createBindGroup({
       layout: pipeline.getBindGroupLayout(0),
       entries: bgEntries,
     });
+  }
 
+  createVertexBuffers(
+    state: VertexState<
+      {
+        stepMode: GPUInputStepMode;
+        arrayStride: number;
+        vbOffset?: number;
+      },
+      {
+        format: GPUVertexFormat;
+        offset: number;
+      } & TestData
+    >,
+    vertexCount: number = 20,
+    instanceCount: number = 20
+  ): VertexState<{ buffer: GPUBuffer; vbOffset?: number }, {}> {
     // Create the vertex buffers
     const vertexBuffers: VertexState<{ buffer: GPUBuffer; vbOffset?: number }, {}> = [];
 
-    for (const buffer of pipelineAndTestState) {
+    for (const buffer of state) {
       const maxCount = buffer.stepMode === 'instance' ? instanceCount : vertexCount;
 
       // Fill the vertex data with garbage so that we don't get `0` (which could be a test value)
@@ -595,7 +625,34 @@ struct VSOutputs {
       });
     }
 
-    // Run the test shader.
+    return vertexBuffers;
+  }
+
+  runTest(
+    buffers: VertexState<
+      {
+        stepMode: GPUInputStepMode;
+        arrayStride: number;
+        vbOffset?: number;
+      },
+      {
+        offset: number;
+        format: GPUVertexFormat;
+        shaderComponentCount?: number;
+      }
+    >,
+    // Default to using 20 vertices and 20 instances so that we cover each of the test data at least
+    // once (at the time of writing the largest testData has 16 values).
+    vertexCount: number = 20,
+    instanceCount: number = 20
+  ) {
+    const { testData, pipeline } = this.createPipelineAndTestData(
+      buffers,
+      vertexCount,
+      instanceCount
+    );
+    const expectedDataBG = this.createExpectedBG(testData, pipeline);
+    const vertexBuffers = this.createVertexBuffers(testData);
     this.submitRenderPass(pipeline, vertexBuffers, expectedDataBG, vertexCount, instanceCount);
   }
 }

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -570,8 +570,8 @@ struct VSOutputs {
 
   createVertexBuffers(
     state: VertexLayoutState<{ vbOffset?: number }, TestData>,
-    vertexCount: number = 20,
-    instanceCount: number = 20
+    vertexCount: number,
+    instanceCount: number
   ): VertexState<{ buffer: GPUBuffer; vbOffset?: number }, {}> {
     // Create the vertex buffers
     const vertexBuffers: VertexState<{ buffer: GPUBuffer; vbOffset?: number }, {}> = [];
@@ -617,7 +617,7 @@ struct VSOutputs {
       instanceCount
     );
     const expectedDataBG = this.createExpectedBG(testData, pipeline);
-    const vertexBuffers = this.createVertexBuffers(testData);
+    const vertexBuffers = this.createVertexBuffers(testData, vertexCount, instanceCount);
     this.submitRenderPass(pipeline, vertexBuffers, expectedDataBG, vertexCount, instanceCount);
   }
 }

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -69,6 +69,11 @@ type VertexBuffer<V, A> = V & {
 };
 type VertexState<V, A> = VertexBuffer<V, A>[];
 
+type VertexLayoutState<V, A> = VertexState<
+  { stepMode: GPUInputStepMode; arrayStride: number } & V,
+  { format: GPUVertexFormat; offset: number } & A
+>;
+
 function mapBufferAttribs<V, A1, A2>(
   buffer: VertexBuffer<V, A1>,
   f: (v: V, a: VertexAttrib<A1>) => A2
@@ -511,31 +516,12 @@ struct VSOutputs {
   }
 
   createPipelineAndTestData<V, A>(
-    state: VertexState<
-      {
-        stepMode: GPUInputStepMode;
-        arrayStride: number;
-      } & V,
-      {
-        offset: number;
-        format: GPUVertexFormat;
-      } & A
-    >,
+    state: VertexLayoutState<V, A>,
     vertexCount: number,
     instanceCount: number
   ): {
     pipeline: GPURenderPipeline;
-    testData: VertexState<
-      {
-        stepMode: GPUInputStepMode;
-        arrayStride: number;
-      } & V,
-      {
-        offset: number;
-        format: GPUVertexFormat;
-      } & A &
-        TestData
-    >;
+    testData: VertexLayoutState<V, A & TestData>;
   } {
     // Gather the test data and some additional test state for attribs.
     const pipelineAndTestState = mapStateAttribs(state, (buffer, attrib) => {
@@ -583,17 +569,7 @@ struct VSOutputs {
   }
 
   createVertexBuffers(
-    state: VertexState<
-      {
-        stepMode: GPUInputStepMode;
-        arrayStride: number;
-        vbOffset?: number;
-      },
-      {
-        format: GPUVertexFormat;
-        offset: number;
-      } & TestData
-    >,
+    state: VertexLayoutState<{ vbOffset?: number }, TestData>,
     vertexCount: number = 20,
     instanceCount: number = 20
   ): VertexState<{ buffer: GPUBuffer; vbOffset?: number }, {}> {
@@ -629,18 +605,7 @@ struct VSOutputs {
   }
 
   runTest(
-    buffers: VertexState<
-      {
-        stepMode: GPUInputStepMode;
-        arrayStride: number;
-        vbOffset?: number;
-      },
-      {
-        offset: number;
-        format: GPUVertexFormat;
-        shaderComponentCount?: number;
-      }
-    >,
+    buffers: VertexLayoutState<{ vbOffset?: number }, { shaderComponentCount?: number }>,
     // Default to using 20 vertices and 20 instances so that we cover each of the test data at least
     // once (at the time of writing the largest testData has 16 values).
     vertexCount: number = 20,


### PR DESCRIPTION
This will allow using the individual components in tests that need
custom handling beyond what runTest can do.

@kainino0x PTAL at the Typescriptness. The types of the helper functions are pretty massive but I couldn't get them to be smaller (I wanted to use generic "extends" but that requires declaring interfaces etc).



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
