### PR TITLE
api,validation,encoding,programmable,pipeline_bind_group_compat plan

### DIFF
--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -181,7 +181,7 @@ g.test('it_is_invalid_to_draw_in_a_render_pass_with_missing_bind_groups')
     }, !_success);
   });
 
-g.test('bgl_binding_mismatch_in_bind_group_and_pipeline_layout')
+g.test('bgl_binding_mismatch')
   .desc(
     'Tests the binding number must exist or not exist in both bindGroups[i].layout and pipelineLayout.bgls[i]'
   )
@@ -202,7 +202,7 @@ g.test('bgl_binding_mismatch_in_bind_group_and_pipeline_layout')
   )
   .unimplemented();
 
-g.test('bgl_visibility_mismatch_in_bind_group_and_pipeline_layout')
+g.test('bgl_visibility_mismatch')
   .desc('Tests the visibility in bindGroups[i].layout and pipelineLayout.bgls[i] must be matched')
   .params(u =>
     u
@@ -222,7 +222,7 @@ g.test('bgl_visibility_mismatch_in_bind_group_and_pipeline_layout')
   )
   .unimplemented();
 
-g.test('bgl_resource_type_mismatch_in_bind_group_and_pipeline_layout')
+g.test('bgl_resource_type_mismatch')
   .desc(
     'Tests the binding resource type in bindGroups[i].layout and pipelineLayout.bgls[i] must be matched'
   )

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -219,6 +219,7 @@ g.test('bgl_visibility_mismatch')
               GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
             ] as const)
       )
+      .combine('useU32Array', [false, true])
   )
   .unimplemented();
 
@@ -231,7 +232,8 @@ g.test('bgl_resource_type_mismatch')
       .combine('encoderType', kProgrammableEncoderTypes)
       .expand('call', p => getTestCmds(p.encoderType))
       .beginSubcases()
-      .combine('bgResource', kResourceTypes)
+      .combine('bgResourceType', kResourceTypes)
       .combine('plResourceType', kResourceTypes)
+      .combine('useU32Array', [false, true])
   )
   .unimplemented();


### PR DESCRIPTION
Add basic test plan and leave the more detailed compatiable tests of binding resources in TODOs.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
