### PR TITLE
Fix a bug about max color attachment

### DIFF
--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -102,8 +102,8 @@ g.test('a_render_pass_with_only_one_depth_attachment_is_ok').fn(t => {
 
 g.test('OOB_color_attachment_indices_are_handled')
   .paramsSimple([
-    { colorAttachmentsCount: 4, _success: true }, // Control case
-    { colorAttachmentsCount: 5, _success: false }, // Out of bounds
+    { colorAttachmentsCount: 8, _success: true }, // Control case
+    { colorAttachmentsCount: 9, _success: false }, // Out of bounds
   ])
   .fn(async t => {
     const { colorAttachmentsCount, _success } = t.params;


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
