### PR TITLE
Add Chrome Origin Trial tokens

### DIFF
--- a/src/common/tools/dev_server.ts
+++ b/src/common/tools/dev_server.ts
@@ -90,6 +90,17 @@ watcher.on('change', dirtyCompileCache);
 
 const app = express();
 
+// Send Chrome Origin Trial tokens
+app.use((req, res, next) => {
+  res.header('Origin-Trial', [
+    // Token for http://localhost:8080
+    'AhE99tXCz7rNPbO9trRshOXiTObuhJOKUFfJi6mfwaVOlPJgsKyWSFUx7ZPzAWuNs4lEluGMIHpTD45OxcrrCQoAAABJeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODAiLCJmZWF0dXJlIjoiV2ViR1BVIiwiZXhwaXJ5IjoxNjQzMTU1MTk5fQ==',
+    // Token for http://localhost:8081
+    'AomphwDQ4T13IQ60e0AoVyx8nETxPfRb8KxRUHab+ZuRBqynAAu6WIV8x6uRQKZkuqTe4fG3adBOUXTK2dC7lg8AAABJeyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjgwODEiLCJmZWF0dXJlIjoiV2ViR1BVIiwiZXhwaXJ5IjoxNjQzMTU1MTk5fQ==',
+  ]);
+  next();
+});
+
 // Set up logging
 app.use(morgan('dev'));
 

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -12,6 +12,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins&display=swap" rel="stylesheet">
     <meta name="viewport" content="width=device-width" />
+    <!-- Chrome Origin Trial token for https://gpuweb.github.io (see dev_server.ts for localhost tokens) -->
+    <meta http-equiv="origin-trial" content="At6MXIsdbkOn9G7zcCbxYbgOwf4A8s3jBUW4cqnyDtzPnexBb1bdPkdDRtinADOTelA+/Fn3XEKutibMyzD0Kw0AAABQeyJvcmlnaW4iOiJodHRwczovL2dwdXdlYi5naXRodWIuaW86NDQzIiwiZmVhdHVyZSI6IldlYkdQVSIsImV4cGlyeSI6MTY0MzE1NTE5OX0=">
     <link rel="stylesheet" href="third_party/normalize.min.css" />
     <script src="third_party/jquery/jquery-3.3.1.min.js"></script>
     <style>


### PR DESCRIPTION
Allows the CTS to be run without a command line flag, from gpuweb.github.io or via the dev server (`npm start`).