### PR TITLE
Do validation checks inside createEncoder's finish()

### DIFF
--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -5,7 +5,7 @@ TODO: Add sparse color attachment compatibility test when defined by specificati
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { range, unreachable } from '../../../common/util/util.js';
+import { range } from '../../../common/util/util.js';
 import {
   kRegularTextureFormats,
   kSizedDepthStencilFormats,

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -5,7 +5,7 @@ TODO: Add sparse color attachment compatibility test when defined by specificati
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { range } from '../../../common/util/util.js';
+import { range, unreachable } from '../../../common/util/util.js';
 import {
   kRegularTextureFormats,
   kSizedDepthStencilFormats,
@@ -15,7 +15,7 @@ import {
   kTextureFormatInfo,
 } from '../../capability_info.js';
 
-import { ValidationTest, CommandBufferMaker } from './validation_test.js';
+import { ValidationTest } from './validation_test.js';
 
 const kColorAttachmentCounts = range(kMaxColorAttachments, i => i + 1);
 const kDepthStencilAttachmentFormats = [
@@ -28,7 +28,8 @@ class F extends ValidationTest {
   createAttachmentTextureView(format: GPUTextureFormat, sampleCount?: number) {
     return this.device
       .createTexture({
-        size: [1, 1, 1],
+        // Size matching the "arbitrary" size used by ValidationTest helpers.
+        size: [16, 16, 1],
         format,
         usage: GPUTextureUsage.RENDER_ATTACHMENT,
         sampleCount,
@@ -58,52 +59,6 @@ class F extends ValidationTest {
       stencilLoadValue: 1,
       stencilStoreOp: 'discard',
     };
-  }
-
-  createPassOrBundleEncoder(
-    encoderType: 'render pass' | 'render bundle',
-    colorFormats: Iterable<GPUTextureFormat>,
-    depthStencilFormat?: GPUTextureFormat,
-    sampleCount?: number
-  ): CommandBufferMaker<'render pass' | 'render bundle'> {
-    const encoder = this.device.createCommandEncoder();
-    const passDesc: GPURenderPassDescriptor = {
-      colorAttachments: Array.from(colorFormats, desc =>
-        this.createColorAttachment(desc, sampleCount)
-      ),
-      depthStencilAttachment:
-        depthStencilFormat !== undefined
-          ? this.createDepthAttachment(depthStencilFormat, sampleCount)
-          : undefined,
-    };
-    const pass = encoder.beginRenderPass(passDesc);
-    switch (encoderType) {
-      case 'render bundle': {
-        const bundleEncoder = this.device.createRenderBundleEncoder({
-          colorFormats,
-          depthStencilFormat,
-          sampleCount,
-        });
-
-        return {
-          encoder: bundleEncoder,
-          finish() {
-            const bundle = bundleEncoder.finish();
-            pass.executeBundles([bundle]);
-            pass.endPass();
-            return encoder.finish();
-          },
-        };
-      }
-      case 'render pass':
-        return {
-          encoder: pass,
-          finish() {
-            pass.endPass();
-            return encoder.finish();
-          },
-        };
-    }
   }
 
   createRenderPipeline(
@@ -155,15 +110,14 @@ g.test('render_pass_and_bundle,color_format')
       colorFormats: [bundleFormat],
     });
     const bundle = bundleEncoder.finish();
-    const encoder = t.device.createCommandEncoder();
+
+    const { encoder, validateFinishAndSubmit } = t.createEncoder('non-pass');
     const pass = encoder.beginRenderPass({
       colorAttachments: [t.createColorAttachment(passFormat)],
     });
     pass.executeBundles([bundle]);
     pass.endPass();
-    t.expectValidationError(() => {
-      t.queue.submit([encoder.finish()]);
-    }, passFormat !== bundleFormat);
+    validateFinishAndSubmit(passFormat === bundleFormat, true);
   });
 
 g.test('render_pass_and_bundle,color_count')
@@ -186,15 +140,13 @@ g.test('render_pass_and_bundle,color_count')
     });
     const bundle = bundleEncoder.finish();
 
-    const encoder = t.device.createCommandEncoder();
+    const { encoder, validateFinishAndSubmit } = t.createEncoder('non-pass');
     const pass = encoder.beginRenderPass({
       colorAttachments: range(passCount, () => t.createColorAttachment('rgba8unorm')),
     });
     pass.executeBundles([bundle]);
     pass.endPass();
-    t.expectValidationError(() => {
-      t.queue.submit([encoder.finish()]);
-    }, passCount !== bundleCount);
+    validateFinishAndSubmit(passCount === bundleCount, true);
   });
 
 g.test('render_pass_and_bundle,depth_format')
@@ -213,7 +165,8 @@ g.test('render_pass_and_bundle,depth_format')
       depthStencilFormat: bundleFormat,
     });
     const bundle = bundleEncoder.finish();
-    const encoder = t.device.createCommandEncoder();
+
+    const { encoder, validateFinishAndSubmit } = t.createEncoder('non-pass');
     const pass = encoder.beginRenderPass({
       colorAttachments: [t.createColorAttachment('rgba8unorm')],
       depthStencilAttachment:
@@ -221,9 +174,7 @@ g.test('render_pass_and_bundle,depth_format')
     });
     pass.executeBundles([bundle]);
     pass.endPass();
-    t.expectValidationError(() => {
-      t.queue.submit([encoder.finish()]);
-    }, passFormat !== bundleFormat);
+    validateFinishAndSubmit(passFormat === bundleFormat, true);
   });
 
 g.test('render_pass_and_bundle,sample_count')
@@ -240,15 +191,13 @@ g.test('render_pass_and_bundle,sample_count')
       sampleCount: bundleSampleCount,
     });
     const bundle = bundleEncoder.finish();
-    const encoder = t.device.createCommandEncoder();
+    const { encoder, validateFinishAndSubmit } = t.createEncoder('non-pass');
     const pass = encoder.beginRenderPass({
       colorAttachments: [t.createColorAttachment('rgba8unorm', renderSampleCount)],
     });
     pass.executeBundles([bundle]);
     pass.endPass();
-    t.expectValidationError(() => {
-      t.queue.submit([encoder.finish()]);
-    }, renderSampleCount !== bundleSampleCount);
+    validateFinishAndSubmit(renderSampleCount === bundleSampleCount, true);
   });
 
 g.test('render_pass_or_bundle_and_pipeline,color_format')
@@ -268,12 +217,11 @@ Test that color attachment formats in render passes or bundles match the pipelin
     const { encoderType, encoderFormat, pipelineFormat } = t.params;
     const pipeline = t.createRenderPipeline([{ format: pipelineFormat }]);
 
-    const { encoder, finish } = t.createPassOrBundleEncoder(encoderType, [encoderFormat]);
+    const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
+      attachmentInfo: { colorFormats: [encoderFormat] },
+    });
     encoder.setPipeline(pipeline);
