### PR TITLE
wgsl: Test that vertex shaders must return builtin(position)

### DIFF
--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -133,3 +133,27 @@ g.test('type')
     );
     t.expectCompileResult(expectation, code);
   });
+
+g.test('missing_vertex_position')
+  .desc(`Test that vertex shaders are required to output [[builtin(position)]].`)
+  .params(u =>
+    u
+      .combine('use_struct', [true, false] as const)
+      .combine('attribute', ['[[builtin(position)]]', '[[location(0)]]'] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    const code = `
+    struct S {
+      ${t.params.attribute} value : vec4<f32>;
+    };
+
+    [[stage(vertex)]]
+    fn main() -> ${t.params.use_struct ? 'S' : `${t.params.attribute} vec4<f32>`} {
+      return ${t.params.use_struct ? 'S' : 'vec4<f32>'}();
+    }
+    `;
+
+    // Expect to pass only when using [[builtin(position)]].
+    t.expectCompileResult(t.params.attribute === '[[builtin(position)]]', code);
+  });


### PR DESCRIPTION
Tested with macOS on ToT Chromium.

<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
