### PR TITLE
common/util: Fix subtle bug introduced in #785

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -111,7 +111,7 @@ export function raceWithRejectOnTimeout<T>(p: Promise<T>, ms: number, msg: strin
     const handle = timeout(() => {
       reject(new PromiseTimeoutError(msg));
     }, ms);
-    p.finally(() => clearTimeout(handle));
+    p = p.finally(() => clearTimeout(handle));
   });
   return Promise.race([p, timeoutPromise]) as Promise<T>;
 }


### PR DESCRIPTION
Apparently you cannot use a Promise that has had `.finally()` called on it for other `.then()` /  `.finally()` type uses, you *must* use the returned Promise.

Fixes weird failures that have been observed in the Chromium CTS roll.