### PR TITLE
wgsl type parameter generator

### DIFF
--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -8,16 +8,7 @@ TODO: add tests to check that textureLoad operations stay in-bounds.
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { assert } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
-import { align } from '../../util/math.js';
-import {
-  ScalarType,
-  kScalarTypeInfo,
-  kVectorContainerTypes,
-  kVectorContainerTypeInfo,
-  kMatrixContainerTypes,
-  kMatrixContainerTypeInfo,
-  kScalarTypes,
-} from '../types.js';
+import { generateTypes, supportedScalarTypes, supportsAtomics } from '../types.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -110,110 +101,9 @@ function testFillArrayBuffer(
   new constructor(array, zeroByteStart, zeroByteCount / constructor.BYTES_PER_ELEMENT).fill(0);
 }
 
-const kArrayLength = 3;
-
 /**
  * Generate a bunch of indexable types (vec, mat, sized/unsized array) for testing.
  */
-function* generateIndexableTypes({
-  storageClass,
-  baseType,
-  atomic = false,
-}: {
-  /** Unsized array will only be generated for storageClass "storage". */
-  storageClass: string;
-  /** Base scalar type (i32/u32/f32/bool). */
-  baseType: ScalarType;
-  /** Whether to wrap the baseType in `atomic<>`. */
-  atomic?: boolean;
-}) {
-  const scalarInfo = kScalarTypeInfo[baseType];
-  if (atomic) assert(scalarInfo.supportsAtomics, 'type does not support atomics');
-  const scalarType = atomic ? `atomic<${baseType}>` : baseType;
-
-  // Don't generate vec2<atomic<i32>> etc.
-  if (!atomic) {
-    // Vector types
-    for (const vectorType of kVectorContainerTypes) {
-      yield {
-        type: `${vectorType}<${scalarType}>`,
-        _typeInfo: { elementBaseType: baseType, ...kVectorContainerTypeInfo[vectorType] },
-      };
-    }
-
-    // Matrices can only be f32.
-    if (baseType === 'f32') {
-      for (const matrixType of kMatrixContainerTypes) {
-        const matrixInfo = kMatrixContainerTypeInfo[matrixType];
-        yield {
-          type: `${matrixType}<${scalarType}>`,
-          _typeInfo: {
-            elementBaseType: `vec${matrixInfo.innerLength}<${scalarType}>`,
-            ...matrixInfo,
-          },
-        };
-      }
-    }
-  }
-
-  const arrayTypeInfo = {
-    elementBaseType: baseType,
-    arrayLength: kArrayLength,
-    layout: scalarInfo.layout
-      ? {
-          alignment: scalarInfo.layout.alignment,
-          size:
-            storageClass === 'uniform'
-              ? // Uniform storage class must have array elements aligned to 16.
-                kArrayLength *
-                arrayStride({
-                  ...scalarInfo.layout,
-                  alignment: 16,
-                })
-              : kArrayLength * arrayStride(scalarInfo.layout),
-        }
-      : undefined,
-  };
-
-  // Sized array
-  if (storageClass === 'uniform') {
-    yield { type: `[[stride(16)]] array<${scalarType},${kArrayLength}>`, _typeInfo: arrayTypeInfo };
-  } else {
-    yield { type: `array<${scalarType},${kArrayLength}>`, _typeInfo: arrayTypeInfo };
-  }
-  // Unsized array
-  if (storageClass === 'storage') {
-    yield { type: `array<${scalarType}>`, _typeInfo: arrayTypeInfo };
-  }
-}
-
-function arrayStride(elementLayout: { size: number; alignment: number }) {
-  return align(elementLayout.size, elementLayout.alignment);
-}
-
-/** Generates scalarTypes (i32/u32/f32/bool) that support the specified usage. */
-function* supportedScalarTypes(p: { atomic: boolean; storageClass: string }) {
-  for (const scalarType of kScalarTypes) {
-    const info = kScalarTypeInfo[scalarType];
-
-    // Test atomics only on supported scalar types.
-    if (p.atomic && !info.supportsAtomics) continue;
-
-    // Storage and uniform require host-sharable types.
-    const isHostShared = p.storageClass === 'storage' || p.storageClass === 'uniform';
-    if (isHostShared && info.layout === undefined) continue;
-
-    yield scalarType;
-  }
-}
-
-/** Atomic access requires atomic type and storage/workgroup memory. */
-function supportsAtomics(p: { storageClass: string; storageMode: string | undefined }) {
-  return (
-    (p.storageClass === 'storage' && p.storageMode === 'read_write') ||
-    p.storageClass === 'workgroup'
-  );
-}
 
 g.test('linear_memory')
   .desc(
@@ -245,13 +135,29 @@ g.test('linear_memory')
         { storageClass: 'workgroup', access: 'read' },
         { storageClass: 'workgroup', access: 'write' },
       ] as const)
