### PR TITLE
ShaderValidationTest: remove string overload

### DIFF
--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -12,10 +12,8 @@ export class ShaderValidationTest extends GPUTest {
    * ```ts
    * t.expectCompileResult(true, `wgsl code`); // Expect success
    * t.expectCompileResult(false, `wgsl code`); // Expect validation error with any error string
-   * t.expectCompileResult('substr', `wgsl code`); // Expect validation error containing 'substr'
    * ```
    *
-   * TODO(gpuweb/gpuweb#1813): Remove the "string" overload if there are no standard error codes.
    */
   expectCompileResult(expectedResult: boolean | string, code: string) {
     let shaderModule: GPUShaderModule;
@@ -36,23 +34,6 @@ export class ShaderValidationTest extends GPUTest {
         .map(m => `${m.lineNum}:${m.linePos}: ${m.type}: ${m.message}`)
         .join('\n');
       error.extra.compilationInfo = compilationInfo;
-
-      if (typeof expectedResult === 'string') {
-        for (const msg of compilationInfo.messages) {
-          if (msg.type === 'error' && msg.message.indexOf(expectedResult) !== -1) {
-            error.message =
-              `Found expected compilationInfo message substring «${expectedResult}».\n` +
-              messagesLog;
-            this.rec.debug(error);
-            return;
-          }
-        }
-
-        // Here, no error message was found, but one was expected.
-        error.message = `Missing expected substring «${expectedResult}».\n` + messagesLog;
-        this.rec.validationFailed(error);
-        return;
-      }
 
       if (compilationInfo.messages.some(m => m.type === 'error')) {
         if (expectedResult) {

--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -13,7 +13,7 @@ export class ShaderValidationTest extends GPUTest {
    * t.expectCompileResult(true, `wgsl code`); // Expect success
    * t.expectCompileResult(false, `wgsl code`); // Expect validation error with any error string
    * ```
-   *
+   * foobar
    */
   expectCompileResult(expectedResult: boolean | string, code: string) {
     let shaderModule: GPUShaderModule;

--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -15,7 +15,7 @@ export class ShaderValidationTest extends GPUTest {
    * ```
    * foobar
    */
-  expectCompileResult(expectedResult: boolean | string, code: string) {
+  expectCompileResult(expectedResult: boolean, code: string) {
     let shaderModule: GPUShaderModule;
     this.expectGPUError(
       'validation',


### PR DESCRIPTION
There are no standard error codes in the WGSL spec.
So remove support for checking them.
See https://github.com/gpuweb/gpuweb/issues/1813





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
