### PR TITLE
Updating deprecated TextureUsage flags

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -991,7 +991,7 @@ class ImageCopyTest extends GPUTest {
 
     const inputTexture = this.device.createTexture({
       size: copySize,
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
       format: 'r32float',
     });
     this.queue.writeTexture(

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -75,7 +75,7 @@ g.test('depth_compare_func')
     const depthTexture = t.device.createTexture({
       size: { width: 1, height: 1 },
       format,
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
     });
     const depthTextureView = depthTexture.createView();
 
@@ -162,7 +162,7 @@ g.test('reverse_depth')
     const depthTexture = t.device.createTexture({
       size: { width: 1, height: 1 },
       format: depthBufferFormat,
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
     });
     const depthTextureView = depthTexture.createView();
 

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -58,7 +58,7 @@ class F extends GPUTest {
     const outputTexture = this.device.createTexture({
       format: 'rgba8unorm',
       size: [1, 1, 1],
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
     });
     const bindGroup = this.device.createBindGroup({
       layout: computePipeline.getBindGroupLayout(0),
@@ -832,7 +832,10 @@ creation of that GPUBuffer, all the contents in that GPUBuffer have been initial
     const outputTexture = t.device.createTexture({
       format: 'rgba8unorm',
       size: [1, 1, 1],
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE,
+      usage:
+        GPUTextureUsage.COPY_SRC |
+        GPUTextureUsage.RENDER_ATTACHMENT |
+        GPUTextureUsage.STORAGE_BINDING,
     });
 
     // Initialize outputTexture to green.

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -148,10 +148,10 @@ function getRequiredTextureUsage(
       usage |= GPUConst.TextureUsage.COPY_SRC;
       break;
     case ReadMethod.Sample:
-      usage |= GPUConst.TextureUsage.SAMPLED;
+      usage |= GPUConst.TextureUsage.TEXTURE_BINDING;
       break;
     case ReadMethod.Storage:
-      usage |= GPUConst.TextureUsage.STORAGE;
+      usage |= GPUConst.TextureUsage.STORAGE_BINDING;
       break;
     case ReadMethod.DepthTest:
     case ReadMethod.StencilTest:
@@ -507,7 +507,7 @@ const kTestParams = kUnitCaseParamsBuilder
 
     return (
       ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 && !info.renderable) ||
-      ((usage & GPUConst.TextureUsage.STORAGE) !== 0 && !info.storage)
+      ((usage & GPUConst.TextureUsage.STORAGE_BINDING) !== 0 && !info.storage)
     );
   })
   .combine('nonPowerOfTwo', [false, true])

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -176,7 +176,7 @@ g.test('anisotropic_filter_checkerboard')
       mipLevelCount: 1,
       size: { width: textureSize, height: textureSize, depthOrArrayLayers: 1 },
       format: kTextureFormat,
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
     });
 
     const textureEncoder = t.device.createCommandEncoder();

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -140,8 +140,8 @@ g.test('texture_binding_must_have_correct_usage')
       .combine('usage', kTextureUsages)
       .unless(({ entry, usage }) => {
         const info = texBindingTypeInfo(entry);
-        // Can't create the texture for this (usage=STORAGE and sampleCount=4), so skip.
-        return usage === GPUConst.TextureUsage.STORAGE && info.resource === 'sampledTexMS';
+        // Can't create the texture for this (usage=STORAGE_BINDING and sampleCount=4), so skip.
+        return usage === GPUConst.TextureUsage.STORAGE_BINDING && info.resource === 'sampledTexMS';
       })
   )
   .fn(async t => {
@@ -204,7 +204,7 @@ g.test('texture_must_have_correct_component_type')
     const goodDescriptor = {
       size: { width: 16, height: 16, depthOrArrayLayers: 1 },
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     // Control case
@@ -278,7 +278,7 @@ g.test('texture_must_have_correct_dimension')
     const texture = t.device.createTexture({
       size: { width: 16, height, depthOrArrayLayers },
       format: 'rgba8unorm' as const,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
       dimension: getTextureDimensionFromView(dimension),
     });
 

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -74,7 +74,7 @@ g.test('zero_size')
       mipLevelCount,
       dimension,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const success = zeroArgument === 'none';
@@ -103,7 +103,7 @@ g.test('dimension_type_and_format_compatibility')
       size: [info.blockWidth, info.blockHeight, 1],
       dimension,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     t.expectValidationError(() => {
@@ -140,7 +140,7 @@ g.test('mipLevelCount,format')
       mipLevelCount,
       dimension,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const success = mipLevelCount <= 6;
@@ -194,7 +194,7 @@ g.test('mipLevelCount,bound_check')
       mipLevelCount: 0,
       dimension,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const mipLevelCount = maxMipLevelCount(descriptor);
@@ -214,7 +214,7 @@ g.test('mipLevelCount,bound_check,bigger_than_integer_bit_width')
       size: [32, 32],
       mipLevelCount: 100,
       format: 'rgba8unorm' as const,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     t.expectValidationError(() => {
@@ -242,7 +242,7 @@ g.test('sampleCount,various_sampleCount_with_all_formats')
       sampleCount,
       dimension,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const success =
@@ -257,7 +257,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
   .desc(
     `Test texture creation with valid sample count when dimensions, arrayLayerCount, mipLevelCount, format, and usage varies.
      Texture can be single sample (sampleCount is 1) or multi-sample (sampleCount is 4).
-     Multisample texture requires that 1) its dimension is 2d or undefined, 2) its format supports multisample, 3) its mipLevelCount and arrayLayerCount are 1, 4) its usage doesn't include STORAGE.`
+     Multisample texture requires that 1) its dimension is 2d or undefined, 2) its format supports multisample, 3) its mipLevelCount and arrayLayerCount are 1, 4) its usage doesn't include STORAGE_BINDING.`
   )
   .params(u =>
     u
@@ -278,7 +278,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
         const info = kTextureFormatInfo[format];
         return (
           ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 && !info.renderable) ||
-          ((usage & GPUConst.TextureUsage.STORAGE) !== 0 && !info.storage)
+          ((usage & GPUConst.TextureUsage.STORAGE_BINDING) !== 0 && !info.storage)
         );
       })
   )
