### PR TITLE
wgsl: Add test for [[interpolate]] parameters

### DIFF
--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -1,0 +1,68 @@
+export const description = `Validation tests for the interpolate attribute`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { generateShader } from './util.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+// List of valid interpolation attributes.
+const kValidInterpolationAttributes = [
+  '',
+  '[[interpolate(flat)]]',
+  '[[interpolate(perspective)]]',
+  '[[interpolate(perspective, center)]]',
+  '[[interpolate(perspective, centroid)]]',
+  '[[interpolate(perspective, sample)]]',
+  '[[interpolate(linear)]]',
+  '[[interpolate(linear, center)]]',
+  '[[interpolate(linear, centroid)]]',
+  '[[interpolate(linear, sample)]]',
+] as const;
+
+g.test('parameters')
+  .desc(`Test that all combinations of interpolation type and sampling are validated correctly.`)
+  .params(u =>
+    u
+      .combine('stage', ['vertex', 'fragment'] as const)
+      .combine('io', ['in', 'out'] as const)
+      .combine('use_struct', [true, false] as const)
+      .combine('type', ['', 'flat', 'perspective', 'linear'] as const)
+      .combine('sampling', ['', 'center', 'centroid', 'sample'] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    if (t.params.stage === 'vertex' && t.params.use_struct === false) {
+      t.skip('vertex output must include a position builtin, so must use a struct');
+    }
+
+    let interpolate = '';
+    if (t.params.type !== '' || t.params.sampling !== '') {
+      interpolate = '[[interpolate(';
+      if (t.params.type !== '') {
+        interpolate += `${t.params.type}, `;
+      }
+      interpolate += `${t.params.sampling})]]`;
+    }
+    const code = generateShader({
+      attribute: '[[location(0)]]' + interpolate,
+      type: 'f32',
+      stage: t.params.stage,
+      io: t.params.io,
+      use_struct: t.params.use_struct,
+    });
+
+    t.expectCompileResult(
+      kValidInterpolationAttributes.some(x => x === interpolate),
+      code
+    );
+  });
+
+g.test('require_location')
+  .desc(`Test that [[interpolate]] is only accepted with user-defined IO.`)
+  .unimplemented();
+
+g.test('integral_types')
+  .desc(`Test that the implementation requires [[interpolate(flat)]] for integral user-defined IO.`)
+  .unimplemented();

--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -21,7 +21,7 @@ const kValidInterpolationAttributes = [
   '[[interpolate(linear, sample)]]',
 ] as const;
 
-g.test('parameters')
+g.test('type_and_sampling')
   .desc(`Test that all combinations of interpolation type and sampling are validated correctly.`)
   .params(u =>
     u

--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -8,7 +8,7 @@ import { generateShader } from './util.js';
 export const g = makeTestGroup(ShaderValidationTest);
 
 // List of valid interpolation attributes.
-const kValidInterpolationAttributes = [
+const kValidInterpolationAttributes = new Set([
   '',
   '[[interpolate(flat)]]',
   '[[interpolate(perspective)]]',
@@ -19,7 +19,7 @@ const kValidInterpolationAttributes = [
   '[[interpolate(linear, center)]]',
   '[[interpolate(linear, centroid)]]',
   '[[interpolate(linear, sample)]]',
-] as const;
+]);
 
 g.test('type_and_sampling')
   .desc(`Test that all combinations of interpolation type and sampling are validated correctly.`)
@@ -53,10 +53,7 @@ g.test('type_and_sampling')
       use_struct: t.params.use_struct,
     });
 
-    t.expectCompileResult(
-      kValidInterpolationAttributes.some(x => x === interpolate),
-      code
-    );
+    t.expectCompileResult(kValidInterpolationAttributes.has(interpolate), code);
   });
 
 g.test('require_location')


### PR DESCRIPTION
Tested on macOS with ToT Chromium.

<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
