### PR TITLE
Remove 'read-only' from storageTextureBindingEntries()

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -704,10 +704,7 @@ export function textureBindingEntries(includeUndefined: boolean): readonly BGLEn
  * Note: Generates different `access` options, but not `format` or `viewDimension` options.
  */
 export function storageTextureBindingEntries(format: GPUTextureFormat): readonly BGLEntry[] {
-  return [
-    { storageTexture: { access: 'read-only', format } },
-    { storageTexture: { access: 'write-only', format } },
-  ] as const;
+  return [{ storageTexture: { access: 'write-only', format } }] as const;
 }
 /** Generate a list of possible texture-or-storageTexture-typed BGLEntry values. */
 export function sampledAndStorageBindingEntries(


### PR DESCRIPTION
https://www.w3.org/TR/webgpu/#enumdef-gpustoragetextureaccess
Now only contains "write-only"

Fixes a number of tests in `webgpu:api,validation,createBindGroupLayout,*`
