### PR TITLE
Roll @webgpu/types to 0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/node": "^14.11.10",
         "@types/offscreencanvas": "^2019.6.2",
         "@typescript-eslint/parser": "^4.22.0",
-        "@webgpu/types": "^0.1.5",
+        "@webgpu/types": "^0.1.6",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.0.1",
         "chokidar": "^3.4.3",
@@ -1360,9 +1360,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.5.tgz",
-      "integrity": "sha512-IdKNVQmX+enHf0Qq899M6qpfvSjLaWJ9mektGLC74Ja7SItQ3KqKotTabsGUXa8SvYix4Iw+2jPPWUsNeOIOEg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.6.tgz",
+      "integrity": "sha512-5c3ZxNmGwVhTo8nW0b0iEaSVLTx89D056c7JzbzC2f9J+qebRM+U9rH52q9Z/HwZbZQTUAYX5UGp0c4BNv61Ew==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10795,9 +10795,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.5.tgz",
-      "integrity": "sha512-IdKNVQmX+enHf0Qq899M6qpfvSjLaWJ9mektGLC74Ja7SItQ3KqKotTabsGUXa8SvYix4Iw+2jPPWUsNeOIOEg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.6.tgz",
+      "integrity": "sha512-5c3ZxNmGwVhTo8nW0b0iEaSVLTx89D056c7JzbzC2f9J+qebRM+U9rH52q9Z/HwZbZQTUAYX5UGp0c4BNv61Ew==",
       "dev": true
     },
     "abbrev": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/node": "^14.11.10",
         "@types/offscreencanvas": "^2019.6.2",
         "@typescript-eslint/parser": "^4.22.0",
-        "@webgpu/types": "^0.1.4",
+        "@webgpu/types": "^0.1.5",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.0.1",
         "chokidar": "^3.4.3",
@@ -1360,9 +1360,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.4.tgz",
-      "integrity": "sha512-nR0L4xBKUSksLKdFVxcshBL2M9ofAWneYYmK5/5iQJukY4q8a9hcXJwvH7QKQemiK3jxXuCMPkDzFCu/1+5Xvg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.5.tgz",
+      "integrity": "sha512-IdKNVQmX+enHf0Qq899M6qpfvSjLaWJ9mektGLC74Ja7SItQ3KqKotTabsGUXa8SvYix4Iw+2jPPWUsNeOIOEg==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10795,9 +10795,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.4.tgz",
-      "integrity": "sha512-nR0L4xBKUSksLKdFVxcshBL2M9ofAWneYYmK5/5iQJukY4q8a9hcXJwvH7QKQemiK3jxXuCMPkDzFCu/1+5Xvg==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.5.tgz",
+      "integrity": "sha512-IdKNVQmX+enHf0Qq899M6qpfvSjLaWJ9mektGLC74Ja7SItQ3KqKotTabsGUXa8SvYix4Iw+2jPPWUsNeOIOEg==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "^0.1.5",
+    "@webgpu/types": "^0.1.6",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",
     "chokidar": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "^0.1.4",
+    "@webgpu/types": "^0.1.5",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",
     "chokidar": "^3.4.3",

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -9,6 +9,12 @@ import { checkElementsEqualGenerated } from '../../../util/check_contents.js';
 
 export const g = makeTestGroup(GPUTest);
 
+const kMaxComputeWorkgroupSize = [
+  DefaultLimits.maxComputeWorkgroupSizeX,
+  DefaultLimits.maxComputeWorkgroupSizeY,
+  DefaultLimits.maxComputeWorkgroupSizeZ,
+];
+
 g.test('memcpy').fn(async t => {
   const data = new Uint32Array([0x01020304]);
 
@@ -70,19 +76,13 @@ g.test('large_dispatch')
         315,
         628,
         2179,
-        DefaultLimits.maxComputePerDimensionDispatchSize,
+        DefaultLimits.maxComputeWorkgroupsPerDimension,
       ])
       // Test some reasonable workgroup sizes.
       .beginSubcases()
       // 0 == x axis; 1 == y axis; 2 == z axis.
       .combine('largeDimension', [0, 1, 2] as const)
