### PR TITLE
Add new limits to DefaultLimits, update compute tests

### DIFF
--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -3,6 +3,7 @@ Basic command buffer compute tests.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { DefaultLimits } from '../../../constants.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { checkElementsEqualGenerated } from '../../../util/check_contents.js';
 
@@ -65,22 +66,29 @@ g.test('memcpy').fn(async t => {
 });
 
 g.test('large_dispatch')
-  .desc(
-    `
-TODO: add query for the maximum dispatch size and test closer to those limits.
-
-Test reasonably-sized large dispatches (see also stress tests).
-`
-  )
+  .desc(`Test reasonably-sized large dispatches (see also: stress tests).`)
   .params(u =>
     u
       // Reasonably-sized powers of two, and some stranger larger sizes.
-      .combine('dispatchSize', [256, 512, 1024, 2048, 315, 628, 1053, 2179] as const)
+      .combine('dispatchSize', [
+        256,
+        2048,
+        315,
+        628,
+        2179,
+        DefaultLimits.maxComputePerDimensionDispatchSize,
+      ])
       // Test some reasonable workgroup sizes.
-      .combine('workgroupSize', [1, 2, 4, 8, 16, 32, 64] as const)
       .beginSubcases()
       // 0 == x axis; 1 == y axis; 2 == z axis.
       .combine('largeDimension', [0, 1, 2] as const)
+      .expand('workgroupSize', p => [
+        1,
+        2,
+        8,
+        32,
+        DefaultLimits.maxComputeWorkgroupSize[p.largeDimension],
+      ])
   )
   .fn(async t => {
     // The output storage buffer is filled with this value.

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -70,6 +70,8 @@ g.test('dispatch_sizes')
   Workgroup sizes:
     - valid: { zero, one, just under limit }
     - invalid: { just over limit, way over limit }
+
+  TODO: Verify that the invalid cases don't execute any invocations at all.
 `
   )
   .params(u =>

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -5,6 +5,7 @@ Does **not** test usage scopes (resource_usages/) or programmable pass stuff (pr
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { DefaultLimits } from '../../../../constants.js';
 import { ValidationTest } from '../../validation_test.js';
 
 class F extends ValidationTest {
@@ -60,35 +61,53 @@ setPipeline should generate an error iff using an 'invalid' pipeline.
     }, t.params.state === 'invalid');
   });
 
+const kMaxDispatch = DefaultLimits.maxComputePerDimensionDispatchSize;
 g.test('dispatch_sizes')
   .desc(
-    `
-Test 'direct' and 'indirect' dispatch with various sizes.
-  - workgroup sizes:
-    - valid, {[0, 0, 0], [1, 1, 1]}
-    - invalid, TODO: workSizes {x,y,z} just under and above limit, once limit is established.
+    `Test 'direct' and 'indirect' dispatch with various sizes.
+
+  Only direct dispatches can produce validation errors.
+  Workgroup sizes:
+    - valid: { zero, one, just under limit }
+    - invalid: { just over limit, way over limit }
 `
   )
   .params(u =>
     u
       .combine('dispatchType', ['direct', 'indirect'] as const)
+      .combine('largeDimValue', [0, 1, kMaxDispatch, kMaxDispatch + 1, 0x7fff_ffff, 0xffff_ffff])
       .beginSubcases()
-      .combine('workSizes', [
-        [0, 0, 0],
-        [1, 1, 1],
-      ] as const)
+      .combine('largeDimIndex', [0, 1, 2] as const)
+      .combine('smallDimValue', [0, 1])
   )
   .fn(t => {
+    const { dispatchType, largeDimIndex, smallDimValue, largeDimValue } = t.params;
+
     const pipeline = t.createNoOpComputePipeline();
-    const [x, y, z] = t.params.workSizes;
+
+    const workSizes = [smallDimValue, smallDimValue, smallDimValue];
+    workSizes[largeDimIndex] = largeDimValue;
+
     const { encoder, finish } = t.createEncoder('compute pass');
     encoder.setPipeline(pipeline);
-    if (t.params.dispatchType === 'direct') {
+    if (dispatchType === 'direct') {
+      const [x, y, z] = workSizes;
       encoder.dispatch(x, y, z);
-    } else if (t.params.dispatchType === 'indirect') {
-      encoder.dispatchIndirect(t.createIndirectBuffer('valid', new Uint32Array([x, y, z])), 0);
+    } else if (dispatchType === 'indirect') {
+      encoder.dispatchIndirect(t.createIndirectBuffer('valid', new Uint32Array(workSizes)), 0);
     }
-    t.queue.submit([finish()]);
+
+    const shouldError =
+      dispatchType === 'direct' &&
+      (workSizes[0] > kMaxDispatch || workSizes[1] > kMaxDispatch || workSizes[2] > kMaxDispatch);
+
+    if (shouldError) {
+      t.expectValidationError(() => {
+        finish();
+      });
+    } else {
+      t.queue.submit([finish()]);
+    }
   });
 
 const kBufferData = new Uint32Array(6).fill(1);

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -9,6 +9,8 @@ import { assert, unreachable } from '../common/util/util.js';
 
 import { GPUConst } from './constants.js';
 
+// Base device limits can be found in constants.ts.
+
 // Queries
 
 /** Maximum number of queries in GPUQuerySet, by spec. */

--- a/src/webgpu/constants.ts
+++ b/src/webgpu/constants.ts
@@ -56,12 +56,22 @@ export const GPUConst = {
   MapMode,
 } as const;
 
-type Limits = Omit<GPUSupportedLimits, '__brand'>;
+type Limits = Omit<GPUSupportedLimits, '__brand'> & {
+  maxComputeWorkgroupStorageSize: number;
+  maxComputeWorkgroupInvocations: number;
+  maxComputeWorkgroupSize: readonly [number, number, number];
+  maxComputePerDimensionDispatchSize: number;
+  minUniformBufferOffsetAlignment: number;
+  minStorageBufferOffsetAlignment: number;
+  maxInterStageShaderComponents: number;
+};
+/** Base limits, per spec. */
 export const DefaultLimits: Limits = {
   maxTextureDimension1D: 8192,
   maxTextureDimension2D: 8192,
   maxTextureDimension3D: 2048,
   maxTextureArrayLayers: 2048,
+
   maxBindGroups: 4,
   maxDynamicUniformBuffersPerPipelineLayout: 8,
   maxDynamicStorageBuffersPerPipelineLayout: 4,
@@ -70,9 +80,19 @@ export const DefaultLimits: Limits = {
   maxStorageBuffersPerShaderStage: 4,
   maxStorageTexturesPerShaderStage: 4,
   maxUniformBuffersPerShaderStage: 12,
+
   maxUniformBufferBindingSize: 16384,
   maxStorageBufferBindingSize: 134217728,
+  minUniformBufferOffsetAlignment: 256,
+  minStorageBufferOffsetAlignment: 256,
+
   maxVertexBuffers: 8,
   maxVertexAttributes: 16,
   maxVertexBufferArrayStride: 2048,
+  maxInterStageShaderComponents: 60,
+
+  maxComputeWorkgroupStorageSize: 16352,
+  maxComputeWorkgroupInvocations: 256,
+  maxComputeWorkgroupSize: [256, 256, 64],
+  maxComputePerDimensionDispatchSize: 65535,
 };

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -192,11 +192,15 @@ function canonicalizeDescriptor(
     ? Array.from(new Set(desc.requiredFeatures)).sort()
     : [];
 
-  const limitsCanonicalized: Record<string, number> = { ...DefaultLimits };
+  /** Canonicalized version of the requested limits: in canonical order, with only values which are
+   * specified _and_ non-default. */
+  const limitsCanonicalized: Record<string, number> = {};
   if (desc.requiredLimits) {
-    for (const k of Object.keys(desc.requiredLimits)) {
-      if (desc.requiredLimits[k] !== undefined) {
-        limitsCanonicalized[k] = desc.requiredLimits[k];
+    for (const [k, defaultValue] of Object.entries(DefaultLimits)) {
+      const requestedValue = desc.requiredLimits[k];
+      // Skip adding a limit to limitsCanonicalized if it is the same as the default.
+      if (requestedValue !== undefined && requestedValue !== defaultValue) {
+        limitsCanonicalized[k] = requestedValue;
       }
     }
   }


### PR DESCRIPTION
Fixes the limitsCanonicalized so they don't include ALL limits (even those which are probably going to become unconfigurable).

Soft-blocked on gpuweb/gpuweb#1898

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
