### PR TITLE
wgsl: Remove [[block]] attribute from all tests

### DIFF
--- a/src/stress/compute/compute_pass.spec.ts
+++ b/src/stress/compute/compute_pass.spec.ts
@@ -21,7 +21,7 @@ GPUComputePipeline.`
       compute: {
         module: t.device.createShaderModule({
           code: `
-            [[block]] struct Buffer { data: array<u32>; };
+            struct Buffer { data: array<u32>; };
             [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
             [[stage(compute), workgroup_size(1)]] fn main(
                 [[builtin(global_invocation_id)]] id: vec3<u32>) {
@@ -66,7 +66,7 @@ GPUComputePipeline.`
     const stages = iterRange(kNumIterations, i => ({
       module: t.device.createShaderModule({
         code: `
-        [[block]] struct Buffer { data: u32; };
+        struct Buffer { data: u32; };
         [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
         [[stage(compute), workgroup_size(1)]] fn main${i}() {
           buffer.data = buffer.data + 1u;
@@ -110,7 +110,7 @@ groups.`
     );
     const module = t.device.createShaderModule({
       code: `
-        [[block]] struct Buffer { data: array<u32>; };
+        struct Buffer { data: array<u32>; };
         [[group(0), binding(0)]] var<storage, read_write> buffer1: Buffer;
         [[group(0), binding(1)]] var<storage, read_write> buffer2: Buffer;
         [[stage(compute), workgroup_size(1)]] fn main(
@@ -159,7 +159,7 @@ g.test('many_dispatches')
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const module = t.device.createShaderModule({
       code: `
-        [[block]] struct Buffer { data: array<u32>; };
+        struct Buffer { data: array<u32>; };
         [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
         [[stage(compute), workgroup_size(1)]] fn main(
             [[builtin(global_invocation_id)]] id: vec3<u32>) {
@@ -201,7 +201,7 @@ g.test('huge_dispatches')
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const module = t.device.createShaderModule({
       code: `
-        [[block]] struct Buffer { data: array<u32>; };
+        struct Buffer { data: array<u32>; };
         [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
         [[stage(compute), workgroup_size(1)]] fn main(
             [[builtin(global_invocation_id)]] id: vec3<u32>) {

--- a/src/stress/queue/submit.spec.ts
+++ b/src/stress/queue/submit.spec.ts
@@ -22,7 +22,7 @@ results verified at the end of the test.`
       compute: {
         module: t.device.createShaderModule({
           code: `
-            [[block]] struct Buffer { data: array<u32>; };
+            struct Buffer { data: array<u32>; };
             [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
             [[stage(compute), workgroup_size(1)]] fn main(
                 [[builtin(global_invocation_id)]] id: vec3<u32>) {
@@ -66,7 +66,7 @@ submit() call.`
       compute: {
         module: t.device.createShaderModule({
           code: `
-            [[block]] struct Buffer { data: array<u32>; };
+            struct Buffer { data: array<u32>; };
             [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
             [[stage(compute), workgroup_size(1)]] fn main(
                 [[builtin(global_invocation_id)]] id: vec3<u32>) {

--- a/src/stress/render/render_pass.spec.ts
+++ b/src/stress/render/render_pass.spec.ts
@@ -157,7 +157,7 @@ buffer.`
     const kSize = 128;
     const module = t.device.createShaderModule({
       code: `
-    [[block]] struct Uniforms { index: u32; };
+    struct Uniforms { index: u32; };
     [[group(0), binding(0)]] var<uniform> uniforms: Uniforms;
     [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
       let index = uniforms.index;

--- a/src/stress/render/vertex_buffers.spec.ts
+++ b/src/stress/render/vertex_buffers.spec.ts
@@ -17,7 +17,7 @@ function createHugeVertexBuffer(t: GPUTest, size: number) {
     compute: {
       module: t.device.createShaderModule({
         code: `
-        [[block]] struct Buffer { data: array<vec2<u32>>; };
+        struct Buffer { data: array<vec2<u32>>; };
         [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
         [[stage(compute), workgroup_size(1)]] fn main(
             [[builtin(global_invocation_id)]] id: vec3<u32>) {

--- a/src/stress/shaders/entry_points.spec.ts
+++ b/src/stress/shaders/entry_points.spec.ts
@@ -10,7 +10,7 @@ export const g = makeTestGroup(GPUTest);
 
 const makeCode = (numEntryPoints: number) => {
   const kBaseCode = `
-      [[block]] struct Buffer { data: u32; };
+      struct Buffer { data: u32; };
       [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
       fn main() { buffer.data = buffer.data + 1u;  }
       `;

--- a/src/stress/shaders/non_halting.spec.ts
+++ b/src/stress/shaders/non_halting.spec.ts
@@ -19,7 +19,7 @@ device loss.`
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const module = t.device.createShaderModule({
       code: `
-        [[block]] struct Buffer { data: u32; };
+        struct Buffer { data: u32; };
         [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
         [[stage(compute), workgroup_size(1)]] fn main() {
           loop {
@@ -56,7 +56,7 @@ device loss.`
   .fn(async t => {
     const module = t.device.createShaderModule({
       code: `
-        [[block]] struct Data { counter: u32; increment: u32; };
+        struct Data { counter: u32; increment: u32; };
         [[group(0), binding(0)]] var<uniform> data: Data;
         [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
           var counter: u32 = data.counter;
@@ -126,7 +126,7 @@ device loss.`
   .fn(async t => {
     const module = t.device.createShaderModule({
       code: `
-        [[block]] struct Data { counter: u32; increment: u32; };
+        struct Data { counter: u32; increment: u32; };
         [[group(0), binding(0)]] var<uniform> data: Data;
         [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
           return vec4<f32>(0.0, 0.0, 0.0, 1.0);

--- a/src/stress/shaders/slow.spec.ts
+++ b/src/stress/shaders/slow.spec.ts
@@ -15,7 +15,7 @@ g.test('compute')
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const module = t.device.createShaderModule({
       code: `
-        [[block]] struct Buffer { data: array<u32>; };
+        struct Buffer { data: array<u32>; };
         [[group(0), binding(0)]] var<storage, read_write> buffer: Buffer;
         [[stage(compute), workgroup_size(1)]] fn main(
             [[builtin(global_invocation_id)]] id: vec3<u32>) {
@@ -48,7 +48,7 @@ g.test('vertex')
   .fn(async t => {
     const module = t.device.createShaderModule({
       code: `
-        [[block]] struct Data { counter: u32; increment: u32; };
+        struct Data { counter: u32; increment: u32; };
         [[group(0), binding(0)]] var<uniform> data: Data;
         [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
           var counter: u32 = data.counter;
@@ -120,7 +120,7 @@ g.test('fragment')
   .fn(async t => {
     const module = t.device.createShaderModule({
       code: `
-        [[block]] struct Data { counter: u32; increment: u32; };
+        struct Data { counter: u32; increment: u32; };
         [[group(0), binding(0)]] var<uniform> data: Data;
         [[stage(vertex)]] fn vmain() -> [[builtin(position)]] vec4<f32> {
           return vec4<f32>(0.0, 0.0, 0.0, 1.0);

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -309,7 +309,7 @@ class F extends GPUTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-            [[block]] struct Params {
+            struct Params {
               copyLayer: f32;
             };
             [[group(0), binding(0)]] var<uniform> param: Params;

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -827,7 +827,7 @@ class ImageCopyTest extends GPUTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            [[block]] struct Params {
+            struct Params {
               stencilBitIndex: u32;
             };
             [[group(0), binding(0)]] var<uniform> param: Params;

--- a/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
@@ -43,14 +43,14 @@ export class ProgrammableStateTest extends GPUTest {
   ): GPUComputePipeline | GPURenderPipeline {
     switch (encoderType) {
       case 'compute pass': {
-        const wgsl = `[[block]] struct Data {
+        const wgsl = `struct Data {
             value : i32;
           };
-    
+
           [[group(${groups.a}), binding(0)]] var<storage> a : Data;
           [[group(${groups.b}), binding(0)]] var<storage> b : Data;
           [[group(${groups.out}), binding(0)]] var<storage, read_write> out : Data;
-    
+
           [[stage(compute), workgroup_size(1)]] fn main() {
             out.value = ${algorithm};
             return;
@@ -79,14 +79,14 @@ export class ProgrammableStateTest extends GPUTest {
           `,
 
           fragment: `
-            [[block]] struct Data {
+            struct Data {
               value : i32;
             };
-    
+
             [[group(${groups.a}), binding(0)]] var<storage> a : Data;
             [[group(${groups.b}), binding(0)]] var<storage> b : Data;
             [[group(${groups.out}), binding(0)]] var<storage, read_write> out : Data;
-    
+
             [[stage(fragment)]] fn frag_main() -> [[location(0)]] vec4<f32> {
               out.value = ${algorithm};
               return vec4<f32>(1.0, 0.0, 0.0, 1.0);

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -29,7 +29,7 @@ g.test('memcpy').fn(async t => {
     compute: {
       module: t.device.createShaderModule({
         code: `
-          [[block]] struct Data {
+          struct Data {
               value : u32;
           };
 
@@ -107,7 +107,7 @@ g.test('large_dispatch')
       compute: {
         module: t.device.createShaderModule({
           code: `
-            [[block]] struct OutputBuffer {
+            struct OutputBuffer {
               value : array<u32>;
             };
 

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -53,7 +53,7 @@ export class BufferSyncTest extends GPUTest {
   // Create a compute pipeline and write given data into storage buffer.
   createStorageWriteComputePipeline(value: number): GPUComputePipeline {
     const wgslCompute = `
-      [[block]] struct Data {
+      struct Data {
         a : i32;
       };
 
@@ -84,7 +84,7 @@ export class BufferSyncTest extends GPUTest {
     `,
 
       fragment: `
-      [[block]] struct Data {
+      struct Data {
         a : i32;
       };
 

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -216,7 +216,7 @@ g.test('large_draw')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-          [[block]] struct Params {
+          struct Params {
             numVertices: u32;
             numInstances: u32;
           };

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -196,7 +196,7 @@ g.test('GPUBlendComponent')
         ],
         module: t.device.createShaderModule({
           code: `
-[[block]] struct Uniform {
+struct Uniform {
   color: vec4<f32>;
 };
 [[group(0), binding(0)]] var<uniform> u : Uniform;

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -101,7 +101,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
         return vf;
       }
 
-      [[block]] struct Output {
+      struct Output {
         // Each fragment (that didn't get clipped) writes into one element of this output.
         // (Anything that doesn't get written is already zero.)
         fragInputZDiff: array<f32, ${kNumTestPoints}>;

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -117,7 +117,7 @@ struct Inputs {
 
     const fragmentModule = t.device.createShaderModule({
       code: `
-[[block]] struct Output {
+struct Output {
   value : u32;
 };
 
@@ -562,7 +562,7 @@ ${accumulateVariableDeclarationsInFragmentShader}
 struct OutPrimitive {
 ${vertexInputShaderLocations.map(i => `  attrib${i} : ${wgslFormat};`).join('\n')}
 };
-[[block]] struct OutBuffer {
+struct OutBuffer {
   primitives : [[stride(${vertexInputShaderLocations.length * 4})]] array<OutPrimitive>;
 };
 [[group(0), binding(0)]] var<storage, read_write> outBuffer : OutBuffer;

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -504,7 +504,7 @@ g.test('uniform_buffer')
 
     const computeShaderModule = t.device.createShaderModule({
       code: `
-  [[block]] struct UBO {
+  struct UBO {
       value : vec4<u32>;
   };
   [[group(0), binding(0)]] var<uniform> ubo : UBO;
@@ -539,7 +539,7 @@ g.test('readonly_storage_buffer')
 
     const computeShaderModule = t.device.createShaderModule({
       code: `
-    [[block]] struct SSBO {
+    struct SSBO {
         value : vec4<u32>;
     };
     [[group(0), binding(0)]] var<storage, read> ssbo : SSBO;
@@ -574,7 +574,7 @@ g.test('storage_buffer')
 
     const computeShaderModule = t.device.createShaderModule({
       code: `
-    [[block]] struct SSBO {
+    struct SSBO {
         value : vec4<u32>;
     };
     [[group(0), binding(0)]] var<storage, read_write> ssbo : SSBO;

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -55,14 +55,14 @@ export const checkContentsBySampling: CheckContents = (
         entryPoint: 'main',
         module: t.device.createShaderModule({
           code: `
-            [[block]] struct Constants {
+            struct Constants {
               level : i32;
             };
 
             [[group(0), binding(0)]] var<uniform> constants : Constants;
             [[group(0), binding(1)]] var myTexture : texture${_multisampled}${_xd}<${shaderType}>;
 
-            [[block]] struct Result {
+            struct Result {
               values : [[stride(4)]] array<${shaderType}>;
             };
             [[group(0), binding(3)]] var<storage, read_write> result : Result;

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -127,7 +127,7 @@ class VertexStateTest extends GPUTest {
         }
 
         vsInputs += `  [[location(${i})]] attrib${i} : ${shaderType};\n`;
-        vsBindings += `[[block]] struct S${i} { data : array<vec4<${a.shaderBaseType}>, ${maxCount}>; };\n`;
+        vsBindings += `struct S${i} { data : array<vec4<${a.shaderBaseType}>, ${maxCount}>; };\n`;
         vsBindings += `[[group(0), binding(${i})]] var<${storageType}> providedData${i} : S${i};\n`;
 
         // Generate the all the checks for the attributes.

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -410,7 +410,7 @@ export class GPUTest extends Fixture {
 
     const readsPerRow = Math.ceil(minBytesPerRow / expectedDataSize);
     const reducer = `
-    [[block]] struct Buffer { data: array<u32>; };
+    struct Buffer { data: array<u32>; };
     [[group(0), binding(0)]] var<storage, read> expected: Buffer;
     [[group(0), binding(1)]] var<storage, read> in: Buffer;
     [[group(0), binding(2)]] var<storage, read_write> out: Buffer;

--- a/src/webgpu/shader/execution/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/builtin/builtin.ts
@@ -311,12 +311,10 @@ ${parameterTypes
   .join('\n')}
 };
 
-[[block]]
 struct Inputs {
   test : array<Parameters, ${cases.length}>;
 };
 
-[[block]]
 struct Outputs {
   test : [[stride(${kValueStride})]] array<${storageType(returnType)}, ${cases.length}>;
 };

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -41,12 +41,12 @@ function runShaderTest(
   });
 
   const source = `
-    [[block]] struct Constants {
+    struct Constants {
       zero: u32;
     };
     [[group(1), binding(0)]] var<uniform> constants: Constants;
 
-    [[block]] struct Result {
+    struct Result {
       value: u32;
     };
     [[group(1), binding(1)]] var<storage, write> result: Result;
@@ -211,7 +211,7 @@ g.test('linear_memory')
           bufferBindingSize = layout.size;
           const qualifiers = storageClass === 'storage' ? `storage, ${storageMode}` : storageClass;
           globalSource += `
-          [[block]] struct TestData {
+          struct TestData {
             data: ${type};
           };
           [[group(0), binding(0)]] var<${qualifiers}> s: TestData;`;

--- a/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
+++ b/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
@@ -81,7 +81,7 @@ class DerivativesTest extends GPUTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            [[block]] struct Uniforms {
+            struct Uniforms {
               numIterations : i32;
             };
             [[binding(0), group(0)]] var<uniform> uniforms : Uniforms;
@@ -89,18 +89,18 @@ class DerivativesTest extends GPUTest {
             [[stage(fragment)]] fn main(
               [[builtin(position)]] FragCoord : vec4<f32>,
               [[location(0)]] fragUV: vec2<f32>) -> [[location(0)]] vec4<f32> {
-                
+
                 // Loop to exercise uniform control flow of gradient operations, to trip FXC's
                 // warning X3570: gradient instruction used in a loop with varying iteration, attempting to unroll the loop
                 var summed_dx : f32 = 0.0;
                 var summed_dy : f32 = 0.0;
                 for (var i = 0; i < uniforms.numIterations; i = i + 1) {
-                  
+
                   // Bogus condition to make this a "loop with varying iteration".
                   if (fragUV.x > 500.0) {
                     break;
                   }
-                  
+
                   // Do the gradient operations within the loop
                   let dx = dpdxCoarse(fragUV.x);
                   let dy = dpdyCoarse(fragUV.y);

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -98,11 +98,9 @@ g.test('inputs')
 
     // WGSL shader that stores every builtin value to a buffer, for every invocation in the grid.
     const wgsl = `
-      [[block]]
       struct S {
         data : array<u32>;
       };
-      [[block]]
       struct V {
         data : array<vec3<u32>>;
       };

--- a/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
@@ -28,7 +28,6 @@ g.test('shared_with_buffer')
     // The test shader defines a structure that contains members decorated with built-in variable
     // attributes, and also layout attributes for the storage buffer.
     const wgsl = `
-      [[block]]
       struct S {
         /* byte offset:  0 */ [[size(32)]]  [[builtin(workgroup_id)]] group_id : vec3<u32>;
         /* byte offset: 32 */               [[builtin(local_invocation_index)]] local_index : u32;

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -231,7 +231,7 @@ g.test('compute,zero_init')
   .batch(15)
   .fn(async t => {
     let moduleScope = `
-      [[block]] struct Output {
+      struct Output {
         failed : atomic<u32>;
       };
       [[group(0), binding(0)]] var <storage, read_write> output : Output;

--- a/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
@@ -1,6 +1,5 @@
 // v-0035: The access decoration is required for 'particles'.
 
-[[block]]
 struct Particles {
   particles : [[stride(16)]] array<f32, 4>;
 };

--- a/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
@@ -1,7 +1,6 @@
 // pass v-0034: The access decoration appears on a type used as the store type of variable
 // 'particles', which is in 'storage' storage class.
 
-[[block]]
 struct Particles {
   particles : [[stride(16)]] array<f32, 4>;
 };

--- a/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
@@ -1,7 +1,6 @@
 // v-0034: The access decoration appears on a type used as the store type of variable
 // 'particles', which is in the 'uniform' storage class.
 
-[[block]]
 struct Particles {
   particles : [[stride(16)]] array<f32, 4>;
 };

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
@@ -1,7 +1,6 @@
 // v-0015: variable 's' store type is struct 'SArr' that has a runtime-sized member but its storage class is not 'storage'.
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
-[[block]]
 struct SArr{
   data : RTArr;
 };

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
@@ -1,7 +1,6 @@
 // v-0015 - This fails because of the aliased runtime array is not last member of the struct.
 
 type RTArr = [[stride (16)]] array<vec4<f32>>;
-[[block]]
 struct S {
   data : RTArr;
   b : f32;

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
@@ -1,6 +1,5 @@
 // v-0015 - This fails because of the runtime array is not last member of the struct.
 
-[[block]]
 struct Foo {
   a : [[stride (16)]] array<f32>;
   b : f32;

--- a/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
@@ -1,6 +1,5 @@
 // v-0032 - This fails because the runtime array does not have a stride attribute.
 
-[[block]]
 struct Foo {
   a : array<f32>;
 };

--- a/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
@@ -1,7 +1,6 @@
 # v-0039: variable 's' is in storage storage class so it must be declared with group and binding
 # decoration.
 
-[[block]]
 struct PositionBuffer {
   pos: vec2<f32>;
 };

--- a/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
@@ -1,7 +1,6 @@
 # v-0040: variable 'u' is in uniform storage class so it must be declared with group and binding
 # decoration.
 
-[[block]]
 struct Params {
   count: i32;
 };

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
@@ -1,6 +1,5 @@
 // v-0032: variable 'u' has an initializer, however its storage class is 'storage'.
 
-[[block]]
 struct PositionBuffer {
   pos: vec2<f32>;
 };

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
@@ -1,6 +1,5 @@
 // v-0032: variable 'u' has an initializer, however its storage class is 'uniform'.
 
-[[block]]
 struct Params {
   count: i32;
 };

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -55,7 +55,7 @@ function doTest(
   const shader = `
   [[group(0), binding(0)]] var tex : texture_2d<${shaderType}>;
 
-  [[block]] struct Output {
+  struct Output {
     ${rep.componentOrder.map(C => `result${C} : ${shaderType};`).join('\n')}
   };
   [[group(0), binding(1)]] var<storage, read_write> output : Output;


### PR DESCRIPTION
This has been removed from WGSL.

<hr>

**Author checklist for test code/plans:**

- [X] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [X] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [X] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
