### PR TITLE
Fix bug in testing copyExternalImageToTexture with *-srgb dst formats

### DIFF
--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -15,18 +15,6 @@ import { CopyToTextureUtils, isFp16Format } from '../../util/copy_to_texture.js'
 import { canvasTypes, allCanvasTypes, createCanvas } from '../../util/create_elements.js';
 import { kTexelRepresentationInfo } from '../../util/texture/texel_data.js';
 
-/**
- * If the destination format specifies a transfer function,
- * copyExternalImageToTexture (like B2T/T2T copies) should ignore it.
- */
-function formatForExpectedPixels(format: RegularTextureFormat): RegularTextureFormat {
-  return format === 'rgba8unorm-srgb'
-    ? 'rgba8unorm'
-    : format === 'bgra8unorm-srgb'
-    ? 'bgra8unorm'
-    : format;
-}
-
 class F extends CopyToTextureUtils {
   // TODO: Cache the generated canvas to avoid duplicated initialization.
   init2DCanvasContent({
@@ -286,7 +274,7 @@ g.test('copy_contents_from_2d_context_canvas')
 
     // Construct expected value for different dst color format
     const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
-    const format: RegularTextureFormat = formatForExpectedPixels(dstColorFormat);
+    const format: RegularTextureFormat = dstColorFormat;
 
     // For 2d canvas, get expected pixels with getImageData(), which returns unpremultiplied
     // values.
@@ -392,7 +380,7 @@ g.test('copy_contents_from_gl_context_canvas')
 
     // Construct expected value for different dst color format
     const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
-    const format: RegularTextureFormat = formatForExpectedPixels(dstColorFormat);
+    const format: RegularTextureFormat = dstColorFormat;
     const expectedPixels = t.getExpectedPixels({
       context: canvasContext,
       width,


### PR DESCRIPTION
In current cts implementation in webgpu:web_platform,copyToTexture,canvas:*,
*-srgb dst formats has been transferred to no -srgb formats to get the
expected results.

This CL fix this issue by remove the wrongly conversion.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
