### PR TITLE
Add refttests for different size of canvas and swapchain

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html
@@ -14,7 +14,8 @@
   <canvas id="cvs_smaller_than_back_buffer" width="3" height="4"></canvas>
   <canvas id="cvs_change_size_after_configure" width="3" height="4"></canvas>
   <canvas id="cvs_change_size_and_reconfigure" width="3" height="4"></canvas>
-  <canvas id="cvs_back_buffer_css_different_size" width="6" height="8" style="width: 12px; height: 16px;"></canvas>
+  <canvas id="back_buffer_smaller_than_cvs_and_css" width="6" height="8" style="width: 12px; height: 16px;"></canvas>
+  <canvas id="cvs_smaller_than_back_buffer_and_css" width="3" height="4" style="width: 12px; height: 16px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
     import { run } from './canvas_size_different_with_back_buffer_size.html.js';

--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html
@@ -1,0 +1,20 @@
+<html class="reftest-wait">
+  <title>WebGPU canvas_back_buffer_different_size</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta
+    name=fuzzy
+    content="128;48"
+  />
+  <link rel="match" 
+        href="./ref/canvas_size_different_with_back_buffer_size-ref.html" />
+
+  <canvas id="cvs_larger_than_back_buffer" width="6" height="8"></canvas>
+  <canvas id="cvs_same_as_back_buffer" width="3" height="4"></canvas>
+  <canvas id="cvs_smaller_than_back_buffer" width="3" height="4"></canvas>
+  <script src="/common/reftest-wait.js"></script>
+  <script type="module">
+    import { run } from './canvas_size_different_with_back_buffer_size.html.js';
+    run();
+  </script>
+</html>

--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html
@@ -3,8 +3,8 @@
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta
-    name=fuzzy
-    content="128;48"
+    name="assert"
+    content="WebGPU canvas should present correctly with different size of back buffer"
   />
   <link rel="match" 
         href="./ref/canvas_size_different_with_back_buffer_size-ref.html" />
@@ -12,6 +12,9 @@
   <canvas id="cvs_larger_than_back_buffer" width="6" height="8"></canvas>
   <canvas id="cvs_same_as_back_buffer" width="3" height="4"></canvas>
   <canvas id="cvs_smaller_than_back_buffer" width="3" height="4"></canvas>
+  <canvas id="cvs_change_size_after_configure" width="3" height="4"></canvas>
+  <canvas id="cvs_change_size_and_reconfigure" width="3" height="4"></canvas>
+  <canvas id="cvs_back_buffer_css_different_size" width="6" height="8" style="width: 12px; height: 16px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
     import { run } from './canvas_size_different_with_back_buffer_size.html.js';

