### PR TITLE
api,validation,state,device_mismatched plan

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -504,8 +504,9 @@ g.test('binding_resources,device_mismatch')
   .desc(
     `
     Tests createBindGroup cannot be called with various resources created from another device
-    - two resources from same device
-    - two resources from different device
+    Test with two resources to make sure all resources can be validated:
+    - resource0 and resource1 from same device
+    - resource0 and resource1 from different device
     `
   )
   .paramsSubcasesOnly(u =>
@@ -517,6 +518,10 @@ g.test('binding_resources,device_mismatch')
         'storageTexture',
         'externalTexture',
       ] as const)
-      .combine('mismatched', [true, false])
+      .combineWithParams([
+        { resource0Mismatched: false, resource1Mismatched: false }, //control case
+        { resource0Mismatched: true, resource1Mismatched: false },
+        { resource0Mismatched: false, resource1Mismatched: true },
+      ])
   )
   .unimplemented();

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -492,3 +492,31 @@ g.test('texture,resource_state')
       });
     }, state === 'invalid');
   });
+
+g.test('bind_group_layout,device_mismatch')
+  .desc(
+    'Tests createBindGroup cannot be called with a bind group layout created from another device'
+  )
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();
+
+g.test('binding_resources,device_mismatch')
+  .desc(
+    `
+    Tests createBindGroup cannot be called with various resources created from another device
+    - two resources from same device
+    - two resources from different device
+    `
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('bindingResource', [
+        'buffer',
+        'sampler',
+        'texture',
+        'storageTexture',
+        'externalTexture',
+      ] as const)
+      .combine('mismatched', [true, false])
+  )
+  .unimplemented();

--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -174,3 +174,17 @@ The entryPoint assigned in descriptor include:
     const _success = shaderModuleEntryPoint === stageEntryPoint;
     t.doCreateComputePipelineTest(isAsync, _success, descriptor);
   });
+
+g.test('pipeline_layout,device_mismatch')
+  .desc(
+    'Tests createComputePipeline(Async) cannot be called with a pipeline layout created from another device'
+  )
+  .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
+  .unimplemented();
+
+g.test('shader_module,device_mismatch')
+  .desc(
+    'Tests createComputePipeline(Async) cannot be called with a shader module created from another device'
+  )
+  .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
+  .unimplemented();

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -107,9 +107,14 @@ g.test('bind_group_layouts,device_mismatch')
   .desc(
     `
     Tests createPipelineLayout cannot be called with bind group layouts created from another device
-    - two layouts from same device
-    - two layouts from different device
+    Test with two layouts to make sure all layouts can be validated:
+    - layout0 and layout1 from same device
+    - layout0 and layout1 from different device
     `
   )
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .paramsSubcasesOnly([
+    { layout0Mismatched: false, layout1Mismatched: false }, // control case
+    { layout0Mismatched: true, layout1Mismatched: false },
+    { layout0Mismatched: false, layout1Mismatched: true },
+  ])
   .unimplemented();

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -102,3 +102,14 @@ g.test('number_of_bind_group_layouts_exceeds_the_maximum_value').fn(async t => {
     t.device.createPipelineLayout(badPipelineLayoutDescriptor);
   });
 });
+
+g.test('bind_group_layouts,device_mismatch')
+  .desc(
+    `
+    Tests createPipelineLayout cannot be called with bind group layouts created from another device
+    - two layouts from same device
+    - two layouts from different device
+    `
+  )
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -187,3 +187,17 @@ g.test('sample_count_must_be_valid')
 
     t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
   });
