### PR TITLE
StoreOp 'clear' -> 'discard'

### DIFF
--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -1,7 +1,7 @@
 export const description = `API Operation Tests for RenderPass StoreOp.
 Tests a render pass with a resolveTarget resolves correctly for many combinations of:
   - number of color attachments, some with and some without a resolveTarget
-  - renderPass storeOp set to {'store', 'clear'}
+  - renderPass storeOp set to {'store', 'discard'}
   - resolveTarget mip level {0, >0} (TODO?: different mip level from colorAttachment)
   - resolveTarget {2d array layer, TODO: 3d slice} {0, >0} with {2d, TODO: 3d} resolveTarget
     (TODO?: different z from colorAttachment)
@@ -30,7 +30,7 @@ export const g = makeTestGroup(GPUTest);
 g.test('render_pass_resolve')
   .params(u =>
     u
-      .combine('storeOperation', ['clear', 'store'] as const)
+      .combine('storeOperation', ['discard', 'store'] as const)
       .beginSubcases()
       .combine('numColorAttachments', [2, 4] as const)
       .combine('slotsToResolve', kSlotsToResolve)

--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -2,22 +2,22 @@ export const description = `API Operation Tests for RenderPass StoreOp.
 
   Test Coverage:
 
-  - Tests that color and depth-stencil store operations {'clear', 'store'} work correctly for a
+  - Tests that color and depth-stencil store operations {'discard', 'store'} work correctly for a
     render pass with both a color attachment and depth-stencil attachment.
       TODO: use depth24plus-stencil8
 
-  - Tests that store operations {'clear', 'store'} work correctly for a render pass with multiple
+  - Tests that store operations {'discard', 'store'} work correctly for a render pass with multiple
     color attachments.
       TODO: test with more interesting loadOp values
 
-  - Tests that store operations {'clear', 'store'} work correctly for a render pass with a color
+  - Tests that store operations {'discard', 'store'} work correctly for a render pass with a color
     attachment for:
       - All renderable color formats
       - mip level set to {'0', mip > '0'}
       - array layer set to {'0', layer > '1'} for 2D textures
       TODO: depth slice set to {'0', slice > '0'} for 3D textures
 
-  - Tests that store operations {'clear', 'store'} work correctly for a render pass with a
+  - Tests that store operations {'discard', 'store'} work correctly for a render pass with a
     depth-stencil attachment for:
       - All renderable depth-stencil formats
       - mip level set to {'0', mip > '0'}
@@ -47,7 +47,7 @@ const kNumColorAttachments: NumColorAttachments[] = [1, 2, 3, 4];
 // Test with a zero and non-zero array layer.
 const kArrayLayers: number[] = [0, 1];
 
-const kStoreOps: GPUStoreOp[] = ['clear', 'store'];
+const kStoreOps: GPUStoreOp[] = ['discard', 'store'];
 
 const kHeight = 2;
 const kWidth = 2;
@@ -107,7 +107,7 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
 
     // Check that the correct store operation occurred.
     let expectedColorValue: PerTexelComponent<number> = {};
