### PR TITLE
Implement some initial stress tests

### DIFF
--- a/src/stress/adapter/device_allocation.ts
+++ b/src/stress/adapter/device_allocation.ts
@@ -7,7 +7,17 @@ import { makeTestGroup } from '../../common/framework/test_group.js';
 
 export const g = makeTestGroup(Fixture);
 
-g.test('coexisting').desc(`Tests allocation of many coexisting GPUDevice objects.`).unimplemented();
+g.test('coexisting')
+  .desc(
+    `Tests allocation of many coexisting GPUDevice objects.
+
+TODO: These stress tests might not make sense. Allocating lots of GPUDevices is
+currently crashy in Chrome, and there's not a great reason for applications to
+do it. UAs should probably limit the number of simultaneously active devices,
+but this is effectively blocked on implementing GPUDevice.destroy() to give
+applications the necessary controls.`
+  )
+  .unimplemented();
 
 g.test('continuous,with_destroy')
   .desc(

--- a/src/stress/compute/compute_pass.spec.ts
+++ b/src/stress/compute/compute_pass.spec.ts
@@ -3,6 +3,7 @@ Stress tests covering GPUComputePassEncoder usage.
 `;
 
 import { makeTestGroup } from '../../common/framework/test_group.js';
+import { iterRange } from '../../common/util/util.js';
 import { GPUTest } from '../../webgpu/gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -12,26 +13,230 @@ g.test('many')
     `Tests execution of a huge number of compute passes using the same
 GPUComputePipeline.`
   )
-  .unimplemented();
+  .fn(async t => {
+    const kNumElements = 64;
+    const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
+    const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+    const pipeline = t.device.createComputePipeline({
+      compute: {
+        module: t.device.createShaderModule({
+          code: `
+            [[block]] struct Buffer { data: array<u32>; };
+            [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+            [[stage(compute), workgroup_size(1)]] fn main(
+                [[builtin(global_invocation_id)]] id: vec3<u32>) {
+              buffer.data[id.x] = buffer.data[id.x] + 1u;
+            }
+          `,
+        }),
+        entryPoint: 'main',
+      },
+    });
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+    const kNumIterations = 250_000;
+    for (let i = 0; i < kNumIterations; ++i) {
+      const encoder = t.device.createCommandEncoder();
+      const pass = encoder.beginComputePass();
+      pass.setPipeline(pipeline);
+      pass.setBindGroup(0, bindGroup);
+      pass.dispatch(kNumElements);
+      pass.endPass();
+      t.device.queue.submit([encoder.finish()]);
+    }
+    t.expectGPUBufferValuesEqual(
+      buffer,
+      new Uint32Array([...iterRange(kNumElements, x => x + kNumIterations)])
+    );
+  });
 
 g.test('pipeline_churn')
   .desc(
     `Tests execution of a huge number of compute passes which each use a different
 GPUComputePipeline.`
   )
-  .unimplemented();
+  .fn(async t => {
+    const kNumElements = 64;
+    const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
+    const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+    const module1 = t.device.createShaderModule({
+      code: `
+        [[block]] struct Buffer { data: array<u32>; };
+        [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+        [[stage(compute), workgroup_size(1)]] fn main(
+            [[builtin(global_invocation_id)]] id: vec3<u32>) {
+          buffer.data[id.x] = buffer.data[id.x] + 1u;
+        }
+      `,
+    });
+    const module2 = t.device.createShaderModule({
+      code: `
+        [[block]] struct Buffer { data: array<u32>; };
+        [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+        [[stage(compute), workgroup_size(1)]] fn main(
+            [[builtin(global_invocation_id)]] id: vec3<u32>) {
+          buffer.data[id.x] = buffer.data[id.x] + 2u;
+        }
+      `,
+    });
+    const kNumIterations = 250_000;
+    for (let i = 0; i < kNumIterations; ++i) {
+      const module = i % 2 === 0 ? module1 : module2;
+      const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+      const bindGroup = t.device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [{ binding: 0, resource: { buffer } }],
+      });
+
+      const encoder = t.device.createCommandEncoder();
+      const pass = encoder.beginComputePass();
+      pass.setPipeline(pipeline);
+      pass.setBindGroup(0, bindGroup);
+      pass.dispatch(kNumElements);
+      pass.endPass();
+      t.device.queue.submit([encoder.finish()]);
+    }
+    const kTotalAddition = (kNumIterations / 2) * 3;
+    t.expectGPUBufferValuesEqual(
+      buffer,
+      new Uint32Array([...iterRange(kNumElements, x => x + kTotalAddition)])
+    );
+  });
 
 g.test('bind_group_churn')
   .desc(
     `Tests execution of compute passes which switch between a huge number of bind
 groups.`
   )
-  .unimplemented();
+  .fn(async t => {
+    const kNumElements = 64;
+    const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
+    const buffer1 = t.makeBufferWithContents(
+      data,
+      GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+    );
+    const buffer2 = t.makeBufferWithContents(
+      data,
+      GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+    );
+    const module = t.device.createShaderModule({
+      code: `
+        [[block]] struct Buffer { data: array<u32>; };
+        [[group(0), binding(0)]] var<storage, read_write> buffer1: Buffer;
+        [[group(0), binding(1)]] var<storage, read_write> buffer2: Buffer;
+        [[stage(compute), workgroup_size(1)]] fn main(
+            [[builtin(global_invocation_id)]] id: vec3<u32>) {
+          buffer1.data[id.x] = buffer1.data[id.x] + 1u;
+          buffer2.data[id.x] = buffer2.data[id.x] + 2u;
+        }
+      `,
+    });
+    const kNumIterations = 250_000;
+    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    for (let i = 0; i < kNumIterations; ++i) {
+      const buffer1Binding = i % 2;
+      const buffer2Binding = buffer1Binding ^ 1;
+      const bindGroup = t.device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: buffer1Binding, resource: { buffer: buffer1 } },
+          { binding: buffer2Binding, resource: { buffer: buffer2 } },
+        ],
+      });
+      pass.setBindGroup(0, bindGroup);
+      pass.dispatch(kNumElements);
+    }
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    const kTotalAddition = (kNumIterations / 2) * 3;
+    t.expectGPUBufferValuesEqual(
+      buffer1,
+      new Uint32Array([...iterRange(kNumElements, x => x + kTotalAddition)])
+    );
+    t.expectGPUBufferValuesEqual(
+      buffer2,
+      new Uint32Array([...iterRange(kNumElements, x => x + kTotalAddition)])
+    );
+  });
 
 g.test('many_dispatches')
   .desc(`Tests execution of compute passes with a huge number of dispatch calls`)
-  .unimplemented();
+  .fn(async t => {
+    const kNumElements = 64;
+    const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
+    const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+    const module = t.device.createShaderModule({
+      code: `
+        [[block]] struct Buffer { data: array<u32>; };
+        [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+        [[stage(compute), workgroup_size(1)]] fn main(
+            [[builtin(global_invocation_id)]] id: vec3<u32>) {
+          buffer.data[id.x] = buffer.data[id.x] + 1u;
+        }
+      `,
+    });
+    const kNumIterations = 1_000_000;
+    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+    pass.setBindGroup(0, bindGroup);
+    for (let i = 0; i < kNumIterations; ++i) {
+      pass.dispatch(kNumElements);
+    }
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    t.expectGPUBufferValuesEqual(
+      buffer,
+      new Uint32Array([...iterRange(kNumElements, x => x + kNumIterations)])
+    );
+  });
 
 g.test('huge_dispatches')
   .desc(`Tests execution of compute passes with huge dispatch calls`)
-  .unimplemented();
+  .fn(async t => {
+    const kDimensions = [512, 512, 128];
+    const kNumElements = kDimensions[0] * kDimensions[1] * kDimensions[2];
+    const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
+    const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+    const module = t.device.createShaderModule({
+      code: `
+        [[block]] struct Buffer { data: array<u32>; };
+        [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+        [[stage(compute), workgroup_size(1)]] fn main(
+            [[builtin(global_invocation_id)]] id: vec3<u32>) {
+          let index = (id.z * 512u + id.y) * 512u + id.x;
+          buffer.data[index] = buffer.data[index] + 1u;
+        }
+      `,
+    });
+    const kNumIterations = 16;
+    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+    for (let i = 0; i < kNumIterations; ++i) {
+      const encoder = t.device.createCommandEncoder();
+      const pass = encoder.beginComputePass();
+      pass.setBindGroup(0, bindGroup);
+      pass.setPipeline(pipeline);
+      pass.dispatch(kDimensions[0], kDimensions[1], kDimensions[2]);
+      pass.endPass();
+      t.device.queue.submit([encoder.finish()]);
+      await t.device.queue.onSubmittedWorkDone();
+    }
+    t.expectGPUBufferValuesEqual(
+      buffer,
+      new Uint32Array([...iterRange(kNumElements, x => x + kNumIterations)])
+    );
+  });

--- a/src/stress/device/bind_group_allocation.spec.ts
+++ b/src/stress/device/bind_group_allocation.spec.ts
@@ -9,7 +9,31 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('coexisting')
   .desc(`Tests allocation of many coexisting GPUBindGroup objects.`)
-  .unimplemented();
+  .fn(t => {
+    const kNumGroups = 1_000_000;
+    const buffer = t.device.createBuffer({
+      size: 64,
+      usage: GPUBufferUsage.STORAGE,
+    });
+    const layout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type: 'storage' },
+        },
+      ],
+    });
+    const bindGroups = [];
+    for (let i = 0; i < kNumGroups; ++i) {
+      bindGroups.push(
+        t.device.createBindGroup({
+          layout,
+          entries: [{ binding: 0, resource: { buffer } }],
+        })
+      );
+    }
+  });
 
 g.test('continuous')
   .desc(
@@ -17,4 +41,25 @@ g.test('continuous')
 Objects are sequentially created and dropped for GC over a very large number of
 iterations.`
   )
-  .unimplemented();
+  .fn(t => {
+    const kNumGroups = 5_000_000;
+    const buffer = t.device.createBuffer({
+      size: 64,
+      usage: GPUBufferUsage.STORAGE,
+    });
+    const layout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type: 'storage' },
+        },
+      ],
+    });
+    for (let i = 0; i < kNumGroups; ++i) {
+      t.device.createBindGroup({
+        layout,
+        entries: [{ binding: 0, resource: { buffer } }],
+      });
+    }
+  });