-
-    t.expectValidationError(() => {
-      t.queue.submit([finish()]);
-    }, encoderFormat !== pipelineFormat);
+    validateFinishAndSubmit(encoderFormat === pipelineFormat, true);
   });
 
 g.test('render_pass_or_bundle_and_pipeline,color_count')
@@ -296,15 +244,11 @@ TODO: Add sparse color attachment compatibility test when defined by specificati
     const { encoderType, encoderCount, pipelineCount } = t.params;
     const pipeline = t.createRenderPipeline(range(pipelineCount, () => ({ format: 'rgba8unorm' })));
 
-    const { encoder, finish } = t.createPassOrBundleEncoder(
-      encoderType,
-      range(encoderCount, () => 'rgba8unorm')
-    );
+    const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
+      attachmentInfo: { colorFormats: range(encoderCount, () => 'rgba8unorm') },
+    });
     encoder.setPipeline(pipeline);
-
-    t.expectValidationError(() => {
-      t.queue.submit([finish()]);
-    }, encoderCount !== pipelineCount);
+    validateFinishAndSubmit(encoderCount === pipelineCount, true);
   });
 
 g.test('render_pass_or_bundle_and_pipeline,depth_format')
@@ -329,16 +273,11 @@ Test that the depth attachment format in render passes or bundles match the pipe
       pipelineFormat !== undefined ? { format: pipelineFormat } : undefined
     );
 
-    const { encoder, finish } = t.createPassOrBundleEncoder(
-      encoderType,
-      ['rgba8unorm'],
-      encoderFormat
-    );
+    const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
+      attachmentInfo: { colorFormats: ['rgba8unorm'], depthStencilFormat: encoderFormat },
+    });
     encoder.setPipeline(pipeline);
-
-    t.expectValidationError(() => {
-      t.queue.submit([finish()]);
-    }, encoderFormat !== pipelineFormat);
+    validateFinishAndSubmit(encoderFormat === pipelineFormat, true);
   });
 
 g.test('render_pass_or_bundle_and_pipeline,sample_count')
@@ -350,44 +289,50 @@ Test that the sample count in render passes or bundles match the pipeline sample
   .params(u =>
     u
       .combine('encoderType', ['render pass', 'render bundle'] as const)
+      .combine('attachmentType', ['color', 'depthstencil'] as const)
       .beginSubcases()
       .combine('encoderSampleCount', kTextureSampleCounts)
       .combine('pipelineSampleCount', kTextureSampleCounts)
   )
   .fn(t => {
-    const { encoderType, encoderSampleCount, pipelineSampleCount } = t.params;
+    const { encoderType, attachmentType, encoderSampleCount, pipelineSampleCount } = t.params;
 
-    // For color texture
-    const pipelineWithoutDepthStencil = t.createRenderPipeline(
-      [{ format: 'rgba8unorm' }],
-      undefined,
-      pipelineSampleCount
-    );
+    switch (attachmentType) {
+      case 'color':
+        {
+          const pipelineWithoutDepthStencil = t.createRenderPipeline(
+            [{ format: 'rgba8unorm' }],
+            undefined,
+            pipelineSampleCount
+          );
 
-    const {
-      encoder: encoderWithoutDepthStencil,
-      finish: finishWithoutDepthStencil,
-    } = t.createPassOrBundleEncoder(encoderType, ['rgba8unorm'], undefined, encoderSampleCount);
-    encoderWithoutDepthStencil.setPipeline(pipelineWithoutDepthStencil);
+          const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
+            attachmentInfo: { colorFormats: ['rgba8unorm'], sampleCount: encoderSampleCount },
+          });
+          encoder.setPipeline(pipelineWithoutDepthStencil);
+          validateFinishAndSubmit(encoderSampleCount === pipelineSampleCount, true);
+        }
+        break;
+      case 'depthstencil':
+        {
+          const pipelineWithDepthStencilOnly = t.createRenderPipeline(
+            [],
+            { format: 'depth24plus-stencil8' },
+            pipelineSampleCount
+          );
 
-    t.expectValidationError(() => {
-      t.queue.submit([finishWithoutDepthStencil()]);
-    }, encoderSampleCount !== pipelineSampleCount);
-
-    // For DepthStencil texture
-    const pipelineWithDepthStencilOnly = t.createRenderPipeline(
-      [],
-      { format: 'depth24plus-stencil8' },
-      pipelineSampleCount
-    );
-
-    const {
-      encoder: encoderWithDepthStencilOnly,
-      finish: finishWithDepthStencilOnly,
-    } = t.createPassOrBundleEncoder(encoderType, [], 'depth24plus-stencil8', encoderSampleCount);
-    encoderWithDepthStencilOnly.setPipeline(pipelineWithDepthStencilOnly);
-
-    t.expectValidationError(() => {
-      t.queue.submit([finishWithDepthStencilOnly()]);
-    }, encoderSampleCount !== pipelineSampleCount);
+          const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
+            attachmentInfo: {
+              colorFormats: [],
+              depthStencilFormat: 'depth24plus-stencil8',
+              sampleCount: encoderSampleCount,
+            },
+          });
+          encoder.setPipeline(pipelineWithDepthStencilOnly);
+          validateFinishAndSubmit(encoderSampleCount === pipelineSampleCount, true);
+        }
+        break;
+      default:
+        unreachable();
+    }
   });

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -297,42 +297,19 @@ Test that the sample count in render passes or bundles match the pipeline sample
   .fn(t => {
     const { encoderType, attachmentType, encoderSampleCount, pipelineSampleCount } = t.params;
 
-    switch (attachmentType) {
-      case 'color':
-        {
-          const pipelineWithoutDepthStencil = t.createRenderPipeline(
-            [{ format: 'rgba8unorm' }],
-            undefined,
-            pipelineSampleCount
-          );
+    const colorFormats = attachmentType === 'color' ? ['rgba8unorm' as const] : [];
+    const depthStencilFormat =
+      attachmentType === 'depthstencil' ? ('depth24plus-stencil8' as const) : undefined;
 
-          const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
-            attachmentInfo: { colorFormats: ['rgba8unorm'], sampleCount: encoderSampleCount },
-          });
-          encoder.setPipeline(pipelineWithoutDepthStencil);
-          validateFinishAndSubmit(encoderSampleCount === pipelineSampleCount, true);
-        }
-        break;
-      case 'depthstencil':
-        {
-          const pipelineWithDepthStencilOnly = t.createRenderPipeline(
-            [],
-            { format: 'depth24plus-stencil8' },
-            pipelineSampleCount
-          );
+    const pipeline = t.createRenderPipeline(
+      colorFormats.map(format => ({ format })),
+      depthStencilFormat ? { format: depthStencilFormat } : undefined,
+      pipelineSampleCount
+    );
 
-          const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
-            attachmentInfo: {
-              colorFormats: [],
-              depthStencilFormat: 'depth24plus-stencil8',
-              sampleCount: encoderSampleCount,
-            },
-          });
-          encoder.setPipeline(pipelineWithDepthStencilOnly);
-          validateFinishAndSubmit(encoderSampleCount === pipelineSampleCount, true);
-        }
-        break;
-      default:
-        unreachable();
-    }
+    const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
+      attachmentInfo: { colorFormats, depthStencilFormat, sampleCount: encoderSampleCount },
+    });
+    encoder.setPipeline(pipeline);
+    validateFinishAndSubmit(encoderSampleCount === pipelineSampleCount, true);
   });

