### PR TITLE
Make reftest slightly fuzzy to account for apparent differences

### DIFF
--- a/src/webgpu/web_platform/reftests/README.txt
+++ b/src/webgpu/web_platform/reftests/README.txt
@@ -10,3 +10,6 @@ This tests things like:
 
 TODO: Test all possible output texture formats (currently only testing bgra8unorm).
 TODO: Test all possible ways to write into those formats (currently only testing B2T copy).
+
+TODO: Why is there sometimes a difference of 1 (e.g. 3f vs 40) in canvas_size_different_with_back_buffer_size?
+And why does chromium's image_diff show diffs on other pixels that don't seem to have diffs?

--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html
@@ -6,7 +6,8 @@
     name="assert"
     content="WebGPU canvas should present correctly with different size of back buffer"
   />
-  <link rel="match" 
+  <meta name=fuzzy content="maxDifference=1;totalPixels=0-2000">
+  <link rel="match"
         href="./ref/canvas_size_different_with_back_buffer_size-ref.html" />
 
   <canvas id="cvs_larger_than_back_buffer" width="6" height="8"></canvas>


### PR DESCRIPTION
Failed here:
https://chromium-review.googlesource.com/c/chromium/src/+/3079142/3
https://ci.chromium.org/ui/p/chromium/builders/try/dawn-linux-x64-deps-rel/17573/overview

From manual inspection of the actual and expected pngs, there's a difference of up to 1 in each channel in the interpolated areas. Apparently there is a very slight difference in how they get interpolated, and that's fine.
Chromium's `image_diff` image seems to show diffs in the solid areas too, but I don't see it by manual inspection.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