--- a/src/stress/device/texture_allocation.spec.ts
+++ b/src/stress/device/texture_allocation.spec.ts
@@ -18,7 +18,7 @@ are sequentially created and destroyed over a very large number of iterations.`
   )
   .unimplemented();
 
-g.test('continuous,no_destory')
+g.test('continuous,no_destroy')
   .desc(
     `Tests allocation and implicit GC of many GPUTexture objects over time. Objects
 are sequentially created and dropped for GC over a very large number of

--- a/src/stress/queue/submit.spec.ts
+++ b/src/stress/queue/submit.spec.ts
@@ -3,6 +3,7 @@ Stress tests for command submission to GPUQueue objects.
 `;
 
 import { makeTestGroup } from '../../common/framework/test_group.js';
+import { iterRange } from '../../common/util/util.js';
 import { GPUTest } from '../../webgpu/gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -10,14 +11,90 @@ export const g = makeTestGroup(GPUTest);
 g.test('huge_command_buffer')
   .desc(
     `Tests submission of huge command buffers to a GPUQueue. Huge buffers are
-encoded by chaining together repeated sequences of compute and copy
-operations, with expected results verified at the end of the test.`
+encoded by chaining together long sequences of compute passes, with expected
+results verified at the end of the test.`
   )
-  .unimplemented();
+  .fn(async t => {
+    const kNumElements = 64;
+    const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
+    const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+    const pipeline = t.device.createComputePipeline({
+      compute: {
+        module: t.device.createShaderModule({
+          code: `
+            [[block]] struct Buffer { data: array<u32>; };
+            [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+            [[stage(compute), workgroup_size(1)]] fn main(
+                [[builtin(global_invocation_id)]] id: vec3<u32>) {
+              buffer.data[id.x] = buffer.data[id.x] + 1u;
+            }
+          `,
+        }),
+        entryPoint: 'main',
+      },
+    });
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+    const encoder = t.device.createCommandEncoder();
+    const kNumIterations = 500_000;
+    for (let i = 0; i < kNumIterations; ++i) {
+      const pass = encoder.beginComputePass();
+      pass.setPipeline(pipeline);
+      pass.setBindGroup(0, bindGroup);
+      pass.dispatch(kNumElements);
+      pass.endPass();
+    }
+    t.device.queue.submit([encoder.finish()]);
+    t.expectGPUBufferValuesEqual(
+      buffer,
+      new Uint32Array([...iterRange(kNumElements, x => x + kNumIterations)])
+    );
+  });
 
 g.test('many_command_buffers')
   .desc(
     `Tests submission of a huge number of command buffers to a GPUQueue by a single
 submit() call.`
   )
