### PR TITLE
Fix robust_access_vertex.spec.ts

### DIFF
--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -167,7 +167,12 @@ class DrawCall {
     if (partialLastNumber) {
       size -= 3;
     }
-    this.device.queue.writeBuffer(vertexBuffer, 0, vertexArray, size);
+    this.device.queue.writeBuffer(
+      vertexBuffer,
+      0,
+      vertexArray,
+      size / vertexArray.BYTES_PER_ELEMENT
+    );
     return vertexBuffer;
   }
 
@@ -227,22 +232,22 @@ interface VertexInfo {
 }
 
 const typeInfoMap: { [k: string]: VertexInfo } = {
-  float: {
+  float32: {
     wgslType: 'f32',
     size: 4,
     validationFunc: 'return valid(v);',
   },
-  float2: {
+  float32x2: {
     wgslType: 'vec2<f32>',
     size: 8,
     validationFunc: 'return valid(v.x) && valid(v.y);',
   },
-  float3: {
+  float32x3: {
     wgslType: 'vec3<f32>',
     size: 12,
     validationFunc: 'return valid(v.x) && valid(v.y) && valid(v.z);',
   },
-  float4: {
+  float32x4: {
     wgslType: 'vec4<f32>',
     size: 16,
     validationFunc: `return valid(v.x) && valid(v.y) && valid(v.z) && valid(v.w) ||


### PR DESCRIPTION
- Was using incorrect (old) enums for GPUVertexFormat
- queue.writeBuffer was taking an offset in bytes, not in elements

Bug: crbug.com/dawn/983





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
