### PR TITLE
wgsl: Add built-in variable validation tests

### DIFF
--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -1,0 +1,135 @@
+export const description = `Validation tests for entry point built-in variables`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { generateShader } from './util.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+// List of all built-in variables and their stage, in|out usage, and type.
+// Taken from table in Section 15:
+// https://www.w3.org/TR/2021/WD-WGSL-20211013/#builtin-variables
+const kBuiltins = [
+  { name: 'vertex_index', stage: 'vertex', io: 'in', type: 'u32' },
+  { name: 'instance_index', stage: 'vertex', io: 'in', type: 'u32' },
+  { name: 'position', stage: 'vertex', io: 'out', type: 'vec4<f32>' },
+  { name: 'position', stage: 'fragment', io: 'in', type: 'vec4<f32>' },
+  { name: 'front_facing', stage: 'fragment', io: 'in', type: 'bool' },
+  { name: 'local_invocation_id', stage: 'compute', io: 'in', type: 'vec3<u32>' },
+  { name: 'local_invocation_index', stage: 'compute', io: 'in', type: 'u32' },
+  { name: 'global_invocation_id', stage: 'compute', io: 'in', type: 'vec3<u32>' },
+  { name: 'workgroup_id', stage: 'compute', io: 'in', type: 'vec3<u32>' },
+  { name: 'num_workgroups', stage: 'compute', io: 'in', type: 'vec3<u32>' },
+  { name: 'sample_index', stage: 'fragment', io: 'in', type: 'u32' },
+  { name: 'sample_mask', stage: 'fragment', io: 'in', type: 'u32' },
+  { name: 'sample_mask', stage: 'fragment', io: 'out', type: 'u32' },
+] as const;
+
+// List of types to test against.
+const kTestTypes = [
+  'bool',
+  'u32',
+  'i32',
+  'f32',
+  'vec2<bool>',
+  'vec2<u32>',
+  'vec2<i32>',
+  'vec2<f32>',
+  'vec3<bool>',
+  'vec3<u32>',
+  'vec3<i32>',
+  'vec3<f32>',
+  'vec4<bool>',
+  'vec4<u32>',
+  'vec4<i32>',
+  'vec4<f32>',
+  'mat2x2<f32>',
+  'mat2x3<f32>',
+  'mat2x4<f32>',
+  'mat3x2<f32>',
+  'mat3x3<f32>',
+  'mat3x4<f32>',
+  'mat4x2<f32>',
+  'mat4x3<f32>',
+  'mat4x4<f32>',
+  'atomic<u32>',
+  'atomic<i32>',
+  'array<bool,4>',
+  'array<u32,4>',
+  'array<i32,4>',
+  'array<f32,4>',
+  'MyStruct',
+] as const;
+
+g.test('stage_inout')
+  .desc(
+    `Test that each [[builtin]] attribute is validated against the required stage and in/out usage for that built-in variable.`
+  )
+  .params(u =>
+    u
+      .combineWithParams(kBuiltins)
+      .combine('use_struct', [true, false] as const)
+      .combine('target_stage', ['vertex', 'fragment', 'compute'] as const)
+      .combine('target_io', ['in', 'out'] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    const code = generateShader({
+      attribute: `[[builtin(${t.params.name})]]`,
+      type: t.params.type,
+      stage: t.params.target_stage,
+      io: t.params.target_io,
+      use_struct: t.params.use_struct,
+    });
+
+    // Expect to pass iff the built-in table contains an entry that matches.
+    const expectation = kBuiltins.some(
+      x =>
+        x.name === t.params.name &&
+        x.stage === t.params.target_stage &&
+        x.io === t.params.target_io &&
+        x.type === t.params.type
+    );
+    t.expectCompileResult(expectation, code);
+  });
+
+g.test('type')
+  .desc(
+    `Test that each [[builtin]] attribute is validated against the required type of that built-in variable.`
+  )
+  .params(u =>
+    u
+      .combineWithParams(kBuiltins)
+      .combine('use_struct', [true, false] as const)
+      .combine('target_type', kTestTypes)
+      .beginSubcases()
+  )
+  .fn(t => {
+    let code = '';
+
+    if (t.params.target_type === 'MyStruct') {
+      // Generate a struct that contains the correct built-in type.
+      code += 'struct MyStruct {\n';
+      code += `  value : ${t.params.type};\n`;
+      code += '};\n\n';
+    }
+
+    code += generateShader({
+      attribute: `[[builtin(${t.params.name})]]`,
+      type: t.params.target_type,
+      stage: t.params.stage,
+      io: t.params.io,
+      use_struct: t.params.use_struct,
+    });
+
+    // Expect to pass iff the built-in table contains an entry that matches.
+    const expectation = kBuiltins.some(
+      x =>
+        x.name === t.params.name &&
+        x.stage === t.params.stage &&
+        x.io === t.params.io &&
+        x.type === t.params.target_type
+    );
+    t.expectCompileResult(expectation, code);
+  });

--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -3,6 +3,8 @@ export const description = `Validation tests for entry point user-defined IO`;
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
+import { generateShader } from './util.js';
+
 export const g = makeTestGroup(ShaderValidationTest);
 
 // List of types to test against.
