### PR TITLE
More changes to match spec getMappedRange/unmap behavior

### DIFF
--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -61,7 +61,7 @@ g.test('mapAsync')
         buffer.getMappedRange();
       });
 
-      // Should be a validation error since the buffer is invalid.
+      // Should be a validation error since the buffer failed to be mapped.
       t.expectGPUError('validation', () => buffer.unmap());
     } else {
       await promise;
@@ -76,8 +76,8 @@ g.test('mappedAtCreation,full_getMappedRange')
   .desc(
     `Test creating a very large buffer mappedAtCreation buffer should produce
 an out-of-memory error if allocation fails.
-  - Because the buffer can be immediately mapped, getMappedRange throws an OperationError only because such a
-    large ArrayBuffer cannot be created.
+  - Because the buffer can be immediately mapped, getMappedRange throws an OperationError only
+    because such a large ArrayBuffer cannot be created.
   - unmap() should not throw.
   `
   )
@@ -99,14 +99,15 @@ an out-of-memory error if allocation fails.
 
     let mapping: ArrayBuffer | undefined = undefined;
     if (oom) {
-      // Note: It is always valid to get mapped ranges of a GPUBuffer that is mapped at creation, even if it is invalid,
-      // because the Content timeline might not know it is invalid.
-      t.shouldThrow('OperationError', f);
+      // getMappedRange is normally valid on OOM buffers, but this one fails because the
+      // (default) range is too large to create the returned ArrayBuffer.
+      t.shouldThrow('RangeError', f);
     } else {
       mapping = f();
     }
 
-    t.expectGPUError('validation', () => buffer.unmap(), oom);
+    // Should be valid because buffer is mapped, regardless of OOM.
+    buffer.unmap();
     if (mapping !== undefined) {
       t.expect(mapping.byteLength === 0, 'Mapping should be detached');
     }
@@ -134,9 +135,13 @@ an out-of-memory error if allocation fails.
       oom
     );
 
+    // Note: It is always valid to get mapped ranges of a GPUBuffer that is mapped at creation,
+    // even if it is invalid, because the Content timeline might not know it is invalid.
+    // Should be valid because mappedAtCreation was set, regardless of OOM.
     const mapping = buffer.getMappedRange(0, 16);
     t.expect(mapping.byteLength === 16);
 
-    t.expectGPUError('validation', () => buffer.unmap(), oom);
+    // Should be valid because buffer is mapped, regardless of OOM.
+    buffer.unmap();
     t.expect(mapping.byteLength === 0, 'Mapping should be detached');
   });

--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -341,6 +341,25 @@ g.test('getMappedRange,state,mappedAtCreation')
     t.expect(data.byteLength === 0);
   });
 
+g.test('getMappedRange,state,invalid_mappedAtCreation')
+  .desc(
+    `mappedAtCreation should return a mapped buffer, even if the buffer is invalid.
+Like VRAM allocation (see map_oom), validation can be performed asynchronously (in the GPU process)
+so the Content process doesn't necessarily know the buffer is invalid.`
+  )
+  .fn(async t => {
+    const buffer = t.expectGPUError('validation', () =>
+      t.device.createBuffer({
+        mappedAtCreation: true,
+        size: 16,
+        usage: 0xffff_ffff, // Invalid usage
+      })
+    );
+
+    // Should still be valid.
+    buffer.getMappedRange();
+  });
+
 g.test('getMappedRange,state,mappedAgain')
   .desc(
     'Test that it is valid to call getMappedRange in the mapped state, even if there is a duplicate mapAsync before'


### PR DESCRIPTION
I _think_ all of these changes are correct, but not positive.

Adds a new test about getMappedRange on buffers that fail validation, which seems reasonable?

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
