### PR TITLE
cmdline: Add new flag to allow overriding of the GPU provider

### DIFF
--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -1,12 +1,12 @@
 /* eslint no-console: "off" */
 
-import { setGPUProvider } from '../../webgpu/util/navigator_gpu.js';
 import { DefaultTestFileLoader } from '../internal/file_loader.js';
 import { prettyPrintLog } from '../internal/logging/log_message.js';
 import { Logger } from '../internal/logging/logger.js';
 import { LiveTestCaseResult } from '../internal/logging/result.js';
 import { parseQuery } from '../internal/query/parseQuery.js';
 import { parseExpectationsForTestQuery } from '../internal/query/query.js';
+import { setGPUProvider } from '../util/navigator_gpu.js';
 import { assert, unreachable } from '../util/util.js';
 
 import sys from './helper/sys.js';

--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -1,5 +1,6 @@
 /* eslint no-console: "off" */
 
+import { setGPUProvider } from '../../webgpu/util/navigator_gpu.js';
 import { DefaultTestFileLoader } from '../internal/file_loader.js';
 import { prettyPrintLog } from '../internal/logging/log_message.js';
 import { Logger } from '../internal/logging/logger.js';
@@ -20,6 +21,7 @@ function usage(rc: number): never {
   console.log('  --debug         Include debug messages in logging.');
   console.log('  --print-json    Print the complete result JSON in the output.');
   console.log('  --expectations  Path to expectations file.');
+  console.log('  --gpu-provider  Path to node module that provides the GPU implementation.');
   return sys.exit(rc);
 }
 
@@ -49,6 +51,9 @@ for (let i = 0; i < sys.args.length; ++i) {
     } else if (a === '--expectations') {
       const expectationsFile = new URL(sys.args[++i], `file://${sys.cwd()}`).pathname;
       loadWebGPUExpectations = import(expectationsFile).then(m => m.expectations);
+    } else if (a === '--gpu-provider') {
+      const modulePath = sys.args[++i];
+      setGPUProvider(() => require(modulePath).gpu);
     } else {
       console.log('unrecognized flag: ', a);
       usage(1);

--- a/src/common/util/navigator_gpu.ts
+++ b/src/common/util/navigator_gpu.ts
@@ -1,6 +1,6 @@
 /// <reference types="@webgpu/types" />
 
-import { assert } from '../../common/util/util.js';
+import { assert } from './util.js';
 
 /**
  * Finds and returns the `navigator.gpu` object (or equivalent, for non-browser implementations).
@@ -26,6 +26,7 @@ let gpuProvider: GPUProvider = defaultGPUProvider;
  * Sets the function to create and return a new GPU instance.
  */
 export function setGPUProvider(provider: GPUProvider) {
+  assert(impl === undefined, 'setGPUProvider() should not be after getGPU()');
   gpuProvider = provider;
 }
 

--- a/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
@@ -5,9 +5,9 @@ Tests passing various requiredLimits to GPUAdapter.requestDevice.
 import { Fixture } from '../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
+import { getGPU } from '../../../../common/util/navigator_gpu.js';
 import { assert } from '../../../../common/util/util.js';
 import { DefaultLimits } from '../../../constants.js';
-import { getGPU } from '../../../util/navigator_gpu.js';
 
 const kLimitTypes = keysOf(DefaultLimits);
 

--- a/src/webgpu/api/validation/error_scope.spec.ts
+++ b/src/webgpu/api/validation/error_scope.spec.ts
@@ -17,8 +17,8 @@ TODO: consider slightly revising these tests to make sure they're complete. {
 
 import { Fixture } from '../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { getGPU } from '../../../common/util/navigator_gpu.js';
 import { assert, raceWithRejectOnTimeout } from '../../../common/util/util.js';
-import { getGPU } from '../../util/navigator_gpu.js';
 
 class F extends Fixture {
   _device: GPUDevice | undefined = undefined;

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -1,4 +1,5 @@
 import { SkipTestCase } from '../../common/framework/fixture.js';
+import { getGPU } from '../../common/util/navigator_gpu.js';
 import {
   assert,
   raceWithRejectOnTimeout,
@@ -6,8 +7,6 @@ import {
   assertReject,
 } from '../../common/util/util.js';
 import { DefaultLimits } from '../constants.js';
-
-import { getGPU } from './navigator_gpu.js';
 
 export interface DeviceProvider {
   acquire(): GPUDevice;

--- a/src/webgpu/util/navigator_gpu.ts
+++ b/src/webgpu/util/navigator_gpu.ts
@@ -2,6 +2,33 @@
 
 import { assert } from '../../common/util/util.js';
 
+/**
+ * Finds and returns the `navigator.gpu` object (or equivalent, for non-browser implementations).
+ * Throws an exception if not found.
+ */
+function defaultGPUProvider(): GPU {
+  assert(
+    typeof navigator !== 'undefined' && navigator.gpu !== undefined,
+    'No WebGPU implementation found'
+  );
+  return navigator.gpu;
+}
+
+/**
+ * GPUProvider is a function that creates and returns a new GPU instance.
+ * May throw an exception if a GPU cannot be created.
+ */
+export type GPUProvider = () => GPU;
+
+let gpuProvider: GPUProvider = defaultGPUProvider;
+
+/**
+ * Sets the function to create and return a new GPU instance.
+ */
+export function setGPUProvider(provider: GPUProvider) {
+  gpuProvider = provider;
+}
+
 let impl: GPU | undefined = undefined;
 
 /**
@@ -13,11 +40,7 @@ export function getGPU(): GPU {
     return impl;
   }
 
-  assert(
-    typeof navigator !== 'undefined' && navigator.gpu !== undefined,
-    'No WebGPU implementation found'
-  );
+  impl = gpuProvider();
 
-  impl = navigator.gpu;
   return impl;
 }


### PR DESCRIPTION
Allows non-web implementations to provide a custom Node module that implements the GPU interface.

For additional context, see:
https://dawn-review.googlesource.com/c/dawn/+/64940/19/src/dawn_node/Module.cpp#38