### PR TITLE
Implement api,validation,encoding,cmds,render,other,*

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/render/render.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/render.ts
@@ -12,17 +12,17 @@ export function buildBufferOffsetAndSizeOOBTestParams(minAlignment: number, buff
   return kRenderEncodeTypeParams.combineWithParams([
     // Explicit size
     { offset: 0, size: 0, _valid: true },
-    { offset: 0, size: 1, _valid: true }, // control case
+    { offset: 0, size: 1, _valid: true },
     { offset: 0, size: 4, _valid: true },
     { offset: 0, size: 5, _valid: true },
     { offset: 0, size: bufferSize, _valid: true },
     { offset: 0, size: bufferSize + 4, _valid: false },
     { offset: minAlignment, size: bufferSize, _valid: false },
     { offset: minAlignment, size: bufferSize - minAlignment, _valid: true },
-    { offset: bufferSize - 1, size: 1, _valid: false },
+    { offset: bufferSize - minAlignment, size: minAlignment, _valid: true },
     { offset: bufferSize, size: 1, _valid: false },
     // Implicit size: buffer.size - offset
-    { offset: 0, size: undefined, _valid: true }, // control case
+    { offset: 0, size: undefined, _valid: true },
     { offset: minAlignment, size: undefined, _valid: true },
     { offset: bufferSize - minAlignment, size: undefined, _valid: true },
     { offset: bufferSize, size: undefined, _valid: true },

--- a/src/webgpu/api/validation/encoding/cmds/render/render.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/render.ts
@@ -2,7 +2,7 @@ import { kUnitCaseParamsBuilder } from '../../../../../../common/framework/param
 import { kRenderEncodeTypes } from '../../../validation_test.js';
 
 export const kRenderEncodeTypeParams = kUnitCaseParamsBuilder.combine(
-  'encoder',
+  'encoderType',
   kRenderEncodeTypes
 );
 
@@ -11,21 +11,21 @@ export const kBufferStates = ['valid', 'invalid', 'destroyed'] as const;
 export function buildBufferOffsetAndSizeOOBTestParams(minAlignment: number, bufferSize: number) {
   return kRenderEncodeTypeParams.combineWithParams([
     // Explicit size
-    { offset: 0, size: 0 },
-    { offset: 0, size: 1 }, // control case
-    { offset: 0, size: 4 },
-    { offset: 0, size: 5 },
-    { offset: 0, size: bufferSize },
-    { offset: 0, size: bufferSize + 4 },
-    { offset: minAlignment, size: bufferSize },
-    { offset: minAlignment, size: bufferSize - minAlignment },
-    { offset: bufferSize - 1, size: 1 },
-    { offset: bufferSize, size: 1 },
+    { offset: 0, size: 0, _valid: true },
+    { offset: 0, size: 1, _valid: true }, // control case
+    { offset: 0, size: 4, _valid: true },
+    { offset: 0, size: 5, _valid: true },
+    { offset: 0, size: bufferSize, _valid: true },
+    { offset: 0, size: bufferSize + 4, _valid: false },
+    { offset: minAlignment, size: bufferSize, _valid: false },
+    { offset: minAlignment, size: bufferSize - minAlignment, _valid: true },
+    { offset: bufferSize - 1, size: 1, _valid: false },
+    { offset: bufferSize, size: 1, _valid: false },
     // Implicit size: buffer.size - offset
-    { offset: 0, size: undefined }, // control case
-    { offset: minAlignment, size: undefined },
-    { offset: bufferSize - minAlignment, size: undefined },
-    { offset: bufferSize, size: undefined },
-    { offset: bufferSize + minAlignment, size: undefined },
+    { offset: 0, size: undefined, _valid: true }, // control case
+    { offset: minAlignment, size: undefined, _valid: true },
+    { offset: bufferSize - minAlignment, size: undefined, _valid: true },
+    { offset: bufferSize, size: undefined, _valid: true },
+    { offset: bufferSize + minAlignment, size: undefined, _valid: false },
   ]);
 }

--- a/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
@@ -21,7 +21,20 @@ Tests index buffer must be valid.
   `
   )
   .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('state', kBufferStates))
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, state } = t.params;
+    const indexBuffer = t.createBufferWithState(state, {
+      size: 16,
+      usage: GPUBufferUsage.INDEX,
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setIndexBuffer(indexBuffer, 'uint32');
+
+    t.expectValidationError(() => {
+      t.queue.submit([finish()]);
+    }, state !== 'valid');
+  });
 
 g.test('index_buffer_usage')
   .desc(
@@ -36,7 +49,20 @@ Tests index buffer must have 'Index' usage.
       GPUConst.BufferUsage.COPY_DST | GPUConst.BufferUsage.INDEX,
     ] as const)
   )
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, usage } = t.params;
+    const indexBuffer = t.device.createBuffer({
+      size: 16,
+      usage,
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setIndexBuffer(indexBuffer, 'uint32');
+
+    t.expectValidationError(() => {
+      finish();
+    }, (usage | GPUConst.BufferUsage.INDEX) !== usage);
+  });
 
 g.test('offset_alignment')
   .desc(
@@ -51,7 +77,22 @@ Tests offset must be a multiple of index format’s byte size.
         return p.indexFormat === 'uint16' ? ([0, 1, 2] as const) : ([0, 2, 4] as const);
       })
   )
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, indexFormat, offset } = t.params;
+    const indexBuffer = t.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.INDEX,
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setIndexBuffer(indexBuffer, indexFormat, offset);
+
+    const alignment =
+      indexFormat === 'uint16' ? Uint16Array.BYTES_PER_ELEMENT : Uint32Array.BYTES_PER_ELEMENT;
+    t.expectValidationError(() => {
+      finish();
+    }, offset % alignment !== 0);
+  });
 
 g.test('offset_and_size_oob')
   .desc(
@@ -60,4 +101,17 @@ Tests offset and size cannot be larger than index buffer size.
   `
   )
   .paramsSubcasesOnly(buildBufferOffsetAndSizeOOBTestParams(4, 256))
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, offset, size, _valid } = t.params;
+    const indexBuffer = t.device.createBuffer({
+      size: 256,
+      usage: GPUBufferUsage.INDEX,
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setIndexBuffer(indexBuffer, 'uint32', offset, size);
+
+    t.expectValidationError(() => {
+      finish();
+    }, !_valid);
+  });

--- a/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
@@ -32,7 +32,11 @@ Tests index buffer must be valid.
     encoder.setIndexBuffer(indexBuffer, 'uint32');
 
     t.expectValidationError(() => {
-      t.queue.submit([finish()]);
+      if (state === 'destroyed') {
+        t.queue.submit([finish()]);
+      } else {
+        finish();
+      }
     }, state !== 'valid');
   });
 

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -5,7 +5,17 @@ Validation tests for setPipeline on render pass and render bundle.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { ValidationTest, kRenderEncodeTypes } from '../../../validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+class F extends ValidationTest {
+  createRenderPipeline(state: 'valid' | 'invalid'): GPURenderPipeline {
+    if (state === 'valid') {
+      return this.createNoOpRenderPipeline();
+    }
+
+    return this.createErrorRenderPipeline();
+  }
+}
+
+export const g = makeTestGroup(F);
 
 g.test('invalid_pipeline')
   .desc(
@@ -14,6 +24,16 @@ Tests setPipeline should generate an error iff using an 'invalid' pipeline.
   `
   )
   .paramsSubcasesOnly(u =>
-    u.combine('encoder', kRenderEncodeTypes).combine('state', ['valid', 'invalid'] as const)
+    u.combine('encoderType', kRenderEncodeTypes).combine('state', ['valid', 'invalid'] as const)
   )
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, state } = t.params;
+    const pipeline = t.createRenderPipeline(state);
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setPipeline(pipeline);
+
+    t.expectValidationError(() => {
+      finish();
+    }, state === 'invalid');
+  });

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -5,17 +5,7 @@ Validation tests for setPipeline on render pass and render bundle.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { ValidationTest, kRenderEncodeTypes } from '../../../validation_test.js';
 
-class F extends ValidationTest {
-  createRenderPipeline(state: 'valid' | 'invalid'): GPURenderPipeline {
-    if (state === 'valid') {
-      return this.createNoOpRenderPipeline();
-    }
-
-    return this.createErrorRenderPipeline();
-  }
-}
-
-export const g = makeTestGroup(F);
+export const g = makeTestGroup(ValidationTest);
 
 g.test('invalid_pipeline')
   .desc(
@@ -28,7 +18,7 @@ Tests setPipeline should generate an error iff using an 'invalid' pipeline.
   )
   .fn(t => {
     const { encoderType, state } = t.params;
-    const pipeline = t.createRenderPipeline(state);
+    const pipeline = t.createRenderPipelineWithState(state);
 
     const { encoder, finish } = t.createEncoder(encoderType);
     encoder.setPipeline(pipeline);

--- a/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
@@ -27,7 +27,20 @@ Tests slot must be less than the maxVertexBuffers in device limits.
       DefaultLimits.maxVertexBuffers,
     ] as const)
   )
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, slot } = t.params;
+    const vertexBuffer = t.createBufferWithState('valid', {
+      size: 16,
+      usage: GPUBufferUsage.VERTEX,
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setVertexBuffer(slot, vertexBuffer);
+
+    t.expectValidationError(() => {
+      finish();
+    }, slot >= DefaultLimits.maxVertexBuffers);
+  });
 
 g.test('vertex_buffer')
   .desc(
@@ -36,7 +49,20 @@ Tests vertex buffer must be valid.
   `
   )
   .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('state', kBufferStates))
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, state } = t.params;
+    const vertexBuffer = t.createBufferWithState(state, {
+      size: 16,
+      usage: GPUBufferUsage.VERTEX,
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setVertexBuffer(0, vertexBuffer);
+
+    t.expectValidationError(() => {
+      t.queue.submit([finish()]);
+    }, state !== 'valid');
+  });
 
 g.test('vertex_buffer_usage')
   .desc(
@@ -51,7 +77,20 @@ Tests vertex buffer must have 'Vertex' usage.
       GPUConst.BufferUsage.COPY_DST | GPUConst.BufferUsage.VERTEX,
     ] as const)
   )
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, usage } = t.params;
+    const vertexBuffer = t.device.createBuffer({
+      size: 16,
+      usage,
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setVertexBuffer(0, vertexBuffer);
+
+    t.expectValidationError(() => {
+      finish();
+    }, (usage | GPUConst.BufferUsage.VERTEX) !== usage);
+  });
 
 g.test('offset_alignment')
   .desc(
@@ -60,7 +99,20 @@ Tests offset must be a multiple of 4.
   `
   )
   .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('offset', [0, 2, 4] as const))
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, offset } = t.params;
+    const vertexBuffer = t.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.VERTEX,
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setVertexBuffer(0, vertexBuffer, offset);
+
+    t.expectValidationError(() => {
+      finish();
+    }, offset % 4 !== 0);
+  });
 
 g.test('offset_and_size_oob')
   .desc(
@@ -69,4 +121,17 @@ Tests offset and size cannot be larger than vertex buffer size.
   `
   )
   .paramsSubcasesOnly(buildBufferOffsetAndSizeOOBTestParams(4, 256))
