### PR TITLE
Fix writeBuffer in robust_access_vertex

### DIFF
--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -157,22 +157,16 @@ class DrawCall {
   // If |partialLastNumber| is true, delete one byte off the end
   private generateVertexBuffer(vertexArray: Float32Array, partialLastNumber: boolean): GPUBuffer {
     let size = vertexArray.byteLength;
+    let length = vertexArray.length;
     if (partialLastNumber) {
-      size -= 1;
+      size -= 1; // Shave off one byte from the buffer size.
+      length -= 1; // And one whole element from the writeBuffer.
     }
     const vertexBuffer = this.device.createBuffer({
       size,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
     });
-    if (partialLastNumber) {
-      size -= 3;
-    }
-    this.device.queue.writeBuffer(
-      vertexBuffer,
-      0,
-      vertexArray,
-      size / vertexArray.BYTES_PER_ELEMENT
-    );
+    this.device.queue.writeBuffer(vertexBuffer, 0, vertexArray, 0, length);
     return vertexBuffer;
   }
 


### PR DESCRIPTION
Followup to #639

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
