### PR TITLE
Expect RangeError if setBindGroup if dynamic offsets fail start+length check

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -312,15 +312,22 @@ g.test('u32array_start_and_length')
     });
 
     const { encoder, finish } = t.createEncoder('render pass');
-    encoder.setBindGroup(
-      0,
-      bindGroup,
-      new Uint32Array(offsets),
-      dynamicOffsetsDataStart,
-      dynamicOffsetsDataLength
-    );
 
-    t.expectValidationError(() => {
-      finish();
-    }, !_success);
+    const doSetBindGroup = () => {
+      encoder.setBindGroup(
+        0,
+        bindGroup,
+        new Uint32Array(offsets),
+        dynamicOffsetsDataStart,
+        dynamicOffsetsDataLength
+      );
+    };
+
+    if (_success) {
+      doSetBindGroup();
+    } else {
+      t.shouldThrow('RangeError', doSetBindGroup);
+    }
+
+    finish();
   });


### PR DESCRIPTION
Related spec pr: https://github.com/gpuweb/gpuweb/pull/1811
Dawn issue: crbug.com/dawn/984





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
