### PR TITLE
Add support for resources/ directory

### DIFF
--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -65,6 +65,7 @@ Whenever a new generally-useful helper is added, it should be indexed here.
 
 ### General Helpers
 
+- {@link common/framework/resources}: Provides the path to the `resources/` directory.
 - {@link common/util/util}: Miscellaneous utilities.
     - {@link common/util/util.assert | assert}: Assert a condition, otherwise throw an exception.
     - {@link common/util/util.unreachable | unreachable}: Assert unreachable code.

--- a/src/common/framework/resources.ts
+++ b/src/common/framework/resources.ts
@@ -1,0 +1,22 @@
+/**
+ * Base path for resources. The default value is correct for non-worker WPT, but standalone and
+ * workers must access resources using a different base path, so tihs is overridden in
+ * `test_worker-worker.ts` and `standalone.ts`.
+ */
+let baseResourcePath = './resources';
+
+/**
+ * Get a path to a resource in the `resources` directory, relative to the current execution context
+ * (html file or worker .js file), for `fetch()`, `<img>`, `<video>`, etc.
+ */
+export function getResourcePath(pathRelativeToResourcesDir: string) {
+  return baseResourcePath + '/' + pathRelativeToResourcesDir;
+}
+
+/**
+ * Set the base resource path (path to the `resources` directory relative to the current
+ * execution context).
+ */
+export function setBaseResourcePath(path: string) {
+  baseResourcePath = path;
+}

--- a/src/common/runtime/helper/test_worker-worker.ts
+++ b/src/common/runtime/helper/test_worker-worker.ts
@@ -1,3 +1,4 @@
+import { setBaseResourcePath } from '../../framework/resources.js';
 import { DefaultTestFileLoader } from '../../internal/file_loader.js';
 import { Logger } from '../../internal/logging/logger.js';
 import { parseQuery } from '../../internal/query/parseQuery.js';
@@ -9,6 +10,8 @@ import { assert } from '../../util/util.js';
 declare const self: any;
 
 const loader = new DefaultTestFileLoader();
+
+setBaseResourcePath('../../../resources');
 
 self.onmessage = async (ev: MessageEvent) => {
   const query: string = ev.data.query;

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -1,5 +1,6 @@
 // Implements the standalone test runner (see also: /standalone/index.html).
 
+import { setBaseResourcePath } from '../framework/resources.js';
 import { DefaultTestFileLoader } from '../internal/file_loader.js';
 import { Logger } from '../internal/logging/logger.js';
 import { LiveTestCaseResult } from '../internal/logging/result.js';
@@ -23,6 +24,8 @@ const debug = optionEnabled('debug');
 
 Logger.globalDebugMode = debug;
 const logger = new Logger();
+
+setBaseResourcePath('../out/resources');
 
 const worker = optionEnabled('worker') ? new TestWorker(debug) : undefined;
 

--- a/src/resources/README.md
+++ b/src/resources/README.md
@@ -1,0 +1,2 @@
+Always use `getResourcePath()` to get the appropriate path to these resources depending
+on the context (WPT, standalone, worker, etc.)

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -2,6 +2,7 @@ export const description = `
 copyExternalImageToTexture Validation Tests in Queue.
 `;
 
+import { getResourcePath } from '../../../../../common/framework/resources.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { raceWithRejectOnTimeout, unreachable, assert } from '../../../../../common/util/util.js';
 import {
@@ -305,7 +306,7 @@ g.test('source_image,crossOrigin')
     const { sourceImage, isOriginClean, contentFrom, copySize } = t.params;
 
     const crossOriginUrl = 'https://get.webgl.org/conformance-resources/opengl_logo.jpg';
-    const originCleanUrl = '../out/resources/Di-3d.png';
+    const originCleanUrl = getResourcePath('Di-3d.png');
 
     const img = document.createElement('img');
     img.src = isOriginClean ? originCleanUrl : crossOriginUrl;


### PR DESCRIPTION
I haven't actually tested this in a real WPT setup, but I'm pretty sure this sets the paths correctly.


<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