-      .expand('workgroupSize', p => [
-        1,
-        2,
-        8,
-        32,
-        DefaultLimits.maxComputeWorkgroupSize[p.largeDimension],
-      ])
+      .expand('workgroupSize', p => [1, 2, 8, 32, kMaxComputeWorkgroupSize[p.largeDimension]])
   )
   .fn(async t => {
     // The output storage buffer is filled with this value.

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -61,7 +61,7 @@ setPipeline should generate an error iff using an 'invalid' pipeline.
     validateFinishAndSubmitGivenState(state);
   });
 
-const kMaxDispatch = DefaultLimits.maxComputePerDimensionDispatchSize;
+const kMaxDispatch = DefaultLimits.maxComputeWorkgroupsPerDimension;
 g.test('dispatch_sizes')
   .desc(
     `Test 'direct' and 'indirect' dispatch with various sizes.

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -199,7 +199,7 @@ g.test('source_canvas,contexts')
         '2d',
         'bitmaprenderer',
         'experimental-webgl',
-        'gpupresent',
+        'webgpu',
         'webgl',
         'webgl2',
       ] as const)

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -324,9 +324,9 @@ export class ValidationTest extends GPUTest {
       occlusionQuerySet?: GPUQuerySet;
     } = {}
   ): CommandBufferMaker<T> {
-    const fullAttachmentInfo: GPURenderBundleEncoderDescriptor = {
+    const fullAttachmentInfo = {
       // Defaults if not overridden:
-      colorFormats: ['rgba8unorm'] as GPUTextureFormat[],
+      colorFormats: ['rgba8unorm'],
       sampleCount: 1,
       // Passed values take precedent.
       ...attachmentInfo,

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -26,8 +26,8 @@ export class ValidationTest extends GPUTest {
       usage:
         GPUTextureUsage.COPY_SRC |
         GPUTextureUsage.COPY_DST |
-        GPUTextureUsage.SAMPLED |
-        GPUTextureUsage.STORAGE |
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.STORAGE_BINDING |
         GPUTextureUsage.RENDER_ATTACHMENT,
     };
 
@@ -141,7 +141,7 @@ export class ValidationTest extends GPUTest {
       this.device.createTexture({
         size: { width: 16, height: 16, depthOrArrayLayers: 1 },
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.SAMPLED,
+        usage: GPUTextureUsage.TEXTURE_BINDING,
         sampleCount,
       })
     );
@@ -153,7 +153,7 @@ export class ValidationTest extends GPUTest {
       this.device.createTexture({
         size: { width: 16, height: 16, depthOrArrayLayers: 1 },
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.STORAGE,
+        usage: GPUTextureUsage.STORAGE_BINDING,
       })
     );
   }
@@ -175,7 +175,7 @@ export class ValidationTest extends GPUTest {
     const texture = this.device.createTexture({
       size: { width: 0, height: 0, depthOrArrayLayers: 0 },
       format: 'rgba8unorm',
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     });
     this.device.popErrorScope();
     return texture;
@@ -324,9 +324,9 @@ export class ValidationTest extends GPUTest {
       occlusionQuerySet?: GPUQuerySet;
     } = {}
   ): CommandBufferMaker<T> {
-    const fullAttachmentInfo = {
+    const fullAttachmentInfo: GPURenderBundleEncoderDescriptor = {
       // Defaults if not overridden:
-      colorFormats: ['rgba8unorm'],
+      colorFormats: ['rgba8unorm'] as GPUTextureFormat[],
       sampleCount: 1,
       // Passed values take precedent.
       ...attachmentInfo,

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -604,9 +604,9 @@ assertTypeTrue<TypeEqual<GPUTextureSampleType, typeof kTextureSampleTypes[number
 /** Binding type info (including class limits) for the specified GPUStorageTextureBindingLayout. */
 export function storageTextureBindingTypeInfo(d: GPUStorageTextureBindingLayout) {
   /* prettier-ignore */
-  switch (d.access) {
-    case 'read-only':  return { usage: GPUConst.TextureUsage.STORAGE, ...kBindingKind.storageTex, ...kValidStagesAll,          };
-    case 'write-only': return { usage: GPUConst.TextureUsage.STORAGE, ...kBindingKind.storageTex, ...kValidStagesStorageWrite, };
+  switch (d.access ?? 'write-only') {
+    case 'read-only':  return { usage: GPUConst.TextureUsage.STORAGE_BINDING, ...kBindingKind.storageTex, ...kValidStagesAll,          };
+    case 'write-only': return { usage: GPUConst.TextureUsage.STORAGE_BINDING, ...kBindingKind.storageTex, ...kValidStagesStorageWrite, };
   }
 }
 /** List of all GPUStorageTextureAccess values. */

--- a/src/webgpu/constants.ts
+++ b/src/webgpu/constants.ts
@@ -20,7 +20,9 @@ checkType<Omit<GPUBufferUsage, '__brand'>>(BufferUsage);
 const TextureUsage = {
   COPY_SRC: 0x01,
   COPY_DST: 0x02,
+  TEXTURE_BINDING: 0x04,
   SAMPLED: 0x04,
+  STORAGE_BINDING: 0x08,
   STORAGE: 0x08,
   RENDER_ATTACHMENT: 0x10,
 } as const;
@@ -56,17 +58,8 @@ export const GPUConst = {
   MapMode,
 } as const;
 
-type Limits = Omit<GPUSupportedLimits, '__brand'> & {
-  maxComputeWorkgroupStorageSize: number;
-  maxComputeWorkgroupInvocations: number;
-  maxComputeWorkgroupSize: readonly [number, number, number];
-  maxComputePerDimensionDispatchSize: number;
-  minUniformBufferOffsetAlignment: number;
-  minStorageBufferOffsetAlignment: number;
-  maxInterStageShaderComponents: number;
-};
 /** Base limits, per spec. */
-export const DefaultLimits: Limits = {
+export const DefaultLimits = {
   maxTextureDimension1D: 8192,
   maxTextureDimension2D: 8192,
   maxTextureDimension3D: 2048,
@@ -92,7 +85,10 @@ export const DefaultLimits: Limits = {
   maxInterStageShaderComponents: 60,
 
   maxComputeWorkgroupStorageSize: 16352,
-  maxComputeWorkgroupInvocations: 256,
-  maxComputeWorkgroupSize: [256, 256, 64],
-  maxComputePerDimensionDispatchSize: 65535,
+  maxComputeInvocationsPerWorkgroup: 256,
+  maxComputeWorkgroupSizeX: 256,
+  maxComputeWorkgroupSizeY: 256,
+  maxComputeWorkgroupSizeZ: 64,
+  maxComputeWorkgroupsPerDimension: 65535,
 };
+checkType<Omit<GPUSupportedLimits, '__brand'>>(DefaultLimits);

--- a/src/webgpu/idl/constants/flags.spec.ts
+++ b/src/webgpu/idl/constants/flags.spec.ts
@@ -32,8 +32,8 @@ g.test('BufferUsage,values')
 const kTextureUsageExp = {
   COPY_SRC: 0x01,
   COPY_DST: 0x02,
-  SAMPLED: 0x04,
-  STORAGE: 0x08,
+  TEXTURE_BINDING: 0x04,
+  STORAGE_BINDING: 0x08,
   RENDER_ATTACHMENT: 0x10,
 };
 g.test('TextureUsage,count').fn(t => {

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -119,20 +119,20 @@ got [${failedByteActualValues.join(', ')}]`;
   }
 
   doTestAndCheckResult(
-    imageBitmapCopyView: GPUImageCopyImageBitmap,
+    srcCopyView: GPUImageCopyExternalImage,
     dstTextureCopyView: GPUImageCopyTexture,
     copySize: GPUExtent3DDict,
     bytesPerPixel: number,
     expectedData: Uint8ClampedArray
   ): void {
-    this.device.queue.copyImageBitmapToTexture(imageBitmapCopyView, dstTextureCopyView, copySize);
+    this.device.queue.copyExternalImageToTexture(srcCopyView, dstTextureCopyView, copySize);
 
-    const imageBitmap = imageBitmapCopyView.imageBitmap;
+    const imageSource = srcCopyView.source;
     const dstTexture = dstTextureCopyView.texture;
 
-    const bytesPerRow = calculateRowPitch(imageBitmap.width, bytesPerPixel);
+    const bytesPerRow = calculateRowPitch(imageSource.width, bytesPerPixel);
     const testBuffer = this.device.createBuffer({
-      size: bytesPerRow * imageBitmap.height,
+      size: bytesPerRow * imageSource.height,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
 
@@ -141,15 +141,15 @@ got [${failedByteActualValues.join(', ')}]`;
     encoder.copyTextureToBuffer(
       { texture: dstTexture, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
       { buffer: testBuffer, bytesPerRow },
-      { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 }
+      { width: imageSource.width, height: imageSource.height, depthOrArrayLayers: 1 }
     );
     this.device.queue.submit([encoder.finish()]);
 
     this.checkCopyImageBitmapResult(
       testBuffer,
       expectedData,
-      imageBitmap.width,
-      imageBitmap.height,
+      imageSource.width,
+      imageSource.height,
       bytesPerPixel
     );
   }
@@ -307,7 +307,7 @@ g.test('from_ImageData')
     });
 
     t.doTestAndCheckResult(
-      { imageBitmap, origin: { x: 0, y: 0 } },
+      { source: imageBitmap, origin: { x: 0, y: 0 } },
       { texture: dst },
       { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 },
       dstBytesPerPixel,
@@ -397,7 +397,7 @@ g.test('from_canvas')
     });
 
     t.doTestAndCheckResult(
-      { imageBitmap, origin: { x: 0, y: 0 } },
+      { source: imageBitmap, origin: { x: 0, y: 0 } },
       { texture: dst },
       { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 },
       dstBytesPerPixel,

--- a/src/webgpu/web_platform/reftests/canvas_clear.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_clear.html.ts
@@ -3,13 +3,13 @@ import { runRefTest } from './gpu_ref_test.js';
 runRefTest(async t => {
   const canvas = document.getElementById('gpucanvas') as HTMLCanvasElement;
 
-  const ctx = (canvas.getContext('gpupresent') as unknown) as GPUCanvasContext;
-  const swapChain = ctx.configureSwapChain({
+  const ctx = (canvas.getContext('webgpu') as unknown) as GPUCanvasContext;
+  ctx.configure({
     device: t.device,
     format: 'bgra8unorm',
   });
 
-  const colorAttachment = swapChain.getCurrentTexture();
+  const colorAttachment = ctx.getCurrentTexture();
   const colorAttachmentView = colorAttachment.createView();
 
   const encoder = t.device.createCommandEncoder();

--- a/src/webgpu/web_platform/reftests/canvas_complex.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_complex.html.ts
@@ -7,7 +7,7 @@ declare const cvs: HTMLCanvasElement;
 
 export function run(format: GPUTextureFormat) {
   runRefTest(async t => {
-    const ctx = (cvs.getContext('gpupresent') as unknown) as GPUCanvasContext;
+    const ctx = (cvs.getContext('webgpu') as unknown) as GPUCanvasContext;
 
     switch (format) {
       case 'bgra8unorm':
@@ -17,7 +17,7 @@ export function run(format: GPUTextureFormat) {
         unreachable();
     }
 
-    const swapChain = ctx.configureSwapChain({
+    ctx.configure({
       device: t.device,
       format,
       usage: GPUTextureUsage.COPY_DST,
@@ -69,7 +69,7 @@ export function run(format: GPUTextureFormat) {
     }
     buffer.unmap();
 
-    const texture = swapChain.getCurrentTexture();
+    const texture = ctx.getCurrentTexture();
 
     const encoder = t.device.createCommandEncoder();
     encoder.copyBufferToTexture({ buffer, bytesPerRow }, { texture }, [2, 2, 1]);


### PR DESCRIPTION
Rolls the WebGPU types from 0.1.4 to 0.1.5 and fixes any (visible) issues that resulted.