### PR TITLE
Add validation and operations tests for clearBuffer

### DIFF
--- a/src/webgpu/api/operation/command_buffer/clearBuffer.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/clearBuffer.spec.ts
@@ -1,0 +1,54 @@
+export const description = `
+API operations tests for clearBuffer.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('clear')
+  .desc(
+    `Validate the correctness of the clear by filling the srcBuffer with testable data, doing
+  clearBuffer(), and verifying the content of the whole srcBuffer with MapRead:
+  Clear {4 bytes, part of, the whole} buffer {with, without} a non-zero valid offset that
+  - covers the whole buffer
+  - covers the beginning of the buffer
+  - covers the end of the buffer
+  - covers neither the beginning nor the end of the buffer`
+  )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('offset', [0, 4, 8, 16, undefined])
+      .combine('size', [0, 4, 8, 16, undefined])
+      .expand('bufferSize', p => [
+        (p.offset || 0) + (p.size || 16),
+        (p.offset || 0) + (p.size || 16) + 8,
+      ])
+  )
+  .fn(async t => {
+    const { offset, size, bufferSize } = t.params;
+
+    const bufferData = new Uint8Array(bufferSize);
+    for (let i = 0; i < bufferSize; ++i) {
+      bufferData[i] = i + 1;
+    }
+
+    const buffer = t.makeBufferWithContents(
+      bufferData,
+      GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC
+    );
+
+    const encoder = t.device.createCommandEncoder();
+    encoder.clearBuffer(buffer, offset, size);
+    t.device.queue.submit([encoder.finish()]);
+
+    const expectOffset = offset === undefined ? 0 : offset;
+    const expectSize = size === undefined ? bufferSize - expectOffset : size;
+
+    for (let i = 0; i < expectSize; ++i) {
+      bufferData[expectOffset + i] = 0;
+    }
+
+    t.expectGPUBufferValuesEqual(buffer, bufferData);
+  });

--- a/src/webgpu/api/operation/command_buffer/clearBuffer.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/clearBuffer.spec.ts
@@ -22,8 +22,8 @@ g.test('clear')
       .combine('offset', [0, 4, 8, 16, undefined])
       .combine('size', [0, 4, 8, 16, undefined])
       .expand('bufferSize', p => [
-        (p.offset || 0) + (p.size || 16),
-        (p.offset || 0) + (p.size || 16) + 8,
+        (p.offset ?? 0) + (p.size ?? 16),
+        (p.offset ?? 0) + (p.size ?? 16) + 8,
       ])
   )
   .fn(async t => {
@@ -43,8 +43,8 @@ g.test('clear')
     encoder.clearBuffer(buffer, offset, size);
     t.device.queue.submit([encoder.finish()]);
 
-    const expectOffset = offset === undefined ? 0 : offset;
-    const expectSize = size === undefined ? bufferSize - expectOffset : size;
+    const expectOffset = offset ?? 0;
+    const expectSize = size ?? bufferSize - expectOffset;
 
     for (let i = 0; i < expectSize; ++i) {
       bufferData[expectOffset + i] = 0;

--- a/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
@@ -42,7 +42,14 @@ g.test('invalid_buffer')
 
 g.test('default_args')
   .desc(`Test that calling clearBuffer with a default offset and size is valid.`)
+  .paramsSubcasesOnly([
+    { offset: undefined, size: undefined },
+    { offset: 4, size: undefined },
+    { offset: undefined, size: 8 },
+  ] as const)
   .fn(async t => {
+    const { offset, size } = t.params;
+
     const buffer = t.device.createBuffer({
       size: 16,
       usage: GPUBufferUsage.COPY_DST,
@@ -50,8 +57,8 @@ g.test('default_args')
 
     t.TestClearBuffer({
       buffer,
-      offset: undefined,
-      size: undefined,
+      offset,
+      size,
       isSuccess: true,
     });
   });
@@ -94,6 +101,7 @@ g.test('size_alignment')
     { size: 4, _isSuccess: true },
     { size: 5, _isSuccess: false },
     { size: 8, _isSuccess: true },
+    { size: 20, _isSuccess: false },
     { size: undefined, _isSuccess: true },
   ] as const)
   .fn(async t => {
@@ -127,6 +135,7 @@ g.test('offset_alignment')
     { offset: 4, _isSuccess: true },
     { offset: 5, _isSuccess: false },
     { offset: 8, _isSuccess: true },
+    { offset: 20, _isSuccess: false },
     { offset: undefined, _isSuccess: true },
   ] as const)
   .fn(async t => {
@@ -170,10 +179,12 @@ g.test('overflow')
   });
 
 g.test('out_of_bounds')
-  .desc(`Test that clears which exceed the buffer bounds invalid.`)
+  .desc(`Test that clears which exceed the buffer bounds are invalid.`)
   .paramsSubcasesOnly([
     { offset: 0, size: 32, _isSuccess: true },
     { offset: 0, size: 36 },
+    { offset: 32, size: 0, _isSuccess: true },
+    { offset: 32, size: 4 },
     { offset: 36, size: 4 },
     { offset: 36, size: 0 },
     { offset: 20, size: 16 },

--- a/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
@@ -1,0 +1,196 @@
+export const description = `
+API validation tests for clearBuffer.
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { kBufferUsages } from '../../../../capability_info.js';
+import { kMaxSafeMultipleOf8 } from '../../../../util/math.js';
+import { ValidationTest } from '../../validation_test.js';
+
+class F extends ValidationTest {
+  TestClearBuffer(options: {
+    buffer: GPUBuffer;
+    offset: number | undefined;
+    size: number | undefined;
+    isSuccess: boolean;
+  }): void {
+    const { buffer, offset, size, isSuccess } = options;
+
+    const commandEncoder = this.device.createCommandEncoder();
+    commandEncoder.clearBuffer(buffer, offset, size);
+
+    this.expectValidationError(() => {
+      commandEncoder.finish();
+    }, !isSuccess);
+  }
+}
+
+export const g = makeTestGroup(F);
+
+g.test('invalid_buffer')
+  .desc(`Test that clearing an error buffer fails.`)
+  .fn(async t => {
+    const errorBuffer = t.getErrorBuffer();
+
+    t.TestClearBuffer({
+      buffer: errorBuffer,
+      offset: 0,
+      size: 8,
+      isSuccess: false,
+    });
+  });
+
+g.test('default_args')
+  .desc(`Test that calling clearBuffer with a default offset and size is valid.`)
+  .fn(async t => {
+    const buffer = t.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.COPY_DST,
+    });
+
+    t.TestClearBuffer({
+      buffer,
+      offset: undefined,
+      size: undefined,
+      isSuccess: true,
+    });
+  });
+
+g.test('buffer_usage')
+  .desc(`Test that only buffers with COPY_DST usage are valid to use with copyBuffers.`)
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('usage', kBufferUsages)
+  )
+  .fn(async t => {
+    const { usage } = t.params;
+
+    const buffer = t.device.createBuffer({
+      size: 16,
+      usage,
+    });
+
+    t.TestClearBuffer({
+      buffer,
+      offset: 0,
+      size: 16,
+      isSuccess: usage === GPUBufferUsage.COPY_DST,
+    });
+  });
+
+g.test('size_alignment')
+  .desc(
+    `
+    Test that the clear size must be 4 byte aligned.
+    - Test size is not a multiple of 4.
+    - Test size is 0.
+    - Test size overflows the buffer size.
+    - Test size is omitted.
+  `
+  )
+  .paramsSubcasesOnly([
+    { size: 0, _isSuccess: true },
+    { size: 2, _isSuccess: false },
+    { size: 4, _isSuccess: true },
+    { size: 5, _isSuccess: false },
+    { size: 8, _isSuccess: true },
+    { size: undefined, _isSuccess: true },
+  ] as const)
+  .fn(async t => {
+    const { size, _isSuccess: isSuccess } = t.params;
+
+    const buffer = t.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.COPY_DST,
+    });
+
+    t.TestClearBuffer({
+      buffer,
+      offset: 0,
+      size,
+      isSuccess,
+    });
+  });
+
+g.test('offset_alignment')
+  .desc(
+    `
+    Test that the clear offsets must be 4 byte aligned.
+    - Test offset is not a multiple of 4.
+    - Test offset is larger than the buffer size.
+    - Test offset is omitted.
+  `
+  )
+  .paramsSubcasesOnly([
+    { offset: 0, _isSuccess: true },
+    { offset: 2, _isSuccess: false },
+    { offset: 4, _isSuccess: true },
+    { offset: 5, _isSuccess: false },
+    { offset: 8, _isSuccess: true },
+    { offset: undefined, _isSuccess: true },
+  ] as const)
+  .fn(async t => {
+    const { offset, _isSuccess: isSuccess } = t.params;
+
+    const buffer = t.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.COPY_DST,
+    });
+
+    t.TestClearBuffer({
+      buffer,
+      offset,
+      size: 8,
+      isSuccess,
+    });
+  });
+
+g.test('overflow')
+  .desc(`Test that clears which may cause arthimetic overflows are invalid.`)
+  .paramsSubcasesOnly([
+    { offset: 0, size: kMaxSafeMultipleOf8 },
+    { offset: 16, size: kMaxSafeMultipleOf8 },
+    { offset: kMaxSafeMultipleOf8, size: 16 },
+    { offset: kMaxSafeMultipleOf8, size: kMaxSafeMultipleOf8 },
+  ] as const)
+  .fn(async t => {
+    const { offset, size } = t.params;
+
+    const buffer = t.device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.COPY_DST,
+    });
+
+    t.TestClearBuffer({
+      buffer,
+      offset,
+      size,
+      isSuccess: false,
+    });
+  });
+
+g.test('out_of_bounds')
+  .desc(`Test that clears which exceed the buffer bounds invalid.`)
+  .paramsSubcasesOnly([
+    { offset: 0, size: 32, _isSuccess: true },
+    { offset: 0, size: 36 },
+    { offset: 36, size: 4 },
+    { offset: 36, size: 0 },
+    { offset: 20, size: 16 },
+    { offset: 20, size: 12, _isSuccess: true },
+  ] as const)
+  .fn(async t => {
+    const { offset, size, _isSuccess = false } = t.params;
+
+    const buffer = t.device.createBuffer({
+      size: 32,
+      usage: GPUBufferUsage.COPY_DST,
+    });
+
+    t.TestClearBuffer({
+      buffer,
+      offset,
+      size,
+      isSuccess: _isSuccess,
+    });
+  });


### PR DESCRIPTION
<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
