### PR TITLE
Depth/stencil formats should be invalid for 3D textures

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -9,6 +9,7 @@ import {
   kTextureDimensions,
   kTextureUsages,
   kUncompressedTextureFormats,
+  kRegularTextureFormats,
   textureDimensionAndFormatCompatible,
 } from '../../capability_info.js';
 import { DefaultLimits, GPUConst } from '../../constants.js';
@@ -531,11 +532,11 @@ g.test('texture_size,2d_texture,compressed_format')
 
 g.test('texture_size,3d_texture,uncompressed_format')
   .desc(
-    `Test that depth/stencil formats are invalid for 3D texture and regular formats have particualr textures size limits for 3D texture.`
+    `Test texture size requirement for 3D texture with uncompressed format. Note that depth/stencil formats are invalid for 3D textures, so we only test regular formats.`
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('format', kUncompressedTextureFormats)
+      .combine('format', kRegularTextureFormats)
       .combine('size', [
         // Test the bound of width
         [DefaultLimits.maxTextureDimension3D - 1, 1, 1],
@@ -553,8 +554,7 @@ g.test('texture_size,3d_texture,uncompressed_format')
   )
   .fn(async t => {
     const { format, size } = t.params;
-    const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
+    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -566,9 +566,7 @@ g.test('texture_size,3d_texture,uncompressed_format')
     const success =
       size[0] <= DefaultLimits.maxTextureDimension3D &&
       size[1] <= DefaultLimits.maxTextureDimension3D &&
-      size[2] <= DefaultLimits.maxTextureDimension3D &&
-      !info.depth &&
-      !info.stencil;
+      size[2] <= DefaultLimits.maxTextureDimension3D;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -551,7 +551,8 @@ g.test('texture_size,3d_texture,uncompressed_format')
   )
   .fn(async t => {
     const { format, size } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -563,7 +564,9 @@ g.test('texture_size,3d_texture,uncompressed_format')
     const success =
       size[0] <= DefaultLimits.maxTextureDimension3D &&
       size[1] <= DefaultLimits.maxTextureDimension3D &&
-      size[2] <= DefaultLimits.maxTextureDimension3D;
+      size[2] <= DefaultLimits.maxTextureDimension3D &&
+      !info.depth &&
+      !info.stencil;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -530,7 +530,9 @@ g.test('texture_size,2d_texture,compressed_format')
   });
 
 g.test('texture_size,3d_texture,uncompressed_format')
-  .desc(`Test texture size requirement for 3D texture with uncompressed format.`)
+  .desc(
+    `Test that depth/stencil formats are invalid for 3D texture and regular formats have particualr textures size limits for 3D texture.`
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('format', kUncompressedTextureFormats)


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
