### PR TITLE
Revert "Adds ETC2 and ASTC types to enable testing when relevant."

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/offscreencanvas": "^2019.6.2",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "^0.1.7",
+    "@webgpu/types": "^0.1.6",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -665,42 +665,51 @@ g.test('color_textures,compressed,non_array')
     u
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
-      .combine('textureSizeInBlocks', [
-        // The heights and widths in blocks are all power of 2
-        { src: { width: 16, height: 8 }, dst: { width: 16, height: 8 } },
-        // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4 blocks
-        { src: { width: 15, height: 8 }, dst: { width: 16, height: 8 } },
+      .combine('textureSize', [
+        // The heights and widths are all power of 2
+        {
+          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+        },
+        // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
+        {
+          srcTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+        },
         // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
-        // of 4 blocks
-        { src: { width: 16, height: 8 }, dst: { width: 15, height: 8 } },
-        // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4 blocks
-        { src: { width: 16, height: 13 }, dst: { width: 16, height: 8 } },
+        // of 4
+        {
+          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
+        },
+        // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
+        {
+          srcTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+        },
         // The virtual height of the destination texture at mipmap level 2 (13) is not a
-        // multiple of 4 blocks
-        { src: { width: 16, height: 8 }, dst: { width: 16, height: 13 } },
-        // None of the widths or heights in blocks are power of 2
-        { src: { width: 15, height: 13 }, dst: { width: 15, height: 13 } },
+        // multiple of 4
+        {
+          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
+        },
+        // None of the widths or heights are power of 2
+        {
+          srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
+          dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
+        },
       ])
       .combine('copyBoxOffsets', kCopyBoxOffsetsForWholeDepth)
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
-    const { textureSizeInBlocks, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
-    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     t.DoCopyTextureToTextureTest(
-      {
-        width: textureSizeInBlocks.src.width * blockWidth,
-        height: textureSizeInBlocks.src.height * blockHeight,
-        depthOrArrayLayers: 1,
-      },
-      {
-        width: textureSizeInBlocks.dst.width * blockWidth,
-        height: textureSizeInBlocks.dst.height * blockHeight,
-        depthOrArrayLayers: 1,
-      },
+      textureSize.srcTextureSize,
+      textureSize.dstTextureSize,
       format,
       copyBoxOffsets,
       srcCopyLevel,
@@ -760,32 +769,30 @@ g.test('color_textures,compressed,array')
     u
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
-      .combine('textureSizeInBlocks', [
-        // The heights and widths in blocks are all power of 2
-        { src: { width: 2, height: 2 }, dst: { width: 2, height: 2 } },
-        // None of the widths or heights in blocks are power of 2
-        { src: { width: 15, height: 13 }, dst: { width: 15, height: 13 } },
+      .combine('textureSize', [
+        // The heights and widths are all power of 2
+        {
+          srcTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
+          dstTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
+        },
+        // None of the widths or heights are power of 2
+        {
+          srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
+          dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
+        },
       ])
+
       .combine('copyBoxOffsets', kCopyBoxOffsetsFor2DArrayTextures)
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
-    const { textureSizeInBlocks, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
-    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     t.DoCopyTextureToTextureTest(
-      {
-        width: textureSizeInBlocks.src.width * blockWidth,
-        height: textureSizeInBlocks.src.height * blockHeight,
-        depthOrArrayLayers: 5,
-      },
-      {
-        width: textureSizeInBlocks.dst.width * blockWidth,
-        height: textureSizeInBlocks.dst.height * blockHeight,
-        depthOrArrayLayers: 5,
-      },
+      textureSize.srcTextureSize,
+      textureSize.dstTextureSize,
       format,
       copyBoxOffsets,
       srcCopyLevel,

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -506,6 +506,11 @@ g.test('texture_size,2d_texture,compressed_format')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
+    assert(
+      DefaultLimits.maxTextureDimension2D % info.blockWidth === 0 &&
+        DefaultLimits.maxTextureDimension2D % info.blockHeight === 0
+    );
+
     const descriptor: GPUTextureDescriptor = {
       size,
       dimension,

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -586,13 +586,8 @@ g.test('copy_ranges_with_compressed_texture_formats')
   .fn(async t => {
     const { format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
-    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
-    const kTextureSize = {
-      width: 15 * blockWidth,
-      height: 12 * blockHeight,
-      depthOrArrayLayers: 3,
-    };
+    const kTextureSize = { width: 60, height: 48, depthOrArrayLayers: 3 };
     const kMipLevelCount = 4;
 
     const srcTexture = t.device.createTexture({

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -125,11 +125,8 @@ const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtIn
   'depth24unorm-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth24unorm-stencil8'],
   'depth32float-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth32float-stencil8'],
 } as const);
-
-// Separated compressed formats by type
-const kBCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
+const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                         ] as const, {
-  // Block Compression (BC) formats
   'bc1-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
   'bc1-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
   'bc2-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
@@ -145,58 +142,11 @@ const kBCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
   'bc7-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
   'bc7-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
 } as const);
-const kETC2TextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                           ] as const, {
-  // Ericsson Compression (ETC2) formats
-  'etc2-rgb8unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgb8unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgb8a1unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgb8a1unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgba8unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgba8unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
-  'eac-r11unorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'eac-r11snorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'eac-rg11unorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
-  'eac-rg11snorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
-} as const);
-const kASTCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,             ,              ,                           ] as const, {
-  // Adaptable Scalable Compression (ASTC) formats
-  'astc-4x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc'],
-  'astc-4x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc'],
-  'astc-5x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc'],
-  'astc-5x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc'],
-  'astc-5x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc'],
-  'astc-5x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc'],
-  'astc-6x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc'],
-  'astc-6x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc'],
-  'astc-6x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc'],
-  'astc-6x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc'],
-  'astc-8x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc'],
-  'astc-8x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc'],
-  'astc-8x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc'],
-  'astc-8x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc'],
-  'astc-8x8-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc'],
-  'astc-8x8-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc'],
-  'astc-10x5-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc'],
-  'astc-10x5-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc'],
-  'astc-10x6-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc'],
-  'astc-10x6-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc'],
-  'astc-10x8-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc'],
-  'astc-10x8-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc'],
-  'astc-10x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc'],
-  'astc-10x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc'],
-  'astc-12x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc'],
-  'astc-12x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc'],
-  'astc-12x12-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc'],
-  'astc-12x12-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc'],
-} as const);
 
 // Definitions for use locally. To access the table entries, use `kTextureFormatInfo`.
 
 // TODO: Consider generating the exports below programmatically by filtering the big list, instead
 // of using these local constants? Requires some type magic though.
