### PR TITLE
shader/execution/builtin: Overhaul builtin tests

### DIFF
--- a/src/webgpu/shader/execution/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/builtin/abs.spec.ts
@@ -3,12 +3,18 @@ Execution Tests for the 'abs' builtin function
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { assert } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { NumberRepr } from '../../../util/conversion.js';
-import { generateTypes } from '../../types.js';
+import {
+  F32,
+  F32Bits,
+  I32Bits,
+  TypeF32,
+  TypeI32,
+  TypeU32,
+  U32Bits,
+} from '../../../util/conversion.js';
 
-import { kBit, kValue, runShaderTest } from './builtin.js';
+import { anyOf, kBit, kValue, run } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -26,61 +32,48 @@ Component-wise when T is a vector.
   )
   .params(u =>
     u
-      .combineWithParams([{ storageClass: 'storage', storageMode: 'read_write' }] as const)
-      .combine('containerType', ['scalar', 'vector'] as const)
-      .combine('isAtomic', [false])
-      .combine('baseType', ['u32'] as const)
-      .expandWithParams(generateTypes)
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    assert(t.params._kTypeInfo !== undefined, 'generated type is undefined');
-    runShaderTest(
-      t,
-      t.params.storageClass,
-      t.params.storageMode,
-      t.params.type,
-      t.params._kTypeInfo.arrayLength,
-      'abs',
-      Uint32Array,
-      /* prettier-ignore */ [
-        // Min and Max u32
-        {input: NumberRepr.fromU32Bits(kBit.u32.min), expected: [NumberRepr.fromU32Bits(kBit.u32.min)] },
-        {input: NumberRepr.fromU32Bits(kBit.u32.max), expected: [NumberRepr.fromU32Bits(kBit.u32.max)] },
-        // Powers of 2: -2^i: 0 =< i =< 31
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to0), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to0)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to1), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to1)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to2), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to2)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to3), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to3)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to4), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to4)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to5), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to5)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to6), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to6)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to7), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to7)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to8), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to8)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to9), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to9)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to10), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to10)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to11), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to11)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to12), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to12)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to13), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to13)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to14), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to14)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to15), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to15)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to16), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to16)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to17), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to17)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to18), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to18)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to19), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to19)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to20), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to20)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to21), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to21)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to22), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to22)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to23), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to23)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to24), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to24)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to25), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to25)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to26), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to26)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to27), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to27)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to28), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to28)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to29), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to29)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to30), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to30)] },
-        {input: NumberRepr.fromU32Bits(kBit.powTwo.to31), expected: [NumberRepr.fromU32Bits(kBit.powTwo.to31)] },
-      ]
-    );
+    run(t, 'abs', [TypeU32], TypeU32, t.params, [
+      // Min and Max u32
+      { input: U32Bits(kBit.u32.min), expected: U32Bits(kBit.u32.min) },
+      { input: U32Bits(kBit.u32.max), expected: U32Bits(kBit.u32.max) },
+      // Powers of 2: -2^i: 0 =< i =< 31
+      { input: U32Bits(kBit.powTwo.to0), expected: U32Bits(kBit.powTwo.to0) },
+      { input: U32Bits(kBit.powTwo.to1), expected: U32Bits(kBit.powTwo.to1) },
+      { input: U32Bits(kBit.powTwo.to2), expected: U32Bits(kBit.powTwo.to2) },
+      { input: U32Bits(kBit.powTwo.to3), expected: U32Bits(kBit.powTwo.to3) },
+      { input: U32Bits(kBit.powTwo.to4), expected: U32Bits(kBit.powTwo.to4) },
+      { input: U32Bits(kBit.powTwo.to5), expected: U32Bits(kBit.powTwo.to5) },
+      { input: U32Bits(kBit.powTwo.to6), expected: U32Bits(kBit.powTwo.to6) },
+      { input: U32Bits(kBit.powTwo.to7), expected: U32Bits(kBit.powTwo.to7) },
+      { input: U32Bits(kBit.powTwo.to8), expected: U32Bits(kBit.powTwo.to8) },
+      { input: U32Bits(kBit.powTwo.to9), expected: U32Bits(kBit.powTwo.to9) },
+      { input: U32Bits(kBit.powTwo.to10), expected: U32Bits(kBit.powTwo.to10) },
+      { input: U32Bits(kBit.powTwo.to11), expected: U32Bits(kBit.powTwo.to11) },
+      { input: U32Bits(kBit.powTwo.to12), expected: U32Bits(kBit.powTwo.to12) },
+      { input: U32Bits(kBit.powTwo.to13), expected: U32Bits(kBit.powTwo.to13) },
+      { input: U32Bits(kBit.powTwo.to14), expected: U32Bits(kBit.powTwo.to14) },
+      { input: U32Bits(kBit.powTwo.to15), expected: U32Bits(kBit.powTwo.to15) },
+      { input: U32Bits(kBit.powTwo.to16), expected: U32Bits(kBit.powTwo.to16) },
+      { input: U32Bits(kBit.powTwo.to17), expected: U32Bits(kBit.powTwo.to17) },
+      { input: U32Bits(kBit.powTwo.to18), expected: U32Bits(kBit.powTwo.to18) },
+      { input: U32Bits(kBit.powTwo.to19), expected: U32Bits(kBit.powTwo.to19) },
+      { input: U32Bits(kBit.powTwo.to20), expected: U32Bits(kBit.powTwo.to20) },
+      { input: U32Bits(kBit.powTwo.to21), expected: U32Bits(kBit.powTwo.to21) },
+      { input: U32Bits(kBit.powTwo.to22), expected: U32Bits(kBit.powTwo.to22) },
+      { input: U32Bits(kBit.powTwo.to23), expected: U32Bits(kBit.powTwo.to23) },
+      { input: U32Bits(kBit.powTwo.to24), expected: U32Bits(kBit.powTwo.to24) },
+      { input: U32Bits(kBit.powTwo.to25), expected: U32Bits(kBit.powTwo.to25) },
+      { input: U32Bits(kBit.powTwo.to26), expected: U32Bits(kBit.powTwo.to26) },
+      { input: U32Bits(kBit.powTwo.to27), expected: U32Bits(kBit.powTwo.to27) },
+      { input: U32Bits(kBit.powTwo.to28), expected: U32Bits(kBit.powTwo.to28) },
+      { input: U32Bits(kBit.powTwo.to29), expected: U32Bits(kBit.powTwo.to29) },
+      { input: U32Bits(kBit.powTwo.to30), expected: U32Bits(kBit.powTwo.to30) },
+      { input: U32Bits(kBit.powTwo.to31), expected: U32Bits(kBit.powTwo.to31) },
+    ]);
   });
 
 g.test('integer_builtin_functions,abs_signed')
@@ -98,64 +91,51 @@ If e evaluates to the largest negative value, then the result is e.
   )
   .params(u =>
     u
-      .combineWithParams([{ storageClass: 'storage', storageMode: 'read_write' }] as const)
-      .combine('containerType', ['scalar', 'vector'] as const)
-      .combine('isAtomic', [false])
-      .combine('baseType', ['i32'] as const)
-      .expandWithParams(generateTypes)
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    assert(t.params._kTypeInfo !== undefined, 'generated type is undefined');
-    runShaderTest(
-      t,
-      t.params.storageClass,
-      t.params.storageMode,
-      t.params.type,
-      t.params._kTypeInfo.arrayLength,
-      'abs',
-      Int32Array,
-      /* prettier-ignore */ [
-        // Min and max i32
-        // If e evaluates to the largest negative value, then the result is e.
-        {input: NumberRepr.fromI32Bits(kBit.i32.negative.min), expected: [NumberRepr.fromI32Bits(kBit.i32.negative.min)] },
-        {input: NumberRepr.fromI32Bits(kBit.i32.negative.max), expected: [NumberRepr.fromI32Bits(kBit.i32.positive.min)] },
-        {input: NumberRepr.fromI32Bits(kBit.i32.positive.max), expected: [NumberRepr.fromI32Bits(kBit.i32.positive.max)] },
-        {input: NumberRepr.fromI32Bits(kBit.i32.positive.min), expected: [NumberRepr.fromI32Bits(kBit.i32.positive.min)] },
-        // input: -1 * pow(2, n), n = {-31, ..., 0 }, expected: [pow(2, n), n = {-31, ..., 0}]
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to0), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to0)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to1), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to1)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to2), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to2)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to3), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to3)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to4), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to4)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to5), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to5)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to6), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to6)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to7), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to7)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to8), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to8)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to9), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to9)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to10), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to10)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to11), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to11)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to12), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to12)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to13), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to13)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to14), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to14)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to15), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to15)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to16), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to16)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to17), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to17)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to18), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to18)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to19), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to19)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to20), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to20)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to21), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to21)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to22), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to22)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to23), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to23)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to24), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to24)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to25), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to25)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to26), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to26)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to27), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to27)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to28), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to28)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to29), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to29)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to30), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to30)] },
-        {input: NumberRepr.fromI32Bits(kBit.negPowTwo.to31), expected: [NumberRepr.fromI32Bits(kBit.powTwo.to31)] },
-      ]
-    );
+    run(t, 'abs', [TypeI32], TypeI32, t.params, [
+      // Min and max i32
+      // If e evaluates to the largest negative value, then the result is e.
+      { input: I32Bits(kBit.i32.negative.min), expected: I32Bits(kBit.i32.negative.min) },
+      { input: I32Bits(kBit.i32.negative.max), expected: I32Bits(kBit.i32.positive.min) },
+      { input: I32Bits(kBit.i32.positive.max), expected: I32Bits(kBit.i32.positive.max) },
+      { input: I32Bits(kBit.i32.positive.min), expected: I32Bits(kBit.i32.positive.min) },
+      // input: -1 * pow(2, n), n = {-31, ..., 0 }, expected: pow(2, n), n = {-31, ..., 0}]
+      { input: I32Bits(kBit.negPowTwo.to0), expected: I32Bits(kBit.powTwo.to0) },
+      { input: I32Bits(kBit.negPowTwo.to1), expected: I32Bits(kBit.powTwo.to1) },
+      { input: I32Bits(kBit.negPowTwo.to2), expected: I32Bits(kBit.powTwo.to2) },
+      { input: I32Bits(kBit.negPowTwo.to3), expected: I32Bits(kBit.powTwo.to3) },
+      { input: I32Bits(kBit.negPowTwo.to4), expected: I32Bits(kBit.powTwo.to4) },
+      { input: I32Bits(kBit.negPowTwo.to5), expected: I32Bits(kBit.powTwo.to5) },
+      { input: I32Bits(kBit.negPowTwo.to6), expected: I32Bits(kBit.powTwo.to6) },
+      { input: I32Bits(kBit.negPowTwo.to7), expected: I32Bits(kBit.powTwo.to7) },
+      { input: I32Bits(kBit.negPowTwo.to8), expected: I32Bits(kBit.powTwo.to8) },
+      { input: I32Bits(kBit.negPowTwo.to9), expected: I32Bits(kBit.powTwo.to9) },
+      { input: I32Bits(kBit.negPowTwo.to10), expected: I32Bits(kBit.powTwo.to10) },
+      { input: I32Bits(kBit.negPowTwo.to11), expected: I32Bits(kBit.powTwo.to11) },
+      { input: I32Bits(kBit.negPowTwo.to12), expected: I32Bits(kBit.powTwo.to12) },
+      { input: I32Bits(kBit.negPowTwo.to13), expected: I32Bits(kBit.powTwo.to13) },
+      { input: I32Bits(kBit.negPowTwo.to14), expected: I32Bits(kBit.powTwo.to14) },
+      { input: I32Bits(kBit.negPowTwo.to15), expected: I32Bits(kBit.powTwo.to15) },
+      { input: I32Bits(kBit.negPowTwo.to16), expected: I32Bits(kBit.powTwo.to16) },
+      { input: I32Bits(kBit.negPowTwo.to17), expected: I32Bits(kBit.powTwo.to17) },
+      { input: I32Bits(kBit.negPowTwo.to18), expected: I32Bits(kBit.powTwo.to18) },
+      { input: I32Bits(kBit.negPowTwo.to19), expected: I32Bits(kBit.powTwo.to19) },
+      { input: I32Bits(kBit.negPowTwo.to20), expected: I32Bits(kBit.powTwo.to20) },
+      { input: I32Bits(kBit.negPowTwo.to21), expected: I32Bits(kBit.powTwo.to21) },
+      { input: I32Bits(kBit.negPowTwo.to22), expected: I32Bits(kBit.powTwo.to22) },
+      { input: I32Bits(kBit.negPowTwo.to23), expected: I32Bits(kBit.powTwo.to23) },
+      { input: I32Bits(kBit.negPowTwo.to24), expected: I32Bits(kBit.powTwo.to24) },
+      { input: I32Bits(kBit.negPowTwo.to25), expected: I32Bits(kBit.powTwo.to25) },
+      { input: I32Bits(kBit.negPowTwo.to26), expected: I32Bits(kBit.powTwo.to26) },
+      { input: I32Bits(kBit.negPowTwo.to27), expected: I32Bits(kBit.powTwo.to27) },
+      { input: I32Bits(kBit.negPowTwo.to28), expected: I32Bits(kBit.powTwo.to28) },
+      { input: I32Bits(kBit.negPowTwo.to29), expected: I32Bits(kBit.powTwo.to29) },
+      { input: I32Bits(kBit.negPowTwo.to30), expected: I32Bits(kBit.powTwo.to30) },
+      { input: I32Bits(kBit.negPowTwo.to31), expected: I32Bits(kBit.powTwo.to31) },
+    ]);
   });
 
 g.test('float_builtin_functions,abs_float')