-      .expand('atomic', p => (supportsAtomics(p) ? [false, true] : [false]))
-      .expand('baseType', supportedScalarTypes)
+      .combineWithParams([
+        { containerType: 'array' },
+        { containerType: 'matrix' },
+        { containerType: 'vector' },
+      ] as const)
+      .expand('supportsAtomics', p => (supportsAtomics(p) ? [false, true] : [false]))
       .beginSubcases()
-      .expandWithParams(generateIndexableTypes)
+      .expand('baseType', supportedScalarTypes)
+      .expandWithParams(generateTypes)
   )
   .fn(async t => {
-    const { storageClass, storageMode, access, atomic, baseType, type, _typeInfo } = t.params;
+    const {
+      storageClass,
+      storageMode,
+      access,
+      supportsAtomics,
+      baseType,
+      type,
+      _kTypeInfo,
+    } = t.params;
+
+    assert(_kTypeInfo !== undefined, 'not an indexable type');
+    assert('arrayLength' in _kTypeInfo);
 
     let usesCanary = false;
     let globalSource = '';
@@ -274,8 +180,8 @@ g.test('linear_memory')
       case 'uniform':
       case 'storage':
         {
-          assert(_typeInfo.layout !== undefined);
-          const layout = _typeInfo.layout;
+          assert(_kTypeInfo.layout !== undefined);
+          const layout = _kTypeInfo.layout;
           bufferBindingSize = layout.size;
           const qualifiers = storageClass === 'storage' ? `storage, ${storageMode}` : storageClass;
           globalSource += `
@@ -326,10 +232,10 @@ g.test('linear_memory')
         ? [
             // Exactly in bounds (should be OK)
             '0',
-            `${_typeInfo.arrayLength} - 1`,
+            `${_kTypeInfo.arrayLength} - 1`,
             // Exactly out of bounds
             '-1',
-            `${_typeInfo.arrayLength}`,
+            `${_kTypeInfo.arrayLength}`,
             // Far out of bounds
             '-1000000',
             '1000000',
@@ -339,9 +245,9 @@ g.test('linear_memory')
         : [
             // Exactly in bounds (should be OK)
             '0u',
-            `${_typeInfo.arrayLength}u - 1u`,
+            `${_kTypeInfo.arrayLength}u - 1u`,
             // Exactly out of bounds
-            `${_typeInfo.arrayLength}u`,
+            `${_kTypeInfo.arrayLength}u`,
             // Far out of bounds
             '1000000u',
             `${kMaxU32}u`,
@@ -358,22 +264,24 @@ g.test('linear_memory')
         // Produce the accesses to the variable.
         for (const indexToTest of indicesToTest) {
           const exprIndex = `(${indexToTest})${exprIndexAddon}`;
-          const exprZeroElement = `${_typeInfo.elementBaseType}()`;
+          const exprZeroElement = `${_kTypeInfo.elementBaseType}()`;
           const exprElement = `s.data[${exprIndex}]`;
 
           switch (access) {
             case 'read':
               {
-                const exprLoadElement = atomic ? `atomicLoad(&${exprElement})` : exprElement;
+                const exprLoadElement = supportsAtomics
+                  ? `atomicLoad(&${exprElement})`
+                  : exprElement;
                 let condition = `${exprLoadElement} != ${exprZeroElement}`;
-                if ('innerLength' in _typeInfo) condition = `any(${condition})`;
+                if ('innerLength' in _kTypeInfo) condition = `any(${condition})`;
                 testFunctionSource += `
                   if (${condition}) { return ${nextErrorReturnValue()}; }`;
               }
               break;
 
             case 'write':
-              if (atomic) {
+              if (supportsAtomics) {
                 testFunctionSource += `
                   atomicStore(&s.data[${exprIndex}], ${exprZeroElement});`;
               } else {
@@ -412,9 +320,7 @@ g.test('linear_memory')
       }`;
 
     // Run it.
-    if (bufferBindingSize !== undefined) {
-      assert(baseType !== 'bool', 'case should have been filtered out');
-
+    if (bufferBindingSize !== undefined && baseType !== 'bool') {
       const expectedData = new ArrayBuffer(testBufferSize);
       const bufferBindingEnd = bufferBindingOffset + bufferBindingSize;
       testFillArrayBuffer(expectedData, baseType, {

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -50,7 +50,7 @@ export function* generateTypes({
   storageClass,
   baseType,
   containerType,
-  supportsAtomics = false,
+  isAtomic = false,
 }: {
   storageClass: string;
   /** Base scalar type (i32/u32/f32/bool). */
@@ -58,13 +58,13 @@ export function* generateTypes({
   /** Container type (scalar/vector/matrix/array) */
   containerType: ContainerType;
   /** Whether to wrap the baseType in `atomic<>`. */
-  supportsAtomics?: boolean;
+  isAtomic?: boolean;
 }) {
   const scalarInfo = kScalarTypeInfo[baseType];
-  if (supportsAtomics) {
+  if (isAtomic) {
     assert(scalarInfo.supportsAtomics, 'type does not support atomics');
   }
-  const scalarType = supportsAtomics ? `atomic<${baseType}>` : baseType;
+  const scalarType = isAtomic ? `atomic<${baseType}>` : baseType;
 
   // Storage and uniform require host-sharable types.
   if (storageClass === 'storage' || storageClass === 'uniform') {
@@ -171,12 +171,12 @@ export function supportsAtomics(p: {
 }
 
 /** Generates an iterator of supported base types (i32/u32/f32/bool) */
-export function* supportedScalarTypes(p: { supportsAtomics: boolean; storageClass: string }) {
+export function* supportedScalarTypes(p: { isAtomic: boolean; storageClass: string }) {
   for (const scalarType of kScalarTypes) {
     const info = kScalarTypeInfo[scalarType];
 
     // Test atomics only on supported scalar types.
-    if (p.supportsAtomics && !info.supportsAtomics) continue;
+    if (p.isAtomic && !info.supportsAtomics) continue;
 
     // Storage and uniform require host-sharable types.
     const isHostShared = p.storageClass === 'storage' || p.storageClass === 'uniform';

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -1,7 +1,13 @@
 import { keysOf } from '../../common/util/data_tables.js';
+import { assert } from '../../common/util/util.js';
+import { align } from '../util/math.js';
 
-/** WGSL plain scalar type names. */
+const kArrayLength = 3;
+
+export type ContainerType = 'scalar' | 'vector' | 'matrix' | 'atomic' | 'array';
 export type ScalarType = 'i32' | 'u32' | 'f32' | 'bool';
+
+export const HostSharableTypes = ['i32', 'u32', 'f32'] as const;
 
 /** Info for each plain scalar type. */
 export const kScalarTypeInfo = /* prettier-ignore */ {
@@ -36,3 +42,146 @@ export const kMatrixContainerTypeInfo = /* prettier-ignore */ {
 } as const;
 /** List of all matNxN<> container types. */
 export const kMatrixContainerTypes = keysOf(kMatrixContainerTypeInfo);
+
+/**
+ * Generate a bunch types (vec, mat, sized/unsized array) for testing.
+ */
+export function* generateTypes({
+  storageClass,
+  baseType,
+  containerType,
+  supportsAtomics = false,
+}: {
+  storageClass: string;
+  /** Base scalar type (i32/u32/f32/bool). */
+  baseType: ScalarType;
+  /** Container type (scalar/vector/matrix/array) */
+  containerType: ContainerType;
+  /** Whether to wrap the baseType in `atomic<>`. */
+  supportsAtomics?: boolean;
+}) {
+  const scalarInfo = kScalarTypeInfo[baseType];
+  if (supportsAtomics) {
+    assert(scalarInfo.supportsAtomics, 'type does not support atomics');
+  }
+  const scalarType = supportsAtomics ? `atomic<${baseType}>` : baseType;
+
+  // Storage and uniform require host-sharable types.
+  if (storageClass === 'storage' || storageClass === 'uniform') {
+    assert(isHostSharable(baseType), 'type ' + baseType.toString() + ' is not host sharable');
+  }
+
+  // Scalar types
+  if (containerType === 'scalar') {
+    yield {
+      type: `${scalarType}`,
+      _kTypeInfo: {
+        elementBaseType: `${scalarType}`,
+        ...scalarInfo,
+      },
+    };
+  }
+
+  // Vector types
+  if (containerType === 'vector') {
+    for (const vectorType of kVectorContainerTypes) {
+      yield {
+        type: `${vectorType}<${scalarType}>`,
+        _kTypeInfo: { elementBaseType: baseType, ...kVectorContainerTypeInfo[vectorType] },
+      };
+    }
+  }
+
+  if (containerType === 'matrix') {
+    // Matrices can only be f32.
+    if (baseType === 'f32') {
+      for (const matrixType of kMatrixContainerTypes) {
+        const matrixInfo = kMatrixContainerTypeInfo[matrixType];
+        yield {
+          type: `${matrixType}<${scalarType}>`,
+          _kTypeInfo: {
+            elementBaseType: `vec${matrixInfo.innerLength}<${scalarType}>`,
+            ...matrixInfo,
+          },
+        };
+      }
+    }
+  }
+
+  // Array types
+  if (containerType === 'array') {
+    const arrayTypeInfo = {
+      elementBaseType: `${baseType}`,
+      arrayLength: kArrayLength,
+      layout: scalarInfo.layout
+        ? {
+            alignment: scalarInfo.layout.alignment,
+            size:
+              storageClass === 'uniform'
+                ? // Uniform storage class must have array elements aligned to 16.
+                  kArrayLength *
+                  arrayStride({
+                    ...scalarInfo.layout,
+                    alignment: 16,
+                  })
+                : kArrayLength * arrayStride(scalarInfo.layout),
+          }
+        : undefined,
+    };
+
+    // Sized
+    if (storageClass === 'uniform') {
+      yield {
+        type: `[[stride(16)]] array<${scalarType},${kArrayLength}>`,
+        _kTypeInfo: arrayTypeInfo,
+      };
+    } else {
+      yield { type: `array<${scalarType},${kArrayLength}>`, _kTypeInfo: arrayTypeInfo };
+    }
+    // Unsized
+    if (storageClass === 'storage') {
+      yield { type: `array<${scalarType}>`, _kTypeInfo: arrayTypeInfo };
+    }
+  }
+
+  function arrayStride(elementLayout: { size: number; alignment: number }) {
+    return align(elementLayout.size, elementLayout.alignment);
+  }
+
+  function isHostSharable(baseType: ScalarType) {
+    for (const sharableType of HostSharableTypes) {
+      if (sharableType === baseType) return true;
+    }
+    return false;
+  }
+}
+
+/** Atomic access requires scalar/array container type and storage/workgroup memory. */
+export function supportsAtomics(p: {
+  storageClass: string;
+  storageMode: string | undefined;
+  access: string;
+  containerType: ContainerType;
+}) {
+  return (
+    ((p.storageClass === 'storage' && p.storageMode === 'read_write') ||
+      p.storageClass === 'workgroup') &&
+    (p.containerType === 'scalar' || p.containerType === 'array')
+  );
+}
+
+/** Generates an iterator of supported base types (i32/u32/f32/bool) */
+export function* supportedScalarTypes(p: { supportsAtomics: boolean; storageClass: string }) {
+  for (const scalarType of kScalarTypes) {
+    const info = kScalarTypeInfo[scalarType];
+
+    // Test atomics only on supported scalar types.
+    if (p.supportsAtomics && !info.supportsAtomics) continue;
+
+    // Storage and uniform require host-sharable types.
+    const isHostShared = p.storageClass === 'storage' || p.storageClass === 'uniform';
+    if (isHostShared && info.layout === undefined) continue;
+
+    yield scalarType;
+  }
+}


### PR DESCRIPTION
This PR uses the idea of a wgsl type iterator generator form [this indexable type generator](https://github.com/gpuweb/cts/blob/main/src/webgpu/shader/execution/robust_access.spec.ts#L118). I implements a similar one that can generates types based on the following, and asserts if the type is invalid (eg. 'bool' with storage storage class or as an atomic base type).
- type container (scalar, vector, matrix, array)
- the base type (bool, i32, u32, f32)
- whether its atomic


The motivation is having a type generator that other test can reuse. (eg. testing builtin functions such as [this](https://github.com/gpuweb/cts/pull/730/files#diff-d403b8a26ac9412452ae3eb1640fa5eb01ec4e483245553bb3cce05d206e0747R72) one that working on).

Here are two examples:

```
g.test('example1')
.desc(`generates these types: f32, vecN<f32>, matMxN<f32>`)
.params(u =>
  u
  .combineWithParams([{ storageClass: 'storage' }] as const)
    .combineWithParams([
      { containerType: 'scalar' },
      { containerType: 'vector' },
      { containerType: 'matrix' },
    ] as const)
    .combineWithParams([{ supportsAtomics: false }] as const)
    .combineWithParams([{ baseType: 'f32' }] as const)
    .beginSubcases()
    .expandWithParams(generateTypes)
).unimplemented();

g.test('example2')
.desc(`generates these types: atomic<u32>, array<atomic<u32>, 3>, array<atomic<32>>`)
.params(u =>
  u
  .combineWithParams([{ storageClass: 'storage' }] as const)
    .combineWithParams([
      { containerType: 'scalar' },
      { containerType: 'array' },
    ] as const)
    .combineWithParams([{ supportsAtomics: true }] as const)
    .combineWithParams([{ baseType: 'u32' }] as const)
    .beginSubcases()
    .expandWithParams(generateTypes)
).unimplemented();

```

<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
