### PR TITLE
Add validation tests on writeTexture() with depth/stencil formats

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -3,11 +3,11 @@ copyTextureToBuffer and copyBufferToTexture validation tests not covered by
 the general image_copy tests, or by destroyed,*.
 
 TODO:
-- Move all the tests here to image_copy/ and test writeTexture() with depth/stencil formats.
+- Move all the tests here to image_copy/.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { assert } from '../../../../../common/util/util.js';
+import { assert, unreachable } from '../../../../../common/util/util.js';
 import {
   kDepthStencilFormats,
   depthStencilBufferTextureCopySupported,
@@ -39,6 +39,20 @@ class ImageCopyTest extends ValidationTest {
     encoder.copyTextureToBuffer(source, destination, copySize);
     validateFinishAndSubmit(isSuccess, true);
   }
+
+  testWriteTexture(
+    destination: GPUImageCopyTexture,
+    uploadData: Uint8Array,
+    dataLayout: GPUImageDataLayout,
+    copySize: GPUExtent3DStrict,
+    isSuccess: boolean
+  ): void {
+    this.expectGPUError(
+      'validation',
+      () => this.queue.writeTexture(destination, uploadData, dataLayout, copySize),
+      !isSuccess
+    );
+  }
 }
 
 export const g = makeTestGroup(ImageCopyTest);