@@ -172,103 +152,96 @@ Component-wise when T is a vector. (GLSLstd450Fabs)
   )
   .params(u =>
     u
-      .combineWithParams([{ storageClass: 'storage', storageMode: 'read_write' }] as const)
-      .combine('containerType', ['scalar', 'vector'] as const)
-      .combine('isAtomic', [false])
-      .combine('baseType', ['f32'] as const)
-      .expandWithParams(generateTypes)
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    assert(t.params._kTypeInfo !== undefined, 'generated type is undefined');
-    runShaderTest(
-      t,
-      t.params.storageClass,
-      t.params.storageMode,
-      t.params.type,
-      t.params._kTypeInfo.arrayLength,
-      'abs',
-      Float32Array,
-      /* prettier-ignore */ [
-        // Min and Max f32
-        {input: NumberRepr.fromF32Bits(kBit.f32.negative.max), expected: [NumberRepr.fromF32Bits(0x0080_0000)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.negative.min), expected: [NumberRepr.fromF32Bits(0x7f7f_ffff)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.positive.min), expected: [NumberRepr.fromF32Bits(kBit.f32.positive.min)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.positive.max), expected: [NumberRepr.fromF32Bits(kBit.f32.positive.max)] },
+    run(t, 'abs', [TypeF32], TypeF32, t.params, [
+      // Min and Max f32
+      { input: F32Bits(kBit.f32.negative.max), expected: F32Bits(0x0080_0000) },
+      { input: F32Bits(kBit.f32.negative.min), expected: F32Bits(0x7f7f_ffff) },
+      { input: F32Bits(kBit.f32.positive.min), expected: F32Bits(kBit.f32.positive.min) },
+      { input: F32Bits(kBit.f32.positive.max), expected: F32Bits(kBit.f32.positive.max) },
 
-        // Subnormal f32
-        // TODO(sarahM0): Check if this is needed (or if it has to fail). If yes add other values.
-        {input: NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.max), expected: [NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.max), NumberRepr.fromF32(0)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.min), expected: [NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.min), NumberRepr.fromF32(0)] },
+      // Subnormal f32
+      // TODO(sarahM0): Check if this is needed (or if it has to fail). If yes add other values.
+      {
+        input: F32Bits(kBit.f32.subnormal.positive.max),
+        expected: anyOf(F32Bits(kBit.f32.subnormal.positive.max), F32(0)),
+      },
+      {
+        input: F32Bits(kBit.f32.subnormal.positive.min),
+        expected: anyOf(F32Bits(kBit.f32.subnormal.positive.min), F32(0)),
+      },
 
-        // Infinity f32
-        {input: NumberRepr.fromF32Bits(kBit.f32.infinity.negative), expected: [NumberRepr.fromF32Bits(kBit.f32.infinity.positive)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.infinity.positive), expected: [NumberRepr.fromF32Bits(kBit.f32.infinity.positive)] },
+      // Infinity f32
+      { input: F32Bits(kBit.f32.infinity.negative), expected: F32Bits(kBit.f32.infinity.positive) },
+      { input: F32Bits(kBit.f32.infinity.positive), expected: F32Bits(kBit.f32.infinity.positive) },
 
-        // Powers of 2.0: -2.0^i: -1 >= i >= -31
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus1), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus1)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus2), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus2)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus3), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus3)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus4), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus4)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus5), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus5)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus6), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus6)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus7), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus7)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus8), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus8)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus9), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus9)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus10), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus10)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus11), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus11)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus12), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus12)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus13), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus13)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus14), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus14)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus15), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus15)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus16), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus16)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus17), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus17)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus18), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus18)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus19), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus19)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus20), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus20)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus21), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus21)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus22), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus22)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus23), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus23)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus24), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus24)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus25), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus25)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus26), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus26)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus27), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus27)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus28), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus28)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus29), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus29)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus30), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus30)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.toMinus31), expected: [NumberRepr.fromF32(kValue.powTwo.toMinus31)] },
+      // Powers of 2.0: -2.0^i: -1 >= i >= -31
+      { input: F32(kValue.negPowTwo.toMinus1), expected: F32(kValue.powTwo.toMinus1) },
+      { input: F32(kValue.negPowTwo.toMinus2), expected: F32(kValue.powTwo.toMinus2) },
+      { input: F32(kValue.negPowTwo.toMinus3), expected: F32(kValue.powTwo.toMinus3) },
+      { input: F32(kValue.negPowTwo.toMinus4), expected: F32(kValue.powTwo.toMinus4) },
+      { input: F32(kValue.negPowTwo.toMinus5), expected: F32(kValue.powTwo.toMinus5) },
+      { input: F32(kValue.negPowTwo.toMinus6), expected: F32(kValue.powTwo.toMinus6) },
+      { input: F32(kValue.negPowTwo.toMinus7), expected: F32(kValue.powTwo.toMinus7) },
+      { input: F32(kValue.negPowTwo.toMinus8), expected: F32(kValue.powTwo.toMinus8) },
+      { input: F32(kValue.negPowTwo.toMinus9), expected: F32(kValue.powTwo.toMinus9) },
+      { input: F32(kValue.negPowTwo.toMinus10), expected: F32(kValue.powTwo.toMinus10) },
+      { input: F32(kValue.negPowTwo.toMinus11), expected: F32(kValue.powTwo.toMinus11) },
+      { input: F32(kValue.negPowTwo.toMinus12), expected: F32(kValue.powTwo.toMinus12) },
+      { input: F32(kValue.negPowTwo.toMinus13), expected: F32(kValue.powTwo.toMinus13) },
+      { input: F32(kValue.negPowTwo.toMinus14), expected: F32(kValue.powTwo.toMinus14) },
+      { input: F32(kValue.negPowTwo.toMinus15), expected: F32(kValue.powTwo.toMinus15) },
+      { input: F32(kValue.negPowTwo.toMinus16), expected: F32(kValue.powTwo.toMinus16) },
+      { input: F32(kValue.negPowTwo.toMinus17), expected: F32(kValue.powTwo.toMinus17) },
+      { input: F32(kValue.negPowTwo.toMinus18), expected: F32(kValue.powTwo.toMinus18) },
+      { input: F32(kValue.negPowTwo.toMinus19), expected: F32(kValue.powTwo.toMinus19) },
+      { input: F32(kValue.negPowTwo.toMinus20), expected: F32(kValue.powTwo.toMinus20) },
+      { input: F32(kValue.negPowTwo.toMinus21), expected: F32(kValue.powTwo.toMinus21) },
+      { input: F32(kValue.negPowTwo.toMinus22), expected: F32(kValue.powTwo.toMinus22) },
+      { input: F32(kValue.negPowTwo.toMinus23), expected: F32(kValue.powTwo.toMinus23) },
+      { input: F32(kValue.negPowTwo.toMinus24), expected: F32(kValue.powTwo.toMinus24) },
+      { input: F32(kValue.negPowTwo.toMinus25), expected: F32(kValue.powTwo.toMinus25) },
+      { input: F32(kValue.negPowTwo.toMinus26), expected: F32(kValue.powTwo.toMinus26) },
+      { input: F32(kValue.negPowTwo.toMinus27), expected: F32(kValue.powTwo.toMinus27) },
+      { input: F32(kValue.negPowTwo.toMinus28), expected: F32(kValue.powTwo.toMinus28) },
+      { input: F32(kValue.negPowTwo.toMinus29), expected: F32(kValue.powTwo.toMinus29) },
+      { input: F32(kValue.negPowTwo.toMinus30), expected: F32(kValue.powTwo.toMinus30) },
+      { input: F32(kValue.negPowTwo.toMinus31), expected: F32(kValue.powTwo.toMinus31) },
 
