### PR TITLE
Add tests for behavior on lost devices

### DIFF
--- a/src/manual/README.txt
+++ b/src/manual/README.txt
@@ -2,7 +2,7 @@ WebGPU tests that require manual intervention.
 
 Many of these test may be HTML pages rather than using the harness.
 
-Add informal notes here on possible stress tests.
+Add informal notes here on possible manual tests.
 
 - Suspending or hibernating the machine.
 - Manually crashing or relaunching the browser's GPU process.

--- a/src/manual/device_lost.spec.ts
+++ b/src/manual/device_lost.spec.ts
@@ -1,0 +1,30 @@
+export const description = `
+Tests of behavior while the device is lost.
+
+- x= every method in the API.
+
+TODO: implement
+`;
+
+import { Fixture } from '../common/framework/fixture.js';
+import { makeTestGroup } from '../common/framework/test_group.js';
+import { runDeviceLossTests } from '../webgpu/api/validation/state/device_lost.js';
+
+export const g = makeTestGroup(Fixture);
+
+g.test('no_crash')
+  .desc(
+    `Test doing a bunch of operations after the GPU process is manually terminated.
+
+This effectively only tests is that there are no crashes. It's not actually possible to
+check for validation errors: once a device is lost, it can't _track_ validation errors
+(popErrorScope throws an exception).`
+  )
+  .params(u => u.combine('lost', [false, true]))
+  .fn(async t => {
+    const { lost } = t.params;
+
+    await runDeviceLossTests(() => {
+      if (lost) alert('Please terminate the GPU process manually');
+    });
+  });

--- a/src/manual/listing.ts
+++ b/src/manual/listing.ts
@@ -1,0 +1,5 @@
+/* eslint-disable import/no-restricted-paths */
+import { TestSuiteListing } from '../common/internal/test_suite_listing.js';
+import { makeListing } from '../common/tools/crawl.js';
+
+export const listing: Promise<TestSuiteListing> = makeListing(__filename);

--- a/src/webgpu/api/validation/state/device_lost.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost.spec.ts
@@ -1,0 +1,30 @@
+export const description = `
+Tests of behavior while the device is lost.
+
+- x= every method in the API.
+
+TODO: implement
+`;
+
+import { Fixture } from '../../../../common/framework/fixture.js';
+import { makeTestGroup } from '../../../../common/internal/test_group.js';
+import { runDeviceLossTests } from './device_lost.js';
+
+export const g = makeTestGroup(Fixture);
+
+g.test('no_crash')
+  .desc(
+    `Test doing a bunch of operations after device.destroy() is called.
+
+This effectively only tests is that there are no crashes. It's not actually possible to
+check for validation errors: once a device is lost, it can't _track_ validation errors
+(popErrorScope throws an exception).`
+  )
+  .params(u => u.combine('lost', [false, true]))
+  .fn(async t => {
+    const { lost } = t.params;
+
+    await runDeviceLossTests(device => {
+      if (lost) device.destroy();
+    });
+  });

--- a/src/webgpu/api/validation/state/device_lost.ts
+++ b/src/webgpu/api/validation/state/device_lost.ts
@@ -1,0 +1,24 @@
+import { assert } from '../../../../common/util/util.js';
+import { getGPU } from '../../../util/navigator_gpu.js';
+
+/**
+ * Run the device loss tests. This function is used in device_lost validation tests as well as
+ * device_lost manual tests (where the gpu process is crashed manually).
+ */
+export async function runDeviceLossTests(loseDevice: (device: GPUDevice) => void) {
+    const adapter = await getGPU().requestAdapter();
+    assert(adapter !== null);
+    const device = await adapter.requestDevice();
+
+    const tests = [];
+    {
+      const cmdbuf = device.createCommandEncoder().finish();
+      tests.push(() => {
+        device.queue.submit([cmdbuf]);
+      });
+    }
+
+    loseDevice(device);
+
+    await Promise.all(tests.map(post => post()));
+}

--- a/src/webgpu/api/validation/state/device_lost/README.txt
+++ b/src/webgpu/api/validation/state/device_lost/README.txt
@@ -1,5 +1,1 @@
-Tests of behavior while the device is lost.
-
-- x= every method in the API.
-
-TODO: implement
+FIXME


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
