### PR TITLE
port startPlayingAndWaitForVideo from WebGL CTS

### DIFF
--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -62,6 +62,7 @@ Whenever a new generally-useful helper is added, it should be indexed here.
 - {@link webgpu/util/texture/subresource}: Helpers for working with texture subresource ranges.
 - {@link webgpu/util/texture/texel_data}: Helpers encoding/decoding texel formats.
 - {@link webgpu/shader/types}: Helpers for WGSL data types.
+- {@link webgpu/web_platform/util}: Helpers for web platform features (e.g. video elements).
 
 ### General Helpers
 

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -1,0 +1,59 @@
+import { raceWithRejectOnTimeout } from '../../common/util/util.js';
+
+/**
+ * Starts playing a video and waits for it to be consumable.
+ * Promise resolves after the callback has been called.
+ *
+ * @param video An HTML5 Video element.
+ * @param callback Function to call when video is ready.
+ *
+ * Copied from https://github.com/KhronosGroup/WebGL/blob/main/sdk/tests/js/webgl-test-utils.js
+ */
+export function startPlayingAndWaitForVideo(
+  video: HTMLVideoElement,
+  callback: () => void
+): Promise<void> {
+  return raceWithRejectOnTimeout(
+    new Promise((resolve, reject) => {
+      const callbackAndResolve = () => {
+        callback();
+        resolve();
+      };
+
+      if (video.error) {
+        reject(new Error('Video failed to load: ' + video.error));
+        return;
+      }
+
+      video.addEventListener(
+        'error',
+        e => reject(new Error('Video playback failed: ' + e.message)),
+        true
+      );
+
+      if ('requestVideoFrameCallback' in video) {
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        (video as any).requestVideoFrameCallback(() => {
+          callbackAndResolve();
+        });
+      } else {
+        // If requestVideoFrameCallback isn't available, check each frame if the video has advanced.
+        const timeWatcher = () => {
+          if (video.currentTime > 0) {
+            callbackAndResolve();
+          } else {
+            requestAnimationFrame(timeWatcher);
+          }
+        };
+        timeWatcher();
+      }
+
+      video.loop = true;
+      video.muted = true;
+      video.preload = 'auto';
+      video.play();
+    }),
+    2000,
+    'Video never became ready'
+  );
+}


### PR DESCRIPTION
Tested by modifying #675 and it still works.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
