### PR TITLE
webgpu/shader/execution: Fix bad WGSL generation

### DIFF
--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -146,7 +146,16 @@ g.test('linear_memory')
       .expandWithParams(generateTypes)
   )
   .fn(async t => {
-    const { storageClass, storageMode, access, isAtomic, baseType, type, _kTypeInfo } = t.params;
+    const {
+      storageClass,
+      storageMode,
+      access,
+      isAtomic,
+      containerType,
+      baseType,
+      type,
+      _kTypeInfo,
+    } = t.params;
 
     assert(_kTypeInfo !== undefined, 'not an indexable type');
     assert('arrayLength' in _kTypeInfo);
@@ -264,7 +273,7 @@ g.test('linear_memory')
               {
                 const exprLoadElement = isAtomic ? `atomicLoad(&${exprElement})` : exprElement;
                 let condition = `${exprLoadElement} != ${exprZeroElement}`;
-                if ('innerLength' in _kTypeInfo) condition = `any(${condition})`;
+                if (containerType === 'matrix') condition = `any(${condition})`;
                 testFunctionSource += `
                   if (${condition}) { return ${nextErrorReturnValue()}; }`;
               }


### PR DESCRIPTION
Subcases of `webgpu:shader,execution,robust_access:linear_memory,*` tests were attempting to call `any()` on boolean scalars. No such overload exists.

Currently for these tests, only matrices, when indexed, produce a vector. So instead of checking fro `innerLength`, check the outer container type is a matrix.

Fixes 6 test cases.
