### PR TITLE
Add a stress test for mapAtCreation+getMappedRange

### DIFF
--- a/src/stress/README.txt
+++ b/src/stress/README.txt
@@ -11,6 +11,11 @@ Add informal notes here on possible stress tests.
     memory in ~64MB chunks until OOM.
     - Fill with arbitrary data
     - If mappable: then, once max is reached, try to mapAsync all of them.
+- Test buffer mapping conditions around real-VRAM-OOM (as opposed to shmem OOM):
+  - while(!oom) { allocate 512MB (non-mappable) }
+  - Try to allocate 64MB to fill a little extra space (ignore OOM if it happens).
+  - Try to allocate 512MB with `mappedAtCreation:true`, expect this to OOM (theoretically this should be VRAM OOM and not shmem OOM).
+  - Test getMappedRange of a small range, it should still succeed in returning a (dummy) range.
 - Allocating and {dropping, destroying} ~64MB {{unmappable, mapAtCreation, mappable} buffers, textures} for a while.
     - Fill with arbitrary data
 - Creating a huge number of ShaderModules/RenderPipelines/ComputePipelines.


### PR DESCRIPTION
- [ ] Are there other mapping behaviors we can test once we're in a VRAM OOM condition? I haven't thought of any so far...


<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
