### PR TITLE
Remove the parameter 'opts' in makeBufferWithContents

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -351,10 +351,7 @@ class ImageCopyTest extends GPUTest {
         break;
       }
       case 'CopyB2T': {
-        const buffer = this.makeBufferWithContents(partialData, GPUBufferUsage.COPY_SRC, {
-          padToMultipleOf4: true,
-        });
-
+        const buffer = this.makeBufferWithContents(partialData, GPUBufferUsage.COPY_SRC);
         const encoder = this.device.createCommandEncoder();
         encoder.copyBufferToTexture(
           { buffer, ...appliedDataLayout },

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -733,12 +733,8 @@ export class GPUTest extends Fixture {
    *
    * TODO: Several call sites would be simplified if this took ArrayBuffer as well.
    */
-  makeBufferWithContents(
-    dataArray: TypedArrayBufferView,
-    usage: GPUBufferUsageFlags,
-    opts: { padToMultipleOf4?: boolean } = {}
-  ): GPUBuffer {
-    return this.trackForCleanup(makeBufferWithContents(this.device, dataArray, usage, opts));
+  makeBufferWithContents(dataArray: TypedArrayBufferView, usage: GPUBufferUsageFlags): GPUBuffer {
+    return this.trackForCleanup(makeBufferWithContents(this.device, dataArray, usage));
   }
 
   /**

--- a/src/webgpu/util/buffer.ts
+++ b/src/webgpu/util/buffer.ts
@@ -4,16 +4,17 @@ import { align } from './math.js';
 
 /**
  * Creates a buffer with the contents of some TypedArray.
+ * The buffer size will always be aligned to 4 as we set mappedAtCreation === true when creating the
+ * buffer.
  */
 export function makeBufferWithContents(
   device: GPUDevice,
   dataArray: TypedArrayBufferView,
-  usage: GPUBufferUsageFlags,
-  opts: { padToMultipleOf4?: boolean } = {}
+  usage: GPUBufferUsageFlags
 ): GPUBuffer {
   const buffer = device.createBuffer({
     mappedAtCreation: true,
-    size: align(dataArray.byteLength, opts.padToMultipleOf4 ? 4 : 1),
+    size: align(dataArray.byteLength, 4),
     usage,
   });
   memcpy({ src: dataArray }, { dst: buffer.getMappedRange() });


### PR DESCRIPTION
This patch removes the parameter 'opts' in makeBufferWithContents to
indicate whether the buffer size should be aligned to 4 because in
this function the returned buffer is always created with
'mappedAtCreation' set to true, so the size of the returned buffer
should always be a multiple of 4.





<hr>

**Author checklist for test code/plans:**

- [ ] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [ ] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [ ] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [ ] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [ ] Existing (or new) test helpers are used where they would reduce complexity.
- [ ] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
