### PR TITLE
Implement api,validation,state,device_mismatched: Part Ⅰ

### DIFF
--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -185,7 +185,7 @@ g.test('pipeline_layout,device_mismatch')
 
     const layoutDescriptor = { bindGroupLayouts: [] };
     const layout = mismatched
-      ? t.getDeviceMismatchedPipelineLayout(layoutDescriptor)
+      ? t.mismatchedDevice.createPipelineLayout(layoutDescriptor)
       : t.device.createPipelineLayout(layoutDescriptor);
 
     const descriptor = {
@@ -213,7 +213,7 @@ g.test('shader_module,device_mismatch')
 
     const code = '[[stage(compute), workgroup_size(1)]] fn main() {}';
     const module = mismatched
-      ? t.getDeviceMismatchedShaderModule({ code })
+      ? t.mismatchedDevice.createShaderModule({ code })
       : t.device.createShaderModule({ code });
 
     const descriptor = {

--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -62,13 +62,9 @@ class F extends ValidationTest {
         this.shouldReject('OperationError', this.device.createComputePipelineAsync(descriptor));
       }
     } else {
-      if (_success) {
+      this.expectValidationError(() => {
         this.device.createComputePipeline(descriptor);
-      } else {
-        this.expectValidationError(() => {
-          this.device.createComputePipeline(descriptor);
-        });
-      }
+      }, !_success);
     }
   }
 }
@@ -180,11 +176,52 @@ g.test('pipeline_layout,device_mismatch')
     'Tests createComputePipeline(Async) cannot be called with a pipeline layout created from another device'
   )
   .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
-  .unimplemented();
+  .fn(async t => {
+    const { isAsync, mismatched } = t.params;
+
+    if (mismatched) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+
+    const layoutDescriptor = { bindGroupLayouts: [] };
+    const layout = mismatched
+      ? t.getDeviceMismatchedPipelineLayout(layoutDescriptor)
+      : t.device.createPipelineLayout(layoutDescriptor);
+
+    const descriptor = {
+      layout,
+      compute: {
+        module: t.getShaderModule('compute', 'main'),
+        entryPoint: 'main',
+      },
+    };
+
+    t.doCreateComputePipelineTest(isAsync, !mismatched, descriptor);
+  });
 
 g.test('shader_module,device_mismatch')
   .desc(
     'Tests createComputePipeline(Async) cannot be called with a shader module created from another device'
   )
   .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
-  .unimplemented();
+  .fn(async t => {
+    const { isAsync, mismatched } = t.params;
+
+    if (mismatched) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+
+    const code = '[[stage(compute), workgroup_size(1)]] fn main() {}';
+    const module = mismatched
+      ? t.getDeviceMismatchedShaderModule({ code })
+      : t.device.createShaderModule({ code });
+
+    const descriptor = {
+      compute: {
+        module,
+        entryPoint: 'main',
+      },
+    };
+
+    t.doCreateComputePipelineTest(isAsync, !mismatched, descriptor);
+  });

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -117,4 +117,27 @@ g.test('bind_group_layouts,device_mismatch')
     { layout0Mismatched: true, layout1Mismatched: false },
     { layout0Mismatched: false, layout1Mismatched: true },
   ])
-  .unimplemented();
+  .fn(async t => {
+    const { layout0Mismatched, layout1Mismatched } = t.params;
+
+    const mismatched = layout0Mismatched || layout1Mismatched;
+
+    if (mismatched) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+
+    const bglDescriptor: GPUBindGroupLayoutDescriptor = {
+      entries: [],
+    };
+
+    const layout0 = layout0Mismatched
+      ? t.getDeviceMismatchedBindGroupLayout(bglDescriptor)
+      : t.device.createBindGroupLayout(bglDescriptor);
+    const layout1 = layout1Mismatched
+      ? t.getDeviceMismatchedBindGroupLayout(bglDescriptor)
+      : t.device.createBindGroupLayout(bglDescriptor);
+
+    t.expectValidationError(() => {
+      t.device.createPipelineLayout({ bindGroupLayouts: [layout0, layout1] });
+    }, mismatched);
+  });

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -131,10 +131,10 @@ g.test('bind_group_layouts,device_mismatch')
     };
 
     const layout0 = layout0Mismatched
