### PR TITLE
Add test plan CopyTextureToBuffer() with depth aspect operation tests

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1104,6 +1104,22 @@ g.test('undefined_params')
     });
   });
 
+g.test('coppy_from_depth_aspect')
+  .desc(
+    `
+  Validate the correctness of copyTextureToBuffer() with depth aspect.
+
+  For all the texture formats that support calling copyTextureToBuffer() with depth aspect:
+  - Initialize the depth aspect of the source texture by assigning depth values to
+    "[[builtin(frag_depth)]] f32" in a fragment shader
+  - Copy the depth aspect of the source texture into the destination buffer
+  - Check if the data in the destination buffer is expected
+  - Test the copies from / into zero / non-zero array layer / mipmap levels
+  - Test copying multiple array layers
+  `
+  )
+  .unimplemented();
+
 g.test('copy_from_stencil_aspect')
   .desc(
     `


### PR DESCRIPTION
This patch adds the test plan for the operation tests about
CopyTextureToBuffer() with depth aspects. Note that WebGPU doesn't
support calling CopyBufferToTexture() with depth aspects.





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