--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -24,11 +24,9 @@ class ImageCopyTest extends ValidationTest {
     copySize: GPUExtent3DStrict,
     isSuccess: boolean
   ): void {
-    const encoder = this.device.createCommandEncoder();
+    const { encoder, validateFinishAndSubmit } = this.createEncoder('non-pass');
     encoder.copyBufferToTexture(source, destination, copySize);
-    this.expectValidationError(() => {
-      this.device.queue.submit([encoder.finish()]);
-    }, !isSuccess);
+    validateFinishAndSubmit(isSuccess, true);
   }
 
   testCopyTextureToBuffer(
@@ -37,11 +35,9 @@ class ImageCopyTest extends ValidationTest {
     copySize: GPUExtent3DStrict,
     isSuccess: boolean
   ): void {
-    const encoder = this.device.createCommandEncoder();
+    const { encoder, validateFinishAndSubmit } = this.createEncoder('non-pass');
     encoder.copyTextureToBuffer(source, destination, copySize);
-    this.expectValidationError(() => {
-      this.device.queue.submit([encoder.finish()]);
-    }, !isSuccess);
+    validateFinishAndSubmit(isSuccess, true);
   }
 }
 

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -6,7 +6,7 @@ Does **not** test usage scopes (resource_usages/) or programmable pass stuff (pr
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { DefaultLimits } from '../../../../constants.js';
-import { ValidationTest } from '../../validation_test.js';
+import { ResourceState, ValidationTest } from '../../validation_test.js';
 
 class F extends ValidationTest {
   createComputePipeline(state: 'valid' | 'invalid'): GPUComputePipeline {
@@ -17,7 +17,7 @@ class F extends ValidationTest {
     return this.createErrorComputePipeline();
   }
 
-  createIndirectBuffer(state: 'valid' | 'invalid' | 'destroyed', data: Uint32Array): GPUBuffer {
+  createIndirectBuffer(state: ResourceState, data: Uint32Array): GPUBuffer {
     const descriptor: GPUBufferDescriptor = {
       size: data.byteLength,
       usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST,
@@ -53,12 +53,12 @@ setPipeline should generate an error iff using an 'invalid' pipeline.
   )
   .params(u => u.beginSubcases().combine('state', ['valid', 'invalid'] as const))
   .fn(t => {
-    const pipeline = t.createComputePipeline(t.params.state);
-    const { encoder, finish } = t.createEncoder('compute pass');
+    const { state } = t.params;
+    const pipeline = t.createComputePipeline(state);
+
+    const { encoder, validateFinishAndSubmitGivenState } = t.createEncoder('compute pass');
     encoder.setPipeline(pipeline);
-    t.expectValidationError(() => {
-      finish();
-    }, t.params.state === 'invalid');
+    validateFinishAndSubmitGivenState(state);
   });
 
 const kMaxDispatch = DefaultLimits.maxComputePerDimensionDispatchSize;
@@ -90,7 +90,7 @@ g.test('dispatch_sizes')
     const workSizes = [smallDimValue, smallDimValue, smallDimValue];
     workSizes[largeDimIndex] = largeDimValue;
 
-    const { encoder, finish } = t.createEncoder('compute pass');
+    const { encoder, validateFinishAndSubmit } = t.createEncoder('compute pass');
     encoder.setPipeline(pipeline);
     if (dispatchType === 'direct') {
       const [x, y, z] = workSizes;
@@ -103,13 +103,7 @@ g.test('dispatch_sizes')
       dispatchType === 'direct' &&
       (workSizes[0] > kMaxDispatch || workSizes[1] > kMaxDispatch || workSizes[2] > kMaxDispatch);
 
-    if (shouldError) {
-      t.expectValidationError(() => {
-        finish();
-      });
-    } else {
-      t.queue.submit([finish()]);
-    }
+    validateFinishAndSubmit(!shouldError, true);
   });
 
 const kBufferData = new Uint32Array(6).fill(1);
@@ -146,10 +140,14 @@ TODO: test specifically which call the validation error occurs in.
     const { state, offset } = t.params;
     const pipeline = t.createNoOpComputePipeline();
     const buffer = t.createIndirectBuffer(state, kBufferData);
-    const { encoder, finish } = t.createEncoder('compute pass');
+
+    const { encoder, validateFinishAndSubmit } = t.createEncoder('compute pass');
     encoder.setPipeline(pipeline);
-    t.expectValidationError(() => {
-      encoder.dispatchIndirect(buffer, offset);
-      t.queue.submit([finish()]);
-    }, state !== 'valid' || offset % 4 !== 0 || offset + 3 * Uint32Array.BYTES_PER_ELEMENT > kBufferData.byteLength);
+    encoder.dispatchIndirect(buffer, offset);
+
+    const finishShouldError =
+      state === 'invalid' ||
+      offset % 4 !== 0 ||
+      offset + 3 * Uint32Array.BYTES_PER_ELEMENT > kBufferData.byteLength;
+    validateFinishAndSubmit(!finishShouldError, state !== 'destroyed');
   });

--- a/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
@@ -36,7 +36,7 @@ Tests indirect buffer must be valid.
       usage: GPUBufferUsage.INDIRECT,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinishAndSubmitGivenState } = t.createEncoder(encoderType);
     encoder.setPipeline(pipeline);
     if (indexed) {
       const indexBuffer = t.makeIndexBuffer();
@@ -46,13 +46,7 @@ Tests indirect buffer must be valid.
       encoder.drawIndirect(indirectBuffer, 0);
     }
 
-    t.expectValidationError(() => {
-      if (state === 'destroyed') {
-        t.queue.submit([finish()]);
-      } else {
-        finish();
-      }
-    }, state !== 'valid');
+    validateFinishAndSubmitGivenState(state);
   });
 
 g.test('indirect_buffer_usage')
@@ -75,7 +69,7 @@ Tests indirect buffer must have 'Indirect' usage.
       usage,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setPipeline(t.createNoOpRenderPipeline());
     if (indexed) {
       const indexBuffer = t.makeIndexBuffer();
@@ -84,10 +78,7 @@ Tests indirect buffer must have 'Indirect' usage.
     } else {
       encoder.drawIndirect(indirectBuffer, 0);
     }
-
-    t.expectValidationError(() => {
-      finish();
-    }, (usage | GPUConst.BufferUsage.INDIRECT) !== usage);
+    validateFinish((usage & GPUBufferUsage.INDIRECT) !== 0);
   });
 
 g.test('indirect_offset_alignment')