-        // Powers of 2.0: -2.0^i: 1 <= i <= 31
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to1), expected: [NumberRepr.fromF32(kValue.powTwo.to1)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to2), expected: [NumberRepr.fromF32(kValue.powTwo.to2)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to3), expected: [NumberRepr.fromF32(kValue.powTwo.to3)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to4), expected: [NumberRepr.fromF32(kValue.powTwo.to4)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to5), expected: [NumberRepr.fromF32(kValue.powTwo.to5)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to6), expected: [NumberRepr.fromF32(kValue.powTwo.to6)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to7), expected: [NumberRepr.fromF32(kValue.powTwo.to7)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to8), expected: [NumberRepr.fromF32(kValue.powTwo.to8)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to9), expected: [NumberRepr.fromF32(kValue.powTwo.to9)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to10), expected: [NumberRepr.fromF32(kValue.powTwo.to10)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to11), expected: [NumberRepr.fromF32(kValue.powTwo.to11)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to12), expected: [NumberRepr.fromF32(kValue.powTwo.to12)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to13), expected: [NumberRepr.fromF32(kValue.powTwo.to13)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to14), expected: [NumberRepr.fromF32(kValue.powTwo.to14)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to15), expected: [NumberRepr.fromF32(kValue.powTwo.to15)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to16), expected: [NumberRepr.fromF32(kValue.powTwo.to16)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to17), expected: [NumberRepr.fromF32(kValue.powTwo.to17)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to18), expected: [NumberRepr.fromF32(kValue.powTwo.to18)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to19), expected: [NumberRepr.fromF32(kValue.powTwo.to19)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to20), expected: [NumberRepr.fromF32(kValue.powTwo.to20)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to21), expected: [NumberRepr.fromF32(kValue.powTwo.to21)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to22), expected: [NumberRepr.fromF32(kValue.powTwo.to22)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to23), expected: [NumberRepr.fromF32(kValue.powTwo.to23)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to24), expected: [NumberRepr.fromF32(kValue.powTwo.to24)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to25), expected: [NumberRepr.fromF32(kValue.powTwo.to25)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to26), expected: [NumberRepr.fromF32(kValue.powTwo.to26)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to27), expected: [NumberRepr.fromF32(kValue.powTwo.to27)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to28), expected: [NumberRepr.fromF32(kValue.powTwo.to28)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to29), expected: [NumberRepr.fromF32(kValue.powTwo.to29)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to30), expected: [NumberRepr.fromF32(kValue.powTwo.to30)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to31), expected: [NumberRepr.fromF32(kValue.powTwo.to31)] },
-      ]
-    );
+      // Powers of 2.0: -2.0^i: 1 <= i <= 31
+      { input: F32(kValue.negPowTwo.to1), expected: F32(kValue.powTwo.to1) },
+      { input: F32(kValue.negPowTwo.to2), expected: F32(kValue.powTwo.to2) },
+      { input: F32(kValue.negPowTwo.to3), expected: F32(kValue.powTwo.to3) },
+      { input: F32(kValue.negPowTwo.to4), expected: F32(kValue.powTwo.to4) },
+      { input: F32(kValue.negPowTwo.to5), expected: F32(kValue.powTwo.to5) },
+      { input: F32(kValue.negPowTwo.to6), expected: F32(kValue.powTwo.to6) },
+      { input: F32(kValue.negPowTwo.to7), expected: F32(kValue.powTwo.to7) },
+      { input: F32(kValue.negPowTwo.to8), expected: F32(kValue.powTwo.to8) },
+      { input: F32(kValue.negPowTwo.to9), expected: F32(kValue.powTwo.to9) },
+      { input: F32(kValue.negPowTwo.to10), expected: F32(kValue.powTwo.to10) },
+      { input: F32(kValue.negPowTwo.to11), expected: F32(kValue.powTwo.to11) },
+      { input: F32(kValue.negPowTwo.to12), expected: F32(kValue.powTwo.to12) },
+      { input: F32(kValue.negPowTwo.to13), expected: F32(kValue.powTwo.to13) },
+      { input: F32(kValue.negPowTwo.to14), expected: F32(kValue.powTwo.to14) },
+      { input: F32(kValue.negPowTwo.to15), expected: F32(kValue.powTwo.to15) },
+      { input: F32(kValue.negPowTwo.to16), expected: F32(kValue.powTwo.to16) },
+      { input: F32(kValue.negPowTwo.to17), expected: F32(kValue.powTwo.to17) },
+      { input: F32(kValue.negPowTwo.to18), expected: F32(kValue.powTwo.to18) },
+      { input: F32(kValue.negPowTwo.to19), expected: F32(kValue.powTwo.to19) },
+      { input: F32(kValue.negPowTwo.to20), expected: F32(kValue.powTwo.to20) },
+      { input: F32(kValue.negPowTwo.to21), expected: F32(kValue.powTwo.to21) },
+      { input: F32(kValue.negPowTwo.to22), expected: F32(kValue.powTwo.to22) },
+      { input: F32(kValue.negPowTwo.to23), expected: F32(kValue.powTwo.to23) },
+      { input: F32(kValue.negPowTwo.to24), expected: F32(kValue.powTwo.to24) },
+      { input: F32(kValue.negPowTwo.to25), expected: F32(kValue.powTwo.to25) },
+      { input: F32(kValue.negPowTwo.to26), expected: F32(kValue.powTwo.to26) },
+      { input: F32(kValue.negPowTwo.to27), expected: F32(kValue.powTwo.to27) },
+      { input: F32(kValue.negPowTwo.to28), expected: F32(kValue.powTwo.to28) },
+      { input: F32(kValue.negPowTwo.to29), expected: F32(kValue.powTwo.to29) },
+      { input: F32(kValue.negPowTwo.to30), expected: F32(kValue.powTwo.to30) },
+      { input: F32(kValue.negPowTwo.to31), expected: F32(kValue.powTwo.to31) },
+    ]);
   });

--- a/src/webgpu/shader/execution/builtin/all.spec.ts
+++ b/src/webgpu/shader/execution/builtin/all.spec.ts
@@ -3,113 +3,12 @@ Execution Tests for the 'all' builtin function
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { assert, TypedArrayBufferViewConstructor } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { NumberRepr, NumberType } from '../../../util/conversion.js';
-import { generateTypes } from '../../types.js';
+import { False, True, TypeBool, TypeVec, vec2, vec3, vec4 } from '../../../util/conversion.js';
 
-import { Case, runShaderTestImpl } from './builtin.js';
+import { run } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
-export function runShaderTest<F extends NumberType>(
-  t: GPUTest,
-  storageClass: string,
-  storageMode: string,
-  type: string,
-  arrayLength: number,
-  builtin: string,
-  arrayType: TypedArrayBufferViewConstructor,
-  cases: Array<Case<F>>
-): void {
-  const source = `
-    [[block]]
-    struct Data {
-      values : [[stride(16)]] array<${type}, ${cases.length}>;
-    };
-
-    [[group(0), binding(0)]] var<${storageClass}, ${storageMode}> inputs : Data;
-    [[group(0), binding(1)]] var<${storageClass}, write> outputs : Data;
-
-    let dim_mask = 0x000Fu; // bits 0 through 3
-    let pos0_field = 0x0010u; // bit 4
-    let pos1_field = 0x0020u; // bit 5
-    let pos2_field = 0x0040u; // bit 6
-    let pos3_field = 0x0080u; // bit 7
-
-    fn get_val(input: u32, field: u32) -> bool {
-      return field == (input & field);
-    }
-
-    fn test_scalar(input: u32) -> u32 {
-      let bool_input = get_val(input, pos0_field);
-      if (${builtin}(bool_input)) {
-        return 1u;
-      }
-      return 0u;
-    }
-    
-     fn test_vec2(input: u32) -> u32 {
-      let bool_input = vec2<bool>(get_val(input, pos0_field), 
-                                  get_val(input, pos1_field));
-      if (${builtin}(bool_input)) {
-        return 1u;
-      }
-      return 0u;
-    }
-
-     fn test_vec3(input: u32) -> u32 {
-      let bool_input = vec3<bool>(get_val(input, pos0_field), 
-                                  get_val(input, pos1_field),
-                                  get_val(input, pos2_field));
-      if (${builtin}(bool_input)) {
-        return 1u;
-      }
-      return 0u;
-    }
-    
-    fn test_vec4(input: u32) -> u32 {
-      let bool_input = vec4<bool>(get_val(input, pos0_field),
-                                  get_val(input, pos1_field),
-                                  get_val(input, pos2_field),
-                                  get_val(input, pos3_field));
-      if (${builtin}(bool_input)) {
-        return 1u;
-      }
-      return 0u;
-    }
-    
-    [[stage(compute), workgroup_size(1)]]
-    fn main() {
-      for(var i = 0; i < ${cases.length}; i = i + 1) {
-        let input : ${type} = inputs.values[i];
-        let dim : ${type} = input & dim_mask;
-        if (dim == 0u || dim == 1u) {
-          outputs.values[i] = test_scalar(inputs.values[i]);
-        } 
-        if (dim == 2u) {
-          outputs.values[i] = test_vec2(inputs.values[i]);
-        }
-        if (dim == 3u) {
-          outputs.values[i] = test_vec3(inputs.values[i]);
-        }
-        if (dim == 4u) {
-          outputs.values[i] = test_vec4(inputs.values[i]);
-        }
-      }
-    }
-  `;
-  runShaderTestImpl(
-    t,
-    storageClass,
-    storageMode,
-    type,
-    arrayLength,
-    builtin,
-    arrayType,
-    cases,
-    source
-  );
-}
 
 g.test('logical_builtin_functions,vector_all')
   .uniqueId('d140d173a2acf981')
