### PR TITLE
Update destinationOffset alignment to 256 in resolveQuerySet tests

### DIFF
--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -99,7 +99,7 @@ Tests that resolve query set with invalid destinationOffset:
 - destinationOffset out of range
   `
   )
-  .paramsSubcasesOnly(u => u.combine('destinationOffset', [0, 8, 256, 512, 768]))
+  .paramsSubcasesOnly(u => u.combine('destinationOffset', [0, 128, 256, 384, 512, 768]))
   .fn(async t => {
     const { destinationOffset } = t.params;
     const querySet = t.device.createQuerySet({ type: 'occlusion', count: kQueryCount });


### PR DESCRIPTION
We have updated the destinationOffset alignment of resolveQuerySet
to 256 in SPEC. These tests need to be updated to align with the
change.

Also update the existing cases to use helper functions.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
