### PR TITLE
Implement `any` tests

### DIFF
--- a/src/webgpu/shader/execution/builtin/all.spec.ts
+++ b/src/webgpu/shader/execution/builtin/all.spec.ts
@@ -36,7 +36,7 @@ e: vecN<bool> all(e): bool Returns true if each component of e is true. (OpAll)
       vec2: {
         type: TypeVec(2, TypeBool),
         cases: [
-          { input: vec2(False, True), expected: False },
+          { input: vec2(False, False), expected: False },
           { input: vec2(True, False), expected: False },
           { input: vec2(False, True), expected: False },
           { input: vec2(True, True), expected: True },

--- a/src/webgpu/shader/execution/builtin/any.spec.ts
+++ b/src/webgpu/shader/execution/builtin/any.spec.ts
@@ -1,0 +1,86 @@
+export const description = `
+Execution Tests for the 'any' builtin function
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+import { False, True, TypeBool, TypeVec, vec2, vec3, vec4 } from '../../../util/conversion.js';
+
+import { run } from './builtin.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('logical_builtin_functions,vector_any')
+  .uniqueId('ac2b3a100379d70f')
+  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions')
+  .desc(
+    `
+vector any:
+e: vecN<bool> any(e): bool Returns true if any component of e is true. (OpAny)
+
+Please read the following guidelines before contributing:
+https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
+`
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
+  )
+  .fn(async t => {
+    const overloads = {
+      scalar: {
+        type: TypeBool,
+        cases: [
+          { input: False, expected: False },
+          { input: True, expected: True },
+        ],
+      },
+      vec2: {
+        type: TypeVec(2, TypeBool),
+        cases: [
+          { input: vec2(False, False), expected: False },
+          { input: vec2(True, False), expected: True },
+          { input: vec2(False, True), expected: True },
+          { input: vec2(True, True), expected: True },
+        ],
+      },
+      vec3: {
+        type: TypeVec(3, TypeBool),
+        cases: [
+          { input: vec3(False, False, False), expected: False },
+          { input: vec3(True, False, False), expected: True },
+          { input: vec3(False, True, False), expected: True },
+          { input: vec3(True, True, False), expected: True },
+          { input: vec3(False, False, True), expected: True },
+          { input: vec3(True, False, True), expected: True },
+          { input: vec3(False, True, True), expected: True },
+          { input: vec3(True, True, True), expected: True },
+        ],
+      },
+      vec4: {
+        type: TypeVec(4, TypeBool),
+        cases: [
+          { input: vec4(False, False, False, False), expected: False },
+          { input: vec4(False, True, False, False), expected: True },
+          { input: vec4(False, False, True, False), expected: True },
+          { input: vec4(False, True, True, False), expected: True },
+          { input: vec4(False, False, False, True), expected: True },
+          { input: vec4(False, True, False, True), expected: True },
+          { input: vec4(False, False, True, True), expected: True },
+          { input: vec4(False, True, True, True), expected: True },
+          { input: vec4(True, False, False, False), expected: True },
+          { input: vec4(True, False, False, True), expected: True },
+          { input: vec4(True, False, True, False), expected: True },
+          { input: vec4(True, False, True, True), expected: True },
+          { input: vec4(True, True, False, False), expected: True },
+          { input: vec4(True, True, False, True), expected: True },
+          { input: vec4(True, True, True, False), expected: True },
+          { input: vec4(True, True, True, True), expected: True },
+        ],
+      },
+    };
+    const overload = overloads[t.params.overload];
+
+    run(t, 'any', [overload.type], TypeBool, t.params, overload.cases);
+  });

--- a/src/webgpu/shader/execution/builtin/logical_built_in_functions.spec.ts
+++ b/src/webgpu/shader/execution/builtin/logical_built_in_functions.spec.ts
@@ -5,21 +5,6 @@ import { GPUTest } from '../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('logical_builtin_functions,vector_any')
-  .uniqueId('ac2b3a100379d70f')
-  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions')
-  .desc(
-    `
-vector any:
-e: vecN<bool> any(e): bool Returns true if any component of e is true. (OpAny)
-
-Please read the following guidelines before contributing:
-https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
-`
-  )
-  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
-  .unimplemented();
-
 g.test('logical_builtin_functions,scalar_select')
   .uniqueId('50b1f627c11098a1')
   .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#logical-builtin-functions')


### PR DESCRIPTION
Also includes a small fix for a test case in `all` that these tests are based off of.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
