### PR TITLE
Adding test for vertex-only render pipeline: Part 1

### DIFF
--- a/src/webgpu/api/operation/render_pipeline/vertex_only_render_pipeline.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/vertex_only_render_pipeline.spec.ts
@@ -1,0 +1,29 @@
+export const description = `
+Test vertex-only render pipeline.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+class F extends GPUTest {}
+
+export const g = makeTestGroup(F);
+
+g.test('draw_depth_and_stencil_with_vertex_only_pipeline')
+  .desc(
+    `
+TODO:
+- Test drawing depth and stencil with vertex-only render pipelines by
+  1. Create a color attachment and depth-stencil attachment of 4 pixels in a line, clear the color
+     to RGBA(0.0, 0.0, 0.0, 0.0), depth to 0.0 and stencil to 0x0
+  2. Use a depth and stencil test disabled vertex-only render pipeline to modify the depth of middle
+     2 pixels to 0.5, while leaving stencil unchanged
+  3. Use another depth and stencil test disabled vertex-only render pipeline to modify the stencil
+     of right 2 pixels to 0x1, while leaving depth unchanged
+  4. Use a complete render pipeline to draw all 4 pixels with color RGBA(0.0, 1.0, 0.0, 1.0), but
+     with depth test requiring depth no less than 0.5 and stencil test requiring stencil equals to 0x1
+  5. Validate that only the third pixel is of color RGBA(0.0, 1.0, 0.0, 1.0), and all other pixels
+     are RGBA(0.0, 0.0, 0.0, 0.0).
+`
+  )
+  .unimplemented();

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -91,6 +91,7 @@ class F extends ValidationTest {
       sampleCount?: number;
       depthStencil?: GPUDepthStencilState;
       fragmentShaderCode?: string;
+      noFragment?: boolean;
     } = {}
   ): GPURenderPipelineDescriptor {
     const defaultTargets: GPUColorTargetState[] = [{ format: 'rgba8unorm' }];
@@ -103,6 +104,7 @@ class F extends ValidationTest {
         kTextureFormatInfo[targets[0] ? targets[0].format : 'rgba8unorm'].sampleType,
         4
       ),
+      noFragment = false,
     } = options;
 
     return {
@@ -115,13 +117,15 @@ class F extends ValidationTest {
         }),
         entryPoint: 'main',
       },
-      fragment: {
-        module: this.device.createShaderModule({
-          code: fragmentShaderCode,
-        }),
-        entryPoint: 'main',
-        targets,
-      },
+      fragment: noFragment
+        ? undefined
+        : {
+            module: this.device.createShaderModule({
+              code: fragmentShaderCode,
+            }),
+            entryPoint: 'main',
+            targets,
+          },
       layout: this.getPipelineLayout(),
       primitive: { topology },
       multisample: { count: sampleCount },
@@ -178,7 +182,45 @@ g.test('basic_use_of_createRenderPipeline')
     t.doCreateRenderPipelineTest(isAsync, true, descriptor);
   });
 
-g.test('at_least_one_color_state_is_required')
+g.test('create_vertex_only_pipeline_with_without_depth_stencil_state')
+  .desc(
+    `Test creating vertex-only render pipeline. A vertex-only render pipeline have no fragment
+state (and thus have no color state), and can be create with or without depth stencil state.`
+  )
+  .params(u =>
+    u
+      .combine('isAsync', [false, true])
+      .beginSubcases()
+      .combine('depthStencilFormat', [
+        'depth24plus',
+        'depth24plus-stencil8',
+        'depth32float',
+        '',
+      ] as const)
+      .combine('haveColor', [false, true])
+  )
+  .fn(async t => {
+    const { isAsync, depthStencilFormat, haveColor } = t.params;
+
+    let depthStencilState: GPUDepthStencilState | undefined;
+    if (depthStencilFormat === '') {
+      depthStencilState = undefined;
+    } else {
+      depthStencilState = { format: depthStencilFormat };
+    }
+
+    // Having targets or not should have no effect in result, since it will not appear in the
+    // descriptor in vertex-only render pipeline
+    const descriptor = t.getDescriptor({
+      noFragment: true,
+      depthStencil: depthStencilState,
+      targets: haveColor ? [{ format: 'rgba8unorm' }] : [],
+    });
+
+    t.doCreateRenderPipelineTest(isAsync, true, descriptor);
+  });
+
+g.test('at_least_one_color_state_is_required_for_complete_pipeline')
   .params(u => u.combine('isAsync', [false, true]))
   .fn(async t => {
     const { isAsync } = t.params;


### PR DESCRIPTION
In this patch a basic test for creating vertex-only render pipeline and a test plan for operation test for vertex-only render pipeline is added.

Bug: dawn:1142




<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
