### PR TITLE
Reland "Adds ETC2 and ASTC types to enable testing when relevant."

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/offscreencanvas": "^2019.6.2",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "^0.1.6",
+    "@webgpu/types": "^0.1.7",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -665,51 +665,42 @@ g.test('color_textures,compressed,non_array')
     u
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
-      .combine('textureSize', [
-        // The heights and widths are all power of 2
-        {
-          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-        },
-        // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4
-        {
-          srcTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-        },
+      .combine('textureSizeInBlocks', [
+        // The heights and widths in blocks are all power of 2
+        { src: { width: 16, height: 8 }, dst: { width: 16, height: 8 } },
+        // The virtual width of the source texture at mipmap level 2 (15) is not a multiple of 4 blocks
+        { src: { width: 15, height: 8 }, dst: { width: 16, height: 8 } },
         // The virtual width of the destination texture at mipmap level 2 (15) is not a multiple
-        // of 4
-        {
-          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 60, height: 32, depthOrArrayLayers: 1 },
-        },
-        // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4
-        {
-          srcTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-        },
+        // of 4 blocks
+        { src: { width: 16, height: 8 }, dst: { width: 15, height: 8 } },
+        // The virtual height of the source texture at mipmap level 2 (13) is not a multiple of 4 blocks
+        { src: { width: 16, height: 13 }, dst: { width: 16, height: 8 } },
         // The virtual height of the destination texture at mipmap level 2 (13) is not a
-        // multiple of 4
-        {
-          srcTextureSize: { width: 64, height: 32, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 64, height: 52, depthOrArrayLayers: 1 },
-        },
-        // None of the widths or heights are power of 2
-        {
-          srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
-          dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 1 },
-        },
+        // multiple of 4 blocks
+        { src: { width: 16, height: 8 }, dst: { width: 16, height: 13 } },
+        // None of the widths or heights in blocks are power of 2
+        { src: { width: 15, height: 13 }, dst: { width: 15, height: 13 } },
       ])
       .combine('copyBoxOffsets', kCopyBoxOffsetsForWholeDepth)
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
-    const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const { textureSizeInBlocks, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     t.DoCopyTextureToTextureTest(
-      textureSize.srcTextureSize,
-      textureSize.dstTextureSize,
+      {
+        width: textureSizeInBlocks.src.width * blockWidth,
+        height: textureSizeInBlocks.src.height * blockHeight,
+        depthOrArrayLayers: 1,
+      },
+      {
+        width: textureSizeInBlocks.dst.width * blockWidth,
+        height: textureSizeInBlocks.dst.height * blockHeight,
+        depthOrArrayLayers: 1,
+      },
       format,
       copyBoxOffsets,
       srcCopyLevel,
@@ -769,30 +760,32 @@ g.test('color_textures,compressed,array')
     u
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
-      .combine('textureSize', [
-        // The heights and widths are all power of 2
-        {
-          srcTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
-          dstTextureSize: { width: 8, height: 8, depthOrArrayLayers: 5 },
-        },
-        // None of the widths or heights are power of 2
-        {
-          srcTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
-          dstTextureSize: { width: 60, height: 52, depthOrArrayLayers: 5 },
-        },
+      .combine('textureSizeInBlocks', [
+        // The heights and widths in blocks are all power of 2
+        { src: { width: 2, height: 2 }, dst: { width: 2, height: 2 } },
+        // None of the widths or heights in blocks are power of 2
+        { src: { width: 15, height: 13 }, dst: { width: 15, height: 13 } },
       ])
-
       .combine('copyBoxOffsets', kCopyBoxOffsetsFor2DArrayTextures)
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
-    const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const { textureSizeInBlocks, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     t.DoCopyTextureToTextureTest(
-      textureSize.srcTextureSize,
-      textureSize.dstTextureSize,
+      {
+        width: textureSizeInBlocks.src.width * blockWidth,
+        height: textureSizeInBlocks.src.height * blockHeight,
+        depthOrArrayLayers: 5,
+      },
+      {
+        width: textureSizeInBlocks.dst.width * blockWidth,
+        height: textureSizeInBlocks.dst.height * blockHeight,
+        depthOrArrayLayers: 5,
+      },
       format,
       copyBoxOffsets,
       srcCopyLevel,

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -130,11 +130,16 @@ g.test('mipLevelCount,format')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
+    // Compute dimensions such that the dimensions are less than 2^6 (32) but also a multiple of the format block size.
+    const maxMipLevelCount = 6;
+    const textureWidth =
+      Math.floor(((1 << maxMipLevelCount) - 1) / info.blockWidth) * info.blockWidth;
+    const textureHeight =
+      Math.floor(((1 << maxMipLevelCount) - 1) / info.blockHeight) * info.blockHeight;
+
     // Note that compressed formats are not valid for 1D. They have already been filtered out for 1D in this test.
     // So there is no dilemma about size.width equals 1 vs size.width % info.blockHeight equals 0 for 1D compressed formats.
-    const size = dimension === '1d' ? [32, 1, 1] : [32, 32, 1];
-    assert(32 % info.blockWidth === 0 && 32 % info.blockHeight === 0);
-
+    const size = dimension === '1d' ? [textureWidth, 1, 1] : [textureWidth, textureHeight, 1];
     const descriptor = {
       size,
       mipLevelCount,
@@ -143,7 +148,7 @@ g.test('mipLevelCount,format')
       usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
-    const success = mipLevelCount <= 6;
+    const success = mipLevelCount <= maxMipLevelCount;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);
@@ -236,9 +241,10 @@ g.test('sampleCount,various_sampleCount_with_all_formats')
   .fn(async t => {
     const { dimension, sampleCount, format } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     const descriptor = {
-      size: [32, 32, 1],
+      size: [32 * blockWidth, 32 * blockHeight, 1],
       sampleCount,
       dimension,
       format,
@@ -285,13 +291,14 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
   .fn(async t => {
     const { dimension, sampleCount, format, mipLevelCount, arrayLayerCount, usage } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     const size =
       dimension === '1d'
-        ? [32, 1, 1]
+        ? [32 * blockWidth, 1 * blockHeight, 1]
         : dimension === '2d' || dimension === undefined
-        ? [32, 32, arrayLayerCount]
-        : [32, 32, 32];
+        ? [32 * blockWidth, 32 * blockHeight, arrayLayerCount]
+        : [32 * blockWidth, 32 * blockHeight, 32];
     const descriptor = {
       size,
       mipLevelCount,
@@ -505,11 +512,6 @@ g.test('texture_size,2d_texture,compressed_format')
     const { dimension, format, size } = t.params;
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
-
-    assert(
-      DefaultLimits.maxTextureDimension2D % info.blockWidth === 0 &&
-        DefaultLimits.maxTextureDimension2D % info.blockHeight === 0
-    );
 
     const descriptor: GPUTextureDescriptor = {
       size,

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -130,7 +130,7 @@ g.test('mipLevelCount,format')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    // Compute dimensions such that the dimensions are in range [17, 32] and alinged with the
+    // Compute dimensions such that the dimensions are in range [17, 32] and aligned with the
     // format block size so that there will be exactly 6 mip levels.
     const maxMipLevelCount = 5;
     const textureWidth =

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -130,15 +130,18 @@ g.test('mipLevelCount,format')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    // Compute dimensions such that the dimensions are less than 2^6 (32) but also a multiple of the format block size.
-    const maxMipLevelCount = 6;
-    const textureWidth =
-      Math.floor(((1 << maxMipLevelCount) - 1) / info.blockWidth) * info.blockWidth;
+    // Compute dimensions such that the dimensions are in range [17, 32] and alinged with the
+    // format block size so that there will be exactly 6 mip levels.
+    const maxMipLevelCount = 5;
+    const textureWidth = Math.floor((1 << maxMipLevelCount) / info.blockWidth) * info.blockWidth;
     const textureHeight =
       Math.floor(((1 << maxMipLevelCount) - 1) / info.blockHeight) * info.blockHeight;
+    assert(17 <= textureWidth && textureWidth <= 32);
+    assert(17 <= textureHeight && textureHeight <= 32);
 
-    // Note that compressed formats are not valid for 1D. They have already been filtered out for 1D in this test.
-    // So there is no dilemma about size.width equals 1 vs size.width % info.blockHeight equals 0 for 1D compressed formats.
+    // Note that compressed formats are not valid for 1D. They have already been filtered out for 1D
+    // in this test. So there is no dilemma about size.width equals 1 vs
+    // size.width % info.blockHeight equals 0 for 1D compressed formats.
     const size = dimension === '1d' ? [textureWidth, 1, 1] : [textureWidth, textureHeight, 1];
     const descriptor = {
       size,

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -133,7 +133,8 @@ g.test('mipLevelCount,format')
     // Compute dimensions such that the dimensions are in range [17, 32] and alinged with the
     // format block size so that there will be exactly 6 mip levels.
     const maxMipLevelCount = 5;
-    const textureWidth = Math.floor((1 << maxMipLevelCount) / info.blockWidth) * info.blockWidth;
+    const textureWidth =
+      Math.floor(((1 << maxMipLevelCount) - 1) / info.blockWidth) * info.blockWidth;
     const textureHeight =
       Math.floor(((1 << maxMipLevelCount) - 1) / info.blockHeight) * info.blockHeight;
     assert(17 <= textureWidth && textureWidth <= 32);

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -38,10 +38,11 @@ g.test('format')
   .fn(async t => {
     const { textureFormat, viewFormat } = t.params;
     await t.selectDeviceForTextureFormatOrSkipTestCase([textureFormat, viewFormat]);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[textureFormat];
 
     const texture = t.device.createTexture({
       format: textureFormat,
-      size: [4, 4],
+      size: [blockWidth, blockHeight],
       usage: GPUTextureUsage.TEXTURE_BINDING,
     });
 
@@ -103,7 +104,7 @@ g.test('aspect')
 
     const texture = t.device.createTexture({
       format,
-      size: [4, 4, 1],
+      size: [info.blockWidth, info.blockHeight, 1],
       usage: GPUTextureUsage.TEXTURE_BINDING,
     });
 

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -586,8 +586,13 @@ g.test('copy_ranges_with_compressed_texture_formats')
   .fn(async t => {
     const { format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
-    const kTextureSize = { width: 60, height: 48, depthOrArrayLayers: 3 };
+    const kTextureSize = {
+      width: 15 * blockWidth,
+      height: 12 * blockHeight,
+      depthOrArrayLayers: 3,
+    };
     const kMipLevelCount = 4;
 
     const srcTexture = t.device.createTexture({

--- a/src/webgpu/api/validation/image_copy/README.txt
+++ b/src/webgpu/api/validation/image_copy/README.txt
@@ -22,7 +22,6 @@ Test coverage:
 	- required_bytes_in_copy: testing minimal data size and data size too small for various combinations of bytesPerRow, rowsPerImage, copyExtent and offset. for the copy method, bytesPerRow is computed as bytesInACompleteRow aligned to be a multiple of 256 + bytesPerRowPadding * 256.
 	- texel_block_alignment_on_rows_per_image: for all formats.
 	- offset_alignment: for all formats.
-	- bound_on_bytes_per_row: for all formats and various combinations of bytesPerRow and copyExtent. for writeTexture, bytesPerRow is computed as (blocksPerRow * bytesPerBlock + additionalBytesPerRow) and copyExtent.width is computed as copyWidthInBlocks * blockWidth. for the copy methods bytesPerRow is aligned to be a multiple of 256.
 	- bound_on_offset: for various combinations of offset and dataSize.
 
 * texture copy range:

--- a/src/webgpu/api/validation/image_copy/README.txt
+++ b/src/webgpu/api/validation/image_copy/README.txt
@@ -22,7 +22,7 @@ Test coverage:
 	- required_bytes_in_copy: testing minimal data size and data size too small for various combinations of bytesPerRow, rowsPerImage, copyExtent and offset. for the copy method, bytesPerRow is computed as bytesInACompleteRow aligned to be a multiple of 256 + bytesPerRowPadding * 256.
 	- texel_block_alignment_on_rows_per_image: for all formats.
 	- offset_alignment: for all formats.
-	- bound_on_bytes_per_row: for all formats and various combinations of bytesPerRow and copyExtent. for writeTexture, bytesPerRow is computed as (blocksPerRow * blockWidth * bytesPerBlock + additionalBytesPerRow) and copyExtent.width is computed as copyWidthInBlocks * blockWidth. for the copy methods, both values are mutliplied by 256.
+	- bound_on_bytes_per_row: for all formats and various combinations of bytesPerRow and copyExtent. for writeTexture, bytesPerRow is computed as (blocksPerRow * bytesPerBlock + additionalBytesPerRow) and copyExtent.width is computed as copyWidthInBlocks * blockWidth. for the copy methods bytesPerRow is aligned to be a multiple of 256.
 	- bound_on_offset: for various combinations of offset and dataSize.
 
 * texture copy range:

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -4,6 +4,7 @@ import {
   DepthStencilFormat,
   depthStencilFormatCopyableAspects,
 } from '../../../capability_info.js';
+import { align } from '../../../util/math.js';
 import { ImageCopyType } from '../../../util/texture/layout.js';
 import { ValidationTest } from '../validation_test.js';
 
@@ -85,21 +86,29 @@ export class ImageCopyTest extends ValidationTest {
     }
   }
 
-  // This is a helper function used for creating a texture when we don't have to be very
-  // precise about its size as long as it's big enough and properly aligned.
+  /**
+   * Creates a texture when all that is needed is an aligned texture given the format and desired
+   * dimensions/origin. The resultant texture guarantees that a copy with the same size and origin
+   * should be possible.
+   */
   createAlignedTexture(
     format: SizedTextureFormat,
-    copySize: Required<GPUExtent3DDict> = { width: 1, height: 1, depthOrArrayLayers: 1 },
+    size: Required<GPUExtent3DDict> = {
+      width: 1,
+      height: 1,
+      depthOrArrayLayers: 1,
+    },
     origin: Required<GPUOrigin3DDict> = { x: 0, y: 0, z: 0 },
     dimension: Required<GPUTextureDimension> = '2d'
   ): GPUTexture {
     const info = kTextureFormatInfo[format];
+    const alignedSize = {
+      width: align(Math.max(1, size.width + origin.x), info.blockWidth),
+      height: align(Math.max(1, size.height + origin.y), info.blockHeight),
+      depthOrArrayLayers: Math.max(1, size.depthOrArrayLayers + origin.z),
+    };
     return this.device.createTexture({
-      size: {
-        width: Math.max(1, copySize.width + origin.x) * info.blockWidth,
-        height: Math.max(1, copySize.height + origin.y) * info.blockHeight,
-        depthOrArrayLayers: Math.max(1, copySize.depthOrArrayLayers + origin.z),
-      },
+      size: alignedSize,
       dimension,
       format,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,

--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -293,13 +293,6 @@ g.test('bound_on_bytes_per_row')
             copyWidthInBlocks: 384 / info.bytesPerBlock,
             _success: p.method === 'WriteTexture',
           },
-          // Copying larger texture when padding in bytesPerRow is not enough should fail.
-          {
-            bytesPerRow: 256,
-            widthInBlocks: 256 / info.bytesPerBlock,
-            copyWidthInBlocks: 256 / info.bytesPerBlock + 1,
-            _success: false,
-          },
           // When bytesPerRow is smaller than bytesInLastRow copying should fail.
           {
             bytesPerRow: 256,

--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -149,7 +149,6 @@ g.test('required_bytes_in_copy')
     // to make this happen we align the bytesInACompleteRow value and multiply
     // bytesPerRowPadding by 256.
     const bytesPerRowAlignment = method === 'WriteTexture' ? 1 : 256;
-
     const copyWidth = copyWidthInBlocks * info.blockWidth;
     const copyHeight = copyHeightInBlocks * info.blockHeight;
     const offset = offsetInBlocks * info.bytesPerBlock;
@@ -162,7 +161,11 @@ g.test('required_bytes_in_copy')
     const layout = { offset, bytesPerRow, rowsPerImage };
     const minDataSize = dataBytesForCopyOrFail({ layout, format, copySize, method });
 
-    const texture = t.createAlignedTexture(format, copySize);
+    const texture = t.createAlignedTexture(format, {
+      width: copyWidthInBlocks,
+      height: copyHeightInBlocks,
+      depthOrArrayLayers: copyDepth,
+    });
 
     t.testRun({ texture }, { offset, bytesPerRow, rowsPerImage }, copySize, {
       dataSize: minDataSize,
@@ -285,7 +288,7 @@ g.test('bound_on_bytes_per_row')
     // In the CopyB2T and CopyT2B cases we need to have bytesPerRow 256-aligned.
     const bytesPerRowAlignment = method === 'WriteTexture' ? 1 : 256;
 
-    const copyWidth = align(copyWidthInBlocks * info.blockWidth, bytesPerRowAlignment);
+    const copyWidth = copyWidthInBlocks * info.blockWidth;
     const copyHeight = copyHeightInBlocks * info.blockHeight;
     const bytesPerRow = align(
       blocksPerRow * info.bytesPerBlock + additionalPaddingPerRow,

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -231,7 +231,7 @@ g.test('format')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    const size = { width: 32, height: 32, depthOrArrayLayers };
+    const size = { width: 32 * info.blockWidth, height: 32 * info.blockHeight, depthOrArrayLayers };
     const texture = t.device.createTexture({
       size,
       dimension,

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -302,8 +302,8 @@ g.test('origin_alignment')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    const origin = { x: 0, y: 0, z: 0 };
     const size = { width: 0, height: 0, depthOrArrayLayers };
+    const origin = { x: 0, y: 0, z: 0 };
     let success = true;
 
     origin[coordinateToTest] = valueToCoordinate;
@@ -379,12 +379,12 @@ g.test('size_alignment')
       .expand('valueToCoordinate', texelBlockAlignmentTestExpanderForValueToCoordinate)
   )
   .fn(async t => {
-    const { valueToCoordinate, coordinateToTest, format, method } = t.params;
+    const { valueToCoordinate, coordinateToTest, dimension, format, method } = t.params;
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    const origin = { x: 0, y: 0, z: 0 };
     const size = { width: 0, height: 0, depthOrArrayLayers: 0 };
+    const origin = { x: 0, y: 0, z: 0 };
     let success = true;
 
     size[coordinateToTest] = valueToCoordinate;
@@ -399,13 +399,10 @@ g.test('size_alignment')
       }
     }
 
-    const texture = t.createAlignedTexture(format, size, origin);
+    const texture = t.createAlignedTexture(format, size, origin, dimension);
 
-    const bytesPerRow = align(
-      (align(size.width, info.blockWidth) / info.blockWidth) * info.bytesPerBlock,
-      256
-    );
-    const rowsPerImage = align(size.height, info.blockHeight) / info.blockHeight;
+    const bytesPerRow = align(Math.max(1, size.width) * info.bytesPerBlock, 256);
+    const rowsPerImage = size.height;
     t.testRun({ texture, origin }, { bytesPerRow, rowsPerImage }, size, {
       dataSize: 1,
       method,

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -401,8 +401,11 @@ g.test('size_alignment')
 
     const texture = t.createAlignedTexture(format, size, origin, dimension);
 
-    const bytesPerRow = align(Math.max(1, size.width) * info.bytesPerBlock, 256);
-    const rowsPerImage = size.height;
+    const bytesPerRow = align(
+      Math.max(1, Math.ceil(size.width / info.blockWidth)) * info.bytesPerBlock,
+      256
+    );
+    const rowsPerImage = Math.ceil(size.height / info.blockHeight);
     t.testRun({ texture, origin }, { bytesPerRow, rowsPerImage }, size, {
       dataSize: 1,
       method,

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -125,8 +125,11 @@ const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtIn
   'depth24unorm-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth24unorm-stencil8'],
   'depth32float-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth32float-stencil8'],
 } as const);
-const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
+
+// Separated compressed formats by type
+const kBCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
                            [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                         ] as const, {
+  // Block Compression (BC) formats
   'bc1-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
   'bc1-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
   'bc2-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
@@ -142,11 +145,58 @@ const kCompressedTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfo
   'bc7-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
   'bc7-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
 } as const);
+const kETC2TextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
+                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                           ] as const, {
+  // Ericsson Compression (ETC2) formats
+  'etc2-rgb8unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgb8unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgb8a1unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgb8a1unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgba8unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgba8unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+  'eac-r11unorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'eac-r11snorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'eac-rg11unorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+  'eac-rg11snorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+} as const);
+const kASTCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
+                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,             ,              ,                           ] as const, {
+  // Adaptable Scalable Compression (ASTC) formats
+  'astc-4x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc'],
+  'astc-4x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc'],
+  'astc-5x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc'],
+  'astc-5x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc'],
+  'astc-5x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc'],
+  'astc-5x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc'],
+  'astc-6x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc'],
+  'astc-6x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc'],
+  'astc-6x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc'],
+  'astc-6x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc'],
+  'astc-8x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc'],
+  'astc-8x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc'],
+  'astc-8x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc'],
+  'astc-8x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc'],
+  'astc-8x8-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc'],
+  'astc-8x8-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc'],
+  'astc-10x5-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc'],
+  'astc-10x5-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc'],
+  'astc-10x6-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc'],
+  'astc-10x6-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc'],
+  'astc-10x8-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc'],
+  'astc-10x8-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc'],
+  'astc-10x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc'],
+  'astc-10x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc'],
+  'astc-12x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc'],
+  'astc-12x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc'],
+  'astc-12x12-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc'],
+  'astc-12x12-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc'],
+} as const);
 
 // Definitions for use locally. To access the table entries, use `kTextureFormatInfo`.
 
 // TODO: Consider generating the exports below programmatically by filtering the big list, instead
 // of using these local constants? Requires some type magic though.
