### PR TITLE
Test copy from webgpu context canvas to webgpu texture

### DIFF
--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -124,6 +124,7 @@ function canCopyFromContextType(contextName: string) {
     case 'experimental-webgl':
     case 'webgl':
     case 'webgl2':
+    case 'webgpu':
       return true;
     default:
       return false;

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -26,6 +26,11 @@ const kDefaultHeight = 32;
 const kDefaultDepth = 1;
 const kDefaultMipLevelCount = 6;
 
+/** Valid contextId for HTMLCanvasElement/OffscreenCanvas,
+ *  spec: https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext
+ */
+export const kValidContextId = ['2d', 'bitmaprenderer', 'webgl', 'webgl2', 'webgpu'] as const;
+
 function computeMipMapSize(width: number, height: number, mipLevel: number) {
   return {
     mipWidth: Math.max(width >> mipLevel, 1),
@@ -121,7 +126,6 @@ function generateCopySizeForDstOOB({ mipLevel, dstOrigin }: WithDstOriginMipLeve
 function canCopyFromContextType(contextName: string) {
   switch (contextName) {
     case '2d':
-    case 'experimental-webgl':
     case 'webgl':
     case 'webgl2':
     case 'webgpu':
@@ -197,14 +201,7 @@ g.test('source_canvas,contexts')
   )
   .params(u =>
     u //
-      .combine('contextType', [
-        '2d',
-        'bitmaprenderer',
-        'experimental-webgl',
-        'webgpu',
-        'webgl',
-        'webgl2',
-      ] as const)
+      .combine('contextType', kValidContextId)
       .beginSubcases()
       .combine('copySize', [
         { width: 0, height: 0, depthOrArrayLayers: 0 },
@@ -242,14 +239,14 @@ g.test('source_offscreenCanvas,contexts')
   Test OffscreenCanvas as source image with different contexts.
 
   Call OffscreenCanvas.getContext() with different context type.
-  Only '2d', 'webgl', 'webgl2' is valid context type.
+  Only '2d', 'webgl', 'webgl2', 'webgpu' is valid context type.
 
   Check whether 'OperationError' is generated when context type is invalid.
   `
   )
   .params(u =>
     u //
-      .combine('contextType', ['2d', 'bitmaprenderer', 'webgl', 'webgl2'] as const)
+      .combine('contextType', kValidContextId)
       .beginSubcases()
       .combine('copySize', [
         { width: 0, height: 0, depthOrArrayLayers: 0 },
@@ -265,7 +262,9 @@ g.test('source_offscreenCanvas,contexts')
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
-    const ctx = canvas.getContext(contextType);
+    // Workaround the compile error that 'webgpu' is not a valid
+    // OffscreenRenderingContextId.
+    const ctx = canvas.getContext(contextType as OffscreenRenderingContextId);
     if (ctx === null) {
       t.skip('Failed to get context for canvas element');
       return;

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -36,6 +36,9 @@ import { PerTexelComponent, kTexelRepresentationInfo } from './util/texture/texe
 
 const devicePool = new DevicePool();
 
+// TODO: When DevicePool becomes able to provide multiple devices at once, use the usual one instead of a new one.
+const mismatchedDevicePool = new DevicePool();
+
 const kResourceStateValues = ['valid', 'invalid', 'destroyed'] as const;
 export type ResourceState = typeof kResourceStateValues[number];
 export const kResourceStates: readonly ResourceState[] = kResourceStateValues;
@@ -62,6 +65,12 @@ export class GPUTest extends Fixture {
   /** Must not be replaced once acquired. */
   private acquiredDevice: GPUDevice | undefined;
 
+  // Some tests(e.g. Device mismatched validation) require another GPUDevice
+  // different from the default GPUDevice of GPUTest. It is only used to
+  //create device mismatched objects.
+  private mismatchedProvider: DeviceProvider | undefined;
+  private mismatchedAcquiredDevice: GPUDevice | undefined;
+
   /** GPUDevice for the test to use. */
   get device(): GPUDevice {
     assert(
@@ -72,6 +81,46 @@ export class GPUTest extends Fixture {
       this.acquiredDevice = this.provider.acquire();
     }
     return this.acquiredDevice;
+  }
+
+  /** GPUDevice for tests requires another device from default one.
+   *  e.g. creating objects required creating mismatched objects required
+   * by device mismatched validation tests.
+   */
+  get mismatchedDevice(): GPUDevice {
+    assert(
+      this.mismatchedProvider !== undefined,
+      'No provider available right now; did you "await" selectMismatchedDeviceOrSkipTestCase?'
+    );
+    if (!this.mismatchedAcquiredDevice) {
+      this.mismatchedAcquiredDevice = this.mismatchedProvider.acquire();
+    }
+    return this.mismatchedAcquiredDevice;
+  }
+
+  /**
+   * Create other device different with current test device, which could be got by `.mismatchedDevice`.
+   * A `descriptor` may be undefined, which returns a `default` mismatched device.
+   * If the request descriptor or feature name can't be supported, throws an exception to skip the entire test case.
+   */
+  async selectMismatchedDeviceOrSkipTestCase(
+    descriptor:
+      | UncanonicalizedDeviceDescriptor
+      | GPUFeatureName
+      | undefined
+      | Array<GPUFeatureName | undefined>
+  ): Promise<void> {
+    assert(
+      this.mismatchedProvider === undefined,
+      "Can't selectMismatchedDeviceOrSkipTestCase() multiple times"
+    );
+
+    this.mismatchedProvider =
+      descriptor === undefined
+        ? await mismatchedDevicePool.reserve()
+        : await mismatchedDevicePool.reserve(initUncanonicalizedDeviceDescriptor(descriptor));
+
+    this.mismatchedAcquiredDevice = this.mismatchedProvider.acquire();
   }
 
   /** GPUQueue for the test to use. (Same as `t.device.queue`.) */
@@ -100,6 +149,28 @@ export class GPUTest extends Fixture {
         }
       }
       // The GPUDevice and GPUQueue should now have no outstanding references.
+
+      if (threw) {
+        if (threw instanceof TestOOMedShouldAttemptGC) {
+          // Try to clean up, in case there are stray GPU resources in need of collection.
+          await attemptGarbageCollection();
+        }
+        throw threw;
+      }
+    }
+
+    if (this.mismatchedProvider) {
+      // TODO(kainino0x): Deduplicate this with code in GPUTest.finalize
+      let threw: undefined | Error;
+      {
+        const provider = this.mismatchedProvider;
+        this.mismatchedProvider = undefined;
+        try {
+          await mismatchedDevicePool.release(provider);
+        } catch (ex) {
+          threw = ex;
+        }
+      }
 
       if (threw) {
         if (threw instanceof TestOOMedShouldAttemptGC) {

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -5,7 +5,7 @@ TODO: consider whether external_texture and copyToTexture video tests should be 
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { unreachable, assert, memcpy } from '../../../common/util/util.js';
+import { assert, memcpy } from '../../../common/util/util.js';
 import {
   RegularTextureFormat,
   kTextureFormatInfo,
@@ -140,41 +140,197 @@ class F extends CopyToTextureUtils {
     return { canvas, canvasContext: gl };
   }
 
-  getExpectedPixels({
-    context,
+  getInitGPUCanvasData(
+    width: number,
+    height: number,
+    premultiplied: boolean,
+    paintOpaqueRects: boolean
+  ): Uint8ClampedArray {
+    const rectWidth = Math.floor(width / 2);
+    const rectHeight = Math.floor(height / 2);
+
+    const alphaValue = paintOpaqueRects ? 255 : 153;
+    const colorValue = premultiplied ? alphaValue : 255;
+
+    // BGRA8Unorm texture
+    const initialData = new Uint8ClampedArray(4 * width * height);
+    const maxRectHeightIndex = width * rectHeight;
+    for (let pixelIndex = 0; pixelIndex < initialData.length / 4; ++pixelIndex) {
+      const index = pixelIndex * 4;
+
+      // Top-half two rectangles
+      if (pixelIndex < maxRectHeightIndex) {
+        // top-left side rectangle
+        if (pixelIndex % width < rectWidth) {
+          // top-left side rectangle
+          initialData[index] = colorValue;
+          initialData[index + 1] = 0;
+          initialData[index + 2] = 0;
+          initialData[index + 3] = alphaValue;
+        } else {
+          // top-right side rectangle
+          initialData[index] = 0;
+          initialData[index + 1] = colorValue;
+          initialData[index + 2] = 0;
+          initialData[index + 3] = alphaValue;
+        }
+      } else {
+        // Bottom-half two rectangles
+        // bottom-left side rectangle
+        if (pixelIndex % width < rectWidth) {
+          initialData[index] = 0;
+          initialData[index + 1] = 0;
+          initialData[index + 2] = colorValue;
+          initialData[index + 3] = alphaValue;
+        } else {
+          // bottom-right side rectangle
+          initialData[index] = colorValue;
+          initialData[index + 1] = colorValue;
+          initialData[index + 2] = colorValue;
+          initialData[index + 3] = alphaValue;
+        }
+      }
+    }
+    return initialData;
+  }
+
+  initGPUCanvasContent({
+    device,
+    canvasType,
     width,
     height,
-    format,
-    contextType,
-    srcPremultiplied,
-    dstPremultiplied,
+    premultiplied,
+    paintOpaqueRects,
   }: {
-    context:
-      | CanvasRenderingContext2D
-      | OffscreenCanvasRenderingContext2D
-      | WebGLRenderingContext
-      | WebGL2RenderingContext;
+    device: GPUDevice;
+    canvasType: canvasTypes;
     width: number;
     height: number;
-    format: RegularTextureFormat;
-    contextType: '2d' | 'gl';
-    srcPremultiplied: boolean;
-    dstPremultiplied: boolean;
-  }): Uint8ClampedArray {
+    premultiplied: boolean;
+    paintOpaqueRects: boolean;
+  }): {
+    canvas: HTMLCanvasElement | OffscreenCanvas;
+  } {
+    const canvas = createCanvas(this, canvasType, width, height);
+
+    const gpuContext = canvas.getContext('webgpu') as GPUCanvasContext | null;
+
+    if (gpuContext === null) {
+      this.skip(canvasType + ' canvas webgpu context not available');
+    }
+
+    const alphaMode = premultiplied ? 'premultiplied' : 'opaque';
+
+    gpuContext.configure({
+      device,
+      format: 'bgra8unorm',
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+      compositingAlphaMode: alphaMode,
+    });
+
+    // BGRA8Unorm texture
+    const initialData = this.getInitGPUCanvasData(width, height, premultiplied, paintOpaqueRects);
+    const canvasTexture = gpuContext.getCurrentTexture();
+    device.queue.writeTexture(
+      { texture: canvasTexture },
+      initialData,
+      {
+        bytesPerRow: width * 4,
+        rowsPerImage: height,
+      },
+      {
+        width,
+        height,
+        depthOrArrayLayers: 1,
+      }
+    );
+
+    return { canvas };
+  }
+
+  getSourceCanvas2DContent(
+    context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+    width: number,
+    height: number
+  ): Uint8ClampedArray {
+    return context.getImageData(0, 0, width, height).data;
+  }
+
+  getSourceCanvasGLContent(
+    gl: WebGLRenderingContext | WebGL2RenderingContext,
+    width: number,
+    height: number
+  ): Uint8ClampedArray {
+    const bytesPerPixel = 4;
+
+    const sourcePixels = new Uint8ClampedArray(width * height * bytesPerPixel);
+    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, sourcePixels);
+
+    const finalResult = new Uint8ClampedArray(width * height * bytesPerPixel);
+    for (let i = 0; i < height; ++i) {
+      for (let j = 0; j < width; ++j) {
+        const pixelPos = i * width + j;
+        // WebGL readPixel returns pixels from bottom-left origin. Using CopyExternalImageToTexture
+        // to copy from WebGL Canvas keeps top-left origin. So the expectation from webgl.readPixel should
+        // be flipped.
+        const dstPixelPos = (height - i - 1) * width + j;
+
+        memcpy(
+          { src: sourcePixels, start: pixelPos * bytesPerPixel, length: bytesPerPixel },
+          { dst: finalResult, start: dstPixelPos * bytesPerPixel }
+        );
+      }
+    }
+
+    return finalResult;
+  }
+
+  getSourceCanvasGPUContent(
+    width: number,
+    height: number,
+    premultipliedAlpha: boolean,
+    paintOpaqueRects: boolean
+  ): Uint8ClampedArray {
+    const bytesPerPixel = 4;
+
+    const rgbaPixels = this.getInitGPUCanvasData(
+      width,
+      height,
+      premultipliedAlpha,
+      paintOpaqueRects
+    );
+
+    // The source canvas has bgra8unorm back resource. We
+    // swizzle the channels to align with 2d/webgl canvas and
+    // clear alpha to opaque when context compositingAlphaMode
+    // is set to opaque (follow webgpu spec).
+    for (let i = 0; i < height; ++i) {
+      for (let j = 0; j < width; ++j) {
+        const pixelPos = i * width + j;
+        const r = rgbaPixels[pixelPos * bytesPerPixel + 2];
+        if (!premultipliedAlpha) {
+          rgbaPixels[pixelPos * bytesPerPixel + 3] = 255;
+        }
+
+        rgbaPixels[pixelPos * bytesPerPixel + 2] = rgbaPixels[pixelPos * bytesPerPixel];
+        rgbaPixels[pixelPos * bytesPerPixel] = r;
+      }
+    }
+
+    return rgbaPixels;
+  }
+
+  getExpectedPixels(
+    sourcePixels: Uint8ClampedArray,
+    width: number,
+    height: number,
+    format: RegularTextureFormat,
+    srcPremultiplied: boolean,
+    dstPremultiplied: boolean
+  ): Uint8ClampedArray {
     const bytesPerPixel = kTextureFormatInfo[format].bytesPerBlock;
 
     const expectedPixels = new Uint8ClampedArray(bytesPerPixel * width * height);
-    let sourcePixels;
-    if (contextType === '2d') {
-      const ctx = context as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
-      sourcePixels = ctx.getImageData(0, 0, width, height).data;
-    } else if (contextType === 'gl') {
-      sourcePixels = new Uint8ClampedArray(width * height * 4);
-      const gl = context as WebGLRenderingContext | WebGL2RenderingContext;
-      gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, sourcePixels);
-    } else {
-      unreachable();
-    }
 
     // Generate expectedPixels
     // Use getImageData and readPixels to get canvas contents.
@@ -205,14 +361,9 @@ class F extends CopyToTextureUtils {
           rgba.B /= rgba.A;
         }
 
-        // WebGL readPixel returns pixels from bottom-left origin. Using CopyExternalImageToTexture
-        // to copy from WebGL Canvas keeps top-left origin. So the expectation from webgl.readPixel should
-        // be flipped.
-        const dstPixelPos = contextType === 'gl' ? (height - i - 1) * width + j : pixelPos;
-
         memcpy(
           { src: rep.pack(rep.encode(rgba)) },
-          { dst: expectedPixels, start: dstPixelPos * bytesPerPixel }
+          { dst: expectedPixels, start: pixelPos * bytesPerPixel }
         );
       }
     }
@@ -290,15 +441,15 @@ g.test('copy_contents_from_2d_context_canvas')
 
     // For 2d canvas, get expected pixels with getImageData(), which returns unpremultiplied
     // values.
-    const expectedPixels = t.getExpectedPixels({
-      context: canvasContext,
+    const sourcePixels = t.getSourceCanvas2DContent(canvasContext, width, height);
+    const expectedPixels = t.getExpectedPixels(
+      sourcePixels,
       width,
       height,
       format,
-      contextType: '2d',
-      srcPremultiplied: false,
-      dstPremultiplied,
-    });
+      false,
+      dstPremultiplied
+    );
 
     t.doTestAndCheckResult(
       { source: canvas, origin: { x: 0, y: 0 } },
@@ -393,15 +544,137 @@ g.test('copy_contents_from_gl_context_canvas')
     // Construct expected value for different dst color format
     const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
     const format: RegularTextureFormat = formatForExpectedPixels(dstColorFormat);
-    const expectedPixels = t.getExpectedPixels({
-      context: canvasContext,
+    const sourcePixels = t.getSourceCanvasGLContent(canvasContext, width, height);
+    const expectedPixels = t.getExpectedPixels(
+      sourcePixels,
       width,
       height,
       format,
-      contextType: 'gl',
+      srcPremultiplied,
+      dstPremultiplied
+    );
+
+    t.doTestAndCheckResult(
+      { source: canvas, origin: { x: 0, y: 0 } },
+      {
+        texture: dst,
+        origin: { x: 0, y: 0 },
+        colorSpace: 'srgb',
+        premultipliedAlpha: dstPremultiplied,
+      },
+      { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
+      dstBytesPerPixel,
+      expectedPixels,
+      isFp16Format(dstColorFormat)
+    );
+  });
+
+g.test('copy_contents_from_gpu_context_canvas')
+  .desc(
+    `
+  Test HTMLCanvasElement and OffscreenCanvas with webgpu context
+  can be copied to WebGPU texture correctly.
+
+  It creates HTMLCanvasElement/OffscreenCanvas with 'webgpu'.
+  Use stencil + clear to render red rect for top-left, green rect
+  for top-right, blue rect for bottom-left and white for bottom-right.
+  And do premultiply alpha in advance if the webgl/webgl2 context is created
+  with premultipliedAlpha : true.
+
+  Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
+  of dst texture, and read the contents out to compare with the canvas contents.
+
+  The tests covers:
+  - Valid canvas type
+  - Valid webgl/webgl2 context type
+  - TODO: color space tests need to be added
+  - TODO: Add error tolerance for rgb10a2unorm dst texture format
+
+  And the expected results are all passed.
+  `
+  )
+  .params(u =>
+    u
+      .combine('canvasType', allCanvasTypes)
+      .combine('srcAndDstInSameGPUDevice', [true, false])
+      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('srcPremultiplied', [true, false])
+      .combine('dstPremultiplied', [true, false])
+      .beginSubcases()
+      .combine('width', [1, 2, 4, 15, 255, 256])
+      .combine('height', [1, 2, 4, 15, 255, 256])
+  )
+  .fn(async t => {
+    const {
+      width,
+      height,
+      canvasType,
+      srcAndDstInSameGPUDevice,
+      dstColorFormat,
       srcPremultiplied,
       dstPremultiplied,
+    } = t.params;
+
+    let device = t.device;
+
+    if (!srcAndDstInSameGPUDevice) {
+      const adapter = await navigator.gpu.requestAdapter();
+      if (adapter === null) {
+        this.skip('Request GPUAdapter failed');
+      }
+
+      device = await adapter.requestDevice();
+      if (device === null) {
+        this.skip('Adapter requets GPUDevice failed');
+      }
+    }
+
+    // When dst texture format is rgb10a2unorm, the generated expected value of the result
+    // may have tiny errors compared to the actual result when the channel value is
+    // not 1.0 or 0.0.
+    // For example, we init the pixel with r channel to 0.6. And the denormalized value for
+    // 10-bit channel is 613.8, which needs to call "round" or other function to get an integer.
+    // It is possible that gpu adopt different "round" as our cpu implementation(we use Math.round())
+    // and it will generate tiny errors.
+    // So the cases with rgb10a2unorm dst texture format are handled specially by by painting opaque rects
+    // to ensure they will have stable result after alphaOps(should keep the same value).
+    const { canvas } = t.initGPUCanvasContent({
+      device,
+      canvasType,
+      width,
+      height,
+      premultiplied: srcPremultiplied,
+      paintOpaqueRects: dstColorFormat === 'rgb10a2unorm',
     });
+
+    const dst = t.device.createTexture({
+      size: {
+        width,
+        height,
+        depthOrArrayLayers: 1,
+      },
+      format: dstColorFormat,
+      usage:
+        GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    // Construct expected value for different dst color format
+    const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
+    const format: RegularTextureFormat = formatForExpectedPixels(dstColorFormat);
+    const sourcePixels = t.getSourceCanvasGPUContent(
+      width,
+      height,
+      srcPremultiplied,
+      dstColorFormat === 'rgb10a2unorm'
+    );
+    const expectedPixels = t.getExpectedPixels(
+      sourcePixels,
+      width,
+      height,
+      format,
+      srcPremultiplied,
+      dstPremultiplied
+    );
 
     t.doTestAndCheckResult(
       { source: canvas, origin: { x: 0, y: 0 } },

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -336,7 +336,7 @@ class F extends CopyToTextureUtils {
     return finalResult;
   }
 
-  getSourceCanvasGPUContent(
+  calculateSourceContentOnCPU(
     width: number,
     height: number,
     premultipliedAlpha: boolean,
@@ -714,7 +714,7 @@ g.test('copy_contents_from_gpu_context_canvas')
     // Construct expected value for different dst color format
     const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
     const format: RegularTextureFormat = formatForExpectedPixels(dstColorFormat);
-    const sourcePixels = t.getSourceCanvasGPUContent(
+    const sourcePixels = t.calculateSourceContentOnCPU(
       width,
       height,
       srcPremultiplied,


### PR DESCRIPTION
Latest spec changes allow WebGPU copy from webgpu context canvas
to webgpu texture.

The PR address this spec changes in cts.





<hr>

**Author checklist for test code/plans:**

- [x] All outstanding work is tracked with "TODO" in a test/file description or `.unimplemented()` on a test.
- [x] New helpers, if any, are documented using `/** doc comments */` and can be found via `helper_index.txt`.
- [x] (Optional, sometimes not possible.) Tests pass (or partially pass without unexpected issues) in an implementation. (Add any extra details above.)

**[Reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md) for test code/plans:** (Note: feel free to pull in other reviewers at any time for any reason.)

- [x] The test path is reasonable, the [description](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) "describes the test, succinctly, but in enough detail that a reader can read only the test plans in a file or directory and evaluate the completeness of the test coverage."
- [ ] Tests appear to cover this area completely, except for outstanding TODOs. Validation tests use control cases.
    (This is critical for coverage. Assume anything without a TODO will be forgotten about forever.)
- [x] Existing (or new) test helpers are used where they would reduce complexity.
- [x] TypeScript code is readable and understandable (is unobtrusive, has reasonable type-safety/verbosity/dynamicity).
