### PR TITLE
Fix filtering sampler validation in createBindGroup.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -112,15 +112,14 @@ g.test('binding_must_contain_resource_defined_in_layout')
     const resource = t.getBindingResource(resourceType);
 
     let resourceBindingIsCompatible;
-    switch (resourceType) {
+    switch (info.resource) {
       // Either type of sampler may be bound to a filtering sampler binding.
       case 'filtSamp':
-        resourceBindingIsCompatible =
-          info.resource === 'filtSamp' || info.resource === 'nonFiltSamp';
+        resourceBindingIsCompatible = resourceType === 'filtSamp' || resourceType === 'nonFiltSamp';
         break;
       // But only non-filtering samplers can be used with non-filtering sampler bindings.
       case 'nonFiltSamp':
-        resourceBindingIsCompatible = info.resource === 'nonFiltSamp';
+        resourceBindingIsCompatible = resourceType === 'nonFiltSamp';
         break;
       default:
         resourceBindingIsCompatible = info.resource === resourceType;


### PR DESCRIPTION
This test was updated in https://github.com/gpuweb/cts/pull/611,
but that PR incorrectly reversed the operands of the check.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
