### PR TITLE
Implement `min()` tests for integer types

### DIFF
--- a/src/webgpu/shader/execution/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/builtin/builtin.ts
@@ -158,7 +158,8 @@ export type Config = {
   // Where the input values are read from
   storageClass: 'uniform' | 'storage_r' | 'storage_rw';
   // If defined, scalar test cases will be packed into vectors of the given width.
-  // Requires that all input cases are of a single scalar parameter type.
+  // Requires that all parameters of the builtin overload are of a scalar type,
+  // and the return type of the builtin overload is also a scalar type.
   // If the number of test cases is not a multiple of the vector width, then the
   // last scalar value is repeated to fill the last vector value.
   vectorize?: number;
@@ -232,10 +233,10 @@ export function run(
 
   // If the 'vectorize' config option was provided, pack the cases into vectors.
   if (cfg.vectorize !== undefined) {
-    // Note: packScalarsToVector() would have thrown if parameters aren't of a single scalar type
-    cases = packScalarsToVector(cases, cfg.vectorize, cmpFloats);
-    parameterTypes = [TypeVec(cfg.vectorize, parameterTypes[0] as ScalarType)];
-    returnType = TypeVec(cfg.vectorize, returnType as ScalarType);
+    const packed = packScalarsToVector(parameterTypes, returnType, cases, cfg.vectorize, cmpFloats);
+    cases = packed.cases;
+    parameterTypes = packed.parameterTypes;
+    returnType = packed.returnType;
   }
 
   // Currently all values are packed into buffers of 16 byte strides
@@ -372,58 +373,84 @@ fn main() {
 
 /**
  * Packs a list of scalar test cases into a smaller list of vector cases.
- * Requires that all input cases are of a single scalar parameter type.
+ * Requires that all parameters of the builtin overload are of a scalar type,
+ * and the return type of the builtin overload is also a scalar type.
  * If `cases.length` is not a multiple of `vectorWidth`, then the last scalar
  * test case value is repeated to fill the vector value.
  */
 function packScalarsToVector(
+  parameterTypes: Array<Type>,
+  returnType: Type,
   cases: CaseList,
   vectorWidth: number,
   cmpFloats: FloatMatch
-): CaseList {
-  const asScalar = function (val: Array<Value> | Value): Scalar {
-    if (val instanceof Scalar) {
-      return val;
+): { cases: CaseList; parameterTypes: Array<Type>; returnType: Type } {
+  // Validate that the parameters and return type are all vectorizable
+  for (let i = 0; i < parameterTypes.length; i++) {
+    const ty = parameterTypes[i];
+    if (!(ty instanceof ScalarType)) {
+      throw new Error(
+        `packScalarsToVector() can only be used on scalar parameter types, but the ${i}'th parameter type is a ${ty}'`
+      );
     }
-    if (val instanceof Array && val.length === 1) {
-      return asScalar(val[0]);
-    }
-    throw new Error('packScalarsToVector() requires all Case values to be a single scalar Value');
-  };
+  }
+  if (!(returnType instanceof ScalarType)) {
+    throw new Error(
+      `packScalarsToVector() can only be used with a scalar return type, but the return type is a ${returnType}'`
+    );
+  }
+
+  const packedCases: Array<Case> = [];
+  const packedParameterTypes = parameterTypes.map(p => TypeVec(vectorWidth, p as ScalarType));
+  const packedReturnType = new VectorType(vectorWidth, returnType as ScalarType);
+
   const clampCaseIdx = (idx: number) => Math.min(idx, cases.length - 1);
-  const packed: Array<Case> = [];
+
   let caseIdx = 0;
   while (caseIdx < cases.length) {
-    const inputElements = new Array<Scalar>(vectorWidth);
+    // Construct the vectorized inputs from the scalar cases
+    const packedInputs = new Array<Vector>(parameterTypes.length);
+    for (let paramIdx = 0; paramIdx < parameterTypes.length; paramIdx++) {
+      const inputElements = new Array<Scalar>(vectorWidth);
+      for (let i = 0; i < vectorWidth; i++) {
+        const input = cases[clampCaseIdx(caseIdx + i)].input;
+        inputElements[i] = (input instanceof Array ? input[paramIdx] : input) as Scalar;
+      }
+      packedInputs[paramIdx] = new Vector(inputElements);
+    }
+
+    // Gather the comparators for the packed cases
     const comparators = new Array<Comparator>(vectorWidth);
     for (let i = 0; i < vectorWidth; i++) {
-      const c = cases[clampCaseIdx(caseIdx + i)];
-      inputElements[i] = asScalar(c.input);
-      comparators[i] = toComparator(c.expected);
+      comparators[i] = toComparator(cases[clampCaseIdx(caseIdx + i)].expected);
     }
-    const vec = new Vector(inputElements);
-    packed.push({
-      input: [vec],
-      expected: (got: Value) => {
-        let matched = true;
-        const gElements = new Array<string>(vectorWidth);
-        const eElements = new Array<string>(vectorWidth);
-        for (let i = 0; i < vectorWidth; i++) {
-          const d = comparators[i]((got as Vector).elements[i], cmpFloats);
-          matched = matched && d.matched;
-          gElements[i] = d.got;
-          eElements[i] = d.expected;
-        }
-        return {
-          matched,
-          got: `${vec.type}(${gElements.join(', ')})`,
-          expected: `${vec.type}(${eElements.join(', ')})`,
-        };
-      },
-    });
+    const packedComparator = (got: Value) => {
+      let matched = true;
+      const gElements = new Array<string>(vectorWidth);
+      const eElements = new Array<string>(vectorWidth);
+      for (let i = 0; i < vectorWidth; i++) {
+        const d = comparators[i]((got as Vector).elements[i], cmpFloats);
+        matched = matched && d.matched;
+        gElements[i] = d.got;
+        eElements[i] = d.expected;
+      }
+      return {
+        matched,
+        got: `${packedReturnType}(${gElements.join(', ')})`,
+        expected: `${packedReturnType}(${eElements.join(', ')})`,
+      };
+    };
+
+    // Append the new packed case
+    packedCases.push({ input: packedInputs, expected: packedComparator });
     caseIdx += vectorWidth;
   }
-  return packed;
+
+  return {
+    cases: packedCases,
+    parameterTypes: packedParameterTypes,
+    returnType: packedReturnType,
+  };
 }
 
 // TODO(sarahM0): Perhaps instead of kBit and kValue tables we could have one table

--- a/src/webgpu/shader/execution/builtin/integer_built_in_functions.spec.ts
+++ b/src/webgpu/shader/execution/builtin/integer_built_in_functions.spec.ts
@@ -80,36 +80,6 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
   .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
   .unimplemented();
 
-g.test('integer_builtin_functions,unsigned_min')
-  .uniqueId('29aba7ede5b93cdd')
-  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions')
-  .desc(
-    `
-unsigned min:
-T is u32 or vecN<u32> min(e1: T ,e2: T) -> T Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a vector. (GLSLstd450UMin)
-
-Please read the following guidelines before contributing:
-https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
-`
-  )
-  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
-  .unimplemented();
-
-g.test('integer_builtin_functions,signed_min')
-  .uniqueId('60c8ecdf409b45fc')
-  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions')
-  .desc(
-    `
-signed min:
-T is i32 or vecN<i32> min(e1: T ,e2: T) -> T Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a vector. (GLSLstd45SUMin)
-
-Please read the following guidelines before contributing:
-https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
-`
-  )
-  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
-  .unimplemented();
-
 g.test('integer_builtin_functions,bit_reversal')
   .uniqueId('8a7550f1097993f8')
   .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions')

--- a/src/webgpu/shader/execution/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/builtin/min.spec.ts
@@ -1,0 +1,72 @@
+export const description = `
+Execution Tests for the 'min' builtin function
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+import { i32, i32Bits, TypeI32, TypeU32, u32 } from '../../../util/conversion.js';
+
+import { run } from './builtin.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('integer_builtin_functions,unsigned_min')
+  .uniqueId('29aba7ede5b93cdd')
+  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions')
+  .desc(
+    `
+unsigned min:
+T is u32 or vecN<u32> min(e1: T ,e2: T) -> T Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a vector. (GLSLstd450UMin)
+
+Please read the following guidelines before contributing:
+https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
+`
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    run(t, 'min', [TypeU32, TypeU32], TypeU32, t.params, [
+      { input: [u32(1), u32(2)], expected: u32(1) },
+      { input: [u32(2), u32(1)], expected: u32(1) },
+      { input: [u32(0x70000000), u32(0x80000000)], expected: u32(0x70000000) },
+      { input: [u32(0x80000000), u32(0x70000000)], expected: u32(0x70000000) },
+      { input: [u32(0), u32(0xffffffff)], expected: u32(0) },
+      { input: [u32(0xffffffff), u32(0)], expected: u32(0) },
+      { input: [u32(0), u32(0xffffffff)], expected: u32(0) },
+    ]);
+  });
+
+g.test('integer_builtin_functions,signed_min')
+  .uniqueId('60c8ecdf409b45fc')
+  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions')
+  .desc(
+    `
+signed min:
+T is i32 or vecN<i32> min(e1: T ,e2: T) -> T Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a vector. (GLSLstd45SUMin)
+
+Please read the following guidelines before contributing:
+https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
+`
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    run(t, 'min', [TypeI32, TypeI32], TypeI32, t.params, [
+      { input: [i32(1), i32(2)], expected: i32(1) },
+      { input: [i32(2), i32(1)], expected: i32(1) },
+      { input: [i32(-1), i32(-2)], expected: i32(-2) },
+      { input: [i32(-2), i32(-1)], expected: i32(-2) },
+      { input: [i32(1), i32(-1)], expected: i32(-1) },
+      { input: [i32(-1), i32(1)], expected: i32(-1) },
+      { input: [i32Bits(0x70000000), i32Bits(0x80000000)], expected: i32Bits(0x80000000) },
+      { input: [i32Bits(0x80000000), i32Bits(0x70000000)], expected: i32Bits(0x80000000) },
+      { input: [i32Bits(0xffffffff), i32(0)], expected: i32Bits(0xffffffff) },
+      { input: [i32(0), i32Bits(0xffffffff)], expected: i32Bits(0xffffffff) },
+    ]);
+  });

--- a/src/webgpu/shader/execution/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/builtin/min.spec.ts
@@ -29,6 +29,9 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
   )
   .fn(async t => {
     run(t, 'min', [TypeU32, TypeU32], TypeU32, t.params, [
+      { input: [u32(1), u32(1)], expected: u32(1) },
+      { input: [u32(0), u32(0)], expected: u32(0) },
+      { input: [u32(0xffffffff), u32(0xffffffff)], expected: u32(0xffffffff) },
       { input: [u32(1), u32(2)], expected: u32(1) },
       { input: [u32(2), u32(1)], expected: u32(1) },
       { input: [u32(0x70000000), u32(0x80000000)], expected: u32(0x70000000) },
@@ -58,6 +61,9 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
   )
   .fn(async t => {
     run(t, 'min', [TypeI32, TypeI32], TypeI32, t.params, [
+      { input: [i32(1), i32(1)], expected: i32(1) },
+      { input: [i32(0), i32(0)], expected: i32(0) },
+      { input: [i32(-1), i32(-1)], expected: i32(-1) },
       { input: [i32(1), i32(2)], expected: i32(1) },
       { input: [i32(2), i32(1)], expected: i32(1) },
       { input: [i32(-1), i32(-2)], expected: i32(-2) },


### PR DESCRIPTION
`shader/execution/builtin`: Support vectorization of multiple parameters - Adjust `packScalarsToVector()` to that it can handle builtin overloads with multiple parameters.

Add `shader/execution/builtin`: Add min() test for integers

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