@@ -40,85 +42,6 @@ const kTestTypes = [
   { type: 'array<f32,4>', _valid: false },
   { type: 'MyStruct', _valid: false },
 ] as const;
-
-/**
- * Generate an entry point that uses a user-defined IO variable.
- *
- * @param attribute The attribute to use for the user-defined IO.
- * @param type The type to use for the user-defined IO.
- * @param stage The shader stage.
- * @param io An "in|out" string specifying whether the user-defined IO is an input or an output.
- * @param use_struct True to wrap the user-defined IO in a struct.
- * @returns The generated shader code.
- */
-function generateShader({
-  attribute,
-  type,
-  stage,
-  io,
-  use_struct,
-}: {
-  attribute: string;
-  type: string;
-  stage: string;
-  io: string;
-  use_struct: boolean;
-}) {
-  let code = '';
-
-  if (use_struct) {
-    // Generate a struct that wraps the location attribute variable.
-    code += 'struct S {\n';
-    code += `  ${attribute} value : ${type};\n`;
-    if (stage === 'vertex' && io === 'out') {
-      // Add position builtin for vertex outputs.
-      code += `  [[builtin(position)]] position : vec4<f32>;\n`;
-    }
-    code += '};\n\n';
-  }
-
-  if (stage !== '') {
-    // Generate the entry point attributes.
-    code += `[[stage(${stage})]]`;
-    if (stage === 'compute') {
-      code += ' [[workgroup_size(1)]]';
-    }
-  }
-
-  // Generate the entry point parameter and return type.
-  let param = '';
-  let retType = '';
-  let retVal = '';
-  if (io === 'in') {
-    if (use_struct) {
-      param = `in : S`;
-    } else {
-      param = `${attribute} value : ${type}`;
-    }
-
-    // Vertex shaders must always return `builtin(position)`.
-    if (stage === 'vertex') {
-      retType = `-> [[builtin(position)]] vec4<f32>`;
-      retVal = `return vec4<f32>();`;
-    }
-  } else if (io === 'out') {
-    if (use_struct) {
-      retType = '-> S';
-      retVal = `return S();`;
-    } else {
-      retType = `-> ${attribute} ${type}`;
-      retVal = `return ${type}();`;
-    }
-  }
-
-  code += `
-    fn main(${param}) ${retType} {
-      ${retVal}
-    }
-  `;
-
-  return code;
-}
 
 g.test('stage_inout')
   .desc(`Test validation of user-defined IO stage and in/out usage`)

--- a/src/webgpu/shader/validation/shader_io/util.ts
+++ b/src/webgpu/shader/validation/shader_io/util.ts
@@ -1,0 +1,79 @@
+/**
+ * Generate an entry point that uses an entry point IO variable.
+ *
+ * @param {Object} params
+ * @param params.attribute The entry point IO attribute.
+ * @param params.type The type to use for the entry point IO variable.
+ * @param params.stage The shader stage.
+ * @param params.io An "in|out" string specifying whether the entry point IO is an input or an output.
+ * @param params.use_struct True to wrap the entry point IO in a struct.
+ * @returns The generated shader code.
+ */
+export function generateShader({
+  attribute,
+  type,
+  stage,
+  io,
+  use_struct,
+}: {
+  attribute: string;
+  type: string;
+  stage: string;
+  io: string;
+  use_struct: boolean;
+}) {
+  let code = '';
+
+  if (use_struct) {
+    // Generate a struct that wraps the entry point IO variable.
+    code += 'struct S {\n';
+    code += `  ${attribute} value : ${type};\n`;
+    if (stage === 'vertex' && io === 'out' && !attribute.includes('builtin(position)')) {
+      // Add position builtin for vertex outputs.
+      code += `  [[builtin(position)]] position : vec4<f32>;\n`;
+    }
+    code += '};\n\n';
+  }
+
+  if (stage !== '') {
+    // Generate the entry point attributes.
+    code += `[[stage(${stage})]]`;
+    if (stage === 'compute') {
+      code += ' [[workgroup_size(1)]]';
+    }
+  }
+
+  // Generate the entry point parameter and return type.
+  let param = '';
+  let retType = '';
+  let retVal = '';
+  if (io === 'in') {
+    if (use_struct) {
+      param = `in : S`;
+    } else {
+      param = `${attribute} value : ${type}`;
+    }
+
+    // Vertex shaders must always return `builtin(position)`.
+    if (stage === 'vertex') {
+      retType = `-> [[builtin(position)]] vec4<f32>`;
+      retVal = `return vec4<f32>();`;
+    }
+  } else if (io === 'out') {
+    if (use_struct) {
+      retType = '-> S';
+      retVal = `return S();`;
+    } else {
+      retType = `-> ${attribute} ${type}`;
+      retVal = `return ${type}();`;
+    }
+  }
+
+  code += `
+    fn main(${param}) ${retType} {
+      ${retVal}
+    }
+  `;
+
+  return code;
+}


### PR DESCRIPTION
Test that the use of a built-in variable is only accepted for the
correct combination of stage, in|out usage, and type.

Tested and all passing with top-of-tree Chromium on macOS.

<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
