### PR TITLE
Fix WGSL usage in linear_memory:storageClass="uniform";*

### DIFF
--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -168,7 +168,7 @@ function* generateIndexableTypes({
                 kArrayLength *
                 arrayStride({
                   ...scalarInfo.layout,
-                  alignment: align(scalarInfo.layout.alignment, 16),
+                  alignment: 16,
                 })
               : kArrayLength * arrayStride(scalarInfo.layout),
         }

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -162,12 +162,25 @@ function* generateIndexableTypes({
     layout: scalarInfo.layout
       ? {
           alignment: scalarInfo.layout.alignment,
-          size: kArrayLength * arrayStride(scalarInfo.layout),
+          size:
+            storageClass === 'uniform'
+              ? // Uniform storage class must have array elements aligned to 16.
+                kArrayLength *
+                arrayStride({
+                  ...scalarInfo.layout,
+                  alignment: align(scalarInfo.layout.alignment, 16),
+                })
+              : kArrayLength * arrayStride(scalarInfo.layout),
         }
       : undefined,
   };
+
   // Sized array
-  yield { type: `array<${scalarType},${kArrayLength}>`, _typeInfo: arrayTypeInfo };
+  if (storageClass === 'uniform') {
+    yield { type: `[[stride(16)]] array<${scalarType},${kArrayLength}>`, _typeInfo: arrayTypeInfo };
+  } else {
+    yield { type: `array<${scalarType},${kArrayLength}>`, _typeInfo: arrayTypeInfo };
+  }
   // Unsized array
   if (storageClass === 'storage') {
     yield { type: `array<${scalarType}>`, _typeInfo: arrayTypeInfo };


### PR DESCRIPTION
Arrays in the uniform storage class must have elements
aligned to 16 bytes.

Bug: crbug.com/dawn/1012





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
