### PR TITLE
Fix WGSL syntax in in_pass_encoder.spec.ts

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -907,24 +907,22 @@ g.test('unused_bindings_in_pipeline')
     const wgslVertex = `[[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
   return vec4<f32>();
 }`;
-    // TODO: revisit the shader code once 'image' can be supported in wgsl.
     const wgslFragment = pp`
       ${pp._if(useBindGroup0)}
-      [[group(0), binding(0)]] var<image> image0 : texture_storage_2d<rgba8unorm, read>;
+      [[group(0), binding(0)]] var image0 : texture_storage_2d<rgba8unorm, read>;
       ${pp._endif}
       ${pp._if(useBindGroup1)}
-      [[group(1), binding(0)]] var<image> image1 : texture_storage_2d<rgba8unorm, read>;
+      [[group(1), binding(0)]] var image1 : texture_storage_2d<rgba8unorm, read>;
       ${pp._endif}
       [[stage(fragment)]] fn main() {}
     `;
 
-    // TODO: revisit the shader code once 'image' can be supported in wgsl.
     const wgslCompute = pp`
       ${pp._if(useBindGroup0)}
-      [[group(0), binding(0)]] var<image> image0 : texture_storage_2d<rgba8unorm, read>;
+      [[group(0), binding(0)]] var image0 : texture_storage_2d<rgba8unorm, read>;
       ${pp._endif}
       ${pp._if(useBindGroup1)}
-      [[group(1), binding(0)]] var<image> image1 : texture_storage_2d<rgba8unorm, read>;
+      [[group(1), binding(0)]] var image1 : texture_storage_2d<rgba8unorm, read>;
       ${pp._endif}
       [[stage(compute), workgroup_size(1)]] fn main() {}
     `;


### PR DESCRIPTION
Bug: crbug.com/dawn/982





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
