### PR TITLE
Revise validation tests for depth/stencil formats for copies

### DIFF
--- a/src/webgpu/api/validation/image_copy/README.txt
+++ b/src/webgpu/api/validation/image_copy/README.txt
@@ -21,7 +21,7 @@ Test coverage:
 	- offset_plus_required_bytes_in_copy_overflow
 	- required_bytes_in_copy: testing minimal data size and data size too small for various combinations of bytesPerRow, rowsPerImage, copyExtent and offset. for the copy method, bytesPerRow is computed as bytesInACompleteRow aligned to be a multiple of 256 + bytesPerRowPadding * 256.
 	- texel_block_alignment_on_rows_per_image: for all formats.
-	- texel_block_alignment_on_offset: for all formats.
+	- offset_alignment: for all formats.
 	- bound_on_bytes_per_row: for all formats and various combinations of bytesPerRow and copyExtent. for writeTexture, bytesPerRow is computed as (blocksPerRow * blockWidth * bytesPerBlock + additionalBytesPerRow) and copyExtent.width is computed as copyWidthInBlocks * blockWidth. for the copy methods, both values are mutliplied by 256.
 	- bound_on_offset: for various combinations of offset and dataSize.
 

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -131,6 +131,11 @@ interface WithFormatAndMethod extends WithFormat {
 
 // This is a helper function used for expanding test parameters for texel block alignment tests on offset
 export function texelBlockAlignmentTestExpanderForOffset({ format }: WithFormat) {
+  const info = kTextureFormatInfo[format];
+  if (info.depth || info.stencil) {
+    return valuesToTestDivisibilityBy(4);
+  }
+
   return valuesToTestDivisibilityBy(kTextureFormatInfo[format].bytesPerBlock);
 }
 

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -129,7 +129,7 @@ interface WithFormatAndMethod extends WithFormat {
   method: ImageCopyType;
 }
 
-// This is a helper function used for expanding test parameters for texel block alignment tests on offset
+// This is a helper function used for expanding test parameters for offset alignment, by spec
 export function texelBlockAlignmentTestExpanderForOffset({ format }: WithFormat) {
   const info = kTextureFormatInfo[format];
   if (info.depth || info.stencil) {

--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -120,7 +120,9 @@ g.test('required_bytes_in_copy')
         { copyWidthInBlocks: 5, copyHeightInBlocks: 4, copyDepth: 1, offsetInBlocks: 0 }, // copyDepth = 1
         { copyWidthInBlocks: 7, copyHeightInBlocks: 1, copyDepth: 1, offsetInBlocks: 0 }, // copyHeight = 1 and copyDepth = 1
       ])
-      // If the format is a depth/stencil format, its copy size must equal to subresource's size. So the width, height or depth of copy size should not be 0.
+      // The test texture size will be rounded up from the copy size to the next valid texture size.
+      // If the format is a depth/stencil format, its copy size must equal to subresource's size.
+      // So filter out depth/stencil cases where the rounded-up texture size would be different from the copy size.
       .filter(({ format, copyWidthInBlocks, copyHeightInBlocks, copyDepth }) => {
         const info = kTextureFormatInfo[format];
         return (

--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -120,6 +120,14 @@ g.test('required_bytes_in_copy')
         { copyWidthInBlocks: 5, copyHeightInBlocks: 4, copyDepth: 1, offsetInBlocks: 0 }, // copyDepth = 1
         { copyWidthInBlocks: 7, copyHeightInBlocks: 1, copyDepth: 1, offsetInBlocks: 0 }, // copyHeight = 1 and copyDepth = 1
       ])
+      // If the format is a depth/stencil format, its copy size must equal to subresource's size. So the width, height or depth of copy size should not be 0.
+      .filter(({ format, copyWidthInBlocks, copyHeightInBlocks, copyDepth }) => {
+        const info = kTextureFormatInfo[format];
+        return (
+          (!info.depth && !info.stencil) ||
+          (copyWidthInBlocks > 0 && copyHeightInBlocks > 0 && copyDepth > 0)
+        );
+      })
   )
   .fn(async t => {
     const {
@@ -178,24 +186,32 @@ g.test('rows_per_image_alignment')
       .filter(formatCopyableWithMethod)
       .beginSubcases()
       .expand('rowsPerImage', texelBlockAlignmentTestExpanderForRowsPerImage)
+      // Copy height is info.blockHeight, so rowsPerImage must be equal or greater than it.
+      .filter(({ rowsPerImage, format }) => rowsPerImage >= kTextureFormatInfo[format].blockHeight)
   )
   .fn(async t => {
     const { rowsPerImage, format, method } = t.params;
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    const size = { width: 0, height: 0, depthOrArrayLayers: 0 };
+    const size = { width: info.blockWidth, height: info.blockHeight, depthOrArrayLayers: 1 };
+    const texture = t.device.createTexture({
+      size,
+      format,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+    });
 
-    const texture = t.createAlignedTexture(format, size);
-
-    t.testRun({ texture }, { bytesPerRow: 0, rowsPerImage }, size, {
-      dataSize: 1,
+    t.testRun({ texture }, { bytesPerRow: 256, rowsPerImage }, size, {
+      dataSize: info.bytesPerBlock,
       method,
       success: true,
     });
   });
 
-g.test('texel_block_alignment_on_offset')
+g.test('offset_alignment')
+  .desc(
+    `If texture format is not depth/stencil format, offset should be aligned with texture block. If texture format is depth/stencil format, offset should be a multiple of 4.`
+  )
   .params(u =>
     u
       .combine('method', kImageCopyTypes)
@@ -209,14 +225,26 @@ g.test('texel_block_alignment_on_offset')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    const size = { width: 0, height: 0, depthOrArrayLayers: 0 };
+    const size = { width: info.blockWidth, height: info.blockHeight, depthOrArrayLayers: 1 };
+    const texture = t.device.createTexture({
+      size,
+      format,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+    });
 
-    const texture = t.createAlignedTexture(format, size);
+    let success = false;
+    if (method === 'WriteTexture') success = true;
+    if (info.depth || info.stencil) {
+      if (offset % 4 === 0) success = true;
+    } else {
+      if (offset % info.bytesPerBlock === 0) success = true;
+    }
 
-    const success =
-      method === 'WriteTexture' || offset % kTextureFormatInfo[format].bytesPerBlock === 0;
-
-    t.testRun({ texture }, { offset, bytesPerRow: 0 }, size, { dataSize: offset, method, success });
+    t.testRun({ texture }, { offset, bytesPerRow: 256 }, size, {
+      dataSize: offset + info.bytesPerBlock,
+      method,
+      success,
+    });
   });
 
 g.test('bound_on_bytes_per_row')

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -9,6 +9,7 @@ export const description = `
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert } from '../../../../common/util/util.js';
 import {
+  kColorTextureFormats,
   kSizedTextureFormats,
   kTextureFormatInfo,
   textureDimensionAndFormatCompatible,
@@ -276,7 +277,8 @@ g.test('origin_alignment')
   .params(u =>
     u
       .combine('method', kImageCopyTypes)
-      .combine('format', kSizedTextureFormats)
+      // No need to test depth/stencil formats because its copy origin must be [0, 0, 0], which is already aligned with block size.
+      .combine('format', kColorTextureFormats)
       .filter(formatCopyableWithMethod)
       .combineWithParams([
         { depthOrArrayLayers: 1, dimension: '2d' },
@@ -367,7 +369,8 @@ g.test('size_alignment')
   .params(u =>
     u
       .combine('method', kImageCopyTypes)
-      .combine('format', kSizedTextureFormats)
+      // No need to test depth/stencil formats because its copy size must be subresource's size, which is already aligned with block size.
+      .combine('format', kColorTextureFormats)
       .filter(formatCopyableWithMethod)
       .combine('dimension', ['2d', '3d'] as const)
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))


### PR DESCRIPTION
If the copied format is depth/stencil format, it requires that:
  - copy size must exactly equals to copied subresource's size
  - offset in buffer must be a multiple of 4





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
