### PR TITLE
Fix bugs introduced with memcpy

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -194,7 +194,7 @@ function subarrayAsU8(
   if (buf instanceof ArrayBuffer) {
     return new Uint8Array(buf, start, length);
   } else {
-    const sub = buf.subarray(start, length ? start + length : undefined);
+    const sub = buf.subarray(start, length !== undefined ? start + length : undefined);
     return new Uint8Array(sub.buffer, sub.byteOffset, sub.byteLength);
   }
 }

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -346,8 +346,9 @@ class ImageCopyTest extends GPUTest {
         break;
       }
       case 'CopyB2T': {
-        assert(partialData.byteLength % 4 === 0, 'partialData must be multiple of 4 bytes');
-        const buffer = this.makeBufferWithContents(partialData, GPUBufferUsage.COPY_SRC);
+        const buffer = this.makeBufferWithContents(partialData, GPUBufferUsage.COPY_SRC, {
+          padToMultipleOf4: true,
+        });
 
         const encoder = this.device.createCommandEncoder();
         encoder.copyBufferToTexture(

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -465,7 +465,7 @@ struct VSOutputs {
           ((index * componentCount + component) * expectedComponentSize) %
           data.expectedData.byteLength;
         memcpy(
-          { src: data.expectedData, start: sourceExpectedOffset, length: vertexComponentSize },
+          { src: data.expectedData, start: sourceExpectedOffset, length: expectedComponentSize },
           { dst: expandedExpectedData, start: targetExpectedOffset }
         );
       }

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -535,8 +535,12 @@ export class GPUTest extends Fixture {
    *
    * TODO: Several call sites would be simplified if this took ArrayBuffer as well.
    */
-  makeBufferWithContents(dataArray: TypedArrayBufferView, usage: GPUBufferUsageFlags): GPUBuffer {
-    return makeBufferWithContents(this.device, dataArray, usage);
+  makeBufferWithContents(
+    dataArray: TypedArrayBufferView,
+    usage: GPUBufferUsageFlags,
+    opts: { padToMultipleOf4?: boolean } = {}
+  ): GPUBuffer {
+    return makeBufferWithContents(this.device, dataArray, usage, opts);
   }
 
   /**

--- a/src/webgpu/util/buffer.ts
+++ b/src/webgpu/util/buffer.ts
@@ -1,4 +1,5 @@
 import { memcpy, TypedArrayBufferView } from '../../common/util/util.js';
+
 import { align } from './math.js';
 
 /**

--- a/src/webgpu/util/buffer.ts
+++ b/src/webgpu/util/buffer.ts
@@ -1,4 +1,5 @@
 import { memcpy, TypedArrayBufferView } from '../../common/util/util.js';
+import { align } from './math.js';
 
 /**
  * Creates a buffer with the contents of some TypedArray.
@@ -6,11 +7,12 @@ import { memcpy, TypedArrayBufferView } from '../../common/util/util.js';
 export function makeBufferWithContents(
   device: GPUDevice,
   dataArray: TypedArrayBufferView,
-  usage: GPUBufferUsageFlags
+  usage: GPUBufferUsageFlags,
+  opts: { padToMultipleOf4?: boolean } = {}
 ): GPUBuffer {
   const buffer = device.createBuffer({
     mappedAtCreation: true,
-    size: dataArray.byteLength,
+    size: align(dataArray.byteLength, opts.padToMultipleOf4 ? 4 : 1),
     usage,
   });
   memcpy({ src: dataArray }, { dst: buffer.getMappedRange() });


### PR DESCRIPTION
Fixes a bunch of tests broken in #616.

- now correctly copy 0 bytes instead of attempting to copy all remaining elements in the source array.
- fix incorrect assertion
- typo


<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
