### PR TITLE
Add tests for requiredLimits in requestDevice

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -3,7 +3,7 @@ Tests for GPUAdapter.requestDevice.
 
 TODO:
 - descriptor is {null, undefined}
-- descriptor with the combinations of features and limits
+- descriptor with the combinations of features
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';

--- a/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
@@ -1,0 +1,148 @@
+export const description = `
+Tests passing various requiredLimits to GPUAdapter.requestDevice.
+`;
+
+import { Fixture } from '../../../../common/framework/fixture.js';
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { assert } from '../../../../common/util/util.js';
+import { DefaultLimits } from '../../../constants.js';
+
+const kLimitTypes = keysOf(DefaultLimits);
+
+const kMaxUnsignedLongValue = 4294967295;
+/** Clamps a numeric value to the valid unsigned long range, as defined by WebIDL */
+function clampToUnsignedLong(value: number): number {
+  return Math.min(kMaxUnsignedLongValue, Math.max(0, value));
+}
+
+export const g = makeTestGroup(Fixture);
+
+g.test('unknown_limits')
+  .desc(
+    `
+    Test that specifiying limits that aren't part of the supported limit set causes
+    requestDevice to reject.`
+  )
+  .fn(async t => {
+    const adapter = await navigator.gpu.requestAdapter();
+    assert(adapter !== null);
+
+    const requiredLimits: Record<string, number> = { unknownLimitName: 9000 };
+
+    t.shouldReject('OperationError', adapter.requestDevice({ requiredLimits }));
+  });
+
+g.test('default_limits')
+  .desc(
+    `
+    Test that each supported limit can be specified with the default values required by the
+    spec.
+    - Tests each limit`
+  )
+  .paramsSubcasesOnly(u =>
+    u.combine('limit', kLimitTypes).unless(p => typeof DefaultLimits[p.limit] !== 'number')
+  )
+  .fn(async t => {
+    const { limit } = t.params;
+
+    const adapter = await navigator.gpu.requestAdapter();
+    assert(adapter !== null);
+
+    const requiredLimits: Record<string, number> = {};
+    requiredLimits[limit] = DefaultLimits[limit];
+
+    const device = await adapter.requestDevice({ requiredLimits });
+    assert(device !== null);
+    t.expect(
+      device.limits[limit] === requiredLimits[limit],
+      'Devices reported limit should match the required limit'
+    );
+  });
+
+g.test('adapter_limits')
+  .desc(
+    `
+    Test that each supported limit can be specified with the adapter's reported values.
+    - Tests each limit`
+  )
+  .paramsSubcasesOnly(u =>
+    u.combine('limit', kLimitTypes).unless(p => typeof DefaultLimits[p.limit] !== 'number')
+  )
+  .fn(async t => {
+    const { limit } = t.params;
+
+    const adapter = await navigator.gpu.requestAdapter();
+    assert(adapter !== null);
+
+    const requiredLimits: Record<string, number> = {};
+    requiredLimits[limit] = adapter.limits[limit];
+
+    const device = await adapter.requestDevice({ requiredLimits });
+    assert(device !== null);
+    t.expect(
+      device.limits[limit] === requiredLimits[limit],
+      'Devices reported limit should match the required limit'
+    );
+  });
+
+g.test('better_than_supported')
+  .desc(
+    `
+    Test that specifying a better limit than what the adapter supports causes requestDevice to
+    reject.
+    - Tests each limit
+    - Tests requesting better limits by various amounts`
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('limit', kLimitTypes)
+      .combine('over', [1, 32, 65535])
+      .unless(p => typeof DefaultLimits[p.limit] !== 'number')
+  )
+  .fn(async t => {
+    const { limit, over } = t.params;
+
+    const adapter = await navigator.gpu.requestAdapter();
+    assert(adapter !== null);
+
+    const mult = limit.startsWith('min') ? -1 : 1;
+
+    const requiredLimits: Record<string, number> = {};
+    requiredLimits[limit] = clampToUnsignedLong(adapter.limits[limit] + over * mult);
+
+    t.shouldReject('OperationError', adapter.requestDevice({ requiredLimits }));
+  });
+
+g.test('worse_than_default')
+  .desc(
+    `
+    Test that specifying a worse limit than the default values required by the spec cause the value
+    to clamp.
+    - Tests each limit
+    - Tests requesting worse limits by various amounts`
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('limit', kLimitTypes)
+      .combine('under', [1, 32, 65535])
+      .unless(p => typeof DefaultLimits[p.limit] !== 'number')
+  )
+  .fn(async t => {
+    const { limit, under } = t.params;
+
+    const adapter = await navigator.gpu.requestAdapter();
+    assert(adapter !== null);
+
+    const mult = limit.startsWith('min') ? -1 : 1;
+
+    const requiredLimits: Record<string, number> = {};
+    requiredLimits[limit] = clampToUnsignedLong(DefaultLimits[limit] - under * mult);
+
+    const device = await adapter.requestDevice({ requiredLimits });
+    assert(device !== null);
+    t.expect(
+      device.limits[limit] === DefaultLimits[limit],
+      'Devices reported limit should match the default limit'
+    );
+  });

