### PR TITLE
Implement `correctlyRounded` and update tests to use it

### DIFF
--- a/src/common/internal/query/json_param_value.ts
+++ b/src/common/internal/query/json_param_value.ts
@@ -1,15 +1,51 @@
 import { assert, sortObjectByKey } from '../../util/util.js';
 import { JSONWithUndefined } from '../params_utils.js';
 
-// JSON can't represent `undefined` and by default stores it as `null`.
-// Instead, store `undefined` as this magic string value in JSON.
+// JSON can't represent various values and by default stores them as `null`.
+// Instead, storing them as a magic string values in JSON.
 const jsUndefinedMagicValue = '_undef_';
+const jsNaNMagicValue = '_nan_';
+const jsPositiveInfinityMagicValue = '_posinfinity_';
+const jsNegativeInfinityMagicValue = '_neginfinity_';
+
+const toStringMagicValue = new Map<unknown, string>([
+  [undefined, jsUndefinedMagicValue],
+  [NaN, jsNaNMagicValue],
+  [Number.POSITIVE_INFINITY, jsPositiveInfinityMagicValue],
+  [Number.NEGATIVE_INFINITY, jsNegativeInfinityMagicValue],
+]);
+
+const fromStringMagicValue = new Map<string, unknown>([
+  [jsUndefinedMagicValue, undefined],
+  [jsNaNMagicValue, NaN],
+  [jsPositiveInfinityMagicValue, Number.POSITIVE_INFINITY],
+  [jsNegativeInfinityMagicValue, Number.NEGATIVE_INFINITY],
+]);
+
+// -0 needs to be handled separately, because -0 === +0 returns true. Not
+// special casing +0/0, since it behaves intuitively. Assuming that if -0 is
+// being used, the differentiation from +0 is desired.
+const jsNegativeZeroMagicValue = '_negzero_';
 
 function stringifyFilter(k: string, v: unknown): unknown {
-  // Make sure no one actually uses the magic value as a parameter.
-  assert(v !== jsUndefinedMagicValue);
+  // Make sure no one actually uses a magic value as a parameter.
+  if (typeof v === 'string') {
+    assert(
+      !fromStringMagicValue.has(v),
+      `${v} is a magic value for stringification, so cannot be used`
+    );
 
-  return v === undefined ? jsUndefinedMagicValue : v;
+    assert(
+      v !== jsNegativeZeroMagicValue,
+      `${v} is a magic value for stringification, so cannot be used`
+    );
+  }
+
+  if (Object.is(v, -0)) {
+    return jsNegativeZeroMagicValue;
+  }
+
+  return toStringMagicValue.has(v) ? toStringMagicValue.get(v) : v;
 }
 
 export function stringifyParamValue(value: JSONWithUndefined): string {
@@ -29,6 +65,20 @@ export function stringifyParamValueUniquely(value: JSONWithUndefined): string {
   });
 }
 
+// 'any' is part of the JSON.parse reviver interface, so cannot be avoided.
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+function parseParamValueReviver(k: string, v: any): any {
+  if (k === jsNegativeZeroMagicValue) {
+    return -0;
+  }
+
+  if (fromStringMagicValue.has(k)) {
+    return fromStringMagicValue.get(k);
+  }
+
+  return v;
+}
+
 export function parseParamValue(s: string): JSONWithUndefined {
-  return JSON.parse(s, (k, v) => (v === jsUndefinedMagicValue ? undefined : v));
+  return JSON.parse(s, parseParamValueReviver);
 }

--- a/src/webgpu/shader/execution/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/builtin/abs.spec.ts
@@ -14,7 +14,7 @@ import {
   u32Bits,
 } from '../../../util/conversion.js';
 
