### PR TITLE
wgsl: Test built-in variables with indirect dispatch

### DIFF
--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -177,21 +177,25 @@ g.test('inputs')
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
-    if (t.params.dispatch === 'direct') {
-      pass.dispatch(t.params.numGroups.x, t.params.numGroups.y, t.params.numGroups.z);
-    } else if (t.params.dispatch === 'indirect') {
-      const dispatchBuffer = t.device.createBuffer({
-        size: 3 * Uint32Array.BYTES_PER_ELEMENT,
-        usage: GPUBufferUsage.INDIRECT,
-        mappedAtCreation: true,
-      });
-      t.trackForCleanup(dispatchBuffer);
-      const dispatchData = new Uint32Array(dispatchBuffer.getMappedRange());
-      dispatchData[0] = t.params.numGroups.x;
-      dispatchData[1] = t.params.numGroups.y;
-      dispatchData[2] = t.params.numGroups.z;
-      dispatchBuffer.unmap();
-      pass.dispatchIndirect(dispatchBuffer, 0);
+    switch (t.params.dispatch) {
+      case 'direct':
+        pass.dispatch(t.params.numGroups.x, t.params.numGroups.y, t.params.numGroups.z);
+        break;
+      case 'indirect': {
+        const dispatchBuffer = t.device.createBuffer({
+          size: 3 * Uint32Array.BYTES_PER_ELEMENT,
+          usage: GPUBufferUsage.INDIRECT,
+          mappedAtCreation: true,
+        });
+        t.trackForCleanup(dispatchBuffer);
+        const dispatchData = new Uint32Array(dispatchBuffer.getMappedRange());
+        dispatchData[0] = t.params.numGroups.x;
+        dispatchData[1] = t.params.numGroups.y;
+        dispatchData[2] = t.params.numGroups.z;
+        dispatchBuffer.unmap();
+        pass.dispatchIndirect(dispatchBuffer, 0);
+        break;
+      }
     }
     pass.endPass();
     t.queue.submit([encoder.finish()]);

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -12,6 +12,7 @@ g.test('inputs')
   .params(u =>
     u
       .combine('method', ['param', 'struct', 'mixed'] as const)
+      .combine('dispatch', ['direct', 'indirect'] as const)
       .combineWithParams([
         {
           groupSize: { x: 1, y: 1, z: 1 },
@@ -176,7 +177,22 @@ g.test('inputs')
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
-    pass.dispatch(t.params.numGroups.x, t.params.numGroups.y, t.params.numGroups.z);
+    if (t.params.dispatch === 'direct') {
+      pass.dispatch(t.params.numGroups.x, t.params.numGroups.y, t.params.numGroups.z);
+    } else if (t.params.dispatch === 'indirect') {
+      const dispatchBuffer = t.device.createBuffer({
+        size: 3 * Uint32Array.BYTES_PER_ELEMENT,
+        usage: GPUBufferUsage.INDIRECT,
+        mappedAtCreation: true,
+      });
+      t.trackForCleanup(dispatchBuffer);
+      const dispatchData = new Uint32Array(dispatchBuffer.getMappedRange());
+      dispatchData[0] = t.params.numGroups.x;
+      dispatchData[1] = t.params.numGroups.y;
+      dispatchData[2] = t.params.numGroups.z;
+      dispatchBuffer.unmap();
+      pass.dispatchIndirect(dispatchBuffer, 0);
+    }
     pass.endPass();
     t.queue.submit([encoder.finish()]);
 


### PR DESCRIPTION
Make sure that the compute shader built-in variables receive correct
values when dispatchIndirect is used.

Tested on macOS with ToT Chromium.

<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
