### PR TITLE
Add `nextAfter` utility and tests

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -3,7 +3,9 @@ Util math unit tests.
 `;
 
 import { makeTestGroup } from '../common/framework/test_group.js';
-import { diffULP } from '../webgpu/util/math.js';
+import { kBit } from '../webgpu/shader/execution/builtin/builtin.js';
+import { f32, f32Bits, Scalar } from '../webgpu/util/conversion.js';
+import { diffULP, nextAfter } from '../webgpu/util/math.js';
 
 import { UnitTest } from './unit_test.js';
 
@@ -77,4 +79,71 @@ g.test('test,math,diffULP')
     const got = diffULP(a, b);
     const expect = t.params.ulp;
     t.expect(got === expect, `diffULP(${a}, ${b}) returned ${got}. Expected ${expect}`);
+  });
+
+interface nextAfterCase {
+  val: number;
+  dir: boolean;
+  result: Scalar;
+}
+
+g.test('test,math,nextAfter')
+  .paramsSimple<nextAfterCase>([
+    // Edge Cases
+    { val: NaN, dir: true, result: f32Bits(0x7fffffff) },
+    { val: NaN, dir: false, result: f32Bits(0x7fffffff) },
+    { val: Number.POSITIVE_INFINITY, dir: true, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: Number.POSITIVE_INFINITY, dir: false, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: Number.NEGATIVE_INFINITY, dir: true, result: f32Bits(kBit.f32.infinity.negative) },
+    { val: Number.NEGATIVE_INFINITY, dir: false, result: f32Bits(kBit.f32.infinity.negative) },
+
+    // Zeroes
+    { val: -0, dir: true, result: f32Bits(kBit.f32.subnormal.positive.min) },
+    { val: +0, dir: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
+    // Skipping these, since the testing framework does not distinguish between
+    // +0 and -0, so throws an error about duplicate cases.
+    // { val: +0, dir: true, result: f32Bits(kBit.f32.subnormal.positive.min) },
+    // { val: -0, dir: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
+
+    // Subnormals
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, result: f32Bits(0x00000002) },
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, result: f32(0) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, result: f32Bits(0x007ffffe) },
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, result: f32Bits(0x807ffffe) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, result: f32Bits(kBit.f32.negative.max) },
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, result: f32(0) },
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, result: f32Bits(0x80000002) },
+
+    // Normals
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.positive.max), dir: true, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: hexToF32(kBit.f32.positive.max), dir: false, result: f32Bits(0x7f7ffffe) },
+    { val: hexToF32(kBit.f32.positive.min), dir: true, result: f32Bits(0x00800001) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.positive.min), dir: false, result: f32Bits(kBit.f32.subnormal.positive.max) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.negative.max), dir: true, result: f32Bits(kBit.f32.subnormal.negative.min) },
+    { val: hexToF32(kBit.f32.negative.max), dir: false, result: f32Bits(0x80800001) },
+    { val: hexToF32(kBit.f32.negative.min), dir: true, result: f32Bits(0xff7ffffe) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.negative.min), dir: false, result: f32Bits(kBit.f32.infinity.negative) },
+    { val: hexToF32(0x03800000), dir: true, result: f32Bits(0x03800001) },
+    { val: hexToF32(0x03800000), dir: false, result: f32Bits(0x037fffff) },
+    { val: hexToF32(0x83800000), dir: true, result: f32Bits(0x837fffff) },
+    { val: hexToF32(0x83800000), dir: false, result: f32Bits(0x83800001) },
+  ])
+  .fn(t => {
+    const val = t.params.val;
+    const dir = t.params.dir;
+    const expect = t.params.result;
+    const expect_type = typeof expect;
+    const got = nextAfter(val, dir);
+    const got_type = typeof got;
+    t.expect(
+      got.value === expect.value || (Number.isNaN(got.value) && Number.isNaN(expect.value)),
+      `nextAfter(${val}, ${dir}) returned ${got} (${got_type}). Expected ${expect} (${expect_type})`
+    );
   });

--- a/src/webgpu/shader/execution/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/builtin/builtin.ts
@@ -535,6 +535,10 @@ export const kBit = {
         min: 0x0000_0001,
         max: 0x007f_ffff,
       },
+      negative: {
+        max: 0x8000_0001,
+        min: 0x807f_ffff,
+      },
     },
     nan: {
       negative: {

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -69,10 +69,12 @@ export function diffULP(a: number, b: number): number {
 /**
  * @returns the next single precision floating point value after |val|,
  * towards +inf if |dir| is true, otherwise towards -inf.
+ * For -/+0 the nextAfter will be the closest subnormal in the correct
+ * direction, since -0 === +0.
  */
 export function nextAfter(val: number, dir: boolean = true): Scalar {
   if (Number.isNaN(val)) {
-    return f32Bits(0x7fffffff);
+    return f32Bits(kBit.f32.nan.positive.s);
   }
 
   if (val === Number.POSITIVE_INFINITY) {

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1,4 +1,7 @@
 import { assert } from '../../common/util/util.js';
+import { kBit } from '../shader/execution/builtin/builtin.js';
+
+import { f32Bits, Scalar } from './conversion.js';
 
 /**
  * A multiple of 8 guaranteed to be way too large to allocate (just under 8 pebibytes).
@@ -61,4 +64,49 @@ export function diffULP(a: number, b: number): number {
     return Math.max(bits_a, bits_b) - Math.min(bits_a, bits_b);
   }
   return bits_a + bits_b;
+}
+
+/**
+ * @returns the next single precision floating point value after |val|,
+ * towards +inf if |dir| is true, otherwise towards -inf.
+ */
+export function nextAfter(val: number, dir: boolean = true): Scalar {
+  if (Number.isNaN(val)) {
+    return f32Bits(0x7fffffff);
+  }
+
+  if (val === Number.POSITIVE_INFINITY) {
+    return f32Bits(kBit.f32.infinity.positive);
+  }
+
+  if (val === Number.NEGATIVE_INFINITY) {
+    return f32Bits(kBit.f32.infinity.negative);
+  }
+
+  const u32_val = new Uint32Array(new Float32Array([val]).buffer)[0];
+  if (u32_val === kBit.f32.positive.zero || u32_val === kBit.f32.negative.zero) {
+    if (dir) {
+      return f32Bits(kBit.f32.subnormal.positive.min);
+    } else {
+      return f32Bits(kBit.f32.subnormal.negative.max);
+    }
+  }
+
+  let result = u32_val;
+  const is_positive = (u32_val & 0x80000000) === 0;
+  if (dir === is_positive) {
+    result += 1;
+  } else {
+    result -= 1;
+  }
+
+  // Checking for overflow
+  if ((result & 0x7f800000) === 0x7f800000) {
+    if (dir) {
+      return f32Bits(kBit.f32.infinity.positive);
+    } else {
+      return f32Bits(kBit.f32.infinity.negative);
+    }
+  }
+  return f32Bits(result);
 }


### PR DESCRIPTION



<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
