### PR TITLE
Implement External Texture Follow Up Test Changes

### DIFF
--- a/src/webgpu/web_platform/copyToTexture/video.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/video.spec.ts
@@ -3,8 +3,6 @@ copyToTexture with HTMLVideoElement (and other video-type sources?).
 
 - videos with various encodings, color spaces, metadata
 
-TODO: get test videos from WebGL CTS
-TODO(kainino0x): (and set up the build to deal with data files)
 TODO: consider whether external_texture and copyToTexture video tests should be in the same file
 TODO: plan
 `;

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -4,20 +4,11 @@ Tests for external textures from HTMLVideoElement (and other video-type sources?
 - videos with various encodings, color spaces, metadata
 
 TODO: consider whether external_texture and copyToTexture video tests should be in the same file
-
-Test Coverage:
-  - Tests that we can import an HTMLVideoElement into a GPUExternalTexture, sample from it for all
-  supported video formats {vp8, vp9, ogg, mp4}, and ensure the GPUExternalTexture is destroyed by
-  a microtask. 
-    TODO: Multiplanar scenarios
-    TODO: Pull microtask destruction into its own test
-  - Tests that we can import an HTMLVideoElement into a GPUExternalTexture and use it in a compute 
-  shader
-    TODO: Change this test to instead load texture data into a storage texture.
 `;
 
 import { getResourcePath } from '../../../common/framework/resources.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { resolveOnTimeout } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
 import { startPlayingAndWaitForVideo } from '../../web_platform/util.js';
 
@@ -33,10 +24,85 @@ const kVideoSources: string[] = [
 
 export const g = makeTestGroup(GPUTest);
 
+function createExternalTextureSamplingTestPipeline(t: GPUTest): GPURenderPipeline {
+  const pipeline = t.device.createRenderPipeline({
+    vertex: {
+      module: t.device.createShaderModule({
+        code: `
+        [[stage(vertex)]] fn main([[builtin(vertex_index)]] VertexIndex : u32) -> [[builtin(position)]] vec4<f32> {
+            var pos = array<vec4<f32>, 6>(
+              vec4<f32>( 1.0,  1.0, 0.0, 1.0),
+              vec4<f32>( 1.0, -1.0, 0.0, 1.0),
+              vec4<f32>(-1.0, -1.0, 0.0, 1.0),
+              vec4<f32>( 1.0,  1.0, 0.0, 1.0),
+              vec4<f32>(-1.0, -1.0, 0.0, 1.0),
+              vec4<f32>(-1.0,  1.0, 0.0, 1.0)
+            );
+            return pos[VertexIndex];
+        }
+        `,
+      }),
+      entryPoint: 'main',
+    },
+    fragment: {
+      module: t.device.createShaderModule({
+        code: `
+        [[group(0), binding(0)]] var s : sampler;
+        [[group(0), binding(1)]] var t : texture_external;
+
+        [[stage(fragment)]] fn main([[builtin(position)]] FragCoord : vec4<f32>)
+                                 -> [[location(0)]] vec4<f32> {
+            return textureSampleLevel(t, s, FragCoord.xy / vec2<f32>(16.0, 16.0));
+        }
+        `,
+      }),
+      entryPoint: 'main',
+      targets: [
+        {
+          format: kFormat,
+        },
+      ],
+    },
+    primitive: { topology: 'triangle-list' },
+  });
+
+  return pipeline;
+}
+
+function createExternalTextureSamplingTestBindGroup(
+  t: GPUTest,
+  video: HTMLVideoElement,
+  pipeline: GPURenderPipeline
+): GPUBindGroup {
+  const linearSampler = t.device.createSampler();
+
+  const externalTextureDescriptor = { source: video };
+  const externalTexture = t.device.importExternalTexture(externalTextureDescriptor);
+
+  const bindGroup = t.device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [
+      {
+        binding: 0,
+        resource: linearSampler,
+      },
+      {
+        binding: 1,
+        resource: externalTexture,
+      },
+    ],
+  });
+
+  return bindGroup;
+}
+
 g.test('importExternalTexture,sample')
   .desc(
     `
-Test that importing different video formats into an external texture and sampling from them works correctly.
+Tests that we can import an HTMLVideoElement into a GPUExternalTexture, sample from it for all
+supported video formats {vp8, vp9, ogg, mp4}, and ensure the GPUExternalTexture is destroyed by
+a microtask. 
+TODO: Multiplanar scenarios
 `
   )
   .params(u =>
@@ -55,65 +121,10 @@ Test that importing different video formats into an external texture and samplin
         usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
       });
 
