### PR TITLE
src/common/util: Fix 5 second stall at end of test run

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -104,7 +104,16 @@ export function rejectOnTimeout(ms: number, msg: string): Promise<never> {
  * and otherwise passes the result through.
  */
 export function raceWithRejectOnTimeout<T>(p: Promise<T>, ms: number, msg: string): Promise<T> {
-  return Promise.race([p, rejectOnTimeout(ms, msg)]);
+  // Setup a promise that will reject after `ms` milliseconds. We cancel this timeout when
+  // `p` is finalized, so the JavaScript VM doesn't hang around waiting for the timer to
+  // complete, once the test runner has finished executing the tests.
+  const timeoutPromise = new Promise((_resolve, reject) => {
+    const handle = timeout(() => {
+      reject(new PromiseTimeoutError(msg));
+    }, ms);
+    p.finally(() => clearTimeout(handle));
+  });
+  return Promise.race([p, timeoutPromise]) as Promise<T>;
 }
 
 /**


### PR DESCRIPTION
The `DeviceHolder.ensureRelease()` method calls `await raceWithRejectOnTimeout()` with a 5 second timeout. For the NodeJS command line test runner, this sets up a `setTimeout()` callback that the Node VM always has to wait on before quitting the process.

To fix this, cancel the `setTimeout()` if the other promise completes first.
