### PR TITLE
Fix validation errors in operation,vertex_state,index_format

### DIFF
--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -57,22 +57,19 @@ class IndexFormatTest extends GPUTest {
       // TODO?: These positions will create triangles that cut right through pixel centers. If this
       // results in different rasterization results on different hardware, tweak to avoid this.
       code: `
-        let pos: array<vec2<f32>, 4> = array<vec2<f32>, 4>(
-          vec2<f32>(0.01,  0.98),
-          vec2<f32>(0.99, -0.98),
-          vec2<f32>(0.99,  0.98),
-          vec2<f32>(0.01, -0.98));
-
         [[stage(vertex)]]
         fn main([[builtin(vertex_index)]] VertexIndex : u32)
              -> [[builtin(position)]] vec4<f32> {
-          var Position : vec4<f32>;
+          var pos = array<vec2<f32>, 4>(
+            vec2<f32>(0.01,  0.98),
+            vec2<f32>(0.99, -0.98),
+            vec2<f32>(0.99,  0.98),
+            vec2<f32>(0.01, -0.98));
+
           if (VertexIndex == 0xFFFFu || VertexIndex == 0xFFFFFFFFu) {
-            Position = vec4<f32>(-0.99, -0.98, 0.0, 1.0);
-          } else {
-            Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+            return vec4<f32>(-0.99, -0.98, 0.0, 1.0);
           }
-          return Position;
+          return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
         }
       `,
     });
@@ -183,12 +180,12 @@ export const g = makeTestGroup(IndexFormatTest);
 g.test('index_format,uint16')
   .desc('Test rendering result of indexed draw with index format of uint16.')
   .paramsSubcasesOnly([
-    { indexOffset: 0, _expectedShape: kSquare },
-    { indexOffset: 6, _expectedShape: kBottomLeftTriangle },
-    { indexOffset: 18, _expectedShape: kNothing },
+    { indexOffset: 0, _indexCount: 10, _expectedShape: kSquare },
+    { indexOffset: 6, _indexCount: 6, _expectedShape: kBottomLeftTriangle },
+    { indexOffset: 18, _indexCount: 0, _expectedShape: kNothing },
   ])
   .fn(t => {
-    const { indexOffset, _expectedShape } = t.params;
+    const { indexOffset, _indexCount, _expectedShape } = t.params;
 
     // If this is written as uint16 but interpreted as uint32, it will have index 1 and 2 be both 0
     // and render nothing.
@@ -196,7 +193,7 @@ g.test('index_format,uint16')
     // list, otherwise it also render nothing.
     const indices: number[] = [1, 2, 0, 0, 0, 0, 0, 1, 3, 0];
     const indexBuffer = t.CreateIndexBuffer(indices, 'uint16');
-    const result = t.run(indexBuffer, indices.length, 'uint16', indexOffset);
+    const result = t.run(indexBuffer, _indexCount, 'uint16', indexOffset);
 
     const expectedTextureValues = t.CreateExpectedUint8Array(_expectedShape);
     t.expectGPUBufferValuesEqual(result, expectedTextureValues);
@@ -205,19 +202,19 @@ g.test('index_format,uint16')
 g.test('index_format,uint32')
   .desc('Test rendering result of indexed draw with index format of uint32.')
   .paramsSubcasesOnly([
-    { indexOffset: 0, _expectedShape: kSquare },
-    { indexOffset: 12, _expectedShape: kBottomLeftTriangle },
-    { indexOffset: 36, _expectedShape: kNothing },
+    { indexOffset: 0, _indexCount: 10, _expectedShape: kSquare },
+    { indexOffset: 12, _indexCount: 7, _expectedShape: kBottomLeftTriangle },
+    { indexOffset: 36, _indexCount: 0, _expectedShape: kNothing },
   ])
   .fn(t => {
-    const { indexOffset, _expectedShape } = t.params;
+    const { indexOffset, _indexCount, _expectedShape } = t.params;
 
     // If this is interpreted as uint16, then it would be 0, 1, 0, ... and would draw nothing.
     // And the index buffer size - offset must be not less than the size required by triangle
     // list, otherwise it also render nothing.
     const indices: number[] = [1, 2, 0, 0, 0, 0, 0, 1, 3, 0];
     const indexBuffer = t.CreateIndexBuffer(indices, 'uint32');
-    const result = t.run(indexBuffer, indices.length, 'uint32', indexOffset);
+    const result = t.run(indexBuffer, _indexCount, 'uint32', indexOffset);
 
     const expectedTextureValues = t.CreateExpectedUint8Array(_expectedShape);
     t.expectGPUBufferValuesEqual(result, expectedTextureValues);


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
