### PR TITLE
Implement index buffer OOB validation test for drawIndexed/Indirect

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -5,7 +5,6 @@ and parameters as expect.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { unreachable } from '../../../../../../common/util/util.js';
 import { ValidationTest } from '../../../validation_test.js';
 
 interface DrawIndexedParameter {
@@ -45,8 +44,6 @@ class F extends ValidationTest {
         encoder.drawIndexedIndirect(indirectBuffer, 0);
         break;
       }
-      default:
-        unreachable();
     }
   }
 }

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -150,7 +150,7 @@ drawIndexedIndirect as it is GPU-validated.
   .params(u =>
     u
       .combine('bufferSizeInElements', [10, 100])
-      // Binding size always smaller than buffer size, make sure that setIndexBuffer succeed
+      // Binding size is always no larger than buffer size, make sure that setIndexBuffer succeed
       .combine('bindingSizeInElements', [10])
       .combine('drawIndexCount', [10, 11])
       .combine('drawType', ['drawIndexed', 'drawIndexedIndirect'] as const)

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -5,50 +5,50 @@ and parameters as expect.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
 import { ValidationTest } from '../../../validation_test.js';
 
 interface DrawIndexedParameter {
   indexCount: number;
+  instanceCount?: number;
   firstIndex?: number;
   baseVertex?: number;
-  instanceCount?: number;
   firstInstance?: number;
 }
 
-class F extends ValidationTest {
-  callDrawIndexed(
-    encoder: GPURenderEncoderBase,
-    drawType: 'drawIndexed' | 'drawIndexedIndirect',
-    param: DrawIndexedParameter
-  ) {
-    switch (drawType) {
-      case 'drawIndexed': {
-        encoder.drawIndexed(
-          param.indexCount,
-          param.instanceCount || 1,
-          param.firstIndex || 0,
-          param.baseVertex || 0,
-          param.firstInstance || 0
-        );
-        break;
-      }
-      case 'drawIndexedIndirect': {
-        const indirectArray = new Int32Array([
-          param.indexCount,
-          param.instanceCount || 1,
-          param.firstIndex || 0,
-          param.baseVertex || 0,
-          param.firstInstance || 0,
-        ]);
-        const indirectBuffer = this.makeBufferWithContents(indirectArray, GPUBufferUsage.INDIRECT);
-        encoder.drawIndexedIndirect(indirectBuffer, 0);
-        break;
-      }
+function callDrawIndexed(
+  test: GPUTest,
+  encoder: GPURenderEncoderBase,
+  drawType: 'drawIndexed' | 'drawIndexedIndirect',
+  param: DrawIndexedParameter
+) {
+  switch (drawType) {
+    case 'drawIndexed': {
+      encoder.drawIndexed(
+        param.indexCount,
+        param.instanceCount ?? 1,
+        param.firstIndex ?? 0,
+        param.baseVertex ?? 0,
+        param.firstInstance ?? 0
+      );
+      break;
+    }
+    case 'drawIndexedIndirect': {
+      const indirectArray = new Int32Array([
+        param.indexCount,
+        param.instanceCount ?? 1,
+        param.firstIndex ?? 0,
+        param.baseVertex ?? 0,
+        param.firstInstance ?? 0,
+      ]);
+      const indirectBuffer = test.makeBufferWithContents(indirectArray, GPUBufferUsage.INDIRECT);
+      encoder.drawIndexedIndirect(indirectBuffer, 0);
+      break;
     }
   }
 }
 
-export const g = makeTestGroup(F);
+export const g = makeTestGroup(ValidationTest);
 
 g.test(`unused_buffer_bound`)
   .desc(
@@ -121,7 +121,7 @@ drawIndexedIndirect as it is GPU-validated.
 
     renderEncoder.setPipeline(renderPipeline);
 
-    t.callDrawIndexed(renderEncoder, drawType, drawCallParam);
+    callDrawIndexed(t, renderEncoder, drawType, drawCallParam);
 
     commandBufferMaker.validateFinishAndSubmit(isFinishSuccess, true);
   });


### PR DESCRIPTION
Implement index buffer OOB validation test for drawIndexed and drawIndexedIndirect

Implement the index buffer OOB test to check calling drawIndexed with OOB index buffer access result in validation error when finish encoder, while drawIndexedIndirect will cause no CPU validation error.
This is a part of vertex access validation test for draw.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
