### PR TITLE
CopyExternalImageToTexture should always copy source from top-left or…

### DIFF
--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -205,9 +205,14 @@ class F extends CopyToTextureUtils {
           rgba.B /= rgba.A;
         }
 
+        // WebGL readPixel returns pixels from bottom-left origin. Using CopyExternalImageToTexture
+        // to copy from WebGL Canvas keeps top-left origin. So the expectation from webgl.readPixel should
+        // be flipped.
+        const dstPixelPos = contextType === 'gl' ? (height - i - 1) * width + j : pixelPos;
+
         memcpy(
           { src: rep.pack(rep.encode(rgba)) },
-          { dst: expectedPixels, start: pixelPos * bytesPerPixel }
+          { dst: expectedPixels, start: dstPixelPos * bytesPerPixel }
         );
       }
     }


### PR DESCRIPTION
…igin

According to the spec
decision(https://github.com/gpuweb/gpuweb/issues/2110). We need to change
the expectation that copy from WebGL canvas. The current implementation
use webgl.readPixels to generate expectation, which the origin is
bottom-left. We need to flip it.





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