-      const pipeline = t.device.createRenderPipeline({
-        vertex: {
-          module: t.device.createShaderModule({
-            code: `
-              [[stage(vertex)]] fn main([[builtin(vertex_index)]] VertexIndex : u32) -> [[builtin(position)]] vec4<f32> {
-                  var pos = array<vec4<f32>, 6>(
-                    vec4<f32>( 1.0,  1.0, 0.0, 1.0),
-                    vec4<f32>( 1.0, -1.0, 0.0, 1.0),
-                    vec4<f32>(-1.0, -1.0, 0.0, 1.0),
-                    vec4<f32>( 1.0,  1.0, 0.0, 1.0),
-                    vec4<f32>(-1.0, -1.0, 0.0, 1.0),
-                    vec4<f32>(-1.0,  1.0, 0.0, 1.0)
-                  );
-                  return pos[VertexIndex];
-              }
-              `,
-          }),
-          entryPoint: 'main',
-        },
-        fragment: {
-          module: t.device.createShaderModule({
-            code: `
-              [[group(0), binding(0)]] var s : sampler;
-              [[group(0), binding(1)]] var t : texture_external;
+      const pipeline = createExternalTextureSamplingTestPipeline(t);
 
-              [[stage(fragment)]] fn main([[builtin(position)]] FragCoord : vec4<f32>)
-                                       -> [[location(0)]] vec4<f32> {
-                  return textureSampleLevel(t, s, FragCoord.xy / vec2<f32>(16.0, 16.0));
-              }
-              `,
-          }),
-          entryPoint: 'main',
-          targets: [
-            {
-              format: kFormat,
-            },
-          ],
-        },
-        primitive: { topology: 'triangle-list' },
-      });
+      const bindGroup = createExternalTextureSamplingTestBindGroup(t, video, pipeline);
 
-      const linearSampler = t.device.createSampler();
-
-      const externalTextureDescriptor = { source: video };
-      const externalTexture = t.device.importExternalTexture(externalTextureDescriptor);
-
-      const bindGroup = t.device.createBindGroup({
-        layout: pipeline.getBindGroupLayout(0),
-        entries: [
-          {
-            binding: 0,
-            resource: linearSampler,
-          },
-          {
-            binding: 1,
-            resource: externalTexture,
-          },
-        ],
-      });
       const commandEncoder = t.device.createCommandEncoder();
       const passEncoder = commandEncoder.beginRenderPass({
         colorAttachments: [
@@ -151,12 +162,37 @@ Test that importing different video formats into an external texture and samplin
           exp: new Uint8Array([0x00, 0xff, 0x00, 0xff]),
         }
       );
+    });
+  });
 
