### PR TITLE
Fix typos noticed in conversion utilities

### DIFF
--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -382,7 +382,8 @@ export class Scalar {
 
 /** Create an f32 from a numeric value, a JS `number`. */
 export function f32(value: number): Scalar {
-  return new Scalar(TypeF32, value, new Float32Array([value]));
+  const arr = new Float32Array([value]);
+  return new Scalar(TypeF32, arr[0], arr);
 }
 /** Create an f32 from a bit representation, a uint32 represented as a JS `number`. */
 export function f32Bits(bits: number): Scalar {
@@ -391,7 +392,7 @@ export function f32Bits(bits: number): Scalar {
 }
 /** Create an f16 from a bit representation, a uint16 represented as a JS `number`. */
 export function f16Bits(bits: number): Scalar {
-  const arr = new Uint32Array([bits]);
+  const arr = new Uint16Array([bits]);
   return new Scalar(TypeF16, float16BitsToFloat32(bits), arr);
 }
 

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -398,15 +398,18 @@ export function f16Bits(bits: number): Scalar {
 
 /** Create an i32 from a numeric value, a JS `number`. */
 export function i32(value: number): Scalar {
-  return new Scalar(TypeI32, value, new Int32Array([value]));
+  const arr = new Int32Array([value]);
+  return new Scalar(TypeI32, arr[0], arr);
 }
 /** Create an i16 from a numeric value, a JS `number`. */
 export function i16(value: number): Scalar {
-  return new Scalar(TypeI16, value, new Int16Array([value]));
+  const arr = new Int16Array([value]);
+  return new Scalar(TypeI16, arr[0], arr);
 }
 /** Create an i8 from a numeric value, a JS `number`. */
 export function i8(value: number): Scalar {
-  return new Scalar(TypeI8, value, new Int8Array([value]));
+  const arr = new Int8Array([value]);
+  return new Scalar(TypeI8, arr[0], arr);
 }
 
 /** Create an i32 from a bit representation, a uint32 represented as a JS `number`. */
@@ -427,15 +430,18 @@ export function i8Bits(bits: number): Scalar {
 
 /** Create a u32 from a numeric value, a JS `number`. */
 export function u32(value: number): Scalar {
-  return new Scalar(TypeU32, value, new Uint32Array([value]));
+  const arr = new Uint32Array([value]);
+  return new Scalar(TypeU32, arr[0], arr);
 }
 /** Create a u16 from a numeric value, a JS `number`. */
 export function u16(value: number): Scalar {
-  return new Scalar(TypeU16, value, new Uint16Array([value]));
+  const arr = new Uint16Array([value]);
+  return new Scalar(TypeU16, arr[0], arr);
 }
 /** Create a u8 from a numeric value, a JS `number`. */
 export function u8(value: number): Scalar {
-  return new Scalar(TypeU8, value, new Uint8Array([value]));
+  const arr = new Uint8Array([value]);
+  return new Scalar(TypeU8, arr[0], arr);
 }
 
 /** Create an u32 from a bit representation, a uint32 represented as a JS `number`. */
@@ -459,7 +465,8 @@ export function bool(value: boolean): Scalar {
   // WGSL does not support using 'bool' types directly in storage / uniform
   // buffers, so instead we pack booleans in a u32, where 'false' is zero and
   // 'true' is any non-zero value.
-  return new Scalar(TypeBool, value, new Uint32Array([value ? 1 : 0]));
+  const arr = new Uint32Array([value ? 1 : 0]);
+  return new Scalar(TypeBool, arr[0], arr);
 }
 
 /** A 'true' literal value */

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -466,7 +466,7 @@ export function bool(value: boolean): Scalar {
   // buffers, so instead we pack booleans in a u32, where 'false' is zero and
   // 'true' is any non-zero value.
   const arr = new Uint32Array([value ? 1 : 0]);
-  return new Scalar(TypeBool, arr[0], arr);
+  return new Scalar(TypeBool, value, arr);
 }
 
 /** A 'true' literal value */


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
