### PR TITLE
some stress tests for shaders and render passes

### DIFF
--- a/src/stress/render/render_pass.spec.ts
+++ b/src/stress/render/render_pass.spec.ts
@@ -3,33 +3,352 @@ Stress tests covering GPURenderPassEncoder usage.
 `;
 
 import { makeTestGroup } from '../../common/framework/test_group.js';
+import { range } from '../../common/util/util.js';
 import { GPUTest } from '../../webgpu/gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
+const colorDictToLittleEndianU32 = (color: GPUColorDict) => {
+  const byte = (x: number, shift: number) => (x * 255) << shift;
+  return (byte(color.r, 0) | byte(color.g, 8) | byte(color.b, 16) | byte(color.a, 24)) >>> 0;
+};
+
 g.test('many')
   .desc(
-    `Tests execution of a huge number of render passes using the same
-GPURenderPipeline.`
+    `Tests execution of a huge number of render passes using the same GPURenderPipeline. This uses
+a single render pass for every output fragment, with each pass executing a one-vertex draw call.`
   )
-  .unimplemented();
+  .fn(async t => {
+    const kSize = 1024;
+    const module = t.device.createShaderModule({
+      code: `
+    [[stage(vertex)]] fn vmain([[builtin(vertex_index)]] index: u32)
+        -> [[builtin(position)]] vec4<f32> {
+      let position = vec2<f32>(f32(index % ${kSize}u), f32(index / ${kSize}u));
+      let r = vec2<f32>(1.0 / f32(${kSize}));
+      let a = 2.0 * r;
+      let b = r - vec2<f32>(1.0);
+      return vec4<f32>(fma(position, a, b), 0.0, 1.0);
+    }
+    [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+      return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+    }
+    `,
+    });
+    const pipeline = t.device.createRenderPipeline({
+      vertex: { module, entryPoint: 'vmain', buffers: [] },
+      primitive: { topology: 'point-list' },
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module,
+        entryPoint: 'fmain',
+      },
+    });
+    const renderTarget = t.device.createTexture({
+      size: [kSize, kSize],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const renderPassDescriptor: GPURenderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: 'load',
+          storeOp: 'store',
+        },
+      ],
+    };
+    const encoder = t.device.createCommandEncoder();
+    range(kSize * kSize, i => {
+      const pass = encoder.beginRenderPass(renderPassDescriptor);
+      pass.setPipeline(pipeline);
+      pass.draw(1, 1, i);
+      pass.endPass();
+    });
+    t.device.queue.submit([encoder.finish()]);
+    t.expectSingleColor(renderTarget, 'rgba8unorm', {
+      size: [kSize, kSize, 1],
+      exp: { R: 1, G: 0, B: 1, A: 1 },
+    });
+  });
 
 g.test('pipeline_churn')
   .desc(
-    `Tests execution of a huge number of render passes which each use a different
-GPURenderPipeline.`
+    `Tests execution of a large number of render pipelines, each within its own render pass. Each
+pass does a single draw call, with one pass per output fragment.`
   )
-  .unimplemented();
+  .fn(async t => {
+    const kWidth = 64;
+    const kHeight = 8;
+    const module = t.device.createShaderModule({
+      code: `
+    [[stage(vertex)]] fn vmain([[builtin(vertex_index)]] index: u32)
+        -> [[builtin(position)]] vec4<f32> {
+      let position = vec2<f32>(f32(index % ${kWidth}u), f32(index / ${kWidth}u));
+      let size = vec2<f32>(f32(${kWidth}), f32(${kHeight}));
+      let r = vec2<f32>(1.0) / size;
+      let a = 2.0 * r;
+      let b = r - vec2<f32>(1.0);
+      return vec4<f32>(fma(position, a, b), 0.0, 1.0);
+    }
+    [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+      return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+    }
+    `,
+    });
+    const renderTarget = t.device.createTexture({
+      size: [kWidth, kHeight],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const depthTarget = t.device.createTexture({
+      size: [kWidth, kHeight],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      format: 'depth24plus-stencil8',
+    });
+    const renderPassDescriptor: GPURenderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: 'load',
+          storeOp: 'store',
+        },
+      ],
+      depthStencilAttachment: {
+        view: depthTarget.createView(),
+        depthLoadValue: 'load',
+        depthStoreOp: 'store',
+        stencilLoadValue: 'load',
+        stencilStoreOp: 'discard',
+      },
+    };
+    const encoder = t.device.createCommandEncoder();
+    range(kWidth * kHeight, i => {
+      const pipeline = t.device.createRenderPipeline({
+        vertex: { module, entryPoint: 'vmain', buffers: [] },
+        primitive: { topology: 'point-list' },
+        depthStencil: {
+          format: 'depth24plus-stencil8',
+
+          // Not really used, but it ensures that each pipeline is unique.
+          depthBias: i,
+        },
+        fragment: {
+          targets: [{ format: 'rgba8unorm' }],
+          module,
+          entryPoint: 'fmain',
+        },
+      });
+      const pass = encoder.beginRenderPass(renderPassDescriptor);
+      pass.setPipeline(pipeline);
+      pass.draw(1, 1, i);
+      pass.endPass();
+    });
+    t.device.queue.submit([encoder.finish()]);
+    t.expectSingleColor(renderTarget, 'rgba8unorm', {
+      size: [kWidth, kHeight, 1],
+      exp: { R: 1, G: 0, B: 1, A: 1 },
+    });
+  });
 
 g.test('bind_group_churn')
   .desc(
-    `Tests execution of compute passes which switch between a huge number of bind
-groups.`
+    `Tests execution of render passes which switch between a huge number of bind groups. This uses
+a single render pass with a single pipeline, and one draw call per fragment of the output texture.
+Each draw call is made with a unique bind group 0, with binding 0 referencing a unique uniform
+buffer.`
   )
-  .unimplemented();
+  .fn(async t => {
+    const kSize = 128;
+    const module = t.device.createShaderModule({
+      code: `
+    [[block]] struct Uniforms { index: u32; };
+    [[group(0), binding(0)]] var<uniform> uniforms: Uniforms;
+    [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
+      let index = uniforms.index;
+      let position = vec2<f32>(f32(index % ${kSize}u), f32(index / ${kSize}u));
+      let r = vec2<f32>(1.0 / f32(${kSize}));
+      let a = 2.0 * r;
+      let b = r - vec2<f32>(1.0);
+      return vec4<f32>(fma(position, a, b), 0.0, 1.0);
+    }
+    [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+      return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+    }
+    `,
+    });
+    const layout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.VERTEX,
+          buffer: { type: 'uniform' },
+        },
+      ],
+    });
+    const pipeline = t.device.createRenderPipeline({
+      layout: t.device.createPipelineLayout({ bindGroupLayouts: [layout] }),
+      vertex: { module, entryPoint: 'vmain', buffers: [] },
+      primitive: { topology: 'point-list' },
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module,
+        entryPoint: 'fmain',
+      },
+    });
+    const renderTarget = t.device.createTexture({
+      size: [kSize, kSize],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const renderPassDescriptor: GPURenderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: 'load',
+          storeOp: 'store',
+        },
+      ],
+    };
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass(renderPassDescriptor);
+    pass.setPipeline(pipeline);
+    range(kSize * kSize, i => {
+      const buffer = t.device.createBuffer({
+        size: 4,
+        usage: GPUBufferUsage.UNIFORM,
+        mappedAtCreation: true,
+      });
+      new Uint32Array(buffer.getMappedRange())[0] = i;
+      buffer.unmap();
+      pass.setBindGroup(
+        0,
+        t.device.createBindGroup({ layout, entries: [{ binding: 0, resource: { buffer } }] })
+      );
+      pass.draw(1, 1);
+    });
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    t.expectSingleColor(renderTarget, 'rgba8unorm', {
+      size: [kSize, kSize, 1],
+      exp: { R: 1, G: 0, B: 1, A: 1 },
+    });
+  });
 
 g.test('many_draws')
-  .desc(`Tests execution of render passes with a huge number of draw calls`)
-  .unimplemented();
+  .desc(
+    `Tests execution of render passes with a huge number of draw calls. This uses a single
+render pass with a single pipeline, and one draw call per fragment of the output texture.`
+  )
+  .fn(async t => {
+    const kSize = 4096;
+    const module = t.device.createShaderModule({
+      code: `
+    [[stage(vertex)]] fn vmain([[builtin(vertex_index)]] index: u32)
+        -> [[builtin(position)]] vec4<f32> {
+      let position = vec2<f32>(f32(index % ${kSize}u), f32(index / ${kSize}u));
+      let r = vec2<f32>(1.0 / f32(${kSize}));
+      let a = 2.0 * r;
+      let b = r - vec2<f32>(1.0);
+      return vec4<f32>(fma(position, a, b), 0.0, 1.0);
+    }
+    [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+      return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+    }
+    `,
+    });
+    const pipeline = t.device.createRenderPipeline({
+      vertex: { module, entryPoint: 'vmain', buffers: [] },
+      primitive: { topology: 'point-list' },
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module,
+        entryPoint: 'fmain',
+      },
+    });
+    const renderTarget = t.device.createTexture({
+      size: [kSize, kSize],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const renderPassDescriptor: GPURenderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: 'load',
+          storeOp: 'store',
+        },
+      ],
+    };
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass(renderPassDescriptor);
+    pass.setPipeline(pipeline);
+    range(kSize * kSize, i => pass.draw(1, 1, i));
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    t.expectSingleColor(renderTarget, 'rgba8unorm', {
+      size: [kSize, kSize, 1],
+      exp: { R: 1, G: 0, B: 1, A: 1 },
+    });
+  });
 
-g.test('huge_draws').desc(`Tests execution of render passes with huge draw calls`).unimplemented();
+g.test('huge_draws')
+  .desc(
+    `Tests execution of several render passes with huge draw calls. Each pass uses a single draw
+call which draws multiple vertices for each fragment of a large output texture.`
+  )
+  .fn(async t => {
+    const kSize = 32768;
+    const kTextureSize = 4096;
+    const kVertsPerFragment = (kSize * kSize) / (kTextureSize * kTextureSize);
+    const module = t.device.createShaderModule({
+      code: `
+    [[stage(vertex)]] fn vmain([[builtin(vertex_index)]] vert_index: u32)
+        -> [[builtin(position)]] vec4<f32> {
+      let index = vert_index / ${kVertsPerFragment}u;
+      let position = vec2<f32>(f32(index % ${kTextureSize}u), f32(index / ${kTextureSize}u));
+      let r = vec2<f32>(1.0 / f32(${kTextureSize}));
+      let a = 2.0 * r;
+      let b = r - vec2<f32>(1.0);
+      return vec4<f32>(fma(position, a, b), 0.0, 1.0);
+    }
+    [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+      return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+    }
+    `,
+    });
+    const pipeline = t.device.createRenderPipeline({
+      vertex: { module, entryPoint: 'vmain', buffers: [] },
+      primitive: { topology: 'point-list' },
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module,
+        entryPoint: 'fmain',
+      },
+    });
+    const renderTarget = t.device.createTexture({
+      size: [kTextureSize, kTextureSize],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const renderPassDescriptor: GPURenderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: 'load',
+          storeOp: 'store',
+        },
+      ],
+    };
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass(renderPassDescriptor);
+    pass.setPipeline(pipeline);
+    pass.draw(kSize * kSize);
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    t.expectSingleColor(renderTarget, 'rgba8unorm', {
+      size: [kTextureSize, kTextureSize, 1],
+      exp: { R: 1, G: 0, B: 1, A: 1 },
+    });
+  });

--- a/src/stress/render/vertex_buffers.spec.ts
+++ b/src/stress/render/vertex_buffers.spec.ts
@@ -7,9 +7,122 @@ import { GPUTest } from '../../webgpu/gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('huge')
-  .desc(
-    `Tests execution of draw calls using as many huge vertex buffers as are
-supported by the device, with as many attributes as are supported.`
-  )
-  .unimplemented();
+function createHugeVertexBuffer(t: GPUTest, size: number) {
+  const kBufferSize = size * size * 8;
+  const buffer = t.device.createBuffer({
+    size: kBufferSize,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+  });
+  const pipeline = t.device.createComputePipeline({
+    compute: {
+      module: t.device.createShaderModule({
+        code: `
+        [[block]] struct Buffer { data: array<vec2<u32>>; };
+        [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+        [[stage(compute), workgroup_size(1)]] fn main(
+            [[builtin(global_invocation_id)]] id: vec3<u32>) {
+          let base = id.x * ${size}u;
+          for (var x: u32 = 0u; x < ${size}u; x = x + 1u) {
+            buffer.data[base + x] = vec2<u32>(x, id.x);
+          }
+        }
+        `,
+      }),
+      entryPoint: 'main',
+    },
+  });
+  const bindGroup = t.device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [
+      {
+        binding: 0,
+        resource: { buffer },
+      },
+    ],
+  });
+  const encoder = t.device.createCommandEncoder();
+  const pass = encoder.beginComputePass();
+  pass.setPipeline(pipeline);
+  pass.setBindGroup(0, bindGroup);
+  pass.dispatch(size);
+  pass.endPass();
+
+  const vertexBuffer = t.device.createBuffer({
+    size: kBufferSize,
+    usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+  });
+  encoder.copyBufferToBuffer(buffer, 0, vertexBuffer, 0, kBufferSize);
+  t.device.queue.submit([encoder.finish()]);
+  return vertexBuffer;
+}
+
+g.test('many')
+  .desc(`Tests execution of draw calls using a huge vertex buffer.`)
+  .fn(async t => {
+    const kSize = 4096;
+    const buffer = createHugeVertexBuffer(t, kSize);
+    const module = t.device.createShaderModule({
+      code: `
+    [[stage(vertex)]] fn vmain([[location(0)]] position: vec2<u32>)
+        -> [[builtin(position)]] vec4<f32> {
+      let r = vec2<f32>(1.0 / f32(${kSize}));
+      let a = 2.0 * r;
+      let b = r - vec2<f32>(1.0);
+      return vec4<f32>(fma(vec2<f32>(position), a, b), 0.0, 1.0);
+    }
+    [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+      return vec4<f32>(1.0, 0.0, 1.0, 1.0);
+    }
+    `,
+    });
+    const pipeline = t.device.createRenderPipeline({
+      vertex: {
+        module,
+        entryPoint: 'vmain',
+        buffers: [
+          {
+            arrayStride: 8,
+            attributes: [
+              {
+                format: 'uint32x2',
+                offset: 0,
+                shaderLocation: 0,
+              },
+            ],
+          },
+        ],
+      },
+      primitive: { topology: 'point-list' },
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module,
+        entryPoint: 'fmain',
+      },
+    });
+    const renderTarget = t.device.createTexture({
+      size: [kSize, kSize],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const renderPassDescriptor: GPURenderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: 'load',
+          storeOp: 'store',
+        },
+      ],
+    };
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass(renderPassDescriptor);
+    pass.setPipeline(pipeline);
+    pass.setVertexBuffer(0, buffer);
+    pass.draw(kSize * kSize);
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    t.expectSingleColor(renderTarget, 'rgba8unorm', {
+      size: [kSize, kSize, 1],
+      exp: { R: 1, G: 0, B: 1, A: 1 },
+    });
+  });

--- a/src/stress/shaders/non_halting.spec.ts
+++ b/src/stress/shaders/non_halting.spec.ts
@@ -8,13 +8,180 @@ import { GPUTest } from '../../webgpu/gpu_test.js';
 export const g = makeTestGroup(GPUTest);
 
 g.test('compute')
-  .desc(`Tests execution of compute passes with non-halting dispatch operations.`)
-  .unimplemented();
+  .desc(
+    `Tests execution of compute passes with non-halting dispatch operations.
+
+This is expected to hang for a bit, but it should ultimately result in graceful
+device loss.`
+  )
+  .fn(async t => {
+    const data = new Uint32Array([0]);
+    const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+    const module = t.device.createShaderModule({
+      code: `
+        [[block]] struct Buffer { data: u32; };
+        [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+        [[stage(compute), workgroup_size(1)]] fn main() {
+          loop {
+            if (buffer.data == 1u) {
+              break;
+            }
+            buffer.data = buffer.data + 2u;
+          }
+        }
+      `,
+    });
+    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatch(1);
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    await t.device.lost;
+  });
 
 g.test('vertex')
-  .desc(`Tests execution of render passes with a non-halting vertex stage.`)
-  .unimplemented();
+  .desc(
+    `Tests execution of render passes with a non-halting vertex stage.
+
+This is expected to hang for a bit, but it should ultimately result in graceful
+device loss.`
+  )
+  .fn(async t => {
+    const module = t.device.createShaderModule({
+      code: `
+        [[block]] struct Data { counter: u32; increment: u32; };
+        [[group(0), binding(0)]] var<uniform> data: Data;
+        [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
+          var counter: u32 = data.counter;
+          loop {
+            if (counter % 2u == 1u) {
+              break;
+            }
+            counter = counter + data.increment;
+          }
+          return vec4<f32>(1.0, 1.0, 0.0, f32(counter));
+        }
+        [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+          return vec4<f32>(1.0);
+        }
+      `,
+    });
+
+    const pipeline = t.device.createRenderPipeline({
+      vertex: { module, entryPoint: 'vmain', buffers: [] },
+      primitive: { topology: 'point-list' },
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module,
+        entryPoint: 'fmain',
+      },
+    });
+    const uniforms = t.makeBufferWithContents(new Uint32Array([0, 2]), GPUBufferUsage.UNIFORM);
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: { buffer: uniforms },
+        },
+      ],
+    });
+    const renderTarget = t.device.createTexture({
+      size: [1, 1],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: [0, 0, 0, 0],
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(1);
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    await t.device.lost;
+  });
 
 g.test('fragment')
-  .desc(`Tests execution of render passes with a non-halting fragment stage.`)
-  .unimplemented();
+  .desc(
+    `Tests execution of render passes with a non-halting fragment stage.
+
+This is expected to hang for a bit, but it should ultimately result in graceful
+device loss.`
+  )
+  .fn(async t => {
+    const module = t.device.createShaderModule({
+      code: `
+        [[block]] struct Data { counter: u32; increment: u32; };
+        [[group(0), binding(0)]] var<uniform> data: Data;
+        [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
+          return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }
+        [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+          var counter: u32 = data.counter;
+          loop {
+            if (counter % 2u == 1u) {
+              break;
+            }
+            counter = counter + data.increment;
+          }
+          return vec4<f32>(1.0 / f32(counter), 0.0, 0.0, 1.0);
+        }
+      `,
+    });
+
+    const pipeline = t.device.createRenderPipeline({
+      vertex: { module, entryPoint: 'vmain', buffers: [] },
+      primitive: { topology: 'point-list' },
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module,
+        entryPoint: 'fmain',
+      },
+    });
+    const uniforms = t.makeBufferWithContents(new Uint32Array([0, 2]), GPUBufferUsage.UNIFORM);
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: { buffer: uniforms },
+        },
+      ],
+    });
+    const renderTarget = t.device.createTexture({
+      size: [1, 1],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: [0, 0, 0, 0],
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(1);
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    await t.device.lost;
+  });

--- a/src/stress/shaders/slow.spec.ts
+++ b/src/stress/shaders/slow.spec.ts
@@ -9,12 +9,180 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('compute')
   .desc(`Tests execution of compute passes with very long-running dispatch operations.`)
-  .unimplemented();
+  .fn(async t => {
+    const kDispatchSize = 1000;
+    const data = new Uint32Array(kDispatchSize);
+    const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
+    const module = t.device.createShaderModule({
+      code: `
+        [[block]] struct Buffer { data: array<u32>; };
+        [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
+        [[stage(compute), workgroup_size(1)]] fn main(
+            [[builtin(global_invocation_id)]] id: vec3<u32>) {
+          loop {
+            if (buffer.data[id.x] == 1000000u) {
+              break;
+            }
+            buffer.data[id.x] = buffer.data[id.x] + 1u;
+          }
+        }
+      `,
+    });
+    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatch(kDispatchSize);
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    t.expectGPUBufferValuesEqual(buffer, new Uint32Array(new Array(kDispatchSize).fill(1000000)));
+  });
 
 g.test('vertex')
   .desc(`Tests execution of render passes with a very long-running vertex stage.`)
-  .unimplemented();
+  .fn(async t => {
+    const module = t.device.createShaderModule({
+      code: `
+        [[block]] struct Data { counter: u32; increment: u32; };
+        [[group(0), binding(0)]] var<uniform> data: Data;
+        [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
+          var counter: u32 = data.counter;
+          loop {
+            counter = counter + data.increment;
+            if (counter % 50000000u == 0u) {
+              break;
+            }
+          }
+          return vec4<f32>(1.0, 1.0, 0.0, f32(counter));
+        }
+        [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+          return vec4<f32>(1.0, 1.0, 0.0, 1.0);
+        }
+      `,
+    });
+
+    const pipeline = t.device.createRenderPipeline({
+      vertex: { module, entryPoint: 'vmain', buffers: [] },
+      primitive: { topology: 'point-list' },
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module,
+        entryPoint: 'fmain',
+      },
+    });
+    const uniforms = t.makeBufferWithContents(new Uint32Array([0, 1]), GPUBufferUsage.UNIFORM);
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: { buffer: uniforms },
+        },
+      ],
+    });
+    const renderTarget = t.device.createTexture({
+      size: [3, 3],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: [0, 0, 0, 0],
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(1);
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    t.expectSinglePixelIn2DTexture(
+      renderTarget,
+      'rgba8unorm',
+      { x: 1, y: 1 },
+      {
+        exp: new Uint8Array([255, 255, 0, 255]),
+      }
+    );
+  });
 
 g.test('fragment')
   .desc(`Tests execution of render passes with a very long-running fragment stage.`)
-  .unimplemented();
+  .fn(async t => {
+    const module = t.device.createShaderModule({
+      code: `
+        [[block]] struct Data { counter: u32; increment: u32; };
+        [[group(0), binding(0)]] var<uniform> data: Data;
+        [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
+          return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }
+        [[stage(fragment)]] fn fmain() -> [[location(0)]] vec4<f32> {
+          var counter: u32 = data.counter;
+          loop {
+            counter = counter + data.increment;
+            if (counter % 50000000u == 0u) {
+              break;
+            }
+          }
+          return vec4<f32>(1.0, 1.0, 1.0 / f32(counter), 1.0);
+        }
+      `,
+    });
+
+    const pipeline = t.device.createRenderPipeline({
+      vertex: { module, entryPoint: 'vmain', buffers: [] },
+      primitive: { topology: 'point-list' },
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module,
+        entryPoint: 'fmain',
+      },
+    });
+    const uniforms = t.makeBufferWithContents(new Uint32Array([0, 1]), GPUBufferUsage.UNIFORM);
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: { buffer: uniforms },
+        },
+      ],
+    });
+    const renderTarget = t.device.createTexture({
+      size: [3, 3],
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      format: 'rgba8unorm',
+    });
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: renderTarget.createView(),
+          loadValue: [0, 0, 0, 0],
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(1);
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+    t.expectSinglePixelIn2DTexture(
+      renderTarget,
+      'rgba8unorm',
+      { x: 1, y: 1 },
+      {
+        exp: new Uint8Array([255, 255, 0, 255]),
+      }
+    );
+  });


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