-import { anyOf, kBit, kValue, run } from './builtin.js';
+import { anyOf, Config, correctlyRoundedThreshold, kBit, kValue, run } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -95,7 +95,10 @@ If e evaluates to the largest negative value, then the result is e.
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    run(t, 'abs', [TypeI32], TypeI32, t.params, [
+    const cfg: Config = t.params;
+    cfg.cmpFloats = correctlyRoundedThreshold();
+
+    run(t, 'abs', [TypeI32], TypeI32, cfg, [
       // Min and max i32
       // If e evaluates to the largest negative value, then the result is e.
       { input: i32Bits(kBit.i32.negative.min), expected: i32Bits(kBit.i32.negative.min) },
@@ -156,7 +159,10 @@ Component-wise when T is a vector. (GLSLstd450Fabs)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    run(t, 'abs', [TypeF32], TypeF32, t.params, [
+    const cfg: Config = t.params;
+    cfg.cmpFloats = correctlyRoundedThreshold();
+
+    run(t, 'abs', [TypeF32], TypeF32, cfg, [
       // Min and Max f32
       { input: f32Bits(kBit.f32.negative.max), expected: f32Bits(0x0080_0000) },
       { input: f32Bits(kBit.f32.negative.min), expected: f32Bits(0x7f7f_ffff) },

--- a/src/webgpu/shader/execution/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/builtin/builtin.ts
@@ -1,6 +1,7 @@
 import { Colors } from '../../../../common/util/colors.js';
 import { GPUTest } from '../../../gpu_test.js';
 import {
+  f32,
   ScalarType,
   Scalar,
   Vector,
@@ -10,7 +11,7 @@ import {
   TypeU32,
   VectorType,
 } from '../../../util/conversion.js';
-import { diffULP } from '../../../util/math.js';
+import { correctlyRounded, diffULP } from '../../../util/math.js';
 
 /** Comparison describes the result of a Comparator function. */
 export interface Comparison {
@@ -55,6 +56,17 @@ export function ulpThreshold(ulp: number): FloatMatch {
       return true;
     }
     return diffULP(got, expected) <= ulp;
+  };
+}
+
+/**
+ * @returns a FloatMatch that returns true iff |expected| is a correctly round
+ * to |got|.
+ * |got| must be expressible as a float32.
+ */
+export function correctlyRoundedThreshold(): FloatMatch {
+  return (got, expected) => {
+    return correctlyRounded(f32(got), expected);
   };
 }
 

--- a/src/webgpu/shader/execution/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/builtin/ceil.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { f32, f32Bits, TypeF32 } from '../../../util/conversion.js';
 
-import { anyOf, kBit, kValue, run } from './builtin.js';
+import { anyOf, Config, correctlyRoundedThreshold, kBit, kValue, run } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -28,7 +28,10 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    run(t, 'ceil', [TypeF32], TypeF32, t.params, [
+    const cfg: Config = t.params;
+    cfg.cmpFloats = correctlyRoundedThreshold();
+
+    run(t, 'ceil', [TypeF32], TypeF32, cfg, [
       // Small positive numbers
       { input: f32(0.1), expected: f32(1.0) },
       { input: f32(0.9), expected: f32(1.0) },

--- a/src/webgpu/shader/execution/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/builtin/floor.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { f32, f32Bits, TypeF32 } from '../../../util/conversion.js';
 
-import { anyOf, kBit, kValue, run } from './builtin.js';
+import { anyOf, Config, correctlyRoundedThreshold, kBit, kValue, run } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -25,7 +25,10 @@ T is f32 or vecN<f32> floor(e: T ) -> T Returns the floor of e. Component-wise w
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    run(t, 'floor', [TypeF32], TypeF32, t.params, [
+    const cfg: Config = t.params;
+    cfg.cmpFloats = correctlyRoundedThreshold();
+
+    run(t, 'floor', [TypeF32], TypeF32, cfg, [
       // Small positive numbers
       { input: f32(0.1), expected: f32(0.0) },
       { input: f32(0.9), expected: f32(0.0) },

--- a/src/webgpu/shader/execution/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/builtin/min.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { i32, i32Bits, TypeI32, TypeU32, u32 } from '../../../util/conversion.js';
 
-import { run } from './builtin.js';
+import { Config, correctlyRoundedThreshold, run } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -28,7 +28,10 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    run(t, 'min', [TypeU32, TypeU32], TypeU32, t.params, [
+    const cfg: Config = t.params;
+    cfg.cmpFloats = correctlyRoundedThreshold();
+
+    run(t, 'min', [TypeU32, TypeU32], TypeU32, cfg, [
       { input: [u32(1), u32(1)], expected: u32(1) },
       { input: [u32(0), u32(0)], expected: u32(0) },
       { input: [u32(0xffffffff), u32(0xffffffff)], expected: u32(0xffffffff) },
@@ -60,7 +63,10 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    run(t, 'min', [TypeI32, TypeI32], TypeI32, t.params, [
+    const cfg: Config = t.params;
+    cfg.cmpFloats = correctlyRoundedThreshold();
+
+    run(t, 'min', [TypeI32, TypeI32], TypeI32, cfg, [
       { input: [i32(1), i32(1)], expected: i32(1) },
       { input: [i32(0), i32(0)], expected: i32(0) },
       { input: [i32(-1), i32(-1)], expected: i32(-1) },

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1,7 +1,7 @@
 import { assert } from '../../common/util/util.js';
 import { kBit } from '../shader/execution/builtin/builtin.js';
 
-import { f32Bits, Scalar } from './conversion.js';
+import { f32, f32Bits, Scalar } from './conversion.js';
 
 /**
  * A multiple of 8 guaranteed to be way too large to allocate (just under 8 pebibytes).
@@ -71,6 +71,7 @@ export function diffULP(a: number, b: number): number {
  * towards +inf if |dir| is true, otherwise towards -inf.
  * For -/+0 the nextAfter will be the closest subnormal in the correct
  * direction, since -0 === +0.
+ * |val| must be expressible as a f32.
  */
 export function nextAfter(val: number, dir: boolean = true): Scalar {
   if (Number.isNaN(val)) {
@@ -85,8 +86,8 @@ export function nextAfter(val: number, dir: boolean = true): Scalar {
     return f32Bits(kBit.f32.infinity.negative);
   }
 
-  const u32_val = new Uint32Array(new Float32Array([val]).buffer)[0];
-  if (u32_val === kBit.f32.positive.zero || u32_val === kBit.f32.negative.zero) {
+  // -/+0 === 0 returns true
+  if (val === 0) {
     if (dir) {
       return f32Bits(kBit.f32.subnormal.positive.min);
     } else {
@@ -94,8 +95,13 @@ export function nextAfter(val: number, dir: boolean = true): Scalar {
     }
   }
 
-  let result = u32_val;
+  // number is float64 internally, so need to test if value is expressible as a float32.
+  const converted: number = new Float32Array([val])[0];
+  assert(val === converted, `${val} is not expressible as a f32.`);
+
+  const u32_val = new Uint32Array(new Float32Array([val]).buffer)[0];
   const is_positive = (u32_val & 0x80000000) === 0;
+  let result = u32_val;
   if (dir === is_positive) {
     result += 1;
   } else {
@@ -111,4 +117,51 @@ export function nextAfter(val: number, dir: boolean = true): Scalar {
     }
   }
   return f32Bits(result);
+}
+
+/**
+ * @returns if a test value is correctly rounded to an target value. Only
+ * defined for |test_values| being a float32. target values may be any number.
+ *
+ * Correctly rounded means that if the target value is precisely expressible
+ * as a float32, then |test_value| === |target|.
+ * Otherwise |test_value| needs to be either the closest expressible number greater
+ * or less than |target|.
+ */
+export function correctlyRounded(test_value: Scalar, target: number): boolean {
+  assert(test_value.type.kind === 'f32', `${test_value} is expected to be a 'f32'`);
+
+  if (Number.isNaN(target)) {
+    return Number.isNaN(test_value.value.valueOf() as number);
+  }
+
+  if (target === Number.POSITIVE_INFINITY) {
+    return test_value.value === f32Bits(kBit.f32.infinity.positive).value;
+  }
+
+  if (target === Number.NEGATIVE_INFINITY) {
+    return test_value.value === f32Bits(kBit.f32.infinity.negative).value;
+  }
+
+  const target32 = new Float32Array([target])[0];
+  const converted: number = target32;
+  if (target === converted) {
+    // expected is precisely expressible in float32
+    return test_value.value === f32(target32).value;
+  }
+
+  let after_target: Scalar;
+  let before_target: Scalar;
+
+  if (converted > target) {
+    // target32 is rounded towards +inf, so is after_target
+    after_target = f32(target32);
+    before_target = nextAfter(target32, false);
+  } else {
+    // target32 is rounded towards -inf, so is before_target
+    after_target = nextAfter(target32, true);
+    before_target = f32(target32);
+  }
+
+  return test_value.value === before_target.value || test_value.value === after_target.value;
 }


### PR DESCRIPTION
This also reworks and expands the magic values for JSON
stringification.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [x] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
