### PR TITLE
map_oom.spec.ts fixes

### DIFF
--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -76,7 +76,7 @@ g.test('mappedAtCreation,full_getMappedRange')
   .desc(
     `Test creating a very large buffer mappedAtCreation buffer should produce
 an out-of-memory error if allocation fails.
-  - Because the buffer can be immediately mapped, getMappedRange does not throw an OperationError. It throws a OperationError because such a
+  - Because the buffer can be immediately mapped, getMappedRange throws an OperationError only because such a
     large ArrayBuffer cannot be created.
   - unmap() should not throw.
   `
@@ -134,18 +134,8 @@ an out-of-memory error if allocation fails.
       oom
     );
 
-    const f = () => buffer.getMappedRange(0, 16);
-
-    let mapping: ArrayBuffer | undefined = undefined;
-    if (oom) {
-      // Smaller range inside a too-big mapping
-      t.shouldThrow('OperationError', () => {
-        mapping = f();
-        t.expect(mapping.byteLength === 16);
-      });
-    } else {
-      mapping = f();
-    }
+    const mapping = buffer.getMappedRange(0, 16);
+    t.expect(mapping.byteLength === 16);
 
     t.expectGPUError('validation', () => buffer.unmap(), oom);
     if (mapping !== undefined) {

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -138,7 +138,5 @@ an out-of-memory error if allocation fails.
     t.expect(mapping.byteLength === 16);
 
     t.expectGPUError('validation', () => buffer.unmap(), oom);
-    if (mapping !== undefined) {
-      t.expect(mapping.byteLength === 0, 'Mapping should be detached');
-    }
+    t.expect(mapping.byteLength === 0, 'Mapping should be detached');
   });

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -61,10 +61,8 @@ g.test('mapAsync')
         buffer.getMappedRange();
       });
 
-      // Should throw an OperationError because the buffer is already unmapped.
-      t.shouldThrow('OperationError', () => {
-        buffer.unmap();
-      });
+      // Should be a validation error since the buffer is invalid.
+      t.expectGPUError('validation', () => buffer.unmap());
     } else {
       await promise;
       const arraybuffer = buffer.getMappedRange();
@@ -78,7 +76,7 @@ g.test('mappedAtCreation,full_getMappedRange')
   .desc(
     `Test creating a very large buffer mappedAtCreation buffer should produce
 an out-of-memory error if allocation fails.
-  - Because the buffer can be immediately mapped, getMappedRange does not throw an OperationError. It throws a RangeError because such a
+  - Because the buffer can be immediately mapped, getMappedRange does not throw an OperationError. It throws a OperationError because such a
     large ArrayBuffer cannot be created.
   - unmap() should not throw.
   `
@@ -101,11 +99,14 @@ an out-of-memory error if allocation fails.
 
     let mapping: ArrayBuffer | undefined = undefined;
     if (oom) {
-      t.shouldThrow('RangeError', f);
+      // Note: It is always valid to get mapped ranges of a GPUBuffer that is mapped at creation, even if it is invalid,
+      // because the Content timeline might not know it is invalid.
+      t.shouldThrow('OperationError', f);
     } else {
       mapping = f();
     }
-    buffer.unmap();
+
+    t.expectGPUError('validation', () => buffer.unmap(), oom);
     if (mapping !== undefined) {
       t.expect(mapping.byteLength === 0, 'Mapping should be detached');
     }
@@ -125,15 +126,29 @@ an out-of-memory error if allocation fails.
       .combine('usage', kBufferUsages)
   )
   .fn(async t => {
-    const { usage, size } = t.params;
+    const { oom, usage, size } = t.params;
 
-    const buffer = t.expectGPUError('out-of-memory', () =>
-      t.device.createBuffer({ mappedAtCreation: true, size, usage })
+    const buffer = t.expectGPUError(
+      'out-of-memory',
+      () => t.device.createBuffer({ mappedAtCreation: true, size, usage }),
+      oom
     );
 
-    // Smaller range inside a too-big mapping
-    const mapping = buffer.getMappedRange(0, 16);
-    t.expect(mapping.byteLength === 16);
-    buffer.unmap();
-    t.expect(mapping.byteLength === 0, 'Mapping should be detached');
+    const f = () => buffer.getMappedRange(0, 16);
+
+    let mapping: ArrayBuffer | undefined = undefined;
+    if (oom) {
+      // Smaller range inside a too-big mapping
+      t.shouldThrow('OperationError', () => {
+        mapping = f();
+        t.expect(mapping.byteLength === 16);
+      });
+    } else {
+      mapping = f();
+    }
+
+    t.expectGPUError('validation', () => buffer.unmap(), oom);
+    if (mapping !== undefined) {
+      t.expect(mapping.byteLength === 0, 'Mapping should be detached');
+    }
   });


### PR DESCRIPTION
Fix map_oom.spec.ts to current webgpu spec

* `unmap` on an invalid buffer should be invalid (https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap: unmap on an unmapped or destroyed buffer => validation error)
* `getMappedRange` throws `OperationError` instead of `RangeError` (https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange)


<hr>

**Author checklist for test code/plans:**

- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
