### PR TITLE
Fix desynchronized @webgpu/types dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/offscreencanvas": "^2019.6.2",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.22.0",
-        "@webgpu/types": "^0.1.6",
+        "@webgpu/types": "0.1.7",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.0.1",
@@ -1374,9 +1374,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.6.tgz",
-      "integrity": "sha512-5c3ZxNmGwVhTo8nW0b0iEaSVLTx89D056c7JzbzC2f9J+qebRM+U9rH52q9Z/HwZbZQTUAYX5UGp0c4BNv61Ew==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.7.tgz",
+      "integrity": "sha512-KOcGuwHPFHHXlXRS9HQSIpUwp9IgocqfMflEnOO8Hhykwk+UlYCxyUwbAN0VgQSpF0slrLcjtz0IRBeuAW1hsw==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10591,9 +10591,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.6.tgz",
-      "integrity": "sha512-5c3ZxNmGwVhTo8nW0b0iEaSVLTx89D056c7JzbzC2f9J+qebRM+U9rH52q9Z/HwZbZQTUAYX5UGp0c4BNv61Ew==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.7.tgz",
+      "integrity": "sha512-KOcGuwHPFHHXlXRS9HQSIpUwp9IgocqfMflEnOO8Hhykwk+UlYCxyUwbAN0VgQSpF0slrLcjtz0IRBeuAW1hsw==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/offscreencanvas": "^2019.6.2",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "^0.1.7",
+    "@webgpu/types": "0.1.7",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",


### PR DESCRIPTION
This dependency got desynced between `package.json` and `package-lock.json` during some revert shenanigans, which I think(?) resulted in `npm ci` throwing up its hands and installing the latest package matching `^0.1.17`, which is 0.1.18.

- Fix the desync by updating `package-lock.json` to `0.0.17`
- Require exactly `0.1.17` instead of `^0.1.17`. In theory this shouldn't make any difference (https://semver.org/#spec-item-4), but in this case it might.