### PR TITLE
Fixing the vertex buffer robust access test

### DIFF
--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -565,10 +565,8 @@ g.test('vertex_buffer_access')
     const numVertices = 4;
     // Each buffer is bound to this many attributes (2 would mean 2 attributes per buffer)
     const attributesPerBuffer = 2;
-    // Random values to fill our buffer with to avoid collisions with other tests
-    const arbitraryValues = Array(5)
-      .fill(0)
-      .map(v => Math.ceil(Math.random() * 1024));
+    // Some arbitrary values to fill our buffer with to avoid collisions with other tests
+    const arbitraryValues = [990, 685, 446, 175];
 
     // A valid value is 0 or one in the buffer
     const validValues =

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -5,65 +5,85 @@ Test coverage:
 
 The following will be parameterized (all combinations tested):
 
-1) Draw call indexed? (false / true)
-  - Run the draw call using an index buffer
+1) Draw call type? (drawIndexed, drawIndirect, drawIndexedIndirect)
+  - Run the draw call using an index buffer and/or an indirect buffer.
+  - Direct draw will not test, as vertex buffer OOB are CPU validated and treated as validation errors.
+  - Also the instance step mode vertex buffer OOB are CPU validated for drawIndexed, so we only test
+    robustness access for vertex step mode vertex buffers.
 
-2) Draw call indirect? (false / true)
-  - Run the draw call using an indirect buffer
+2) Draw call parameter (vertexCount, firstVertex, indexCount, firstIndex, baseVertex, instanceCount,
+  firstInstance, vertexCountInIndexBuffer)
+  - The parameter which will go out of bounds. Filtered depending on the draw call type.
+  - vertexCount, firstVertex: used for drawIndirect only, test for vertex step mode buffer OOB
+  - instanceCount, firstInstance: used for both drawIndirect and drawIndexedIndirect, test for
+    instance step mode buffer OOB
+  - baseVertex, vertexCountInIndexBuffer: used for both drawIndexed and drawIndexedIndirect, test
+    for vertex step mode buffer OOB. vertexCountInIndexBuffer indicates how many vertices are used
+    within the index buffer, i.e. [0, 1, ..., vertexCountInIndexBuffer-1].
+  - indexCount, firstIndex: used for drawIndexedIndirect only, validate the vertex buffer access
+    when the vertex itself is OOB in index buffer. This won't happen in drawIndexed as we have index
+    buffer OOB CPU validation for it.
 
-3) Draw call parameter (vertexCount, firstVertex, indexCount, firstIndex, baseVertex, instanceCount,
-  firstInstance)
-  - The parameter which will go out of bounds. Filtered depending on if the draw call is indexed.
-
-4) Attribute type (float, vec2, vec3, vec4)
+3) Attribute type (float32, float32x2, float32x3, float32x4)
   - The input attribute type in the vertex shader
 
-5) Error scale (1, 4, 10^2, 10^4, 10^6)
+4) Error scale (0, 1, 4, 10^2, 10^4, 10^6)
   - Offset to add to the correct draw call parameter
+  - 0 For control case
 
-6) Additional vertex buffers (0, +4)
+5) Additional vertex buffers (0, +4)
   - Tests that no OOB occurs if more vertex buffers are used
 
-The tests will also have another vertex buffer bound for an instanced attribute, to make sure
-instanceCount / firstInstance are tested.
+6) Partial last number and offset vertex buffer (false, true)
+  - Tricky cases that make vertex buffer OOB.
+  - Partial last number will make vertex buffer 1 byte less than enough, making the last vertex OOB
+    with 1 byte.
+  - Offset vertex buffer will bind the vertex buffer to render pass with 4 bytes offset, causing OOB
+  - For drawIndexed, these two flag will be surpressed for instance step mode vertex buffer to make
+    sure it pass the CPU validation.
+
+The tests will have one instance step mode vertex buffer bound for instanced attributes, to make
+sure instanceCount / firstInstance are tested.
 
 The tests will include multiple attributes per vertex buffer.
 
