### PR TITLE
wgsl: Use 1.0 instead of 0.5 for color tests

### DIFF
--- a/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
@@ -131,7 +131,7 @@ g.test('shared_between_stages')
 
       [[stage(vertex)]]
       fn vert_main([[builtin(vertex_index)]] index : u32) -> Interface {
-        return Interface(vec4<f32>(vertices[index], 0.0, 1.0), 0.5);
+        return Interface(vec4<f32>(vertices[index], 0.0, 1.0), 1.0);
       }
 
       [[stage(fragment)]]
@@ -187,8 +187,8 @@ g.test('shared_between_stages')
     t.queue.submit([encoder.finish()]);
 
     // Test a few points to make sure we rendered a half-red/half-green triangle.
-    const redPixel = new Uint8Array([128, 0, 0, 255]);
-    const greenPixel = new Uint8Array([0, 128, 0, 255]);
+    const redPixel = new Uint8Array([255, 0, 0, 255]);
+    const greenPixel = new Uint8Array([0, 255, 0, 255]);
     for (const p of [
       { x: 16, y: 15 },
       { x: 16, y: 15 },


### PR DESCRIPTION
The color value 0.5 rounds to either 127 or 128, so use 1.0 instead to
make the test more portable.

<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
