### PR TITLE
Fix validation,image_copy,texture_related:size_alignment:*

### DIFF
--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -257,10 +257,11 @@ g.test('size_alignment')
 
     const texture = t.createAlignedTexture(format, size, origin);
 
-    assert(size.width % info.blockWidth === 0);
-    const bytesPerRow = align(size.width / info.blockWidth, 256);
-    assert(size.height % info.blockHeight === 0);
-    const rowsPerImage = size.height / info.blockHeight;
+    const bytesPerRow = align(
+      (align(size.width, info.blockWidth) / info.blockWidth) * info.bytesPerBlock,
+      256
+    );
+    const rowsPerImage = align(size.height, info.blockHeight) / info.blockHeight;
     t.testRun({ texture, origin }, { bytesPerRow, rowsPerImage }, size, {
       dataSize: 1,
       method,


### PR DESCRIPTION
This patch fixes 2 issues in the test body of
validation,image_copy,texture_related:size_alignment:* which causes
failures when testing compressed formats:
1. Removed 2 incorrect assert statements as they will be triggerred
   when success === false.
2. Correct the formula to compute bytesPerRow and rowsPerImage.





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