-      // This function submits the same render pass as above, but should result in an error because the
-      // GPUExternalTexture will be destroyed via microtask upon requestAnimationFrame.
-      const ensureDestroyed = function () {
-        const commandEncoder2 = t.device.createCommandEncoder();
-        const passEncoder2 = commandEncoder2.beginRenderPass({
+g.test('importExternalTexture,destroy')
+  .desc(
+    `
+Tests that a GPUExternalTexture is destroyed by a microtask and that using it after it has been
+destroyed results in an error.
+`
+  )
+  .fn(async t => {
+    const videoUrl = getResourcePath('red-green.webmvp8.webm');
+    const video = document.createElement('video');
+    video.src = videoUrl;
+
+    let commandEncoder: GPUCommandEncoder;
+
+    await startPlayingAndWaitForVideo(video, async () => {
+      await Promise.resolve().then(() => {
+        const colorAttachment = t.device.createTexture({
+          format: kFormat,
+          size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
+          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+        });
+
+        const pipeline = createExternalTextureSamplingTestPipeline(t);
+
+        const bindGroup = createExternalTextureSamplingTestBindGroup(t, video, pipeline);
+
+        commandEncoder = t.device.createCommandEncoder();
+        const passEncoder = commandEncoder.beginRenderPass({
           colorAttachments: [
             {
               view: colorAttachment.createView(),
@@ -165,15 +201,19 @@ Test that importing different video formats into an external texture and samplin
             },
           ],
         });
-        passEncoder2.setPipeline(pipeline);
-        passEncoder2.setBindGroup(0, bindGroup);
-        passEncoder2.draw(6);
-        passEncoder2.endPass();
+        passEncoder.setPipeline(pipeline);
+        passEncoder.setBindGroup(0, bindGroup);
+        passEncoder.draw(6);
+        passEncoder.endPass();
+      });
 
-        t.expectGPUError('validation', () => t.device.queue.submit([commandEncoder2.finish()]));
-      };
+      // This should trigger a microtask that destroys the GPUExternalTexture, which will cause
+      // a validation error when we try to use the destroyed GPUExternalTexture.
+      await Promise.resolve().then(() => {
+        t.expectGPUError('validation', () => t.device.queue.submit([commandEncoder.finish()]));
+      });
 
-      requestAnimationFrame(ensureDestroyed);
+      await resolveOnTimeout(0);
     });
   });
 
@@ -192,27 +232,26 @@ Tests that we can import an HTMLVideoElement into a GPUExternalTexture and use i
       const externalTextureDescriptor = { source: video };
       const externalTexture = t.device.importExternalTexture(externalTextureDescriptor);
 
-      const result = t.device.createBuffer({
-        size: 8,
-        usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+      const outputTexture = t.device.createTexture({
+        format: 'rgba8unorm',
+        size: [2, 1, 1],
+        usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE,
       });
 
       const pipeline = t.device.createComputePipeline({
         compute: {
+          // Shader will load a pixel near the upper left and lower right corners, which are then
+          // stored in storage texture.
           module: t.device.createShaderModule({
-            code: `
-              [[block]] struct Data {
-                  height : i32;
-                  width : i32;
-              };
-    
+            code: `    
               [[group(0), binding(0)]] var t : texture_external;
-              [[group(0), binding(1)]] var<storage, read_write> dst : Data;
-    
+              [[group(0), binding(1)]] var outImage : texture_storage_2d<rgba8unorm, write>;
+
               [[stage(compute), workgroup_size(1)]] fn main() {
-                var dims : vec2<i32> = textureDimensions(t);
-                dst.width = dims.x;
-                dst.height = dims.y;
+                var red : vec4<f32> = textureLoad(t, vec2<i32>(10,10));
+                textureStore(outImage, vec2<i32>(0, 0), red);
+                var green : vec4<f32> = textureLoad(t, vec2<i32>(70,118));
+                textureStore(outImage, vec2<i32>(1, 0), green);
                 return;
               }
             `,
@@ -224,7 +263,7 @@ Tests that we can import an HTMLVideoElement into a GPUExternalTexture and use i
       const bg = t.device.createBindGroup({
         entries: [
           { binding: 0, resource: externalTexture },
-          { binding: 1, resource: { buffer: result, offset: 0, size: 8 } },
+          { binding: 1, resource: outputTexture.createView() },
         ],
         layout: pipeline.getBindGroupLayout(0),
       });
@@ -237,8 +276,24 @@ Tests that we can import an HTMLVideoElement into a GPUExternalTexture and use i
       pass.endPass();
       t.device.queue.submit([encoder.finish()]);
 
-      // Check that video dimension are returned correctly as 128x80
-      const resultData = new Uint32Array([128, 80]);
-      t.expectGPUBufferValuesEqual(result, resultData);
+      // Pixel loaded from top left corner should be red.
+      t.expectSinglePixelIn2DTexture(
+        outputTexture,
+        kFormat,
+        { x: 0, y: 0 },
+        {
+          exp: new Uint8Array([0xff, 0x00, 0x00, 0xff]),
+        }
+      );
+
+      // Pixel loaded from Bottom right corner should be green.
+      t.expectSinglePixelIn2DTexture(
+        outputTexture,
+        kFormat,
+        { x: 1, y: 0 },
+        {
+          exp: new Uint8Array([0x00, 0xff, 0x00, 0xff]),
+        }
+      );
     });
   });

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -11,13 +11,17 @@ import { raceWithRejectOnTimeout } from '../../common/util/util.js';
  */
 export function startPlayingAndWaitForVideo(
   video: HTMLVideoElement,
-  callback: () => void
+  callback: () => unknown
 ): Promise<void> {
   return raceWithRejectOnTimeout(
     new Promise((resolve, reject) => {
-      const callbackAndResolve = () => {
-        callback();
-        resolve();
+      const callbackAndResolve = async () => {
+        try {
+          await callback()
+          resolve();
+        } catch(ex) {
+          reject();
+        }
       };
 
       if (video.error) {

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -17,9 +17,9 @@ export function startPlayingAndWaitForVideo(
     new Promise((resolve, reject) => {
       const callbackAndResolve = async () => {
         try {
-          await callback()
+          await callback();
           resolve();
-        } catch(ex) {
+        } catch (ex) {
           reject();
         }
       };


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
