### PR TITLE
Add operation tests on T2B copies with stencil aspects

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -703,6 +703,75 @@ class ImageCopyTest extends GPUTest {
     );
   }
 
+  async DoCopyFromStencilTest(
+    format: DepthStencilFormat,
+    textureSize: readonly [number, number, number],
+    bytesPerRow: number,
+    rowsPerImage: number,
+    offset: number,
+    mipLevel: number
+  ): Promise<void> {
+    const srcTexture = this.device.createTexture({
+      size: textureSize,
+      usage:
+        GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+      format,
+      mipLevelCount: mipLevel + 1,
+    });
+
+    // Initialize srcTexture with queue.writeTexture()
+    const copySize = [textureSize[0] >> mipLevel, textureSize[1] >> mipLevel, textureSize[2]];
+    const initialData = this.generateData(
+      align(copySize[0] * copySize[1] * copySize[2], kBufferSizeAlignment)
+    );
+    this.queue.writeTexture(
+      { texture: srcTexture, aspect: 'stencil-only', mipLevel },
+      initialData,
+      { bytesPerRow: copySize[0], rowsPerImage: copySize[1] },
+      copySize
+    );
+
+    // Copy the stencil aspect from srcTexture into outputBuffer.
+    const outputBufferSize = align(
+      offset +
+        dataBytesForCopyOrFail({
+          layout: { bytesPerRow, rowsPerImage },
+          format: 'stencil8',
+          copySize,
+          method: 'CopyT2B',
+        }),
+      kBufferSizeAlignment
+    );
+    const outputBuffer = this.device.createBuffer({
+      size: outputBufferSize,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+    const encoder = this.device.createCommandEncoder();
+    encoder.copyTextureToBuffer(
+      { texture: srcTexture, aspect: 'stencil-only', mipLevel },
+      { buffer: outputBuffer, offset, bytesPerRow, rowsPerImage },
+      copySize
+    );
+    this.queue.submit([encoder.finish()]);
+
+    // Validate the data in outputBuffer is what we expect.
+    const expectedData = new Uint8Array(outputBufferSize);
+    for (let z = 0; z < copySize[2]; ++z) {
+      const baseExpectedOffset = offset + z * bytesPerRow * rowsPerImage;
+      const baseInitialiDataOffset = z * copySize[0] * copySize[1];
+      for (let y = 0; y < copySize[1]; ++y) {
+        expectedData.set(
+          initialData.slice(
+            baseInitialiDataOffset + y * copySize[0],
+            baseInitialiDataOffset + (y + 1) * copySize[0]
+          ),
+          baseExpectedOffset + y * bytesPerRow
+        );
+      }
+    }
+    this.expectGPUBufferValuesEqual(outputBuffer, expectedData);
+  }
+
   // TODO(crbug.com/dawn/868): Revisit this when consolidating texture helpers.
   async checkStencilTextureContent(
     stencilTexture: GPUTexture,
@@ -1405,26 +1474,11 @@ g.test('undefined_params')
     });
   });
 
