### PR TITLE
Fix vertex shader in api,operation,rendering,depth:depth_compare_func

### DIFF
--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -83,16 +83,9 @@ g.test('depth_compare_func')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-            struct Output {
-              [[builtin(position)]] Position : vec4<f32>;
-              [[location(0)]] color : vec4<f32>;
-            };
-
             [[stage(vertex)]] fn main(
-              [[builtin(vertex_index)]] VertexIndex : u32) -> Output {
-              var output : Output;
-              output.Position = vec4<f32>(0.5, 0.5, 0.5, 1.0);
-              return output;
+              [[builtin(vertex_index)]] VertexIndex : u32) -> [[builtin(position)]] vec4<f32> {
+              return vec4<f32>(0.5, 0.5, 0.5, 1.0);
             }
             `,
         }),


### PR DESCRIPTION
This patch fixes the incorrect vertex shader in the operation test
api,operation,rendering,depth:depth_compare_func by removing an
unused vertex output which doesn't have its corresponding fragment
input.





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