@@ -122,72 +21,63 @@ e: vecN<bool> all(e): bool Returns true if each component of e is true. (OpAll)
   )
   .params(u =>
     u
-      .combineWithParams([{ storageClass: 'storage', storageMode: 'read_write' }] as const)
-      .combine('containerType', ['scalar'] as const)
-      .combine('isAtomic', [false])
-      .combine('baseType', ['u32'] as const)
-      .expandWithParams(generateTypes)
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
   )
   .fn(async t => {
-    assert(t.params._kTypeInfo !== undefined, 'generated type is undefined');
-    runShaderTest(
-      t,
-      t.params.storageClass,
-      t.params.storageMode,
-      t.params.type,
-      t.params._kTypeInfo.arrayLength,
-      'all',
-      Uint32Array,
-      /*
-       * Since bools are not host shareable, bit packing to/from u32s is
-       * required.
-       * Input format:
-       *   bits 0 to 3: number of dimensions of the vector to be passed in,
-       *                1 indicates use a scalar. Not all of the space is
-       *                needed, but makes it easier to read, since things are
-       *                aligned on hex digits.
-       *   bit 5: value for scalar or position 0 in vector
-       *   bit 6: value for position 1 in vector
-       *   bit 7: value for position 2 in vector
-       *   bit 8: value for position 3 in vector
-       * Output format:
-       *   bit 0: return value of all
-       */
-      /* prettier-ignore */ [
-        // Scalars
-        { input: NumberRepr.fromU32(0x01), expected: [NumberRepr.fromU32(0)] }, // F -> F
-        { input: NumberRepr.fromU32(0x11), expected: [NumberRepr.fromU32(1)] }, // T -> T
-        // vec2
-        { input: NumberRepr.fromU32(0x02), expected: [NumberRepr.fromU32(0)] }, // [ F, F ] -> F
-        { input: NumberRepr.fromU32(0x12), expected: [NumberRepr.fromU32(0)] }, // [ T, F ] -> F
-        { input: NumberRepr.fromU32(0x22), expected: [NumberRepr.fromU32(0)] }, // [ F, T ] -> F
-        { input: NumberRepr.fromU32(0x32), expected: [NumberRepr.fromU32(1)] }, // [ T, T ] -> T
-        // vec3
-        { input: NumberRepr.fromU32(0x03), expected: [NumberRepr.fromU32(0)] }, // [ F, F, F ] -> F
-        { input: NumberRepr.fromU32(0x13), expected: [NumberRepr.fromU32(0)] }, // [ T, F, F ] -> F
-        { input: NumberRepr.fromU32(0x23), expected: [NumberRepr.fromU32(0)] }, // [ F, T, F ] -> F
-        { input: NumberRepr.fromU32(0x33), expected: [NumberRepr.fromU32(0)] }, // [ T, T, F ] -> F
-        { input: NumberRepr.fromU32(0x43), expected: [NumberRepr.fromU32(0)] }, // [ F, F, T ] -> F
-        { input: NumberRepr.fromU32(0x53), expected: [NumberRepr.fromU32(0)] }, // [ T, F, T ] -> F
-        { input: NumberRepr.fromU32(0x63), expected: [NumberRepr.fromU32(0)] }, // [ F, T, T ] -> F
-        { input: NumberRepr.fromU32(0x73), expected: [NumberRepr.fromU32(1)] }, // [ T, T, T ] -> T
-        // vec4
-        { input: NumberRepr.fromU32(0x04), expected: [NumberRepr.fromU32(0)] }, // [ F, F, F, F ] -> F
-        { input: NumberRepr.fromU32(0x14), expected: [NumberRepr.fromU32(0)] }, // [ F, T, F, F ] -> F
-        { input: NumberRepr.fromU32(0x24), expected: [NumberRepr.fromU32(0)] }, // [ F, F, T, F ] -> F
-        { input: NumberRepr.fromU32(0x34), expected: [NumberRepr.fromU32(0)] }, // [ F, T, T, F ] -> F
-        { input: NumberRepr.fromU32(0x44), expected: [NumberRepr.fromU32(0)] }, // [ F, F, F, T ] -> F
-        { input: NumberRepr.fromU32(0x54), expected: [NumberRepr.fromU32(0)] }, // [ F, T, F, T ] -> F
-        { input: NumberRepr.fromU32(0x64), expected: [NumberRepr.fromU32(0)] }, // [ F, F, T, T ] -> F
-        { input: NumberRepr.fromU32(0x74), expected: [NumberRepr.fromU32(0)] }, // [ F, T, T, T ] -> F
-        { input: NumberRepr.fromU32(0x84), expected: [NumberRepr.fromU32(0)] }, // [ T, F, F, F ] -> F
-        { input: NumberRepr.fromU32(0x94), expected: [NumberRepr.fromU32(0)] }, // [ T, F, F, T ] -> F
-        { input: NumberRepr.fromU32(0xA4), expected: [NumberRepr.fromU32(0)] }, // [ T, F, T, F ] -> F
-        { input: NumberRepr.fromU32(0xB4), expected: [NumberRepr.fromU32(0)] }, // [ T, F, T, T ] -> F
-        { input: NumberRepr.fromU32(0xC4), expected: [NumberRepr.fromU32(0)] }, // [ T, T, F, F ] -> F
-        { input: NumberRepr.fromU32(0xD4), expected: [NumberRepr.fromU32(0)] }, // [ T, T, F, T ] -> F
-        { input: NumberRepr.fromU32(0xE4), expected: [NumberRepr.fromU32(0)] }, // [ T, T, T, F ] -> F
-        { input: NumberRepr.fromU32(0xF4), expected: [NumberRepr.fromU32(1)] }, // [ T, T, T, T ] -> T
-      ]
-    );
+    const overloads = {
+      scalar: {
+        type: TypeBool,
+        cases: [
+          { input: False, expected: False },
+          { input: True, expected: True },
+        ],
+      },
+      vec2: {
+        type: TypeVec(2, TypeBool),
+        cases: [
+          { input: vec2(False, True), expected: False },
+          { input: vec2(True, False), expected: False },
+          { input: vec2(False, True), expected: False },
+          { input: vec2(True, True), expected: True },
+        ],
+      },
+      vec3: {
+        type: TypeVec(3, TypeBool),
+        cases: [
+          { input: vec3(False, False, False), expected: False },
+          { input: vec3(True, False, False), expected: False },
+          { input: vec3(False, True, False), expected: False },
+          { input: vec3(True, True, False), expected: False },
+          { input: vec3(False, False, True), expected: False },
+          { input: vec3(True, False, True), expected: False },
+          { input: vec3(False, True, True), expected: False },
+          { input: vec3(True, True, True), expected: True },
+        ],
+      },
+      vec4: {
+        type: TypeVec(4, TypeBool),
+        cases: [
+          { input: vec4(False, False, False, False), expected: False },
+          { input: vec4(False, True, False, False), expected: False },
+          { input: vec4(False, False, True, False), expected: False },
+          { input: vec4(False, True, True, False), expected: False },
+          { input: vec4(False, False, False, True), expected: False },
+          { input: vec4(False, True, False, True), expected: False },
+          { input: vec4(False, False, True, True), expected: False },
+          { input: vec4(False, True, True, True), expected: False },
+          { input: vec4(True, False, False, False), expected: False },
+          { input: vec4(True, False, False, True), expected: False },
+          { input: vec4(True, False, True, False), expected: False },
+          { input: vec4(True, False, True, True), expected: False },
+          { input: vec4(True, True, False, False), expected: False },
+          { input: vec4(True, True, False, True), expected: False },
+          { input: vec4(True, True, True, False), expected: False },
+          { input: vec4(True, True, True, True), expected: True },
+        ],
+      },
+    };
+    const overload = overloads[t.params.overload];
+
+    run(t, 'all', [overload.type], TypeBool, t.params, overload.cases);
   });

--- a/src/webgpu/shader/execution/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/builtin/builtin.ts
@@ -1,53 +1,277 @@
 import { Colors } from '../../../../common/util/colors.js';
-import {
-  TypedArrayBufferView,
-  TypedArrayBufferViewConstructor,
-} from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { NumberType, NumberRepr } from '../../../util/conversion.js';
+import {
+  ScalarType,
+  Scalar,
+  Vector,
+  Value,
+  Type,
+  TypeVec,
+  TypeU32,
+  VectorType,
+} from '../../../util/conversion.js';
 
-export type Case<T extends NumberType> = {
-  input: NumberRepr<T>;
-  expected: Array<NumberRepr<T>>;
-};
+/** Comparison describes the result of a Comparator function. */
+export interface Comparison {
+  matched: boolean; // True if the two values were considered a match
+  got: string; // The string representation of the 'got' value (possibly with markup)
+  expected: string; // The string representation of the 'expected' value (possibly with markup)
+}
 
