### PR TITLE
Change uniqueId() parameter to string. Update the test plans.

### DIFF
--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -123,15 +123,15 @@ interface TestBuilderWithName<F extends Fixture> extends TestBuilderWithParams<F
   /**
    * A noop function with the purpose of highlighting value `id`.
    *
-   * @param id a value uniquely assigned to this test.
+   * @param id a token uniquely assigned to this test.
    */
-  uniqueId(id: number): this;
+  uniqueId(id: string): this;
   /**
    * Parameterize the test, generating multiple cases, each possibly having subcases.
    *
    * The `unit` value passed to the `cases` callback is an immutable constant
    * `CaseParamsBuilder<{}>` representing the "unit" builder `[ {} ]`,
-   * provided for convienience. The non-callback overload can be used if `unit` is not needed.
+   * provided for convenience. The non-callback overload can be used if `unit` is not needed.
    */
   params<CaseP extends {}, SubcaseP extends {}>(
     cases: (unit: CaseParamsBuilder<{}>) => ParamsBuilderBase<CaseP, SubcaseP>
@@ -192,7 +192,7 @@ class TestBuilder {
     return this;
   }
 
-  uniqueId(id: number): this {
+  uniqueId(id: string): this {
     return this;
   }
 

--- a/src/webgpu/shader/execution/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/builtin/abs.spec.ts
@@ -12,13 +12,14 @@ import { kBit, kValue, runShaderTest } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('abs_uint')
-  .uniqueId(0x59ff84968a839124)
+g.test('abs_unsigned,integer_builtin_functions')
+  .uniqueId('59ff84968a839124')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210831#integer-builtin-function
+https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions
 scalar case, unsigned abs:
-T is u32 or vecN<u32> abs(e: T ) -> T Result is e.
+abs(e: T ) -> T
+T is u32 or vecN<u32>. Result is e.
 This is provided for symmetry with abs for signed integers.
 Component-wise when T is a vector.
 `
@@ -84,15 +85,17 @@ Component-wise when T is a vector.
     );
   });
 
-g.test('abs_int')
-  .uniqueId(0x59ff84968a839124)
+g.test('abs_signed,integer_builtin_functions')
+  .uniqueId('d8fc581d17db6ae8')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210831#integer-builtin-function
-scalar case, unsigned abs:
-T is u32 or vecN<u32> abs(e: T ) -> T Result is e.
-This is provided for symmetry with abs for signed integers.
+https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions
+signed abs:
+abs(e: T ) -> T
+T is i32 or vecN<i32>. The result is the absolute value of e.
 Component-wise when T is a vector.
+If e evaluates to the largest negative value, then the result is e.
+(GLSLstd450SAbs)
 `
   )
   .params(u =>
@@ -159,15 +162,16 @@ Component-wise when T is a vector.
     );
   });
 
-g.test('abs_float')
-  .uniqueId(0x59ff84968a839124)
+g.test('abs_float,float_builtin_functions')
+  .uniqueId('2c1782b6a8dec8cb')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210831#integer-builtin-function
-scalar case, unsigned abs:
-T is u32 or vecN<u32> abs(e: T ) -> T Result is e.
-This is provided for symmetry with abs for signed integers.
-Component-wise when T is a vector.
+https://www.w3.org/TR/2021/WD-WGSL-20210929/#float-builtin-functions
+float abs:
+abs(e: T ) -> T
+T is f32 or vecN<f32>
+Returns the absolute value of e (e.g. e with a positive sign bit).
+Component-wise when T is a vector. (GLSLstd450Fabs)
 `
   )
   .params(u =>
@@ -192,9 +196,7 @@ Component-wise when T is a vector.
       Float32Array,
       /* prettier-ignore */ [
         // Min and Max f32
-        // TODO(sarahM0): This is not in spec. Double check this.
-        // If e evaluates to the largest negative value, then the result is e.
-        {input: NumberRepr.fromF32Bits(kBit.f32.negative.max), expected: [NumberRepr.fromF32Bits(0x800000)] },
+        {input: NumberRepr.fromF32Bits(kBit.f32.negative.max), expected: [NumberRepr.fromF32Bits(0x0080_0000)] },
         {input: NumberRepr.fromF32Bits(kBit.f32.negative.min), expected: [NumberRepr.fromF32Bits(0x7f7f_ffff)] },
         {input: NumberRepr.fromF32Bits(kBit.f32.positive.min), expected: [NumberRepr.fromF32Bits(kBit.f32.positive.min)] },
         {input: NumberRepr.fromF32Bits(kBit.f32.positive.max), expected: [NumberRepr.fromF32Bits(kBit.f32.positive.max)] },

--- a/src/webgpu/shader/execution/builtin/logical_built_in_functions.spec.ts
+++ b/src/webgpu/shader/execution/builtin/logical_built_in_functions.spec.ts
@@ -1,54 +1,67 @@
-export const description = `WGSL Logical built-in functions execution test`;
+export const description = `WGSL execution test. Section: Logical built-in functions`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('builtin,all')
-  .uniqueId(0x16815cc7b249ff78)
+g.test('vector_all,logical_builtin_functions')
+  .uniqueId('d140d173a2acf981')
   .desc(
     `
+https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions
 vector all:
-e: vecN<bool> all(e): bool Returns true if each component of e is true.
-(OpAll)
+e: vecN<bool> all(e): bool Returns true if each component of e is true. (OpAll)
+
+Please read the following guidelines before contributing:
+https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
 `
   )
   .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
   .unimplemented();
 
-g.test('builtin,any')
-  .uniqueId(0x55e14f481a7f3e66)
+g.test('vector_any,logical_builtin_functions')
+  .uniqueId('ac2b3a100379d70f')
   .desc(
     `
+https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions
 vector any:
-e: vecN<bool> any(e): bool Returns true if any component of e is true.
-(OpAny)
+e: vecN<bool> any(e): bool Returns true if any component of e is true. (OpAny)
+
+Please read the following guidelines before contributing:
+https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
 `
   )
   .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
   .unimplemented();
 
-g.test('builtin,select_scalar')
-  .uniqueId(0xb9bd4dd5c8b4b0d7)
+g.test('scalar_select,logical_builtin_functions')
+  .uniqueId('50b1f627c11098a1')
   .desc(
     `
+https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions
 scalar select:
-T is a scalar select(f:T,t:T,cond: bool): T Returns t when cond is true, and f otherwise.
-(OpSelect)
+T is a scalar or a vector select(f:T,t:T,cond: bool): T
+Returns t when cond is true, and f otherwise. (OpSelect)
+
+Please read the following guidelines before contributing:
+https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
 `
   )
   .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
   .unimplemented();
 
-g.test('builtin,select_vector')
-  .uniqueId(0xbf77b7217032259b)
+g.test('vector_select,logical_builtin_functions')
+  .uniqueId('7f386e1295111c09')
   .desc(
     `
+https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions
 vector select:
 T is a scalar select(f: vecN<T>,t: vecN<T,cond: vecN<bool>>) Component-wise selection.
-Result component i is evaluated as select(f[i],t[i],cond[i]).
-(OpSelect)
+Result component i is evaluated as select(f[i],t[i],cond[i]). (OpSelect)
+
+Please read the following guidelines before contributing:
+https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
 `
   )
   .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))


### PR DESCRIPTION
- Change uniqueId() parameter from number to string to avoid data loss when converting int to double.
- Update test plans to the latest release of WGSL spec.
- Remove float abs TODO as it was invalid.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