--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html.ts
@@ -203,7 +203,7 @@ export function run() {
         [back_buffer_width, back_buffer_height],
         [
           [red, red, red, red, green, green],
-          [red, red, red, red, green, green],
+          [red, red, green, red, green, green],
           [red, red, red, red, green, green],
           [red, red, red, red, green, green],
           [blue, blue, blue, blue, yellow, yellow],

--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html.ts
@@ -1,0 +1,208 @@
+import { assert } from '../../../common/util/util.js';
+
+import { runRefTest } from './gpu_ref_test.js';
+
+// <canvas> element from html page
+declare const cvs_larger_than_back_buffer: HTMLCanvasElement;
+declare const cvs_same_as_back_buffer: HTMLCanvasElement;
+declare const cvs_smaller_than_back_buffer: HTMLCanvasElement;
+
+export function run() {
+  runRefTest(async t => {
+    const red = new Uint8Array([0x00, 0x00, 0xff, 0xff]);
+    const green = new Uint8Array([0x00, 0xff, 0x00, 0xff]);
+    const blue = new Uint8Array([0xff, 0x00, 0x00, 0xff]);
+    const yellow = new Uint8Array([0x00, 0xff, 0xff, 0xff]);
+
+    {
+      const ctx = cvs_larger_than_back_buffer.getContext('gpupresent');
+      assert(ctx !== null);
+      const width = cvs_larger_than_back_buffer.width / 2;
+      const height = cvs_larger_than_back_buffer.height / 2;
+      ctx.configure({
+        device: t.device,
+        format: 'bgra8unorm',
+        usage: GPUTextureUsage.COPY_DST,
+        size: [width, height, 1], // half of the canvas width and height.
+      });
+
+      const rows = height;
+      const bytesPerRow = 256;
+      const buffer = t.device.createBuffer({
+        mappedAtCreation: true,
+        size: rows * bytesPerRow,
+        usage: GPUBufferUsage.COPY_SRC,
+      });
+      const mapping = buffer.getMappedRange();
+      const data = new Uint8Array(mapping);
+      // 1st row
+      data.set(red, 0);
+      data.set(red, 4);
+      data.set(green, 8);
+
+      // 2nd row
+      data.set(red, 256 + 0);
+      data.set(red, 256 + 4);
+      data.set(green, 256 + 8);
+
+      // 3rd row
+      data.set(blue, 256 * 2 + 0);
+      data.set(blue, 256 * 2 + 4);
+      data.set(yellow, 256 * 2 + 8);
+
+      // 4th row
+      data.set(blue, 256 * 3 + 0);
+      data.set(blue, 256 * 3 + 4);
+      data.set(yellow, 256 * 3 + 8);
+      buffer.unmap();
+
+      const texture = ctx.getCurrentTexture();
+
+      const encoder = t.device.createCommandEncoder();
+      encoder.copyBufferToTexture({ buffer, bytesPerRow }, { texture }, [width, height, 1]);
+      t.device.queue.submit([encoder.finish()]);
+      await t.device.queue.onSubmittedWorkDone();
+    }
+
+    {
+      const ctx = cvs_same_as_back_buffer.getContext('gpupresent');
+      assert(ctx !== null);
+      ctx.configure({
+        device: t.device,
+        format: 'bgra8unorm',
+        usage: GPUTextureUsage.COPY_DST,
+      });
+
+      const rows = cvs_same_as_back_buffer.height;
+      const bytesPerRow = 256;
+      const buffer = t.device.createBuffer({
+        mappedAtCreation: true,
+        size: rows * bytesPerRow,
+        usage: GPUBufferUsage.COPY_SRC,
+      });
+      const mapping = buffer.getMappedRange();
+      const data = new Uint8Array(mapping);
+      // 1st row
+      data.set(red, 0); // red
+      data.set(red, 4); // red
+      data.set(green, 8); // green
+
+      // 2nd row
+      data.set(red, 256 + 0); // red
+      data.set(red, 256 + 4); // red
+      data.set(green, 256 + 8); // blue
+
+      // 3rd row
+      data.set(blue, 256 * 2 + 0); // blue
+      data.set(blue, 256 * 2 + 4); // blue
+      data.set(yellow, 256 * 2 + 8); // red
+
+      // 4th row
+      data.set(blue, 256 * 3 + 0); // blue
+      data.set(blue, 256 * 3 + 4); // blue
+      data.set(yellow, 256 * 3 + 8); // yellow
+      buffer.unmap();
+
+      const texture = ctx.getCurrentTexture();
+
+      const encoder = t.device.createCommandEncoder();
+      encoder.copyBufferToTexture({ buffer, bytesPerRow }, { texture }, [3, 4, 1]);
+      t.device.queue.submit([encoder.finish()]);
+      await t.device.queue.onSubmittedWorkDone();
+    }
+
+    {
+      const ctx = cvs_smaller_than_back_buffer.getContext('gpupresent');
+      assert(ctx !== null);
+      const width = cvs_smaller_than_back_buffer.width * 2;
+      const height = cvs_smaller_than_back_buffer.height * 2;
+      ctx.configure({
+        device: t.device,
+        format: 'bgra8unorm',
+        usage: GPUTextureUsage.COPY_DST,
+        size: [width, height, 1], // double size of the canvas width and height.
+      });
+
+      const rows = height;
+      const bytesPerRow = 256;
+      const buffer = t.device.createBuffer({
+        mappedAtCreation: true,
+        size: rows * bytesPerRow,
+        usage: GPUBufferUsage.COPY_SRC,
+      });
+      const mapping = buffer.getMappedRange();
+      const data = new Uint8Array(mapping);
+      // 1st row
+      data.set(red, 0); // red
+      data.set(red, 4); // red
+      data.set(red, 8); // red
+      data.set(red, 12); // red
+      data.set(green, 16); // green
+      data.set(green, 20); // green
+
+      // 2nd row
+      data.set(red, 256 + 0); // red
+      data.set(red, 256 + 4); // red
+      data.set(red, 256 + 8); // red
+      data.set(red, 256 + 12); // red
+      data.set(green, 256 + 16); // green
+      data.set(green, 256 + 20); // green
+
+      // 3rd row
+      data.set(red, 256 * 2 + 0); // red
+      data.set(red, 256 * 2 + 4); // red
+      data.set(red, 256 * 2 + 8); // red
+      data.set(red, 256 * 2 + 12); // red
+      data.set(green, 256 * 2 + 16); // blue
+      data.set(green, 256 * 2 + 20); // blue
+
+      // 4th row
+      data.set(red, 256 * 3 + 0); // red
+      data.set(red, 256 * 3 + 4); // red
+      data.set(red, 256 * 3 + 8); // red
+      data.set(red, 256 * 3 + 12); // red
+      data.set(green, 256 * 3 + 16); // blue
+      data.set(green, 256 * 3 + 20); // blue
+
+      // 5th row
+      data.set(blue, 256 * 4 + 0); // blue
+      data.set(blue, 256 * 4 + 4); // blue
+      data.set(blue, 256 * 4 + 8); // blue
+      data.set(blue, 256 * 4 + 12); // blue
+      data.set(yellow, 256 * 4 + 16); // red
+      data.set(yellow, 256 * 4 + 20); // red
+
+      // 6th row
+      data.set(blue, 256 * 5 + 0); // blue
+      data.set(blue, 256 * 5 + 4); // blue
+      data.set(blue, 256 * 5 + 8); // blue
+      data.set(blue, 256 * 5 + 12); // blue
+      data.set(yellow, 256 * 5 + 16); // red
+      data.set(yellow, 256 * 5 + 20); // red
+
+      // 7th row
+      data.set(blue, 256 * 6 + 0); // blue
+      data.set(blue, 256 * 6 + 4); // blue
+      data.set(blue, 256 * 6 + 8); // blue
+      data.set(blue, 256 * 6 + 12); // blue
+      data.set(yellow, 256 * 6 + 16); // yellow
+      data.set(yellow, 256 * 6 + 20); // yellow
+
+      // 8th row
+      data.set(blue, 256 * 7 + 0); // blue
+      data.set(blue, 256 * 7 + 4); // blue
+      data.set(blue, 256 * 7 + 8); // blue
+      data.set(blue, 256 * 7 + 12); // blue
+      data.set(yellow, 256 * 7 + 16); // yellow
+      data.set(yellow, 256 * 7 + 20); // yellow
+      buffer.unmap();
+
+      const texture = ctx.getCurrentTexture();
+
+      const encoder = t.device.createCommandEncoder();
+      encoder.copyBufferToTexture({ buffer, bytesPerRow }, { texture }, [6, 8, 1]);
+      t.device.queue.submit([encoder.finish()]);
+      await t.device.queue.onSubmittedWorkDone();
+    }
+  });
+}

--- a/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
@@ -2,20 +2,23 @@
   <title>WebGPU canvas_back_buffer_different_size (ref)</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
-  <canvas id="cvs_larger_than_back_buffer_ref" width="6" height="8"></canvas>
+  <canvas id="cvs_larger_than_back_buffer_ref" width="3" height="4" style="width: 6px; height: 8px;"></canvas>
   <canvas id="cvs_same_as_back_buffer_ref" width="3" height="4"></canvas>
-  <canvas id="cvs_smaller_than_back_buffer_ref" width="3" height="4"></canvas>
+  <canvas id="cvs_smaller_than_back_buffer_ref" width="6" height="8" style="width: 3px; height: 4px;"></canvas>
+  <canvas id="cvs_change_size_after_configure_ref" width="3" height="4" style="width: 6px; height: 8px;"></canvas>
+  <canvas id="cvs_change_size_and_reconfigure_ref" width="6" height="8"></canvas>
+  <canvas id="cvs_back_buffer_css_different_size_ref" width="3" height="4" style="width: 12px; height: 16px;"></canvas>
   <script>
   {
     const context = cvs_larger_than_back_buffer_ref.getContext('2d');
     context.fillStyle = "#FF0000";
-    context.fillRect(0, 0, 4, 4);
+    context.fillRect(0, 0, 2, 2);
     context.fillStyle = "#00FF00";
-    context.fillRect(4, 0, 2, 4);
+    context.fillRect(2, 0, 1, 2);
     context.fillStyle = "#0000FF";
-    context.fillRect(0, 4, 4, 4);
+    context.fillRect(0, 2, 2, 2);
     context.fillStyle = "#FFFF00";
-    context.fillRect(4, 4, 2, 4);
+    context.fillRect(2, 2, 1, 2);
     }
 
     {
@@ -32,6 +35,42 @@
 
     {
     const context = cvs_smaller_than_back_buffer_ref.getContext('2d');
+    context.fillStyle = "#FF0000";
+    context.fillRect(0, 0, 4, 4);
+    context.fillStyle = "#00FF00";
+    context.fillRect(4, 0, 2, 4);
+    context.fillStyle = "#0000FF";
+    context.fillRect(0, 4, 4, 4);
+    context.fillStyle = "#FFFF00";
+    context.fillRect(4, 4, 2, 4);
+    }
+
+    {
+    const context = cvs_change_size_after_configure_ref.getContext('2d');
+    context.fillStyle = "#FF0000";
+    context.fillRect(0, 0, 2, 2);
+    context.fillStyle = "#00FF00";
+    context.fillRect(2, 0, 1, 2);
+    context.fillStyle = "#0000FF";
+    context.fillRect(0, 2, 2, 2);
+    context.fillStyle = "#FFFF00";
+    context.fillRect(2, 2, 1, 2);
+    }
+
+    {
+    const context = cvs_change_size_and_reconfigure_ref.getContext('2d');
+    context.fillStyle = "#FF0000";
+    context.fillRect(0, 0, 4, 4);
+    context.fillStyle = "#00FF00";
+    context.fillRect(4, 0, 2, 4);
+    context.fillStyle = "#0000FF";
+    context.fillRect(0, 4, 4, 4);
+    context.fillStyle = "#FFFF00";
+    context.fillRect(4, 4, 2, 4);
+    }
+
+    {
+    const context = cvs_back_buffer_css_different_size_ref.getContext('2d');
     context.fillStyle = "#FF0000";
     context.fillRect(0, 0, 2, 2);
     context.fillStyle = "#00FF00";

--- a/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
@@ -88,6 +88,7 @@
     context.fillRect(0, 0, 4, 4);
     context.fillStyle = "#00FF00";
     context.fillRect(4, 0, 2, 4);
+    context.fillRect(2, 1, 1, 1);
     context.fillStyle = "#0000FF";
     context.fillRect(0, 4, 4, 4);
     context.fillStyle = "#FFFF00";

--- a/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
@@ -7,7 +7,8 @@
   <canvas id="cvs_smaller_than_back_buffer_ref" width="6" height="8" style="width: 3px; height: 4px;"></canvas>
   <canvas id="cvs_change_size_after_configure_ref" width="3" height="4" style="width: 6px; height: 8px;"></canvas>
   <canvas id="cvs_change_size_and_reconfigure_ref" width="6" height="8"></canvas>
-  <canvas id="cvs_back_buffer_css_different_size_ref" width="3" height="4" style="width: 12px; height: 16px;"></canvas>
+  <canvas id="back_buffer_smaller_than_cvs_and_css_ref" width="3" height="4" style="width: 12px; height: 16px;"></canvas>
+  <canvas id="cvs_smaller_than_back_buffer_and_css" width="6" height="8" style="width: 12px; height: 16px;"></canvas>
   <script>
   {
     const context = cvs_larger_than_back_buffer_ref.getContext('2d');
@@ -70,7 +71,7 @@
     }
 
     {
-    const context = cvs_back_buffer_css_different_size_ref.getContext('2d');
+    const context = back_buffer_smaller_than_cvs_and_css_ref.getContext('2d');
     context.fillStyle = "#FF0000";
     context.fillRect(0, 0, 2, 2);
     context.fillStyle = "#00FF00";
@@ -79,6 +80,18 @@
     context.fillRect(0, 2, 2, 2);
     context.fillStyle = "#FFFF00";
     context.fillRect(2, 2, 1, 2);
+    }
+
+    {
+    const context = cvs_smaller_than_back_buffer_and_css.getContext('2d');
+    context.fillStyle = "#FF0000";
+    context.fillRect(0, 0, 4, 4);
+    context.fillStyle = "#00FF00";
+    context.fillRect(4, 0, 2, 4);
+    context.fillStyle = "#0000FF";
+    context.fillRect(0, 4, 4, 4);
+    context.fillStyle = "#FFFF00";
+    context.fillRect(4, 4, 2, 4);
     }
   </script>
 </html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
@@ -1,0 +1,45 @@
+<html>
+  <title>WebGPU canvas_back_buffer_different_size (ref)</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <canvas id="cvs_larger_than_back_buffer_ref" width="6" height="8"></canvas>
+  <canvas id="cvs_same_as_back_buffer_ref" width="3" height="4"></canvas>
+  <canvas id="cvs_smaller_than_back_buffer_ref" width="3" height="4"></canvas>
+  <script>
+  {
+    const context = cvs_larger_than_back_buffer_ref.getContext('2d');
+    context.fillStyle = "#FF0000";
+    context.fillRect(0, 0, 4, 4);
+    context.fillStyle = "#00FF00";
+    context.fillRect(4, 0, 2, 4);
+    context.fillStyle = "#0000FF";
+    context.fillRect(0, 4, 4, 4);
+    context.fillStyle = "#FFFF00";
+    context.fillRect(4, 4, 2, 4);
+    }
+
+    {
+    const context = cvs_same_as_back_buffer_ref.getContext('2d');
+    context.fillStyle = "#FF0000";
+    context.fillRect(0, 0, 2, 2);
+    context.fillStyle = "#00FF00";
+    context.fillRect(2, 0, 1, 2);
+    context.fillStyle = "#0000FF";
+    context.fillRect(0, 2, 2, 2);
+    context.fillStyle = "#FFFF00";
+    context.fillRect(2, 2, 1, 2);
+    }
+
+    {
+    const context = cvs_smaller_than_back_buffer_ref.getContext('2d');
+    context.fillStyle = "#FF0000";
+    context.fillRect(0, 0, 2, 2);
+    context.fillStyle = "#00FF00";
+    context.fillRect(2, 0, 1, 2);
+    context.fillStyle = "#0000FF";
+    context.fillRect(0, 2, 2, 2);
+    context.fillStyle = "#FFFF00";
+    context.fillRect(2, 2, 1, 2);
+    }
+  </script>
+</html>


### PR DESCRIPTION
This tests covers the cases that user config webgpu back
buffer with larger than/smaller than/equal to canvas size.

WebGPU canvas should present things by doing
downscaling/upscaling/no-changes for the back buffer.

Bug: https://crbug.com/dawn/936



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
