### PR TITLE
Introduce expectGPUBufferRepeatsSingleValue

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -433,7 +433,7 @@ export class GPUTest extends Fixture {
       layout: pipeline.getBindGroupLayout(0),
       entries: [
         { binding: 0, resource: { buffer: expectedDataBuffer } },
-        { binding: 1, resource: { buffer: storageBuffer, } },
+        { binding: 1, resource: { buffer: storageBuffer } },
         { binding: 2, resource: { buffer: resultBuffer } },
       ],
     });


### PR DESCRIPTION
This helper offloads work onto the GPU if the buffer is large enough,
rather than the typical behavior of reading back values to validate on
the CPU. This makes it more suitable for checking the contents of large
buffers quickly.

This is then used by expectSingleColor to validate its buffer of
copied texture data. For an empirical comparison, verifying the contents
of a 4k texture could take ~7-10 seconds before this change, and with
this change it takes only a few milliseconds.





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
