### PR TITLE
Add `diffULP` utility function

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -1,0 +1,50 @@
+export const description = `
+Util math unit tests.
+`;
+
+import { makeTestGroup } from '../common/framework/test_group.js';
+import { diffULP } from '../webgpu/util/math.js';
+
+import { UnitTest } from './unit_test.js';
+
+export const g = makeTestGroup(UnitTest);
+
+interface DiffULPCase {
+  a: number;
+  b: number;
+  ulp: number;
+}
+
+function hexToF32(hex: number): number {
+  return new Float32Array(new Uint32Array([hex]).buffer)[0];
+}
+
+g.test('test,math,diffULP')
+  .paramsSimple<DiffULPCase>([
+    { a: 0, b: 0, ulp: 0 },
+    { a: 1, b: 2, ulp: 2 ** 23 }, // Single exponent step
+    { a: 2, b: 1, ulp: 2 ** 23 }, // Single exponent step
+    { a: 2, b: 4, ulp: 2 ** 23 }, // Single exponent step
+    { a: 4, b: 2, ulp: 2 ** 23 }, // Single exponent step
+    { a: -1, b: -2, ulp: 2 ** 23 }, // Single exponent step
+    { a: -2, b: -1, ulp: 2 ** 23 }, // Single exponent step
+    { a: -2, b: -4, ulp: 2 ** 23 }, // Single exponent step
+    { a: -4, b: -2, ulp: 2 ** 23 }, // Single exponent step
+    { a: hexToF32(0x00800000), b: hexToF32(0x00800001), ulp: 1 }, // Single mantissa step
+    { a: hexToF32(0x00800001), b: hexToF32(0x00800000), ulp: 1 }, // Single mantissa step
+    { a: hexToF32(0x03800000), b: hexToF32(0x03800001), ulp: 1 }, // Single mantissa step
+    { a: hexToF32(0x03800001), b: hexToF32(0x03800000), ulp: 1 }, // Single mantissa step
+    { a: -hexToF32(0x00800000), b: -hexToF32(0x00800001), ulp: 1 }, // Single mantissa step
+    { a: -hexToF32(0x00800001), b: -hexToF32(0x00800000), ulp: 1 }, // Single mantissa step
+    { a: -hexToF32(0x03800000), b: -hexToF32(0x03800001), ulp: 1 }, // Single mantissa step
+    { a: -hexToF32(0x03800001), b: -hexToF32(0x03800000), ulp: 1 }, // Single mantissa step
+    { a: hexToF32(0x00800000), b: -hexToF32(0x00800000), ulp: 2 ** 24 }, // Two exponent steps
+    { a: -hexToF32(0x00800000), b: hexToF32(0x00800000), ulp: 2 ** 24 }, // Two exponent steps
+  ])
+  .fn(t => {
+    const a = t.params.a;
+    const b = t.params.b;
+    const got = diffULP(a, b);
+    const expect = t.params.ulp;
+    t.expect(got === expect, `diffULP(${a}, ${b}) returned ${got}. Expected ${expect}`);
+  });

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -29,3 +29,23 @@ export function clamp(n: number, { min, max }: { min: number; max: number }): nu
   assert(max >= min);
   return Math.min(Math.max(n, min), max);
 }
+
+/**
+ * Return the Units of Last Place difference between the numbers a and b.
+ * Requires `a` and `b` to be finite numbers.
+ */
+export function diffULP(a: number, b: number): number {
+  const arr = new Uint32Array(new Float32Array([a, b]).buffer);
+  const u32_a = arr[0];
+  const u32_b = arr[1];
+
+  const sign_a = (u32_a & 0x80000000) !== 0;
+  const sign_b = (u32_b & 0x80000000) !== 0;
+  const masked_a = u32_a & 0x7fffffff;
+  const masked_b = u32_b & 0x7fffffff;
+
+  if (sign_a === sign_b) {
+    return Math.max(masked_a, masked_b) - Math.min(masked_a, masked_b);
+  }
+  return masked_a + masked_b;
+}


### PR DESCRIPTION
Will be used for CTS tests that need to check that builtins and arithmatic have acceptable precision.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
