### PR TITLE
Add 3 new var duplications wgsl tests

### DIFF
--- a/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope-v2.fail.wgsl
@@ -1,0 +1,9 @@
+// v-0014 - This fails because variable `i` is redeclared
+
+[[stage(fragment)]]
+fn main() {
+  for (var i: i32 = 0; i < 10; i = i + 1) {
+    var i: i32 = 1;
+  }
+  return;
+}

--- a/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope-v2.fail.wgsl
@@ -1,4 +1,4 @@
-// v-0014 - This fails because variable `i` is redeclared
+// This fails because variable `i` is redeclared
 
 [[stage(fragment)]]
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope-v3.fail.wgsl
@@ -1,0 +1,11 @@
+// v-0014 - This fails because variable `a` is redeclared.
+
+fn func(a: i32) -> i32 {
+  var a : u32 = 1u;
+  return 0;
+}
+
+[[stage(fragment)]]
+fn main() {
+  return;
+}

--- a/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope-v3.fail.wgsl
@@ -1,4 +1,4 @@
-// v-0014 - This fails because variable `a` is redeclared.
+// This fails because variable `a` is redeclared.
 
 fn func(a: i32) -> i32 {
   var a : u32 = 1u;

--- a/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope.fail.wgsl
@@ -1,0 +1,8 @@
+// v-0014 - This fails because variable `a` is redeclared.
+
+[[stage(fragment)]]
+fn main() {
+  var a : u32 = 1u;
+  var a : u32 = 2u;
+  return;
+}

--- a/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-var-in-one-scope.fail.wgsl
@@ -1,4 +1,4 @@
-// v-0014 - This fails because variable `a` is redeclared.
+// This fails because variable `a` is redeclared.
 
 [[stage(fragment)]]
 fn main() {


### PR DESCRIPTION
This is continues #669 according to [wgsl spec](https://www.w3.org/TR/WGSL/#declaration-and-scope).

This tests is passed in Chrome Canary but not in Firefox Nightly. I am tested it blindly by copy pasting, please be more careful.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
