### PR TITLE
Clamp limits between 0 and their maximum IDL value

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
@@ -7,15 +7,9 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
 import { getGPU } from '../../../../common/util/navigator_gpu.js';
 import { assert } from '../../../../common/util/util.js';
-import { DefaultLimits } from '../../../constants.js';
+import { DefaultLimits, LimitMaximum } from '../../../constants.js';
 
 const kLimitTypes = keysOf(DefaultLimits);
-
-const kMaxUnsignedLongValue = 4294967295;
-/** Clamps a numeric value to the valid unsigned long range, as defined by WebIDL */
-function clampToUnsignedLong(value: number): number {
-  return Math.min(kMaxUnsignedLongValue, Math.max(0, value));
-}
 
 export const g = makeTestGroup(Fixture);
 
@@ -98,7 +92,7 @@ g.test('better_than_supported')
     const mult = limit.startsWith('min') ? -1 : 1;
 
     const requiredLimits = {
-      [limit]: clampToUnsignedLong(adapter.limits[limit] + over * mult),
+      [limit]: Math.max(Math.min(adapter.limits[limit] + over * mult, LimitMaximum[limit]), 0),
     };
 
     t.shouldReject('OperationError', adapter.requestDevice({ requiredLimits }));
@@ -129,7 +123,10 @@ g.test('worse_than_default')
     const mult = limit.startsWith('min') ? -1 : 1;
 
     const requiredLimits = {
-      [limit]: clampToUnsignedLong((DefaultLimits[limit] as number) - under * mult),
+      [limit]: Math.max(
+        Math.min((DefaultLimits[limit] as number) - under * mult, LimitMaximum[limit]),
+        0
+      ),
     };
 
     const device = await adapter.requestDevice({ requiredLimits });

--- a/src/webgpu/constants.ts
+++ b/src/webgpu/constants.ts
@@ -92,3 +92,39 @@ export const DefaultLimits = {
   maxComputeWorkgroupsPerDimension: 65535,
 };
 checkType<Omit<GPUSupportedLimits, '__brand'>>(DefaultLimits);
+
+const kMaxUnsignedLongValue = 4294967295;
+const kMaxUnsignedLongLongValue = Number.MAX_SAFE_INTEGER;
+export const LimitMaximum = {
+  maxTextureDimension1D: kMaxUnsignedLongValue,
+  maxTextureDimension2D: kMaxUnsignedLongValue,
+  maxTextureDimension3D: kMaxUnsignedLongValue,
+  maxTextureArrayLayers: kMaxUnsignedLongValue,
+
+  maxBindGroups: kMaxUnsignedLongValue,
+  maxDynamicUniformBuffersPerPipelineLayout: kMaxUnsignedLongValue,
+  maxDynamicStorageBuffersPerPipelineLayout: kMaxUnsignedLongValue,
+  maxSampledTexturesPerShaderStage: kMaxUnsignedLongValue,
+  maxSamplersPerShaderStage: kMaxUnsignedLongValue,
+  maxStorageBuffersPerShaderStage: kMaxUnsignedLongValue,
+  maxStorageTexturesPerShaderStage: kMaxUnsignedLongValue,
+  maxUniformBuffersPerShaderStage: kMaxUnsignedLongValue,
+
+  maxUniformBufferBindingSize: kMaxUnsignedLongLongValue,
+  maxStorageBufferBindingSize: kMaxUnsignedLongLongValue,
+  minUniformBufferOffsetAlignment: kMaxUnsignedLongValue,
+  minStorageBufferOffsetAlignment: kMaxUnsignedLongValue,
+
+  maxVertexBuffers: kMaxUnsignedLongValue,
+  maxVertexAttributes: kMaxUnsignedLongValue,
+  maxVertexBufferArrayStride: kMaxUnsignedLongValue,
+  maxInterStageShaderComponents: kMaxUnsignedLongValue,
+
+  maxComputeWorkgroupStorageSize: kMaxUnsignedLongValue,
+  maxComputeInvocationsPerWorkgroup: kMaxUnsignedLongValue,
+  maxComputeWorkgroupSizeX: kMaxUnsignedLongValue,
+  maxComputeWorkgroupSizeY: kMaxUnsignedLongValue,
+  maxComputeWorkgroupSizeZ: kMaxUnsignedLongValue,
+  maxComputeWorkgroupsPerDimension: kMaxUnsignedLongValue,
+};
+checkType<Omit<GPUSupportedLimits, '__brand'>>(LimitMaximum);


### PR DESCRIPTION
requestDevice_limits.spec.ts was sometimes producing negative values
if the parameterization subtracted a value larger than the supported
limit value itself. Fix this by clamping to 0.
Also, the test clamped always to the maximum unsigned long value which
is incorrect for limits that are unsigned long long. Fix this to clamp
to Number.MAX_SAFE_INTEGER for limits that can be larger.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
