### PR TITLE
Adds ETC2 and ASTC types to enable testing when relevant.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^14.11.10",
     "@types/offscreencanvas": "^2019.6.2",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "^0.1.6",
+    "@webgpu/types": "^0.1.7",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -665,40 +665,91 @@ g.test('color_textures,compressed,non_array')
     u
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
-      .combine('textureSize', [
-        // The heights and widths are all power of 2
-        {
-          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-        },
-        // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
-        {
-          srcTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-        },
-        // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
-        // of 4
-        {
-          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
-        },
-        // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
-        {
-          srcTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-        },
-        // The virtual height of the destination texture at mipmap level 2 (13) is not a
-        // multiple of 4
-        {
-          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
-        },
-        // None of the widths or heights are power of 2
-        {
-          srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
-        },
-      ])
+      .expand('textureSize', p => {
+        const { blockWidth, blockHeight } = kTextureFormatInfo[p.format];
+        return [
+          // The heights and widths are all power of 2
+          {
+            srcTextureSize: {
+              width: 16 * blockWidth,
+              height: 8 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+            dstTextureSize: {
+              width: 16 * blockWidth,
+              height: 8 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+          },
+          // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
+          {
+            srcTextureSize: {
+              width: 15 * blockWidth,
+              height: 8 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+            dstTextureSize: {
+              width: 16 * blockWidth,
+              height: 8 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+          },
+          // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
+          // of 4
+          {
+            srcTextureSize: {
+              width: 16 * blockWidth,
+              height: 8 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+            dstTextureSize: {
+              width: 15 * blockWidth,
+              height: 8 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+          },
+          // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
+          {
+            srcTextureSize: {
+              width: 16 * blockWidth,
+              height: 13 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+            dstTextureSize: {
+              width: 16 * blockWidth,
+              height: 8 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+          },
+          // The virtual height of the destination texture at mipmap level 2 (13) is not a
+          // multiple of 4
+          {
+            srcTextureSize: {
+              width: 16 * blockWidth,
+              height: 8 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+            dstTextureSize: {
+              width: 16 * blockWidth,
+              height: 13 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+          },
+          // None of the widths or heights are power of 2
+          {
+            srcTextureSize: {
+              width: 15 * blockWidth,
+              height: 13 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+            dstTextureSize: {
+              width: 15 * blockWidth,
+              height: 13 * blockHeight,
+              depthOrArrayLayers: 1,
+            },
+          },
+        ];
+      })
       .combine('copyBoxOffsets', kCopyBoxOffsetsForWholeDepth)
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])
@@ -769,19 +820,37 @@ g.test('color_textures,compressed,array')
     u
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
-      .combine('textureSize', [
-        // The heights and widths are all power of 2
-        {
-          srcTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
-          dstTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
-        },
-        // None of the widths or heights are power of 2
-        {
-          srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
-          dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
-        },
-      ])
-
+      .expand('textureSize', p => {
+        const { blockWidth, blockHeight } = kTextureFormatInfo[p.format];
+        return [
+          // The heights and widths are all power of 2
+          {
+            srcTextureSize: {
+              width: 2 * blockWidth,
+              height: 2 * blockHeight,
+              depthOrArrayLayers: 5,
+            },
+            dstTextureSize: {
+              width: 2 * blockWidth,
+              height: 2 * blockHeight,
+              depthOrArrayLayers: 5,
+            },
+          },
+          // None of the widths or heights are power of 2
+          {
+            srcTextureSize: {
+              width: 15 * blockWidth,
+              height: 13 * blockHeight,
+              depthOrArrayLayers: 5,
+            },
+            dstTextureSize: {
+              width: 15 * blockWidth,
+              height: 13 * blockHeight,
+              depthOrArrayLayers: 5,
+            },
+          },
+        ];
+      })
       .combine('copyBoxOffsets', kCopyBoxOffsetsFor2DArrayTextures)
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -665,102 +665,42 @@ g.test('color_textures,compressed,non_array')
     u
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
-      .expand('textureSize', p => {
-        const { blockWidth, blockHeight } = kTextureFormatInfo[p.format];
-        return [
-          // The heights and widths are all power of 2
-          {
-            srcTextureSize: {
-              width: 16 * blockWidth,
-              height: 8 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-            dstTextureSize: {
-              width: 16 * blockWidth,
-              height: 8 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-          },
-          // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
-          {
-            srcTextureSize: {
-              width: 15 * blockWidth,
-              height: 8 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-            dstTextureSize: {
-              width: 16 * blockWidth,
-              height: 8 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-          },
-          // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
-          // of 4
-          {
-            srcTextureSize: {
-              width: 16 * blockWidth,
-              height: 8 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-            dstTextureSize: {
-              width: 15 * blockWidth,
-              height: 8 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-          },
-          // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
-          {
-            srcTextureSize: {
-              width: 16 * blockWidth,
-              height: 13 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-            dstTextureSize: {
-              width: 16 * blockWidth,
-              height: 8 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-          },
-          // The virtual height of the destination texture at mipmap level 2 (13) is not a
-          // multiple of 4
-          {
-            srcTextureSize: {
-              width: 16 * blockWidth,
-              height: 8 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-            dstTextureSize: {
-              width: 16 * blockWidth,
-              height: 13 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-          },
-          // None of the widths or heights are power of 2
-          {
-            srcTextureSize: {
-              width: 15 * blockWidth,
-              height: 13 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-            dstTextureSize: {
-              width: 15 * blockWidth,
-              height: 13 * blockHeight,
-              depthOrArrayLayers: 1,
-            },
-          },
-        ];
-      })
+      .combine('textureSizeInBlocks', [
+        // The heights and widths are all power of 2
+        { src: { width: 16, height: 8 }, dst: { width: 16, height: 8 } },
+        // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
+        { src: { width: 15, height: 8 }, dst: { width: 16, height: 8 } },
+        // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
+        // of 4
+        { src: { width: 16, height: 8 }, dst: { width: 15, height: 8 } },
+        // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
+        { src: { width: 16, height: 13 }, dst: { width: 16, height: 8 } },
+        // The virtual height of the destination texture at mipmap level 2 (13) is not a
+        // multiple of 4
+        { src: { width: 16, height: 8 }, dst: { width: 16, height: 13 } },
+        // None of the widths or heights are power of 2
+        { src: { width: 15, height: 13 }, dst: { width: 15, height: 13 } },
+      ])
       .combine('copyBoxOffsets', kCopyBoxOffsetsForWholeDepth)
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
-    const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const { textureSizeInBlocks, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     t.DoCopyTextureToTextureTest(
-      textureSize.srcTextureSize,
-      textureSize.dstTextureSize,
+      {
+        width: textureSizeInBlocks.src.width * blockWidth,
+        height: textureSizeInBlocks.src.height * blockHeight,
+        depthOrArrayLayers: 1,
+      },
+      {
+        width: textureSizeInBlocks.dst.width * blockWidth,
+        height: textureSizeInBlocks.dst.height * blockHeight,
+        depthOrArrayLayers: 1,
+      },
       format,
       copyBoxOffsets,
       srcCopyLevel,
@@ -820,48 +760,32 @@ g.test('color_textures,compressed,array')
     u
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
-      .expand('textureSize', p => {
-        const { blockWidth, blockHeight } = kTextureFormatInfo[p.format];
-        return [
-          // The heights and widths are all power of 2
-          {
-            srcTextureSize: {
-              width: 2 * blockWidth,
-              height: 2 * blockHeight,
-              depthOrArrayLayers: 5,
-            },
-            dstTextureSize: {
-              width: 2 * blockWidth,
-              height: 2 * blockHeight,
-              depthOrArrayLayers: 5,
-            },
-          },
-          // None of the widths or heights are power of 2
-          {
-            srcTextureSize: {
-              width: 15 * blockWidth,
-              height: 13 * blockHeight,
-              depthOrArrayLayers: 5,
-            },
-            dstTextureSize: {
-              width: 15 * blockWidth,
-              height: 13 * blockHeight,
-              depthOrArrayLayers: 5,
-            },
-          },
-        ];
-      })
+      .combine('textureSizeInBlocks', [
+        // The heights and widths are all power of 2
+        { src: { width: 2, height: 2 }, dst: { width: 2, height: 2 } },
+        // None of the widths or heights are power of 2
+        { src: { width: 15, height: 13 }, dst: { width: 15, height: 13 } },
+      ])
       .combine('copyBoxOffsets', kCopyBoxOffsetsFor2DArrayTextures)
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
-    const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const { textureSizeInBlocks, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     t.DoCopyTextureToTextureTest(
-      textureSize.srcTextureSize,
-      textureSize.dstTextureSize,
+      {
+        width: textureSizeInBlocks.src.width * blockWidth,
+        height: textureSizeInBlocks.src.height * blockHeight,
+        depthOrArrayLayers: 5,
+      },
+      {
+        width: textureSizeInBlocks.dst.width * blockWidth,
+        height: textureSizeInBlocks.dst.height * blockHeight,
+        depthOrArrayLayers: 5,
+      },
       format,
       copyBoxOffsets,
       srcCopyLevel,

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -666,19 +666,19 @@ g.test('color_textures,compressed,non_array')
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
       .combine('textureSizeInBlocks', [
-        // The heights and widths are all power of 2
+        // The heights and widths in blocks are all power of 2
         { src: { width: 16, height: 8 }, dst: { width: 16, height: 8 } },
-        // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
+        // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4 blocks
         { src: { width: 15, height: 8 }, dst: { width: 16, height: 8 } },
         // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
-        // of 4
+        // of 4 blocks
         { src: { width: 16, height: 8 }, dst: { width: 15, height: 8 } },
-        // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
+        // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4 blocks
         { src: { width: 16, height: 13 }, dst: { width: 16, height: 8 } },
         // The virtual height of the destination texture at mipmap level 2 (13) is not a
-        // multiple of 4
+        // multiple of 4 blocks
         { src: { width: 16, height: 8 }, dst: { width: 16, height: 13 } },
-        // None of the widths or heights are power of 2
+        // None of the widths or heights in blocks are power of 2
         { src: { width: 15, height: 13 }, dst: { width: 15, height: 13 } },
       ])
       .combine('copyBoxOffsets', kCopyBoxOffsetsForWholeDepth)
@@ -761,9 +761,9 @@ g.test('color_textures,compressed,array')
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
       .combine('textureSizeInBlocks', [
-        // The heights and widths are all power of 2
+        // The heights and widths in blocks are all power of 2
         { src: { width: 2, height: 2 }, dst: { width: 2, height: 2 } },
-        // None of the widths or heights are power of 2
+        // None of the widths or heights in blocks are power of 2
         { src: { width: 15, height: 13 }, dst: { width: 15, height: 13 } },
       ])
       .combine('copyBoxOffsets', kCopyBoxOffsetsFor2DArrayTextures)

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -506,11 +506,6 @@ g.test('texture_size,2d_texture,compressed_format')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    assert(
-      DefaultLimits.maxTextureDimension2D % info.blockWidth === 0 &&
-        DefaultLimits.maxTextureDimension2D % info.blockHeight === 0
-    );
-
     const descriptor: GPUTextureDescriptor = {
       size,
       dimension,

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -326,8 +326,14 @@ g.test('depth_stencil_copy_restrictions')
       .combine('dstCopyLevel', [0, 1])
   )
   .fn(async t => {
-    const { format, copyBoxOffsets, srcTextureSize, dstTextureSize, srcCopyLevel, dstCopyLevel } =
-      t.params;
+    const {
+      format,
+      copyBoxOffsets,
+      srcTextureSize,
+      dstTextureSize,
+      srcCopyLevel,
+      dstCopyLevel,
+    } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const kMipLevelCount = 3;

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -326,14 +326,8 @@ g.test('depth_stencil_copy_restrictions')
       .combine('dstCopyLevel', [0, 1])
   )
   .fn(async t => {
-    const {
-      format,
-      copyBoxOffsets,
-      srcTextureSize,
-      dstTextureSize,
-      srcCopyLevel,
-      dstCopyLevel,
-    } = t.params;
+    const { format, copyBoxOffsets, srcTextureSize, dstTextureSize, srcCopyLevel, dstCopyLevel } =
+      t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const kMipLevelCount = 3;
@@ -586,8 +580,13 @@ g.test('copy_ranges_with_compressed_texture_formats')
   .fn(async t => {
     const { format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
-    const kTextureSize = { width: 60, height: 48, depthOrArrayLayers: 3 };
+    const kTextureSize = {
+      width: 15 * blockWidth,
+      height: 12 * blockHeight,
+      depthOrArrayLayers: 3,
+    };
     const kMipLevelCount = 4;
 
     const srcTexture = t.device.createTexture({

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -125,8 +125,11 @@ const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtIn
   'depth24unorm-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth24unorm-stencil8'],
   'depth32float-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth32float-stencil8'],
 } as const);
-const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
+
+// Separated compressed formats by type
+const kBCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                         ] as const, {
+  // Block Compression (BC) formats
   'bc1-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
   'bc1-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
   'bc2-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
@@ -142,11 +145,58 @@ const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfo
   'bc7-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
   'bc7-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
 } as const);
+const kETC2TextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
+                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                           ] as const, {
+  // Ericsson Compression (ETC2) formats
+  'etc2-rgb8unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgb8unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgb8a1unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgb8a1unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgba8unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgba8unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+  'eac-r11unorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'eac-r11snorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'eac-rg11unorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+  'eac-rg11snorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+} as const);
+const kASTCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
+                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,             ,              ,                           ] as const, {
+  // Adaptable Scalable Compression (ASTC) formats
+  'astc-4x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc'],
+  'astc-4x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc'],
+  'astc-5x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc'],
+  'astc-5x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc'],
+  'astc-5x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc'],
+  'astc-5x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc'],
+  'astc-6x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc'],
+  'astc-6x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc'],
+  'astc-6x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc'],
+  'astc-6x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc'],
+  'astc-8x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc'],
+  'astc-8x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc'],
+  'astc-8x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc'],
+  'astc-8x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc'],
+  'astc-8x8-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc'],
+  'astc-8x8-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc'],
+  'astc-10x5-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc'],
+  'astc-10x5-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc'],
+  'astc-10x6-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc'],
+  'astc-10x6-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc'],
+  'astc-10x8-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc'],
+  'astc-10x8-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc'],
+  'astc-10x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc'],
+  'astc-10x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc'],
+  'astc-12x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc'],
+  'astc-12x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc'],
+  'astc-12x12-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc'],
+  'astc-12x12-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc'],
+} as const);
 
 // Definitions for use locally. To access the table entries, use `kTextureFormatInfo`.
 
 // TODO: Consider generating the exports below programmatically by filtering the big list, instead
 // of using these local constants? Requires some type magic though.
