### PR TITLE
Fix Index Buffer OOB validation for DrawIndexed

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -155,25 +155,26 @@ g.test('out_of_bounds')
       u
         .combine('indirect', [false, true])
         .combineWithParams([
-          { indexCount: 5, firstIndex: 1, isSuccess: true }, // draw the last 5 out of 6 index
-          { indexCount: 1, firstIndex: 5, isSuccess: true }, // draw the last 1 out of 6 index
-          { indexCount: 6, firstIndex: 1, isSuccess: false }, // indexCount + firstIndex out of bound
-          { indexCount: 0, firstIndex: 6, isSuccess: true }, // firstIndex point to the one after last, but (indexCount + firstIndex) * stride <= bufferSize, valid
-          { indexCount: 0, firstIndex: 7, isSuccess: false }, // (indexCount + firstIndex) * stride > bufferSize, invalid
-          { indexCount: 1, firstIndex: 6, isSuccess: false }, // indexCount valid, but (indexCount + firstIndex) out of bound
-          { indexCount: 6, firstIndex: 10000, isSuccess: false }, // firstIndex much larger than the bound
-          { indexCount: 7, firstIndex: 0, isSuccess: false }, // only indexCount out of bound
-          { indexCount: 10000, firstIndex: 0, isSuccess: false }, // indexCount much larger than the bound
-          { indexCount: 0xffffffff, firstIndex: 0xffffffff, isSuccess: false }, // max uint32 value
-          { indexCount: 0xffffffff, firstIndex: 2, isSuccess: false }, // max uint32 indexCount and small firstIndex
-          { indexCount: 2, firstIndex: 0xffffffff, isSuccess: false }, // small indexCount and max uint32 firstIndex
+          { indexCount: 5, firstIndex: 1 }, // draw the last 5 out of 6 index
+          { indexCount: 1, firstIndex: 5 }, // draw the last 1 out of 6 index
+          { indexCount: 6, firstIndex: 1 }, // indexCount + firstIndex out of bound
+          { indexCount: 0, firstIndex: 6 }, // firstIndex point to the one after last, but (indexCount + firstIndex) * stride <= bufferSize, valid
+          { indexCount: 0, firstIndex: 7 }, // (indexCount + firstIndex) * stride > bufferSize, invalid
+          { indexCount: 1, firstIndex: 6 }, // indexCount valid, but (indexCount + firstIndex) out of bound
+          { indexCount: 6, firstIndex: 10000 }, // firstIndex much larger than the bound
+          { indexCount: 7, firstIndex: 0 }, // only indexCount out of bound
+          { indexCount: 10000, firstIndex: 0 }, // indexCount much larger than the bound
+          { indexCount: 0xffffffff, firstIndex: 0xffffffff }, // max uint32 value
+          { indexCount: 0xffffffff, firstIndex: 2 }, // max uint32 indexCount and small firstIndex
+          { indexCount: 2, firstIndex: 0xffffffff }, // small indexCount and max uint32 firstIndex
         ] as const)
         .combine('instanceCount', [1, 10000]) // normal and large instanceCount
   )
   .fn(t => {
-    const { indirect, indexCount, firstIndex, instanceCount, isSuccess } = t.params;
+    const { indirect, indexCount, firstIndex, instanceCount } = t.params;
 
     const indexBuffer = t.createIndexBuffer([0, 1, 2, 3, 1, 2]);
+    const isSuccess: boolean = indexCount + firstIndex <= 6;
 
     if (indirect) {
       t.drawIndexedIndirect(
@@ -202,17 +203,18 @@ g.test('out_of_bounds_zero_sized_index_buffer')
       u
         .combine('indirect', [false, true])
         .combineWithParams([
-          { indexCount: 3, firstIndex: 1, isSuccess: false }, // indexCount + firstIndex out of bound
-          { indexCount: 0, firstIndex: 1, isSuccess: false }, // indexCount is 0 but firstIndex out of bound
-          { indexCount: 3, firstIndex: 0, isSuccess: false }, // only indexCount out of bound
-          { indexCount: 0, firstIndex: 0, isSuccess: true }, // just zeros, valid
+          { indexCount: 3, firstIndex: 1 }, // indexCount + firstIndex out of bound
+          { indexCount: 0, firstIndex: 1 }, // indexCount is 0 but firstIndex out of bound
+          { indexCount: 3, firstIndex: 0 }, // only indexCount out of bound
+          { indexCount: 0, firstIndex: 0 }, // just zeros, valid
         ] as const)
         .combine('instanceCount', [1, 10000]) // normal and large instanceCount
   )
   .fn(t => {
-    const { indirect, indexCount, firstIndex, instanceCount, isSuccess } = t.params;
+    const { indirect, indexCount, firstIndex, instanceCount } = t.params;
 
     const indexBuffer = t.createIndexBuffer([]);
+    const isSuccess: boolean = indexCount + firstIndex <= 0;
 
     if (indirect) {
       t.drawIndexedIndirect(

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -8,9 +8,6 @@ TODO: review and make sure these notes are covered:
 >             - indexCount largeish
 >             - firstIndex {=, >} 0
 >     - x= {drawIndexed, drawIndexedIndirect}
-
-TODO: Since there are no errors here, these should be "robustness" operation tests (with multiple
-valid results).
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
@@ -83,7 +80,8 @@ class F extends ValidationTest {
     instanceCount: number,
     firstIndex: number,
     baseVertex: number,
-    firstInstance: number
+    firstInstance: number,
+    isSuccess: boolean
   ) {
     const pipeline = this.createRenderPipeline();
 
@@ -94,10 +92,21 @@ class F extends ValidationTest {
     pass.drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
     pass.endPass();
 
-    this.device.queue.submit([encoder.finish()]);
+    if (isSuccess) {
+      this.device.queue.submit([encoder.finish()]);
+    } else {
+      this.expectValidationError(() => {
+        encoder.finish();
+      });
+    }
   }
 
-  drawIndexedIndirect(indexBuffer: GPUBuffer, bufferArray: Uint32Array, indirectOffset: number) {
+  drawIndexedIndirect(
+    indexBuffer: GPUBuffer,
+    bufferArray: Uint32Array,
+    indirectOffset: number,
+    isSuccess: boolean
+  ) {
     const indirectBuffer = this.device.createBuffer({
       mappedAtCreation: true,
       size: bufferArray.byteLength,
@@ -115,7 +124,13 @@ class F extends ValidationTest {
     pass.drawIndexedIndirect(indirectBuffer, indirectOffset);
     pass.endPass();
 
-    this.device.queue.submit([encoder.finish()]);
+    if (isSuccess) {
+      this.device.queue.submit([encoder.finish()]);
+    } else {
+      this.expectValidationError(() => {
+        encoder.finish();
+      });
+    }
   }
 }
 
@@ -123,9 +138,8 @@ export const g = makeTestGroup(F);
 
 g.test('out_of_bounds')
   .desc(
-    `Test drawing with out of bound index access to make sure the implementation is robust
-    with the following indexCount and firstIndex conditions
-    - valid draw
+    `Test drawing with out of bound index access to make sure encoder validation catch the
+    following indexCount and firstIndex OOB conditions
     - either is within bound but indexCount + firstIndex is out of bound
     - only firstIndex is out of bound
     - only indexCount is out of bound
@@ -140,22 +154,24 @@ g.test('out_of_bounds')
     u =>
       u
         .combine('indirect', [false, true])
-        .beginSubcases()
         .combineWithParams([
-          { indexCount: 6, firstIndex: 1 }, // indexCount + firstIndex out of bound
-          { indexCount: 0, firstIndex: 6 }, // indexCount is 0 but firstIndex out of bound
-          { indexCount: 6, firstIndex: 6 }, // only firstIndex out of bound
-          { indexCount: 6, firstIndex: 10000 }, // firstIndex much larger than the bound
-          { indexCount: 7, firstIndex: 0 }, // only indexCount out of bound
-          { indexCount: 10000, firstIndex: 0 }, // indexCount much larger than the bound
-          { indexCount: 0xffffffff, firstIndex: 0xffffffff }, // max uint32 value
-          { indexCount: 0xffffffff, firstIndex: 2 }, // max uint32 indexCount and small firstIndex
-          { indexCount: 2, firstIndex: 0xffffffff }, // small indexCount and max uint32 firstIndex
+          { indexCount: 5, firstIndex: 1, isSuccess: true }, // draw the last 5 out of 6 index
+          { indexCount: 1, firstIndex: 5, isSuccess: true }, // draw the last 1 out of 6 index
+          { indexCount: 6, firstIndex: 1, isSuccess: false }, // indexCount + firstIndex out of bound
+          { indexCount: 0, firstIndex: 6, isSuccess: true }, // firstIndex point to the one after last, but (indexCount + firstIndex) * stride <= bufferSize, valid
+          { indexCount: 0, firstIndex: 7, isSuccess: false }, // (indexCount + firstIndex) * stride > bufferSize, invalid
+          { indexCount: 1, firstIndex: 6, isSuccess: false }, // indexCount valid, but (indexCount + firstIndex) out of bound
+          { indexCount: 6, firstIndex: 10000, isSuccess: false }, // firstIndex much larger than the bound
+          { indexCount: 7, firstIndex: 0, isSuccess: false }, // only indexCount out of bound
+          { indexCount: 10000, firstIndex: 0, isSuccess: false }, // indexCount much larger than the bound
+          { indexCount: 0xffffffff, firstIndex: 0xffffffff, isSuccess: false }, // max uint32 value
+          { indexCount: 0xffffffff, firstIndex: 2, isSuccess: false }, // max uint32 indexCount and small firstIndex
+          { indexCount: 2, firstIndex: 0xffffffff, isSuccess: false }, // small indexCount and max uint32 firstIndex
         ] as const)
         .combine('instanceCount', [1, 10000]) // normal and large instanceCount
   )
   .fn(t => {
-    const { indirect, indexCount, firstIndex, instanceCount } = t.params;
+    const { indirect, indexCount, firstIndex, instanceCount, isSuccess } = t.params;
 
     const indexBuffer = t.createIndexBuffer([0, 1, 2, 3, 1, 2]);
 
@@ -163,17 +179,18 @@ g.test('out_of_bounds')
       t.drawIndexedIndirect(
         indexBuffer,
         new Uint32Array([indexCount, instanceCount, firstIndex, 0, 0]),
-        0
+        0,
+        isSuccess
       );
     } else {
-      t.drawIndexed(indexBuffer, indexCount, instanceCount, firstIndex, 0, 0);
+      t.drawIndexed(indexBuffer, indexCount, instanceCount, firstIndex, 0, 0, isSuccess);
     }
   });
 
 g.test('out_of_bounds_zero_sized_index_buffer')
   .desc(
-    `Test drawing with an empty index buffer to make sure the implementation is robust
-    with the following indexCount and firstIndex conditions
+    `Test drawing with an empty index buffer to make sure the encoder validation catch the
+    following indexCount and firstIndex conditions
     - indexCount + firstIndex is out of bound
     - indexCount is 0 but firstIndex is out of bound
     - only indexCount is out of bound
@@ -185,15 +202,15 @@ g.test('out_of_bounds_zero_sized_index_buffer')
       u
         .combine('indirect', [false, true])
         .combineWithParams([
-          { indexCount: 3, firstIndex: 1 }, // indexCount + firstIndex out of bound
-          { indexCount: 0, firstIndex: 1 }, // indexCount is 0 but firstIndex out of bound
-          { indexCount: 3, firstIndex: 0 }, // only indexCount out of bound
-          { indexCount: 0, firstIndex: 0 }, // just zeros
+          { indexCount: 3, firstIndex: 1, isSuccess: false }, // indexCount + firstIndex out of bound
+          { indexCount: 0, firstIndex: 1, isSuccess: false }, // indexCount is 0 but firstIndex out of bound
+          { indexCount: 3, firstIndex: 0, isSuccess: false }, // only indexCount out of bound
+          { indexCount: 0, firstIndex: 0, isSuccess: true }, // just zeros, valid
         ] as const)
         .combine('instanceCount', [1, 10000]) // normal and large instanceCount
   )
   .fn(t => {
-    const { indirect, indexCount, firstIndex, instanceCount } = t.params;
+    const { indirect, indexCount, firstIndex, instanceCount, isSuccess } = t.params;
 
     const indexBuffer = t.createIndexBuffer([]);
 
@@ -201,9 +218,10 @@ g.test('out_of_bounds_zero_sized_index_buffer')
       t.drawIndexedIndirect(
         indexBuffer,
         new Uint32Array([indexCount, instanceCount, firstIndex, 0, 0]),
-        0
+        0,
+        isSuccess
       );
     } else {
-      t.drawIndexed(indexBuffer, indexCount, instanceCount, firstIndex, 0, 0);
+      t.drawIndexed(indexBuffer, indexCount, instanceCount, firstIndex, 0, 0, isSuccess);
     }
   });


### PR DESCRIPTION
Change the test to expect the validation errors for index buffer OOB in DrawIndexed. Tests for DrawIndexedIndirect (indirect=true) is also included but should be skipped in WebGPUExpectation (I will upload that CL once this PR is landed), as DrawIndexedIndirect doesn't validate the index buffer range yet and thus disallowed in Dawn.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