-The vertex buffers will be filled by repeating a few chosen values until the end of the buffer.
+The vertex buffers will be filled by repeating a few values randomly chosen for each test until the
+end of the buffer.
 
 The test will run a render pipeline which verifies the following:
-1) All vertex attribute values occur in the buffer or are zero
+1) All vertex attribute values occur in the buffer or are 0 (for control case it can't be 0)
 2) All gl_VertexIndex values are within the index buffer or 0
 
 TODO:
 
 A suppression may be needed for d3d12 on tests that have non-zero baseVertex, since d3d12 counts
 from 0 instead of from baseVertex (will fail check for gl_VertexIndex).
-
-Vertex buffer contents could be randomized to prevent the case where a previous test creates
-a similar buffer to ours and the OOB-read seems valid. This should be deterministic, which adds
-more complexity that we may not need.`;
+`;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { assert } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
-
-export const g = makeTestGroup(GPUTest);
 
 // Encapsulates a draw call (either indexed or non-indexed)
 class DrawCall {
   private device: GPUDevice;
   private vertexBuffers: GPUBuffer[];
-  private indexBuffer: GPUBuffer;
 
   // Add a float offset when binding vertex buffer
   private offsetVertexBuffer: boolean;
+
+  // Keep instance step mode vertex buffer in range, in order to test vertex step
+  // mode buffer OOB in drawIndexed. Setting true will surpress partialLastNumber
+  // and offsetVertexBuffer for instance step mode vertex buffer.
+  private keepInstanceStepModeBufferInRange: boolean;
 
   // Draw
   public vertexCount: number;
   public firstVertex: number;
 
   // DrawIndexed
-  public indexCount: number;
+  public vertexCountInIndexBuffer: number; // For generating index buffer in drawIndexed and drawIndexedIndirect
+  public indexCount: number; // For accessing index buffer in drawIndexed and drawIndexedIndirect
   public firstIndex: number;
   public baseVertex: number;
 
@@ -76,17 +96,15 @@ class DrawCall {
     vertexArrays: Float32Array[],
     vertexCount: number,
     partialLastNumber: boolean,
-    offsetVertexBuffer: boolean
+    offsetVertexBuffer: boolean,
+    keepInstanceStepModeBufferInRange: boolean
   ) {
     this.device = device;
-    this.vertexBuffers = vertexArrays.map(v => this.generateVertexBuffer(v, partialLastNumber));
-
-    const indexArray = new Uint16Array(vertexCount).fill(0).map((_, i) => i);
-    this.indexBuffer = this.generateIndexBuffer(indexArray);
 
     // Default arguments (valid call)
     this.vertexCount = vertexCount;
     this.firstVertex = 0;
+    this.vertexCountInIndexBuffer = vertexCount;
     this.indexCount = vertexCount;
     this.firstIndex = 0;
     this.baseVertex = 0;
@@ -94,6 +112,22 @@ class DrawCall {
     this.firstInstance = 0;
 
     this.offsetVertexBuffer = offsetVertexBuffer;
+    this.keepInstanceStepModeBufferInRange = keepInstanceStepModeBufferInRange;
+
+    // Since vertexInIndexBuffer is mutable, index buffer generating should be deferred to right before calling draw
+
+    // Generate vertex buffer
+    if (keepInstanceStepModeBufferInRange) {
+      // Surpress partialLastNumber for the first vertex buffer, aka the instance step mode buffer
+      this.vertexBuffers = [
+        this.generateVertexBuffer(vertexArrays[0], false),
+        ...vertexArrays
+          .slice(1, vertexArrays.length)
+          .map(v => this.generateVertexBuffer(v, partialLastNumber)),
+      ];
+    } else {
+      this.vertexBuffers = vertexArrays.map(v => this.generateVertexBuffer(v, partialLastNumber));
+    }
   }
 
   // Insert a draw call into |pass| with specified type
@@ -121,8 +155,11 @@ class DrawCall {
 
   // Insert an indexed draw call into |pass|
   public drawIndexed(pass: GPURenderPassEncoder) {
+    // Generate index buffer
+    const indexArray = new Uint32Array(this.vertexCountInIndexBuffer).fill(0).map((_, i) => i);
+    const indexBuffer = this.generateIndexBuffer(indexArray);
     this.bindVertexBuffers(pass);
-    pass.setIndexBuffer(this.indexBuffer, 'uint16');
+    pass.setIndexBuffer(indexBuffer, 'uint32');
     pass.drawIndexed(
       this.indexCount,
       this.instanceCount,
@@ -140,15 +177,25 @@ class DrawCall {
 
   // Insert an indexed indirect draw call into |pass|
   public drawIndexedIndirect(pass: GPURenderPassEncoder) {
+    // Generate index buffer
+    const indexArray = new Uint32Array(this.vertexCountInIndexBuffer).fill(0).map((_, i) => i);
+    const indexBuffer = this.generateIndexBuffer(indexArray);
     this.bindVertexBuffers(pass);
-    pass.setIndexBuffer(this.indexBuffer, 'uint16');
+    pass.setIndexBuffer(indexBuffer, 'uint32');
     pass.drawIndexedIndirect(this.generateIndexedIndirectBuffer(), 0);
   }
 
   // Bind all vertex buffers generated
   private bindVertexBuffers(pass: GPURenderPassEncoder) {
     let currSlot = 0;
-    for (let i = 0; i < this.vertexBuffers.length; i++) {
+    // Deal with the instance step mode buffer
+    pass.setVertexBuffer(
+      currSlot++,
+      this.vertexBuffers[0],
+      !this.keepInstanceStepModeBufferInRange && this.offsetVertexBuffer ? 4 : 0
+    );
+    // Deal with the rest vertex step mode buffer
+    for (let i = 1; i < this.vertexBuffers.length; i++) {
       pass.setVertexBuffer(currSlot++, this.vertexBuffers[i], this.offsetVertexBuffer ? 4 : 0);
     }
   }
@@ -171,9 +218,11 @@ class DrawCall {
   }
 
   // Create an index buffer from |indexArray|
-  private generateIndexBuffer(indexArray: Uint16Array): GPUBuffer {
+  private generateIndexBuffer(indexArray: Uint32Array): GPUBuffer {
+    const byteLength = indexArray.byteLength;
+    assert(byteLength % 4 === 0); // Since indexArray is Uint32Array, (byteLength % 4) must be 0
     const indexBuffer = this.device.createBuffer({
-      size: indexArray.byteLength,
+      size: byteLength,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
     this.device.queue.writeBuffer(indexBuffer, 0, indexArray);
@@ -221,92 +270,99 @@ class DrawCall {
 // Parameterize different sized types
 interface VertexInfo {
   wgslType: string;
-  size: number;
+  sizeInBytes: number;
   validationFunc: string;
 }
 
 const typeInfoMap: { [k: string]: VertexInfo } = {
   float32: {
     wgslType: 'f32',
-    size: 4,
+    sizeInBytes: 4,
     validationFunc: 'return valid(v);',
   },
   float32x2: {
     wgslType: 'vec2<f32>',
-    size: 8,
+    sizeInBytes: 8,
     validationFunc: 'return valid(v.x) && valid(v.y);',
   },
   float32x3: {
     wgslType: 'vec3<f32>',
-    size: 12,
+    sizeInBytes: 12,
     validationFunc: 'return valid(v.x) && valid(v.y) && valid(v.z);',
   },
   float32x4: {
     wgslType: 'vec4<f32>',
-    size: 16,
+    sizeInBytes: 16,
     validationFunc: `return valid(v.x) && valid(v.y) && valid(v.z) && valid(v.w) ||
                             v.x == 0.0 && v.y == 0.0 && v.z == 0.0 && (v.w == 0.0 || v.w == 1.0);`,
   },
 };
 
-g.test('vertexAccess')
-  .params(u =>
-    u
-      .combine('indexed', [false, true])
-      .combine('indirect', [false, true])
-      .expand('drawCallTestParameter', p =>
-        p.indexed
-          ? (['indexCount', 'instanceCount', 'firstIndex', 'baseVertex', 'firstInstance'] as const)
-          : (['vertexCount', 'instanceCount', 'firstVertex', 'firstInstance'] as const)
-      )
-      .beginSubcases()
-      .combine('type', Object.keys(typeInfoMap))
-      .combine('additionalBuffers', [0, 4])
-      .combine('partialLastNumber', [false, true])
-      .combine('offsetVertexBuffer', [false, true])
-      .combine('errorScale', [1, 4, 10 ** 2, 10 ** 4, 10 ** 6])
-  )
-  .fn(async t => {
-    const p = t.params;
-    const typeInfo = typeInfoMap[p.type];
-
-    // Number of vertices to draw, odd so that uint16 index buffers are aligned to size 4
-    const numVertices = 4;
-    // Each buffer will be bound to this many attributes (2 would mean 2 attributes per buffer)
-    const attributesPerBuffer = 2;
+class F extends GPUTest {
+  generateBufferContents(
+    numVertices: number,
+    attributesPerBuffer: number,
+    typeInfo: VertexInfo,
+    arbitraryValues: number[],
+    bufferCount: number
+  ): Float32Array[] {
     // Make an array big enough for the vertices, attributes, and size of each element
-    const vertexArray = new Float32Array(numVertices * attributesPerBuffer * (typeInfo.size / 4));
+    const vertexArray = new Float32Array(
+      numVertices * attributesPerBuffer * (typeInfo.sizeInBytes / 4)
+    );
 
-    // Sufficiently unusual values to fill our buffer with to avoid collisions with other tests
-    const arbitraryValues = [759, 329, 908];
     for (let i = 0; i < vertexArray.length; ++i) {
       vertexArray[i] = arbitraryValues[i % arbitraryValues.length];
     }
-    // A valid value is 0 or one in the buffer
-    const validValues = [0, ...arbitraryValues];
 
-    // Instance step mode buffer, vertex step mode buffer
-    const bufferContents = [vertexArray, vertexArray];
-    // Additional buffers (vertex step mode)
-    for (let i = 0; i < p.additionalBuffers; i++) {
+    // Only the first buffer is instance step mode, all others are vertex step mode buffer
+    assert(bufferCount >= 2);
+    const bufferContents: Float32Array[] = [];
+    for (let i = 0; i < bufferCount; i++) {
       bufferContents.push(vertexArray);
     }
 
-    // Mutable draw call
-    const draw = new DrawCall(
-      t.device,
-      bufferContents,
-      numVertices,
-      p.partialLastNumber,
-      p.offsetVertexBuffer
-    );
+    return bufferContents;
+  }
 
-    // Create attributes listing
+  generateVertexBufferDescriptors(bufferCount: number, attributesPerBuffer: number, type: string) {
+    const typeInfo = typeInfoMap[type];
+    // Vertex buffer descriptors
+    const buffers: GPUVertexBufferLayout[] = [];
+    {
+      let currAttribute = 0;
+      for (let i = 0; i < bufferCount; i++) {
+        buffers.push({
+          arrayStride: attributesPerBuffer * typeInfo.sizeInBytes,
+          stepMode: i === 0 ? 'instance' : 'vertex',
+          attributes: Array(attributesPerBuffer)
+            .fill(0)
+            .map((_, i) => ({
+              shaderLocation: currAttribute++,
+              offset: i * typeInfo.sizeInBytes,
+              format: type as GPUVertexFormat,
+            })),
+        });
+      }
+    }
+    return buffers;
+  }
+
+  generateVertexShaderCode(
+    bufferCount: number,
+    attributesPerBuffer: number,
+    validValues: number[],
+    typeInfo: VertexInfo,
+    vertexIndexOffset: number,
+    numVertices: number,
+    isIndexed: boolean
+  ): string {
+    // Create layout and attributes listing
     let layoutStr = 'struct Attributes {';
     const attributeNames = [];
     {
       let currAttribute = 0;
-      for (let i = 0; i < bufferContents.length; i++) {
+      for (let i = 0; i < bufferCount; i++) {
         for (let j = 0; j < attributesPerBuffer; j++) {
           layoutStr += `[[location(${currAttribute})]] a_${currAttribute} : ${typeInfo.wgslType};\n`;
           attributeNames.push(`a_${currAttribute}`);
@@ -316,72 +372,69 @@ g.test('vertexAccess')
     }
     layoutStr += '};';
 
-    // Vertex buffer descriptors
-    const buffers: GPUVertexBufferLayout[] = [];
-    {
-      let currAttribute = 0;
-      for (let i = 0; i < bufferContents.length; i++) {
-        buffers.push({
-          arrayStride: attributesPerBuffer * typeInfo.size,
-          stepMode: i === 0 ? 'instance' : 'vertex',
-          attributes: Array(attributesPerBuffer)
-            .fill(0)
-            .map((_, i) => ({
-              shaderLocation: currAttribute++,
-              offset: i * typeInfo.size,
-              format: p.type as GPUVertexFormat,
-            })),
-        });
+    const vertexShaderCode: string = `
+      ${layoutStr}
+
+      fn valid(f : f32) -> bool {
+        return ${validValues.map(v => `f == ${v}.0`).join(' || ')};
       }
-    }
 
-    // Offset the range checks for gl_VertexIndex in the shader if we use BaseVertex
-    let vertexIndexOffset = 0;
-    if (p.drawCallTestParameter === 'baseVertex') {
-      vertexIndexOffset += p.errorScale;
-    }
+      fn validationFunc(v : ${typeInfo.wgslType}) -> bool {
+        ${typeInfo.validationFunc}
+      }
 
-    const pipeline = t.device.createRenderPipeline({
+      [[stage(vertex)]] fn main(
+        [[builtin(vertex_index)]] VertexIndex : u32,
+        attributes : Attributes
+        ) -> [[builtin(position)]] vec4<f32> {
+        var attributesInBounds : bool = ${attributeNames
+          .map(a => `validationFunc(attributes.${a})`)
+          .join(' && ')};
+        var indexInBounds : bool = VertexIndex == 0u ||
+            (VertexIndex >= ${vertexIndexOffset}u &&
+            VertexIndex < ${vertexIndexOffset + numVertices}u);
+
+        var Position : vec4<f32>;
+        if (attributesInBounds && (${!isIndexed} || indexInBounds)) {
+          // Success case, move the vertex out of the viewport
+          Position = vec4<f32>(-1.0, 0.0, 0.0, 1.0);
+        } else {
+          // Failure case, move the vertex inside the viewport
+          Position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }
+        return Position;
+      }`;
+    return vertexShaderCode;
+  }
+
+  createRenderPipeline(
+    bufferCount: number,
+    attributesPerBuffer: number,
+    validValues: number[],
+    typeInfo: VertexInfo,
+    vertexIndexOffset: number,
+    numVertices: number,
+    isIndexed: boolean,
+    buffers: GPUVertexBufferLayout[]
+  ): GPURenderPipeline {
+    const pipeline = this.device.createRenderPipeline({
       vertex: {
-        module: t.device.createShaderModule({
-          code: `
-            ${layoutStr}
-
-            fn valid(f : f32) -> bool {
-              return ${validValues.map(v => `f == ${v}.0`).join(' || ')};
-            }
-
-            fn validationFunc(v : ${typeInfo.wgslType}) -> bool {
-              ${typeInfo.validationFunc}
-            }
-
-            [[stage(vertex)]] fn main(
-              [[builtin(vertex_index)]] VertexIndex : u32,
-              attributes : Attributes
-              ) -> [[builtin(position)]] vec4<f32> {
-              var attributesInBounds : bool = ${attributeNames
-                .map(a => `validationFunc(attributes.${a})`)
-                .join(' && ')};
-              var indexInBounds : bool = VertexIndex == 0u ||
-                  (VertexIndex >= ${vertexIndexOffset}u &&
-                   VertexIndex < ${vertexIndexOffset + numVertices}u);
-
-              var Position : vec4<f32>;
-              if (attributesInBounds && (${!p.indexed} || indexInBounds)) {
-                // Success case, move the vertex out of the viewport
-                Position = vec4<f32>(-1.0, 0.0, 0.0, 1.0);
-              } else {
-                // Failure case, move the vertex inside the viewport
-                Position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
-              }
-              return Position;
-            }`,
+        module: this.device.createShaderModule({
+          code: this.generateVertexShaderCode(
+            bufferCount,
+            attributesPerBuffer,
+            validValues,
+            typeInfo,
+            vertexIndexOffset,
+            numVertices,
+            isIndexed
+          ),
         }),
         entryPoint: 'main',
         buffers,
       },
       fragment: {
-        module: t.device.createShaderModule({
+        module: this.device.createShaderModule({
           code: `
             [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
               return vec4<f32>(1.0, 0.0, 0.0, 1.0);
@@ -392,19 +445,47 @@ g.test('vertexAccess')
       },
       primitive: { topology: 'point-list' },
     });
+    return pipeline;
+  }
+
+  doTest(
+    bufferCount: number,
+    attributesPerBuffer: number,
+    dataType: string,
+    validValues: number[],
+    vertexIndexOffset: number,
+    numVertices: number,
+    isIndexed: boolean,
+    isIndirect: boolean,
+    drawCall: DrawCall
+  ): void {
+    // Vertex buffer descriptors
+    const buffers: GPUVertexBufferLayout[] = this.generateVertexBufferDescriptors(
+      bufferCount,
+      attributesPerBuffer,
+      dataType
+    );
 
     // Pipeline setup, texture setup
-    const colorAttachment = t.device.createTexture({
+    const pipeline = this.createRenderPipeline(
+      bufferCount,
+      attributesPerBuffer,
+      validValues,
+      typeInfoMap[dataType],
+      vertexIndexOffset,
+      numVertices,
+      isIndexed,
+      buffers
+    );
+
+    const colorAttachment = this.device.createTexture({
       format: 'rgba8unorm',
       size: { width: 1, height: 1, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
     const colorAttachmentView = colorAttachment.createView();
 
-    // Offset the draw call parameter we are testing by |errorScale|
-    draw[p.drawCallTestParameter] += p.errorScale;
-
-    const encoder = t.device.createCommandEncoder();
+    const encoder = this.device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
@@ -417,16 +498,109 @@ g.test('vertexAccess')
     pass.setPipeline(pipeline);
 
     // Run the draw variant
-    draw.insertInto(pass, p.indexed, p.indirect);
+    drawCall.insertInto(pass, isIndexed, isIndirect);
 
     pass.endPass();
-    t.device.queue.submit([encoder.finish()]);
+    this.device.queue.submit([encoder.finish()]);
 
     // Validate we see green instead of red, meaning no fragment ended up on-screen
-    t.expectSinglePixelIn2DTexture(
+    this.expectSinglePixelIn2DTexture(
       colorAttachment,
       'rgba8unorm',
       { x: 0, y: 0 },
       { exp: new Uint8Array([0x00, 0xff, 0x00, 0xff]), layout: { mipLevel: 0 } }
+    );
+  }
+}
+
+export const g = makeTestGroup(F);
+
+g.test('vertex_buffer_access')
+  .params(u =>
+    u
+      .combineWithParams([
+        { indexed: false, indirect: true },
+        { indexed: true, indirect: false },
+        { indexed: true, indirect: true },
+      ])
+      .expand(
+        'drawCallTestParameter',
+        p =>
+          p.indirect
+            ? p.indexed
+              ? ([
+                  'indexCount',
+                  'instanceCount',
+                  'firstIndex',
+                  'baseVertex',
+                  'firstInstance',
+                  'vertexCountInIndexBuffer',
+                ] as const) // For drawIndexedIndirect
+              : (['vertexCount', 'instanceCount', 'firstVertex', 'firstInstance'] as const) // For drawIndirected
+            : (['baseVertex', 'vertexCountInIndexBuffer'] as const) // For drawIndexed
+      )
+      .combine('type', Object.keys(typeInfoMap))
+      .combine('additionalBuffers', [0, 4])
+      .combine('partialLastNumber', [false, true])
+      .combine('offsetVertexBuffer', [false, true])
+      .combine('errorScale', [0, 1, 4, 10 ** 2, 10 ** 4, 10 ** 6])
+  )
+  .fn(async t => {
+    const p = t.params;
+    const typeInfo = typeInfoMap[p.type];
+
+    // Number of vertices to draw
+    const numVertices = 4;
+    // Each buffer will be bound to this many attributes (2 would mean 2 attributes per buffer)
+    const attributesPerBuffer = 2;
+    // Random values to fill our buffer with to avoid collisions with other tests
+    const arbitraryValues = Array(5)
+      .fill(0)
+      .map(v => Math.ceil(Math.random() * 1024));
+
+    // A valid value is 0 or one in the buffer
+    const validValues =
+      p.errorScale === 0 && !p.offsetVertexBuffer && !p.partialLastNumber
+        ? arbitraryValues // Control case with no OOB access, must read back valid values in buffer
+        : [0, ...arbitraryValues]; // Testing case with OOB access, can be 0 for OOB data
+
+    // Generate vertex buffer contents. Only the first buffer is instance step mode, all others are vertex step mode
+    const bufferCount = p.additionalBuffers + 2; // At least one instance step mode and one vertex step mode buffer
+    const bufferContents = t.generateBufferContents(
+      numVertices,
+      attributesPerBuffer,
+      typeInfo,
+      arbitraryValues,
+      bufferCount
+    );
+
+    // Mutable draw call
+    const draw = new DrawCall(
+      t.device,
+      bufferContents,
+      numVertices,
+      p.partialLastNumber,
+      p.offsetVertexBuffer,
+      p.indexed && !p.indirect // keep instance step mode buffer in range for drawIndexed
+    );
+
+    // Offset the draw call parameter we are testing by |errorScale|
+    draw[p.drawCallTestParameter] += p.errorScale;
+    // Offset the range checks for gl_VertexIndex in the shader if we use BaseVertex
+    let vertexIndexOffset = 0;
+    if (p.drawCallTestParameter === 'baseVertex') {
+      vertexIndexOffset += p.errorScale;
+    }
+
+    t.doTest(
+      bufferCount,
+      attributesPerBuffer,
+      p.type,
+      validValues,
+      vertexIndexOffset,
+      numVertices,
+      p.indexed,
+      p.indirect,
+      draw
     );
   });

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -191,15 +191,13 @@ class DrawCall {
   // Bind all vertex buffers generated
   private bindVertexBuffers(pass: GPURenderPassEncoder) {
     let currSlot = 0;
-    // Deal with the instance step mode buffer
-    pass.setVertexBuffer(
-      currSlot++,
-      this.vertexBuffers[0],
-      !this.keepInstanceStepModeBufferInRange && this.offsetVertexBuffer ? 4 : 0
-    );
-    // Deal with the rest vertex step mode buffer
-    for (let i = 1; i < this.vertexBuffers.length; i++) {
-      pass.setVertexBuffer(currSlot++, this.vertexBuffers[i], this.offsetVertexBuffer ? 4 : 0);
+    for (let i = 0; i < this.vertexBuffers.length; i++) {
+      if (i === 0 && this.keepInstanceStepModeBufferInRange) {
+        // Keep the instance step mode buffer in range
+        pass.setVertexBuffer(currSlot++, this.vertexBuffers[i], 0);
+      } else {
+        pass.setVertexBuffer(currSlot++, this.vertexBuffers[i], this.offsetVertexBuffer ? 4 : 0);
+      }
     }
   }
 


### PR DESCRIPTION
Since the behavior for vertex buffer OOB has changed for Draw and DrawIndexed, the robust acccess test should be fixed.
1. All vertex buffer OOB are validated in CPU for Draw, so it is removed from this test.
2. Instance step mode vertex buffer OOB are validated in CPU for DrawIndexed, so we only keep robust access tests of vertex step mode buffer for DrawIndexed.
3. For DrawIndirect and DrawIndexedIndirect, OOB of both step mode of vertex buffer are tested.
4. Add control cases that no OOB happens at all, and ensure that the shader read the correct data.
5. Refactor the code.

Bug: [dawn:1009](https://bugs.chromium.org/p/dawn/issues/detail?id=1009)

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
