### PR TITLE
Add operation tests on  the T2T copies with multisampled depth textures

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1108,7 +1108,7 @@ g.test('copy_multisampled_color')
     t.queue.submit([copyEncoder.finish()]);
 
     // Verify if all the sub-pixel values at the same location of sourceTexture and
-    // destinationTextureare equal.
+    // destinationTexture are equal.
     const renderPipelineForValidation = t.device.createRenderPipeline({
       vertex: {
         module: t.device.createShaderModule({
@@ -1187,6 +1187,162 @@ g.test('copy_multisampled_color')
     t.queue.submit([validationEncoder.finish()]);
 
     t.expectSingleColor(expectedOutputTexture, 'rgba8unorm', {
+      size: [textureSize[0], textureSize[1], textureSize[2]],
+      exp: { R: 0.0, G: 1.0, B: 0.0, A: 1.0 },
+    });
+  });
+
+g.test('copy_multisampled_depth')
+  .desc(
+    `
+  Validate the correctness of copyTextureToTexture() with multisampled depth formats.
+
+  - Initialize the source texture with a triangle in a render pass.
+  - Copy from the source texture into the destination texture with CopyTextureToTexture().
+  - Validate the content in the destination texture with the depth comparation function 'equal'.
+  - Note that in current WebGPU SPEC the mipmap level count and array layer count of a multisampled
+    texture can only be 1.
+  `
+  )
+  .fn(async t => {
+    const textureSize = [32, 16, 1] as const;
+    const kDepthFormat = 'depth24plus';
+    const kSampleCount = 4;
+
+    const sourceTexture = t.device.createTexture({
+      format: kDepthFormat,
+      size: textureSize,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+      sampleCount: kSampleCount,
+    });
+    const destinationTexture = t.device.createTexture({
+      format: kDepthFormat,
+      size: textureSize,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+      sampleCount: kSampleCount,
+    });
+
+    const vertexState: GPUVertexState = {
+      module: t.device.createShaderModule({
+        code: `
+          [[stage(vertex)]]
+          fn main([[builtin(vertex_index)]] VertexIndex : u32)-> [[builtin(position)]] vec4<f32> {
+            var pos : array<vec3<f32>, 6> = array<vec3<f32>, 6>(
+                vec3<f32>(-1.0,  1.0, 0.5),
+                vec3<f32>(-1.0, -1.0, 0.0),
+                vec3<f32>( 1.0,  1.0, 1.0),
+                vec3<f32>(-1.0, -1.0, 0.0),
+                vec3<f32>( 1.0,  1.0, 1.0),
+                vec3<f32>( 1.0, -1.0, 0.5));
+            return vec4<f32>(pos[VertexIndex], 1.0);
+          }`,
+      }),
+      entryPoint: 'main',
+    };
+
+    // Initialize the depth aspect of source texture with a draw call
+    const renderPipelineForInit = t.device.createRenderPipeline({
+      vertex: vertexState,
+      depthStencil: {
+        format: kDepthFormat,
+        depthCompare: 'always',
+        depthWriteEnabled: true,
+      },
+      multisample: {
+        count: kSampleCount,
+      },
+    });
+
+    const encoderForInit = t.device.createCommandEncoder();
+    const renderPassForInit = encoderForInit.beginRenderPass({
+      colorAttachments: [],
+      depthStencilAttachment: {
+        view: sourceTexture.createView(),
+        depthLoadValue: 0.0,
+        depthStoreOp: 'store',
+        stencilLoadValue: 0,
+        stencilStoreOp: 'store',
+      },
+    });
+    renderPassForInit.setPipeline(renderPipelineForInit);
+    renderPassForInit.draw(6);
+    renderPassForInit.endPass();
+    t.queue.submit([encoderForInit.finish()]);
+
+    // Do the texture-to-texture copy
+    const copyEncoder = t.device.createCommandEncoder();
+    copyEncoder.copyTextureToTexture(
+      {
+        texture: sourceTexture,
+      },
+      {
+        texture: destinationTexture,
+      },
+      textureSize
+    );
+    t.queue.submit([copyEncoder.finish()]);
+
+    // Verify the depth values in destinationTexture with depthCompareFunction == 'equal' and
+    // depthWriteEnabled == false in the render pipeline.
+    const kColorFormat = 'rgba8unorm';
+    const renderPipelineForVerify = t.device.createRenderPipeline({
+      vertex: vertexState,
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `
+          [[stage(fragment)]]
+          fn main() -> [[location(0)]] vec4<f32> {
+            return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+          }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: kColorFormat }],
+      },
+      depthStencil: {
+        format: kDepthFormat,
+        depthCompare: 'equal',
+        depthWriteEnabled: false,
+      },
+      multisample: {
+        count: kSampleCount,
+      },
+    });
+    const multisampledColorTexture = t.device.createTexture({
+      format: kColorFormat,
+      size: textureSize,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+      sampleCount: kSampleCount,
+    });
+    const colorTextureAsResolveTarget = t.device.createTexture({
+      format: kColorFormat,
+      size: textureSize,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const encoderForVerify = t.device.createCommandEncoder();
+    const renderPassForVerify = encoderForVerify.beginRenderPass({
+      colorAttachments: [
+        {
+          view: multisampledColorTexture.createView(),
+          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          storeOp: 'discard',
+          resolveTarget: colorTextureAsResolveTarget.createView(),
+        },
+      ],
+      depthStencilAttachment: {
+        view: destinationTexture.createView(),
+        depthLoadValue: 'load',
+        depthStoreOp: 'store',
+        stencilLoadValue: 0,
+        stencilStoreOp: 'store',
+      },
+    });
+    renderPassForVerify.setPipeline(renderPipelineForVerify);
+    renderPassForVerify.draw(6);
+    renderPassForVerify.endPass();
+    t.queue.submit([encoderForVerify.finish()]);
+
+    t.expectSingleColor(colorTextureAsResolveTarget, kColorFormat, {
       size: [textureSize[0], textureSize[1], textureSize[2]],
       exp: { R: 0.0, G: 1.0, B: 0.0, A: 1.0 },
     });

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1282,8 +1282,8 @@ g.test('copy_multisampled_depth')
     );
     t.queue.submit([copyEncoder.finish()]);
 
-    // Verify the depth values in destinationTexture with depthCompareFunction == 'equal' and
-    // depthWriteEnabled == false in the render pipeline.
+    // Verify the depth values in destinationTexture are what we expected with
+    // depthCompareFunction == 'equal' and depthWriteEnabled == false in the render pipeline
     const kColorFormat = 'rgba8unorm';
     const renderPipelineForVerify = t.device.createRenderPipeline({
       vertex: vertexState,


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
