### PR TITLE
Add uniqueId() to class TestBuilder

### DIFF
--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -120,7 +120,12 @@ export class TestGroup<F extends Fixture> implements TestGroupBuilder<F> {
 
 interface TestBuilderWithName<F extends Fixture> extends TestBuilderWithParams<F, {}> {
   desc(description: string): this;
-
+  /**
+   * A noop function with the purpose of highlighting value `id`.
+   *
+   * @param id a value uniquely assigned to this test.
+   */
+  uniqueId(id: number): this;
   /**
    * Parameterize the test, generating multiple cases, each possibly having subcases.
    *
@@ -182,6 +187,10 @@ class TestBuilder {
 
   desc(description: string): this {
     this.description = description.trim();
+    return this;
+  }
+
+  uniqueId(id: number): this {
     return this;
   }
 

--- a/src/webgpu/shader/execution/builtin/logical_built_in_functions.spec.ts
+++ b/src/webgpu/shader/execution/builtin/logical_built_in_functions.spec.ts
@@ -1,0 +1,55 @@
+export const description = `WGSL Logical built-in functions execution test`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('builtin,all')
+  .uniqueId(0x16815cc7b249ff78)
+  .desc(
+    `
+vector all:
+e: vecN<bool> all(e): bool Returns true if each component of e is true.
+(OpAll)
+`
+  )
+  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
+  .unimplemented();
+
+g.test('builtin,any')
+  .uniqueId(0x55e14f481a7f3e66)
+  .desc(
+    `
+vector any:
+e: vecN<bool> any(e): bool Returns true if any component of e is true.
+(OpAny)
+`
+  )
+  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
+  .unimplemented();
+
+g.test('builtin,select_scalar')
+  .uniqueId(0xb9bd4dd5c8b4b0d7)
+  .desc(
+    `
+scalar select:
+T is a scalar select(f:T,t:T,cond: bool): T Returns t when cond is true, and f otherwise.
+(OpSelect)
+`
+  )
+  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
+  .unimplemented();
+
+g.test('builtin,select_vector')
+  .uniqueId(0xbf77b7217032259b)
+  .desc(
+    `
+vector select:
+T is a scalar select(f: vecN<T>,t: vecN<T,cond: vecN<bool>>) Component-wise selection.
+Result component i is evaluated as select(f[i],t[i],cond[i]).
+(OpSelect)
+`
+  )
+  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
+  .unimplemented();


### PR DESCRIPTION
`.uniqueId(<id>)` is used to highlight the `id` assigned to a wgsl test plan. This`id` will be used for tracking changes of wgsl spec and keeping the test plan up to date.

A typical wgsl test plan looks like this:
```
g.test(<name>)
  .uniqueId(<id>)
  .desc(`<description>`)
  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
  .unimplemented();
```
The test `description` is generated by paring the latest version of [wgsl specification](https://www.w3.org/TR/2021/WD-WGSL-20210826/). `id` is `sha1(<description>)[0:8]`. As a result if the next versions of spec changes the `description`, `id` becomes invalid.

`id` can also be used to check whether a test plan with a specific `description` is defined or implemented in cts. ie. `grep -rnw <id> /gpuweb/cts`.

<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
