### PR TITLE
test isInf builtin function

### DIFF
--- a/src/webgpu/shader/execution/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/builtin/builtin.ts
@@ -160,7 +160,8 @@ export type StorageClass = 'uniform' | 'storage_r' | 'storage_rw';
 export type Config = {
   // Where the input values are read from
   storageClass: StorageClass;
-  // If defined, scalar test cases will be packed into vectors of the given width.
+  // If defined, scalar test cases will be packed into vectors of the given
+  // width, which must be 2, 3 or 4.
   // Requires that all parameters of the builtin overload are of a scalar type,
   // and the return type of the builtin overload is also a scalar type.
   // If the number of test cases is not a multiple of the vector width, then the

--- a/src/webgpu/shader/execution/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/builtin/builtin.ts
@@ -205,7 +205,7 @@ function toStorage(ty: Type, expr: string): string {
   }
   if (ty instanceof VectorType) {
     if (ty.elementType.kind === 'bool') {
-      return `select(vec${ty.width}<u32>(0u), vec${ty.width}<u32>(0u), ${expr})`;
+      return `select(vec${ty.width}<u32>(0u), vec${ty.width}<u32>(1u), ${expr})`;
     }
   }
   return expr;

--- a/src/webgpu/shader/execution/builtin/isinf.spec.ts
+++ b/src/webgpu/shader/execution/builtin/isinf.spec.ts
@@ -1,0 +1,62 @@
+export const description = `WGSL execution test. Section: Value-testing built-in functions Function: isInf`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+import { TypeBool, TypeF32, f32, f32Bits, False, True } from '../../../util/conversion.js';
+import { subnormalF32Examples, normalF32Examples } from '../../values.js';
+
+import { run, kBit } from './builtin.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('value_testing_builtin_functions,isInf')
+  .uniqueId('3591ae3f3daa3871')
+  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#value-testing-builtin-functions')
+  .desc(
+    `
+isInf:
+isInf(e: I ) -> T Test for infinity according to IEEE-754. Component-wise when I is a vector. (OpIsInf)
+
+Please read the following guidelines before contributing:
+https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
+`
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = [
+      // Non-infinity
+      { input: f32(0.0), expected: False },
+      { input: f32(10.0), expected: False },
+      { input: f32(-10.0), expected: False },
+      // Infinities
+      { input: f32(Infinity), expected: True },
+      { input: f32(-Infinity), expected: True },
+      { input: f32Bits(kBit.f32.infinity.positive), expected: True },
+      { input: f32Bits(kBit.f32.infinity.negative), expected: True },
+      // NaNs
+      { input: f32(NaN), expected: False },
+      { input: f32(-NaN), expected: False },
+      { input: f32Bits(kBit.f32.nan.positive.s), expected: False },
+      { input: f32Bits(kBit.f32.nan.positive.q), expected: False },
+      { input: f32Bits(kBit.f32.nan.negative.s), expected: False },
+      { input: f32Bits(kBit.f32.nan.negative.q), expected: False },
+    ]
+      // Normal values are not infinite.
+      .concat(
+        normalF32Examples().map(n => {
+          return { input: f32(n), expected: False };
+        })
+      )
+      // Subnormal values are not infinite.
+      .concat(
+        subnormalF32Examples().map(n => {
+          return { input: f32(n), expected: False };
+        })
+      );
+
+    run(t, 'isInf', [TypeF32], TypeBool, t.params, cases);
+  });

--- a/src/webgpu/shader/execution/builtin/value_testing_built_in_functions.spec.ts
+++ b/src/webgpu/shader/execution/builtin/value_testing_built_in_functions.spec.ts
@@ -20,21 +20,6 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
   .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
   .unimplemented();
 
-g.test('value_testing_builtin_functions,isInf')
-  .uniqueId('3591ae3f3daa3871')
-  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#value-testing-builtin-functions')
-  .desc(
-    `
-isInf:
-isInf(e: I ) -> T Test for infinity according to IEEE-754. Component-wise when I is a vector. (OpIsInf)
-
-Please read the following guidelines before contributing:
-https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
-`
-  )
-  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
-  .unimplemented();
-
 g.test('value_testing_builtin_functions,isFinite')
   .uniqueId('bf8ee3764330ceb4')
   .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#value-testing-builtin-functions')

--- a/src/webgpu/shader/values.ts
+++ b/src/webgpu/shader/values.ts
@@ -1,0 +1,65 @@
+export const description = `Special and sample values for WGSL scalar types`;
+
+import { assert } from '../../common/util/util.js';
+import { uint32ToFloat32 } from '../util/conversion.js';
+
+/** Returns an array of subnormal f32 numbers.
+ * Subnnormals are non-zero finite numbers with the minimum representable
+ * exponent.
+ */
+export function subnormalF32Examples(): Array<number> {
+  // The results, as uint32 values.
+  const result_as_bits: number[] = [];
+
+  const max_mantissa = 0x7f_ffff;
+  const sign_bits: [number, number] = [0, 0x8000_0000];
+  for (const sign_bit in sign_bits) {
+    // exponent bits must be zero.
+    const sign_and_exponent = (sign_bit as unknown) as number;
+
+    // Set all bits
+    result_as_bits.push(sign_and_exponent | max_mantissa);
+
+    // Set each of the lower bits individually.
+    for (let lower_bits = 1; lower_bits <= max_mantissa; lower_bits <<= 1) {
+      result_as_bits.push(sign_and_exponent | lower_bits);
+    }
+  }
+  assert(
+    result_as_bits.length === 2 * (1 + 23),
+    'subnormal number sample count is ' + result_as_bits.length.toString()
+  );
+  return result_as_bits.map(u => uint32ToFloat32(u));
+}
+
+/** Returns an array of normal f32 numbers.
+ * Normal numbers are not: zero, Nan, infinity, subnormal.
+ */
+export function normalF32Examples(): Array<number> {
+  const result: number[] = [1.0, -2.0];
+
+  const max_mantissa_as_bits = 0x7f_ffff;
+  const min_exponent_as_bits = 0x0080_0000;
+  const max_exponent_as_bits = 0x7f00_0000; // Max normal exponent
+  const sign_bits = [0, 0x8000_0000];
+  for (const sign_bit in sign_bits) {
+    for (let e = min_exponent_as_bits; e <= max_exponent_as_bits; e += min_exponent_as_bits) {
+      const sign_and_exponent = ((sign_bit as unknown) as number) | e;
+
+      // Set zero mantissa bits
+      result.push(uint32ToFloat32(sign_and_exponent));
+      // Set all mantissa bits
+      result.push(uint32ToFloat32(sign_and_exponent | max_mantissa_as_bits));
+
+      // Set each of the lower bits individually.
+      for (let lower_bits = 1; lower_bits <= max_mantissa_as_bits; lower_bits <<= 1) {
+        result.push(uint32ToFloat32(sign_and_exponent | lower_bits));
+      }
+    }
+  }
+  assert(
+    result.length === 2 + 2 * 254 * 25,
+    'normal number sample count is ' + result.length.toString()
+  );
+  return result;
+}


### PR DESCRIPTION
Forked from https://github.com/gpuweb/cts/pull/799.

---
Test path:
webgpu:shader,execution,builtin,value_testing_built_in_functions:value_testing_builtin_functions,isInf:*

This passes on Dawn / SwiftShader

---

Also contains:
* a fix for a typo in `toStorage()` where all packed booleans were returning `false`.
* test batching to handle case lists that exceed the binding limits for the given storage class.

<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
