### PR TITLE
Verify the TODO/DONE state of checklist items

### DIFF
--- a/src/common/internal/tree.ts
+++ b/src/common/internal/tree.ts
@@ -29,7 +29,7 @@ import { StacklessError } from './util.js';
 // arbitrarily-fine suppressions (instead of having to suppress entire test files, which would
 // lose a lot of coverage).
 //
-// `iterateCollapsedQueries()` produces the list of queries for the variants list.
+// `iterateCollapsedNodes()` produces the list of queries for the variants list.
 //
 // Though somewhat complicated, this system has important benefits:
 //   - Avoids having to suppress entire test files, which would cause large test coverage loss.
@@ -39,27 +39,27 @@ import { StacklessError } from './util.js';
 //   - Enables developers to put any number of tests in one file as appropriate, without worrying
 //     about expectation granularity.
 
-export interface TestSubtree<T extends TestQuery = TestQuery> {
+interface TestTreeNodeBase<T extends TestQuery> {
+  readonly query: T;
   /**
    * Readable "relative" name for display in standalone runner.
    * Not always the exact relative name, because sometimes there isn't
    * one (e.g. s:f:* relative to s:f,*), but something that is readable.
    */
   readonly readableRelativeName: string;
-  readonly query: T;
+  subtreeHasTODOs?: boolean;
+}
+
+export interface TestSubtree<T extends TestQuery = TestQuery> extends TestTreeNodeBase<T> {
   readonly children: Map<string, TestTreeNode>;
   readonly collapsible: boolean;
   description?: string;
   readonly testCreationStack?: Error;
 }
 
-export interface TestTreeLeaf {
-  /**
-   * Readable "relative" name for display in standalone runner.
-   */
-  readonly readableRelativeName: string;
-  readonly query: TestQuerySingleCase;
+export interface TestTreeLeaf extends TestTreeNodeBase<TestQuerySingleCase> {
   readonly run: RunFn;
+  subtreeHasTODOs?: undefined;
 }
 
 export type TestTreeNode = TestSubtree | TestTreeLeaf;
@@ -81,7 +81,7 @@ export class TestTree {
    * Test trees are always rooted at `suite:*`, but they only contain nodes that fit
    * within `forQuery`.
    *
-   * This is used for `iterateCollapsedQueries` which only starts collapsing at the next
+   * This is used for `iterateCollapsedNodes` which only starts collapsing at the next
    * `TestQueryLevel` after `forQuery`.
    */
   readonly forQuery: TestQuery;
@@ -89,6 +89,7 @@ export class TestTree {
 
   constructor(forQuery: TestQuery, root: TestSubtree) {
     this.forQuery = forQuery;
+    TestTree.propagateTODOs(root);
     this.root = root;
     assert(
       root.query.level === 1 && root.query.depthInLevel === 0,
@@ -102,15 +103,27 @@ export class TestTree {
    * - are at a deeper `TestQueryLevel` than `this.forQuery`, and
    * - were not a `Ordering.StrictSubset` of any of the `subqueriesToExpand` during tree creation.
    */
-  iterateCollapsedQueries(
-    includeEmptySubtrees: boolean,
-    alwaysExpandThroughLevel: ExpandThroughLevel
-  ): IterableIterator<TestQuery> {
-    const expandThrough = Math.max(this.forQuery.level, alwaysExpandThroughLevel);
-    return TestTree.iterateSubtreeCollapsedQueries(this.root, includeEmptySubtrees, expandThrough);
+  iterateCollapsedNodes({
+    includeIntermediateNodes = false,
+    includeEmptySubtrees = false,
+    alwaysExpandThroughLevel,
+  }: {
+    /** Whether to include intermediate tree nodes or only collapsed-leaves. */
+    includeIntermediateNodes?: boolean;
+    /** Whether to include collapsed-leaves with no children. */
+    includeEmptySubtrees?: boolean;
+    /** Never collapse nodes up through this level. */
+    alwaysExpandThroughLevel: ExpandThroughLevel;
+  }): IterableIterator<Readonly<TestTreeNode>> {
+    const expandThroughLevel = Math.max(this.forQuery.level, alwaysExpandThroughLevel);
+    return TestTree.iterateSubtreeNodes(this.root, {
+      includeIntermediateNodes,
+      includeEmptySubtrees,
+      expandThroughLevel,
+    });
   }
 
-  iterateLeaves(): IterableIterator<TestTreeLeaf> {
+  iterateLeaves(): IterableIterator<Readonly<TestTreeLeaf>> {
     return TestTree.iterateSubtreeLeaves(this.root);
   }
 
@@ -130,28 +143,31 @@ export class TestTree {
     return TestTree.subtreeToString('(root)', this.root, '');
   }
 
-  static *iterateSubtreeCollapsedQueries(
+  static *iterateSubtreeNodes(
     subtree: TestSubtree,
-    includeEmptySubtrees: boolean,
-    expandThroughLevel: number
-  ): IterableIterator<TestQuery> {
+    opts: {
+      includeIntermediateNodes: boolean;
+      includeEmptySubtrees: boolean;
+      expandThroughLevel: number;
+    }
+  ): IterableIterator<TestTreeNode> {
+    if (opts.includeIntermediateNodes) {
+      yield subtree;
+    }
+
     for (const [, child] of subtree.children) {
       if ('children' in child) {
         // Is a subtree
-        const collapsible = child.collapsible && child.query.level > expandThroughLevel;
+        const collapsible = child.collapsible && child.query.level > opts.expandThroughLevel;
         if (child.children.size > 0 && !collapsible) {
-          yield* TestTree.iterateSubtreeCollapsedQueries(
-            child,
-            includeEmptySubtrees,
-            expandThroughLevel
-          );
-        } else if (child.children.size > 0 || includeEmptySubtrees) {
+          yield* TestTree.iterateSubtreeNodes(child, opts);
+        } else if (child.children.size > 0 || opts.includeEmptySubtrees) {
           // Don't yield empty subtrees (e.g. files with no tests) unless includeEmptySubtrees
-          yield child.query;
+          yield child;
         }
       } else {
         // Is a leaf
-        yield child.query;
+        yield child;
       }
     }
   }
@@ -166,9 +182,22 @@ export class TestTree {
     }
   }
 
+  /** Propagate the "subtreeHasTODOs" state upward from leaves to parent nodes. */
+  static propagateTODOs(subtree: TestSubtree): boolean {
+    subtree.subtreeHasTODOs ||= false;
+    for (const [, child] of subtree.children) {
+      if ('children' in child) {
+        const childHasTODOs = TestTree.propagateTODOs(child);
+        subtree.subtreeHasTODOs ||= childHasTODOs;
+      }
+    }
+    return subtree.subtreeHasTODOs;
+  }
+
   static subtreeToString(name: string, tree: TestTreeNode, indent: string): string {
     const collapsible = 'run' in tree ? '>' : tree.collapsible ? '+' : '-';
-    let s = indent + `${collapsible} ${JSON.stringify(name)} => ${tree.query}`;
+    const todo = tree.subtreeHasTODOs === undefined ? '' : tree.subtreeHasTODOs ? ' TODO' : ' DONE';
+    let s = indent + `${collapsible}${todo} ${JSON.stringify(name)} => ${tree.query}`;
     if ('children' in tree) {
       if (tree.description !== undefined) {
         s += `\n${indent}  | ${JSON.stringify(tree.description)}`;
@@ -215,8 +244,7 @@ export async function loadTreeForQuery(
   for (const entry of specs) {
     if (entry.file.length === 0 && 'readme' in entry) {
       // Suite-level readme.
-      assert(subtreeL0.description === undefined);
-      subtreeL0.description = entry.readme.trim();
+      setSubtreeDescription(subtreeL0, entry.readme.trim());
       continue;
     }
 
@@ -241,23 +269,23 @@ export async function loadTreeForQuery(
         entry.file,
         isCollapsible
       );
-      assert(readmeSubtree.description === undefined);
-      readmeSubtree.description = entry.readme.trim();
+      setSubtreeDescription(readmeSubtree, entry.readme.trim());
       continue;
     }
     // Entry is a spec file.
 
     const spec = await loader.importSpecFile(queryToLoad.suite, entry.file);
-    const description = spec.description.trim();
     // subtreeL1 is suite:a,b:*
     const subtreeL1: TestSubtree<TestQueryMultiTest> = addSubtreeForFilePath(
       subtreeL0,
       entry.file,
-      description,
       isCollapsible
     );
+    setSubtreeDescription(subtreeL1, spec.description.trim());
 
+    let groupHasTests = false;
     for (const t of spec.g.iterate()) {
+      groupHasTests = true;
       {
         const queryL2 = new TestQueryMultiCase(suite, entry.file, t.testPath, {});
         const orderingL2 = compareQueries(queryL2, queryToLoad);
@@ -271,10 +299,10 @@ export async function loadTreeForQuery(
       const subtreeL2: TestSubtree<TestQueryMultiCase> = addSubtreeForTestPath(
         subtreeL1,
         t.testPath,
-        t.description,
         t.testCreationStack,
         isCollapsible
       );
+      if (t.description) setSubtreeDescription(subtreeL2, t.description.trim());
 
       // MAINTENANCE_TODO: If tree generation gets too slow, avoid actually iterating the cases in a
       // file if there's no need to (based on the subqueriesToExpand).
@@ -294,6 +322,11 @@ export async function loadTreeForQuery(
         foundCase = true;
       }
     }
+    if (!groupHasTests && !subtreeL1.subtreeHasTODOs) {
+      throw new StacklessError(
+        `${subtreeL1.query} has no tests - it must have "TODO" in its description`
+      );
+    }
   }
 
   for (const [i, sq] of subqueriesToExpandEntries) {
@@ -308,6 +341,14 @@ export async function loadTreeForQuery(
   assert(foundCase, 'Query does not match any cases');
 
   return new TestTree(queryToLoad, subtreeL0);
+}
+
+function setSubtreeDescription(subtree: TestSubtree<TestQueryMultiFile>, description: string) {
+  assert(subtree.description === undefined);
+  subtree.description = description;
+  if (subtree.description.indexOf('TODO') !== -1) {
+    subtree.subtreeHasTODOs = true;
+  }
 }
 
 function makeTreeForSuite(
@@ -348,7 +389,6 @@ function addSubtreeForDirPath(
 function addSubtreeForFilePath(
   tree: TestSubtree<TestQueryMultiFile>,
   file: string[],
-  description: string,
   isCollapsible: (sq: TestQuery) => boolean
 ): TestSubtree<TestQueryMultiTest> {
   // To start, tree is suite:*
@@ -361,7 +401,6 @@ function addSubtreeForFilePath(
     return {
       readableRelativeName: file[file.length - 1] + kBigSeparator + kWildcard,
       query,
-      description,
       collapsible: isCollapsible(query),
     };
   });
@@ -371,7 +410,6 @@ function addSubtreeForFilePath(
 function addSubtreeForTestPath(
   tree: TestSubtree<TestQueryMultiTest>,
   test: readonly string[],
-  description: string | undefined,
   testCreationStack: Error,
   isCollapsible: (sq: TestQuery) => boolean
 ): TestSubtree<TestQueryMultiCase> {
@@ -406,7 +444,6 @@ function addSubtreeForTestPath(
       readableRelativeName: subqueryTest[subqueryTest.length - 1] + kBigSeparator + kWildcard,
       kWildcard,
       query,
-      description,
       testCreationStack,
       collapsible: isCollapsible(query),
     };

--- a/src/common/tools/checklist.ts
+++ b/src/common/tools/checklist.ts
@@ -19,30 +19,38 @@ function usage(rc: number): void {
 if (process.argv.length === 2) usage(0);
 if (process.argv.length !== 3) usage(1);
 
-type QueriesBySuite = Map<string, TestQuery[]>;
+type QueryInSuite = { readonly query: TestQuery; readonly done: boolean };
+type QueriesInSuite = QueryInSuite[];
+type QueriesBySuite = Map<string, QueriesInSuite>;
 async function loadQueryListFromTextFile(filename: string): Promise<QueriesBySuite> {
   const lines = (await fs.promises.readFile(filename, 'utf8')).split(/\r?\n/);
-  const allQueries = lines.filter(l => l).map(l => parseQuery(l.trim()));
+  const allQueries = lines
+    .filter(l => l)
+    .map(l => {
+      const [doneStr, q] = l.split(/\s+/);
+      assert(doneStr === 'DONE' || doneStr === 'TODO', 'first column must be DONE or TODO');
+      return { query: parseQuery(q), done: doneStr === 'DONE' } as const;
+    });
 
   const queriesBySuite: QueriesBySuite = new Map();
-  for (const query of allQueries) {
-    let suiteQueries = queriesBySuite.get(query.suite);
+  for (const q of allQueries) {
+    let suiteQueries = queriesBySuite.get(q.query.suite);
     if (suiteQueries === undefined) {
       suiteQueries = [];
-      queriesBySuite.set(query.suite, suiteQueries);
+      queriesBySuite.set(q.query.suite, suiteQueries);
     }
 
-    suiteQueries.push(query);
+    suiteQueries.push(q);
   }
 
   return queriesBySuite;
 }
 
-function checkForOverlappingQueries(queries: TestQuery[]): void {
+function checkForOverlappingQueries(queries: QueriesInSuite): void {
   for (let i1 = 0; i1 < queries.length; ++i1) {
     for (let i2 = i1 + 1; i2 < queries.length; ++i2) {
-      const q1 = queries[i1];
-      const q2 = queries[i2];
+      const q1 = queries[i1].query;
+      const q2 = queries[i2].query;
       if (compareQueries(q1, q2) !== Ordering.Unordered) {
         console.log(`    FYI, the following checklist items overlap:\n      ${q1}\n      ${q2}`);
       }
@@ -50,21 +58,32 @@ function checkForOverlappingQueries(queries: TestQuery[]): void {
   }
 }
 
-function checkForUnmatchedSubtrees(tree: TestTree, matchQueries: TestQuery[]): number {
+function checkForUnmatchedSubtreesAndDoneness(
+  tree: TestTree,
+  matchQueries: QueriesInSuite
+): number {
   let subtreeCount = 0;
   const unmatchedSubtrees: TestQuery[] = [];
   const overbroadMatches: [TestQuery, TestQuery][] = [];
+  const donenessMismatches: QueryInSuite[] = [];
   const alwaysExpandThroughLevel = 1; // expand to, at minimum, every file.
-  for (const collapsedSubtree of tree.iterateCollapsedQueries(true, alwaysExpandThroughLevel)) {
+  for (const subtree of tree.iterateCollapsedNodes({
+    includeIntermediateNodes: true,
+    includeEmptySubtrees: true,
+    alwaysExpandThroughLevel,
+  })) {
     subtreeCount++;
+    const subtreeDone = !subtree.subtreeHasTODOs;
+
     let subtreeMatched = false;
     for (const q of matchQueries) {
-      const comparison = compareQueries(q, collapsedSubtree);
-      assert(comparison !== Ordering.StrictSubset); // shouldn't happen, due to subqueriesToExpand
-      if (comparison === Ordering.StrictSuperset) overbroadMatches.push([q, collapsedSubtree]);
+      const comparison = compareQueries(q.query, subtree.query);
       if (comparison !== Ordering.Unordered) subtreeMatched = true;
+      if (comparison === Ordering.StrictSubset) continue;
+      if (comparison === Ordering.StrictSuperset) overbroadMatches.push([q.query, subtree.query]);
+      if (comparison === Ordering.Equal && q.done !== subtreeDone) donenessMismatches.push(q);
     }
-    if (!subtreeMatched) unmatchedSubtrees.push(collapsedSubtree);
+    if (!subtreeMatched) unmatchedSubtrees.push(subtree.query);
   }
 
   if (overbroadMatches.length) {
@@ -76,8 +95,18 @@ function checkForUnmatchedSubtrees(tree: TestTree, matchQueries: TestQuery[]): n
   }
 
   if (unmatchedSubtrees.length) {
-    throw new StacklessError(`Found unmatched tests:\n    ${unmatchedSubtrees.join('\n    ')}`);
+    throw new StacklessError(`Found unmatched tests:\n  ${unmatchedSubtrees.join('\n  ')}`);
   }
+
+  if (donenessMismatches.length) {
+    throw new StacklessError(
+      'Found done/todo mismatches:\n  ' +
+        donenessMismatches
+          .map(q => `marked ${q.done ? 'DONE, but is TODO' : 'TODO, but is DONE'}: ${q.query}`)
+          .join('\n  ')
+    );
+  }
+
   return subtreeCount;
 }
 
@@ -93,10 +122,14 @@ function checkForUnmatchedSubtrees(tree: TestTree, matchQueries: TestQuery[]): n
     checkForOverlappingQueries(queriesInSuite);
     const suiteQuery = new TestQueryMultiFile(suite, []);
     console.log(`  Loading tree ${suiteQuery}...`);
-    const tree = await loadTreeForQuery(loader, suiteQuery, queriesInSuite);
+    const tree = await loadTreeForQuery(
+      loader,
+      suiteQuery,
+      queriesInSuite.map(q => q.query)
+    );
     console.log('  Found no invalid queries in the checklist. Checking for unmatched tests...');
-    const subtreeCount = checkForUnmatchedSubtrees(tree, queriesInSuite);
-    console.log(`  No unmatched tests among ${subtreeCount} subtrees!`);
+    const subtreeCount = checkForUnmatchedSubtreesAndDoneness(tree, queriesInSuite);
+    console.log(`  No unmatched tests or done/todo mismatches among ${subtreeCount} subtrees!`);
   }
   console.log(`Checklist looks good!`);
 })().catch(ex => {

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -84,8 +84,8 @@ const [
 
     lines.push(undefined); // output blank line between prefixes
     const alwaysExpandThroughLevel = 2; // expand to, at minimum, every test.
-    for (const q of tree.iterateCollapsedQueries(false, alwaysExpandThroughLevel)) {
-      const urlQueryString = prefix + q.toString(); // "?worker=0&q=..."
+    for (const { query } of tree.iterateCollapsedNodes({ alwaysExpandThroughLevel })) {
+      const urlQueryString = prefix + query.toString(); // "?worker=0&q=..."
       // Check for a safe-ish path length limit. Filename must be <= 255, and on Windows the whole
       // path must be <= 259. Leave room for e.g.:
       // 'c:\b\s\w\xxxxxxxx\layout-test-results\external\wpt\webgpu\cts_worker=0_q=...-actual.txt'

--- a/src/webgpu/api/operation/buffers/threading.spec.ts
+++ b/src/webgpu/api/operation/buffers/threading.spec.ts
@@ -1,11 +1,29 @@
 export const description = `
-TODO:
-- Copy GPUBuffer to another thread while {pending, mapped mappedAtCreation} on {same,diff} thread
-- Destroy on one thread while {pending, mapped, mappedAtCreation, mappedAtCreation+unmap+mapped}
-  on another thread.
+Tests for valid operations with various client-side thread-shared state of GPUBuffers.
+
+States to test:
+- mapping pending
+- mapped
+- mapped at creation
+- mapped at creation, then unmapped
+- mapped at creation, then unmapped, then re-mapped
+- destroyed
+
+TODO: Look for more things to test.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
+
+g.test('serialize')
+  .desc(
+    `Copy a GPUBuffer to another thread while it is in various states on
+{the sending thread, yet another thread}.`
+  )
+  .unimplemented();
+
+g.test('destroyed')
+  .desc(`Destroy on one thread while in various states in another thread.`)
+  .unimplemented();

--- a/src/webgpu/api/operation/labels.spec.ts
+++ b/src/webgpu/api/operation/labels.spec.ts
@@ -1,10 +1,12 @@
 export const description = `
-For every create function, the descriptor.label is carried over to the object.label.
-
-TODO: implement
+Tests for object labels.
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { GPUTest } from '../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
+
+g.test('object_has_descriptor_label')
+  .desc(`For every create function, the descriptor.label is carried over to the object.label.`)
+  .unimplemented();

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -1,7 +1,5 @@
 export const description = `
 renderPass store op test that drawn quad is either stored or cleared based on storeop
-
-TODO: is this duplicated with api,operation,render_pass,storeOp?
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -10,6 +8,12 @@ import { GPUTest } from '../../../gpu_test.js';
 export const g = makeTestGroup(GPUTest);
 
 g.test('storeOp_controls_whether_1x1_drawn_quad_is_stored')
+  .desc(
+    `
+TODO: is this duplicated with api,operation,render_pass,storeOp?
+TODO: needs review and rename
+`
+  )
   .paramsSimple([
     { storeOp: 'store', _expected: 1 }, //
     { storeOp: 'discard', _expected: 0 },

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -3,13 +3,6 @@ Tests for the general aspects of draw/drawIndexed/drawIndirect/drawIndexedIndire
 
 Primitive topology tested in api/operation/render_pipeline/primitive_topology.spec.ts.
 Index format tested in api/operation/command_buffer/render/state_tracking.spec.ts.
-
-* arguments - Test that draw arguments are passed correctly.
-
-TODO:
-* default_arguments - Test defaults to draw / drawIndexed.
-  - arg= {instance_count, first, first_instance, base_vertex}
-  - mode= {draw, drawIndexed}
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -325,6 +318,15 @@ struct Output {
       }
     }
   });
+
+g.test('default_arguments')
+  .desc(
+    `TODO: Test defaults to draw / drawIndexed. Maybe merge with the 'arguments' test.
+- arg= {instance_count, first, first_instance, base_vertex}
+- mode= {draw, drawIndexed}
+  `
+  )
+  .unimplemented();
 
 g.test('vertex_attributes,basic')
   .desc(

--- a/src/webgpu/api/validation/capability_checks/features/depth_clip_control.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/depth_clip_control.spec.ts
@@ -1,8 +1,12 @@
 export const description = `
-Tests 'depth-clamping' must be enabled for GPUDepthStencilState.clampDepth to be enabled.
+Tests checks that depend on 'depth-clip-control' being enabled.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { ValidationTest } from '../../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
+
+g.test('createRenderPipeline')
+  .desc(`unclippedDepth=true requires 'depth-clip-control'; false or undefined does not.`)
+  .unimplemented();

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -170,6 +170,7 @@ class F extends ValidationTest {
 export const g = makeTestGroup(F);
 
 g.test('basic_use_of_createRenderPipeline')
+  .desc(`TODO: review and add description; shorten name`)
   .params(u => u.combine('isAsync', [false, true]))
   .fn(async t => {
     const { isAsync } = t.params;
@@ -181,7 +182,9 @@ g.test('basic_use_of_createRenderPipeline')
 g.test('create_vertex_only_pipeline_with_without_depth_stencil_state')
   .desc(
     `Test creating vertex-only render pipeline. A vertex-only render pipeline have no fragment
-state (and thus have no color state), and can be create with or without depth stencil state.`
+state (and thus have no color state), and can be create with or without depth stencil state.
+
+TODO: review and shorten name`
   )
   .params(u =>
     u
@@ -217,6 +220,7 @@ state (and thus have no color state), and can be create with or without depth st
   });
 
 g.test('at_least_one_color_state_is_required_for_complete_pipeline')
+  .desc(`TODO: review and add description; shorten name`)
   .params(u => u.combine('isAsync', [false, true]))
   .fn(async t => {
     const { isAsync } = t.params;
@@ -237,6 +241,7 @@ g.test('at_least_one_color_state_is_required_for_complete_pipeline')
   });
 
 g.test('color_formats_must_be_renderable')
+  .desc(`TODO: review and add description; shorten name`)
   .params(u => u.combine('isAsync', [false, true]).combine('format', kTextureFormats))
   .fn(async t => {
     const { isAsync, format } = t.params;
@@ -249,6 +254,7 @@ g.test('color_formats_must_be_renderable')
   });
 
 g.test('sample_count_must_be_valid')
+  .desc(`TODO: review and add description; shorten name`)
   .params(u =>
     u.combine('isAsync', [false, true]).combineWithParams([
       { sampleCount: 0, _success: false },
@@ -274,7 +280,8 @@ g.test('pipeline_output_targets')
   - The scalar type (f32, i32, or u32) must match the sample type of the format.
   - The componentCount of the fragment output (e.g. f32, vec2, vec3, vec4) must not have fewer
     channels than that of the color attachment texture formats. Extra components are allowed and are discarded.
-  `
+
+TODO: review`
   )
   .params(u =>
     u


### PR DESCRIPTION
Verifies that subtrees containing TODOs are not marked as "Done" in the checklist and vice versa.
https://docs.google.com/spreadsheets/d/1YOvxGpgw0i5b8WBC1tgU557Jr5KNb1EQsQLHEMdLGlk/edit?usp=sharing
This improves synchronization between the CTS and that sheet, although it's still TBD how this all fits into a better project management system.

This adds a "subtreeHasTODOs" state to the tree so it could be displayed in the standalone runner, but skipping that for now.

Also adds a check that any file not containing any tests must have a TODO in its description.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.
