### PR TITLE
Add operation tests on T2T copy with multisampled color textures

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1020,7 +1020,7 @@ g.test('copy_multisampled_color')
     `
   Validate the correctness of copyTextureToTexture() with multisampled color formats.
 
-  - Initialize the source texture in a render pass.
+  - Initialize the source texture with a triangle in a render pass.
   - Copy from the source texture into the destination texture with CopyTextureToTexture().
   - Compare every sub-pixel of source texture and destination texture in another render pass:
     - If they are different, then output RED; otherwise output GREEN
@@ -1118,7 +1118,7 @@ g.test('copy_multisampled_color')
           code: `
           [[stage(vertex)]]
           fn main([[builtin(vertex_index)]] VertexIndex : u32) -> [[builtin(position)]] vec4<f32> {
-            var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+            var pos = array<vec2<f32>, 6>(
               vec2<f32>(-1.0,  1.0),
               vec2<f32>(-1.0, -1.0),
               vec2<f32>( 1.0,  1.0),
@@ -1136,16 +1136,15 @@ g.test('copy_multisampled_color')
           [[group(0), binding(0)]] var sourceTexture : texture_multisampled_2d<f32>;
           [[group(0), binding(1)]] var destinationTexture : texture_multisampled_2d<f32>;
           [[stage(fragment)]]
-          fn main() -> [[location(0)]] vec4<f32> {
-            for (var sampleIndex = 0; sampleIndex < 4; sampleIndex = sampleIndex + 1) {
+          fn main([[builtin(position)]] coord_in: vec4<f32>) -> [[location(0)]] vec4<f32> {
+            var coord_in_vec2 = vec2<i32>(i32(coord_in.x), i32(coord_in.y));
+            for (var sampleIndex = 0; sampleIndex < ${kSampleCount};
+              sampleIndex = sampleIndex + 1) {
               var sourceSubPixel : vec4<f32> =
-                textureLoad(sourceTexture, vec2<i32>(0, 0), sampleIndex);
+                textureLoad(sourceTexture, coord_in_vec2, sampleIndex);
               var destinationSubPixel : vec4<f32> =
-                textureLoad(destinationTexture, vec2<i32>(0, 0), sampleIndex);
-              if (sourceSubPixel.r != destinationSubPixel.r ||
-                sourceSubPixel.g != destinationSubPixel.g ||
-                sourceSubPixel.b != destinationSubPixel.b ||
-                sourceSubPixel.a != destinationSubPixel.a) {
+                textureLoad(destinationTexture, coord_in_vec2, sampleIndex);
+              if (!all(sourceSubPixel == destinationSubPixel)) {
                 return vec4<f32>(1.0, 0.0, 0.0, 1.0);
               }
             }

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1137,8 +1137,7 @@ g.test('copy_multisampled_color')
           [[group(0), binding(1)]] var destinationTexture : texture_multisampled_2d<f32>;
           [[stage(fragment)]]
           fn main([[builtin(position)]] coord_in: vec4<f32>) -> [[location(0)]] vec4<f32> {
-            var coord_in_vec2 =
-              vec2<i32>(i32(coord_in.x) * ${textureSize[0]}, i32(coord_in.y) * ${textureSize[1]});
+            var coord_in_vec2 = vec2<i32>(i32(coord_in.x), i32(coord_in.y));
             for (var sampleIndex = 0; sampleIndex < ${kSampleCount};
               sampleIndex = sampleIndex + 1) {
               var sourceSubPixel : vec4<f32> =

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1137,7 +1137,8 @@ g.test('copy_multisampled_color')
           [[group(0), binding(1)]] var destinationTexture : texture_multisampled_2d<f32>;
           [[stage(fragment)]]
           fn main([[builtin(position)]] coord_in: vec4<f32>) -> [[location(0)]] vec4<f32> {
-            var coord_in_vec2 = vec2<i32>(i32(coord_in.x), i32(coord_in.y));
+            var coord_in_vec2 =
+              vec2<i32>(i32(coord_in.x) * ${textureSize[0]}, i32(coord_in.y) * ${textureSize[1]});
             for (var sampleIndex = 0; sampleIndex < ${kSampleCount};
               sampleIndex = sampleIndex + 1) {
               var sourceSubPixel : vec4<f32> =

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1050,6 +1050,7 @@ g.test('copy_multisampled_color')
       sampleCount: kSampleCount,
     });
 
+    // Initialize sourceTexture with a draw call.
     const renderPipelineForInit = t.device.createRenderPipeline({
       vertex: {
         module: t.device.createShaderModule({
@@ -1081,7 +1082,6 @@ g.test('copy_multisampled_color')
         count: kSampleCount,
       },
     });
-
     const initEncoder = t.device.createCommandEncoder();
     const renderPassForInit = initEncoder.beginRenderPass({
       colorAttachments: [
@@ -1097,6 +1097,7 @@ g.test('copy_multisampled_color')
     renderPassForInit.endPass();
     t.queue.submit([initEncoder.finish()]);
 
+    // Do the texture-to-texture copy
     const copyEncoder = t.device.createCommandEncoder();
     copyEncoder.copyTextureToTexture(
       {
@@ -1109,6 +1110,8 @@ g.test('copy_multisampled_color')
     );
     t.queue.submit([copyEncoder.finish()]);
 
+    // Verify if all the sub-pixel values at the same location of sourceTexture and
+    // destinationTextureare equal.
     const renderPipelineForValidation = t.device.createRenderPipeline({
       vertex: {
         module: t.device.createShaderModule({

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1014,3 +1014,181 @@ g.test('copy_depth_stencil')
       );
     }
   });
+
+g.test('copy_multisampled_color')
+  .desc(
+    `
+  Validate the correctness of copyTextureToTexture() with multisampled color formats.
+
+  - Initialize the source texture in a render pass.
+  - Copy from the source texture into the destination texture with CopyTextureToTexture().
+  - Compare every sub-pixel of source texture and destination texture in another render pass:
+    - If they are different, then output RED; otherwise output GREEN
+  - Verify the pixels in the output texture are all GREEN.
+  - Note that in current WebGPU SPEC the mipmap level count and array layer count of a multisampled
+    texture can only be 1.
+  `
+  )
+  .fn(async t => {
+    const textureSize = [32, 16, 1] as const;
+    const kColorFormat = 'rgba8unorm';
+    const kSampleCount = 4;
+
+    const sourceTexture = t.device.createTexture({
+      format: kColorFormat,
+      size: textureSize,
+      usage:
+        GPUTextureUsage.COPY_SRC |
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.RENDER_ATTACHMENT,
+      sampleCount: kSampleCount,
+    });
+    const destinationTexture = t.device.createTexture({
+      format: kColorFormat,
+      size: textureSize,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      sampleCount: kSampleCount,
+    });
+
+    const renderPipelineForInit = t.device.createRenderPipeline({
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+            [[stage(vertex)]]
+            fn main([[builtin(vertex_index)]] VertexIndex : u32) -> [[builtin(position)]] vec4<f32> {
+              var pos = array<vec2<f32>, 3>(
+                  vec2<f32>(-1.0,  1.0),
+                  vec2<f32>( 1.0,  1.0),
+                  vec2<f32>( 1.0, -1.0)
+              );
+              return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `
+            [[stage(fragment)]]
+            fn main() -> [[location(0)]] vec4<f32> {
+              return vec4<f32>(0.3, 0.5, 0.8, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: kColorFormat }],
+      },
+      multisample: {
+        count: kSampleCount,
+      },
+    });
+
+    const initEncoder = t.device.createCommandEncoder();
+    const renderPassForInit = initEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: sourceTexture.createView(),
+          loadValue: [1.0, 0.0, 0.0, 1.0],
+          storeOp: 'store',
+        },
+      ],
+    });
+    renderPassForInit.setPipeline(renderPipelineForInit);
+    renderPassForInit.draw(3);
+    renderPassForInit.endPass();
+    t.queue.submit([initEncoder.finish()]);
+
+    const copyEncoder = t.device.createCommandEncoder();
+    copyEncoder.copyTextureToTexture(
+      {
+        texture: sourceTexture,
+      },
+      {
+        texture: destinationTexture,
+      },
+      textureSize
+    );
+    t.queue.submit([copyEncoder.finish()]);
+
+    const renderPipelineForValidation = t.device.createRenderPipeline({
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+          [[stage(vertex)]]
+          fn main([[builtin(vertex_index)]] VertexIndex : u32) -> [[builtin(position)]] vec4<f32> {
+            var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+              vec2<f32>(-1.0,  1.0),
+              vec2<f32>(-1.0, -1.0),
+              vec2<f32>( 1.0,  1.0),
+              vec2<f32>(-1.0, -1.0),
+              vec2<f32>( 1.0,  1.0),
+              vec2<f32>( 1.0, -1.0));
+            return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+          }`,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `
+          [[group(0), binding(0)]] var sourceTexture : texture_multisampled_2d<f32>;
+          [[group(0), binding(1)]] var destinationTexture : texture_multisampled_2d<f32>;
+          [[stage(fragment)]]
+          fn main() -> [[location(0)]] vec4<f32> {
+            for (var sampleIndex = 0; sampleIndex < 4; sampleIndex = sampleIndex + 1) {
+              var sourceSubPixel : vec4<f32> =
+                textureLoad(sourceTexture, vec2<i32>(0, 0), sampleIndex);
+              var destinationSubPixel : vec4<f32> =
+                textureLoad(destinationTexture, vec2<i32>(0, 0), sampleIndex);
+              if (sourceSubPixel.r != destinationSubPixel.r ||
+                sourceSubPixel.g != destinationSubPixel.g ||
+                sourceSubPixel.b != destinationSubPixel.b ||
+                sourceSubPixel.a != destinationSubPixel.a) {
+                return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+              }
+            }
+            return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+          }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: kColorFormat }],
+      },
+    });
+    const bindGroup = t.device.createBindGroup({
+      layout: renderPipelineForValidation.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: sourceTexture.createView(),
+        },
+        {
+          binding: 1,
+          resource: destinationTexture.createView(),
+        },
+      ],
+    });
+    const expectedOutputTexture = t.device.createTexture({
+      format: kColorFormat,
+      size: textureSize,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    const validationEncoder = t.device.createCommandEncoder();
+    const renderPassForValidation = validationEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: expectedOutputTexture.createView(),
+          loadValue: [1.0, 0.0, 0.0, 1.0],
+          storeOp: 'store',
+        },
+      ],
+    });
+    renderPassForValidation.setPipeline(renderPipelineForValidation);
+    renderPassForValidation.setBindGroup(0, bindGroup);
+    renderPassForValidation.draw(6);
+    renderPassForValidation.endPass();
+    t.queue.submit([validationEncoder.finish()]);
+
+    t.expectSingleColor(expectedOutputTexture, 'rgba8unorm', {
+      size: [textureSize[0], textureSize[1], textureSize[2]],
+      exp: { R: 0.0, G: 1.0, B: 0.0, A: 1.0 },
+    });
+  });


### PR DESCRIPTION






<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
