### PR TITLE
Use min(4, formatSize) for vertex attrib offset alignment

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -646,19 +646,20 @@ g.test('setVertexBuffer_offset_and_attribute_offset')
       .combine('arrayStride', [128])
       .expand('offset', p => {
         const formatInfo = kVertexFormatInfo[p.format];
-        const componentSize = formatInfo.bytesPerComponent;
-        const formatSize = componentSize * formatInfo.componentCount;
-        return [
+        const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+        return new Set([
           0,
-          componentSize,
-          componentSize * 2,
-          componentSize * 3,
+          4,
+          8,
+          formatSize,
+          formatSize * 2,
           p.arrayStride / 2,
-          p.arrayStride - formatSize - componentSize * 3,
-          p.arrayStride - formatSize - componentSize * 2,
-          p.arrayStride - formatSize - componentSize,
+          p.arrayStride - formatSize - 4,
+          p.arrayStride - formatSize - 8,
+          p.arrayStride - formatSize - formatSize,
+          p.arrayStride - formatSize - formatSize * 2,
           p.arrayStride - formatSize,
-        ];
+        ]);
       })
   )
   .fn(t => {
@@ -693,21 +694,21 @@ g.test('non_zero_array_stride_and_attribute_offset')
       .beginSubcases()
       .expand('arrayStride', p => {
         const formatInfo = kVertexFormatInfo[p.format];
-        const componentSize = formatInfo.bytesPerComponent;
-        const formatSize = componentSize * formatInfo.componentCount;
+        const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
 
         return [align(formatSize, 4), align(formatSize, 4) + 4, kMaxVertexBufferArrayStride];
       })
       .expand('offset', p => {
         const formatInfo = kVertexFormatInfo[p.format];
-        const componentSize = formatInfo.bytesPerComponent;
-        const formatSize = componentSize * formatInfo.componentCount;
+        const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
         return new Set(
           [
             0,
-            componentSize,
+            formatSize,
+            4,
             p.arrayStride / 2,
-            p.arrayStride - formatSize - componentSize,
+            p.arrayStride - formatSize * 2,
+            p.arrayStride - formatSize - 4,
             p.arrayStride - formatSize,
           ].map(offset => clamp(offset, { min: 0, max: p.arrayStride - formatSize }))
         );
@@ -982,18 +983,18 @@ g.test('array_stride_zero')
       .combine('stepMode', ['vertex', 'instance'] as const)
       .expand('offset', p => {
         const formatInfo = kVertexFormatInfo[p.format];
-        const componentSize = formatInfo.bytesPerComponent;
-        const formatSize = componentSize * formatInfo.componentCount;
+        const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
         return new Set([
           0,
-          componentSize,
-          componentSize * 2,
-          componentSize * 3,
+          4,
+          8,
+          formatSize,
+          formatSize * 2,
           kMaxVertexBufferArrayStride / 2,
-          kMaxVertexBufferArrayStride - formatSize - componentSize * 3,
-          kMaxVertexBufferArrayStride - formatSize - componentSize * 2,
-          kMaxVertexBufferArrayStride - formatSize - componentSize,
+          kMaxVertexBufferArrayStride - formatSize - 4,
+          kMaxVertexBufferArrayStride - formatSize - 8,
           kMaxVertexBufferArrayStride - formatSize,
+          kMaxVertexBufferArrayStride - formatSize * 2,
         ]);
       })
   )


### PR DESCRIPTION
PTAL, will make a spec PR shortly.


<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