+
+g.test('pipeline_layout,device_mismatch')
+  .desc(
+    'Tests createRenderPipeline(Async) cannot be called with a pipeline layout created from another device'
+  )
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false] as const))
+  .unimplemented();
+
+g.test('shader_module,device_mismatch')
+  .desc(
+    'Tests createRenderPipeline(Async) cannot be called with a shader module created from another device'
+  )
+  .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
+  .unimplemented();

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -23,3 +23,31 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
+
+g.test('color_attachments,device_mismatch')
+  .desc(
+    `
+    Tests beginRenderPass cannot be called with color attachments whose texure view or resolve target is created from another device
+    The 'view' and 'resolveTarget' are:
+    - created from {same, different} device in same color attachment
+    - created from same device in same color attachment, but different in another color attachment
+    `
+  )
+  .paramsSubcasesOnly(u =>
+    u.combine('sameAttachment', [true, false]).combine('mismatched', [true, false])
+  )
+  .unimplemented();
+
+g.test('depth_stencil_attachment,device_mismatch')
+  .desc(
+    'Tests beginRenderPass cannot be called with a depth stencil attachment whose texure view is created from another device'
+  )
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();
+
+g.test('occlusion_query_set,device_mismatch')
+  .desc(
+    'Tests beginRenderPass cannot be called with an occlusion query set created from another device'
+  )
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -29,13 +29,37 @@ g.test('color_attachments,device_mismatch')
     `
     Tests beginRenderPass cannot be called with color attachments whose texure view or resolve target is created from another device
     The 'view' and 'resolveTarget' are:
-    - created from {same, different} device in same color attachment
-    - created from same device in same color attachment, but different in another color attachment
+    - created from same device in ColorAttachment0 and ColorAttachment1
+    - created from different device in ColorAttachment0 and ColorAttachment1
+    - created from same device in ColorAttachment0, but from different device in ColorAttachment1
     `
   )
-  .paramsSubcasesOnly(u =>
-    u.combine('sameAttachment', [true, false]).combine('mismatched', [true, false])
-  )
+  .paramsSubcasesOnly([
+    {
+      view0Mismatched: false,
+      target0Mismatched: false,
+      view1Mismatched: false,
+      target1Mismatched: false,
+    }, // control case
+    {
+      view0Mismatched: false,
+      target0Mismatched: true,
+      view1Mismatched: false,
+      target1Mismatched: true,
+    },
+    {
+      view0Mismatched: false,
+      target0Mismatched: false,
+      view1Mismatched: true,
+      target1Mismatched: false,
+    },
+    {
+      view0Mismatched: false,
+      target0Mismatched: false,
+      view1Mismatched: false,
+      target1Mismatched: true,
+    },
+  ])
   .unimplemented();
 
 g.test('depth_stencil_attachment,device_mismatch')

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -61,6 +61,11 @@ setPipeline should generate an error iff using an 'invalid' pipeline.
     validateFinishAndSubmitGivenState(state);
   });
 
+g.test('pipeline,device_mismatch')
+  .desc('Tests setPipeline cannot be called with a compute pipeline created from another device')
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();
+
 const kMaxDispatch = DefaultLimits.maxComputeWorkgroupsPerDimension;
 g.test('dispatch_sizes')
   .desc(
@@ -151,3 +156,10 @@ TODO: test specifically which call the validation error occurs in.
       offset + 3 * Uint32Array.BYTES_PER_ELEMENT > kBufferData.byteLength;
     validateFinishAndSubmit(!finishShouldError, state !== 'destroyed');
   });
+
+g.test('indirect_dispatch_buffer,device_mismatch')
+  .desc(
+    'Tests dispatchIndirect cannot be called with an indirect buffer created from another device'
+  )
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();

--- a/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
@@ -77,6 +77,17 @@ g.test('copy_with_invalid_buffer').fn(async t => {
   });
 });
 
+g.test('buffer,device_mismatch')
+  .desc(
+    'Tests copyBufferToBuffer cannot be called with src buffer or dst buffer created from another device'
+  )
+  .paramsSubcasesOnly([
+    { srcMismatched: false, dstMismatched: false }, // control case
+    { srcMismatched: true, dstMismatched: false },
+    { srcMismatched: false, dstMismatched: true },
+  ] as const)
+  .unimplemented();
+
 g.test('buffer_usage')
   .paramsSubcasesOnly(u =>
     u //

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -107,6 +107,17 @@ g.test('copy_with_invalid_texture').fn(async t => {
   );
 });
 
