### PR TITLE
New shader test: let duplication

### DIFF
--- a/src/webgpu/shader/validation/wgsl/duplicate-let-name-sibling.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-let-name-sibling.pass.wgsl
@@ -1,0 +1,13 @@
+// v-0014 - This passes because constant `a` is redeclared in a sibling scope.
+
+[[stage(fragment)]]
+fn main() {
+  if (true) {
+    let a = 1.;
+  }
+  if (true) {
+    let a = 2.;
+  }
+  return;
+}
+

--- a/src/webgpu/shader/validation/wgsl/duplicate-let-name-within-func.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-let-name-within-func.fail.wgsl
@@ -1,0 +1,11 @@
+// v-0014 - This fails because constant `a` is redeclared.
+
+[[stage(fragment)]]
+fn main() {
+  let a = 1u;
+  if (true) {
+    let a = 2u;
+  }
+  return;
+}
+


### PR DESCRIPTION
I found that I can declare `let` duplicate in Firefox and all will be ok. It should throw an error.

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
