### PR TITLE
Catch promise rejection from video.play()

### DIFF
--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -1,4 +1,4 @@
-import { raceWithRejectOnTimeout } from '../../common/util/util.js';
+import { ErrorWithExtra, raceWithRejectOnTimeout } from '../../common/util/util.js';
 
 /**
  * Starts playing a video and waits for it to be consumable.
@@ -25,13 +25,15 @@ export function startPlayingAndWaitForVideo(
       };
 
       if (video.error) {
-        reject(new Error('Video failed to load: ' + video.error));
+        reject(
+          new ErrorWithExtra('Video.error: ' + video.error.message, () => ({ error: video.error }))
+        );
         return;
       }
 
       video.addEventListener(
         'error',
-        e => reject(new Error('Video playback failed: ' + e.message)),
+        event => reject(new ErrorWithExtra('Video received "error" event', () => ({ event }))),
         true
       );
 
@@ -55,7 +57,7 @@ export function startPlayingAndWaitForVideo(
       video.loop = true;
       video.muted = true;
       video.preload = 'auto';
-      video.play();
+      video.play().catch(reject);
     }),
     2000,
     'Video never became ready'


### PR DESCRIPTION
Without this, the unhandled promise rejection escapes from the test function and causes a test failure even when the CTS is supposed "expect" a failure in a (sub)case.

Fixes running tests (with subcase expectations) in browser builds without certain codecs available.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
