### PR TITLE
Change depth/stencil sample type to 'depth'

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -697,7 +697,7 @@ g.test('subresources_and_binding_types_combination_for_aspect')
     const aspectSampleType = (format: GPUTextureFormat, aspect: typeof aspect0) => {
       switch (aspect) {
         case 'depth-only':
-          return 'float';
+          return 'depth';
         case 'stencil-only':
           return 'uint';
         case 'all':
@@ -705,7 +705,7 @@ g.test('subresources_and_binding_types_combination_for_aspect')
           if (kTextureFormatInfo[format].stencil) {
             return 'uint';
           }
-          return 'float';
+          return 'depth';
       }
     };
 


### PR DESCRIPTION
Tests were previously indicating that depth/stencil formats should have a sample type of 'float', which is deprecated behavior. Changed it to 'depth'.

This change is blocking https://dawn-review.googlesource.com/c/dawn/+/61861