+/* prettier-ignore */ const   kCompressedTextureFormatInfo = { ...kBCTextureFormatInfo, ...kETC2TextureFormatInfo, ...kASTCTextureFormatInfo } as const;
 /* prettier-ignore */ const        kColorTextureFormatInfo = { ...kRegularTextureFormatInfo, ...kCompressedTextureFormatInfo } as const;
 /* prettier-ignore */ const    kEncodableTextureFormatInfo = { ...kRegularTextureFormatInfo, ...kSizedDepthStencilFormatInfo } as const;
 /* prettier-ignore */ const        kSizedTextureFormatInfo = { ...kRegularTextureFormatInfo, ...kSizedDepthStencilFormatInfo, ...kCompressedTextureFormatInfo } as const;

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -249,19 +249,29 @@ Tests that a BC format passes validation iff the feature is enabled.`
     );
   });
 
-g.test('gpu,with_texture_compression,etc')
+g.test('gpu,with_texture_compression,etc2')
   .desc(
     `Example of a test using a device descriptor.
-
-TODO: Test that an ETC format passes validation iff the feature is enabled.`
+Tests that an ETC2 format passes validation iff the feature is enabled.`
   )
-  .params(u => u.combine('textureCompressionETC', [false, true]))
+  .params(u => u.combine('textureCompressionETC2', [false, true]))
   .fn(async t => {
-    const { textureCompressionETC } = t.params;
+    const { textureCompressionETC2 } = t.params;
 
-    if (textureCompressionETC) {
-      await t.selectDeviceOrSkipTestCase('texture-compression-etc' as GPUFeatureName);
+    if (textureCompressionETC2) {
+      await t.selectDeviceOrSkipTestCase('texture-compression-etc2' as GPUFeatureName);
     }
 
-    // TODO: Should actually test createTexture with an ETC format here.
+    const shouldError = !textureCompressionETC2;
+    t.expectGPUError(
+      'validation',
+      () => {
+        t.device.createTexture({
+          format: 'etc2-rgb8unorm',
+          size: [4, 4, 1],
+          usage: GPUTextureUsage.TEXTURE_BINDING,
+        });
+      },
+      shouldError
+    );
   });


### PR DESCRIPTION
This is a reland of fd20759

Additional changes:
- Updates other tests using kAllTextureFormatInfo to be compatible with the new compressed texture types.
- Overhauls webgpu:api,validation,image_copy,layout_related:bound_on_bytes_per_row:* tests to reflect a more recent version of the testing for validation.

Original change's description:
> Adds ETC2 and ASTC types to enable testing when relevant.
>
> - Modifies texture sizes to be functions of the block sizes to generalize the tests.

<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