+g.test('texture,device_mismatch')
+  .desc(
+    'Tests copyTextureToTexture cannot be called with src texture or dst texture created from another device'
+  )
+  .paramsSubcasesOnly([
+    { srcMismatched: false, dstMismatched: false }, // control case
+    { srcMismatched: true, dstMismatched: false },
+    { srcMismatched: false, dstMismatched: true },
+  ] as const)
+  .unimplemented();
+
 g.test('mipmap_level')
   .paramsSubcasesOnly([
     { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 0 },

--- a/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
@@ -49,6 +49,13 @@ Tests indirect buffer must be valid.
     validateFinishAndSubmitGivenState(state);
   });
 
+g.test('indirect_buffer,device_mismatch')
+  .desc(
+    'Tests draw(Indexed)Indirect cannot be called with an indirect buffer created from another device'
+  )
+  .paramsSubcasesOnly(kIndirectDrawTestParams.combine('mismatched', [true, false]))
+  .unimplemented();
+
 g.test('indirect_buffer_usage')
   .desc(
     `

--- a/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
@@ -29,6 +29,11 @@ Tests index buffer must be valid.
     validateFinishAndSubmitGivenState(state);
   });
 
+g.test('index_buffer,device_mismatch')
+  .desc('Tests setIndexBuffer cannot be called with an index buffer created from another device')
+  .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('mismatched', [true, false]))
+  .unimplemented();
+
 g.test('index_buffer_usage')
   .desc(
     `

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -6,6 +6,8 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { kRenderEncodeTypes } from '../../../util/command_buffer_maker.js';
 import { ValidationTest } from '../../../validation_test.js';
 
+import { kRenderEncodeTypeParams } from './render.js';
+
 export const g = makeTestGroup(ValidationTest);
 
 g.test('invalid_pipeline')
@@ -25,3 +27,8 @@ Tests setPipeline should generate an error iff using an 'invalid' pipeline.
     encoder.setPipeline(pipeline);
     validateFinish(state !== 'invalid');
   });
+
+g.test('pipeline,device_mismatch')
+  .desc('Tests setPipeline cannot be called with a render pipeline created from another device')
+  .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('mismatched', [true, false]))
+  .unimplemented();

--- a/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
@@ -54,6 +54,11 @@ Tests vertex buffer must be valid.
     validateFinishAndSubmitGivenState(state);
   });
 
+g.test('vertex_buffer,device_mismatch')
+  .desc('Tests setVertexBuffer cannot be called with a vertex buffer created from another device')
+  .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('mismatched', [true, false]))
+  .unimplemented();
+
 g.test('vertex_buffer_usage')
   .desc(
     `

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -129,7 +129,7 @@ g.test('bind_group,device_mismatch')
   .desc(
     `
     Tests setBindGroup cannot be called with a bind group created from another device
-    - x= setBindGroup {with, without} Uint32Array
+    - x= setBindGroup {sequence overload, Uint32Array overload}
     `
   )
   .params(u =>

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -132,8 +132,12 @@ g.test('bind_group,device_mismatch')
     - x= setBindGroup {with, without} Uint32Array
     `
   )
-  .paramsSubcasesOnly(u =>
-    u.combine('encoderType', kProgrammableEncoderTypes).combine('mismatched', [true, false])
+  .params(u =>
+    u
+      .combine('encoderType', kProgrammableEncoderTypes)
+      .beginSubcases()
+      .combine('useU32Array', [true, false])
+      .combine('mismatched', [true, false])
   )
   .unimplemented();
 

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -125,6 +125,18 @@ g.test('state_and_binding_index')
     }
   });
 
+g.test('bind_group,device_mismatch')
+  .desc(
+    `
+    Tests setBindGroup cannot be called with a bind group created from another device
+    - x= setBindGroup {with, without} Uint32Array
+    `
+  )
+  .paramsSubcasesOnly(u =>
+    u.combine('encoderType', kProgrammableEncoderTypes).combine('mismatched', [true, false])
+  )
+  .unimplemented();
+
 g.test('dynamic_offsets_passed_but_not_expected')
   .desc('Tests that setBindGroup correctly errors on unexpected dynamicOffsets.')
   .params(u => u.combine('encoderType', kProgrammableEncoderTypes))

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -3,7 +3,7 @@ TODO:
 
 - Start a pipeline statistics query in all possible encoders:
     - queryIndex {in, out of} range for GPUQuerySet
