### PR TITLE
Change blending test target texture format to rgba16float and add helpers for float16

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -8,14 +8,17 @@ import { UnitTest } from './unit_test.js';
 export const g = makeTestGroup(UnitTest);
 
 const cases = [
-  [0b0011110000000000, 1],
-  [0b0000010000000000, 0.00006103515625],
-  [0b0011010101010101, 0.33325195],
-  [0b0111101111111111, 65504],
-  [0b0, 0],
-  [14336, 0.5],
-  [12902, 0.1999512],
-  [22080, 100],
+  [0b0_01111_0000000000, 1],
+  [0b0_00001_0000000000, 0.00006103515625],
+  [0b0_01101_0101010101, 0.33325195],
+  [0b0_11110_1111111111, 65504],
+  [0b0_00000_0000000000, 0],
+  [0b0_01110_0000000000, 0.5],
+  [0b0_01100_1001100110, 0.1999512],
+  [0b0_01111_0000000001, 1.00097656],
+  [0b0_10101_1001000000, 100],
+  [0b1_01100_1001100110, -0.1999512],
+  [0b1_10101_1001000000, -100],
 ];
 
 g.test('conversion,float16BitsToFloat32').fn(t => {
@@ -29,6 +32,6 @@ g.test('conversion,float32ToFloat16Bits').fn(t => {
   cases.forEach(value => {
     // some loose check
     // Does not handle clamping, underflow, overflow, or denormalized numbers.
-    t.expect(Math.abs(float32ToFloat16Bits(value[1]) - value[0]) <= 3, value[1].toString());
+    t.expect(Math.abs(float32ToFloat16Bits(value[1]) - value[0]) <= 1, value[1].toString());
   });
 });

--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -1,0 +1,34 @@
+export const description = `Unit tests for conversion`;
+
+import { makeTestGroup } from '../common/internal/test_group.js';
+import { float16BitsToFloat32, float32ToFloat16Bits } from '../webgpu/util/conversion.js';
+
+import { UnitTest } from './unit_test.js';
+
+export const g = makeTestGroup(UnitTest);
+
+const cases = [
+  [0b0011110000000000, 1],
+  [0b0000010000000000, 0.00006103515625],
+  [0b0011010101010101, 0.33325195],
+  [0b0111101111111111, 65504],
+  [0b0, 0],
+  [14336, 0.5],
+  [12902, 0.1999512],
+  [22080, 100],
+];
+
+g.test('conversion,float16BitsToFloat32').fn(t => {
+  cases.forEach(value => {
+    // some loose check
+    t.expect(Math.abs(float16BitsToFloat32(value[0]) - value[1]) <= 0.00001, value[0].toString(2));
+  });
+});
+
+g.test('conversion,float32ToFloat16Bits').fn(t => {
+  cases.forEach(value => {
+    // some loose check
+    // Does not handle clamping, underflow, overflow, or denormalized numbers.
+    t.expect(Math.abs(float32ToFloat16Bits(value[1]) - value[0]) <= 3, value[1].toString());
+  });
+});

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -10,6 +10,7 @@ TODO:
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, unreachable } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
+import { float32ToFloat16Bits } from '../../../util/conversion.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -117,7 +118,7 @@ g.test('GPUBlendComponent')
     `Test all combinations of parameters for GPUBlendComponent.
 
   Tests that parameters are correctly passed to the backend API and blend computations
-  are done correctly by blending a single pixel. The test uses rgba32float as the format
+  are done correctly by blending a single pixel. The test uses rgba16float as the format
   to avoid checking clamping behavior (tested in api,operation,rendering,blending:clamp,*).
 
   Params:
@@ -148,7 +149,7 @@ g.test('GPUBlendComponent')
       })
   )
   .fn(t => {
-    const textureFormat: GPUTextureFormat = 'rgba32float';
+    const textureFormat: GPUTextureFormat = 'rgba16float';
     const srcColor = t.params.srcColor;
     const dstColor = t.params.dstColor;
     const blendConstant = t.params.blendConstant;
@@ -264,18 +265,25 @@ g.test('GPUBlendComponent')
 
     t.device.queue.submit([commandEncoder.finish()]);
 
-    const tolerance = 0.0001;
+    const tolerance = 0.001;
     const expectedLow = mapColor(expectedColor, v => v - tolerance);
     const expectedHigh = mapColor(expectedColor, v => v + tolerance);
 
-    t.expectSinglePixelBetweenTwoValuesIn2DTexture(
+    t.expectSinglePixelBetweenTwoValuesFloat16In2DTexture(
       renderTarget,
       textureFormat,
       { x: 0, y: 0 },
       {
         exp: [
-          new Float32Array([expectedLow.r, expectedLow.g, expectedLow.b, expectedLow.a]),
-          new Float32Array([expectedHigh.r, expectedHigh.g, expectedHigh.b, expectedHigh.a]),
+          // Use Uint16Array to store Float16 value bits
+          new Uint16Array(
+            [expectedLow.r, expectedLow.g, expectedLow.b, expectedLow.a].map(float32ToFloat16Bits)
+          ),
+          new Uint16Array(
+            [expectedHigh.r, expectedHigh.g, expectedHigh.b, expectedHigh.a].map(
+              float32ToFloat16Bits
+            )
+          ),
         ],
       }
     );

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -14,7 +14,11 @@ import {
   kQueryTypeInfo,
 } from './capability_info.js';
 import { makeBufferWithContents } from './util/buffer.js';
-import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';
+import {
+  checkElementsEqual,
+  checkElementsBetween,
+  checkElementsFloat16Between,
+} from './util/check_contents.js';
 import {
   DevicePool,
   DeviceProvider,
@@ -426,11 +430,16 @@ export class GPUTest extends Fixture {
       slice = 0,
       layout,
       generateWarningOnly = false,
+      checkElementsBetweenFn = checkElementsBetween,
     }: {
       exp: [TypedArrayBufferView, TypedArrayBufferView];
       slice?: number;
       layout?: TextureLayoutOptions;
       generateWarningOnly?: boolean;
+      checkElementsBetweenFn?: (
+        actual: TypedArrayBufferView,
+        expected: readonly [TypedArrayBufferView, TypedArrayBufferView]
+      ) => Error | undefined;
     }
   ): void {
     assert(exp[0].constructor === exp[1].constructor);
@@ -439,11 +448,45 @@ export class GPUTest extends Fixture {
     const typedLength = exp[0].length;
 
     const buffer = this.readSinglePixelFrom2DTexture(src, format, { x, y }, { slice, layout });
-    this.expectGPUBufferValuesPassCheck(buffer, a => checkElementsBetween(a, exp), {
+    this.expectGPUBufferValuesPassCheck(buffer, a => checkElementsBetweenFn(a, exp), {
       type: constructor,
       typedLength,
       mode: generateWarningOnly ? 'warn' : 'fail',
     });
+  }
+
+  /**
+   * Equivalent to expectSinglePixelBetweenTwoValuesIn2DTexture but use special check func
+   * to interpret incoming values as float16
+   */
+  expectSinglePixelBetweenTwoValuesFloat16In2DTexture(
+    src: GPUTexture,
+    format: SizedTextureFormat,
+    { x, y }: { x: number; y: number },
+    {
+      exp,
+      slice = 0,
+      layout,
+      generateWarningOnly = false,
+    }: {
+      exp: [TypedArrayBufferView, TypedArrayBufferView];
+      slice?: number;
+      layout?: TextureLayoutOptions;
+      generateWarningOnly?: boolean;
+    }
+  ): void {
+    this.expectSinglePixelBetweenTwoValuesIn2DTexture(
+      src,
+      format,
+      { x, y },
+      {
+        exp,
+        slice,
+        layout,
+        generateWarningOnly,
+        checkElementsBetweenFn: checkElementsFloat16Between,
+      }
+    );
   }
 
   /**

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -469,7 +469,7 @@ export class GPUTest extends Fixture {
       layout,
       generateWarningOnly = false,
     }: {
-      exp: [TypedArrayBufferView, TypedArrayBufferView];
+      exp: [Uint16Array, Uint16Array];
       slice?: number;
       layout?: TextureLayoutOptions;
       generateWarningOnly?: boolean;

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -456,7 +456,7 @@ export class GPUTest extends Fixture {
   }
 
   /**
-   * Equivalent to expectSinglePixelBetweenTwoValuesIn2DTexture but use special check func
+   * Equivalent to {@link expectSinglePixelBetweenTwoValuesIn2DTexture} but uses a special check func
    * to interpret incoming values as float16
    */
   expectSinglePixelBetweenTwoValuesFloat16In2DTexture(

--- a/src/webgpu/util/check_contents.ts
+++ b/src/webgpu/util/check_contents.ts
@@ -7,6 +7,8 @@ import {
   TypedArrayBufferViewConstructor,
 } from '../../common/util/util.js';
 
+import { float16BitsToFloat32 } from './conversion.js';
+
 /** Generate an expected value at `index`, to test for equality with the actual value. */
 export type CheckElementsGenerator = (index: number) => number;
 /** Check whether the actual `value` at `index` is as expected. */
@@ -57,6 +59,42 @@ export function checkElementsBetween(
   );
   // If there was an error, extend it with additional extras.
   return error ? new ErrorWithExtra(error, () => ({ expected })) : undefined;
+}
+
+/**
+ * Equivalent to checkElementsBetween but interpret value as float16 and convert to JS number before comparison.
+ */
+export function checkElementsFloat16Between(
+  actual: TypedArrayBufferView,
+  expected: readonly [TypedArrayBufferView, TypedArrayBufferView]
+): ErrorWithExtra | undefined {
+  assert(actual.BYTES_PER_ELEMENT === 2, 'bytes per element need to be 2 (16bit)');
+  const actualF32 = new Float32Array(actual.length);
+  actual.forEach((v, i) => {
+    actualF32[i] = float16BitsToFloat32(v);
+  });
+  const expectedF32 = [new Float32Array(expected[0].length), new Float32Array(expected[1].length)];
+  expected[0].forEach((v, i) => {
+    expectedF32[0][i] = float16BitsToFloat32(v);
+  });
+  expected[1].forEach((v, i) => {
+    expectedF32[1][i] = float16BitsToFloat32(v);
+  });
+
+  const error = checkElementsPassPredicate(
+    actualF32,
+    (index, value) =>
+      value >= Math.min(expectedF32[0][index], expectedF32[1][index]) &&
+      value <= Math.max(expectedF32[0][index], expectedF32[1][index]),
+    {
+      predicatePrinter: [
+        { leftHeader: 'between', getValueForCell: index => expectedF32[0][index] },
+        { leftHeader: 'and', getValueForCell: index => expectedF32[1][index] },
+      ],
+    }
+  );
+  // If there was an error, extend it with additional extras.
+  return error ? new ErrorWithExtra(error, () => ({ expectedF32 })) : undefined;
 }
 
 /**

--- a/src/webgpu/util/check_contents.ts
+++ b/src/webgpu/util/check_contents.ts
@@ -62,7 +62,7 @@ export function checkElementsBetween(
 }
 
 /**
- * Equivalent to checkElementsBetween but interpret value as float16 and convert to JS number before comparison.
+ * Equivalent to {@link checkElementsBetween} but interpret values as float16 and convert to JS number before comparison.
  */
 export function checkElementsFloat16Between(
   actual: TypedArrayBufferView,
@@ -70,14 +70,14 @@ export function checkElementsFloat16Between(
 ): ErrorWithExtra | undefined {
   assert(actual.BYTES_PER_ELEMENT === 2, 'bytes per element need to be 2 (16bit)');
   const actualF32 = new Float32Array(actual.length);
-  actual.forEach((v, i) => {
+  actual.forEach((v: number, i: number) => {
     actualF32[i] = float16BitsToFloat32(v);
   });
   const expectedF32 = [new Float32Array(expected[0].length), new Float32Array(expected[1].length)];
-  expected[0].forEach((v, i) => {
+  expected[0].forEach((v: number, i: number) => {
     expectedF32[0][i] = float16BitsToFloat32(v);
   });
-  expected[1].forEach((v, i) => {
+  expected[1].forEach((v: number, i: number) => {
     expectedF32[1][i] = float16BitsToFloat32(v);
   });
 

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -97,6 +97,17 @@ export function float32ToFloat16Bits(n: number) {
 }
 
 /**
+ * Decodes an IEEE754 16 bit floating point number into a JS `number` and returns.
+ */
+export function float16BitsToFloat32(float16Bits: number): number {
+  const buf = new DataView(new ArrayBuffer(Float32Array.BYTES_PER_ELEMENT));
+  // shift exponent and mantissa bits and fill with 0 on right, shift sign bit
+  buf.setUint32(0, ((float16Bits & 0x7fff) << 13) | ((float16Bits & 0x8000) << 16), true);
+  // shifting for bias different: f16 uses a bias of 15, f32 uses a bias of 127
+  return buf.getFloat32(0, true) * 2 ** (127 - 15);
+}
+
+/**
  * Encodes three JS `number` values into RGB9E5, returned as an integer-valued JS `number`.
  *
  * RGB9E5 represents three partial-precision floating-point numbers encoded into a single 32-bit


### PR DESCRIPTION


https://gpuweb.github.io/gpuweb/#plain-color-formats indicates `rgba32float` doesn't have blendable `float` capability. Change to `rgba16float`. Also add update helpers to check float16 render target result. Add helpers to convert float16bits to js number as float32.

This will unblock https://bugs.chromium.org/p/dawn/issues/detail?id=726

As we are adding validation for format blending capability.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
