### PR TITLE
Update api,validation,buffer,mapping:*

### DIFF
--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -1,27 +1,5 @@
 export const description = `
 Validation tests for GPUBuffer.mapAsync, GPUBuffer.unmap and GPUBuffer.getMappedRange.
-
-TODO: review existing tests and merge with this plan:
-> - {mappedAtCreation, await mapAsync}
->     - -> x = getMappedRange
->     - check x.size == mapping size
->     - -> noawait mapAsync
->     - check x.size == mapping size
->     - -> await
->     - check x.size == mapping size
->     - -> unmap
->     - check x.size == 0
->     - -> getMappedRange (should fail)
-> - await mapAsync -> await mapAsync -> getMappedRange
-> - {mappedAtCreation, await mapAsync} -> unmap -> unmap
-> - x = noawait mapAsync -> y = noawait mapAsync
->     - -> getMappedRange (should fail)
->     - -> await x
->     - -> getMappedRange
->     - -> shouldReject(y)
-> - noawait mapAsync -> unmap
-> - {mappedAtCreation, await mapAsync} -> x = getMappedRange -> unmap -> await mapAsync(subrange) -> y = getMappedRange
->     - check x.size == 0, y.size == mapping size
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -246,19 +224,10 @@ g.test('mapAsync,sizeUnspecifiedOOB')
 g.test('mapAsync,offsetAndSizeAlignment')
   .desc("Test that mapAsync fails if the alignment of offset and size isn't correct.")
   .paramsSubcasesOnly(u =>
-    u //
+    u
       .combine('mapMode', kMapModeOptions)
-      .combineWithParams([
-        // Valid cases, 0 and required alignments values are valid.
-        { offset: 0, size: 0 },
-        { offset: kOffsetAlignment, size: kSizeAlignment },
-
-        // Invalid case, offset isn't aligned.
-        { offset: kOffsetAlignment / 2, size: kSizeAlignment },
-
-        // Invalid case, size isn't aligned.
-        { offset: kOffsetAlignment, size: kSizeAlignment / 2 },
-      ])
+      .combine('offset', [0, kOffsetAlignment, kOffsetAlignment / 2])
+      .combine('size', [0, kSizeAlignment, kSizeAlignment / 2])
   )
   .fn(async t => {
     const { mapMode, offset, size } = t.params;
@@ -315,25 +284,76 @@ g.test('getMappedRange,state,mapped')
   .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
     const { mapMode } = t.params;
-    const buffer = t.createMappableBuffer(mapMode, 16);
+    const bufferSize = 16;
+    const buffer = t.createMappableBuffer(mapMode, bufferSize);
     await buffer.mapAsync(mapMode);
 
-    t.testGetMappedRangeCall(true, buffer);
+    const data = buffer.getMappedRange();
+    t.expect(data instanceof ArrayBuffer);
+    t.expect(data.byteLength === bufferSize);
+
+    t.expectValidationError(() => {
+      // map on already mapped buffer should be rejected
+      const mapping = buffer.mapAsync(mapMode);
+      t.expect(data.byteLength === bufferSize);
+      t.shouldReject('OperationError', mapping);
+    });
+
+    t.expect(data.byteLength === bufferSize);
+
+    buffer.unmap();
+
+    t.expect(data.byteLength === 0);
   });
 
 g.test('getMappedRange,state,mappedAtCreation')
   .desc(
     'Test that it is valid to call getMappedRange in the mapped at creation state, for all buffer usages'
   )
-  .paramsSubcasesOnly(u => u.combine('bufferUsage', kBufferUsages))
+  .paramsSubcasesOnly(u =>
+    u.combine('bufferUsage', kBufferUsages).combine('mapMode', kMapModeOptions)
+  )
   .fn(async t => {
-    const { bufferUsage } = t.params;
+    const { bufferUsage, mapMode } = t.params;
+    const bufferSize = 16;
     const buffer = t.device.createBuffer({
       usage: bufferUsage,
-      size: 16,
+      size: bufferSize,
       mappedAtCreation: true,
     });
 
+    const data = buffer.getMappedRange();
+    t.expect(data instanceof ArrayBuffer);
+    t.expect(data.byteLength === bufferSize);
+
+    t.expectValidationError(() => {
+      // map on already mapped buffer should be rejected
+      const mapping = buffer.mapAsync(mapMode);
+      t.expect(data.byteLength === bufferSize);
+      t.shouldReject('OperationError', mapping);
+    });
+
+    t.expect(data.byteLength === bufferSize);
+
+    buffer.unmap();
+
+    t.expect(data.byteLength === 0);
+  });
+
+g.test('getMappedRange,state,mappedAgain')
+  .desc(
+    'Test that it is valid to call getMappedRange in the mapped state, even if there is a duplicate mapAsync before'
+  )
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
+  .fn(async t => {
+    const { mapMode } = t.params;
+    const buffer = t.createMappableBuffer(mapMode, 16);
+    await buffer.mapAsync(mapMode);
+
+    // call mapAsync again on already mapped buffer should fail
+    await t.testMapAsyncCall(false, 'OperationError', buffer, mapMode);
+
+    // getMapppedRange should still success
     t.testGetMappedRangeCall(true, buffer);
   });
 
@@ -367,6 +387,61 @@ Test for various cases of being unmapped: at creation, after a mapAsync call or 
       buffer.unmap();
       t.testGetMappedRangeCall(false, buffer);
     }
+  });
+
+g.test('getMappedRange,subrange,mapped')
+  .desc(
+    `Test that old getMappedRange returned arrybuffer does not exist after unmap and newly returned
+    arraybuffer after new map has correct subrange`
+  )
+  .params(u => u.combine('mapMode', kMapModeOptions))
+  .fn(async t => {
+    const { mapMode } = t.params;
+    const bufferSize = 16;
+    const offset = 8;
+    const subrangeSize = bufferSize - offset;
+    const buffer = t.createMappableBuffer(mapMode, bufferSize);
+    await buffer.mapAsync(mapMode);
+
+    const data0 = buffer.getMappedRange();
+    t.expect(data0 instanceof ArrayBuffer);
+    t.expect(data0.byteLength === bufferSize);
+
+    buffer.unmap();
+
+    await buffer.mapAsync(mapMode, offset);
+    const data1 = buffer.getMappedRange(8);
+
+    t.expect(data0.byteLength === 0);
+    t.expect(data1.byteLength === subrangeSize);
+  });
+
+g.test('getMappedRange,subrange,mappedAtCreation')
+  .desc(
+    `Test that old getMappedRange returned arrybuffer does not exist after unmap and newly returned
+    arraybuffer after new map has correct subrange`
+  )
+  .fn(async t => {
+    const bufferSize = 16;
+    const offset = 8;
+    const subrangeSize = bufferSize - offset;
+    const buffer = t.device.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+      mappedAtCreation: true,
+    });
+
+    const data0 = buffer.getMappedRange();
+    t.expect(data0 instanceof ArrayBuffer);
+    t.expect(data0.byteLength === bufferSize);
+
+    buffer.unmap();
+
+    await buffer.mapAsync(GPUMapMode.READ, offset);
+    const data1 = buffer.getMappedRange(8);
+
+    t.expect(data0.byteLength === 0);
+    t.expect(data1.byteLength === subrangeSize);
   });
 
 g.test('getMappedRange,state,destroyed')
@@ -405,45 +480,63 @@ Test for various cases of being destroyed: at creation, after a mapAsync call or
 g.test('getMappedRange,state,mappingPending')
   .desc('Test that it is invalid to call getMappedRange in the mappingPending state.')
   .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
-  .fn(t => {
+  .fn(async t => {
     const { mapMode } = t.params;
     const buffer = t.createMappableBuffer(mapMode, 16);
 
-    /* noawait */ buffer.mapAsync(mapMode);
+    /* noawait */ const mapping0 = buffer.mapAsync(mapMode);
+    t.expectValidationError(() => {
+      // seconding mapping should be rejected
+      t.shouldReject('OperationError', buffer.mapAsync(mapMode));
+    });
+
+    // invalid in mappingPending state
     t.testGetMappedRangeCall(false, buffer);
+
+    await mapping0;
+
+    // valid after buffer is mapped
+    t.testGetMappedRangeCall(true, buffer);
   });
 
-g.test('getMappedRange,offsetAndSizeAlignment')
-  .desc(
-    `Test that getMappedRange fails if the alignment of offset and size isn't correct.
-  TODO: x= {mappedAtCreation, mapAsync at {0, >0}`
-  )
+g.test('getMappedRange,offsetAndSizeAlignment,mapped')
+  .desc(`Test that getMappedRange fails if the alignment of offset and size isn't correct.`)
   .params(u =>
     u
       .combine('mapMode', kMapModeOptions)
       .beginSubcases()
-      .combineWithParams([
-        // Valid cases, 0 and required alignments values are valid.
-        { offset: 0, size: 0 },
-        { offset: kOffsetAlignment, size: kSizeAlignment },
-
-        // Invalid case, offset isn't aligned.
-        { offset: kOffsetAlignment / 2, size: kSizeAlignment },
-
-        // Invalid case, size isn't aligned.
-        { offset: kOffsetAlignment, size: kSizeAlignment / 2 },
-      ])
+      .combine('mapOffset', [0, kOffsetAlignment])
+      .combine('offset', [0, kOffsetAlignment, kOffsetAlignment / 2])
+      .combine('size', [0, kSizeAlignment, kSizeAlignment / 2])
   )
   .fn(async t => {
-    const { mapMode, offset, size } = t.params;
-    const buffer = t.createMappableBuffer(mapMode, 16);
-    await buffer.mapAsync(mapMode);
+    const { mapMode, mapOffset, offset, size } = t.params;
+    const buffer = t.createMappableBuffer(mapMode, 32);
+    await buffer.mapAsync(mapMode, mapOffset);
 
+    const success = offset % kOffsetAlignment === 0 && size % kSizeAlignment === 0;
+    t.testGetMappedRangeCall(success, buffer, offset + mapOffset, size);
+  });
+
+g.test('getMappedRange,offsetAndSizeAlignment,mappedAtCreation')
+  .desc(`Test that getMappedRange fails if the alignment of offset and size isn't correct.`)
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('offset', [0, kOffsetAlignment, kOffsetAlignment / 2])
+      .combine('size', [0, kSizeAlignment, kSizeAlignment / 2])
+  )
+  .fn(async t => {
+    const { offset, size } = t.params;
+    const buffer = t.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.COPY_DST,
+      mappedAtCreation: true,
+    });
     const success = offset % kOffsetAlignment === 0 && size % kSizeAlignment === 0;
     t.testGetMappedRangeCall(success, buffer, offset, size);
   });
 
