### PR TITLE
Update tests following changes to GPUFragmentState validation

### DIFF
--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -215,7 +215,7 @@ Test that color attachment formats in render passes or bundles match the pipelin
   )
   .fn(t => {
     const { encoderType, encoderFormat, pipelineFormat } = t.params;
-    const pipeline = t.createRenderPipeline([{ format: pipelineFormat }]);
+    const pipeline = t.createRenderPipeline([{ format: pipelineFormat, writeMask: 0 }]);
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
       attachmentInfo: { colorFormats: [encoderFormat] },
@@ -242,7 +242,9 @@ TODO: Add sparse color attachment compatibility test when defined by specificati
   )
   .fn(t => {
     const { encoderType, encoderCount, pipelineCount } = t.params;
-    const pipeline = t.createRenderPipeline(range(pipelineCount, () => ({ format: 'rgba8unorm' })));
+    const pipeline = t.createRenderPipeline(
+      range(pipelineCount, () => ({ format: 'rgba8unorm', writeMask: 0 }))
+    );
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
       attachmentInfo: { colorFormats: range(encoderCount, () => 'rgba8unorm') },
@@ -269,7 +271,7 @@ Test that the depth attachment format in render passes or bundles match the pipe
     await t.selectDeviceForTextureFormatOrSkipTestCase([encoderFormat, pipelineFormat]);
 
     const pipeline = t.createRenderPipeline(
-      [{ format: 'rgba8unorm' }],
+      [{ format: 'rgba8unorm', writeMask: 0 }],
       pipelineFormat !== undefined ? { format: pipelineFormat } : undefined
     );
 
@@ -302,7 +304,7 @@ Test that the sample count in render passes or bundles match the pipeline sample
       attachmentType === 'depthstencil' ? ('depth24plus-stencil8' as const) : undefined;
 
     const pipeline = t.createRenderPipeline(
-      colorFormats.map(format => ({ format })),
+      colorFormats.map(format => ({ format, writeMask: 0 })),
       depthStencilFormat ? { format: depthStencilFormat } : undefined,
       pipelineSampleCount
     );

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -229,7 +229,7 @@ export class ValidationTest extends GPUTest {
           code: '[[stage(fragment)]] fn main() {}',
         }),
         entryPoint: 'main',
-        targets: [{ format: 'rgba8unorm' }],
+        targets: [{ format: 'rgba8unorm', writeMask: 0 }],
       },
       primitive: { topology: 'triangle-list' },
     });


### PR DESCRIPTION
Tests that use fragment shaders that don't write to the output
must declare the color target with writeMask 0.

Spec PR: https://github.com/gpuweb/gpuweb/pull/1918
Bug: crbug.com/dawn/962





<hr>

**Author checklist for test code/plans:**

Updated tests + the Dawn patch that implements this pass.

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