-  .unimplemented();
+  .fn(t => {
+    const { encoderType, offset, size, _valid } = t.params;
+    const vertexBuffer = t.device.createBuffer({
+      size: 256,
+      usage: GPUBufferUsage.VERTEX,
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setVertexBuffer(0, vertexBuffer, offset, size);
+
+    t.expectValidationError(() => {
+      finish();
+    }, !_valid);
+  });

--- a/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
@@ -60,7 +60,11 @@ Tests vertex buffer must be valid.
     encoder.setVertexBuffer(0, vertexBuffer);
 
     t.expectValidationError(() => {
-      t.queue.submit([finish()]);
+      if (state === 'destroyed') {
+        t.queue.submit([finish()]);
+      } else {
+        finish();
+      }
     }, state !== 'valid');
   });
 

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -230,6 +230,11 @@ export class ValidationTest extends GPUTest {
     }
   }
 
+  /** Create a GPURenderPipeline in the specified state. */
+  createRenderPipelineWithState(state: 'valid' | 'invalid'): GPURenderPipeline {
+    return state === 'valid' ? this.createNoOpRenderPipeline() : this.createErrorRenderPipeline();
+  }
+
   /** Return a GPURenderPipeline with default options and no-op vertex and fragment shaders. */
   createNoOpRenderPipeline(): GPURenderPipeline {
     return this.device.createRenderPipeline({

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -252,6 +252,21 @@ export class ValidationTest extends GPUTest {
     });
   }
 
+  /** Return an invalid GPURenderPipeline. */
+  createErrorRenderPipeline(): GPURenderPipeline {
+    this.device.pushErrorScope('validation');
+    const pipeline = this.device.createRenderPipeline({
+      vertex: {
+        module: this.device.createShaderModule({
+          code: '',
+        }),
+        entryPoint: '',
+      },
+    });
+    this.device.popErrorScope();
+    return pipeline;
+  }
+
   /** Return a GPUComputePipeline with a no-op shader. */
   createNoOpComputePipeline(): GPUComputePipeline {
     return this.device.createComputePipeline({


### PR DESCRIPTION
- Add validation test implementation for other render cmds:
  setPipeline
  setIndexBuffer
  setVertexBuffer
  drawIndirect
  drawIndexedIndirect





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
