### PR TITLE
Use vertex-only pipeline when initializing depth aspect

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -328,7 +328,10 @@ class F extends GPUTest {
         }),
         entryPoint: 'main',
       },
-      fragment: {
+      depthStencil,
+    };
+    if (hasColorAttachment) {
+      renderPipelineDescriptor.fragment = {
         module: this.device.createShaderModule({
           code: `
             [[stage(fragment)]]
@@ -337,13 +340,8 @@ class F extends GPUTest {
             }`,
         }),
         entryPoint: 'main',
-        targets: [],
-      },
-      depthStencil,
-    };
-    if (hasColorAttachment) {
-      assert(renderPipelineDescriptor.fragment !== undefined);
-      renderPipelineDescriptor.fragment.targets = [{ format: 'rgba8unorm' }];
+        targets: [{ format: 'rgba8unorm' }],
+      };
     }
     return this.device.createRenderPipeline(renderPipelineDescriptor);
   }
@@ -405,7 +403,6 @@ class F extends GPUTest {
   ): void {
     // Prepare a renderPipeline with depthCompareFunction == 'always' and depthWriteEnabled == true
     // for the initializations of the depth attachment.
-    // TODO: remove the fragment stage when the browsers support null fragment stage.
     const bindGroupLayout = this.GetBindGroupLayoutForT2TCopyWithDepthTests();
     const renderPipeline = this.GetRenderPipelineForT2TCopyWithDepthTests(bindGroupLayout, false, {
       format: depthFormat,


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
