### PR TITLE
Remove some alpha blending factor validation

### DIFF
--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -362,9 +362,9 @@ g.test('pipeline_output_targets,blend')
       fragmentShaderCode: t.getFragmentShaderCode(sampleType, componentCount),
     });
 
-    const blendingReadSrcAlpha =
+    const colorBlendReadsSrcAlpha =
       colorSrcFactor.includes('src-alpha') || colorDstFactor.includes('src-alpha');
-    const meetsExtraBlendingRequirement = !blendingReadSrcAlpha || componentCount === 4;
+    const meetsExtraBlendingRequirement = !colorBlendReadsSrcAlpha || componentCount === 4;
     const _success =
       info.sampleType === sampleType &&
       componentCount >= kTexelRepresentationInfo[format].componentOrder.length &&

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -363,10 +363,7 @@ g.test('pipeline_output_targets,blend')
     });
 
     const blendingReadSrcAlpha =
-      colorSrcFactor.includes('src-alpha') ||
-      colorDstFactor.includes('src-alpha') ||
-      alphaSrcFactor !== 'zero' ||
-      alphaDstFactor.includes('src');
+      colorSrcFactor.includes('src-alpha') || colorDstFactor.includes('src-alpha');
     const meetsExtraBlendingRequirement = !blendingReadSrcAlpha || componentCount === 4;
     const _success =
       info.sampleType === sampleType &&


### PR DESCRIPTION
Validation rules discussed at
https://github.com/gpuweb/gpuweb/issues/2013


<hr>

**Author checklist for test code/plans:**

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
