### PR TITLE
wgsl: Add invariant attribute validation tests

### DIFF
--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -10,7 +10,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 // List of all built-in variables and their stage, in|out usage, and type.
 // Taken from table in Section 15:
 // https://www.w3.org/TR/2021/WD-WGSL-20211013/#builtin-variables
-const kBuiltins = [
+export const kBuiltins = [
   { name: 'vertex_index', stage: 'vertex', io: 'in', type: 'u32' },
   { name: 'instance_index', stage: 'vertex', io: 'in', type: 'u32' },
   { name: 'position', stage: 'vertex', io: 'out', type: 'vec4<f32>' },

--- a/src/webgpu/shader/validation/shader_io/invariant.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/invariant.spec.ts
@@ -1,0 +1,63 @@
+export const description = `Validation tests for the invariant attribute`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { kBuiltins } from './builtins.spec.js';
+import { generateShader } from './util.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('valid_only_with_vertex_position_builtin')
+  .desc(`Test that the invariant attribute is only accepted with the vertex position builtin`)
+  .params(u =>
+    u
+      .combineWithParams(kBuiltins)
+      .combine('use_struct', [true, false] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    const code = generateShader({
+      attribute: `[[builtin(${t.params.name}), invariant]]`,
+      type: t.params.type,
+      stage: t.params.stage,
+      io: t.params.io,
+      use_struct: t.params.use_struct,
+    });
+
+    t.expectCompileResult(t.params.name === 'position', code);
+  });
+
+g.test('not_valid_on_user_defined_io')
+  .desc(`Test that the invariant attribute is not accepted on user-defined IO attributes.`)
+  .params(u => u.combine('use_invariant', [true, false] as const).beginSubcases())
+  .fn(t => {
+    const invariant = t.params.use_invariant ? '[[invariant]]' : '';
+    const code = `
+    struct VertexOut {
+      [[location(0)]] ${invariant} loc0 : vec4<f32>;
+      [[builtin(position)]] position : vec4<f32>;
+    };
+    [[stage(vertex)]]
+    fn main() -> VertexOut {
+      return VertexOut();
+    }
+    `;
+    t.expectCompileResult(!t.params.use_invariant, code);
+  });
+
+g.test('invalid_use_of_parameters')
+  .desc(`Test that no parameters are accepted for the invariant attribute`)
+  .params(u => u.combine('suffix', ['', '()', '(0)'] as const).beginSubcases())
+  .fn(t => {
+    const code = `
+    struct VertexOut {
+      [[builtin(position), invariant${t.params.suffix}]] position : vec4<f32>;
+    };
+    [[stage(vertex)]]
+    fn main() -> VertexOut {
+      return VertexOut();
+    }
+    `;
+    t.expectCompileResult(t.params.suffix === '', code);
+  });


### PR DESCRIPTION
Validate that invariant is only accepted on the position builtin, and
without any parameters.

Tested on macOS with ToT Chromium.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
