### PR TITLE
webgpu/shader/exection/builtin: Fix checkExpectation()

### DIFF
--- a/src/webgpu/shader/execution/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/builtin/abs.spec.ts
@@ -203,8 +203,8 @@ Component-wise when T is a vector. (GLSLstd450Fabs)
 
         // Subnormal f32
         // TODO(sarahM0): Check if this is needed (or if it has to fail). If yes add other values.
-        {input: NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.max), expected: [NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.max)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.min), expected: [NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.min)] },
+        {input: NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.max), expected: [NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.max), NumberRepr.fromF32(0)] },
+        {input: NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.min), expected: [NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.min), NumberRepr.fromF32(0)] },
 
         // Infinity f32
         {input: NumberRepr.fromF32Bits(kBit.f32.infinity.negative), expected: [NumberRepr.fromF32Bits(kBit.f32.infinity.positive)] },


### PR DESCRIPTION
The `expected` field of a case is an array of possible allowed values. The logic was checking that the output value matched *all* the values in the array, which would never work.

Fix the subnormal cases of the `abs()` tests. These are allowed to return 0.

Also simplify the formatted string for 0, Infinity, -Infinity.
