### PR TITLE
Disallow zero-sized buffer bind group bindings

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -296,8 +296,7 @@ g.test('buffer_offset_and_size_for_bind_groups_match')
   .desc(
     `
     Test that a buffer binding's [offset, offset + size) must be contained in the BindGroup entry's buffer.
-    - Test for various offsets and sizes
-    - TODO(#234): disallow zero-sized bindings`
+    - Test for various offsets and sizes`
   )
   .paramsSubcasesOnly([
     { offset: 0, size: 512, _success: true }, // offset 0 is valid
@@ -310,10 +309,10 @@ g.test('buffer_offset_and_size_for_bind_groups_match')
     { offset: 256 * 3, size: undefined, _success: true },
 
     // Zero-sized bindings
-    { offset: 0, size: 0, _success: true },
-    { offset: 256, size: 0, _success: true },
-    { offset: 1024, size: 0, _success: true },
-    { offset: 1024, size: undefined, _success: true },
+    { offset: 0, size: 0, _success: false },
+    { offset: 256, size: 0, _success: false },
+    { offset: 1024, size: 0, _success: false },
+    { offset: 1024, size: undefined, _success: false },
 
     // Unaligned buffer offset is invalid
     { offset: 1, size: 256, _success: false },


### PR DESCRIPTION
Bug: crbug.com/dawn/985

Fixes #234 



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