-    - GPUQuerySet {valid, invalid}
+    - GPUQuerySet {valid, invalid, device mismatched}
     - x ={render pass, compute pass} encoder
 `;
 
@@ -126,3 +126,12 @@ Tests that write timestamp to a invalid query set that failed during creation:
     encoder.encoder.writeTimestamp(querySet, 0);
     encoder.validateFinish(querySetState !== 'invalid');
   });
+
+g.test('timestamo_query,device_mismatch')
+  .desc('Tests writeTimestamp cannot be called with a query set created from another device')
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('encoderType', ['non-pass', 'compute pass', 'render pass'] as const)
+      .combine('mismatched', [true, false])
+  )
+  .unimplemented();

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -127,7 +127,7 @@ Tests that write timestamp to a invalid query set that failed during creation:
     encoder.validateFinish(querySetState !== 'invalid');
   });
 
-g.test('timestamo_query,device_mismatch')
+g.test('timestamp_query,device_mismatch')
   .desc('Tests writeTimestamp cannot be called with a query set created from another device')
   .paramsSubcasesOnly(u =>
     u

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -123,3 +123,14 @@ Tests that resolve query set with invalid destinationOffset:
       encoder.finish();
     }, t.params.destinationOffset > 0);
   });
+
+g.test('query_set_buffer,device_mismatch')
+  .desc(
+    'Tests resolveQuerySet cannot be called with a query set or destination buffer created from another device'
+  )
+  .paramsSubcasesOnly([
+    { querySetMismatched: false, bufferMismatched: false }, // control case
+    { querySetMismatched: true, bufferMismatched: false },
+    { querySetMismatched: false, bufferMismatched: true },
+  ] as const)
+  .unimplemented();

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -10,3 +10,14 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
+
+g.test('render_bundles,device_mismatch')
+  .desc(
+    `
+    Tests executeBundles cannot be called with render bundles created from another device
+    - two bundles from same device
+    - two bundles from different device
+    `
+  )
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -15,9 +15,14 @@ g.test('render_bundles,device_mismatch')
   .desc(
     `
     Tests executeBundles cannot be called with render bundles created from another device
-    - two bundles from same device
-    - two bundles from different device
+    Test with two bundles to make sure all bundles can be validated:
+    - bundle0 and bundle1 from same device
+    - bundle0 and bundle1 from different device
     `
   )
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .paramsSubcasesOnly([
+    { bundle0Mismatched: false, bundle1Mismatched: false }, // control case
+    { bundle0Mismatched: true, bundle1Mismatched: false },
+    { bundle0Mismatched: false, bundle1Mismatched: true },
+  ])
   .unimplemented();

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -70,6 +70,20 @@ g.test('valid')
     );
   });
 
+g.test('texture,device_mismatch')
+  .desc('Tests the image copies cannot be called with a texture created from another device')
+  .paramsSubcasesOnly(u =>
+    u.combine('method', kImageCopyTypes).combine('mismatched', [true, false])
+  )
+  .unimplemented();
+
+g.test('buffer,device_mismatch')
+  .desc('Tests the image copies cannot be called with a buffer created from another device')
+  .paramsSubcasesOnly(u =>
+    u.combine('method', ['CopyB2T', 'CopyT2B'] as const).combine('mismatched', [true, false])
+  )
+  .unimplemented();
+
 g.test('usage')
   .desc(`The texture must have the appropriate COPY_SRC/COPY_DST usage.`)
   .params(u =>

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -609,6 +609,13 @@ g.test('destination_texture,state')
     t.runTest({ source: imageBitmap }, { texture: dstTexture }, copySize, state === 'valid');
   });
 
+g.test('destination_texture,device_mismatch')
+  .desc(
+    'Tests copyExternalImageToTexture cannot be called with a destination texture created from another device'
+  )
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();
+
 g.test('destination_texture,dimension')
   .desc(
     `

