### PR TITLE
Fix a bug about texture and view dimension type compatibility

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -16,6 +16,7 @@ import {
   texBindingTypeInfo,
 } from '../../capability_info.js';
 import { GPUConst } from '../../constants.js';
+import { getTextureDimensionFromView } from '../../util/texture/base.js';
 
 import { ValidationTest } from './validation_test.js';
 
@@ -266,15 +267,22 @@ g.test('texture_must_have_correct_dimension')
       ],
     });
 
+    let height = 16;
+    let depthOrArrayLayers = 6;
+    if (dimension === '1d') {
+      height = 1;
+      depthOrArrayLayers = 1;
+    }
+
     const texture = t.device.createTexture({
-      size: { width: 16, height: 16, depthOrArrayLayers: 6 },
+      size: { width: 16, height, depthOrArrayLayers },
       format: 'rgba8unorm' as const,
       usage: GPUTextureUsage.SAMPLED,
+      dimension: getTextureDimensionFromView(dimension),
     });
 
     const shouldError = viewDimension !== dimension;
-    const arrayLayerCount = dimension === '2d' ? 1 : undefined;
-    const textureView = texture.createView({ dimension, arrayLayerCount });
+    const textureView = texture.createView({ dimension });
 
     t.expectValidationError(() => {
       t.device.createBindGroup({

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -67,3 +67,25 @@ export function virtualMipSize(
       unreachable();
   }
 }
+
+/**
+ * Get texture dimension from view dimension in order to create an compatible texture for a given
+ * view dimension.
+ */
+export function getTextureDimensionFromView(
+  viewDimension: GPUTextureViewDimension
+): GPUTextureDimension {
+  switch (viewDimension) {
+    case '1d':
+      return '1d';
+    case '2d':
+    case '2d-array':
+    case 'cube':
+    case 'cube-array':
+      return '2d';
+    case '3d':
+      return '3d';
+    default:
+      unreachable();
+  }
+}


### PR DESCRIPTION
When we create a view for a particular view dimension type from a
texture, the texture's dimension type should be compatible with
the view's dimension type.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
