### PR TITLE
flip select() conditions in large-draw CTS

### DIFF
--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -221,8 +221,8 @@ g.test('large_draw')
           };
 
           fn selectValue(index: u32, maxIndex: u32) -> f32 {
-            let highOrMid = select(2.0 / 3.0, 0.0, index == maxIndex - 1u);
-            return select(-2.0 / 3.0, highOrMid, index == 0u);
+            let highOrMid = select(0.0, 2.0 / 3.0, index == maxIndex - 1u);
+            return select(highOrMid, -2.0 / 3.0, index == 0u);
           }
 
           [[group(0), binding(0)]] var<uniform> params: Params;


### PR DESCRIPTION
order of conditions was flipped in WGSL

<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