-  .unimplemented();
+  .fn(async t => {
+    const kNumElements = 64;
+    const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
+    const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+    const pipeline = t.device.createComputePipeline({
+      compute: {
+        module: t.device.createShaderModule({
+          code: `
+            [[block]] struct Buffer { data: array<u32>; };
+            [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+            [[stage(compute), workgroup_size(1)]] fn main(
+                [[builtin(global_invocation_id)]] id: vec3<u32>) {
+              buffer.data[id.x] = buffer.data[id.x] + 1u;
+            }
+          `,
+        }),
+        entryPoint: 'main',
+      },
+    });
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+    const kNumIterations = 500_000;
+    const buffers = [];
+    for (let i = 0; i < kNumIterations; ++i) {
+      const encoder = t.device.createCommandEncoder();
+      const pass = encoder.beginComputePass();
+      pass.setPipeline(pipeline);
+      pass.setBindGroup(0, bindGroup);
+      pass.dispatch(kNumElements);
+      pass.endPass();
+      buffers.push(encoder.finish());
+    }
+    t.device.queue.submit(buffers);
+    t.expectGPUBufferValuesEqual(
+      buffer,
+      new Uint32Array([...iterRange(kNumElements, x => x + kNumIterations)])
+    );
+  });

--- a/src/stress/shaders/entry_points.spec.ts
+++ b/src/stress/shaders/entry_points.spec.ts
@@ -3,9 +3,22 @@ Stress tests covering behavior around shader entry points.
 `;
 
 import { makeTestGroup } from '../../common/framework/test_group.js';
+import { range } from '../../common/util/util.js';
 import { GPUTest } from '../../webgpu/gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
+
+const makeCode = (numEntryPoints: number) => {
+  const kBaseCode = `
+      [[block]] struct Buffer { data: u32; };
+      [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+      fn main() { buffer.data = buffer.data + 1u;  }
+      `;
+  const makeEntryPoint = (i: number) => `
+      [[stage(compute), workgroup_size(1)]] fn computeMain${i}() { main(); }
+      `;
+  return kBaseCode + range(numEntryPoints, makeEntryPoint).join('');
+};
 
 g.test('many')
   .desc(
@@ -14,4 +27,52 @@ g.test('many')
 TODO: There may be a normative limit to the number of entry points allowed in
 a shader, in which case this would become a validation test instead.`
   )
