### PR TITLE
Validate DepthStencilState in RenderPipeline descriptor

### DIFF
--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -316,7 +316,7 @@ g.test('depth_stencil_state,stencil_aspect,stencil_test')
     u
       .combine('isAsync', [false, true])
       .combine('format', kDepthStencilFormats)
-      .combine('face', ['front', 'back'])
+      .combine('face', ['front', 'back'] as const)
       .combine('compare', [undefined, ...kCompareFunctions])
   )
   .fn(async t => {
@@ -350,7 +350,7 @@ g.test('depth_stencil_state,stencil_aspect,stencil_write')
         'backFailOp',
         'backDepthFailOp',
         'backPassOp',
-      ])
+      ] as const)
       .combine('op', [undefined, ...kStencilOperations])
   )
   .fn(async t => {
@@ -358,33 +358,30 @@ g.test('depth_stencil_state,stencil_aspect,stencil_write')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    let descriptor: GPURenderPipelineDescriptor;
+    let depthStencil: GPUDepthStencilState;
     switch (faceAndOpType) {
       case 'frontFailOp':
-        descriptor = t.getDescriptor({ depthStencil: { format, stencilFront: { failOp: op } } });
+        depthStencil = { format, stencilFront: { failOp: op } };
         break;
       case 'frontDepthFailOp':
-        descriptor = t.getDescriptor({
-          depthStencil: { format, stencilFront: { depthFailOp: op } },
-        });
+        depthStencil = { format, stencilFront: { depthFailOp: op } };
         break;
       case 'frontPassOp':
-        descriptor = t.getDescriptor({ depthStencil: { format, stencilFront: { passOp: op } } });
+        depthStencil = { format, stencilFront: { passOp: op } };
         break;
       case 'backFailOp':
-        descriptor = t.getDescriptor({ depthStencil: { format, stencilBack: { failOp: op } } });
+        depthStencil = { format, stencilBack: { failOp: op } };
         break;
       case 'backDepthFailOp':
-        descriptor = t.getDescriptor({
-          depthStencil: { format, stencilBack: { depthFailOp: op } },
-        });
+        depthStencil = { format, stencilBack: { depthFailOp: op } };
         break;
       case 'backPassOp':
-        descriptor = t.getDescriptor({ depthStencil: { format, stencilBack: { passOp: op } } });
+        depthStencil = { format, stencilBack: { passOp: op } };
         break;
       default:
         unreachable();
     }
+    const descriptor = t.getDescriptor({ depthStencil });
 
     const stencilWriteEnabled = op !== undefined && op !== 'keep';
     t.doCreateRenderPipelineTest(isAsync, !stencilWriteEnabled || info.stencil, descriptor);

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -324,6 +324,38 @@ export const kTextureAspectInfo: {
 /** List of all GPUTextureAspect values. */
 export const kTextureAspects = keysOf(kTextureAspectInfo);
 
+/** Per-GPUCompareFunction info. */
+export const kCompareFunctionInfo: {
+  readonly [k in GPUCompareFunction]: {};
+} = /* prettier-ignore */ {
+  'never': {},
+  'less': {},
+  'equal': {},
+  'less-equal': {},
+  'greater': {},
+  'not-equal': {},
+  'greater-equal': {},
+  'always': {},
+};
+/** List of all GPUCompareFunction values. */
+export const kCompareFunctions = keysOf(kCompareFunctionInfo);
+
+/** Per-GPUStencilOperation info. */
+export const kStencilOperationInfo: {
+  readonly [k in GPUStencilOperation]: {};
+} = /* prettier-ignore */ {
+  'keep': {},
+  'zero': {},
+  'replace': {},
+  'invert': {},
+  'increment-clamp': {},
+  'decrement-clamp': {},
+  'increment-wrap': {},
+  'decrement-wrap': {},
+};
+/** List of all GPUStencilOperation values. */
+export const kStencilOperations = keysOf(kStencilOperationInfo);
+
 const kDepthStencilFormatCapabilityInBufferTextureCopy = {
   // kUnsizedDepthStencilFormats
   depth24plus: {


### PR DESCRIPTION
The validation rules are:
- The format for DepthStencilState must be a depth/stencil format
- The format must contain appropriate depth/stencil aspect if
depth/stencil test or depth/stencil write is enabled.



<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.
