### PR TITLE
Visually indicate test results of entire subtrees

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -94,10 +94,13 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
   let caseResult: LiveTestCaseResult | undefined;
 
   // Becomes set once the DOM for this case exists.
+  let clearRenderedResult: (() => void) | undefined;
   let updateRenderedResult: (() => void) | undefined;
 
   const name = t.query.toString();
   const runSubtree = async () => {
+    if (clearRenderedResult) clearRenderedResult();
+
     const result : SubtreeResult = emptySubtreeResult();
 
     haveSomeResults = true;
@@ -136,6 +139,12 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
     div.appendChild(casehead);
     div.appendChild(caselogs[0]);
 
+    clearRenderedResult = () => {
+      div.removeAttribute('data-status');
+      casetime.text('ms');
+      caselogs.empty();
+    };
+
     updateRenderedResult = () => {
       if (caseResult) {
         div.setAttribute('data-status', caseResult.status);
@@ -171,6 +180,7 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
 function makeSubtreeHTML(n: TestSubtree, parentLevel: TestQueryLevel): VisualizedSubtree {
   let subtreeResult : SubtreeResult = emptySubtreeResult();
   // Becomes set once the DOM for this case exists.
+  let clearRenderedResult: (() => void) | undefined;
   let updateRenderedResult: (() => void) | undefined;
 
   const { runSubtree, generateSubtreeHTML } = makeSubtreeChildrenHTML(
@@ -179,6 +189,7 @@ function makeSubtreeHTML(n: TestSubtree, parentLevel: TestQueryLevel): Visualize
   );
 
   const runMySubtree = async () => {
+    if (clearRenderedResult) clearRenderedResult();
     subtreeResult = await runSubtree();
     if (updateRenderedResult) updateRenderedResult();
     return subtreeResult;
@@ -204,6 +215,10 @@ function makeSubtreeHTML(n: TestSubtree, parentLevel: TestQueryLevel): Visualize
     div.classList.add(['', 'multifile', 'multitest', 'multicase'][n.query.level]);
     div.appendChild(header);
     div.appendChild(subtreeHTML[0]);
+
+    clearRenderedResult = () => {
+      div.removeAttribute('data-status');
+    };
 
     updateRenderedResult = () => {
       let status = '';

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -29,18 +29,18 @@ const worker = optionEnabled('worker') ? new TestWorker(debug) : undefined;
 const resultsVis = document.getElementById('resultsVis')!;
 
 interface SubtreeResult {
-  pass: number,
-  fail: number,
-  skip: number,
-  total: number,
-  timems: number,
-};
-
-function emptySubtreeResult() {
-  return { pass: 0, fail: 0, skip: 0, total: 0, timems: 0 }
+  pass: number;
+  fail: number;
+  skip: number;
+  total: number;
+  timems: number;
 }
 
-function mergeSubtreeResults(...results : SubtreeResult[]) {
+function emptySubtreeResult() {
+  return { pass: 0, fail: 0, skip: 0, total: 0, timems: 0 };
+}
+
+function mergeSubtreeResults(...results: SubtreeResult[]) {
   const target = emptySubtreeResult();
   for (const result of results) {
     target.pass += result.pass;
@@ -101,7 +101,7 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
   const runSubtree = async () => {
     if (clearRenderedResult) clearRenderedResult();
 
-    const result : SubtreeResult = emptySubtreeResult();
+    const result: SubtreeResult = emptySubtreeResult();
 
     haveSomeResults = true;
     const [rec, res] = logger.record(name);
@@ -116,11 +116,14 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
     result.timems = caseResult.timems;
     switch (caseResult.status) {
       case 'pass':
-        result.pass++; break;
+        result.pass++;
+        break;
       case 'fail':
-        result.fail++; break;
+        result.fail++;
+        break;
       case 'skip':
-        result.fail++; break;
+        result.fail++;
+        break;
     }
 
     if (updateRenderedResult) updateRenderedResult();
@@ -178,7 +181,7 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
 }
 
 function makeSubtreeHTML(n: TestSubtree, parentLevel: TestQueryLevel): VisualizedSubtree {
-  let subtreeResult : SubtreeResult = emptySubtreeResult();
+  let subtreeResult: SubtreeResult = emptySubtreeResult();
   // Becomes set once the DOM for this case exists.
   let clearRenderedResult: (() => void) | undefined;
   let updateRenderedResult: (() => void) | undefined;
@@ -223,7 +226,7 @@ function makeSubtreeHTML(n: TestSubtree, parentLevel: TestQueryLevel): Visualize
     updateRenderedResult = () => {
       let status = '';
       if (subtreeResult.pass > 0) {
-        status += 'pass'
+        status += 'pass';
       }
       if (subtreeResult.fail > 0) {
         status += 'fail';
@@ -250,7 +253,7 @@ function makeSubtreeChildrenHTML(
   const childFns = Array.from(children, subtree => makeTreeNodeHTML(subtree, parentLevel));
 
   const runMySubtree = async () => {
-    const results : SubtreeResult[] = [];
+    const results: SubtreeResult[] = [];
     for (const { runSubtree } of childFns) {
       results.push(await runSubtree());
     }

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -31,13 +31,14 @@ const resultsVis = document.getElementById('resultsVis')!;
 interface SubtreeResult {
   pass: number;
   fail: number;
+  warn: number;
   skip: number;
   total: number;
   timems: number;
 }
 
 function emptySubtreeResult() {
-  return { pass: 0, fail: 0, skip: 0, total: 0, timems: 0 };
+  return { pass: 0, fail: 0, warn: 0, skip: 0, total: 0, timems: 0 };
 }
 
 function mergeSubtreeResults(...results: SubtreeResult[]) {
@@ -45,6 +46,7 @@ function mergeSubtreeResults(...results: SubtreeResult[]) {
   for (const result of results) {
     target.pass += result.pass;
     target.fail += result.fail;
+    target.warn += result.warn;
     target.skip += result.skip;
     target.total += result.total;
     target.timems += result.timems;
@@ -113,7 +115,7 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
     }
 
     result.total++;
-    result.timems = caseResult.timems;
+    result.timems += caseResult.timems;
     switch (caseResult.status) {
       case 'pass':
         result.pass++;
@@ -122,7 +124,10 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
         result.fail++;
         break;
       case 'skip':
-        result.fail++;
+        result.skip++;
+        break;
+      case 'warn':
+        result.warn++;
         break;
     }
 

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -134,6 +134,34 @@
         border-style: solid;
         border-color: #ddd;
       }
+      .subtree::before {
+        float: right;
+        margin-right: 3px;
+      }
+      .subtree[data-status='fail'] {
+        background: #fdd;
+      }
+      .subtree[data-status='fail']::before {
+        content: "⛔"
+      }
+      .subtree[data-status='pass'] {
+        background: #cfc;
+      }
+      .subtree[data-status='pass']::before {
+        content: "✔"
+      }
+      .subtree[data-status='passfail'] {
+        background: repeating-linear-gradient(
+          45deg,
+          #cfc,
+          #cfc 10px,
+          #fdd 10px,
+          #fdd 20px
+        );
+      }
+      .subtree[data-status='passfail']::before {
+        content: "✔/⛔"
+      }
       .subtree:hover {
         border-left-color: #000;
       }

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -139,13 +139,13 @@
         margin-right: 3px;
       }
       .subtree[data-status='fail'], .subtree[data-status='passfail'] {
-        background: linear-gradient(90deg, #fdd, #fdd 90px, #fff 115px);
+        background: linear-gradient(90deg, #fdd, #fdd 16px, #fff 16px);
       }
       .subtree[data-status='fail']::before {
         content: "⛔"
       }
       .subtree[data-status='pass'] {
-        background: linear-gradient(90deg, #cfc, #cfc 90px, #fff 115px);
+        background: linear-gradient(90deg, #cfc, #cfc 16px, #fff 16px);
       }
       .subtree[data-status='pass']::before {
         content: "✔"

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -138,20 +138,17 @@
         float: right;
         margin-right: 3px;
       }
-      .subtree[data-status='fail'] {
-        background: #fdd;
+      .subtree[data-status='fail'], .subtree[data-status='passfail'] {
+        background: linear-gradient(90deg, #fdd, #fdd 90px, #fff 115px);
       }
       .subtree[data-status='fail']::before {
         content: "⛔"
       }
       .subtree[data-status='pass'] {
-        background: #cfc;
+        background: linear-gradient(90deg, #cfc, #cfc 90px, #fff 115px);
       }
       .subtree[data-status='pass']::before {
         content: "✔"
-      }
-      .subtree[data-status='passfail'] {
-        background: #fef;
       }
       .subtree[data-status='passfail']::before {
         content: "✔/⛔"

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -151,13 +151,7 @@
         content: "✔"
       }
       .subtree[data-status='passfail'] {
-        background: repeating-linear-gradient(
-          45deg,
-          #cfc,
-          #cfc 10px,
-          #fdd 10px,
-          #fdd 20px
-        );
+        background: #fef;
       }
       .subtree[data-status='passfail']::before {
         content: "✔/⛔"


### PR DESCRIPTION
Fixes a longstanding annoyance of mine: Clicking "run" on a subtree without expanding the test cases gave no visual indication that tests were being run.

This approach isn't perfect but it at least gives the user some indication of progress being made. Each subtree underneath the one you initially run from will now color itself based on the results of all test cases underneath it, as well as displaying an icon for accessibility. If all tests under the subtree succeed it will turn green, if all of them fail it will turn red, and if it's a mixture of pass and fail you'll get a red/green stripe.

Areas for improvement:
  - Running a subtree with not propagate results up to levels above the one you ran from.
  - Currently collects cumulative time it took to run a subtree but is not displaying it. (Tried, but it felt very noisy.)
  - Could show numeric results (ie: "15/20 passed" or "75% passed")
  - Would be nice to visually indicate which tests are currently being run.

Preview:
<img width="1023" alt="Screenshot 2021-07-16 140049" src="https://user-images.githubusercontent.com/805273/126008574-43f588bb-0c74-47f1-9457-a6611664fe88.png">