-export function runShaderTestImpl<F extends NumberType>(
-  t: GPUTest,
-  storageClass: string,
-  storageMode: string,
-  type: string,
-  arrayLength: number,
-  builtin: string,
-  arrayType: TypedArrayBufferViewConstructor,
-  cases: Array<Case<F>>,
-  source: string
-): void {
-  const inputData: TypedArrayBufferView = new arrayType(cases.length * 4);
+/** Comparator is a function that compares whether the provided value matches an expectation. */
+export interface Comparator {
+  (got: Value): Comparison;
+}
 
-  // an arbitrary approach of mapping cases into inputData:
-  // if the arrayLength > 1, ie. type is a vector, or matrix then
-  //   fill the i-th element with the input value of cases[i+j]
-  // if arrayLength = 1 or i+j > length of cases
-  //   fill the i-th element with input value of  cases[i]
-  // TODO(sarahM0): This is using a TypedArray to convert the value into bits,
-  // but NumberRepr already has bits. There's a chance some numbers won't get the same bit pattern both ways
-  // (having been converted from bits to double back to bits). Probably best to copy the bits in directly.
-  for (let i = 0; i < cases.length; i++) {
-    for (let j = 0; j < arrayLength; j++) {
-      inputData[i * 4 + j] = (i + j < cases.length
-        ? cases[i + j].input.value
-        : cases[i].input.value) as number;
+// diff compares 'got' to 'expected, returning the Comparison information.
+function diff(got: Value, expected: Value): Comparison {
+  {
+    // Check types
+    const gTy = got.type;
+    const eTy = expected.type;
+    if (gTy !== eTy) {
+      return {
+        matched: false,
+        got: `${Colors.red(gTy.toString())}(${got})`,
+        expected: `${Colors.red(eTy.toString())}(${expected})`,
+      };
     }
   }
 
-  const inputBuffer = t.makeBufferWithContents(
-    inputData,
-    GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE
+  if (got instanceof Scalar) {
+    const g = got;
+    const e = expected as Scalar;
+    if (g.value === e.value) {
+      return {
+        matched: true,
+        got: g.toString(),
+        expected: Colors.green(e.toString()),
+      };
+    }
+    return {
+      matched: false,
+      got: g.toString(),
+      expected: Colors.red(e.toString()),
+    };
+  }
+  if (got instanceof Vector) {
+    const gLen = got.elements.length;
+    const eLen = (expected as Vector).elements.length;
+    let matched = gLen === eLen;
+    const gElements = new Array<string>(gLen);
+    const eElements = new Array<string>(eLen);
+    for (let i = 0; i < Math.max(gLen, eLen); i++) {
+      if (i < gLen && i < eLen) {
+        const g = got.elements[i];
+        const e = (expected as Vector).elements[i];
+        const d = diff(g, e);
+        matched = matched && d.matched;
+        gElements[i] = d.got;
+        eElements[i] = d.expected;
+        continue;
+      }
+      matched = false;
+      if (i < gLen) {
+        gElements[i] = got.elements[i].toString();
+      }
+      if (i < eLen) {
+        eElements[i] = (expected as Vector).elements[i].toString();
+      }
+    }
+    return {
+      matched,
+      got: `${got.type}(${gElements.join(', ')})`,
+      expected: `${expected.type}(${eElements.join(', ')})`,
+    };
+  }
+  throw new Error(`unhandled type '${typeof got}`);
+}
+
+/** @returns a Comparator that checks whether a test value matches any of the provided values */
+export function anyOf(...values: Value[]): Comparator {
+  return got => {
+    const failed: Array<string> = [];
+    for (const e of values) {
+      const d = diff(got, e);
+      if (d.matched) {
+        return d;
+      }
+      failed.push(d.expected);
+    }
+    return { matched: false, got: got.toString(), expected: failed.join(' or ') };
+  };
+}
+
+// Helper for converting Values to Comparators.
+function toComparator(input: Value | Comparator): Comparator {
+  if ((input as Value).type !== undefined) {
+    return got => diff(got, input as Value);
+  }
+  return input as Comparator;
+}
+
+/** Case is a single builtin test case. */
+export type Case = {
+  // The input value to the builtin
+  input: Value | Array<Value>;
+  // The expected value, or comparator
+  expected: Value | Comparator;
+};
+
+/** CaseList is a list of Cases */
+export type CaseList = Array<Case>;
+
+/** Configuration for running a builtin test */
+export type Config = {
+  // Where the input values are read from
+  storageClass: 'uniform' | 'storage_r' | 'storage_rw';
+  // If defined, scalar test cases will be packed into vectors of the given width
+  vectorize?: number;
+};
+
+// Helper for returning the WGSL storage type for the given Type.
+function storageType(ty: Type): Type {
+  if (ty instanceof ScalarType) {
+    if (ty.kind === 'bool') {
+      return TypeU32;
+    }
+  }
+  if (ty instanceof VectorType) {
+    return TypeVec(ty.width, storageType(ty.elementType) as ScalarType);
+  }
+  return ty;
+}
+
+// Helper for converting a value of the type 'ty' from the storage type.
+function fromStorage(ty: Type, expr: string): string {
+  if (ty instanceof ScalarType) {
+    if (ty.kind === 'bool') {
+      return `${expr} != 0u`;
+    }
+  }
+  if (ty instanceof VectorType) {
+    if (ty.elementType.kind === 'bool') {
+      return `${expr} != vec${ty.width}<u32>(0u)`;
+    }
+  }
+  return expr;
+}
+
+// Helper for converting a value of the type 'ty' to the storage type.
+function toStorage(ty: Type, expr: string): string {
+  if (ty instanceof ScalarType) {
+    if (ty.kind === 'bool') {
+      return `select(0u, 1u, ${expr})`;
+    }
+  }
+  if (ty instanceof VectorType) {
+    if (ty.elementType.kind === 'bool') {
+      return `select(vec${ty.width}<u32>(0u), vec${ty.width}<u32>(0u), ${expr})`;
+    }
+  }
+  return expr;
+}
+
+/**
+ * Runs a builtin test
+ * @param t the GPUTest
+ * @param builtin the builtin being tested
+ * @param parameterTypes the list of builtin parameter types
+ * @param returnType the return type for the builtin overload
+ * @param cfg test configuration values
+ * @param cases list of test cases
+ */
+export function run(
+  t: GPUTest,
+  builtin: string,
+  parameterTypes: Array<Type>,
+  returnType: Type,
+  cfg: Config = { storageClass: 'storage_r' },
+  cases: CaseList
+) {
+  // If the 'vectorize' config option was provided, pack the cases into vectors.
+  if (cfg.vectorize !== undefined) {
+    cases = packScalarsToVector(cases, cfg.vectorize);
+    parameterTypes = [TypeVec(cfg.vectorize, parameterTypes[0] as ScalarType)];
+    returnType = TypeVec(cfg.vectorize, returnType as ScalarType);
+  }
+
+  // Currently all values are packed into buffers of 16 byte strides
+  const kValueStride = 16;
+
+  // returns the WGSL expression to load the ith parameter of the given type from the input buffer
+  const paramExpr = (ty: Type, i: number) => fromStorage(ty, `inputs.test[i].param${i}`);
+
+  // resolves to the expression that calls the builtin
+  const expr = toStorage(
+    returnType,
+    builtin + '(' + parameterTypes.map(paramExpr).join(', ') + ')'
   );
 
+  // the full WGSL shader source
+  const source = `
+struct Parameters {
+${parameterTypes
+  .map((ty, i) => `  [[size(${kValueStride})]] param${i} : ${storageType(ty)};`)
+  .join('\n')}
+};
+
+[[block]]
+struct Inputs {
+  test : array<Parameters, ${cases.length}>;
+};
+
+[[block]]
+struct Outputs {
+  test : [[stride(${kValueStride})]] array<${storageType(returnType)}, ${cases.length}>;
+};
+
+${
+  cfg.storageClass === 'uniform'
+    ? `[[group(0), binding(0)]] var<uniform> inputs : Inputs;`
+    : `[[group(0), binding(0)]] var<storage, ${
+        cfg.storageClass === 'storage_r' ? 'read' : 'read_write'
+      }> inputs : Inputs;`
+}
+[[group(0), binding(1)]] var<storage, write> outputs : Outputs;
+
+[[stage(compute), workgroup_size(1)]]
+fn main() {
+  for(var i = 0; i < ${cases.length}; i = i + 1) {
+    outputs.test[i] = ${expr};
+  }
+}
+`;
+
+  // Holds all the parameter values for all cases
+  const inputData = new Uint8Array(cases.length * parameterTypes.length * kValueStride);
+
+  // Pack all the input parameter values into the inputData buffer
+  {
+    const caseStride = kValueStride * parameterTypes.length;
+    for (let caseIdx = 0; caseIdx < cases.length; caseIdx++) {
+      const caseBase = caseIdx * caseStride;
+      for (let paramIdx = 0; paramIdx < parameterTypes.length; paramIdx++) {
+        const offset = caseBase + paramIdx * kValueStride;
+        const params = cases[caseIdx].input;
+        if (params instanceof Array) {
+          params[paramIdx].copyTo(inputData, offset);
+        } else {
+          params.copyTo(inputData, offset);
+        }
+      }
+    }
+  }
+  const inputBuffer = t.makeBufferWithContents(
+    inputData,
+    GPUBufferUsage.COPY_SRC |
+      (cfg.storageClass === 'uniform' ? GPUBufferUsage.UNIFORM : GPUBufferUsage.STORAGE)
+  );
+
+  // Construct a buffer to hold the results of the builtin tests
+  const outputBufferSize = cases.length * kValueStride;
   const outputBuffer = t.device.createBuffer({
-    // TODO(sarahM0): investigate why "size: cases.length*4*arrayLength" returns zero
-    size: inputData.length * 4,
+    size: outputBufferSize,
     usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
   });
 
@@ -73,94 +297,89 @@ export function runShaderTestImpl<F extends NumberType>(
 
   t.queue.submit([encoder.finish()]);
 
-  // Returns the string representation of num using the specified color.
-  const formatNum = (num: number | bigint, color = Colors.reset) => {
-    switch (num) {
-      case 0:
-      case Infinity:
-      case -Infinity:
-        return color.bold(num.toString());
-      default:
-        return color.bold(num.toString()) + color(' (0x' + num.toString(16) + ')');
+  const checkExpectation = (outputData: Uint8Array) => {
+    // Read the outputs from the output buffer
+    const outputs = new Array<Value>(cases.length);
+    for (let i = 0; i < cases.length; i++) {
+      outputs[i] = returnType.read(outputData, i * kValueStride);
     }
-  };
 
-  const checkExpectation = (outputData: typeof inputData) => {
     // The list of expectation failures
     const errs: string[] = [];
 
     // For each case...
-    for (let i = 0; i < cases.length; i++) {
-      // String representations of the input, output and expectation values for this case.
-      const inputValue: string[] = [];
-      const outputValue: string[] = [];
-      const expectedValue: string[] = [];
-      let caseMatched = true;
-
-      // For each element in the case...
-      for (let j = 0; j < arrayLength; j++) {
-        const idx = i * 4 + j;
-        const expectedIndex = i + j < cases.length ? i + j : i;
-        inputValue.push(formatNum(inputData[idx]));
-
-        // `cases[expectedIndex].expected` is an array of values that are treated as a pass.
-        // Do any of these expected values match?
-        const elementMatched = cases[expectedIndex].expected.some(e => e.value === outputData[idx]);
-        outputValue.push(formatNum(outputData[idx], elementMatched ? Colors.green : Colors.red));
-
-        const caseExpected: string[] = [];
-        for (const e of cases[expectedIndex].expected) {
-          if (outputData[idx] === e.value) {
-            // This expected value matched
-            caseExpected.push(formatNum(e.value, Colors.green));
-          } else if (elementMatched) {
-            // The element matched, but it wasn't for this value.
-            caseExpected.push(formatNum(e.value, Colors.grey));
-          } else {
-            // The element did not match any expected value
-            caseExpected.push(formatNum(e.value, Colors.red));
-          }
-        }
-        expectedValue.push(caseExpected.join(' or '));
-
-        // If none of the expected values matched, then the case has failed.
-        caseMatched = caseMatched && elementMatched;
-      }
-
-      if (!caseMatched) {
-        if (arrayLength > 1) {
-          errs.push(
-            `${builtin}(${type}(${inputValue.join(', ')}))\n` +
-              `    returned: ${type}(${outputValue.join(', ')})\n` +
-              `    expected: ${type}(${expectedValue.join(', ')})`
-          );
-        } else {
-          errs.push(
-            `${builtin}(${inputValue.join(', ')})\n` +
-              `    returned: ${outputValue.join(', ')}\n` +
-              `    expected: ${expectedValue.join(', ')}`
-          );
-        }
+    for (let caseIdx = 0; caseIdx < cases.length; caseIdx++) {
+      const c = cases[caseIdx];
+      const got = outputs[caseIdx];
+      const cmp = toComparator(c.expected)(got);
+      if (!cmp.matched) {
+        errs.push(`${builtin}(${c.input instanceof Array ? c.input.join(', ') : c.input})
+    returned: ${cmp.got}
+    expected: ${cmp.expected}`);
       }
     }
 
-    if (errs.length > 0) {
-      return new Error(errs.join('\n\n'));
-    }
-    return undefined;
+    return errs.length > 0 ? new Error(errs.join('\n\n')) : undefined;
   };
 
   t.expectGPUBufferValuesPassCheck(outputBuffer, checkExpectation, {
-    type: arrayType,
-    typedLength: inputData.length,
+    type: Uint8Array,
+    typedLength: outputBufferSize,
   });
 }
 
+// Packs a list of scalar test cases into a smaller list of vector cases.
+export function packScalarsToVector(cases: CaseList, vectorWidth: number): CaseList {
+  const asScalar = function (val: Array<Value> | Value): Scalar {
+    if (val instanceof Scalar) {
+      return val;
+    }
+    if (val instanceof Array && val.length === 1) {
+      return asScalar(val[0]);
+    }
+    throw new Error('packScalarsToVector() requires all Case values to be a single scalar Value');
+  };
+  const clampCaseIdx = (idx: number) => Math.min(idx, cases.length - 1);
+  const packed: Array<Case> = [];
+  let caseIdx = 0;
+  while (caseIdx < cases.length) {
+    const inputElements = new Array<Scalar>(vectorWidth);
+    const comparators = new Array<Comparator>(vectorWidth);
+    for (let i = 0; i < vectorWidth; i++) {
+      const c = cases[clampCaseIdx(caseIdx + i)];
+      inputElements[i] = asScalar(c.input);
+      comparators[i] = toComparator(c.expected);
+    }
+    const vec = new Vector(inputElements);
+    packed.push({
+      input: [vec],
+      expected: (got: Value) => {
+        let matched = true;
+        const gElements = new Array<string>(vectorWidth);
+        const eElements = new Array<string>(vectorWidth);
+        for (let i = 0; i < vectorWidth; i++) {
+          const d = comparators[i]((got as Vector).elements[i]);
+          matched = matched && d.matched;
+          gElements[i] = d.got;
+          eElements[i] = d.expected;
+        }
+        return {
+          matched,
+          got: `${vec.type}(${gElements.join(', ')})`,
+          expected: `${vec.type}(${eElements.join(', ')})`,
+        };
+      },
+    });
+    caseIdx += vectorWidth;
+  }
+  return packed;
+}
+
 // TODO(sarahM0): Perhaps instead of kBit and kValue tables we could have one table
-// where every value is a NumberRepr instead of either bits or value?
-// Then tests wouldn't need most of the NumberRepr.fromX calls,
+// where every value is a Scalar instead of either bits or value?
+// Then tests wouldn't need most of the Scalar.fromX calls,
 // and you would probably need fewer table entries in total
-// (since each NumberRepr has both bits and value).
+// (since each Scalar has both bits and value).
 export const kBit = {
   // Limits of int32
   i32: {
@@ -492,45 +711,4 @@ export const kValue = {
     toMinus31: -Math.pow(2, -31),
     toMinus32: -Math.pow(2, -32),
   },
-};
-
-export function runShaderTest<F extends NumberType>(
-  t: GPUTest,
-  storageClass: string,
-  storageMode: string,
-  type: string,
-  arrayLength: number,
-  builtin: string,
-  arrayType: TypedArrayBufferViewConstructor,
-  cases: Array<Case<F>>
-): void {
-  const source = `
-    [[block]]
-    struct Data {
-      values : [[stride(16)]] array<${type}, ${cases.length}>;
-    };
-
-    [[group(0), binding(0)]] var<${storageClass}, ${storageMode}> inputs : Data;
-    [[group(0), binding(1)]] var<${storageClass}, write> outputs : Data;
-
-    [[stage(compute), workgroup_size(1)]]
-    fn main() {
-      for(var i = 0; i < ${cases.length}; i = i + 1) {
-          let input : ${type} = inputs.values[i];
-          let result : ${type} = ${builtin}(input);
-          outputs.values[i] = result;
-      }
-    }
-  `;
-  runShaderTestImpl(
-    t,
-    storageClass,
-    storageMode,
-    type,
-    arrayLength,
-    builtin,
-    arrayType,
-    cases,
-    source
-  );
-}
+} as const;

--- a/src/webgpu/shader/execution/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/builtin/ceil.spec.ts
@@ -3,12 +3,10 @@ Execution Tests for the 'ceil' builtin function
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { assert } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { NumberRepr } from '../../../util/conversion.js';
-import { generateTypes } from '../../types.js';
+import { F32, F32Bits, TypeF32 } from '../../../util/conversion.js';
 
-import { kBit, kValue, runShaderTest } from './builtin.js';
+import { anyOf, kBit, kValue, run } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -26,114 +24,101 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
   )
   .params(u =>
     u
-      .combineWithParams([{ storageClass: 'storage', storageMode: 'read_write' }] as const)
-      .combine('containerType', ['scalar', 'vector'] as const)
-      .combine('isAtomic', [false])
-      .combine('baseType', ['f32'] as const)
-      .expandWithParams(generateTypes)
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    assert(t.params._kTypeInfo !== undefined, 'generated type is undefined');
-    runShaderTest(
-      t,
-      t.params.storageClass,
-      t.params.storageMode,
-      t.params.type,
-      t.params._kTypeInfo.arrayLength,
-      'ceil',
-      Float32Array,
-      /* prettier-ignore */ [
-        // Small positive numbers
-        {input: NumberRepr.fromF32(0.1), expected: [NumberRepr.fromF32(1.0)] },
-        {input: NumberRepr.fromF32(0.9), expected: [NumberRepr.fromF32(1.0)] },
-        {input: NumberRepr.fromF32(1.1), expected: [NumberRepr.fromF32(2.0)] },
-        {input: NumberRepr.fromF32(1.9), expected: [NumberRepr.fromF32(2.0)] },
+    run(t, 'ceil', [TypeF32], TypeF32, t.params, [
+      // Small positive numbers
+      { input: F32(0.1), expected: F32(1.0) },
+      { input: F32(0.9), expected: F32(1.0) },
+      { input: F32(1.1), expected: F32(2.0) },
+      { input: F32(1.9), expected: F32(2.0) },
 
-        // Small negative numbers
-        {input: NumberRepr.fromF32(-0.1), expected: [NumberRepr.fromF32(0.0)] },
-        {input: NumberRepr.fromF32(-0.9), expected: [NumberRepr.fromF32(0.0)] },
-        {input: NumberRepr.fromF32(-1.1), expected: [NumberRepr.fromF32(-1.0)] },
-        {input: NumberRepr.fromF32(-1.9), expected: [NumberRepr.fromF32(-1.0)] },
+      // Small negative numbers
+      { input: F32(-0.1), expected: F32(0.0) },
+      { input: F32(-0.9), expected: F32(0.0) },
+      { input: F32(-1.1), expected: F32(-1.0) },
+      { input: F32(-1.9), expected: F32(-1.0) },
 
-        // Min and Max f32
-        {input: NumberRepr.fromF32Bits(kBit.f32.negative.max), expected: [NumberRepr.fromF32(0.0)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.negative.min), expected: [NumberRepr.fromF32Bits(kBit.f32.negative.min)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.positive.min), expected: [NumberRepr.fromF32(1.0)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.positive.max), expected: [NumberRepr.fromF32Bits(kBit.f32.positive.max)] },
+      // Min and Max f32
+      { input: F32Bits(kBit.f32.negative.max), expected: F32(0.0) },
+      { input: F32Bits(kBit.f32.negative.min), expected: F32Bits(kBit.f32.negative.min) },
+      { input: F32Bits(kBit.f32.positive.min), expected: F32(1.0) },
+      { input: F32Bits(kBit.f32.positive.max), expected: F32Bits(kBit.f32.positive.max) },
 
-        // Subnormal f32
-        {input: NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.max), expected: [NumberRepr.fromF32(1.0), NumberRepr.fromF32(0.0)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.subnormal.positive.min), expected: [NumberRepr.fromF32(1.0), NumberRepr.fromF32(0.0)] },
+      // Subnormal f32
+      { input: F32Bits(kBit.f32.subnormal.positive.max), expected: anyOf(F32(1.0), F32(0.0)) },
+      { input: F32Bits(kBit.f32.subnormal.positive.min), expected: anyOf(F32(1.0), F32(0.0)) },
 
-        // Infinity f32
-        {input: NumberRepr.fromF32Bits(kBit.f32.infinity.negative), expected: [NumberRepr.fromF32Bits(kBit.f32.infinity.negative)] },
-        {input: NumberRepr.fromF32Bits(kBit.f32.infinity.positive), expected: [NumberRepr.fromF32Bits(kBit.f32.infinity.positive)] },
+      // Infinity f32
+      { input: F32Bits(kBit.f32.infinity.negative), expected: F32Bits(kBit.f32.infinity.negative) },
+      { input: F32Bits(kBit.f32.infinity.positive), expected: F32Bits(kBit.f32.infinity.positive) },
 
-        // Powers of +2.0: 2.0^i: 1 <= i <= 31
-        {input: NumberRepr.fromF32(kValue.powTwo.to1), expected: [NumberRepr.fromF32(kValue.powTwo.to1)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to2), expected: [NumberRepr.fromF32(kValue.powTwo.to2)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to3), expected: [NumberRepr.fromF32(kValue.powTwo.to3)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to4), expected: [NumberRepr.fromF32(kValue.powTwo.to4)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to5), expected: [NumberRepr.fromF32(kValue.powTwo.to5)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to6), expected: [NumberRepr.fromF32(kValue.powTwo.to6)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to7), expected: [NumberRepr.fromF32(kValue.powTwo.to7)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to8), expected: [NumberRepr.fromF32(kValue.powTwo.to8)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to9), expected: [NumberRepr.fromF32(kValue.powTwo.to9)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to10), expected: [NumberRepr.fromF32(kValue.powTwo.to10)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to11), expected: [NumberRepr.fromF32(kValue.powTwo.to11)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to12), expected: [NumberRepr.fromF32(kValue.powTwo.to12)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to13), expected: [NumberRepr.fromF32(kValue.powTwo.to13)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to14), expected: [NumberRepr.fromF32(kValue.powTwo.to14)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to15), expected: [NumberRepr.fromF32(kValue.powTwo.to15)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to16), expected: [NumberRepr.fromF32(kValue.powTwo.to16)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to17), expected: [NumberRepr.fromF32(kValue.powTwo.to17)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to18), expected: [NumberRepr.fromF32(kValue.powTwo.to18)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to19), expected: [NumberRepr.fromF32(kValue.powTwo.to19)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to20), expected: [NumberRepr.fromF32(kValue.powTwo.to20)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to21), expected: [NumberRepr.fromF32(kValue.powTwo.to21)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to22), expected: [NumberRepr.fromF32(kValue.powTwo.to22)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to23), expected: [NumberRepr.fromF32(kValue.powTwo.to23)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to24), expected: [NumberRepr.fromF32(kValue.powTwo.to24)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to25), expected: [NumberRepr.fromF32(kValue.powTwo.to25)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to26), expected: [NumberRepr.fromF32(kValue.powTwo.to26)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to27), expected: [NumberRepr.fromF32(kValue.powTwo.to27)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to28), expected: [NumberRepr.fromF32(kValue.powTwo.to28)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to29), expected: [NumberRepr.fromF32(kValue.powTwo.to29)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to30), expected: [NumberRepr.fromF32(kValue.powTwo.to30)] },
-        {input: NumberRepr.fromF32(kValue.powTwo.to31), expected: [NumberRepr.fromF32(kValue.powTwo.to31)] },
+      // Powers of +2.0: 2.0^i: 1 <= i <= 31
+      { input: F32(kValue.powTwo.to1), expected: F32(kValue.powTwo.to1) },
+      { input: F32(kValue.powTwo.to2), expected: F32(kValue.powTwo.to2) },
+      { input: F32(kValue.powTwo.to3), expected: F32(kValue.powTwo.to3) },
+      { input: F32(kValue.powTwo.to4), expected: F32(kValue.powTwo.to4) },
+      { input: F32(kValue.powTwo.to5), expected: F32(kValue.powTwo.to5) },
+      { input: F32(kValue.powTwo.to6), expected: F32(kValue.powTwo.to6) },
+      { input: F32(kValue.powTwo.to7), expected: F32(kValue.powTwo.to7) },
+      { input: F32(kValue.powTwo.to8), expected: F32(kValue.powTwo.to8) },
+      { input: F32(kValue.powTwo.to9), expected: F32(kValue.powTwo.to9) },
+      { input: F32(kValue.powTwo.to10), expected: F32(kValue.powTwo.to10) },
+      { input: F32(kValue.powTwo.to11), expected: F32(kValue.powTwo.to11) },
+      { input: F32(kValue.powTwo.to12), expected: F32(kValue.powTwo.to12) },
+      { input: F32(kValue.powTwo.to13), expected: F32(kValue.powTwo.to13) },
+      { input: F32(kValue.powTwo.to14), expected: F32(kValue.powTwo.to14) },
+      { input: F32(kValue.powTwo.to15), expected: F32(kValue.powTwo.to15) },
+      { input: F32(kValue.powTwo.to16), expected: F32(kValue.powTwo.to16) },
+      { input: F32(kValue.powTwo.to17), expected: F32(kValue.powTwo.to17) },
+      { input: F32(kValue.powTwo.to18), expected: F32(kValue.powTwo.to18) },
+      { input: F32(kValue.powTwo.to19), expected: F32(kValue.powTwo.to19) },
+      { input: F32(kValue.powTwo.to20), expected: F32(kValue.powTwo.to20) },
+      { input: F32(kValue.powTwo.to21), expected: F32(kValue.powTwo.to21) },
+      { input: F32(kValue.powTwo.to22), expected: F32(kValue.powTwo.to22) },
+      { input: F32(kValue.powTwo.to23), expected: F32(kValue.powTwo.to23) },
+      { input: F32(kValue.powTwo.to24), expected: F32(kValue.powTwo.to24) },
+      { input: F32(kValue.powTwo.to25), expected: F32(kValue.powTwo.to25) },
+      { input: F32(kValue.powTwo.to26), expected: F32(kValue.powTwo.to26) },
+      { input: F32(kValue.powTwo.to27), expected: F32(kValue.powTwo.to27) },
+      { input: F32(kValue.powTwo.to28), expected: F32(kValue.powTwo.to28) },
+      { input: F32(kValue.powTwo.to29), expected: F32(kValue.powTwo.to29) },
+      { input: F32(kValue.powTwo.to30), expected: F32(kValue.powTwo.to30) },
+      { input: F32(kValue.powTwo.to31), expected: F32(kValue.powTwo.to31) },
 
-        // Powers of -2.0: -2.0^i: 1 <= i <= 31
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to1), expected: [NumberRepr.fromF32(kValue.negPowTwo.to1)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to2), expected: [NumberRepr.fromF32(kValue.negPowTwo.to2)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to3), expected: [NumberRepr.fromF32(kValue.negPowTwo.to3)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to4), expected: [NumberRepr.fromF32(kValue.negPowTwo.to4)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to5), expected: [NumberRepr.fromF32(kValue.negPowTwo.to5)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to6), expected: [NumberRepr.fromF32(kValue.negPowTwo.to6)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to7), expected: [NumberRepr.fromF32(kValue.negPowTwo.to7)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to8), expected: [NumberRepr.fromF32(kValue.negPowTwo.to8)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to9), expected: [NumberRepr.fromF32(kValue.negPowTwo.to9)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to10), expected: [NumberRepr.fromF32(kValue.negPowTwo.to10)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to11), expected: [NumberRepr.fromF32(kValue.negPowTwo.to11)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to12), expected: [NumberRepr.fromF32(kValue.negPowTwo.to12)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to13), expected: [NumberRepr.fromF32(kValue.negPowTwo.to13)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to14), expected: [NumberRepr.fromF32(kValue.negPowTwo.to14)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to15), expected: [NumberRepr.fromF32(kValue.negPowTwo.to15)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to16), expected: [NumberRepr.fromF32(kValue.negPowTwo.to16)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to17), expected: [NumberRepr.fromF32(kValue.negPowTwo.to17)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to18), expected: [NumberRepr.fromF32(kValue.negPowTwo.to18)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to19), expected: [NumberRepr.fromF32(kValue.negPowTwo.to19)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to20), expected: [NumberRepr.fromF32(kValue.negPowTwo.to20)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to21), expected: [NumberRepr.fromF32(kValue.negPowTwo.to21)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to22), expected: [NumberRepr.fromF32(kValue.negPowTwo.to22)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to23), expected: [NumberRepr.fromF32(kValue.negPowTwo.to23)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to24), expected: [NumberRepr.fromF32(kValue.negPowTwo.to24)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to25), expected: [NumberRepr.fromF32(kValue.negPowTwo.to25)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to26), expected: [NumberRepr.fromF32(kValue.negPowTwo.to26)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to27), expected: [NumberRepr.fromF32(kValue.negPowTwo.to27)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to28), expected: [NumberRepr.fromF32(kValue.negPowTwo.to28)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to29), expected: [NumberRepr.fromF32(kValue.negPowTwo.to29)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to30), expected: [NumberRepr.fromF32(kValue.negPowTwo.to30)] },
-        {input: NumberRepr.fromF32(kValue.negPowTwo.to31), expected: [NumberRepr.fromF32(kValue.negPowTwo.to31)] },
-      ]
-    );
+      // Powers of -2.0: -2.0^i: 1 <= i <= 31
+      { input: F32(kValue.negPowTwo.to1), expected: F32(kValue.negPowTwo.to1) },
+      { input: F32(kValue.negPowTwo.to2), expected: F32(kValue.negPowTwo.to2) },
+      { input: F32(kValue.negPowTwo.to3), expected: F32(kValue.negPowTwo.to3) },
+      { input: F32(kValue.negPowTwo.to4), expected: F32(kValue.negPowTwo.to4) },
+      { input: F32(kValue.negPowTwo.to5), expected: F32(kValue.negPowTwo.to5) },
+      { input: F32(kValue.negPowTwo.to6), expected: F32(kValue.negPowTwo.to6) },
+      { input: F32(kValue.negPowTwo.to7), expected: F32(kValue.negPowTwo.to7) },
+      { input: F32(kValue.negPowTwo.to8), expected: F32(kValue.negPowTwo.to8) },
+      { input: F32(kValue.negPowTwo.to9), expected: F32(kValue.negPowTwo.to9) },
+      { input: F32(kValue.negPowTwo.to10), expected: F32(kValue.negPowTwo.to10) },
+      { input: F32(kValue.negPowTwo.to11), expected: F32(kValue.negPowTwo.to11) },
+      { input: F32(kValue.negPowTwo.to12), expected: F32(kValue.negPowTwo.to12) },
+      { input: F32(kValue.negPowTwo.to13), expected: F32(kValue.negPowTwo.to13) },
+      { input: F32(kValue.negPowTwo.to14), expected: F32(kValue.negPowTwo.to14) },
+      { input: F32(kValue.negPowTwo.to15), expected: F32(kValue.negPowTwo.to15) },
+      { input: F32(kValue.negPowTwo.to16), expected: F32(kValue.negPowTwo.to16) },
+      { input: F32(kValue.negPowTwo.to17), expected: F32(kValue.negPowTwo.to17) },
+      { input: F32(kValue.negPowTwo.to18), expected: F32(kValue.negPowTwo.to18) },
+      { input: F32(kValue.negPowTwo.to19), expected: F32(kValue.negPowTwo.to19) },
+      { input: F32(kValue.negPowTwo.to20), expected: F32(kValue.negPowTwo.to20) },
+      { input: F32(kValue.negPowTwo.to21), expected: F32(kValue.negPowTwo.to21) },
+      { input: F32(kValue.negPowTwo.to22), expected: F32(kValue.negPowTwo.to22) },
+      { input: F32(kValue.negPowTwo.to23), expected: F32(kValue.negPowTwo.to23) },
+      { input: F32(kValue.negPowTwo.to24), expected: F32(kValue.negPowTwo.to24) },
+      { input: F32(kValue.negPowTwo.to25), expected: F32(kValue.negPowTwo.to25) },
+      { input: F32(kValue.negPowTwo.to26), expected: F32(kValue.negPowTwo.to26) },
+      { input: F32(kValue.negPowTwo.to27), expected: F32(kValue.negPowTwo.to27) },
+      { input: F32(kValue.negPowTwo.to28), expected: F32(kValue.negPowTwo.to28) },
+      { input: F32(kValue.negPowTwo.to29), expected: F32(kValue.negPowTwo.to29) },
+      { input: F32(kValue.negPowTwo.to30), expected: F32(kValue.negPowTwo.to30) },
+      { input: F32(kValue.negPowTwo.to31), expected: F32(kValue.negPowTwo.to31) },
+    ]);
   });

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -1,4 +1,5 @@
-import { assert } from '../../common/util/util.js';
+import { Colors } from '../../common/util/colors.js';
+import { assert, TypedArrayBufferView } from '../../common/util/util.js';
 
 import { clamp } from './math.js';
 
@@ -223,124 +224,303 @@ export function uint32ToInt32(u32: number): number {
   return i32Arr[0];
 }
 
-/** A type of number representable by NumberRepr. */
-export type NumberType =
-  | 'f64'
-  | 'f32'
-  | 'f16'
-  | 'u64'
-  | 'u32'
-  | 'u16'
-  | 'u8'
-  | 'i64'
-  | 'i32'
-  | 'i16'
-  | 'i8';
+/** A type of number representable by Scalar. */
+export type ScalarKind = 'f32' | 'f16' | 'u32' | 'u16' | 'u8' | 'i32' | 'i16' | 'i8' | 'bool';
 
-/** Figures out the type that NumberRepr uses to represent its numeric value. */
-type NumberReprValue<T extends NumberType> = T extends 'u64' | 'i64' ? bigint : number;
-/** Figures out the TypedArray type that NumberRepr uses to represent its bit representation. */
-type NumberReprBits<T extends NumberType> = T extends 'u64' | 'i64' | 'f64'
-  ? BigUint64Array
-  : T extends 'u32' | 'i32' | 'f32'
-  ? Uint32Array
-  : T extends 'u16' | 'i16' | 'f16'
-  ? Uint16Array
-  : Uint8Array;
+/** ScalarType describes the type of WGSL Scalar. */
+export class ScalarType {
+  readonly kind: ScalarKind; // The named type
+  readonly size: number; // In bytes
+  readonly read: (buf: Uint8Array, offset: number) => Scalar; // reads a scalar from a buffer
 
-/**
- * Class that encapsulates a single number of various types. Exposes:
- * - the actual numeric value (as a JS `number`, or `bigint` if it's u64/i64)
- * - the bit representation of the number, as a TypedArray of size 1 with the appropriate type.
- */
-export class NumberRepr<T extends NumberType> {
-  readonly value: NumberReprValue<T>;
-  readonly bits: NumberReprBits<T>;
-
-  private constructor(value: NumberReprValue<T>, bits: NumberReprBits<T>) {
-    this.value = value;
-    this.bits = bits;
+  constructor(kind: ScalarKind, size: number, read: (buf: Uint8Array, offset: number) => Scalar) {
+    this.kind = kind;
+    this.size = size;
+    this.read = read;
   }
 
-  /** Create an f64 from a numeric value, a JS `number`. */
-  static fromF64(value: number) {
-    return new NumberRepr<'f64'>(value, new BigUint64Array(new Float64Array([value]).buffer));
-  }
-  /** Create an f32 from a numeric value, a JS `number`. */
-  static fromF32(value: number) {
-    return new NumberRepr<'f32'>(value, new Uint32Array(new Float32Array([value]).buffer));
-  }
-
-  /** Create an f64 from a bit representation, a uint64 represented as a JS `bigint`. */
-  static fromF64Bits(bits: bigint) {
-    const abv = new BigUint64Array([bits]);
-    return new NumberRepr<'f64'>(new Float64Array(abv.buffer)[0], abv);
-  }
-  /** Create an f32 from a bit representation, a uint32 represented as a JS `number`. */
-  static fromF32Bits(bits: number) {
-    const abv = new Uint32Array([bits]);
-    return new NumberRepr<'f32'>(new Float32Array(abv.buffer)[0], abv);
-  }
-  /** Create an f16 from a bit representation, a uint16 represented as a JS `number`. */
-  static fromF16Bits(bits: number) {
-    return new NumberRepr<'f16'>(float16BitsToFloat32(bits), new Uint16Array(bits));
-  }
-
-  /** Create an i32 from a numeric value, a JS `number`. */
-  static fromI32(value: number) {
-    return new NumberRepr<'i32'>(value, new Uint32Array(new Int32Array([value]).buffer));
-  }
-  /** Create an i16 from a numeric value, a JS `number`. */
-  static fromI16(value: number) {
-    return new NumberRepr<'i16'>(value, new Uint16Array(new Int16Array([value]).buffer));
-  }
-  /** Create an i8 from a numeric value, a JS `number`. */
-  static fromI8(value: number) {
-    return new NumberRepr<'i8'>(value, new Uint8Array(new Int8Array([value]).buffer));
-  }
-
-  /** Create an i32 from a bit representation, a uint32 represented as a JS `number`. */
-  static fromI32Bits(bits: number) {
-    const abv = new Uint32Array([bits]);
-    return new NumberRepr<'i32'>(new Int32Array(abv.buffer)[0], abv);
-  }
-  /** Create an i16 from a bit representation, a uint16 represented as a JS `number`. */
-  static fromI16Bits(bits: number) {
-    const abv = new Uint16Array([bits]);
-    return new NumberRepr<'i16'>(new Int16Array(abv.buffer)[0], abv);
-  }
-  /** Create an i8 from a bit representation, a uint8 represented as a JS `number`. */
-  static fromI8Bits(bits: number) {
-    const abv = new Uint8Array([bits]);
-    return new NumberRepr<'i8'>(new Int8Array(abv.buffer)[0], abv);
-  }
-
-  /** Create a u32 from a numeric value, a JS `number`. */
-  static fromU32(value: number) {
-    return new NumberRepr<'u32'>(value, new Uint32Array(value));
-  }
-  /** Create a u16 from a numeric value, a JS `number`. */
-  static fromU16(value: number) {
-    return new NumberRepr<'u16'>(value, new Uint16Array(value));
-  }
-  /** Create a u8 from a numeric value, a JS `number`. */
-  static fromU8(value: number) {
-    return new NumberRepr<'u8'>(value, new Uint8Array(value));
-  }
-
-  /** Create a u32 from a bit representation, a uint32 represented as a JS `number`. */
-  static fromU32Bits(bits: number) {
-    const abv = new Uint32Array([bits]);
-    return new NumberRepr<'u32'>(new Uint32Array(abv.buffer)[0], abv);
-  }
-  /** Create a u16 from a bit representation, a uint16 represented as a JS `number`. */
-  static fromU16Bits(bits: number) {
-    const abv = new Uint16Array([bits]);
-    return new NumberRepr<'u16'>(new Uint16Array(abv.buffer)[0], abv);
-  }
-  /** Create a u8 from a bit representation, a uint8 represented as a JS `number`. */
-  static fromU8Bits(bits: number) {
-    const abv = new Uint8Array([bits]);
-    return new NumberRepr<'u8'>(new Uint8Array(abv.buffer)[0], abv);
+  public toString(): string {
+    return this.kind;
   }
 }
+
+/** ScalarType describes the type of WGSL Vector. */
+export class VectorType {
+  readonly width: number; // Number of elements in the vector
+  readonly elementType: ScalarType; // Element type
+
+  constructor(width: number, elementType: ScalarType) {
+    this.width = width;
+    this.elementType = elementType;
+  }
+
+  /**
+   * @returns a vector constructed from the values read from the buffer at the
+   * given byte offset
+   */
+  public read(buf: Uint8Array, offset: number): Vector {
+    const elements: Array<Scalar> = [];
+    for (let i = 0; i < this.width; i++) {
+      elements[i] = this.elementType.read(buf, offset);
+      offset += this.elementType.size;
+    }
+    return new Vector(elements);
+  }
+
+  public toString(): string {
+    return `vec${this.width}<${this.elementType}>`;
+  }
+}
+
+const vectorTypes = new Map<{ width: number; elementType: ScalarType }, VectorType>();
+
+export function TypeVec(width: number, elementType: ScalarType): VectorType {
+  const key = { width, elementType };
+  let ty = vectorTypes.get(key);
+  if (ty !== undefined) {
+    return ty;
+  }
+  ty = new VectorType(width, elementType);
+  vectorTypes.set(key, ty);
+  return ty;
+}
+
+/** Type is a ScalarType or VectorType. */
+export type Type = ScalarType | VectorType;
+
+export const TypeI32 = new ScalarType('i32', 4, (buf: Uint8Array, offset: number) =>
+  I32(new Int32Array(buf.buffer, offset)[0])
+);
+export const TypeU32 = new ScalarType('u32', 4, (buf: Uint8Array, offset: number) =>
+  U32(new Uint32Array(buf.buffer, offset)[0])
+);
+export const TypeF32 = new ScalarType('f32', 4, (buf: Uint8Array, offset: number) =>
+  F32(new Float32Array(buf.buffer, offset)[0])
+);
+export const TypeI16 = new ScalarType('i16', 2, (buf: Uint8Array, offset: number) =>
+  I16(new Int16Array(buf.buffer, offset)[0])
+);
+export const TypeU16 = new ScalarType('u16', 2, (buf: Uint8Array, offset: number) =>
+  U16(new Uint16Array(buf.buffer, offset)[0])
+);
+export const TypeF16 = new ScalarType('f16', 2, (buf: Uint8Array, offset: number) =>
+  F16Bits(new Uint16Array(buf.buffer, offset)[0])
+);
+export const TypeI8 = new ScalarType('i8', 1, (buf: Uint8Array, offset: number) =>
+  I8(new Int8Array(buf.buffer, offset)[0])
+);
+export const TypeU8 = new ScalarType('u8', 1, (buf: Uint8Array, offset: number) =>
+  U8(new Uint8Array(buf.buffer, offset)[0])
+);
+export const TypeBool = new ScalarType('bool', 4, (buf: Uint8Array, offset: number) =>
+  Bool(new Uint32Array(buf.buffer, offset)[0] !== 0)
+);
+
+/** @returns the number of scalar (element) types of the given Type */
+export function numElementsOf(ty: Type): number {
+  if (ty instanceof ScalarType) {
+    return 1;
+  }
+  if (ty instanceof VectorType) {
+    return ty.width;
+  }
+  throw new Error(`unhandled type ${ty}`);
+}
+
+/** @returns the scalar (element) type of the given Type */
+export function scalarTypeOf(ty: Type): ScalarType {
+  if (ty instanceof ScalarType) {
+    return ty;
+  }
+  if (ty instanceof VectorType) {
+    return ty.elementType;
+  }
+  throw new Error(`unhandled type ${ty}`);
+}
+
+/** ScalarValue is the JS type that can be held by a Scalar */
+type ScalarValue = Boolean | Number;
+
+/** Class that encapsulates a single scalar value of various types. */
+export class Scalar {
+  readonly value: ScalarValue; // The scalar value
+  readonly type: ScalarType; // The type of the scalar
+  readonly bits: Uint8Array; // The scalar value packed in a Uint8Array
+
+  public constructor(type: ScalarType, value: ScalarValue, bits: TypedArrayBufferView) {
+    this.value = value;
+    this.type = type;
+    this.bits = new Uint8Array(bits.buffer);
+  }
+
+  /**
+   * Copies the scalar value to the Uint8Array buffer at the provided byte offset.
+   * @param buffer the destination buffer
+   * @param offset the byte offset within buffer
+   */
+  public copyTo(buffer: Uint8Array, offset: number) {
+    for (let i = 0; i < this.bits.length; i++) {
+      buffer[offset + i] = this.bits[i];
+    }
+  }
+
+  public toString(): string {
+    if (this.type.kind === 'bool') {
+      return Colors.bold(this.value.toString());
+    }
+    switch (this.value) {
+      case 0:
+      case Infinity:
+      case -Infinity:
+        return Colors.bold(this.value.toString());
+      default:
+        return Colors.bold(this.value.toString()) + ' (0x' + this.value.toString(16) + ')';
+    }
+  }
+}
+
+/** Create an f32 from a numeric value, a JS `number`. */
+export function F32(value: number): Scalar {
+  return new Scalar(TypeF32, value, new Float32Array([value]));
+}
+/** Create an f32 from a bit representation, a uint32 represented as a JS `number`. */
+export function F32Bits(bits: number): Scalar {
+  const arr = new Uint32Array([bits]);
+  return new Scalar(TypeF32, new Float32Array(arr.buffer)[0], arr);
+}
+/** Create an f16 from a bit representation, a uint16 represented as a JS `number`. */
+export function F16Bits(bits: number): Scalar {
+  const arr = new Uint32Array([bits]);
+  return new Scalar(TypeF16, float16BitsToFloat32(bits), arr);
+}
+
+/** Create an i32 from a numeric value, a JS `number`. */
+export function I32(value: number): Scalar {
+  return new Scalar(TypeI32, value, new Int32Array([value]));
+}
+/** Create an i16 from a numeric value, a JS `number`. */
+export function I16(value: number): Scalar {
+  return new Scalar(TypeI16, value, new Int16Array([value]));
+}
+/** Create an i8 from a numeric value, a JS `number`. */
+export function I8(value: number): Scalar {
+  return new Scalar(TypeI8, value, new Int8Array([value]));
+}
+
+/** Create an i32 from a bit representation, a uint32 represented as a JS `number`. */
+export function I32Bits(bits: number): Scalar {
+  const arr = new Uint32Array([bits]);
+  return new Scalar(TypeI32, new Int32Array(arr.buffer)[0], arr);
+}
+/** Create an i16 from a bit representation, a uint16 represented as a JS `number`. */
+export function I16Bits(bits: number): Scalar {
+  const arr = new Uint16Array([bits]);
+  return new Scalar(TypeI16, new Int16Array(arr.buffer)[0], arr);
+}
+/** Create an i8 from a bit representation, a uint8 represented as a JS `number`. */
+export function I8Bits(bits: number): Scalar {
+  const arr = new Uint8Array([bits]);
+  return new Scalar(TypeI8, new Int8Array(arr.buffer)[0], arr);
+}
+
+/** Create a u32 from a numeric value, a JS `number`. */
+export function U32(value: number): Scalar {
+  return new Scalar(TypeU32, value, new Uint32Array([value]));
+}
+/** Create a u16 from a numeric value, a JS `number`. */
+export function U16(value: number): Scalar {
+  return new Scalar(TypeU16, value, new Uint16Array([value]));
+}
+/** Create a u8 from a numeric value, a JS `number`. */
+export function U8(value: number): Scalar {
+  return new Scalar(TypeU8, value, new Uint8Array([value]));
+}
+
+/** Create an u32 from a bit representation, a uint32 represented as a JS `number`. */
+export function U32Bits(bits: number): Scalar {
+  const arr = new Uint32Array([bits]);
+  return new Scalar(TypeU32, bits, arr);
+}
+/** Create an u16 from a bit representation, a uint16 represented as a JS `number`. */
+export function U16Bits(bits: number): Scalar {
+  const arr = new Uint16Array([bits]);
+  return new Scalar(TypeU16, bits, arr);
+}
+/** Create an u8 from a bit representation, a uint8 represented as a JS `number`. */
+export function U8Bits(bits: number): Scalar {
+  const arr = new Uint8Array([bits]);
+  return new Scalar(TypeU8, bits, arr);
+}
+
+/** Create a boolean value. */
+export function Bool(value: boolean): Scalar {
+  // WGSL does not support using 'bool' types directly in storage / uniform
+  // buffers, so instead we pack booleans in a u32, where 'false' is zero and
+  // 'true' is any non-zero value.
+  return new Scalar(TypeBool, value, new Uint32Array([value ? 1 : 0]));
+}
+
+/** A 'true' literal value */
+export const True = Bool(true);
+
+/** A 'false' literal value */
+export const False = Bool(false);
+
+/**
+ * Class that encapsulates a vector value.
+ */
+export class Vector {
+  readonly elements: Array<Scalar>;
+  readonly type: VectorType;
+
+  public constructor(elements: Array<Scalar>) {
+    if (elements.length < 2 || elements.length > 4) {
+      throw new Error(`vector element count must be between 2 and 4, got ${elements.length}`);
+    }
+    for (let i = 1; i < elements.length; i++) {
+      const a = elements[0].type;
+      const b = elements[i].type;
+      if (a !== b) {
+        throw new Error(
+          `cannot mix vector element types. Found elements with types '${a}' and '${b}'`
+        );
+      }
+    }
+    this.elements = elements;
+    this.type = TypeVec(elements.length, elements[0].type);
+  }
+
+  /**
+   * Copies the vector value to the Uint8Array buffer at the provided byte offset.
+   * @param buffer the destination buffer
+   * @param offset the byte offset within buffer
+   */
+  public copyTo(buffer: Uint8Array, offset: number) {
+    for (const element of this.elements) {
+      element.copyTo(buffer, offset);
+      offset += this.type.elementType.size;
+    }
+  }
+
+  public toString(): string {
+    return `${this.type}(${this.elements.map(e => e.toString()).join(', ')})`;
+  }
+}
+
+/** Helper for constructing a new two-element vector with the provided values */
+export function vec2(x: Scalar, y: Scalar) {
+  return new Vector([x, y]);
+}
+
+/** Helper for constructing a new three-element vector with the provided values */
+export function vec3(x: Scalar, y: Scalar, z: Scalar) {
+  return new Vector([x, y, z]);
+}
+
+/** Helper for constructing a new four-element vector with the provided values */
+export function vec4(x: Scalar, y: Scalar, z: Scalar, w: Scalar) {
+  return new Vector([x, y, z, w]);
+}
+
+/** Value is a Scalar or Vector value. */
+export type Value = Scalar | Vector;


### PR DESCRIPTION
`NumberRepr` has been replaced with `Scalar`, `Vector`, `ScalarType` and `VectorType`, and a whole bunch of helpers.
These new types provide a cleaner set of primitives to construct test cases, and allows us to consolidate the test logic for all builtin types (instead of an entirely new test for each overload flavor).

Update all the existing builtin tests to use the new framework.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
