### PR TITLE
Remove log message deduplication, hide more log details

### DIFF
--- a/src/common/internal/logging/log_message.ts
+++ b/src/common/internal/logging/log_message.ts
@@ -4,8 +4,7 @@ import { extractImportantStackTrace } from '../stack.js';
 export class LogMessageWithStack extends Error {
   readonly extra: unknown;
 
-  private stackHiddenMessage: string | undefined = undefined;
-  private timesSeen: number = 1;
+  private firstLineOnlyMessage: string | undefined = undefined;
 
   constructor(name: string, ex: Error | ErrorWithExtra) {
     super(ex.message);
@@ -17,26 +16,21 @@ export class LogMessageWithStack extends Error {
     }
   }
 
-  /** Set a flag so the stack is not printed in toJSON(). */
-  setStackHidden(stackHiddenMessage: string) {
-    this.stackHiddenMessage ??= stackHiddenMessage;
-  }
-
-  /** Increment the "seen x times" counter. */
-  incrementTimesSeen() {
-    this.timesSeen++;
+  /** Set a flag so the details and stack are not printed in toJSON(). */
+  setFirstLineOnly(firstLineOnlyMessage: string) {
+    this.firstLineOnlyMessage ??= firstLineOnlyMessage;
   }
 
   toJSON(): string {
     let m = this.name;
-    if (this.message) m += ': ' + this.message;
-    if (this.stackHiddenMessage === undefined && this.stack) {
-      m += '\n' + extractImportantStackTrace(this);
-    } else if (this.stackHiddenMessage) {
-      m += `\n  (${this.stackHiddenMessage})`;
-    }
-    if (this.timesSeen > 1) {
-      m += `\n  (duplicated ${this.timesSeen} times (possibly non-consecutively); use ?debug=1 to show all)`;
+    if (this.firstLineOnlyMessage !== undefined) {
+      if (this.message) m += ': ' + this.message.split('\n')[0];
+      if (this.firstLineOnlyMessage !== '') {
+        m += ` (elided: ${this.firstLineOnlyMessage})`;
+      }
+    } else {
+      if (this.message) m += ': ' + this.message;
+      if (this.stack) m += '\n' + extractImportantStackTrace(this);
     }
     return m;
   }

--- a/src/common/internal/logging/test_case_recorder.ts
+++ b/src/common/internal/logging/test_case_recorder.ts
@@ -13,7 +13,7 @@ enum LogSeverity {
   ThrewException = 5,
 }
 
-const kMaxLogStacks = 2;
+const kMaxDetailedLogs = 2;
 const kMinSeverityForStack = LogSeverity.Warn;
 
 /** Holds onto a LiveTestCaseResult owned by the Logger, and writes the results into it. */
@@ -122,16 +122,6 @@ export class TestCaseRecorder {
   private logImpl(level: LogSeverity, name: string, baseException: Error): void {
     const logMessage = new LogMessageWithStack(name, baseException);
 
-    // Deduplicate errors with the exact same stack
-    if (!this.debugging && logMessage.stack) {
-      const seen = this.messagesForPreviouslySeenStacks.get(logMessage.stack);
-      if (seen) {
-        seen.incrementTimesSeen();
-        return;
-      }
-      this.messagesForPreviouslySeenStacks.set(logMessage.stack, logMessage);
-    }
-
     // Final case status should be the "worst" of all log entries.
     if (this.inSubCase) {
       if (level > this.subCaseStatus) this.subCaseStatus = level;
@@ -139,25 +129,25 @@ export class TestCaseRecorder {
       if (level > this.finalCaseStatus) this.finalCaseStatus = level;
     }
 
-    // setStackHidden for all logs except `kMaxLogStacks` stacks at the highest severity
+    // setFirstLineOnly for all logs except `kMaxLogStacks` stacks at the highest severity
     if (level > this.hideStacksBelowSeverity) {
       this.logLinesAtCurrentSeverity = 0;
       this.hideStacksBelowSeverity = level;
 
-      // Go back and setStackHidden for everything of a lower log level
+      // Go back and setFirstLineOnly for everything of a lower log level
       for (const log of this.logs) {
-        log.setStackHidden('stack hidden; lower-severity');
+        log.setFirstLineOnly('below max severity');
       }
     }
     if (level === this.hideStacksBelowSeverity) {
       this.logLinesAtCurrentSeverity++;
     } else if (level < kMinSeverityForStack) {
-      logMessage.setStackHidden('');
+      logMessage.setFirstLineOnly('');
     } else if (level < this.hideStacksBelowSeverity) {
-      logMessage.setStackHidden('stack hidden; lower-severity');
+      logMessage.setFirstLineOnly('below max severity');
     }
-    if (this.logLinesAtCurrentSeverity > kMaxLogStacks) {
-      logMessage.setStackHidden(`only ${kMaxLogStacks} stacks are shown`);
+    if (this.logLinesAtCurrentSeverity > kMaxDetailedLogs) {
+      logMessage.setFirstLineOnly(`only ${kMaxDetailedLogs} shown`);
     }
 
     this.logs.push(logMessage);


### PR DESCRIPTION
With subcases, this is deduplicating messages across logs. This makes it
hard to see what subcases are failing.
Also, we already have a mechanism to hide all but 2 stacks.

- Remove the log message deduplication and rely on the other thing
- For collapsed messages, hide all but the first line, instead of just
  the stack





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
