### PR TITLE
webgpu/idl: Initialize the GPU

### DIFF
--- a/src/webgpu/idl/idl_test.ts
+++ b/src/webgpu/idl/idl_test.ts
@@ -1,4 +1,5 @@
 import { Fixture } from '../../common/framework/fixture.js';
+import { getGPU } from '../../common/util/navigator_gpu.js';
 import { assert } from '../../common/util/util.js';
 
 interface UnknownObject {
@@ -10,6 +11,11 @@ interface UnknownObject {
  */
 export class IDLTest extends Fixture {
   // TODO: add a helper to check prototype chains
+
+  async init(): Promise<void> {
+    // Ensure the GPU provider is initialized
+    getGPU();
+  }
 
   /**
    * Asserts that a member of an IDL interface has the expected value.


### PR DESCRIPTION
Call `getGPU()` to ensure the GPU provider has a chance to initialize.
Without this, when running with non-web implementations, GPU globals may not be registered, causing tests to fail.