@@ -308,7 +308,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
         kTextureFormatInfo[format].multisample &&
         mipLevelCount === 1 &&
         arrayLayerCount === 1 &&
-        (usage & GPUConst.TextureUsage.STORAGE) === 0);
+        (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0);
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);
@@ -337,7 +337,7 @@ g.test('texture_size,default_value_and_smallest_size,uncompressed_format')
       size,
       dimension,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     t.device.createTexture(descriptor);
@@ -375,7 +375,7 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
       size,
       dimension,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     t.expectValidationError(() => {
@@ -405,7 +405,7 @@ g.test('texture_size,1d_texture')
       size: [width, height, depthOrArrayLayers],
       dimension: '1d' as const,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const success =
@@ -445,7 +445,7 @@ g.test('texture_size,2d_texture,uncompressed_format')
       size,
       dimension,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const success =
@@ -515,7 +515,7 @@ g.test('texture_size,2d_texture,compressed_format')
       size,
       dimension,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const success =
@@ -560,7 +560,7 @@ g.test('texture_size,3d_texture,uncompressed_format')
       size,
       dimension: '3d' as const,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const success =
@@ -633,7 +633,7 @@ g.test('texture_size,3d_texture,compressed_format')
       size,
       dimension: '3d' as const,
       format,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const success =
@@ -681,7 +681,7 @@ g.test('texture_usage')
     // Note that we unconditionally test copy usages for all formats. We don't check copySrc/copyDst in kTextureFormatInfo in capability_info.js
     // if (!info.copySrc && (usage & GPUTextureUsage.COPY_SRC) !== 0) success = false;
     // if (!info.copyDst && (usage & GPUTextureUsage.COPY_DST) !== 0) success = false;
-    if (!info.storage && (usage & GPUTextureUsage.STORAGE) !== 0) success = false;
+    if (!info.storage && (usage & GPUTextureUsage.STORAGE_BINDING) !== 0) success = false;
     if (!info.renderable && (usage & GPUTextureUsage.RENDER_ATTACHMENT) !== 0) success = false;
 
     t.expectValidationError(() => {

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -41,7 +41,7 @@ g.test('format')
     const texture = t.device.createTexture({
       format: textureFormat,
       size: [4, 4],
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     });
 
     const success = viewFormat === undefined || viewFormat === textureFormat;
@@ -70,7 +70,7 @@ g.test('dimension')
       format: 'rgba8unorm' as const,
       dimension: textureDimension,
       size,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
     const texture = t.device.createTexture(textureDescriptor);
 
@@ -103,7 +103,7 @@ g.test('aspect')
     const texture = t.device.createTexture({
       format,
       size: [4, 4, 1],
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     });
 
     const success =
@@ -195,7 +195,7 @@ g.test('array_layers')
           ? [kWidth, kWidth, kWidth]
           : unreachable(),
       mipLevelCount: textureLevels,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const viewDescriptor = { dimension: viewDimension, baseArrayLayer, arrayLayerCount };
@@ -246,7 +246,7 @@ g.test('mip_levels')
       size:
         textureDimension === '1d' ? [32] : textureDimension === '3d' ? [32, 32, 32] : [32, 32, 18],
       mipLevelCount: textureLevels,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
     const viewDescriptor = { dimension: viewDimension, baseMipLevel, mipLevelCount };
@@ -281,7 +281,7 @@ g.test('cube_faces_square')
     const texture = t.device.createTexture({
       format: 'rgba8unorm',
       size,
-      usage: GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
     });
 
     const success = dimension === '2d' || size[0] === size[1];

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -96,8 +96,8 @@ g.test('usage')
       ] as const)
       .beginSubcases()
       .combine('usage', [
-        GPUConst.TextureUsage.COPY_SRC | GPUConst.TextureUsage.SAMPLED,
-        GPUConst.TextureUsage.COPY_DST | GPUConst.TextureUsage.SAMPLED,
+        GPUConst.TextureUsage.COPY_SRC | GPUConst.TextureUsage.TEXTURE_BINDING,
+        GPUConst.TextureUsage.COPY_DST | GPUConst.TextureUsage.TEXTURE_BINDING,
         GPUConst.TextureUsage.COPY_SRC | GPUConst.TextureUsage.COPY_DST,
       ])
   )
@@ -141,7 +141,7 @@ g.test('sample_count')
       size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       sampleCount,
       format: 'rgba8unorm',
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
     });
 
     const success = sampleCount === 1;

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -85,7 +85,7 @@ class TextureUsageTracking extends ValidationTest {
       mipLevelCount = 1,
       sampleCount = 1,
       format = 'rgba8unorm',
-      usage = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.SAMPLED,
+      usage = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
     } = options;
 
     return this.device.createTexture({
@@ -188,7 +188,7 @@ class TextureUsageTracking extends ValidationTest {
     // Create two bind groups. Resource usages conflict between these two bind groups. But resource
     // usage inside each bind group doesn't conflict.
     const view = this.createTexture({
-      usage: GPUTextureUsage.STORAGE | GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
     }).createView();
     const bindGroupLayouts = [
       this.createBindGroupLayout(0, 'sampled-texture', '2d'),
@@ -457,7 +457,10 @@ g.test('subresources_and_binding_types_combination_for_color')
     const texture = t.createTexture({
       arrayLayerCount: TOTAL_LAYERS,
       mipLevelCount: TOTAL_LEVELS,
-      usage: GPUTextureUsage.SAMPLED | GPUTextureUsage.STORAGE | GPUTextureUsage.RENDER_ATTACHMENT,
+      usage:
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.STORAGE_BINDING |
+        GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     const dimension0 = layerCount0 !== 1 ? '2d-array' : '2d';
@@ -765,8 +768,8 @@ g.test('shader_stages_and_visibility')
     // vertex stage is not included. Otherwise, it uses output attachment instead.
     const writeHasVertexStage = Boolean(writeVisibility & GPUShaderStage.VERTEX);
     const texUsage = writeHasVertexStage
-      ? GPUTextureUsage.SAMPLED | GPUTextureUsage.RENDER_ATTACHMENT
-      : GPUTextureUsage.SAMPLED | GPUTextureUsage.STORAGE;
+      ? GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT
+      : GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING;
 
     const texture = t.createTexture({ usage: texUsage });
     const view = texture.createView();
@@ -833,7 +836,7 @@ g.test('replaced_binding')
 
     const sampledView = t.createTexture().createView();
     const sampledStorageView = t
-      .createTexture({ usage: GPUTextureUsage.STORAGE | GPUTextureUsage.SAMPLED })
+      .createTexture({ usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING })
       .createView();
 
     // Create bindGroup0. It has two bindings. These two bindings use different views/subresources.
@@ -899,10 +902,10 @@ g.test('bindings_in_bundle')
           switch (type) {
             case 'multisampled-texture':
             case 'sampled-texture':
-              return 'SAMPLED' as const;
+              return 'TEXTURE_BINDING' as const;
             case 'readonly-storage-texture':
             case 'writeonly-storage-texture':
-              return 'STORAGE' as const;
+              return 'STORAGE_BINDING' as const;
             case 'render-target':
               return 'RENDER_ATTACHMENT' as const;
           }
@@ -928,7 +931,7 @@ g.test('bindings_in_bundle')
           // Storage textures can't be multisampled.
           (p._sampleCount !== undefined &&
             p._sampleCount > 1 &&
-            (p._usage0 === 'STORAGE' || p._usage1 === 'STORAGE')) ||
+            (p._usage0 === 'STORAGE_BINDING' || p._usage1 === 'STORAGE_BINDING')) ||
           // If both are sampled, we create two views of the same texture, so both must be multisampled.
           (p.type0 === 'multisampled-texture' && p.type1 === 'sampled-texture') ||
           (p.type0 === 'sampled-texture' && p.type1 === 'multisampled-texture')
@@ -1035,7 +1038,7 @@ g.test('unused_bindings_in_pipeline')
       setPipeline,
       callDrawOrDispatch,
     } = t.params;
-    const view = t.createTexture({ usage: GPUTextureUsage.STORAGE }).createView();
+    const view = t.createTexture({ usage: GPUTextureUsage.STORAGE_BINDING }).createView();
     const bindGroup0 = t.createBindGroup(0, view, 'readonly-storage-texture', '2d', {
       format: 'rgba8unorm',
     });

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -134,7 +134,7 @@ export class ValidationTest extends GPUTest {
   }
 
   /**
-   * Return an arbitrarily-configured GPUTexture with the `SAMPLED` usage and specified sampleCount.
+   * Return an arbitrarily-configured GPUTexture with the `TEXTURE_BINDING` usage and specified sampleCount.
    */
   getSampledTexture(sampleCount: number = 1): GPUTexture {
     return this.trackForCleanup(
@@ -147,7 +147,7 @@ export class ValidationTest extends GPUTest {
     );
   }
 
-  /** Return an arbitrarily-configured GPUTexture with the `STORAGE` usage. */
+  /** Return an arbitrarily-configured GPUTexture with the `STORAGE_BINDING` usage. */
   getStorageTexture(): GPUTexture {
     return this.trackForCleanup(
       this.device.createTexture({

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -355,8 +355,8 @@ export const kTextureUsageInfo: {
 } = {
   [GPUConst.TextureUsage.COPY_SRC]: {},
   [GPUConst.TextureUsage.COPY_DST]: {},
-  [GPUConst.TextureUsage.SAMPLED]: {},
-  [GPUConst.TextureUsage.STORAGE]: {},
+  [GPUConst.TextureUsage.TEXTURE_BINDING]: {},
+  [GPUConst.TextureUsage.STORAGE_BINDING]: {},
   [GPUConst.TextureUsage.RENDER_ATTACHMENT]: {},
 };
 /** List of all GPUTextureUsage values. */
@@ -593,9 +593,9 @@ assertTypeTrue<TypeEqual<GPUSamplerBindingType, typeof kSamplerBindingTypes[numb
 export function sampledTextureBindingTypeInfo(d: GPUTextureBindingLayout) {
   /* prettier-ignore */
   if (d.multisampled) {
-    return { usage: GPUConst.TextureUsage.SAMPLED, ...kBindingKind.sampledTexMS, ...kValidStagesAll, };
+    return { usage: GPUConst.TextureUsage.TEXTURE_BINDING, ...kBindingKind.sampledTexMS, ...kValidStagesAll, };
   } else {
-    return { usage: GPUConst.TextureUsage.SAMPLED, ...kBindingKind.sampledTex,   ...kValidStagesAll, };
+    return { usage: GPUConst.TextureUsage.TEXTURE_BINDING, ...kBindingKind.sampledTex,   ...kValidStagesAll, };
   }
 }
 /** List of all GPUTextureSampleType values. */

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -242,7 +242,7 @@ Tests that a BC format passes validation iff the feature is enabled.`
         t.device.createTexture({
           format: 'bc1-rgba-unorm',
           size: [4, 4, 1],
-          usage: GPUTextureUsage.SAMPLED,
+          usage: GPUTextureUsage.TEXTURE_BINDING,
         });
       },
       shouldError

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -557,7 +557,7 @@ export class GPUTest extends Fixture {
       mipLevelCount,
       size: { width: textureSizeMipmap0, height: textureSizeMipmap0, depthOrArrayLayers: 1 },
       format,
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
     });
     this.trackForCleanup(texture);
 

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -38,7 +38,7 @@ function doTest(
   const texture = t.device.createTexture({
     format,
     size: [1, 1, 1],
-    usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.SAMPLED,
+    usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
   });
 
   t.device.queue.writeTexture(

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -247,7 +247,7 @@ Tests that we can import an HTMLVideoElement into a GPUExternalTexture and use i
       const outputTexture = t.device.createTexture({
         format: 'rgba8unorm',
         size: [2, 1, 1],
-        usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE,
+        usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
       });
 
       const pipeline = t.device.createComputePipeline({


### PR DESCRIPTION
Just a simple update to move the CTS off the deprecated flag values. Noticed that this was causing a lot of log spam on some CI systems running the CTS.

Changes:
 - `TextureUsage.SAMPLED` -> `TextureUsage.TEXTURE_BINDING`
 - `TextureUsage.STORAGE` -> `TextureUsage.STORAGE_BINDING`