### PR TITLE
Move shader-related type enums and helpers to webgpu/shader/types.ts

### DIFF
--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -1,4 +1,5 @@
 import { keysOf } from '../../common/util/data_tables.js';
+import { assertTypeTrue, TypeEqual } from '../../common/util/types.js';
 
 /** WGSL plain scalar type names. */
 export type ScalarType = 'i32' | 'u32' | 'f32' | 'bool';
@@ -36,3 +37,45 @@ export const kMatrixContainerTypeInfo = /* prettier-ignore */ {
 } as const;
 /** List of all matNxN<> container types. */
 export const kMatrixContainerTypes = keysOf(kMatrixContainerTypeInfo);
+
+export type AccessQualifier = 'read' | 'write';
+export const kAccessQualifiers = ['read', 'write'] as const;
+assertTypeTrue<TypeEqual<AccessQualifier, typeof kAccessQualifiers[number]>>();
+
+export type StorageMode = 'read' | 'write' | 'read_write';
+export const kStorageModes = ['read', 'write', 'read_write'] as const;
+assertTypeTrue<TypeEqual<StorageMode, typeof kStorageModes[number]>>();
+
+export const kStorageClassInfo = /* prettier-ignore */ {
+  'storage':    { validAccess: kAccessQualifiers, validStorageMode: kStorageModes },
+  'uniform':    { validAccess: ['read'],          validStorageMode: [undefined] },
+  'private':    { validAccess: kAccessQualifiers, validStorageMode: [undefined] },
+  'function':   { validAccess: kAccessQualifiers, validStorageMode: [undefined] },
+  'workgroup':  { validAccess: kAccessQualifiers, validStorageMode: [undefined] },
+} as const;
+export const kStorageClasses = keysOf(kStorageClassInfo);
+export type StorageClass = keyof typeof kStorageClassInfo;
+
+/** Generates scalarTypes (i32/u32/f32/bool) that support the specified usage. */
+export function* supportedScalarTypes(p: { atomic: boolean; storageClass: StorageClass }) {
+  for (const scalarType of kScalarTypes) {
+    const info = kScalarTypeInfo[scalarType];
+
+    // Test atomics only on supported scalar types.
+    if (p.atomic && !info.supportsAtomics) continue;
+
+    // Storage and uniform require host-sharable types.
+    const isHostShared = p.storageClass === 'storage' || p.storageClass === 'uniform';
+    if (isHostShared && info.layout === undefined) continue;
+
+    yield scalarType;
+  }
+}
+
+/** Atomic access requires atomic type and storage/workgroup memory. */
+export function supportsAtomics(p: { storageClass: StorageClass; storageMode?: StorageMode }) {
+  return (
+    (p.storageClass === 'storage' && p.storageMode === 'read_write') ||
+    p.storageClass === 'workgroup'
+  );
+}


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
