### PR TITLE
vertex_state,correctness: test up to maxVertexAttributes

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -88,6 +88,15 @@ class VertexStateTest extends GPUTest {
     vertexCount: number,
     instanceCount: number
   ): string {
+    // In the base WebGPU spec maxVertexAttributes is larger than maxUniformBufferPerStage. We'll
+    // use a combination of uniform and storage buffers to cover all possible attributes. This
+    // happens to work because maxUniformBuffer + maxStorageBuffer = 12 + 8 = 20 which is larger
+    // than maxVertexAttributes = 16.
+    // However this might not work in the future for implementations that allow even more vertex
+    // attributes so there will need to be larger changes when that happens.
+    const maxUniformBuffers = kPerStageBindingLimits['uniformBuf'].max;
+    assert(maxUniformBuffers + kPerStageBindingLimits['storageBuf'].max >= kMaxVertexAttributes);
+
     let vsInputs = '';
     let vsChecks = '';
     let vsBindings = '';
@@ -111,9 +120,15 @@ class VertexStateTest extends GPUTest {
           indexBuiltin = `input.instanceIndex`;
         }
 
+        // Start using storage buffers when we run out of uniform buffers.
+        let storageType = 'uniform';
+        if (i >= maxUniformBuffers) {
+          storageType = 'storage, read';
+        }
+
         vsInputs += `  [[location(${i})]] attrib${i} : ${shaderType};\n`;
         vsBindings += `[[block]] struct S${i} { data : array<vec4<${a.shaderBaseType}>, ${maxCount}>; };\n`;
-        vsBindings += `[[group(0), binding(${i})]] var<uniform> providedData${i} : S${i};\n`;
+        vsBindings += `[[group(0), binding(${i})]] var<${storageType}> providedData${i} : S${i};\n`;
 
         // Generate the all the checks for the attributes.
         for (let component = 0; component < shaderComponentCount; component++) {
@@ -511,7 +526,7 @@ struct VSOutputs {
       for (const attrib of buffer.attributes) {
         const expectedDataBuffer = this.makeBufferWithContents(
           new Uint8Array(attrib.expectedData),
-          GPUBufferUsage.UNIFORM
+          GPUBufferUsage.UNIFORM | GPUBufferUsage.STORAGE
         );
         bgEntries.push({
           binding: attrib.shaderLocation,
@@ -925,26 +940,18 @@ g.test('max_buffers_and_attribs')
   .desc(
     `Test a vertex state that loads as many attributes and buffers as possible.
   - For each format.
-  TODO find a way to test maxAttribs. Right now this test is gated on kMaxUniformBuffersPerStage
   `
   )
   .paramsSubcasesOnly(u => u.combine('format', kVertexFormats))
   .fn(t => {
     const { format } = t.params;
-    // The fixture uses one uniform buffer per attribute, so we can't test more than
-    // kMaxUniformBuffersPerStage attributes.
-    const maxTestableAttribs = Math.min(
-      kMaxVertexAttributes,
-      kPerStageBindingLimits['uniformBuf'].max
-    );
-
-    const attributesPerBuffer = Math.ceil(maxTestableAttribs / kMaxVertexBuffers);
+    const attributesPerBuffer = Math.ceil(kMaxVertexAttributes / kMaxVertexBuffers);
     let attributesEmitted = 0;
 
     const state: VertexLayoutState<{}, {}> = [];
     for (let i = 0; i < kMaxVertexBuffers; i++) {
       const attributes: GPUVertexAttribute[] = [];
-      for (let j = 0; j < attributesPerBuffer && attributesEmitted < maxTestableAttribs; j++) {
+      for (let j = 0; j < attributesPerBuffer && attributesEmitted < kMaxVertexAttributes; j++) {
         attributes.push({ format, offset: 0, shaderLocation: attributesEmitted });
         attributesEmitted++;
       }
@@ -1071,21 +1078,14 @@ g.test('discontiguous_location_and_attribs')
 g.test('overlapping_attributes')
   .desc(
     `Test that overlapping attributes in the same vertex buffer works
-   - Test for all formats
-  TODO find a way to test maxAttribs. Right now this test is gated on kMaxUniformBuffersPerStage`
+   - Test for all formats`
   )
   .paramsSubcasesOnly(u => u.combine('format', kVertexFormats))
   .fn(t => {
     const { format } = t.params;
-    // The fixture uses one uniform buffer per attribute, so we can't test more than
-    // kMaxUniformBuffersPerStage attributes.
-    const maxTestableAttribs = Math.min(
-      kMaxVertexAttributes,
-      kPerStageBindingLimits['uniformBuf'].max
-    );
 
     const attributes: GPUVertexAttribute[] = [];
-    for (let i = 0; i < maxTestableAttribs; i++) {
+    for (let i = 0; i < kMaxVertexAttributes; i++) {
       attributes.push({ format, offset: 0, shaderLocation: i });
     }
 


### PR DESCRIPTION
The tests used on uniform buffer per attribute, so they couldn't test
all attributes since maxUniformBufferPerStage < maxVertexAttributes.
Fix this by using storage buffers when we run out of uniform buffers.





<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