+/* prettier-ignore */ const   kCompressedTextureFormatInfo = { ...kBCTextureFormatInfo, ...kETC2TextureFormatInfo, ...kASTCTextureFormatInfo } as const;
 /* prettier-ignore */ const        kColorTextureFormatInfo = { ...kRegularTextureFormatInfo, ...kCompressedTextureFormatInfo } as const;
 /* prettier-ignore */ const    kEncodableTextureFormatInfo = { ...kRegularTextureFormatInfo, ...kSizedDepthStencilFormatInfo } as const;
 /* prettier-ignore */ const        kSizedTextureFormatInfo = { ...kRegularTextureFormatInfo, ...kSizedDepthStencilFormatInfo, ...kCompressedTextureFormatInfo } as const;

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -249,19 +249,29 @@ Tests that a BC format passes validation iff the feature is enabled.`
     );
   });
 
-g.test('gpu,with_texture_compression,etc')
+g.test('gpu,with_texture_compression,etc2')
   .desc(
     `Example of a test using a device descriptor.
-
-TODO: Test that an ETC format passes validation iff the feature is enabled.`
+Tests that an ETC2 format passes validation iff the feature is enabled.`
   )
-  .params(u => u.combine('textureCompressionETC', [false, true]))
+  .params(u => u.combine('textureCompressionETC2', [false, true]))
   .fn(async t => {
-    const { textureCompressionETC } = t.params;
+    const { textureCompressionETC2 } = t.params;
 
-    if (textureCompressionETC) {
-      await t.selectDeviceOrSkipTestCase('texture-compression-etc' as GPUFeatureName);
+    if (textureCompressionETC2) {
+      await t.selectDeviceOrSkipTestCase('texture-compression-etc2' as GPUFeatureName);
     }
 
-    // TODO: Should actually test createTexture with an ETC format here.
+    const shouldError = !textureCompressionETC2;
+    t.expectGPUError(
+      'validation',
+      () => {
+        t.device.createTexture({
+          format: 'etc2-rgb8unorm',
+          size: [4, 4, 1],
+          usage: GPUTextureUsage.TEXTURE_BINDING,
+        });
+      },
+      shouldError
+    );
   });


### PR DESCRIPTION
- Modifies texture sizes to be functions of the block sizes to generalize the tests.

Tests pass on dev build of Chromium with changes from https://chromium-review.googlesource.com/c/chromium/src/+/3219513 patched in on an Intel-Linux-Vulkan environment. (Currently this is one of the only environment combinations with the support enabled/available.)

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
