### PR TITLE
Roll to the lastest WebGPU type definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/offscreencanvas": "^2019.6.2",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.22.0",
-        "@webgpu/types": "0.1.7",
+        "@webgpu/types": "0.1.9",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.0.1",
@@ -1374,9 +1374,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.7.tgz",
-      "integrity": "sha512-KOcGuwHPFHHXlXRS9HQSIpUwp9IgocqfMflEnOO8Hhykwk+UlYCxyUwbAN0VgQSpF0slrLcjtz0IRBeuAW1hsw==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.9.tgz",
+      "integrity": "sha512-CGG93bZ4znugJ7KWdvWYGTemt7rUmdpzt1BOMCHI/5Kgt08tOtnn9sFmk4ZT26aGgwxBT5iC/djCxzbfxVdldA==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10591,9 +10591,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.7.tgz",
-      "integrity": "sha512-KOcGuwHPFHHXlXRS9HQSIpUwp9IgocqfMflEnOO8Hhykwk+UlYCxyUwbAN0VgQSpF0slrLcjtz0IRBeuAW1hsw==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.9.tgz",
+      "integrity": "sha512-CGG93bZ4znugJ7KWdvWYGTemt7rUmdpzt1BOMCHI/5Kgt08tOtnn9sFmk4ZT26aGgwxBT5iC/djCxzbfxVdldA==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/offscreencanvas": "^2019.6.2",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "0.1.7",
+    "@webgpu/types": "0.1.9",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -32,7 +32,7 @@ type VertexBuffer<V, A> = V & {
 type VertexState<V, A> = VertexBuffer<V, A>[];
 
 type VertexLayoutState<V, A> = VertexState<
-  { stepMode: GPUInputStepMode; arrayStride: number } & V,
+  { stepMode: GPUVertexStepMode; arrayStride: number } & V,
   { format: GPUVertexFormat; offset: number } & A
 >;
 
@@ -77,7 +77,7 @@ class VertexStateTest extends GPUTest {
   // a negative number corresponding to the check number (in case you need to debug a failure).
   makeTestWGSL(
     buffers: VertexState<
-      { stepMode: GPUInputStepMode },
+      { stepMode: GPUVertexStepMode },
       {
         format: GPUVertexFormat;
         shaderBaseType: string;
@@ -222,7 +222,7 @@ struct VSOutputs {
 
   makeTestPipeline(
     buffers: VertexState<
-      { stepMode: GPUInputStepMode; arrayStride: number },
+      { stepMode: GPUVertexStepMode; arrayStride: number },
       {
         offset: number;
         format: GPUVertexFormat;
@@ -748,7 +748,7 @@ g.test('buffers_with_varying_step_mode')
   )
   .fn(t => {
     const { stepModes } = t.params;
-    const state = (stepModes as GPUInputStepMode[]).map((stepMode, i) => ({
+    const state = (stepModes as GPUVertexStepMode[]).map((stepMode, i) => ({
       slot: i,
       arrayStride: 4,
       stepMode,

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -53,15 +53,10 @@ import {
 import { GPUConst } from '../../../../constants.js';
 import { ValidationTest } from '../../validation_test.js';
 
-type TextureBindingType =
-  | 'sampled-texture'
-  | 'multisampled-texture'
-  | 'readonly-storage-texture'
-  | 'writeonly-storage-texture';
+type TextureBindingType = 'sampled-texture' | 'multisampled-texture' | 'writeonly-storage-texture';
 const kTextureBindingTypes = [
   'sampled-texture',
   'multisampled-texture',
-  'readonly-storage-texture',
   'writeonly-storage-texture',
 ] as const;
 
@@ -115,10 +110,6 @@ class TextureUsageTracking extends ValidationTest {
         break;
       case 'multisampled-texture':
         entry = { texture: { viewDimension, multisampled: true, sampleType } };
-        break;
-      case 'readonly-storage-texture':
-        assert(format !== undefined);
-        entry = { storageTexture: { access: 'read-only', format, viewDimension } };
         break;
       case 'writeonly-storage-texture':
         assert(format !== undefined);
@@ -267,12 +258,8 @@ g.test('subresources_and_binding_types_combination_for_color')
       .combine('compute', [false, true])
       .combineWithParams([
         { _usageOK: true, type0: 'sampled-texture', type1: 'sampled-texture' },
-        { _usageOK: true, type0: 'sampled-texture', type1: 'readonly-storage-texture' },
         { _usageOK: false, type0: 'sampled-texture', type1: 'writeonly-storage-texture' },
         { _usageOK: false, type0: 'sampled-texture', type1: 'render-target' },
-        { _usageOK: true, type0: 'readonly-storage-texture', type1: 'readonly-storage-texture' },
-        { _usageOK: false, type0: 'readonly-storage-texture', type1: 'writeonly-storage-texture' },
-        { _usageOK: false, type0: 'readonly-storage-texture', type1: 'render-target' },
         // Race condition upon multiple writable storage texture is valid.
         { _usageOK: true, type0: 'writeonly-storage-texture', type1: 'writeonly-storage-texture' },
         { _usageOK: false, type0: 'writeonly-storage-texture', type1: 'render-target' },
@@ -827,7 +814,6 @@ g.test('replaced_binding')
       .combine('callDrawOrDispatch', [false, true])
       .combine('entry', [
         { texture: {} },
-        { storageTexture: { access: 'read-only', format: 'rgba8unorm' } },
         { storageTexture: { access: 'write-only', format: 'rgba8unorm' } },
       ] as const)
   )
@@ -903,7 +889,6 @@ g.test('bindings_in_bundle')
             case 'multisampled-texture':
             case 'sampled-texture':
               return 'TEXTURE_BINDING' as const;
-            case 'readonly-storage-texture':
             case 'writeonly-storage-texture':
               return 'STORAGE_BINDING' as const;
             case 'render-target':
@@ -997,7 +982,6 @@ g.test('bindings_in_bundle')
       switch (t) {
         case 'sampled-texture':
         case 'multisampled-texture':
-        case 'readonly-storage-texture':
           return true;
         default:
           return false;
@@ -1039,7 +1023,7 @@ g.test('unused_bindings_in_pipeline')
       callDrawOrDispatch,
     } = t.params;
     const view = t.createTexture({ usage: GPUTextureUsage.STORAGE_BINDING }).createView();
-    const bindGroup0 = t.createBindGroup(0, view, 'readonly-storage-texture', '2d', {
+    const bindGroup0 = t.createBindGroup(0, view, 'sampled-texture', '2d', {
       format: 'rgba8unorm',
     });
     const bindGroup1 = t.createBindGroup(0, view, 'writeonly-storage-texture', '2d', {

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -695,14 +695,14 @@ assertTypeTrue<TypeEqual<GPUTextureSampleType, typeof kTextureSampleTypes[number
 
 /** Binding type info (including class limits) for the specified GPUStorageTextureBindingLayout. */
 export function storageTextureBindingTypeInfo(d: GPUStorageTextureBindingLayout) {
-  /* prettier-ignore */
-  switch (d.access ?? 'write-only') {
-    case 'read-only':  return { usage: GPUConst.TextureUsage.STORAGE_BINDING, ...kBindingKind.storageTex, ...kValidStagesAll,          };
-    case 'write-only': return { usage: GPUConst.TextureUsage.STORAGE_BINDING, ...kBindingKind.storageTex, ...kValidStagesStorageWrite, };
-  }
+  return {
+    usage: GPUConst.TextureUsage.STORAGE_BINDING,
+    ...kBindingKind.storageTex,
+    ...kValidStagesStorageWrite,
+  };
 }
 /** List of all GPUStorageTextureAccess values. */
-export const kStorageTextureAccessValues = ['read-only', 'write-only'] as const;
+export const kStorageTextureAccessValues = ['write-only'] as const;
 assertTypeTrue<TypeEqual<GPUStorageTextureAccess, typeof kStorageTextureAccessValues[number]>>();
 
 /** GPUBindGroupLayoutEntry, but only the "union" fields, not the common fields. */

--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.html.ts
@@ -27,7 +27,7 @@ export function run() {
 
     function updateWebGPUBackBuffer(
       canvas: HTMLCanvasElement,
-      ctx: GPUPresentationContext,
+      ctx: GPUCanvasContext,
       configureSize: [number, number] | undefined,
       pixels: Array<Array<Uint8Array>>
     ) {


### PR DESCRIPTION
Won't be able to land as-is with the 0.1.8 types package. Requires https://github.com/gpuweb/types/pull/87 to land and be published first, at which point I'll update the packages.json to pull the correct version. Verified locally that it should passes the checks at that point. 