--- a/src/webgpu/api/validation/queue/submit.spec.ts
+++ b/src/webgpu/api/validation/queue/submit.spec.ts
@@ -14,9 +14,14 @@ g.test('command_buffer,device_mismatch')
   .desc(
     `
     Tests submit cannot be called with command buffers created from another device
-    - two command buffers from same device
-    - two command buffers from different device
+    Test with two command buffers to make sure all command buffers can be validated:
+    - cb0 and cb1 from same device
+    - cb0 and cb1 from different device
     `
   )
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .paramsSubcasesOnly([
+    { cb0Mismatched: false, cb1Mismatched: false }, // control case
+    { cb0Mismatched: true, cb1Mismatched: false },
+    { cb0Mismatched: false, cb1Mismatched: true },
+  ])
   .unimplemented();

--- a/src/webgpu/api/validation/queue/submit.spec.ts
+++ b/src/webgpu/api/validation/queue/submit.spec.ts
@@ -1,0 +1,22 @@
+export const description = `
+Tests submit validation.
+
+Note: destroyed buffer/texture/querySet are tested in destroyed/.
+Note: buffer map state is tested in ./buffer_mapped.spec.ts.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ValidationTest } from '../validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('command_buffer,device_mismatch')
+  .desc(
+    `
+    Tests submit cannot be called with command buffers created from another device
+    - two command buffers from same device
+    - two command buffers from different device
+    `
+  )
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();

--- a/src/webgpu/api/validation/queue/submit.spec.ts
+++ b/src/webgpu/api/validation/queue/submit.spec.ts
@@ -1,7 +1,7 @@
 export const description = `
 Tests submit validation.
 
-Note: destroyed buffer/texture/querySet are tested in destroyed/.
+Note: destroyed buffer/texture/querySet are tested in destroyed/. (unless it gets moved here)
 Note: buffer map state is tested in ./buffer_mapped.spec.ts.
 `;
 

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -158,3 +158,8 @@ Tests calling writeBuffer with the buffer missed COPY_DST usage.
       t.device.queue.writeBuffer(buffer, 0, data, 0, data.length);
     }, !_valid);
   });
+
+g.test('buffer,device_mismatch')
+  .desc('Tests writeBuffer cannot be called with a buffer created from another device')
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .unimplemented();

--- a/src/webgpu/api/validation/state/device_mismatched/README.txt
+++ b/src/webgpu/api/validation/state/device_mismatched/README.txt
@@ -1,5 +1,0 @@
-Tests of behavior on one device using objects from another device.
-
-- x= every place in the API where an object is passed (as this, an arg, or a dictionary member).
-
-TODO: implement


### PR DESCRIPTION
- Add validation test plan for one device using objects from another device in all APIs where an object is passed.
- Split tests to each API file.
- The APIs and Objects include:
  - GPUDevice:
    createPipelineLayout with BGLs
    createBindGroup with {BGL, BindResource(buffer,sampler,texture,etc.)}
    createComputePipeline(Async) with {PipelineLayout, ShaderModule}
    createRenderPipeline(Async) with {PipelineLayout, ShaderModule}
  - GPUCommandEncoder:
    beginRenderPass with {Texture views in attachments, OcclusionQuerySet}
    copyBufferToBuffer with Buffers
    copyBufferToTexture/copyTextureToBuffer with {Buffer, Texture} (test in image_copy/)
    copyTextureToTexture with Textures
    writeTimestamp/resolveQuerySet with QuerySet
  - GPUProgrammablePassEncoder
    setBindGroup {with, without} Uint32Array with BindGroup
    x = {compute pass, render pass, render bundle}
  - GPUComputePassEncoder
    setPipeline with ComputePipeline
    beginPipelineStatisticsQuery/writeTimestamp with QuerySet
  - GPURenderEncoderBase
    setPipeline with RenderPipeline
    setIndexBuffer/setVertexBuffer with Buffer
    drawIndirect/drawIndexedIndirect with Buffer
    beginPipelineStatisticsQuery/writeTimestamp with QuerySet
    x = {render pass, render bundle}
  - GPURenderPassEncoder
    executeBundles with RenderBundles
  - GPUQueue
    submit with CommandBuffers
    writeBuffer with Buffer
    writeTexture with Texture (test in image_copy/)
    copyExternalImageToTexture with Texture





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