-    if (t.params.colorStoreOperation === 'clear') {
+    if (t.params.colorStoreOperation === 'discard') {
       // If colorStoreOp was clear, the texture should now contain {0.0, 0.0, 0.0, 0.0}.
       expectedColorValue = { R: 0.0, G: 0.0, B: 0.0, A: 0.0 };
     } else if (t.params.colorStoreOperation === 'store') {
@@ -121,7 +121,7 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
 
     // Check that the correct store operation occurred.
     let expectedDepthValue: PerTexelComponent<number> = {};
-    if (t.params.depthStencilStoreOperation === 'clear') {
+    if (t.params.depthStencilStoreOperation === 'discard') {
       // If depthStencilStoreOperation was clear, the texture's depth component should be 0.0, and
       // the stencil component should be 0.0.
       expectedDepthValue = { Depth: 0.0 };
@@ -186,7 +186,7 @@ g.test('render_pass_store_op,color_attachment_only')
 
     // Check that the correct store operation occurred.
     let expectedValue: PerTexelComponent<number> = {};
-    if (t.params.storeOperation === 'clear') {
+    if (t.params.storeOperation === 'discard') {
       // If colorStoreOp was clear, the texture should now contain {0.0, 0.0, 0.0, 0.0}.
       expectedValue = { R: 0.0, G: 0.0, B: 0.0, A: 0.0 };
     } else if (t.params.storeOperation === 'store') {
@@ -247,7 +247,7 @@ g.test('render_pass_store_op,multiple_color_attachments')
     // Check that the correct store operation occurred.
     let expectedValue: PerTexelComponent<number> = {};
     for (let i = 0; i < t.params.colorAttachments; i++) {
-      if (renderPassColorAttachments[i].storeOp === 'clear') {
+      if (renderPassColorAttachments[i].storeOp === 'discard') {
         // If colorStoreOp was clear, the texture should now contain {0.0, 0.0, 0.0, 0.0}.
         expectedValue = { R: 0.0, G: 0.0, B: 0.0, A: 0.0 };
       } else if (renderPassColorAttachments[i].storeOp === 'store') {
@@ -314,7 +314,7 @@ TODO: Also test unsized depth/stencil formats
     t.device.queue.submit([encoder.finish()]);
 
     let expectedValue: PerTexelComponent<number> = {};
-    if (t.params.storeOperation === 'clear') {
+    if (t.params.storeOperation === 'discard') {
       // If depthStencilStoreOperation was clear, the texture's depth component should be 0.0,
       expectedValue = { Depth: 0.0 };
     } else if (t.params.storeOperation === 'store') {

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -12,7 +12,7 @@ export const g = makeTestGroup(GPUTest);
 g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
   .paramsSimple([
     { storeOp: 'store', _expected: 1 }, //
-    { storeOp: 'clear', _expected: 0 },
+    { storeOp: 'discard', _expected: 0 },
   ] as const)
   .fn(async t => {
     const renderTexture = t.device.createTexture({

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -407,7 +407,7 @@ export class TextureZeroInitTest extends GPUTest {
             colorAttachments: [
               {
                 view: texture.createView(desc),
-                storeOp: 'clear',
+                storeOp: 'discard',
                 loadValue: 'load',
               },
             ],
@@ -419,9 +419,9 @@ export class TextureZeroInitTest extends GPUTest {
             colorAttachments: [],
             depthStencilAttachment: {
               view: texture.createView(desc),
-              depthStoreOp: 'clear',
+              depthStoreOp: 'discard',
               depthLoadValue: 'load',
-              stencilStoreOp: 'clear',
+              stencilStoreOp: 'discard',
               stencilLoadValue: 'load',
             },
           })

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -54,9 +54,9 @@ class F extends ValidationTest {
     return {
       view: this.createAttachmentTextureView(format, sampleCount),
       depthLoadValue: 0,
-      depthStoreOp: 'clear',
+      depthStoreOp: 'discard',
       stencilLoadValue: 1,
-      stencilStoreOp: 'clear',
+      stencilStoreOp: 'discard',
     };
   }
 

--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -132,7 +132,7 @@ Test various validation behaviors when a resolveTarget is provided.
           renderPassColorAttachmentDescriptors.push({
             view: resolveSourceColorAttachment.createView(),
             loadValue: 'load',
-            storeOp: 'clear',
+            storeOp: 'discard',
             resolveTarget: resolveTarget.createView({
               dimension: resolveTargetViewArrayLayerCount === 1 ? '2d' : '2d-array',
               mipLevelCount: resolveTargetViewMipCount,
@@ -169,7 +169,7 @@ Test various validation behaviors when a resolveTarget is provided.
           renderPassColorAttachmentDescriptors.push({
             view: colorAttachment.createView(),
             loadValue: 'load',
-            storeOp: 'clear',
+            storeOp: 'discard',
             resolveTarget: resolveTarget.createView(),
           });
         }

--- a/src/webgpu/api/validation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/validation/render_pass/storeOp.spec.ts
@@ -3,10 +3,10 @@ API Validation Tests for RenderPass StoreOp.
 
 Test Coverage:
   - Tests that when depthReadOnly is true, depthStoreOp must be 'store'.
-    - When depthReadOnly is true and depthStoreOp is 'clear', an error should be generated.
+    - When depthReadOnly is true and depthStoreOp is 'discard', an error should be generated.
 
   - Tests that when stencilReadOnly is true, stencilStoreOp must be 'store'.
-    - When stencilReadOnly is true and stencilStoreOp is 'clear', an error should be generated.
+    - When stencilReadOnly is true and stencilStoreOp is 'discard', an error should be generated.
 
   - Tests that the depthReadOnly value matches the stencilReadOnly value.
     - When depthReadOnly does not match stencilReadOnly, an error should be generated.
@@ -24,10 +24,10 @@ export const g = makeTestGroup(ValidationTest);
 g.test('store_op_and_read_only')
   .paramsSimple([
     { readonly: true, _valid: true },
-    // Using depthReadOnly=true and depthStoreOp='clear' should cause a validation error.
-    { readonly: true, depthStoreOp: 'clear', _valid: false },
-    // Using stencilReadOnly=true and stencilStoreOp='clear' should cause a validation error.
-    { readonly: true, stencilStoreOp: 'clear', _valid: false },
+    // Using depthReadOnly=true and depthStoreOp='discard' should cause a validation error.
+    { readonly: true, depthStoreOp: 'discard', _valid: false },
+    // Using stencilReadOnly=true and stencilStoreOp='discard' should cause a validation error.
+    { readonly: true, stencilStoreOp: 'discard', _valid: false },
     // Mismatched depthReadOnly and stencilReadOnly values should cause a validation error.
     { readonly: false, _valid: true },
     { readonly: false, depthReadOnly: true, _valid: false },

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -621,9 +621,9 @@ g.test('subresources_and_binding_types_combination_for_aspect')
               ? undefined
               : {
                   view: view1,
-                  depthStoreOp: 'clear',
+                  depthStoreOp: 'discard',
                   depthLoadValue: 'load',
-                  stencilStoreOp: 'clear',
+                  stencilStoreOp: 'discard',
                   stencilLoadValue: 'load',
                 },
         });


### PR DESCRIPTION
'clear' has been renamed to 'discard' in the spec.

Trivial change, landing TBR to clear up deprecation warnings from test runs.