@@ -105,7 +96,7 @@ Tests indirect offset must be a multiple of 4.
       usage: GPUBufferUsage.INDIRECT,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setPipeline(pipeline);
     if (indexed) {
       const indexBuffer = t.makeIndexBuffer();
@@ -115,9 +106,7 @@ Tests indirect offset must be a multiple of 4.
       encoder.drawIndirect(indirectBuffer, indirectOffset);
     }
 
-    t.expectValidationError(() => {
-      finish();
-    }, indirectOffset % 4 !== 0);
+    validateFinish(indirectOffset % 4 === 0);
   });
 
 g.test('indirect_offset_oob')
@@ -167,7 +156,7 @@ Tests indirect draw calls with various indirect offsets and buffer sizes.
       usage: GPUBufferUsage.INDIRECT,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setPipeline(pipeline);
     if (indexed) {
       const indexBuffer = t.makeIndexBuffer();
@@ -177,7 +166,5 @@ Tests indirect draw calls with various indirect offsets and buffer sizes.
       encoder.drawIndirect(indirectBuffer, indirectOffset);
     }
 
-    t.expectValidationError(() => {
-      finish();
-    }, !_valid);
+    validateFinish(_valid);
   });

--- a/src/webgpu/api/validation/encoding/cmds/render/render.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/render.ts
@@ -1,5 +1,5 @@
 import { kUnitCaseParamsBuilder } from '../../../../../../common/framework/params_builder.js';
-import { kRenderEncodeTypes } from '../../../validation_test.js';
+import { kRenderEncodeTypes } from '../../../util/command_buffer_maker.js';
 
 export const kRenderEncodeTypeParams = kUnitCaseParamsBuilder.combine(
   'encoderType',

--- a/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
@@ -28,16 +28,9 @@ Tests index buffer must be valid.
       usage: GPUBufferUsage.INDEX,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinishAndSubmitGivenState } = t.createEncoder(encoderType);
     encoder.setIndexBuffer(indexBuffer, 'uint32');
-
-    t.expectValidationError(() => {
-      if (state === 'destroyed') {
-        t.queue.submit([finish()]);
-      } else {
-        finish();
-      }
-    }, state !== 'valid');
+    validateFinishAndSubmitGivenState(state);
   });
 
 g.test('index_buffer_usage')
@@ -60,12 +53,9 @@ Tests index buffer must have 'Index' usage.
       usage,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setIndexBuffer(indexBuffer, 'uint32');
-
-    t.expectValidationError(() => {
-      finish();
-    }, (usage | GPUConst.BufferUsage.INDEX) !== usage);
+    validateFinish((usage & GPUBufferUsage.INDEX) !== 0);
   });
 
 g.test('offset_alignment')
@@ -88,14 +78,12 @@ Tests offset must be a multiple of index format’s byte size.
       usage: GPUBufferUsage.INDEX,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setIndexBuffer(indexBuffer, indexFormat, offset);
 
     const alignment =
       indexFormat === 'uint16' ? Uint16Array.BYTES_PER_ELEMENT : Uint32Array.BYTES_PER_ELEMENT;
-    t.expectValidationError(() => {
-      finish();
-    }, offset % alignment !== 0);
+    validateFinish(offset % alignment === 0);
   });
 
 g.test('offset_and_size_oob')
@@ -112,10 +100,7 @@ Tests offset and size cannot be larger than index buffer size.
       usage: GPUBufferUsage.INDEX,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setIndexBuffer(indexBuffer, 'uint32', offset, size);
-
-    t.expectValidationError(() => {
-      finish();
-    }, !_valid);
+    validateFinish(_valid);
   });

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -3,7 +3,8 @@ Validation tests for setPipeline on render pass and render bundle.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { ValidationTest, kRenderEncodeTypes } from '../../../validation_test.js';
+import { kRenderEncodeTypes } from '../../../util/command_buffer_maker.js';
+import { ValidationTest } from '../../../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
 
@@ -20,10 +21,7 @@ Tests setPipeline should generate an error iff using an 'invalid' pipeline.
     const { encoderType, state } = t.params;
     const pipeline = t.createRenderPipelineWithState(state);
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setPipeline(pipeline);
-
-    t.expectValidationError(() => {
-      finish();
-    }, state === 'invalid');
+    validateFinish(state !== 'invalid');
   });

--- a/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
@@ -34,12 +34,9 @@ Tests slot must be less than the maxVertexBuffers in device limits.
       usage: GPUBufferUsage.VERTEX,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setVertexBuffer(slot, vertexBuffer);
-
-    t.expectValidationError(() => {
-      finish();
-    }, slot >= DefaultLimits.maxVertexBuffers);
+    validateFinish(slot < DefaultLimits.maxVertexBuffers);
   });
 
 g.test('vertex_buffer')
@@ -56,16 +53,9 @@ Tests vertex buffer must be valid.
       usage: GPUBufferUsage.VERTEX,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinishAndSubmitGivenState } = t.createEncoder(encoderType);
     encoder.setVertexBuffer(0, vertexBuffer);
-
-    t.expectValidationError(() => {
-      if (state === 'destroyed') {
-        t.queue.submit([finish()]);
-      } else {
-        finish();
-      }
-    }, state !== 'valid');
+    validateFinishAndSubmitGivenState(state);
   });
 
 g.test('vertex_buffer_usage')
@@ -88,12 +78,9 @@ Tests vertex buffer must have 'Vertex' usage.
       usage,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setVertexBuffer(0, vertexBuffer);
-
-    t.expectValidationError(() => {
-      finish();
-    }, (usage | GPUConst.BufferUsage.VERTEX) !== usage);
+    validateFinish((usage & GPUBufferUsage.VERTEX) !== 0);
   });
 
 g.test('offset_alignment')
@@ -110,12 +97,9 @@ Tests offset must be a multiple of 4.
       usage: GPUBufferUsage.VERTEX,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish: finish } = t.createEncoder(encoderType);
     encoder.setVertexBuffer(0, vertexBuffer, offset);
-
-    t.expectValidationError(() => {
-      finish();
-    }, offset % 4 !== 0);
+    finish(offset % 4 === 0);
   });
 
 g.test('offset_and_size_oob')
