### PR TITLE
Limiting instanceCount in robust_access_vertex to 10**4

### DIFF
--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -532,28 +532,30 @@ class F extends GPUTest {
 export const g = makeTestGroup(F);
 
 g.test('vertex_buffer_access')
-  .params(u =>
-    u
-      .combineWithParams([
-        { indexed: false, indirect: true },
-        { indexed: true, indirect: false },
-        { indexed: true, indirect: true },
-      ])
-      .expand('drawCallTestParameter', function* (p) {
-        if (p.indexed) {
-          yield* ['baseVertex', 'vertexCountInIndexBuffer'] as const;
-          if (p.indirect) {
-            yield* ['indexCount', 'instanceCount', 'firstIndex'] as const;
+  .params(
+    u =>
+      u
+        .combineWithParams([
+          { indexed: false, indirect: true },
+          { indexed: true, indirect: false },
+          { indexed: true, indirect: true },
+        ])
+        .expand('drawCallTestParameter', function* (p) {
+          if (p.indexed) {
+            yield* ['baseVertex', 'vertexCountInIndexBuffer'] as const;
+            if (p.indirect) {
+              yield* ['indexCount', 'instanceCount', 'firstIndex'] as const;
+            }
+          } else if (p.indirect) {
+            yield* ['vertexCount', 'instanceCount', 'firstVertex'] as const;
           }
-        } else if (p.indirect) {
-          yield* ['vertexCount', 'instanceCount', 'firstVertex'] as const;
-        }
-      })
-      .combine('type', Object.keys(typeInfoMap) as GPUVertexFormat[])
-      .combine('additionalBuffers', [0, 4])
-      .combine('partialLastNumber', [false, true])
-      .combine('offsetVertexBuffer', [false, true])
-      .combine('errorScale', [0, 1, 4, 10 ** 2, 10 ** 4, 10 ** 6])
+        })
+        .combine('type', Object.keys(typeInfoMap) as GPUVertexFormat[])
+        .combine('additionalBuffers', [0, 4])
+        .combine('partialLastNumber', [false, true])
+        .combine('offsetVertexBuffer', [false, true])
+        .combine('errorScale', [0, 1, 4, 10 ** 2, 10 ** 4, 10 ** 6])
+        .unless(p => p.drawCallTestParameter === 'instanceCount' && p.errorScale > 10 ** 4) // To avoid timeout
   )
   .fn(async t => {
     const p = t.params;


### PR DESCRIPTION
When testing draw call with a large instanceCount in webgpu:shader,execution,robust_access_vertex:vertex_buffer_access:*, the test may go timeout, especially on Mac. Fix this issue by setting a limitation on it.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
