### PR TITLE
Bump maxUniformBufferBindingSize from 2^14 to 2^16

### DIFF
--- a/src/webgpu/constants.ts
+++ b/src/webgpu/constants.ts
@@ -74,7 +74,7 @@ export const DefaultLimits = {
   maxStorageTexturesPerShaderStage: 4,
   maxUniformBuffersPerShaderStage: 12,
 
-  maxUniformBufferBindingSize: 16384,
+  maxUniformBufferBindingSize: 65536,
   maxStorageBufferBindingSize: 134217728,
   minUniformBufferOffsetAlignment: 256,
   minStorageBufferOffsetAlignment: 256,


### PR DESCRIPTION
See https://github.com/gpuweb/gpuweb/pull/2159

<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests fail because this is a breaking limit change, so it is expected.

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