-g.test('copy_from_stencil_aspect')
-  .desc(
-    `
-  Validate the correctness of copyTextureToBuffer() with stencil aspect.
-
-  For all the texture formats with stencil aspect:
-  - Initialize the source texture with the stencil comparison function "always" and the stencil
-    operation "replace" in a render pass encoder
-  - Copy the stencil aspect of the source texture into the destination buffer
-  - Check if the data in the destination buffer is expected
-  - Test the copies from / into zero / non-zero array layer / mipmap levels
-  - Test copying multiple array layers
-  `
-  )
-  .unimplemented();
-
-g.test('rowsPerImage_and_bytesPerRow_upload_to_stencil_aspect')
+g.test('rowsPerImage_and_bytesPerRow_copy_with_stencil_aspect')
   .desc(
     `Test that copying data with various bytesPerRow and rowsPerImage values and minimum required
-bytes in copy works for copyBufferToTexture() and writeTexture() with stencil aspect.
+bytes in copy works for copyBufferToTexture(), copyTextureToBuffer() and writeTexture() with stencil
+aspect.
 
   Covers a special code path for Metal:
     bufferSize - offset < bytesPerImage * copyExtent.depthOrArrayLayers
@@ -1440,7 +1494,7 @@ bytes in copy works for copyBufferToTexture() and writeTexture() with stencil as
       .filter(t => {
         return kTextureFormatInfo[t.stencilFormat].stencil;
       })
-      .combine('uploadMethod', ['WriteTexture', 'CopyB2T'] as const)
+      .combine('copyMethod', ['WriteTexture', 'CopyB2T', 'CopyT2B'] as const)
       .beginSubcases()
       .combineWithParams(kRowsPerImageAndBytesPerRowParams.paddings)
       .combineWithParams(kRowsPerImageAndBytesPerRowParams.copySizes)
@@ -1452,7 +1506,7 @@ bytes in copy works for copyBufferToTexture() and writeTexture() with stencil as
   .fn(async t => {
     const {
       stencilFormat,
-      uploadMethod,
+      copyMethod,
       bytesPerRowPadding,
       rowsPerImagePadding,
       copyWidthInBlocks,
@@ -1468,34 +1522,47 @@ bytes in copy works for copyBufferToTexture() and writeTexture() with stencil as
     const copyHeight = copyHeightInBlocks * info.blockHeight;
     const rowsPerImage = copyHeightInBlocks + rowsPerImagePadding;
 
-    const bytesPerRowAlignment = uploadMethod === 'WriteTexture' ? 1 : kBytesPerRowAlignment;
+    const bytesPerRowAlignment = copyMethod === 'WriteTexture' ? 1 : kBytesPerRowAlignment;
     const bytesPerRow =
       align(info.bytesPerBlock * copyWidthInBlocks, bytesPerRowAlignment) +
       bytesPerRowPadding * bytesPerRowAlignment;
-    const initialDataSize = dataBytesForCopyOrFail({
-      layout: { bytesPerRow, rowsPerImage },
-      format: 'stencil8',
-      copySize: { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },
-      method: uploadMethod,
-    });
 
     const textureSize = [copyWidth << mipLevel, copyHeight << mipLevel, copyDepth] as const;
-    await t.DoUploadToStencilTest(
-      stencilFormat,
-      textureSize,
-      uploadMethod,
-      bytesPerRow,
-      rowsPerImage,
-      initialDataSize,
-      0,
-      mipLevel
-    );
+    if (copyMethod === 'CopyT2B') {
+      await t.DoCopyFromStencilTest(
+        stencilFormat,
+        textureSize,
+        bytesPerRow,
+        rowsPerImage,
+        0,
+        mipLevel
+      );
+    } else {
+      assert(copyMethod === 'CopyB2T' || copyMethod === 'WriteTexture');
+      const initialDataSize = dataBytesForCopyOrFail({
+        layout: { bytesPerRow, rowsPerImage },
+        format: 'stencil8',
+        copySize: { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },
+        method: copyMethod,
+      });
+
+      await t.DoUploadToStencilTest(
+        stencilFormat,
+        textureSize,
+        copyMethod,
+        bytesPerRow,
+        rowsPerImage,
+        initialDataSize,
+        0,
+        mipLevel
+      );
+    }
   });
 
-g.test('offsets_and_sizes_upload_to_stencil_aspect')
+g.test('offsets_and_sizes_copy_with_stencil_aspect')
   .desc(
     `Test that copying data with various offset values and additional data paddings
-works for copyBufferToTexture() and writeTexture() with stencil aspect.
+works for copyBufferToTexture(), copyTextureToBfufer() and writeTexture() with stencil aspect.
 
   Covers two special code paths for D3D12:
     offset + bytesInCopyExtentPerRow { ==, > } bytesPerRow
@@ -1508,7 +1575,7 @@ works for copyBufferToTexture() and writeTexture() with stencil aspect.
       .filter(t => {
         return kTextureFormatInfo[t.stencilFormat].stencil;
       })
-      .combine('uploadMethod', ['WriteTexture', 'CopyB2T'] as const)
+      .combine('copyMethod', ['WriteTexture', 'CopyB2T', 'CopyT2B'] as const)
       .beginSubcases()
       .combineWithParams(kOffsetsAndSizesParams.offsetsAndPaddings)
       .filter(t => t.offsetInBlocks % 4 === 0)
@@ -1518,7 +1585,7 @@ works for copyBufferToTexture() and writeTexture() with stencil aspect.
   .fn(async t => {
     const {
       stencilFormat,
-      uploadMethod,
+      copyMethod,
       offsetInBlocks,
       dataPaddingInBytes,
       copyDepth,
@@ -1532,23 +1599,34 @@ works for copyBufferToTexture() and writeTexture() with stencil aspect.
     const rowsPerImage = 3;
     const bytesPerRow = 256;
 
-    const minDataSize = dataBytesForCopyOrFail({
-      layout: { offset: initialDataOffset, bytesPerRow, rowsPerImage },
-      format: 'stencil8',
-      copySize,
-      method: uploadMethod,
-    });
-    const initialDataSize = minDataSize + dataPaddingInBytes;
-
     const textureSize = [copySize[0] << mipLevel, copySize[1] << mipLevel, copyDepth] as const;
-    await t.DoUploadToStencilTest(
-      stencilFormat,
-      textureSize,
-      uploadMethod,
-      bytesPerRow,
-      rowsPerImage,
-      initialDataSize,
-      initialDataOffset,
-      mipLevel
-    );
+    if (copyMethod === 'CopyT2B') {
+      await t.DoCopyFromStencilTest(
+        stencilFormat,
+        textureSize,
+        bytesPerRow,
+        rowsPerImage,
+        initialDataOffset,
+        mipLevel
+      );
+    } else {
+      assert(copyMethod === 'CopyB2T' || copyMethod === 'WriteTexture');
+      const minDataSize = dataBytesForCopyOrFail({
+        layout: { offset: initialDataOffset, bytesPerRow, rowsPerImage },
+        format: 'stencil8',
+        copySize,
+        method: copyMethod,
+      });
+      const initialDataSize = minDataSize + dataPaddingInBytes;
+      await t.DoUploadToStencilTest(
+        stencilFormat,
+        textureSize,
+        copyMethod,
+        bytesPerRow,
+        rowsPerImage,
+        initialDataSize,
+        initialDataOffset,
+        mipLevel
+      );
+    }
   });

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -745,12 +745,13 @@ class ImageCopyTest extends GPUTest {
       const baseExpectedOffset = offset + z * bytesPerRow * rowsPerImage;
       const baseInitialiDataOffset = z * copySize[0] * copySize[1];
       for (let y = 0; y < copySize[1]; ++y) {
-        expectedData.set(
-          initialData.slice(
-            baseInitialiDataOffset + y * copySize[0],
-            baseInitialiDataOffset + (y + 1) * copySize[0]
-          ),
-          baseExpectedOffset + y * bytesPerRow
+        memcpy(
+          {
+            src: initialData,
+            start: baseInitialiDataOffset + y * copySize[0],
+            length: copySize[0],
+          },
+          { dst: expectedData, start: baseExpectedOffset + y * bytesPerRow }
         );
       }
     }


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
