### PR TITLE
Add type validation tests for fragment outputs and attachments

### DIFF
--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -1,12 +1,171 @@
 export const description = `
-TODO:
-- Test pipeline outputs with different color targets, depth/stencil targets.
-  - different scalar types in shader (f32, u32, i32) to targets with different format (f32 to unorm/float, u32 to uint)
-  - different componentCounts of the output doesn't matter (e.g. f32, vec2<f32>, vec3<f32>, vec4<f32>)
-    Extra components are discarded and missing components are filled to 0,0,1.
+- Test pipeline outputs with different color target formats.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { unreachable } from '../../../../common/util/util.js';
+import { kRenderableColorTextureFormats, kTextureFormatInfo } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
 
-export const g = makeTestGroup(GPUTest);
+class F extends GPUTest {
+  getExpectedTypeAndComponentCount(
+    format: GPUTextureFormat
+  ): { expectedType: GPUTextureSampleType; expectedComponentCount: number } {
+    let expectedType: GPUTextureSampleType;
+    if (format.endsWith('sint')) {
+      expectedType = 'sint';
+    } else if (format.endsWith('uint')) {
+      expectedType = 'uint';
+    } else {
+      expectedType = 'float';
+    }
+    // Only used for renderable color formats
+    let expectedComponentCount: number = 1;
+    if (format.startsWith('rgba') || format.startsWith('bgra') || format.startsWith('rgb10a2')) {
+      expectedComponentCount = 4;
+    } else if (format.startsWith('rg')) {
+      expectedComponentCount = 2;
+    } else if (format.startsWith('r')) {
+      expectedComponentCount = 1;
+    } else {
+      unreachable();
+    }
+
+    return { expectedType, expectedComponentCount };
+  }
+
+  getFragmentShaderCode(
+    v: string[],
+    sampleType: GPUTextureSampleType,
+    componentCount: number
+  ): string {
+    console.log(v);
+    let fragColorType;
+    let suffix;
+    switch (sampleType) {
+      case 'sint':
+        fragColorType = 'i32';
+        suffix = '';
+        break;
+      case 'uint':
+        fragColorType = 'u32';
+        suffix = 'u';
+        break;
+      default:
+        fragColorType = 'f32';
+        suffix = '.0';
+        break;
+    }
+
+    let outputType;
+    let result;
+    switch (componentCount) {
+      case 1:
+        outputType = fragColorType;
+        result = `${v[0]}${suffix}`;
+        break;
+      case 2:
+        outputType = `vec2<${fragColorType}>`;
+        result = `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix})`;
+        break;
+      case 3:
+        outputType = `vec3<${fragColorType}>`;
+        result = `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix})`;
+        break;
+      case 4:
+        outputType = `vec4<${fragColorType}>`;
+        result = `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix}, ${v[3]}${suffix})`;
+        break;
+      default:
+        unreachable();
+    }
+
+    return `
+    [[stage(fragment)]] fn main() -> [[location(0)]] ${outputType} {
+        return ${result};
+    }`;
+  }
+}
+
+export const g = makeTestGroup(F);
+
+g.test('color,component_count')
+  .desc(
+    `Test that extra components of the output (e.g. f32, vec2<f32>, vec3<f32>, vec4<f32>) are discarded.`
+  )
+  .params(u =>
+    u
+      .combine('format', kRenderableColorTextureFormats)
+      .beginSubcases()
+      .combine('componentCount', [1, 2, 3, 4])
+  )
+  .fn(async t => {
+    const { format, componentCount } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+    const { expectedType, expectedComponentCount } = t.getExpectedTypeAndComponentCount(format);
+
+    // expected RGBA values
+    // extra channels are discarded
+    const v = [0, 1, 0, 1];
+    if (componentCount < expectedComponentCount) {
+      t.skip('componentCount of pipeline output must not be fewer than that of target format');
+    }
+
+    const renderTarget = t.device.createTexture({
+      format,
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const pipeline = t.device.createRenderPipeline({
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+            [[stage(vertex)]] fn main(
+              [[builtin(vertex_index)]] VertexIndex : u32
+              ) -> [[builtin(position)]] vec4<f32> {
+                var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+                    vec2<f32>(-1.0, -3.0),
+                    vec2<f32>(3.0, 1.0),
+                    vec2<f32>(-1.0, 1.0));
+                return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+              }
+              `,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: t.getFragmentShaderCode(
+            v.map(n => n.toString()),
+            expectedType,
+            componentCount
+          ),
+        }),
+        entryPoint: 'main',
+        targets: [{ format }],
+      },
+      primitive: { topology: 'triangle-list' },
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          storeOp: 'store',
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        },
+      ],
+    });
+    pass.setPipeline(pipeline);
+    pass.draw(3);
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+
+    t.expectSingleColor(renderTarget, format, {
+      size: [1, 1, 1],
+      exp: { R: v[0], G: v[1], B: v[2], A: v[3] },
+    });
+  });

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -1,0 +1,7 @@
+export const description = `
+TODO:
+- Test pipeline outputs with different color targets, depth/stencil targets.
+  - different scalar types in shader (f32, u32, i32) to targets with different format (f32 to unorm/float, u32 to uint)
+  - different componentCounts of the output doesn't matter (e.g. f32, vec2<f32>, vec3<f32>, vec4<f32>)
+    Extra components are discarded and missing components are filled to 0,0,1.
+`;

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -5,3 +5,8 @@ TODO:
   - different componentCounts of the output doesn't matter (e.g. f32, vec2<f32>, vec3<f32>, vec4<f32>)
     Extra components are discarded and missing components are filled to 0,0,1.
 `;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -39,7 +39,6 @@ class F extends GPUTest {
     sampleType: GPUTextureSampleType,
     componentCount: number
   ): string {
-    console.log(v);
     let fragColorType;
     let suffix;
     switch (sampleType) {
@@ -101,16 +100,16 @@ g.test('color,component_count')
   )
   .fn(async t => {
     const { format, componentCount } = t.params;
+    const { expectedType, expectedComponentCount } = t.getExpectedTypeAndComponentCount(format);
+    if (componentCount < expectedComponentCount) {
+      t.skip('componentCount of pipeline output must not be fewer than that of target format');
+    }
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
-    const { expectedType, expectedComponentCount } = t.getExpectedTypeAndComponentCount(format);
 
     // expected RGBA values
     // extra channels are discarded
     const v = [0, 1, 0, 1];
-    if (componentCount < expectedComponentCount) {
-      t.skip('componentCount of pipeline output must not be fewer than that of target format');
-    }
 
     const renderTarget = t.device.createTexture({
       format,

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -34,17 +34,20 @@ import {
 import { ValidationTest } from './validation_test.js';
 
 class F extends ValidationTest {
+  getExpectedType(format: GPUTextureFormat): GPUTextureSampleType {
+    if (format.endsWith('sint')) {
+      return 'sint';
+    } else if (format.endsWith('uint')) {
+      return 'uint';
+    } else {
+      return 'float';
+    }
+  }
+
   getExpectedTypeAndComponentCount(
     format: GPUTextureFormat
   ): { expectedType: GPUTextureSampleType; expectedComponentCount: number } {
-    let expectedType: GPUTextureSampleType;
-    if (format.endsWith('sint')) {
-      expectedType = 'sint';
-    } else if (format.endsWith('uint')) {
-      expectedType = 'uint';
-    } else {
-      expectedType = 'float';
-    }
+    const expectedType = this.getExpectedType(format);
     // Only used for renderable color formats
     let expectedComponentCount: number = 1;
     if (format.startsWith('rgba') || format.startsWith('bgra') || format.startsWith('rgb10a2')) {

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -239,18 +239,14 @@ g.test('sample_count_must_be_valid')
     t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
   });
 
-g.test('pipeline_fragment_output_type_must_be_compatible_with_target_color_state_format')
+g.test('pipeline_output_targets')
+  .desc('Pipeline fragment output types must be compatible with target color state format')
   .params(u =>
     u
       .combine('isAsync', [false, true])
       .combine('format', kRenderableColorTextureFormats)
       .beginSubcases()
-      .combine('sampleType', [
-        'float',
-        'uint',
-        'sint',
-        'unfilterable-float',
-      ] as GPUTextureSampleType[])
+      .combine('sampleType', ['float', 'uint', 'sint'] as const)
       .combine('componentCount', [1, 2, 3, 4])
   )
   .fn(async t => {
@@ -264,8 +260,6 @@ g.test('pipeline_fragment_output_type_must_be_compatible_with_target_color_state
     });
 
     const expectedType = t.getExpectedType(format);
-    const _success =
-      expectedType === sampleType ||
-      (expectedType === 'float' && sampleType === 'unfilterable-float');
+    const _success = expectedType === sampleType;
     t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
   });

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -68,9 +68,16 @@ class F extends ValidationTest {
     };
   }
 
-  async tryRenderPass(success: boolean, descriptor: GPURenderPassDescriptor): Promise<void> {
+  async tryRenderPass(
+    success: boolean,
+    descriptor: GPURenderPassDescriptor,
+    pipeline?: GPURenderPipeline
+  ): Promise<void> {
     const commandEncoder = this.device.createCommandEncoder();
     const renderPass = commandEncoder.beginRenderPass(descriptor);
+    if (pipeline !== undefined) {
+      renderPass.setPipeline(pipeline);
+    }
     renderPass.endPass();
 
     this.expectValidationError(() => {
@@ -191,6 +198,57 @@ g.test('attachments_must_match_whether_they_are_used_for_color_or_depth_stencil'
     await t.tryRenderPass(false, descriptor);
   }
 });
+
+g.test('attachments_must_match_fragment_outputs_base_type')
+  .paramsSubcasesOnly([
+    { format: 'rgba8unorm', _success: true }, // valid
+    { format: 'rgba8unorm-srgb', _success: false },
+    { format: 'r8unorm', _success: false },
+    { format: 'bgra8unorm', _success: false },
+    { format: 'r16float', _success: false },
+    { format: 'r32uint', _success: false },
+    { format: 'rgba32float', _success: false },
+  ])
+  .fn(async t => {
+    const { format, _success } = t.params;
+
+    const pipeline = t.device.createRenderPipeline({
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+        [[stage(vertex)]] fn main(
+          [[builtin(vertex_index)]] VertexIndex : u32
+          ) -> [[builtin(position)]] vec4<f32> {
+            return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+          }
+          `,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `
+          [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+            return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+          }
+          `,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+      primitive: { topology: 'triangle-list' },
+    });
+
+    {
+      const descriptor: GPURenderPassDescriptor = {
+        colorAttachments: [
+          t.getColorAttachment(t.createTexture({ format: format as GPUTextureFormat })),
+        ],
+      };
+
+      await t.tryRenderPass(_success, descriptor, pipeline);
+    }
+  });
 
 g.test('check_layer_count_for_color_or_depth_stencil')
   .paramsSimple([

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -182,6 +182,8 @@ const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfo
 /* prettier-ignore */ export const        kDepthStencilFormats: readonly        DepthStencilFormat[] = keysOf(       kDepthStencilFormatInfo);
 /* prettier-ignore */ export const kUncompressedTextureFormats: readonly UncompressedTextureFormat[] = keysOf(kUncompressedTextureFormatInfo);
 
+/* prettier-ignore */ export const kRenderableColorTextureFormats: readonly     ColorTextureFormat[] = kColorTextureFormats.filter(v => kColorTextureFormatInfo[v].renderable);
+
 /** Per-GPUTextureFormat info. */
 // Exists just for documentation. Otherwise could be inferred by `makeTable`.
 // TODO: Refactor this to separate per-aspect data for multi-aspect formats. In particular:

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -61,83 +61,85 @@ export const kBufferUsages = numericKeysOf<GPUBufferUsageFlags>(kBufferUsageInfo
 
 // Note that we repeat the header multiple times in order to make it easier to read.
 const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
-                           ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature'] as const,
-                           [            ,              ,    true,   false,     false,          ,      true,      true,                ,            1,             1,                         ] as const, {
+                           ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature'] as const,
+                           [            ,              ,    true,   false,     false,          ,      true,      true,             ,                ,            1,             1,                         ] as const, {
   // 8-bit formats
-  'r8unorm':               [        true,          true,        ,        ,          ,     false,          ,          ,               1],
-  'r8snorm':               [       false,         false,        ,        ,          ,     false,          ,          ,               1],
-  'r8uint':                [        true,          true,        ,        ,          ,     false,          ,          ,               1],
-  'r8sint':                [        true,          true,        ,        ,          ,     false,          ,          ,               1],
+  'r8unorm':               [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               1],
+  'r8snorm':               [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               1],
+  'r8uint':                [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               1],
+  'r8sint':                [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               1],
   // 16-bit formats
-  'r16uint':               [        true,          true,        ,        ,          ,     false,          ,          ,               2],
-  'r16sint':               [        true,          true,        ,        ,          ,     false,          ,          ,               2],
-  'r16float':              [        true,          true,        ,        ,          ,     false,          ,          ,               2],
-  'rg8unorm':              [        true,          true,        ,        ,          ,     false,          ,          ,               2],
-  'rg8snorm':              [       false,         false,        ,        ,          ,     false,          ,          ,               2],
-  'rg8uint':               [        true,          true,        ,        ,          ,     false,          ,          ,               2],
-  'rg8sint':               [        true,          true,        ,        ,          ,     false,          ,          ,               2],
+  'r16uint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               2],
+  'r16sint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               2],
+  'r16float':              [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               2],
+  'rg8unorm':              [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               2],
+  'rg8snorm':              [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               2],
+  'rg8uint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               2],
+  'rg8sint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               2],
   // 32-bit formats
-  'r32uint':               [        true,          true,        ,        ,          ,      true,          ,          ,               4],
-  'r32sint':               [        true,          true,        ,        ,          ,      true,          ,          ,               4],
-  'r32float':              [        true,          true,        ,        ,          ,      true,          ,          ,               4],
-  'rg16uint':              [        true,          true,        ,        ,          ,     false,          ,          ,               4],
-  'rg16sint':              [        true,          true,        ,        ,          ,     false,          ,          ,               4],
-  'rg16float':             [        true,          true,        ,        ,          ,     false,          ,          ,               4],
-  'rgba8unorm':            [        true,          true,        ,        ,          ,      true,          ,          ,               4],
-  'rgba8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,               4],
-  'rgba8snorm':            [       false,         false,        ,        ,          ,      true,          ,          ,               4],
-  'rgba8uint':             [        true,          true,        ,        ,          ,      true,          ,          ,               4],
-  'rgba8sint':             [        true,          true,        ,        ,          ,      true,          ,          ,               4],
-  'bgra8unorm':            [        true,          true,        ,        ,          ,     false,          ,          ,               4],
-  'bgra8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,               4],
+  'r32uint':               [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               4],
+  'r32sint':               [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               4],
+  'r32float':              [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               4],
+  'rg16uint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               4],
+  'rg16sint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               4],
+  'rg16float':             [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'rgba8unorm':            [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               4],
+  'rgba8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'rgba8snorm':            [       false,         false,        ,        ,          ,      true,          ,          ,      'float',               4],
+  'rgba8uint':             [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               4],
+  'rgba8sint':             [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               4],
+  'bgra8unorm':            [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'bgra8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
   // Packed 32-bit formats
-  'rgb10a2unorm':          [        true,          true,        ,        ,          ,     false,          ,          ,               4],
-  'rg11b10ufloat':         [       false,         false,        ,        ,          ,     false,          ,          ,               4],
-  'rgb9e5ufloat':          [       false,         false,        ,        ,          ,     false,          ,          ,               4],
+  'rgb10a2unorm':          [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'rg11b10ufloat':         [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'rgb9e5ufloat':          [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               4],
   // 64-bit formats
-  'rg32uint':              [        true,          true,        ,        ,          ,      true,          ,          ,               8],
-  'rg32sint':              [        true,          true,        ,        ,          ,      true,          ,          ,               8],
-  'rg32float':             [        true,          true,        ,        ,          ,      true,          ,          ,               8],
-  'rgba16uint':            [        true,          true,        ,        ,          ,      true,          ,          ,               8],
-  'rgba16sint':            [        true,          true,        ,        ,          ,      true,          ,          ,               8],
-  'rgba16float':           [        true,          true,        ,        ,          ,      true,          ,          ,               8],
+  'rg32uint':              [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               8],
+  'rg32sint':              [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               8],
+  'rg32float':             [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               8],
+  'rgba16uint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               8],
+  'rgba16sint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               8],
+  'rgba16float':           [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               8],
   // 128-bit formats
-  'rgba32uint':            [        true,          true,        ,        ,          ,      true,          ,          ,              16],
-  'rgba32sint':            [        true,          true,        ,        ,          ,      true,          ,          ,              16],
-  'rgba32float':           [        true,          true,        ,        ,          ,      true,          ,          ,              16],
+  'rgba32uint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',              16],
+  'rgba32sint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',              16],
+  'rgba32float':           [        true,          true,        ,        ,          ,      true,          ,          ,      'float',              16],
 } as const);
 /* prettier-ignore */
-const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature'] as const;
+const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature'] as const;
 const kSizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [        true,          true,   false,        ,          ,     false,     false,     false,                ,            1,             1,                         ] as const, {
-  'depth32float':          [            ,              ,        ,    true,     false,          ,          ,          ,               4],
-  'depth16unorm':          [            ,              ,        ,    true,     false,          ,          ,          ,               2],
-  'stencil8':              [            ,              ,        ,   false,      true,          ,          ,          ,               1],
+                           [        true,          true,   false,        ,          ,     false,     false,     false,             ,                ,            1,             1,                         ] as const, {
+  'depth32float':          [            ,              ,        ,    true,     false,          ,          ,          ,      'depth',               4],
+  'depth16unorm':          [            ,              ,        ,    true,     false,          ,          ,          ,      'depth',               2],
+  'stencil8':              [            ,              ,        ,   false,      true,          ,          ,          ,       'uint',               1],
 } as const);
+
+// Multi aspect sample type are now set to their first aspect
 const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [        true,          true,   false,        ,          ,     false,     false,     false,       undefined,            1,             1,                         ] as const, {
-  'depth24plus':           [            ,              ,        ,    true,     false,          ,          ,          ],
-  'depth24plus-stencil8':  [            ,              ,        ,    true,      true,          ,          ,          ],
+                           [        true,          true,   false,        ,          ,     false,     false,     false,             ,       undefined,            1,             1,                         ] as const, {
+  'depth24plus':           [            ,              ,        ,    true,     false,          ,          ,          ,      'depth'],
+  'depth24plus-stencil8':  [            ,              ,        ,    true,      true,          ,          ,          ,      'depth'],
   // These should really be sized formats; see below TODO about multi-aspect formats.
-  'depth24unorm-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,                ,             ,              ,  'depth24unorm-stencil8'],
-  'depth32float-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,                ,             ,              ,  'depth32float-stencil8'],
+  'depth24unorm-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth24unorm-stencil8'],
+  'depth32float-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth32float-stencil8'],
 } as const);
 const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [       false,         false,    true,   false,     false,     false,      true,      true,                ,            4,             4,                         ] as const, {
-  'bc1-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,               8,            4,             4, 'texture-compression-bc'],
-  'bc1-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,               8,            4,             4, 'texture-compression-bc'],
-  'bc2-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
-  'bc2-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
-  'bc3-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
-  'bc3-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
-  'bc4-r-unorm':           [            ,              ,        ,        ,          ,          ,          ,          ,               8,            4,             4, 'texture-compression-bc'],
-  'bc4-r-snorm':           [            ,              ,        ,        ,          ,          ,          ,          ,               8,            4,             4, 'texture-compression-bc'],
-  'bc5-rg-unorm':          [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
-  'bc5-rg-snorm':          [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
-  'bc6h-rgb-ufloat':       [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
-  'bc6h-rgb-float':        [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
-  'bc7-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
-  'bc7-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,              16,            4,             4, 'texture-compression-bc'],
+                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                         ] as const, {
+  'bc1-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
+  'bc1-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
+  'bc2-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc2-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc3-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc3-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc4-r-unorm':           [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
+  'bc4-r-snorm':           [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
+  'bc5-rg-unorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc5-rg-snorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc6h-rgb-ufloat':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc6h-rgb-float':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc7-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc7-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
 } as const);
 
 // Definitions for use locally. To access the table entries, use `kTextureFormatInfo`.
@@ -183,7 +185,9 @@ const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfo
 /* prettier-ignore */ export const kUncompressedTextureFormats: readonly UncompressedTextureFormat[] = keysOf(kUncompressedTextureFormatInfo);
 
 // CompressedTextureFormat are unrenderable so filter from RegularTextureFormats for color targets is enough
-/* prettier-ignore */ export const kRenderableColorTextureFormats = kRegularTextureFormats.filter(v => kColorTextureFormatInfo[v].renderable);
+export const kRenderableColorTextureFormats = kRegularTextureFormats.filter(
+  v => kColorTextureFormatInfo[v].renderable
+);
 
 /** Per-GPUTextureFormat info. */
 // Exists just for documentation. Otherwise could be inferred by `makeTable`.

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -182,7 +182,8 @@ const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfo
 /* prettier-ignore */ export const        kDepthStencilFormats: readonly        DepthStencilFormat[] = keysOf(       kDepthStencilFormatInfo);
 /* prettier-ignore */ export const kUncompressedTextureFormats: readonly UncompressedTextureFormat[] = keysOf(kUncompressedTextureFormatInfo);
 
-/* prettier-ignore */ export const kRenderableColorTextureFormats: readonly     ColorTextureFormat[] = kColorTextureFormats.filter(v => kColorTextureFormatInfo[v].renderable);
+// CompressedTextureFormat are unrenderable so filter from RegularTextureFormats for color targets is enough
+/* prettier-ignore */ export const kRenderableColorTextureFormats = kRegularTextureFormats.filter(v => kColorTextureFormatInfo[v].renderable);
 
 /** Per-GPUTextureFormat info. */
 // Exists just for documentation. Otherwise could be inferred by `makeTable`.


### PR DESCRIPTION
https://crbug.com/dawn/811

<hr>

**Author checklist for test code/plans:**

- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
