### PR TITLE
Fix vertex_buffer_used_multiple_times_interleaved vertex OOB error

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -890,10 +890,14 @@ g.test('vertex_buffer_used_multiple_times_interleaved')
           attributes: attribs,
         },
       ],
-      kVertexCount,
+      // Request one vertex more than what we need so we have an extra full stride. Otherwise WebGPU
+      // validation of vertex being in bounds will fail for all vertex buffers at an offset that's
+      // not 0 (since their last stride will go beyond the data for vertex kVertexCount -1).
+      kVertexCount + 1,
       kInstanceCount
     );
-    const vertexBuffer = t.createVertexBuffers(baseData, kVertexCount, kInstanceCount)[0].buffer;
+    const vertexBuffer = t.createVertexBuffers(baseData, kVertexCount + 1, kInstanceCount)[0]
+      .buffer;
 
     // Then we recreate test data by:
     //   1) creating multiple "vertex buffers" that all point at the GPUBuffer above but at


### PR DESCRIPTION
PTAL!


<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
