### PR TITLE
Remove CopyImageBitmapToTexture

### DIFF
--- a/docs/organization.md
+++ b/docs/organization.md
@@ -23,7 +23,7 @@ the root and first few levels looks like the following (some nodes omitted for s
   objects exposed exactly the correct members, and that methods throw when passed incomplete
   dictionaries.
 - **`web-platform`** with tests for Web platform-specific interactions like `GPUSwapChain` and
-  `<canvas>`, WebXR and `GPUCommandEncoder.copyImageBitmapToTexture`.
+  `<canvas>`, WebXR and `GPUQueue.copyExternalImageToTexture`.
 
 At the same time test hierarchies can be used to split the testing of a single sub-object into
 several file for maintainability. For example `GPURenderPipeline` has a large descriptor and some

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -158,7 +158,7 @@ class CopyExternalImageToTextureTest extends ValidationTest {
     validationScopeSuccess: boolean,
     exceptionName?: string
   ): void {
-    // CopyImageBitmapToTexture will generate two types of errors. One is synchronous exceptions;
+    // copyExternalImageToTexture will generate two types of errors. One is synchronous exceptions;
     // the other is asynchronous validation error scope errors.
     if (exceptionName) {
       this.shouldThrow(exceptionName, () => {

--- a/src/webgpu/api/validation/queue/destroyed/texture.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/texture.spec.ts
@@ -2,7 +2,7 @@ export const description = `
 Tests using a destroyed texture on a queue.
 
 - used in {writeTexture,
-  setBindGroup, copyT2T {src,dst}, copyB2T, copyT2B, copyImageBitmapToTexture,
+  setBindGroup, copyT2T {src,dst}, copyB2T, copyT2B, copyExternalImageToTexture,
   color attachment {0,>0}, {D,S,DS} attachment, ..?}
 - x= if applicable, {in pass, in bundle}
 - x= {destroyed, not destroyed (control case)}


### PR DESCRIPTION
CopyImageBitmapToTexture is not official WebGPU API
any more. Remove it from cts





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
