### PR TITLE
createBuffer simultaneous validation error and OOM

### DIFF
--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -13,7 +13,7 @@ const oomAndSizeParams = kUnitCaseParamsBuilder
     return oom
       ? [
           kMaxSafeMultipleOf8,
-          0x2000000000, // 128 GB
+          0x20_0000_0000, // 128 GB
         ]
       : [16];
   });

--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -5,6 +5,8 @@ Tests for validation in createBuffer.
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert } from '../../../../common/util/util.js';
 import { kBufferSizeAlignment } from '../../../capability_info.js';
+import { GPUConst } from '../../../constants.js';
+import { kMaxSafeMultipleOf8 } from '../../../util/math.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
@@ -37,3 +39,34 @@ g.test('usage')
       ])
   )
   .unimplemented();
+
+const BufferUsage = GPUConst.BufferUsage;
+g.test('createBuffer_invalid_and_oom')
+  .desc(
+    `When creating a mappable buffer, it's expected that shmem may be immediately allocated
+(in the content process, before validation occurs in the GPU process). If the buffer is really
+large, though, it could fail shmem allocation before validation fails. Ensure that OOM error is
+hidden behind the "more severe" validation error.`
+  )
+  .paramsSubcasesOnly(u =>
+    u.combineWithParams([
+      { _valid: true, usage: BufferUsage.UNIFORM, size: 16 },
+      { _valid: true, usage: BufferUsage.STORAGE, size: 16 },
+      // Invalid because UNIFORM is not allowed with map usages.
+      { usage: BufferUsage.MAP_WRITE | BufferUsage.UNIFORM, size: 16 },
+      { usage: BufferUsage.MAP_WRITE | BufferUsage.UNIFORM, size: kMaxSafeMultipleOf8 },
+      { usage: BufferUsage.MAP_WRITE | BufferUsage.UNIFORM, size: 0x20_0000_0000 }, // 128 GiB
+      { usage: BufferUsage.MAP_READ | BufferUsage.UNIFORM, size: 16 },
+      { usage: BufferUsage.MAP_READ | BufferUsage.UNIFORM, size: kMaxSafeMultipleOf8 },
+      { usage: BufferUsage.MAP_READ | BufferUsage.UNIFORM, size: 0x20_0000_0000 }, // 128 GiB
+      // Invalid because size is not aligned to 4 bytes.
+      { usage: BufferUsage.STORAGE, size: 15 },
+      { usage: BufferUsage.STORAGE, size: kMaxSafeMultipleOf8 - 1 },
+      { usage: BufferUsage.STORAGE, size: 0x20_0000_0000 - 1 }, // 128 GiB - 1
+    ] as const)
+  )
+  .fn(t => {
+    const { _valid, usage, size } = t.params;
+
+    t.expectGPUError('validation', () => t.device.createBuffer({ size, usage }), !_valid);
+  });


### PR DESCRIPTION
These do not pass in Chromium. https://crbug.com/dawn/995

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
