### PR TITLE
Fix api,operation,vertex_state,correctness,*

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -194,7 +194,7 @@ ${vsChecks}
 }
 
 struct VSOutputs {
-  [[location(0)]] result : i32;
+  [[location(0), interpolate(flat)]] result : i32;
   [[builtin(position)]] position : vec4<f32>;
 };
 
@@ -213,7 +213,8 @@ struct VSOutputs {
   return output;
 }
 
-[[stage(fragment)]] fn fsMain([[location(0)]] result : i32) -> [[location(0)]] i32 {
+[[stage(fragment)]] fn fsMain([[location(0), interpolate(flat)]] result : i32)
+  -> [[location(0)]] i32 {
   return result;
 }
     `;


### PR DESCRIPTION
This patch fixes the shaders in api,operation,vertex_state,
correctness,* as in the latest WGSL SPEC, user-defined IO of scalar
or vector integer type must always be specified as
[[interpolate(flat)]].





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
