### PR TITLE
wgsl: Add tests for duplicate user-defined IO

### DIFF
--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -131,5 +131,55 @@ g.test('nesting')
   });
 
 g.test('duplicates')
-  .desc(`Test validation of duplicate user-defined IO attributes`)
-  .unimplemented();
+  .desc(`Test that duplicated user-defined IO attributes are validated.`)
+  .params(u =>
+    u
+      // Place two [[location(0)]] attributes onto the entry point function.
+      // The function:
+      // - has two non-struct parameters (`p1` and `p2`)
+      // - has two struct parameters each with two members (`s1{a,b}` and `s2{a,b}`)
+      // - returns a struct with two members (`ra` and `rb`)
+      // By default, all of these user-defined IO variables will have unique location attributes.
+      .combine('first', ['p1', 's1a', 's2a', 'ra'] as const)
+      .combine('second', ['p2', 's1b', 's2b', 'rb'] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    const p1 = t.params.first === 'p1' ? '0' : '1';
+    const p2 = t.params.second === 'p2' ? '0' : '2';
+    const s1a = t.params.first === 's1a' ? '0' : '3';
+    const s1b = t.params.second === 's1b' ? '0' : '4';
+    const s2a = t.params.first === 's2a' ? '0' : '5';
+    const s2b = t.params.second === 's2b' ? '0' : '6';
+    const ra = t.params.first === 'ra' ? '0' : '1';
+    const rb = t.params.second === 'rb' ? '0' : '2';
+    const code = `
+    struct S1 {
+      [[location(${s1a})]] a : f32;
+      [[location(${s1b})]] b : f32;
+    };
+    struct S2 {
+      [[location(${s2a})]] a : f32;
+      [[location(${s2b})]] b : f32;
+    };
+    struct R {
+      [[location(${ra})]] a : f32;
+      [[location(${rb})]] b : f32;
+    };
+    [[stage(fragment)]]
+    fn main([[location(${p1})]] p1 : f32,
+            [[location(${p2})]] p2 : f32,
+            s1 : S1,
+            s2 : S2,
+            ) -> R {
+      return R();
+    }
+    `;
+
+    // The test should fail if both [[location(0)]] attributes are on the input parameters or
+    // structures, or it they are both on the output struct. Otherwise it should pass.
+    const firstIsRet = t.params.first === 'ra';
+    const secondIsRet = t.params.second === 'rb';
+    const expectation = firstIsRet !== secondIsRet;
+    t.expectCompileResult(expectation, code);
+  });


### PR DESCRIPTION
Tested on macOS with ToT Chromium.

<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
