### PR TITLE
Handle zero-like cases with ULP accuracy constraints

### DIFF
--- a/src/webgpu/shader/execution/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/builtin/atan.spec.ts
@@ -1,3 +1,4 @@
+
 export const description = `
 Execution Tests for the 'atan' builtin function
 `;
@@ -36,11 +37,24 @@ T is f32 or vecN<f32> atan(e: T ) -> T Returns the arc tangent of e. Component-w
       { input: f32(-Math.sqrt(3)), expected: f32(-Math.PI / 3) },
       { input: f32(-1), expected: f32(-Math.PI / 4) },
       { input: f32(-Math.sqrt(3) / 3), expected: f32(-Math.PI / 6) },
-      { input: f32(0), expected: f32(0) },
       { input: f32(Math.sqrt(3) / 3), expected: f32(Math.PI / 6) },
       { input: f32(1), expected: f32(Math.PI / 4) },
       { input: f32(Math.sqrt(3)), expected: f32(Math.PI / 3) },
       { input: f32Bits(kBit.f32.infinity.positive), expected: f32(Math.PI / 2) },
+      // Zero-like cases
+      { input: f32(0), expected: f32(0) },
+      { input: f32Bits(kBit.f32.positive.min), expected: f32(0) },
+      { input: f32Bits(kBit.f32.negative.max), expected: f32(0) },
+      { input: f32Bits(kBit.f32.positive.zero), expected: f32(0) },
+      { input: f32Bits(kBit.f32.negative.zero), expected: f32(0) },
+      { input: f32Bits(kBit.f32.positive.min), expected: f32Bits(kBit.f32.positive.min) },
+      { input: f32Bits(kBit.f32.negative.max), expected: f32Bits(kBit.f32.negative.max) },
+      { input: f32Bits(kBit.f32.positive.min), expected: f32Bits(kBit.f32.negative.max) },
+      { input: f32Bits(kBit.f32.negative.max), expected: f32Bits(kBit.f32.positive.min) },
+      { input: f32Bits(kBit.f32.positive.zero), expected: f32Bits(kBit.f32.positive.zero) },
+      { input: f32Bits(kBit.f32.negative.zero), expected: f32Bits(kBit.f32.negative.zero) },
+      { input: f32Bits(kBit.f32.positive.zero), expected: f32Bits(kBit.f32.negative.zero) },
+      { input: f32Bits(kBit.f32.negative.zero), expected: f32Bits(kBit.f32.positive.zero) },
     ];
 
     // Spread of cases over wide domain


### PR DESCRIPTION
The added test cases for `atan` exercises this functionality

Fixes #837





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