@@ -46,8 +60,9 @@ export const g = makeTestGroup(ImageCopyTest);
 g.test('depth_stencil_format,copy_usage_and_aspect')
   .desc(
     `
-  Validate the combination of usage and aspect of each depth stencil format in copyBufferToTexture
-  and copyTextureToBuffer. See https://gpuweb.github.io/gpuweb/#depth-formats for more details.
+  Validate the combination of usage and aspect of each depth stencil format in copyBufferToTexture,
+  copyTextureToBuffer and writeTexture. See https://gpuweb.github.io/gpuweb/#depth-formats for more
+  details.
 `
   )
   .params(u =>
@@ -67,8 +82,9 @@ g.test('depth_stencil_format,copy_usage_and_aspect')
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
 
+    const uploadBufferSize = 32;
     const buffer = t.device.createBuffer({
-      size: 32,
+      size: uploadBufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
 
@@ -81,13 +97,28 @@ g.test('depth_stencil_format,copy_usage_and_aspect')
       const success = depthStencilBufferTextureCopySupported('CopyT2B', format, aspect);
       t.testCopyTextureToBuffer({ texture, aspect }, { buffer }, textureSize, success);
     }
+
+    {
+      const success = depthStencilBufferTextureCopySupported('WriteTexture', format, aspect);
+      const uploadData = new Uint8Array(uploadBufferSize);
+      t.testWriteTexture(
+        { texture, aspect },
+        uploadData,
+        {
+          bytesPerRow: textureSize.width,
+          rowsPerImage: textureSize.height,
+        },
+        textureSize,
+        success
+      );
+    }
   });
 
 g.test('depth_stencil_format,copy_buffer_size')
   .desc(
     `
-  Validate the minimum buffer size for each depth stencil format in copyBufferToTexture
-  and copyTextureToBuffer.
+  Validate the minimum buffer size for each depth stencil format in copyBufferToTexture,
+  copyTextureToBuffer and writeTexture.
 
   Given a depth stencil format, a copy aspect ('depth-only' or 'stencil-only'), the copy method
   (buffer-to-texture or texture-to-buffer) and the copy size, validate
@@ -100,7 +131,7 @@ g.test('depth_stencil_format,copy_buffer_size')
     u
       .combine('format', kDepthStencilFormats)
       .combine('aspect', ['depth-only', 'stencil-only'] as const)
-      .combine('copyType', ['CopyB2T', 'CopyT2B'] as const)
+      .combine('copyType', ['CopyB2T', 'CopyT2B', 'WriteTexture'] as const)
       .filter(param =>
         depthStencilBufferTextureCopySupported(param.copyType, param.format, param.aspect)
       )
@@ -124,7 +155,8 @@ g.test('depth_stencil_format,copy_buffer_size')
     const texelAspectSize = depthStencilFormatAspectSize(format, aspect);
     assert(texelAspectSize > 0);
 
-    const bytesPerRow = align(texelAspectSize * copySize.width, kBytesPerRowAlignment);
+    const bytesPerRowAlignment = copyType === 'WriteTexture' ? 1 : kBytesPerRowAlignment;
+    const bytesPerRow = align(texelAspectSize * copySize.width, bytesPerRowAlignment);
     const rowsPerImage = copySize.height;
     const minimumBufferSize =
       bytesPerRow * (rowsPerImage * copySize.depthOrArrayLayers - 1) +
@@ -153,8 +185,7 @@ g.test('depth_stencil_format,copy_buffer_size')
         copySize,
         false
       );
-    } else {
-      assert(copyType === 'CopyT2B');
+    } else if (copyType === 'CopyT2B') {
       t.testCopyTextureToBuffer(
         { texture, aspect },
         { buffer: bigEnoughBuffer, bytesPerRow, rowsPerImage },
@@ -167,6 +198,32 @@ g.test('depth_stencil_format,copy_buffer_size')
         copySize,
         false
       );
+    } else if (copyType === 'WriteTexture') {
+      const enoughUploadData = new Uint8Array(minimumBufferSize);
+      const smallerUploadData = new Uint8Array(minimumBufferSize - kBufferCopyAlignment);
+      t.testWriteTexture(
+        { texture, aspect },
+        enoughUploadData,
+        {
+          bytesPerRow,
+          rowsPerImage,
+        },
+        copySize,
+        true
+      );
+
+      t.testWriteTexture(
+        { texture, aspect },
+        smallerUploadData,
+        {
+          bytesPerRow,
+          rowsPerImage,
+        },
+        copySize,
+        false
+      );
+    } else {
+      unreachable();
     }
   });
 
@@ -174,14 +231,15 @@ g.test('depth_stencil_format,copy_buffer_offset')
   .desc(
     `
     Validate for every depth stencil formats the buffer offset must be a multiple of 4 in
-    copyBufferToTexture() and copyTextureToBuffer().
+    copyBufferToTexture() and copyTextureToBuffer(), but the offset in writeTexture() doesn't always
+    need to be a multiple of 4.
     `
   )
   .params(u =>
     u
       .combine('format', kDepthStencilFormats)
       .combine('aspect', ['depth-only', 'stencil-only'] as const)
-      .combine('copyType', ['CopyB2T', 'CopyT2B'] as const)
+      .combine('copyType', ['CopyB2T', 'CopyT2B', 'WriteTexture'] as const)
       .filter(param =>
         depthStencilBufferTextureCopySupported(param.copyType, param.format, param.aspect)
       )
@@ -203,7 +261,8 @@ g.test('depth_stencil_format,copy_buffer_offset')
     const texelAspectSize = depthStencilFormatAspectSize(format, aspect);
     assert(texelAspectSize > 0);
 
-    const bytesPerRow = align(texelAspectSize * textureSize.width, kBytesPerRowAlignment);
+    const bytesPerRowAlignment = copyType === 'WriteTexture' ? 1 : kBytesPerRowAlignment;
+    const bytesPerRow = align(texelAspectSize * textureSize.width, bytesPerRowAlignment);
     const rowsPerImage = textureSize.height;
     const minimumBufferSize =
       bytesPerRow * (rowsPerImage * textureSize.depthOrArrayLayers - 1) +
@@ -215,7 +274,7 @@ g.test('depth_stencil_format,copy_buffer_offset')
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
 
-    const isSuccess = offset % 4 === 0;
+    const isSuccess = copyType === 'WriteTexture' ? true : offset % 4 === 0;
 
     if (copyType === 'CopyB2T') {
       t.testCopyBufferToTexture(
@@ -224,13 +283,27 @@ g.test('depth_stencil_format,copy_buffer_offset')
         textureSize,
         isSuccess
       );
-    } else {
-      assert(copyType === 'CopyT2B');
+    } else if (copyType === 'CopyT2B') {
       t.testCopyTextureToBuffer(
         { texture, aspect },
         { buffer, offset, bytesPerRow, rowsPerImage },
         textureSize,
         isSuccess
       );
+    } else if (copyType === 'WriteTexture') {
+      const uploadData = new Uint8Array(minimumBufferSize + offset);
+      t.testWriteTexture(
+        { texture, aspect },
+        uploadData,
+        {
+          offset,
+          bytesPerRow,
+          rowsPerImage,
+        },
+        textureSize,
+        isSuccess
+      );
+    } else {
+      unreachable();
     }
   });

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -303,12 +303,13 @@ const kDepthStencilFormatCapabilityInBufferTextureCopy = {
  * Computes whether a copy between a depth/stencil texture aspect and a buffer is supported, by spec.
  */
 export function depthStencilBufferTextureCopySupported(
-  type: 'CopyB2T' | 'CopyT2B',
+  type: 'CopyB2T' | 'CopyT2B' | 'WriteTexture',
   format: DepthStencilFormat,
   aspect: GPUTextureAspect
 ): boolean {
+  const appliedType = type === 'WriteTexture' ? 'CopyB2T' : type;
   const supportedAspects: readonly GPUTextureAspect[] =
-    kDepthStencilFormatCapabilityInBufferTextureCopy[format][type];
+    kDepthStencilFormatCapabilityInBufferTextureCopy[format][appliedType];
   return supportedAspects.includes(aspect);
 }
 


### PR DESCRIPTION





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