--- a/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
@@ -2,12 +2,12 @@ export const description = `
 Tests passing various requiredLimits to GPUAdapter.requestDevice.
 `;
 
-import { getGPU } from '../../../util/navigator_gpu.js';
 import { Fixture } from '../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
 import { assert } from '../../../../common/util/util.js';
 import { DefaultLimits } from '../../../constants.js';
+import { getGPU } from '../../../util/navigator_gpu.js';
 
 const kLimitTypes = keysOf(DefaultLimits);
 
@@ -34,57 +34,41 @@ g.test('unknown_limits')
     t.shouldReject('OperationError', adapter.requestDevice({ requiredLimits }));
   });
 
-g.test('default_limits')
+g.test('supported_limits')
   .desc(
     `
-    Test that each supported limit can be specified with the default values required by the
-    spec.
-    - Tests each limit`
+    Test that each supported limit can be specified with valid values.
+    - Tests each limit with the default values given by the spec
+    - Tests each limit with the supported values given by the adapter`
   )
-  .paramsSubcasesOnly(u =>
-    u.combine('limit', kLimitTypes).unless(p => typeof DefaultLimits[p.limit] !== 'number')
+  .params(u =>
+    u
+      .combine('limit', kLimitTypes)
+      .unless(p => typeof DefaultLimits[p.limit] !== 'number')
+      .beginSubcases()
+      .combine('limitValue', ['default', 'adapter'])
   )
   .fn(async t => {
-    const { limit } = t.params;
+    const { limit, limitValue } = t.params;
 
     const gpu = getGPU();
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
-    if (adapter.limits) { return; }
+    let value: number = -1;
+    switch (limitValue) {
+      case 'default':
+        value = DefaultLimits[limit] as number;
+        break;
+      case 'adapter':
+        value = adapter.limits[limit] as number;
+        break;
+    }
 
-    const requiredLimits = { [limit]: DefaultLimits[limit] as number };
-
-    const device = await adapter.requestDevice({ requiredLimits });
+    const device = await adapter.requestDevice({ requiredLimits: { [limit]: value } });
     assert(device !== null);
     t.expect(
-      device.limits[limit] === requiredLimits[limit],
-      'Devices reported limit should match the required limit'
-    );
-  });
-
-g.test('adapter_limits')
-  .desc(
-    `
-    Test that each supported limit can be specified with the adapter's reported values.
-    - Tests each limit`
-  )
-  .paramsSubcasesOnly(u =>
-    u.combine('limit', kLimitTypes).unless(p => typeof DefaultLimits[p.limit] !== 'number')
-  )
-  .fn(async t => {
-    const { limit } = t.params;
-
-    const gpu = getGPU();
-    const adapter = await gpu.requestAdapter();
-    assert(adapter !== null);
-
-    const requiredLimits = { [limit]: adapter.limits[limit] };
-
-    const device = await adapter.requestDevice({ requiredLimits });
-    assert(device !== null);
-    t.expect(
-      device.limits[limit] === requiredLimits[limit],
+      device.limits[limit] === value,
       'Devices reported limit should match the required limit'
     );
   });
@@ -97,11 +81,12 @@ g.test('better_than_supported')
     - Tests each limit
     - Tests requesting better limits by various amounts`
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
       .combine('limit', kLimitTypes)
-      .combine('over', [1, 32, 65535])
       .unless(p => typeof DefaultLimits[p.limit] !== 'number')
+      .beginSubcases()
+      .combine('over', [1, 32, 65535])
   )
   .fn(async t => {
     const { limit, over } = t.params;
@@ -113,7 +98,7 @@ g.test('better_than_supported')
     const mult = limit.startsWith('min') ? -1 : 1;
 
     const requiredLimits = {
-      [limit]: clampToUnsignedLong(adapter.limits[limit] + over * mult)
+      [limit]: clampToUnsignedLong(adapter.limits[limit] + over * mult),
     };
 
     t.shouldReject('OperationError', adapter.requestDevice({ requiredLimits }));
@@ -127,11 +112,12 @@ g.test('worse_than_default')
     - Tests each limit
     - Tests requesting worse limits by various amounts`
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
       .combine('limit', kLimitTypes)
-      .combine('under', [1, 32, 65535])
       .unless(p => typeof DefaultLimits[p.limit] !== 'number')
+      .beginSubcases()
+      .combine('under', [1, 32, 65535])
   )
   .fn(async t => {
     const { limit, under } = t.params;
@@ -143,7 +129,7 @@ g.test('worse_than_default')
     const mult = limit.startsWith('min') ? -1 : 1;
 
     const requiredLimits = {
-      [limit]: clampToUnsignedLong(DefaultLimits[limit] as number - under * mult)
+      [limit]: clampToUnsignedLong((DefaultLimits[limit] as number) - under * mult),
     };
 
     const device = await adapter.requestDevice({ requiredLimits });


### PR DESCRIPTION
Adds some basic tests for various `requiredLimits` configurations being passed to `requestDevice`. The only limit not covered is `maxComputeWorkgroupSize` because there's currently some confusion about how non-numeric limits should work.

Some limits are currently unsupported in Chrome, so several of the subcases fail there, but I've tested against a WIP Chrome patch that adds the missing limits and it works as expected.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
