### PR TITLE
ShaderValidationTest: remove substring overload

### DIFF
--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -11,10 +11,9 @@ export class ShaderValidationTest extends GPUTest {
    * ```ts
    * t.expectCompileResult(true, `wgsl code`); // Expect success
    * t.expectCompileResult(false, `wgsl code`); // Expect validation error with any error string
-   * t.expectCompileResult('substr', `wgsl code`); // Expect validation error containing 'substr'
    * ```
    */
-  expectCompileResult(result: boolean | string, code: string) {
+  expectCompileResult(result: boolean, code: string) {
     // If an error is expected, push an error scope to catch it.
     // Otherwise, the test harness will catch unexpected errors.
     if (result !== true) {
@@ -35,37 +34,10 @@ export class ShaderValidationTest extends GPUTest {
             niceStack.message = 'Compilation succeeded unexpectedly.';
             this.rec.validationFailed(niceStack);
           } else if (gpuValidationError instanceof GPUValidationError) {
-            if (typeof result === 'string' && gpuValidationError.message.indexOf(result) === -1) {
-              niceStack.message = `Compilation failed, but message missing expected substring \
-«${result}» - ${gpuValidationError.message}`;
-              this.rec.validationFailed(niceStack);
-            } else {
-              niceStack.message = `Compilation failed, as expected - ${gpuValidationError.message}`;
-              this.rec.debug(niceStack);
-            }
+            niceStack.message = `Compilation failed, as expected - ${gpuValidationError.message}`;
+            this.rec.debug(niceStack);
           }
           return;
-        }
-
-        if (typeof result === 'string') {
-          const info = await shaderModule.compilationInfo();
-          for (const message of info.messages) {
-            if (message.type === 'error' && message.message.indexOf(result) !== -1) {
-              niceStack.message = `Compilation failed, as expected - \
-${message.lineNum}:${message.linePos}: ${message.message}`;
-              this.rec.debug(niceStack);
-              return;
-            }
-          }
-          // Here, the expected string was not found.
-
-          // TODO: Pretty-print error messages, with source context.
-          const messagesLog = info.messages
-            .map(m => `${m.lineNum}:${m.linePos}: ${m.type}: ${m.message}`)
-            .join('\n');
-          niceStack.message = `Compilation failed, but no error message with expected substring \
-«${result}»\n${messagesLog}`;
-          this.rec.validationFailed(niceStack);
         }
       });
     }


### PR DESCRIPTION
The WGSL spec won't have standard validation IDs. So remove the support in the
ShaderValidationTest fixture for being able to specify a required substring
in the validation error.





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
