### PR TITLE
Use boundary values as numbers instead of bits in `atan` tests

### DIFF
--- a/src/webgpu/shader/execution/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/builtin/atan.spec.ts
@@ -45,9 +45,11 @@ T is f32 or vecN<f32> atan(e: T ) -> T Returns the arc tangent of e. Component-w
 
     // Spread of cases over wide domain
     const automatic = new Array<Case>(1000);
-    const increment = (kBit.f32.positive.max - kBit.f32.negative.min) / automatic.length;
+    const f32Min = f32Bits(kBit.f32.positive.min).value as number;
+    const f32Max = f32Bits(kBit.f32.positive.max).value as number;
+    const increment = (f32Max - f32Min) / automatic.length;
     for (let i = 0; i < automatic.length; i++) {
-      const x = kBit.f32.negative.min + increment * i;
+      const x = f32Min + increment * i;
       automatic[i] = { input: f32(x), expected: f32(truthFunc(x)) };
     }
 


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