-/* prettier-ignore */ const   kCompressedTextureFormatInfo = { ...kBCTextureFormatInfo, ...kETC2TextureFormatInfo, ...kASTCTextureFormatInfo } as const;
 /* prettier-ignore */ const        kColorTextureFormatInfo = { ...kRegularTextureFormatInfo, ...kCompressedTextureFormatInfo } as const;
 /* prettier-ignore */ const    kEncodableTextureFormatInfo = { ...kRegularTextureFormatInfo, ...kSizedDepthStencilFormatInfo } as const;
 /* prettier-ignore */ const        kSizedTextureFormatInfo = { ...kRegularTextureFormatInfo, ...kSizedDepthStencilFormatInfo, ...kCompressedTextureFormatInfo } as const;

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -249,29 +249,19 @@ Tests that a BC format passes validation iff the feature is enabled.`
     );
   });
 
-g.test('gpu,with_texture_compression,etc2')
+g.test('gpu,with_texture_compression,etc')
   .desc(
     `Example of a test using a device descriptor.
-Tests that an ETC2 format passes validation iff the feature is enabled.`
-  )
-  .params(u => u.combine('textureCompressionETC2', [false, true]))
-  .fn(async t => {
-    const { textureCompressionETC2 } = t.params;
 
-    if (textureCompressionETC2) {
-      await t.selectDeviceOrSkipTestCase('texture-compression-etc2' as GPUFeatureName);
+TODO: Test that an ETC format passes validation iff the feature is enabled.`
+  )
+  .params(u => u.combine('textureCompressionETC', [false, true]))
+  .fn(async t => {
+    const { textureCompressionETC } = t.params;
+
+    if (textureCompressionETC) {
+      await t.selectDeviceOrSkipTestCase('texture-compression-etc' as GPUFeatureName);
     }
 
-    const shouldError = !textureCompressionETC2;
-    t.expectGPUError(
-      'validation',
-      () => {
-        t.device.createTexture({
-          format: 'etc2-rgb8unorm',
-          size: [4, 4, 1],
-          usage: GPUTextureUsage.TEXTURE_BINDING,
-        });
-      },
-      shouldError
-    );
+    // TODO: Should actually test createTexture with an ETC format here.
   });


### PR DESCRIPTION
Reverts gpuweb/cts#805

Upon attempting to roll these changes into Chromium we realized that there are still a few more tests that need to be updated for the newly added formats.