### PR TITLE
Remove stenci8 and depth16unorm references

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -549,8 +549,6 @@ Test the validations on the member 'aspect' of GPUImageCopyTexture in CopyTextur
 
       // kSizedDepthStencilFormats
       depth32float: ['all', 'depth-only'],
-      stencil8: ['all', 'stencil-only'],
-      depth16unorm: ['all', 'depth-only'],
     };
 
     const isSourceAspectValid = kValidAspectsForFormat[format].includes(sourceAspect);

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -136,8 +136,6 @@ const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'sten
 export const kSizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [        true,          true,   false,        ,          ,     false,     false,     false,                ,            1,             1,                         ] as const, {
   'depth32float':          [            ,              ,        ,    true,     false,          ,          ,          ,               4],
-  'depth16unorm':          [            ,              ,        ,    true,     false,          ,          ,          ,               2],
-  'stencil8':              [            ,              ,        ,   false,      true,          ,          ,          ,               1],
 } as const);
 export const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [        true,          true,   false,        ,          ,     false,     false,     false,       undefined,            1,             1,                         ] as const, {
@@ -256,11 +254,6 @@ const kDepthStencilFormatCapabilityInBufferTextureCopy = {
   },
 
   // kSizedDepthStencilFormats
-  depth16unorm: {
-    CopyB2T: ['all', 'depth-only'],
-    CopyT2B: ['all', 'depth-only'],
-    texelAspectSize: { 'depth-only': 2, 'stencil-only': -1 },
-  },
   depth32float: {
     CopyB2T: [],
     CopyT2B: ['all', 'depth-only'],
@@ -275,11 +268,6 @@ const kDepthStencilFormatCapabilityInBufferTextureCopy = {
     CopyB2T: ['stencil-only'],
     CopyT2B: ['depth-only', 'stencil-only'],
     texelAspectSize: { 'depth-only': 4, 'stencil-only': 1 },
-  },
-  stencil8: {
-    CopyB2T: ['all', 'stencil-only'],
-    CopyT2B: ['all', 'stencil-only'],
-    texelAspectSize: { 'depth-only': -1, 'stencil-only': 1 },
   },
 } as const;
 

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -483,28 +483,12 @@ export const kTexelRepresentationInfo: {
       componentInfo: { Depth: { dataType: 'float', bitLength: 32 } },
       pack: components => packComponents([TexelComponent.Depth], components, 32, 'float'),
     },
-    depth16unorm: makeNormalizedInfo([TexelComponent.Depth], 16, { signed: false, sRGB: false }),
     depth24plus: {
       componentOrder: [TexelComponent.Depth],
       componentInfo: { Depth: { dataType: null, bitLength: 24 } },
       encode: applyEach(() => unreachable('depth24plus cannot be encoded'), [TexelComponent.Depth]),
       decode: applyEach(() => unreachable('depth24plus cannot be decoded'), [TexelComponent.Depth]),
       pack: () => unreachable('depth24plus data cannot be packed'),
-    },
-    stencil8: {
-      componentOrder: [TexelComponent.Stencil],
-      componentInfo: { Stencil: { dataType: 'uint', bitLength: 8 } },
-      encode: components => {
-        assert(components.Stencil !== undefined);
-        assertInIntegerRange(components.Stencil, 8, false);
-        return components;
-      },
-      decode: components => {
-        assert(components.Stencil !== undefined);
-        assertInIntegerRange(components.Stencil, 8, false);
-        return components;
-      },
-      pack: components => packComponents([TexelComponent.Stencil], components, 8, 'uint'),
     },
     'depth24unorm-stencil8': {
       componentOrder: [TexelComponent.Depth, TexelComponent.Stencil],


### PR DESCRIPTION
These are causing the roll into Chromium to fail, because they are not
valid formats for GPUTextureDescriptor.





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