-  .unimplemented();
+  .fn(async t => {
+    const data = new Uint32Array([0]);
+    const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+
+    // NOTE: Initial shader compilation time seems to scale exponentially with
+    // this value in Chrome.
+    const kNumEntryPoints = 200;
+
+    const shader = t.device.createShaderModule({
+      code: makeCode(kNumEntryPoints),
+    });
+
+    const layout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type: 'storage' },
+        },
+      ],
+    });
+    const pipelineLayout = t.device.createPipelineLayout({
+      bindGroupLayouts: [layout],
+    });
+    const bindGroup = t.device.createBindGroup({
+      layout,
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    range(kNumEntryPoints, i => {
+      const pipeline = t.device.createComputePipeline({
+        layout: pipelineLayout,
+        compute: {
+          module: shader,
+          entryPoint: `computeMain${i}`,
+        },
+      });
+
+      const pass = encoder.beginComputePass();
+      pass.setPipeline(pipeline);
+      pass.setBindGroup(0, bindGroup);
+      pass.dispatch(1);
+      pass.endPass();
+    });
+
+    t.device.queue.submit([encoder.finish()]);
+    t.expectGPUBufferValuesEqual(buffer, new Uint32Array([kNumEntryPoints]));
+  });


### PR DESCRIPTION
This adds a variety of tests from different categories. The limits in
place for most were chosen to keep running times generally under
~10-20 seconds -- and to avoid TDRs -- during local development,
but they may run (much) longer depending on environment.

<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
