### PR TITLE
Add control case to timestamp_query,invalid_query_set

### DIFF
--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -109,12 +109,20 @@ Tests that write timestamp to a invalid query set that failed during creation:
   `
   )
   .paramsSubcasesOnly(u =>
-    u.combine('encoderType', ['non-pass', 'compute pass', 'render pass'] as const)
+    u
+      .combine('encoderType', ['non-pass', 'compute pass', 'render pass'] as const)
+      .combine('querySetState', ['valid', 'invalid'] as const)
   )
   .fn(async t => {
-    const querySet = t.createQuerySetWithState('invalid');
+    const { encoderType, querySetState } = t.params;
+    await t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
 
-    const encoder = t.createEncoder(t.params.encoderType);
+    const querySet = t.createQuerySetWithState(querySetState, {
+      type: 'timestamp',
+      count: 2,
+    });
+
+    const encoder = t.createEncoder(encoderType);
     encoder.encoder.writeTimestamp(querySet, 0);
-    encoder.validateFinish(false);
+    encoder.validateFinish(querySetState !== 'invalid');
   });


### PR DESCRIPTION
Note: createQuerySetWithState was changed in #646 to preserve the query set type even when asked to create an invalid query set object.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