@@ -132,10 +116,7 @@ Tests offset and size cannot be larger than vertex buffer size.
       usage: GPUBufferUsage.VERTEX,
     });
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setVertexBuffer(0, vertexBuffer, offset, size);
-
-    t.expectValidationError(() => {
-      finish();
-    }, !_valid);
+    validateFinish(_valid);
   });

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -16,8 +16,8 @@ import { kMinDynamicBufferOffsetAlignment } from '../../../../capability_info.js
 import {
   kProgrammableEncoderTypes,
   ProgrammableEncoderType,
-  ValidationTest,
-} from '../../validation_test.js';
+} from '../../util/command_buffer_maker.js';
+import { ResourceState, ValidationTest } from '../../validation_test.js';
 
 class F extends ValidationTest {
   encoderTypeToStageFlag(encoderType: ProgrammableEncoderType): GPUShaderStageFlags {
@@ -57,8 +57,12 @@ class F extends ValidationTest {
     }
   }
 
+  /**
+   * If state is 'invalid', creates an invalid bind group with valid resources.
+   * If state is 'destroyed', creates a valid bind group with destroyed resources.
+   */
   createBindGroup(
-    state: 'valid' | 'invalid' | 'destroyed',
+    state: ResourceState,
     resourceType: 'buffer' | 'texture',
     encoderType: ProgrammableEncoderType,
     indices: number[]
@@ -108,25 +112,10 @@ g.test('state_and_binding_index')
     const maxBindGroups = t.device.limits?.maxBindGroups ?? 4;
 
     async function runTest(index: number) {
-      const { encoder, finish } = t.createEncoder(encoderType);
+      const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
       encoder.setBindGroup(index, t.createBindGroup(state, resourceType, encoderType, [index]));
 
-      const shouldError = index >= maxBindGroups;
-
-      if (!shouldError && state === 'destroyed') {
-        t.device.pushErrorScope('validation');
-        const commandBuffer = finish();
-        const error = await t.device.popErrorScope();
-        t.expect(error === null, `finish() should not fail, but failed with ${error}`);
-        t.expectValidationError(() => {
-          t.queue.submit([commandBuffer]);
-        });
-      } else {
-        t.expectValidationError(() => {
-          t.debug('here');
-          finish();
-        }, shouldError || state !== 'valid');
-      }
+      validateFinishAndSubmit(state !== 'invalid' && index < maxBindGroups, state !== 'destroyed');
     }
 
     // TODO: move to subcases() once we can query the device limits
@@ -144,12 +133,9 @@ g.test('dynamic_offsets_passed_but_not_expected')
     const bindGroup = t.createBindGroup('valid', 'buffer', encoderType, []);
     const dynamicOffsets = [0];
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setBindGroup(0, bindGroup, dynamicOffsets);
-
-    t.expectValidationError(() => {
-      finish();
-    });
+    validateFinish(false);
   });
 
 g.test('dynamic_offsets_match_expectations_in_pass_encoder')
@@ -234,16 +220,13 @@ g.test('dynamic_offsets_match_expectations_in_pass_encoder')
 
     const { encoderType, dynamicOffsets, useU32array, _success } = t.params;
 
-    const { encoder, finish } = t.createEncoder(encoderType);
+    const { encoder, validateFinish } = t.createEncoder(encoderType);
     if (useU32array) {
       encoder.setBindGroup(0, bindGroup, new Uint32Array(dynamicOffsets), 0, dynamicOffsets.length);
     } else {
       encoder.setBindGroup(0, bindGroup, dynamicOffsets);
     }
-
-    t.expectValidationError(() => {
-      finish();
-    }, !_success);
+    validateFinish(_success);
   });
 
 g.test('u32array_start_and_length')
@@ -311,7 +294,7 @@ g.test('u32array_start_and_length')
       })),
     });
 
-    const { encoder, finish } = t.createEncoder('render pass');
+    const { encoder, validateFinish } = t.createEncoder('render pass');
 
     const doSetBindGroup = () => {
       encoder.setBindGroup(
@@ -329,5 +312,6 @@ g.test('u32array_start_and_length')
       t.shouldThrow('RangeError', doSetBindGroup);
     }
 
-    finish();
+    // RangeError in setBindGroup does not cause the encoder to become invalid.
+    validateFinish(true);
   });

--- a/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
@@ -17,11 +17,7 @@ TODO: tests for pipeline statistics queries:
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
-import {
-  beginRenderPassWithQuerySet,
-  createQuerySetWithType,
-  createRenderEncoderWithQuerySet,
-} from './common.js';
+import { beginRenderPassWithQuerySet, createQuerySetWithType } from './common.js';
 
 export const g = makeTestGroup(ValidationTest);
 
@@ -41,19 +37,17 @@ Tests that begin/end occlusion queries mismatch on render pass:
   ] as const)
   .fn(async t => {
     const { begin, end } = t.params;
-    const querySet = createQuerySetWithType(t, 'occlusion', 2);
 
-    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    const occlusionQuerySet = createQuerySetWithType(t, 'occlusion', 2);
+
+    const encoder = t.createEncoder('render pass', { occlusionQuerySet });
     for (let i = 0; i < begin; i++) {
       encoder.encoder.beginOcclusionQuery(i);
     }
     for (let j = 0; j < end; j++) {
       encoder.encoder.endOcclusionQuery();
     }
-
-    t.expectValidationError(() => {
-      encoder.finish();
-    }, begin !== end);
+    encoder.validateFinishAndSubmit(begin === end, true);
   });
 
 g.test('occlusion_query,begin_end_invalid_nesting')
@@ -71,21 +65,19 @@ Tests the invalid nesting of begin/end occlusion queries:
     { calls: [0, 1, 'end', 'end'], _valid: false },
   ] as const)
   .fn(async t => {
-    const querySet = createQuerySetWithType(t, 'occlusion', 2);
+    const { calls, _valid } = t.params;
 
-    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    const occlusionQuerySet = createQuerySetWithType(t, 'occlusion', 2);
 
-    for (const i of t.params.calls) {
+    const encoder = t.createEncoder('render pass', { occlusionQuerySet });
+    for (const i of calls) {
       if (i !== 'end') {
         encoder.encoder.beginOcclusionQuery(i);
       } else {
         encoder.encoder.endOcclusionQuery();
       }
     }
-
-    t.expectValidationError(() => {
-      encoder.finish();
-    }, !t.params._valid);
+    encoder.validateFinishAndSubmit(_valid, true);
   });
 
 g.test('occlusion_query,disjoint_queries_with_same_query_index')

--- a/src/webgpu/api/validation/encoding/queries/common.ts
+++ b/src/webgpu/api/validation/encoding/queries/common.ts
@@ -1,5 +1,4 @@
 import { GPUTest } from '../../../../gpu_test.js';
-import { CommandBufferMaker } from '../../validation_test.js';
 
 export function createQuerySetWithType(
   t: GPUTest,
@@ -36,19 +35,4 @@ export function beginRenderPassWithQuerySet(
     ],
     occlusionQuerySet: querySet,
   });
-}
-
-export function createRenderEncoderWithQuerySet(
-  t: GPUTest,
-  querySet?: GPUQuerySet
-): CommandBufferMaker<'render pass'> {
-  const commandEncoder = t.device.createCommandEncoder();
-  const encoder = beginRenderPassWithQuerySet(t, commandEncoder, querySet);
-  return {
-    encoder,
-    finish: () => {
-      encoder.endPass();
-      return commandEncoder.finish();
-    },
-  } as const;
 }

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kQueryTypes } from '../../../../capability_info.js';
 import { ValidationTest } from '../../validation_test.js';
 
