### PR TITLE
Add no-op function .url() to class TestBuilder

### DIFF
--- a/docs/plan_autogen.md
+++ b/docs/plan_autogen.md
@@ -5,10 +5,8 @@ An `auto-generated test plan` is a [test plan](./intro/plans.md) with a `unique-
 ```
 g.test(<name>)
   .uniqueId(<unique-id>)
-  .desc(
-    <url>
-    <description>
-  )
+  .url(<url>)
+  .desc(<description>)
   .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
   .unimplemented();
 ```
@@ -26,7 +24,7 @@ unique-id = sha1(<section-name> + <description>)
 To implement an auto-generated test plan:
 1. Choose an auto-generated test plan that is not currently under development, ie. looking up the `unique-id` in [this list](https://bugs.chromium.org/p/tint/issues/list) must not return any results.
 2. [Submit](https://chromium.googlesource.com/infra/infra/+/HEAD/appengine/monorail/doc/userguide/working-with-issues.md#How-to-enter-an-issue) a new issue using this [template](https://bugs.chromium.org/p/tint/issues/entry?template=WGSL+CTS+with+a+unique+id). Make sure to include the `unique-id` and `url`.
-3. Implement the test plan. You may change the test name and description; however, the `unique-id` must remain as is.
+3. Implement the test plan. You may modify the test name and description; however, `url` and `unique-id` must remain unchanged.
 4. Add a [comment](https://chromium.googlesource.com/infra/infra/+/HEAD/appengine/monorail/doc/userguide/working-with-issues.md#How-to-comment-on-an-issue) to the issue (created in step 2) with a link to your merged pull request. Then close the issue with status `Fixed`.
 
 # Useful helpers

--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -127,6 +127,12 @@ interface TestBuilderWithName<F extends Fixture> extends TestBuilderWithParams<F
    */
   uniqueId(id: string): this;
   /**
+   * A noop function with the purpose of highlighting value `url`.
+   *
+   * @param url a link to the spec where test is extracted from.
+   */
+  url(url: string): this;
+  /**
    * Parameterize the test, generating multiple cases, each possibly having subcases.
    *
    * The `unit` value passed to the `cases` callback is an immutable constant
@@ -193,6 +199,10 @@ class TestBuilder {
   }
 
   uniqueId(id: string): this {
+    return this;
+  }
+
+  url(url: string): this {
     return this;
   }
 

--- a/src/webgpu/shader/execution/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/builtin/abs.spec.ts
@@ -14,9 +14,9 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abs_unsigned,integer_builtin_functions')
   .uniqueId('59ff84968a839124')
+  .url('https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions
 scalar case, unsigned abs:
 abs(e: T ) -> T
 T is u32 or vecN<u32>. Result is e.
@@ -87,9 +87,9 @@ Component-wise when T is a vector.
 
 g.test('abs_signed,integer_builtin_functions')
   .uniqueId('d8fc581d17db6ae8')
+  .url('https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions
 signed abs:
 abs(e: T ) -> T
 T is i32 or vecN<i32>. The result is the absolute value of e.
@@ -164,9 +164,9 @@ If e evaluates to the largest negative value, then the result is e.
 
 g.test('abs_float,float_builtin_functions')
   .uniqueId('2c1782b6a8dec8cb')
+  .url('https://www.w3.org/TR/2021/WD-WGSL-20210929/#float-builtin-functions')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210929/#float-builtin-functions
 float abs:
 abs(e: T ) -> T
 T is f32 or vecN<f32>

--- a/src/webgpu/shader/execution/builtin/logical_built_in_functions.spec.ts
+++ b/src/webgpu/shader/execution/builtin/logical_built_in_functions.spec.ts
@@ -7,9 +7,9 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('vector_all,logical_builtin_functions')
   .uniqueId('d140d173a2acf981')
+  .url('https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions
 vector all:
 e: vecN<bool> all(e): bool Returns true if each component of e is true. (OpAll)
 
@@ -22,9 +22,9 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
 
 g.test('vector_any,logical_builtin_functions')
   .uniqueId('ac2b3a100379d70f')
+  .url('https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions
 vector any:
 e: vecN<bool> any(e): bool Returns true if any component of e is true. (OpAny)
 
@@ -37,12 +37,11 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
 
 g.test('scalar_select,logical_builtin_functions')
   .uniqueId('50b1f627c11098a1')
+  .url('https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions
 scalar select:
-T is a scalar or a vector select(f:T,t:T,cond: bool): T
-Returns t when cond is true, and f otherwise. (OpSelect)
+T is a scalar or a vector select(f:T,t:T,cond: bool): T Returns t when cond is true, and f otherwise. (OpSelect)
 
 Please read the following guidelines before contributing:
 https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
@@ -52,13 +51,12 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
   .unimplemented();
 
 g.test('vector_select,logical_builtin_functions')
-  .uniqueId('7f386e1295111c09')
+  .uniqueId('8b7bb7f58ee1e479')
+  .url('https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions')
   .desc(
     `
-https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions
 vector select:
-T is a scalar select(f: vecN<T>,t: vecN<T,cond: vecN<bool>>) Component-wise selection.
-Result component i is evaluated as select(f[i],t[i],cond[i]). (OpSelect)
+T is a scalar select(f: vecN<T>,t: vecN<T>,cond: vecN<bool>) Component-wise selection. Result component i is evaluated as select(f[i],t[i],cond[i]). (OpSelect)
 
 Please read the following guidelines before contributing:
 https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md


### PR DESCRIPTION
.url(<https://www.w3.org/TR/<version>/#<section-name>>) is used to highlight the url of a wgsl test plan.


<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