-      ? t.getDeviceMismatchedBindGroupLayout(bglDescriptor)
+      ? t.mismatchedDevice.createBindGroupLayout(bglDescriptor)
       : t.device.createBindGroupLayout(bglDescriptor);
     const layout1 = layout1Mismatched
-      ? t.getDeviceMismatchedBindGroupLayout(bglDescriptor)
+      ? t.mismatchedDevice.createBindGroupLayout(bglDescriptor)
       : t.device.createBindGroupLayout(bglDescriptor);
 
     t.expectValidationError(() => {

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -156,13 +156,9 @@ class F extends ValidationTest {
         this.shouldReject('OperationError', this.device.createRenderPipelineAsync(descriptor));
       }
     } else {
-      if (_success) {
+      this.expectValidationError(() => {
         this.device.createRenderPipeline(descriptor);
-      } else {
-        this.expectValidationError(() => {
-          this.device.createRenderPipeline(descriptor);
-        });
-      }
+      }, !_success);
     }
   }
 }
@@ -377,11 +373,80 @@ g.test('pipeline_layout,device_mismatch')
     'Tests createRenderPipeline(Async) cannot be called with a pipeline layout created from another device'
   )
   .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
-  .unimplemented();
+  .fn(async t => {
+    const { isAsync, mismatched } = t.params;
+
+    if (mismatched) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+
+    const layoutDescriptor = { bindGroupLayouts: [] };
+    const layout = mismatched
+      ? t.getDeviceMismatchedPipelineLayout(layoutDescriptor)
+      : t.device.createPipelineLayout(layoutDescriptor);
+
+    const descriptor = {
+      layout,
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+        [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+          return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }
+      `,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({ code: t.getFragmentShaderCode('float', 4) }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }] as const,
+      },
+    };
+
+    t.doCreateRenderPipelineTest(isAsync, !mismatched, descriptor);
+  });
 
 g.test('shader_module,device_mismatch')
   .desc(
     'Tests createRenderPipeline(Async) cannot be called with a shader module created from another device'
   )
-  .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
-  .unimplemented();
+  .paramsSubcasesOnly(u =>
+    u.combine('isAsync', [true, false]).combineWithParams([
+      { vertex_mismatched: false, fragment_mismatched: false, _success: true },
+      { vertex_mismatched: true, fragment_mismatched: false, _success: false },
+      { vertex_mismatched: false, fragment_mismatched: true, _success: false },
+    ])
+  )
+  .fn(async t => {
+    const { isAsync, vertex_mismatched, fragment_mismatched, _success } = t.params;
+
+    if (vertex_mismatched || fragment_mismatched) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+
+    const code = `
+      [[stage(vertex)]] fn main() -> [[builtin(position)]] vec4<f32> {
+        return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+      }
+    `;
+
+    const descriptor = {
+      vertex: {
+        module: vertex_mismatched
+          ? t.getDeviceMismatchedShaderModule({ code })
+          : t.device.createShaderModule({ code }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: fragment_mismatched
+          ? t.getDeviceMismatchedShaderModule({ code: t.getFragmentShaderCode('float', 4) })
+          : t.device.createShaderModule({ code: t.getFragmentShaderCode('float', 4) }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }] as const,
+      },
+      layout: t.getPipelineLayout(),
+    };
+
+    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+  });

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -382,7 +382,7 @@ g.test('pipeline_layout,device_mismatch')
 
     const layoutDescriptor = { bindGroupLayouts: [] };
     const layout = mismatched
-      ? t.getDeviceMismatchedPipelineLayout(layoutDescriptor)
+      ? t.mismatchedDevice.createPipelineLayout(layoutDescriptor)
       : t.device.createPipelineLayout(layoutDescriptor);
 
     const descriptor = {
@@ -434,13 +434,13 @@ g.test('shader_module,device_mismatch')
     const descriptor = {
       vertex: {
         module: vertex_mismatched
-          ? t.getDeviceMismatchedShaderModule({ code })
+          ? t.mismatchedDevice.createShaderModule({ code })
           : t.device.createShaderModule({ code }),
         entryPoint: 'main',
       },
       fragment: {
         module: fragment_mismatched
-          ? t.getDeviceMismatchedShaderModule({ code: t.getFragmentShaderCode('float', 4) })
+          ? t.mismatchedDevice.createShaderModule({ code: t.getFragmentShaderCode('float', 4) })
           : t.device.createShaderModule({ code: t.getFragmentShaderCode('float', 4) }),
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm' }] as const,

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -48,7 +48,7 @@ g.test('color_attachments,device_mismatch')
       target1Mismatched: true,
     },
     {
-      view0Mismatched: false,
+      view0Mismatched: true,
       target0Mismatched: false,
       view1Mismatched: true,
       target1Mismatched: false,
@@ -60,18 +60,109 @@ g.test('color_attachments,device_mismatch')
       target1Mismatched: true,
     },
   ])
-  .unimplemented();
+  .fn(async t => {
+    const { view0Mismatched, target0Mismatched, view1Mismatched, target1Mismatched } = t.params;
+
+    const mismatched = view0Mismatched || target0Mismatched || view1Mismatched || target1Mismatched;
+
+    if (mismatched) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+
+    const view0Texture = view0Mismatched
+      ? t.getDeviceMismatchedRenderTexture(4)
+      : t.getRenderTexture(4);
+    const target0Texture = target0Mismatched
+      ? t.getDeviceMismatchedRenderTexture()
+      : t.getRenderTexture();
+    const view1Texture = view1Mismatched
+      ? t.getDeviceMismatchedRenderTexture(4)
+      : t.getRenderTexture(4);
+    const target1Texture = target1Mismatched
+      ? t.getDeviceMismatchedRenderTexture()
+      : t.getRenderTexture();
+
+    const encoder = t.createEncoder('non-pass');
+    const pass = encoder.encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: view0Texture.createView(),
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          storeOp: 'store',
+          resolveTarget: target0Texture.createView(),
+        },
+        {
+          view: view1Texture.createView(),
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          storeOp: 'store',
+          resolveTarget: target1Texture.createView(),
+        },
+      ],
+    });
+    pass.endPass();
+
+    encoder.validateFinish(!mismatched);
+  });
 
 g.test('depth_stencil_attachment,device_mismatch')
   .desc(
     'Tests beginRenderPass cannot be called with a depth stencil attachment whose texure view is created from another device'
   )
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .unimplemented();
+  .fn(async t => {
+    const { mismatched } = t.params;
+
+    if (mismatched) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+
+    const descriptor: GPUTextureDescriptor = {
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      format: 'depth24plus-stencil8',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    };
+
+    const depthStencilTexture = mismatched
+      ? t.getDeviceMismatchedTexture(descriptor)
+      : t.device.createTexture(descriptor);
+
+    const encoder = t.createEncoder('non-pass');
+    const pass = encoder.encoder.beginRenderPass({
+      colorAttachments: [],
+      depthStencilAttachment: {
+        view: depthStencilTexture.createView(),
+        depthLoadValue: 0,
+        depthStoreOp: 'store',
+        stencilLoadValue: 0,
+        stencilStoreOp: 'store',
+      },
+    });
+    pass.endPass();
+
+    encoder.validateFinish(!mismatched);
+  });
 
 g.test('occlusion_query_set,device_mismatch')
   .desc(
     'Tests beginRenderPass cannot be called with an occlusion query set created from another device'
   )
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .unimplemented();
+  .fn(async t => {
+    const { mismatched } = t.params;
+
+    if (mismatched) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+
+    const descriptor: GPUQuerySetDescriptor = {
+      type: 'occlusion',
+      count: 1,
+    };
+
+    const occlusionQuerySet = mismatched
+      ? t.getDeviceMismatchedQuerySet(descriptor)
+      : t.device.createQuerySet(descriptor);
+
+    const encoder = t.createEncoder('render pass', { occlusionQuerySet });
+    encoder.validateFinish(!mismatched);
+  });

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -160,7 +160,7 @@ g.test('occlusion_query_set,device_mismatch')
     };
 
     const occlusionQuerySet = mismatched
-      ? t.getDeviceMismatchedQuerySet(descriptor)
+      ? t.mismatchedDevice.createQuerySet(descriptor)
       : t.device.createQuerySet(descriptor);
 
     const encoder = t.createEncoder('render pass', { occlusionQuerySet });

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -25,4 +25,29 @@ g.test('render_bundles,device_mismatch')
     { bundle0Mismatched: true, bundle1Mismatched: false },
     { bundle0Mismatched: false, bundle1Mismatched: true },
   ])
-  .unimplemented();
+  .fn(async t => {
+    const { bundle0Mismatched, bundle1Mismatched } = t.params;
+    const mismatched = bundle0Mismatched || bundle1Mismatched;
+
+    if (mismatched) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+
+    const descriptor: GPURenderBundleEncoderDescriptor = {
+      colorFormats: ['rgba8unorm'],
+    };
+
+    const bundle0Encoder = mismatched
+      ? t.getDeviceMismatchedRenderBundle(descriptor)
+      : t.device.createRenderBundleEncoder(descriptor);
+    const bundle0 = bundle0Encoder.finish();
+    const bundle1Encoder = mismatched
+      ? t.getDeviceMismatchedRenderBundle(descriptor)
+      : t.device.createRenderBundleEncoder(descriptor);
+    const bundle1 = bundle1Encoder.finish();
+
+    const encoder = t.createEncoder('render pass');
+    encoder.encoder.executeBundles([bundle0, bundle1]);
+
+    encoder.validateFinish(!mismatched);
+  });

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -38,11 +38,11 @@ g.test('render_bundles,device_mismatch')
     };
 
     const bundle0Encoder = mismatched
-      ? t.getDeviceMismatchedRenderBundle(descriptor)
+      ? t.mismatchedDevice.createRenderBundleEncoder(descriptor)
       : t.device.createRenderBundleEncoder(descriptor);
     const bundle0 = bundle0Encoder.finish();
     const bundle1Encoder = mismatched
-      ? t.getDeviceMismatchedRenderBundle(descriptor)
+      ? t.mismatchedDevice.createRenderBundleEncoder(descriptor)
       : t.device.createRenderBundleEncoder(descriptor);
     const bundle1 = bundle1Encoder.finish();
 

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -293,33 +293,6 @@ export class ValidationTest extends GPUTest {
     }
   }
 
-  /** Return a GPUBindGroupLayout with descriptor from mismatched device. */
-  getDeviceMismatchedBindGroupLayout(descriptor: GPUBindGroupLayoutDescriptor): GPUBindGroupLayout {
-    return this.mismatchedDevice.createBindGroupLayout(descriptor);
-  }
-
-  /** Return a GPUPipelineLayout with descriptor from mismatched device. */
-  getDeviceMismatchedPipelineLayout(descriptor: GPUPipelineLayoutDescriptor): GPUPipelineLayout {
-    return this.mismatchedDevice.createPipelineLayout(descriptor);
-  }
-
-  /** Return a GPUShaderModule with descriptor from mismatched device. */
-  getDeviceMismatchedShaderModule(descriptor: GPUShaderModuleDescriptor): GPUShaderModule {
-    return this.mismatchedDevice.createShaderModule(descriptor);
-  }
-
-  /** Return a GPURenderBundleEncoder with descriptor from mismatched device. */
-  getDeviceMismatchedRenderBundle(
-    descriptor: GPURenderBundleEncoderDescriptor
-  ): GPURenderBundleEncoder {
-    return this.mismatchedDevice.createRenderBundleEncoder(descriptor);
-  }
-
-  /** Return a GPUQuerySet with descriptor from mismatched device. */
-  getDeviceMismatchedQuerySet(descriptor: GPUQuerySetDescriptor): GPUQuerySet {
-    return this.trackForCleanup(this.mismatchedDevice.createQuerySet(descriptor));
-  }
-
   /** Create an arbitrarily-sized GPUBuffer with the STORAGE usage from mismatched device. */
   getDeviceMismatchedStorageBuffer(): GPUBuffer {
     return this.trackForCleanup(

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -231,12 +231,13 @@ export class ValidationTest extends GPUTest {
   }
 
   /** Return an arbitrarily-configured GPUTexture with the `RENDER_ATTACHMENT` usage. */
-  getRenderTexture(): GPUTexture {
+  getRenderTexture(sampleCount: number = 1): GPUTexture {
     return this.trackForCleanup(
       this.device.createTexture({
         size: { width: 16, height: 16, depthOrArrayLayers: 1 },
         format: 'rgba8unorm',
         usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        sampleCount,
       })
     );
   }
@@ -292,6 +293,33 @@ export class ValidationTest extends GPUTest {
     }
   }
 
+  /** Return a GPUBindGroupLayout with descriptor from mismatched device. */
+  getDeviceMismatchedBindGroupLayout(descriptor: GPUBindGroupLayoutDescriptor): GPUBindGroupLayout {
+    return this.mismatchedDevice.createBindGroupLayout(descriptor);
+  }
+
+  /** Return a GPUPipelineLayout with descriptor from mismatched device. */
+  getDeviceMismatchedPipelineLayout(descriptor: GPUPipelineLayoutDescriptor): GPUPipelineLayout {
+    return this.mismatchedDevice.createPipelineLayout(descriptor);
+  }
+
+  /** Return a GPUShaderModule with descriptor from mismatched device. */
+  getDeviceMismatchedShaderModule(descriptor: GPUShaderModuleDescriptor): GPUShaderModule {
+    return this.mismatchedDevice.createShaderModule(descriptor);
+  }
+
+  /** Return a GPURenderBundleEncoder with descriptor from mismatched device. */
+  getDeviceMismatchedRenderBundle(
+    descriptor: GPURenderBundleEncoderDescriptor
+  ): GPURenderBundleEncoder {
+    return this.mismatchedDevice.createRenderBundleEncoder(descriptor);
+  }
+
+  /** Return a GPUQuerySet with descriptor from mismatched device. */
+  getDeviceMismatchedQuerySet(descriptor: GPUQuerySetDescriptor): GPUQuerySet {
+    return this.trackForCleanup(this.mismatchedDevice.createQuerySet(descriptor));
+  }
+
   /** Create an arbitrarily-sized GPUBuffer with the STORAGE usage from mismatched device. */
   getDeviceMismatchedStorageBuffer(): GPUBuffer {
     return this.trackForCleanup(
@@ -306,29 +334,38 @@ export class ValidationTest extends GPUTest {
     );
   }
 
-  /**
-   * Return an arbitrarily-configured GPUTexture with the `SAMPLED` usage from mismatched device.
-   */
+  /** Return a GPUTexture with descriptor from mismatched device. */
+  getDeviceMismatchedTexture(descriptor: GPUTextureDescriptor): GPUTexture {
+    return this.trackForCleanup(this.mismatchedDevice.createTexture(descriptor));
+  }
+
+  /** Return an arbitrarily-configured GPUTexture with the `SAMPLED` usage from mismatched device. */
   getDeviceMismatchedSampledTexture(sampleCount: number = 1): GPUTexture {
-    return this.trackForCleanup(
-      this.mismatchedDevice.createTexture({
-        size: { width: 4, height: 4, depthOrArrayLayers: 1 },
-        format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING,
-        sampleCount,
-      })
-    );
+    return this.getDeviceMismatchedTexture({
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING,
+      sampleCount,
+    });
   }
 
   /** Return an arbitrarily-configured GPUTexture with the `STORAGE` usage from mismatched device. */
   getDeviceMismatchedStorageTexture(): GPUTexture {
-    return this.trackForCleanup(
-      this.mismatchedDevice.createTexture({
-        size: { width: 4, height: 4, depthOrArrayLayers: 1 },
-        format: 'rgba8unorm',
-        usage: GPUTextureUsage.STORAGE_BINDING,
-      })
-    );
+    return this.getDeviceMismatchedTexture({
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.STORAGE_BINDING,
+    });
+  }
+
+  /** Return an arbitrarily-configured GPUTexture with the `RENDER_ATTACHMENT` usage from mismatched device. */
+  getDeviceMismatchedRenderTexture(sampleCount: number = 1): GPUTexture {
+    return this.getDeviceMismatchedTexture({
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      sampleCount,
+    });
   }
 
   getDeviceMismatchedBindingResource(bindingType: ValidBindableResource): GPUBindingResource {


### PR DESCRIPTION
Complete *.spec.ts in src/webgpu/api/validation and src/webgpu/api/validation/encoding





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