-import { createQuerySetWithType, createRenderEncoderWithQuerySet } from './common.js';
+import { createQuerySetWithType } from './common.js';
 
 export const g = makeTestGroup(ValidationTest);
 
@@ -33,13 +33,10 @@ Tests that set occlusion query set with all types in render pass descriptor:
 
     const querySet = type === undefined ? undefined : createQuerySetWithType(t, type, 1);
 
-    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    const encoder = t.createEncoder('render pass', { occlusionQuerySet: querySet });
     encoder.encoder.beginOcclusionQuery(0);
     encoder.encoder.endOcclusionQuery();
-
-    t.expectValidationError(() => {
-      encoder.finish();
-    }, type !== 'occlusion');
+    encoder.validateFinish(type === 'occlusion');
   });
 
 g.test('occlusion_query,invalid_query_set')
@@ -50,15 +47,12 @@ Tests that begin occlusion query with a invalid query set that failed during cre
   )
   .paramsSubcasesOnly(u => u.combine('querySetState', ['valid', 'invalid'] as const))
   .fn(t => {
-    const querySet = t.createQuerySetWithState(t.params.querySetState);
+    const occlusionQuerySet = t.createQuerySetWithState(t.params.querySetState);
 
-    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    const encoder = t.createEncoder('render pass', { occlusionQuerySet });
     encoder.encoder.beginOcclusionQuery(0);
     encoder.encoder.endOcclusionQuery();
-
-    t.expectValidationError(() => {
-      encoder.finish();
-    }, t.params.querySetState === 'invalid');
+    encoder.validateFinishAndSubmitGivenState(t.params.querySetState);
   });
 
 g.test('occlusion_query,query_index')
@@ -70,15 +64,12 @@ Tests that begin occlusion query with query index:
   )
   .paramsSubcasesOnly(u => u.combine('queryIndex', [0, 2]))
   .fn(t => {
-    const querySet = createQuerySetWithType(t, 'occlusion', 2);
+    const occlusionQuerySet = createQuerySetWithType(t, 'occlusion', 2);
 
-    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    const encoder = t.createEncoder('render pass', { occlusionQuerySet });
     encoder.encoder.beginOcclusionQuery(t.params.queryIndex);
     encoder.encoder.endOcclusionQuery();
-
-    t.expectValidationError(() => {
-      encoder.finish();
-    }, t.params.queryIndex > 0);
+    encoder.validateFinish(t.params.queryIndex < 2);
   });
 
 g.test('timestamp_query,query_type_and_index')
@@ -107,10 +98,7 @@ Tests that write timestamp to all types of query set on all possible encoders:
 
     const encoder = t.createEncoder(encoderType);
     encoder.encoder.writeTimestamp(querySet, queryIndex);
-
-    t.expectValidationError(() => {
-      encoder.finish();
-    }, type !== 'timestamp' || queryIndex >= count);
+    encoder.validateFinish(type === 'timestamp' && queryIndex < count);
   });
 
 g.test('timestamp_query,invalid_query_set')
@@ -128,8 +116,5 @@ Tests that write timestamp to a invalid query set that failed during creation:
 
     const encoder = t.createEncoder(t.params.encoderType);
     encoder.encoder.writeTimestamp(querySet, 0);
-
-    t.expectValidationError(() => {
-      encoder.finish();
-    });
+    encoder.validateFinish(false);
   });

--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -5,7 +5,6 @@ TODO: Test with pipeline statistics queries on {compute, render} as well.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { createRenderEncoderWithQuerySet } from '../../encoding/queries/common.js';
 import { ValidationTest } from '../../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
@@ -19,15 +18,12 @@ Tests that use a destroyed query set in occlusion query on render pass encoder.
   )
   .paramsSubcasesOnly(u => u.combine('querySetState', ['valid', 'destroyed'] as const))
   .fn(t => {
-    const querySet = t.createQuerySetWithState(t.params.querySetState);
+    const occlusionQuerySet = t.createQuerySetWithState(t.params.querySetState);
 
-    const encoder = createRenderEncoderWithQuerySet(t, querySet);
+    const encoder = t.createEncoder('render pass', { occlusionQuerySet });
     encoder.encoder.beginOcclusionQuery(0);
     encoder.encoder.endOcclusionQuery();
-
-    t.expectValidationError(() => {
-      t.queue.submit([encoder.finish()]);
-    }, t.params.querySetState === 'destroyed');
+    encoder.validateFinishAndSubmitGivenState(t.params.querySetState);
   });
 
 g.test('writeTimestamp')
@@ -53,10 +49,7 @@ Tests that use a destroyed query set in writeTimestamp on {non-pass, compute, re
 
     const encoder = t.createEncoder(t.params.encoderType);
     encoder.encoder.writeTimestamp(querySet, 0);
-
-    t.expectValidationError(() => {
-      t.queue.submit([encoder.finish()]);
-    }, t.params.querySetState === 'destroyed');
+    encoder.validateFinishAndSubmitGivenState(t.params.querySetState);
   });
 
 g.test('resolveQuerySet')
@@ -72,10 +65,7 @@ Tests that use a destroyed query set in resolveQuerySet.
 
     const buffer = t.device.createBuffer({ size: 8, usage: GPUBufferUsage.QUERY_RESOLVE });
 
-    const encoder = t.device.createCommandEncoder();
-    encoder.resolveQuerySet(querySet, 0, 1, buffer, 0);
-
-    t.expectValidationError(() => {
-      t.queue.submit([encoder.finish()]);
-    }, t.params.querySetState === 'destroyed');
+    const encoder = t.createEncoder('non-pass');
+    encoder.encoder.resolveQuerySet(querySet, 0, 1, buffer, 0);
+    encoder.validateFinishAndSubmitGivenState(t.params.querySetState);
   });

