### PR TITLE
Update all uses of 'gpupresent' to 'webgpu'

### DIFF
--- a/src/webgpu/web_platform/README.txt
+++ b/src/webgpu/web_platform/README.txt
@@ -1,2 +1,2 @@
-Tests for Web platform-specific interactions like GPUSwapChain and canvas, WebXR,
+Tests for Web platform-specific interactions like GPUCanvasContext and canvas, WebXR,
 ImageBitmaps, and video APIs.

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -1,7 +1,7 @@
 export const description = `
-Tests for GPUCanvasContext.configureSwapChain.
+Tests for GPUCanvasContext.configure.
 
-TODO: Test all options of configureSwapChain.
+TODO: Test all options of configure.
 `;
 
 import { Fixture } from '../../../common/framework/fixture.js';

--- a/src/webgpu/web_platform/canvas/context_creation.spec.ts
+++ b/src/webgpu/web_platform/canvas/context_creation.spec.ts
@@ -2,7 +2,7 @@ export const description = `
 Tests for canvas context creation.
 
 Note there are no context creation attributes for WebGPU (as of this writing).
-Options are configured in configureSwapChain instead.
+Options are configured in configure() instead.
 `;
 
 import { Fixture } from '../../../common/framework/fixture.js';
@@ -42,6 +42,6 @@ g.test('return_type')
       canvas.height = 10;
     }
 
-    const ctx = canvas.getContext('gpupresent');
+    const ctx = canvas.getContext('webgpu');
     t.expect(ctx instanceof GPUCanvasContext);
   });

--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-Tests for GPUSwapChain.getCurrentTexture.
+Tests for GPUCanvasContext.getCurrentTexture.
 `;
 
 import { Fixture } from '../../../common/framework/fixture.js';

--- a/src/webgpu/web_platform/canvas/getPreferredFormat.spec.ts
+++ b/src/webgpu/web_platform/canvas/getPreferredFormat.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-Tests for GPUCanvasContext.getSwapChainPreferredFormat.
+Tests for GPUCanvasContext.getPreferredFormat.
 `;
 
 import { Fixture } from '../../../common/framework/fixture.js';
@@ -8,5 +8,5 @@ import { makeTestGroup } from '../../../common/framework/test_group.js';
 export const g = makeTestGroup(Fixture);
 
 g.test('value')
-  .desc(`Ensure getSwapChainPreferredFormat returns one of the valid values.`)
+  .desc(`Ensure getPreferredFormat returns one of the valid values.`)
   .unimplemented();

--- a/src/webgpu/web_platform/canvas/getPreferredFormat.spec.ts
+++ b/src/webgpu/web_platform/canvas/getPreferredFormat.spec.ts
@@ -7,6 +7,4 @@ import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 export const g = makeTestGroup(Fixture);
 
-g.test('value')
-  .desc(`Ensure getPreferredFormat returns one of the valid values.`)
-  .unimplemented();
+g.test('value').desc(`Ensure getPreferredFormat returns one of the valid values.`).unimplemented();

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -65,7 +65,7 @@ async function initCanvasContent(
   canvasType: canvasTypes
 ): Promise<HTMLCanvasElement | OffscreenCanvas> {
   const canvas = createCanvas(t, canvasType, 2, 2);
-  const ctx = canvas.getContext('gpupresent');
+  const ctx = canvas.getContext('webgpu');
   assert(ctx !== null, 'Failed to get WebGPU context from canvas');
 
   ctx.configure({

--- a/src/webgpu/web_platform/external_texture/canvas.spec.ts
+++ b/src/webgpu/web_platform/external_texture/canvas.spec.ts
@@ -2,7 +2,7 @@ export const description = `
 Tests for external textures with HTMLCanvasElement and OffscreenCanvas sources.
 
 - x= {HTMLCanvasElement, OffscreenCanvas}
-- x= {2d, webgl, webgl2, gpupresent, bitmaprenderer} context, {various context creation attributes}
+- x= {2d, webgl, webgl2, webgpu, bitmaprenderer} context, {various context creation attributes}
 
 TODO: consider whether external_texture and copyToTexture video tests should be in the same file
 TODO: plan

--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html.ts
@@ -66,7 +66,7 @@ export function run() {
     {
       const back_buffer_width = cvs_larger_than_back_buffer.width / 2;
       const back_buffer_height = cvs_larger_than_back_buffer.height / 2;
-      const ctx = cvs_larger_than_back_buffer.getContext('gpupresent');
+      const ctx = cvs_larger_than_back_buffer.getContext('webgpu');
       assert(ctx !== null);
 
       updateWebGPUBackBuffer(
@@ -84,7 +84,7 @@ export function run() {
 
     // Test back buffer is same as canvas size
     {
-      const ctx = cvs_same_as_back_buffer.getContext('gpupresent');
+      const ctx = cvs_same_as_back_buffer.getContext('webgpu');
       assert(ctx !== null);
 
       updateWebGPUBackBuffer(cvs_same_as_back_buffer, ctx, undefined, [
@@ -99,7 +99,7 @@ export function run() {
     {
       const back_buffer_width = cvs_smaller_than_back_buffer.width * 2;
       const back_buffer_height = cvs_smaller_than_back_buffer.height * 2;
-      const ctx = cvs_smaller_than_back_buffer.getContext('gpupresent');
+      const ctx = cvs_smaller_than_back_buffer.getContext('webgpu');
       assert(ctx !== null);
 
       updateWebGPUBackBuffer(
@@ -123,7 +123,7 @@ export function run() {
     {
       const back_buffer_width = cvs_change_size_after_configure.width;
       const back_buffer_height = cvs_change_size_after_configure.height;
-      const ctx = cvs_change_size_after_configure.getContext('gpupresent');
+      const ctx = cvs_change_size_after_configure.getContext('webgpu');
       assert(ctx !== null);
 
       updateWebGPUBackBuffer(
@@ -145,7 +145,7 @@ export function run() {
     // Test js change canvas size after back buffer has been configured
     // and back buffer configure again.
     {
-      const ctx = cvs_change_size_and_reconfigure.getContext('gpupresent');
+      const ctx = cvs_change_size_and_reconfigure.getContext('webgpu');
       assert(ctx !== null);
 
       updateWebGPUBackBuffer(cvs_change_size_and_reconfigure, ctx, undefined, [
@@ -174,7 +174,7 @@ export function run() {
     {
       const back_buffer_width = back_buffer_smaller_than_cvs_and_css.width / 2;
       const back_buffer_height = back_buffer_smaller_than_cvs_and_css.height / 2;
-      const ctx = back_buffer_smaller_than_cvs_and_css.getContext('gpupresent');
+      const ctx = back_buffer_smaller_than_cvs_and_css.getContext('webgpu');
       assert(ctx !== null);
 
       updateWebGPUBackBuffer(
@@ -194,7 +194,7 @@ export function run() {
     {
       const back_buffer_width = cvs_smaller_than_back_buffer_and_css.width * 2;
       const back_buffer_height = cvs_smaller_than_back_buffer_and_css.height * 2;
-      const ctx = cvs_smaller_than_back_buffer_and_css.getContext('gpupresent');
+      const ctx = cvs_smaller_than_back_buffer_and_css.getContext('webgpu');
       assert(ctx !== null);
 
       updateWebGPUBackBuffer(


### PR DESCRIPTION
Also converted any remaining references to `GPUSwapChain`, `configureSwapChain()`, `getSwapChainPreferredFormat()`, etc. to refer to the appropriate `GPUCanvasContext` functionality now.

No new tests or behaviors.