-g.test('getMappedRange,sizeAndOffsetOOB,forMappedAtCreation')
+g.test('getMappedRange,sizeAndOffsetOOB,mappedAtCreation')
   .desc(
     `Test that getMappedRange size + offset must be less than the buffer size for a
     buffer mapped at creation. (and offset has not constraints on its own)`
@@ -493,7 +586,7 @@ g.test('getMappedRange,sizeAndOffsetOOB,forMappedAtCreation')
     t.testGetMappedRangeCall(success, buffer, offset, size);
   });
 
-g.test('getMappedRange,sizeAndOffsetOOB,forMapped')
+g.test('getMappedRange,sizeAndOffsetOOB,mapped')
   .desc('Test that getMappedRange size + offset must be less than the mapAsync range.')
   .paramsSubcasesOnly(u =>
     u //

--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -308,7 +308,8 @@ g.test('getMappedRange,state,mapped')
 
 g.test('getMappedRange,state,mappedAtCreation')
   .desc(
-    'Test that it is valid to call getMappedRange in the mapped at creation state, for all buffer usages'
+    `Test that, in the mapped-at-creation state, it is valid to call getMappedRange, for all buffer usages,
+    and invalid to call mapAsync, for all map modes.`
   )
   .paramsSubcasesOnly(u =>
     u.combine('bufferUsage', kBufferUsages).combine('mapMode', kMapModeOptions)
@@ -391,7 +392,7 @@ Test for various cases of being unmapped: at creation, after a mapAsync call or 
 
 g.test('getMappedRange,subrange,mapped')
   .desc(
-    `Test that old getMappedRange returned arrybuffer does not exist after unmap and newly returned
+    `Test that old getMappedRange returned arraybuffer does not exist after unmap, and newly returned
     arraybuffer after new map has correct subrange`
   )
   .params(u => u.combine('mapMode', kMapModeOptions))
@@ -408,6 +409,7 @@ g.test('getMappedRange,subrange,mapped')
     t.expect(data0.byteLength === bufferSize);
 
     buffer.unmap();
+    t.expect(data0.byteLength === 0);
 
     await buffer.mapAsync(mapMode, offset);
     const data1 = buffer.getMappedRange(8);
@@ -436,6 +438,7 @@ g.test('getMappedRange,subrange,mappedAtCreation')
     t.expect(data0.byteLength === bufferSize);
 
     buffer.unmap();
+    t.expect(data0.byteLength === 0);
 
     await buffer.mapAsync(GPUMapMode.READ, offset);
     const data1 = buffer.getMappedRange(8);


### PR DESCRIPTION
> - {mappedAtCreation, await mapAsync}
>     - -> x = getMappedRange
>     - check x.size == mapping size
>     - -> noawait mapAsync
>     - check x.size == mapping size
>     - -> await
>     - check x.size == mapping size
>     - -> unmap
>     - check x.size == 0
>     - -> getMappedRange (should fail)

added at `getMappedRange,state,mapped/mappedAtCreation`


> - await mapAsync -> await mapAsync -> getMappedRange

added at `getMappedRange,state,mappedAgain`

> - {mappedAtCreation, await mapAsync} -> unmap -> unmap

already exists at `unmap,state,unmapped`


> - x = noawait mapAsync -> y = noawait mapAsync
>     - -> getMappedRange (should fail)
>     - -> await x
>     - -> getMappedRange
>     - -> shouldReject(y)

added at `getMappedRange,state,mappingPending`


> - noawait mapAsync -> unmap

already exists at `unmap,state,mappingPending`


> - {mappedAtCreation, await mapAsync} -> x = getMappedRange -> unmap -> await mapAsync(subrange) -> y = getMappedRange
>     - check x.size == 0, y.size == mapping size

added at `getMappedRange,subrange,mapped/mappedAtCreation`

dawn bug: [dawn: 901](https://bugs.chromium.org/p/dawn/issues/detail?id=901)

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.) (Passed both current chrome impl and after refactored buffer map handle chrome impl)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