--- a/src/webgpu/api/validation/util/command_buffer_maker.ts
+++ b/src/webgpu/api/validation/util/command_buffer_maker.ts
@@ -18,8 +18,6 @@ type EncoderByEncoderType<T extends EncoderType> = {
 /** See {@link webgpu/api/validation/validation_test.ValidationTest.createEncoder |
  * ValidationTest.createEncoder()}. */
 export class CommandBufferMaker<T extends EncoderType> {
-  private readonly t: ValidationTest;
-
   /** `GPU___Encoder` for recording commands into. */
   // Look up the type of the encoder based on `T`. If `T` is a union, this will be too!
   readonly encoder: EncoderByEncoderType<T>;
@@ -51,7 +49,6 @@ export class CommandBufferMaker<T extends EncoderType> {
     encoder: EncoderByEncoderType<EncoderType>,
     finish: (shouldSucceed: boolean) => GPUCommandBuffer
   ) {
-    this.t = t;
     // TypeScript introduces an intersection type here where we don't want one.
     this.encoder = encoder as EncoderByEncoderType<T>;
     this.validateFinish = finish;

--- a/src/webgpu/api/validation/util/command_buffer_maker.ts
+++ b/src/webgpu/api/validation/util/command_buffer_maker.ts
@@ -1,0 +1,76 @@
+import { ResourceState, ValidationTest } from '../validation_test.js';
+
+export const kRenderEncodeTypes = ['render pass', 'render bundle'] as const;
+export type RenderEncodeType = typeof kRenderEncodeTypes[number];
+export const kProgrammableEncoderTypes = ['compute pass', ...kRenderEncodeTypes] as const;
+export type ProgrammableEncoderType = typeof kProgrammableEncoderTypes[number];
+export const kEncoderTypes = ['non-pass', ...kProgrammableEncoderTypes] as const;
+export type EncoderType = typeof kEncoderTypes[number];
+
+// Look up the type of the encoder based on `T`. If `T` is a union, this will be too!
+type EncoderByEncoderType<T extends EncoderType> = {
+  'non-pass': GPUCommandEncoder;
+  'compute pass': GPUComputePassEncoder;
+  'render pass': GPURenderPassEncoder;
+  'render bundle': GPURenderBundleEncoder;
+}[T];
+
+/** See {@link webgpu/api/validation/validation_test.ValidationTest.createEncoder |
+ * ValidationTest.createEncoder()}. */
+export class CommandBufferMaker<T extends EncoderType> {
+  private readonly t: ValidationTest;
+
+  /** `GPU___Encoder` for recording commands into. */
+  // Look up the type of the encoder based on `T`. If `T` is a union, this will be too!
+  readonly encoder: EncoderByEncoderType<T>;
+
+  /**
+   * Finish any passes, finish and record any bundles, and finish/return the command buffer.
+   * Checks for validation errors in (only) the appropriate finish call.
+   */
+  readonly validateFinish: (shouldSucceed: boolean) => GPUCommandBuffer;
+
+  /**
+   * Finish the command buffer and submit it. Checks for validation errors in either the submit or
+   * the appropriate finish call, depending on the state of a resource used in the encoding.
+   */
+  readonly validateFinishAndSubmit: (
+    shouldBeValid: boolean,
+    submitShouldSucceedIfValid: boolean
+  ) => void;
+
+  /**
+   * `validateFinishAndSubmit()` based on the state of a resource in the command encoder.
+   * - `finish()` should fail if the resource is 'invalid'.
+   * - Only `submit()` should fail if the resource is 'destroyed'.
+   */
+  readonly validateFinishAndSubmitGivenState: (resourceState: ResourceState) => void;
+
+  constructor(
+    t: ValidationTest,
+    encoder: EncoderByEncoderType<EncoderType>,
+    finish: (shouldSucceed: boolean) => GPUCommandBuffer
+  ) {
+    this.t = t;
+    // TypeScript introduces an intersection type here where we don't want one.
+    this.encoder = encoder as EncoderByEncoderType<T>;
+    this.validateFinish = finish;
+
+    // Define extra methods like this, otherwise they get unbound when destructured, e.g.:
+    // const { encoder, validateFinishAndSubmit } = t.createEncoder(type);
+
+    this.validateFinishAndSubmit = (
+      shouldBeValid: boolean,
+      submitShouldSucceedIfValid: boolean
+    ) => {
+      const commandBuffer = finish(shouldBeValid);
+      if (shouldBeValid) {
+        t.expectValidationError(() => t.queue.submit([commandBuffer]), !submitShouldSucceedIfValid);
+      }
+    };
+
+    this.validateFinishAndSubmitGivenState = (resourceState: ResourceState) => {
+      this.validateFinishAndSubmit(resourceState !== 'invalid', resourceState !== 'destroyed');
+    };
+  }
+}

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -333,10 +333,10 @@ export class ValidationTest extends GPUTest {
         const pass = this.createEncoder('render pass', { attachmentInfo });
 
         return new CommandBufferMaker(this, rbEncoder, (shouldSucceed: boolean) => {
-          // Bundle should be invalid.
+          // If !shouldSucceed, the resulting bundle should be invalid.
           const rb = this.expectGPUError('validation', () => rbEncoder.finish(), !shouldSucceed);
           pass.encoder.executeBundles([rb]);
-          // Then pass should be invalid because the bundle was invalid.
+          // Then, the pass should also be invalid if the bundle was invalid.
           return pass.validateFinish(shouldSucceed);
         });
       }

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -2,23 +2,9 @@ import { assert, unreachable } from '../../../common/util/util.js';
 import { BindableResource, kMaxQueryCount } from '../../capability_info.js';
 import { GPUTest } from '../../gpu_test.js';
 
-export const kRenderEncodeTypes = ['render pass', 'render bundle'] as const;
-export type RenderEncodeType = typeof kRenderEncodeTypes[number];
-export const kProgrammableEncoderTypes = ['compute pass', ...kRenderEncodeTypes] as const;
-export type ProgrammableEncoderType = typeof kProgrammableEncoderTypes[number];
-export const kEncoderTypes = ['non-pass', ...kProgrammableEncoderTypes] as const;
-export type EncoderType = typeof kEncoderTypes[number];
+import { CommandBufferMaker, EncoderType } from './util/command_buffer_maker.js';
 
-export interface CommandBufferMaker<T extends EncoderType> {
-  // Look up the type of the encoder based on `T`. If `T` is a union, this will be too!
-  readonly encoder: {
-    'non-pass': GPUCommandEncoder;
-    'compute pass': GPUComputePassEncoder;
-    'render pass': GPURenderPassEncoder;
-    'render bundle': GPURenderBundleEncoder;
-  }[T];
-  finish(): GPUCommandBuffer;
-}
+export type ResourceState = 'valid' | 'invalid' | 'destroyed';
 
 /**
  * Base fixture for WebGPU validation tests.
@@ -29,7 +15,7 @@ export class ValidationTest extends GPUTest {
    * A `descriptor` may optionally be passed, which is used when `state` is not `'invalid'`.
    */
   createTextureWithState(
-    state: 'valid' | 'invalid' | 'destroyed',
+    state: ResourceState,
     descriptor?: Readonly<GPUTextureDescriptor>
   ): GPUTexture {
     descriptor = descriptor ?? {
@@ -61,7 +47,7 @@ export class ValidationTest extends GPUTest {
    * if `state` is `'invalid'`, it will be modified to add an invalid combination of usages.
    */
   createBufferWithState(
-    state: 'valid' | 'invalid' | 'destroyed',
+    state: ResourceState,
     descriptor?: Readonly<GPUBufferDescriptor>
   ): GPUBuffer {
     descriptor = descriptor ?? {
@@ -97,26 +83,18 @@ export class ValidationTest extends GPUTest {
    * A `descriptor` may optionally be passed, which is used when `state` is not `'invalid'`.
    */
   createQuerySetWithState(
-    state: 'valid' | 'invalid' | 'destroyed',
-    descriptor?: Readonly<GPUQuerySetDescriptor>
+    state: ResourceState,
+    desc?: Readonly<GPUQuerySetDescriptor>
   ): GPUQuerySet {
-    descriptor = descriptor ?? {
-      type: 'occlusion',
-      count: 2,
-    };
+    const descriptor = { type: 'occlusion' as const, count: 2, ...desc };
 
     switch (state) {
       case 'valid':
         return this.device.createQuerySet(descriptor);
       case 'invalid': {
         // Make the queryset invalid because of the count out of bounds.
-        this.device.pushErrorScope('validation');
-        const queryset = this.device.createQuerySet({
-          type: 'occlusion',
-          count: kMaxQueryCount + 1,
-        });
-        this.device.popErrorScope();
-        return queryset;
+        descriptor.count = kMaxQueryCount + 1;
+        return this.expectGPUError('validation', () => this.device.createQuerySet(descriptor));
       }
       case 'destroyed': {
         const queryset = this.device.createQuerySet(descriptor);
@@ -304,9 +282,6 @@ export class ValidationTest extends GPUTest {
    * GPURenderBundleEncoder, and a `finish` method returning a GPUCommandBuffer.
    * Allows testing methods which have the same signature across multiple encoder interfaces.
    *
-   * TODO(https://github.com/gpuweb/cts/pull/489#issuecomment-812283347):
-   * Make this have stricter validation to ensure errors are generated in the right API call.
-   *
    * @example
    * ```
    * g.test('popDebugGroup')
@@ -326,71 +301,90 @@ export class ValidationTest extends GPUTest {
    *   });
    * ```
    */
-  createEncoder<T extends EncoderType>(encoderType: T): CommandBufferMaker<T> {
-    const colorFormat = 'rgba8unorm';
+  createEncoder<T extends EncoderType>(
+    encoderType: T,
+    {
+      attachmentInfo,
+      occlusionQuerySet,
+    }: {
+      attachmentInfo?: GPURenderBundleEncoderDescriptor;
+      occlusionQuerySet?: GPUQuerySet;
+    } = {}
+  ): CommandBufferMaker<T> {
+    const fullAttachmentInfo = {
+      // Defaults if not overridden:
+      colorFormats: ['rgba8unorm'],
+      sampleCount: 1,
+      // Passed values take precedent.
+      ...attachmentInfo,
+    } as const;
+
     switch (encoderType) {
       case 'non-pass': {
         const encoder = this.device.createCommandEncoder();
-        // TypeScript introduces an intersection type here where it seems like there shouldn't be
-        // one. Maybe there is a soundness issue here, but I don't think there is one in practice.
-        return {
-          encoder,
-          finish: () => {
-            return encoder.finish();
-          },
-        } as CommandBufferMaker<T>;
+
+        return new CommandBufferMaker(this, encoder, (shouldSucceed: boolean) =>
+          this.expectGPUError('validation', () => encoder.finish(), !shouldSucceed)
+        );
       }
       case 'render bundle': {
         const device = this.device;
-        const encoder = device.createRenderBundleEncoder({
-          colorFormats: [colorFormat],
+        const rbEncoder = device.createRenderBundleEncoder(fullAttachmentInfo);
+        const pass = this.createEncoder('render pass', { attachmentInfo });
+
+        return new CommandBufferMaker(this, rbEncoder, (shouldSucceed: boolean) => {
+          // Bundle should be invalid.
+          const rb = this.expectGPUError('validation', () => rbEncoder.finish(), !shouldSucceed);
+          pass.encoder.executeBundles([rb]);
+          // Then pass should be invalid because the bundle was invalid.
+          return pass.validateFinish(shouldSucceed);
         });
-        const pass = this.createEncoder('render pass');
-        return {
-          encoder,
-          finish: () => {
-            const bundle = encoder.finish();
-            pass.encoder.executeBundles([bundle]);
-            return pass.finish();
-          },
-        } as CommandBufferMaker<T>;
       }
       case 'compute pass': {
         const commandEncoder = this.device.createCommandEncoder();
         const encoder = commandEncoder.beginComputePass();
-        return {
-          encoder,
-          finish: () => {
-            encoder.endPass();
-            return commandEncoder.finish();
-          },
-        } as CommandBufferMaker<T>;
+
+        return new CommandBufferMaker(this, encoder, (shouldSucceed: boolean) => {
+          encoder.endPass();
+          return this.expectGPUError('validation', () => commandEncoder.finish(), !shouldSucceed);
+        });
       }
       case 'render pass': {
+        const makeAttachmentView = (format: GPUTextureFormat) =>
+          this.device
+            .createTexture({
+              size: [16, 16, 1],
+              format,
+              usage: GPUTextureUsage.RENDER_ATTACHMENT,
+              sampleCount: fullAttachmentInfo.sampleCount,
+            })
+            .createView();
+
+        const passDesc: GPURenderPassDescriptor = {
+          colorAttachments: Array.from(fullAttachmentInfo.colorFormats, format => ({
+            view: makeAttachmentView(format),
+            loadValue: [0, 0, 0, 0],
+            storeOp: 'store',
+          })),
+          depthStencilAttachment:
+            fullAttachmentInfo.depthStencilFormat !== undefined
+              ? {
+                  view: makeAttachmentView(fullAttachmentInfo.depthStencilFormat),
+                  depthLoadValue: 0,
+                  depthStoreOp: 'discard',
+                  stencilLoadValue: 1,
+                  stencilStoreOp: 'discard',
+                }
+              : undefined,
+          occlusionQuerySet,
+        };
+
         const commandEncoder = this.device.createCommandEncoder();
-        const view = this.device
-          .createTexture({
-            format: colorFormat,
-            size: { width: 16, height: 16, depthOrArrayLayers: 1 },
-            usage: GPUTextureUsage.RENDER_ATTACHMENT,
-          })
-          .createView();
-        const encoder = commandEncoder.beginRenderPass({
-          colorAttachments: [
-            {
-              view,
-              loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
-              storeOp: 'store',
-            },
-          ],
+        const encoder = commandEncoder.beginRenderPass(passDesc);
+        return new CommandBufferMaker(this, encoder, (shouldSucceed: boolean) => {
+          encoder.endPass();
+          return this.expectGPUError('validation', () => commandEncoder.finish(), !shouldSucceed);
         });
-        return {
-          encoder,
-          finish: () => {
-            encoder.endPass();
-            return commandEncoder.finish();
-          },
-        } as CommandBufferMaker<T>;
       }
     }
     unreachable();


### PR DESCRIPTION
And add a finishAndSubmit() helper.

With the fixes, this should ~eliminate cases where we had multiple
(endPass, finish, submit) calls inside one validation error scope and
couldn't make sure the errors came from the right functions.
This also substantially simplifies the finish/submit in most tests.

Folds two other helpers into this one so that all of the `CommandBufferMaker`s are centralized.

Tested locally, and all of the changed tests pass (except for existing known issues).



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
