### PR TITLE
Fix maxStorageTexturesPerShaderStage expectations

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -538,7 +538,7 @@ export const kPerStageBindingLimits: {
   'storageBuf': { class: 'storageBuf', max:  8, },
   'sampler':    { class: 'sampler',    max: 16, },
   'sampledTex': { class: 'sampledTex', max: 16, },
-  'storageTex': { class: 'storageTex', max:  8, },
+  'storageTex': { class: 'storageTex', max:  4, },
 };
 
 /**


### PR DESCRIPTION
`maxStorageTexturesPerShaderStage` is `4` according to:
https://www.w3.org/TR/webgpu/#dom-supported-limits-maxstoragetexturespershaderstage
