### PR TITLE
Implement `fract` tests

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -32,7 +32,7 @@ function hexToFloat64(h32: number, l32: number): number {
 }
 
 g.test('test,math,diffULP')
-  .paramsSimple<DiffULPCase>([
+  .paramsSubcasesOnly<DiffULPCase>([
     { a: 0, b: 0, ulp: 0 },
     { a: 1, b: 2, ulp: 2 ** 23 }, // Single exponent step
     { a: 2, b: 1, ulp: 2 ** 23 }, // Single exponent step
@@ -94,65 +94,128 @@ g.test('test,math,diffULP')
 interface nextAfterCase {
   val: number;
   dir: boolean;
+  flush: boolean;
   result: Scalar;
 }
 
 g.test('test,math,nextAfter')
-  .paramsSimple<nextAfterCase>([
+  .paramsSubcasesOnly<nextAfterCase>([
     // Edge Cases
-    { val: Number.NaN, dir: true, result: f32Bits(0x7fffffff) },
-    { val: Number.NaN, dir: false, result: f32Bits(0x7fffffff) },
-    { val: Number.POSITIVE_INFINITY, dir: true, result: f32Bits(kBit.f32.infinity.positive) },
-    { val: Number.POSITIVE_INFINITY, dir: false, result: f32Bits(kBit.f32.infinity.positive) },
-    { val: Number.NEGATIVE_INFINITY, dir: true, result: f32Bits(kBit.f32.infinity.negative) },
-    { val: Number.NEGATIVE_INFINITY, dir: false, result: f32Bits(kBit.f32.infinity.negative) },
+    { val: Number.NaN, dir: true, flush: true, result: f32Bits(0x7fffffff) },
+    { val: Number.NaN, dir: true, flush: false, result: f32Bits(0x7fffffff) },
+    { val: Number.NaN, dir: false, flush: true, result: f32Bits(0x7fffffff) },
+    { val: Number.NaN, dir: false, flush: false, result: f32Bits(0x7fffffff) },
+    // prettier-ignore
+    { val: Number.POSITIVE_INFINITY, dir: true, flush: true, result: f32Bits(kBit.f32.infinity.positive) },
+    // prettier-ignore
+    { val: Number.POSITIVE_INFINITY, dir: true, flush: false, result: f32Bits(kBit.f32.infinity.positive) },
+    // prettier-ignore
+    { val: Number.POSITIVE_INFINITY, dir: false, flush: true, result: f32Bits(kBit.f32.infinity.positive) },
+    // prettier-ignore
+    { val: Number.POSITIVE_INFINITY, dir: false, flush: false, result: f32Bits(kBit.f32.infinity.positive) },
+    // prettier-ignore
+    { val: Number.NEGATIVE_INFINITY, dir: true, flush: true, result: f32Bits(kBit.f32.infinity.negative) },
+    // prettier-ignore
+    { val: Number.NEGATIVE_INFINITY, dir: true, flush: false, result: f32Bits(kBit.f32.infinity.negative) },
+    // prettier-ignore
+    { val: Number.NEGATIVE_INFINITY, dir: false, flush: true, result: f32Bits(kBit.f32.infinity.negative) },
+    // prettier-ignore
+    { val: Number.NEGATIVE_INFINITY, dir: false, flush: false, result: f32Bits(kBit.f32.infinity.negative) },
 
     // Zeroes
-    { val: +0, dir: true, result: f32Bits(kBit.f32.subnormal.positive.min) },
-    { val: +0, dir: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
-    { val: -0, dir: true, result: f32Bits(kBit.f32.subnormal.positive.min) },
-    { val: -0, dir: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
+    { val: +0, dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: +0, dir: true, flush: false, result: f32Bits(kBit.f32.subnormal.positive.min) },
+    { val: +0, dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
+    { val: +0, dir: false, flush: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
+    { val: -0, dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: -0, dir: true, flush: false, result: f32Bits(kBit.f32.subnormal.positive.min) },
+    { val: -0, dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
+    { val: -0, dir: false, flush: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
 
     // Subnormals
-    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, result: f32Bits(0x00000002) },
-    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, result: f32(0) },
     // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, result: f32Bits(kBit.f32.positive.min) },
-    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, result: f32Bits(0x007ffffe) },
-    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, result: f32Bits(0x807ffffe) },
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
     // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, result: f32Bits(kBit.f32.negative.max) },
-    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, result: f32(0) },
-    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, result: f32Bits(0x80000002) },
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, flush: false, result: f32Bits(0x00000002) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, flush: true, result:  f32Bits(kBit.f32.negative.max) },
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, flush: false, result: f32(0) },
+
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, flush: false, result: f32Bits(kBit.f32.positive.min) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, flush: false, result: f32Bits(0x007ffffe) },
+
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, flush: false, result: f32Bits(0x807ffffe) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, flush: false, result: f32Bits(kBit.f32.negative.max) },
+
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, flush: false, result: f32(0) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, flush: false, result: f32Bits(0x80000002) },
 
     // Normals
     // prettier-ignore
-    { val: hexToF32(kBit.f32.positive.max), dir: true, result: f32Bits(kBit.f32.infinity.positive) },
-    { val: hexToF32(kBit.f32.positive.max), dir: false, result: f32Bits(0x7f7ffffe) },
-    { val: hexToF32(kBit.f32.positive.min), dir: true, result: f32Bits(0x00800001) },
+    { val: hexToF32(kBit.f32.positive.max), dir: true, flush: true, result: f32Bits(kBit.f32.infinity.positive) },
     // prettier-ignore
-    { val: hexToF32(kBit.f32.positive.min), dir: false, result: f32Bits(kBit.f32.subnormal.positive.max) },
+    { val: hexToF32(kBit.f32.positive.max), dir: true, flush: false, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: hexToF32(kBit.f32.positive.max), dir: false, flush: true, result: f32Bits(0x7f7ffffe) },
+    { val: hexToF32(kBit.f32.positive.max), dir: false, flush: false, result: f32Bits(0x7f7ffffe) },
+
+    { val: hexToF32(kBit.f32.positive.min), dir: true, flush: true, result: f32Bits(0x00800001) },
+    { val: hexToF32(kBit.f32.positive.min), dir: true, flush: false, result: f32Bits(0x00800001) },
     // prettier-ignore
-    { val: hexToF32(kBit.f32.negative.max), dir: true, result: f32Bits(kBit.f32.subnormal.negative.min) },
-    { val: hexToF32(kBit.f32.negative.max), dir: false, result: f32Bits(0x80800001) },
-    { val: hexToF32(kBit.f32.negative.min), dir: true, result: f32Bits(0xff7ffffe) },
+    { val: hexToF32(kBit.f32.positive.min), dir: false, flush: true, result: f32(0) },
     // prettier-ignore
-    { val: hexToF32(kBit.f32.negative.min), dir: false, result: f32Bits(kBit.f32.infinity.negative) },
-    { val: hexToF32(0x03800000), dir: true, result: f32Bits(0x03800001) },
-    { val: hexToF32(0x03800000), dir: false, result: f32Bits(0x037fffff) },
-    { val: hexToF32(0x83800000), dir: true, result: f32Bits(0x837fffff) },
-    { val: hexToF32(0x83800000), dir: false, result: f32Bits(0x83800001) },
+    { val: hexToF32(kBit.f32.positive.min), dir: false, flush: false, result: f32Bits(kBit.f32.subnormal.positive.max) },
+
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.negative.max), dir: true, flush: true, result: f32(0) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.negative.max), dir: true, flush: false, result: f32Bits(kBit.f32.subnormal.negative.min) },
+    { val: hexToF32(kBit.f32.negative.max), dir: false, flush: true, result: f32Bits(0x80800001) },
+    { val: hexToF32(kBit.f32.negative.max), dir: false, flush: false, result: f32Bits(0x80800001) },
+
+    { val: hexToF32(kBit.f32.negative.min), dir: true, flush: true, result: f32Bits(0xff7ffffe) },
+    { val: hexToF32(kBit.f32.negative.min), dir: true, flush: false, result: f32Bits(0xff7ffffe) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.negative.min), dir: false, flush: true, result: f32Bits(kBit.f32.infinity.negative) },
+    // prettier-ignore
+    { val: hexToF32(kBit.f32.negative.min), dir: false, flush: false, result: f32Bits(kBit.f32.infinity.negative) },
+
+    { val: hexToF32(0x03800000), dir: true, flush: true, result: f32Bits(0x03800001) },
+    { val: hexToF32(0x03800000), dir: true, flush: false, result: f32Bits(0x03800001) },
+    { val: hexToF32(0x03800000), dir: false, flush: true, result: f32Bits(0x037fffff) },
+    { val: hexToF32(0x03800000), dir: false, flush: false, result: f32Bits(0x037fffff) },
+    { val: hexToF32(0x83800000), dir: true, flush: true, result: f32Bits(0x837fffff) },
+    { val: hexToF32(0x83800000), dir: true, flush: false, result: f32Bits(0x837fffff) },
+    { val: hexToF32(0x83800000), dir: false, flush: true, result: f32Bits(0x83800001) },
+    { val: hexToF32(0x83800000), dir: false, flush: false, result: f32Bits(0x83800001) },
   ])
   .fn(t => {
     const val = t.params.val;
     const dir = t.params.dir;
+    const flush = t.params.flush;
     const expect = t.params.result;
     const expect_type = typeof expect;
-    const got = nextAfter(val, dir);
+    const got = nextAfter(val, dir, flush);
     const got_type = typeof got;
     t.expect(
       got.value === expect.value || (Number.isNaN(got.value) && Number.isNaN(expect.value)),
-      `nextAfter(${val}, ${dir}) returned ${got} (${got_type}). Expected ${expect} (${expect_type})`
+      `nextAfter(${val}, ${dir}, ${flush}) returned ${got} (${got_type}). Expected ${expect} (${expect_type})`
     );
   });
 
@@ -163,7 +226,7 @@ interface correctlyRoundedCase {
 }
 
 g.test('test,math,correctlyRounded')
-  .paramsSimple<correctlyRoundedCase>([
+  .paramsSubcasesOnly<correctlyRoundedCase>([
     // NaN Cases
     { test_val: f32Bits(kBit.f32.nan.positive.s), target: NaN, is_correct: true },
     { test_val: f32Bits(kBit.f32.nan.positive.q), target: NaN, is_correct: true },
@@ -210,68 +273,68 @@ g.test('test,math,correctlyRounded')
     // Zeros
     { test_val: f32Bits(kBit.f32.positive.zero), target: 0, is_correct: true },
     { test_val: f32Bits(kBit.f32.negative.zero), target: 0, is_correct: true },
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: 0, is_correct: false },
-    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: 0, is_correct: false },
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: 0, is_correct: false },
-    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: 0, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: 0, is_correct: true },
 
     { test_val: f32Bits(kBit.f32.positive.zero), target: -0, is_correct: true },
     { test_val: f32Bits(kBit.f32.negative.zero), target: -0, is_correct: true },
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: -0, is_correct: false },
-    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: -0, is_correct: false },
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: -0, is_correct: false },
-    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: -0, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: -0, is_correct: true },
 
     // 32-bit subnormals
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
     // prettier-ignore
     { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
 
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
     // prettier-ignore
     { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
 
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
     // prettier-ignore
     { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
 
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
     // prettier-ignore
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
     // prettier-ignore
     { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
 
@@ -314,27 +377,47 @@ g.test('test,math,correctlyRounded')
     // prettier-ignore
     { test_val: f32Bits(kBit.f32.negative.min), target: hexToF32(kBit.f32.negative.min), is_correct: true },
     { test_val: f32Bits(0x03800000), target: hexToF32(0x03800000), is_correct: true },
+    { test_val: f32Bits(0x03800000), target: hexToF32(0x03800002), is_correct: false },
     { test_val: f32Bits(0x03800001), target: hexToF32(0x03800001), is_correct: true },
+    { test_val: f32Bits(0x03800001), target: hexToF32(0x03800010), is_correct: false },
     { test_val: f32Bits(0x83800000), target: hexToF32(0x83800000), is_correct: true },
+    { test_val: f32Bits(0x83800000), target: hexToF32(0x83800002), is_correct: false },
     { test_val: f32Bits(0x83800001), target: hexToF32(0x83800001), is_correct: true },
+    { test_val: f32Bits(0x83800001), target: hexToF32(0x83800010), is_correct: false },
 
     // 64-bit normals
     // prettier-ignore
     { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
     // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00010, 0x00000001), is_correct: false },
+    // prettier-ignore
     { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00020, 0x00000001), is_correct: false },
     // prettier-ignore
     { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
     // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00030, 0x00000002), is_correct: false },
+    // prettier-ignore
     { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00040, 0x00000002), is_correct: false },
     // prettier-ignore
     { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
     // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00050, 0x00000001), is_correct: false },
+    // prettier-ignore
     { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00060, 0x00000001), is_correct: false },
     // prettier-ignore
     { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
     // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00070, 0x00000002), is_correct: false },
+    // prettier-ignore
     { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00080, 0x00000002), is_correct: false },
   ])
   .fn(t => {
     const test_val = t.params.test_val;

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -32,7 +32,7 @@ function hexToFloat64(h32: number, l32: number): number {
 }
 
 g.test('test,math,diffULP')
-  .paramsSubcasesOnly<DiffULPCase>([
+  .paramsSimple<DiffULPCase>([
     { a: 0, b: 0, ulp: 0 },
     { a: 1, b: 2, ulp: 2 ** 23 }, // Single exponent step
     { a: 2, b: 1, ulp: 2 ** 23 }, // Single exponent step
@@ -425,6 +425,418 @@ g.test('test,math,correctlyRounded')
     const is_correct = t.params.is_correct;
 
     const got = correctlyRounded(test_val, target);
+    t.expect(
+      got === is_correct,
+      `correctlyRounded(${test_val}, ${target}) returned ${got}. Expected ${is_correct}`
+    );
+  });
+
+g.test('test,math,correctlyRoundedNoFlushOnly')
+  .paramsSubcasesOnly<correctlyRoundedCase>([
+    // NaN Cases
+    { test_val: f32Bits(kBit.f32.nan.positive.s), target: NaN, is_correct: true },
+    { test_val: f32Bits(kBit.f32.nan.positive.q), target: NaN, is_correct: true },
+    { test_val: f32Bits(kBit.f32.nan.negative.s), target: NaN, is_correct: true },
+    { test_val: f32Bits(kBit.f32.nan.negative.q), target: NaN, is_correct: true },
+    { test_val: f32Bits(0x7fffffff), target: NaN, is_correct: true },
+    { test_val: f32Bits(0xffffffff), target: NaN, is_correct: true },
+    { test_val: f32Bits(kBit.f32.infinity.positive), target: NaN, is_correct: false },
+    { test_val: f32Bits(kBit.f32.infinity.negative), target: NaN, is_correct: false },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: NaN, is_correct: false },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: NaN, is_correct: false },
+
+    // Infinities
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.positive.s), target: Number.POSITIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.positive.q), target: Number.POSITIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.negative.s), target: Number.POSITIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.negative.q), target: Number.POSITIVE_INFINITY, is_correct: false },
+    { test_val: f32Bits(0x7fffffff), target: Number.POSITIVE_INFINITY, is_correct: false },
+    { test_val: f32Bits(0xffffffff), target: Number.POSITIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.infinity.positive), target: Number.POSITIVE_INFINITY, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.infinity.negative), target: Number.POSITIVE_INFINITY, is_correct: false },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.positive.s), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.positive.q), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.negative.s), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.negative.q), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    { test_val: f32Bits(0x7fffffff), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    { test_val: f32Bits(0xffffffff), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.infinity.positive), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.infinity.negative), target: Number.NEGATIVE_INFINITY, is_correct: true },
+
+    // Zeros
+    { test_val: f32Bits(kBit.f32.positive.zero), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: 0, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: 0, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: 0, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: 0, is_correct: false },
+
+    { test_val: f32Bits(kBit.f32.positive.zero), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: -0, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: -0, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: -0, is_correct: false },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: -0, is_correct: false },
+
+    // 32-bit subnormals
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: false },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: false },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: false },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
+
+    // 64-bit subnormals
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
+
+    // 32-bit normals
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.max), target: hexToF32(kBit.f32.positive.max), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.min), target: hexToF32(kBit.f32.positive.min), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.max), target: hexToF32(kBit.f32.negative.max), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.min), target: hexToF32(kBit.f32.negative.min), is_correct: true },
+    { test_val: f32Bits(0x03800000), target: hexToF32(0x03800000), is_correct: true },
+    { test_val: f32Bits(0x03800000), target: hexToF32(0x03800002), is_correct: false },
+    { test_val: f32Bits(0x03800001), target: hexToF32(0x03800001), is_correct: true },
+    { test_val: f32Bits(0x03800001), target: hexToF32(0x03800010), is_correct: false },
+    { test_val: f32Bits(0x83800000), target: hexToF32(0x83800000), is_correct: true },
+    { test_val: f32Bits(0x83800000), target: hexToF32(0x83800002), is_correct: false },
+    { test_val: f32Bits(0x83800001), target: hexToF32(0x83800001), is_correct: true },
+    { test_val: f32Bits(0x83800001), target: hexToF32(0x83800010), is_correct: false },
+
+    // 64-bit normals
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00010, 0x00000001), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00020, 0x00000001), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00030, 0x00000002), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00040, 0x00000002), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00050, 0x00000001), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00060, 0x00000001), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00070, 0x00000002), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00080, 0x00000002), is_correct: false },
+  ])
+  .fn(t => {
+    const test_val = t.params.test_val;
+    const target = t.params.target;
+    const is_correct = t.params.is_correct;
+
+    const got = correctlyRounded(test_val, target, false, true);
+    t.expect(
+      got === is_correct,
+      `correctlyRounded(${test_val}, ${target}) returned ${got}. Expected ${is_correct}`
+    );
+  });
+
+g.test('test,math,correctlyRoundedFlushToZeroOnly')
+  .paramsSubcasesOnly<correctlyRoundedCase>([
+    // NaN Cases
+    { test_val: f32Bits(kBit.f32.nan.positive.s), target: NaN, is_correct: true },
+    { test_val: f32Bits(kBit.f32.nan.positive.q), target: NaN, is_correct: true },
+    { test_val: f32Bits(kBit.f32.nan.negative.s), target: NaN, is_correct: true },
+    { test_val: f32Bits(kBit.f32.nan.negative.q), target: NaN, is_correct: true },
+    { test_val: f32Bits(0x7fffffff), target: NaN, is_correct: true },
+    { test_val: f32Bits(0xffffffff), target: NaN, is_correct: true },
+    { test_val: f32Bits(kBit.f32.infinity.positive), target: NaN, is_correct: false },
+    { test_val: f32Bits(kBit.f32.infinity.negative), target: NaN, is_correct: false },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: NaN, is_correct: false },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: NaN, is_correct: false },
+
+    // Infinities
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.positive.s), target: Number.POSITIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.positive.q), target: Number.POSITIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.negative.s), target: Number.POSITIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.negative.q), target: Number.POSITIVE_INFINITY, is_correct: false },
+    { test_val: f32Bits(0x7fffffff), target: Number.POSITIVE_INFINITY, is_correct: false },
+    { test_val: f32Bits(0xffffffff), target: Number.POSITIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.infinity.positive), target: Number.POSITIVE_INFINITY, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.infinity.negative), target: Number.POSITIVE_INFINITY, is_correct: false },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.positive.s), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.positive.q), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.negative.s), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.nan.negative.q), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    { test_val: f32Bits(0x7fffffff), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    { test_val: f32Bits(0xffffffff), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.infinity.positive), target: Number.NEGATIVE_INFINITY, is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.infinity.negative), target: Number.NEGATIVE_INFINITY, is_correct: true },
+
+    // Zeros
+    { test_val: f32Bits(kBit.f32.positive.zero), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: 0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: 0, is_correct: true },
+
+    { test_val: f32Bits(kBit.f32.positive.zero), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: -0, is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: -0, is_correct: true },
+
+    // 32-bit subnormals
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.positive.min).value as number, is_correct: true },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.positive.max).value as number, is_correct: true },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.negative.max).value as number, is_correct: true },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.max), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: f32Bits(kBit.f32.subnormal.negative.min).value as number, is_correct: true },
+
+    // 64-bit subnormals
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
+
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
+
+    // 32-bit normals
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.max), target: hexToF32(kBit.f32.positive.max), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.positive.min), target: hexToF32(kBit.f32.positive.min), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.max), target: hexToF32(kBit.f32.negative.max), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(kBit.f32.negative.min), target: hexToF32(kBit.f32.negative.min), is_correct: true },
+    { test_val: f32Bits(0x03800000), target: hexToF32(0x03800000), is_correct: true },
+    { test_val: f32Bits(0x03800000), target: hexToF32(0x03800002), is_correct: false },
+    { test_val: f32Bits(0x03800001), target: hexToF32(0x03800001), is_correct: true },
+    { test_val: f32Bits(0x03800001), target: hexToF32(0x03800010), is_correct: false },
+    { test_val: f32Bits(0x83800000), target: hexToF32(0x83800000), is_correct: true },
+    { test_val: f32Bits(0x83800000), target: hexToF32(0x83800002), is_correct: false },
+    { test_val: f32Bits(0x83800001), target: hexToF32(0x83800001), is_correct: true },
+    { test_val: f32Bits(0x83800001), target: hexToF32(0x83800010), is_correct: false },
+
+    // 64-bit normals
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00010, 0x00000001), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00020, 0x00000001), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00030, 0x00000002), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00040, 0x00000002), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00050, 0x00000001), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00060, 0x00000001), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00070, 0x00000002), is_correct: false },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
+    // prettier-ignore
+    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00080, 0x00000002), is_correct: false },
+  ])
+  .fn(t => {
+    const test_val = t.params.test_val;
+    const target = t.params.target;
+    const is_correct = t.params.is_correct;
+
+    const got = correctlyRounded(test_val, target, true, false);
     t.expect(
       got === is_correct,
       `correctlyRounded(${test_val}, ${target}) returned ${got}. Expected ${is_correct}`

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -114,16 +114,25 @@ g.test('test,math,nextAfterFlushToZero')
     { val: -0, dir: false, result: f32Bits(kBit.f32.negative.max) },
 
     // Subnormals
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, result: f32Bits(kBit.f32.negative.max) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, result: f32Bits(kBit.f32.negative.max) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, result: f32Bits(kBit.f32.negative.max) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, result: f32Bits(kBit.f32.negative.max) },
 
     // Normals
+    // prettier-ignore
     { val: hexToF32(kBit.f32.positive.max), dir: true, result: f32Bits(kBit.f32.infinity.positive) },
     { val: hexToF32(kBit.f32.positive.max), dir: false, result: f32Bits(0x7f7ffffe) },
     { val: hexToF32(kBit.f32.positive.min), dir: true, result: f32Bits(0x00800001) },
@@ -131,6 +140,7 @@ g.test('test,math,nextAfterFlushToZero')
     { val: hexToF32(kBit.f32.negative.max), dir: true, result: f32(0) },
     { val: hexToF32(kBit.f32.negative.max), dir: false, result: f32Bits(0x80800001) },
     { val: hexToF32(kBit.f32.negative.min), dir: true, result: f32Bits(0xff7ffffe) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.negative.min), dir: false, result: f32Bits(kBit.f32.infinity.negative) },
     { val: hexToF32(0x03800000), dir: true, result: f32Bits(0x03800001) },
     { val: hexToF32(0x03800000), dir: false, result: f32Bits(0x037fffff) },
@@ -169,21 +179,27 @@ g.test('test,math,nextAfterNoFlush')
     // Subnormals
     { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, result: f32Bits(0x00000002) },
     { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, result: f32(0) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, result: f32Bits(kBit.f32.positive.min) },
     { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, result: f32Bits(0x007ffffe) },
     { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, result: f32Bits(0x807ffffe) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, result: f32Bits(kBit.f32.negative.max) },
     { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, result: f32(0) },
     { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, result: f32Bits(0x80000002) },
 
     // Normals
+    // prettier-ignore
     { val: hexToF32(kBit.f32.positive.max), dir: true, result: f32Bits(kBit.f32.infinity.positive) },
     { val: hexToF32(kBit.f32.positive.max), dir: false, result: f32Bits(0x7f7ffffe) },
     { val: hexToF32(kBit.f32.positive.min), dir: true, result: f32Bits(0x00800001) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.positive.min), dir: false, result: f32Bits(kBit.f32.subnormal.positive.max) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.negative.max), dir: true, result: f32Bits(kBit.f32.subnormal.negative.min) },
     { val: hexToF32(kBit.f32.negative.max), dir: false, result: f32Bits(0x80800001) },
     { val: hexToF32(kBit.f32.negative.min), dir: true, result: f32Bits(0xff7ffffe) },
+    // prettier-ignore
     { val: hexToF32(kBit.f32.negative.min), dir: false, result: f32Bits(kBit.f32.infinity.negative) },
     { val: hexToF32(0x03800000), dir: true, result: f32Bits(0x03800001) },
     { val: hexToF32(0x03800000), dir: false, result: f32Bits(0x037fffff) },

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -94,128 +94,112 @@ g.test('test,math,diffULP')
 interface nextAfterCase {
   val: number;
   dir: boolean;
-  flush: boolean;
   result: Scalar;
 }
 
-g.test('test,math,nextAfter')
+g.test('test,math,nextAfterFlushToZero')
   .paramsSubcasesOnly<nextAfterCase>([
     // Edge Cases
-    { val: Number.NaN, dir: true, flush: true, result: f32Bits(0x7fffffff) },
-    { val: Number.NaN, dir: true, flush: false, result: f32Bits(0x7fffffff) },
-    { val: Number.NaN, dir: false, flush: true, result: f32Bits(0x7fffffff) },
-    { val: Number.NaN, dir: false, flush: false, result: f32Bits(0x7fffffff) },
-    // prettier-ignore
-    { val: Number.POSITIVE_INFINITY, dir: true, flush: true, result: f32Bits(kBit.f32.infinity.positive) },
-    // prettier-ignore
-    { val: Number.POSITIVE_INFINITY, dir: true, flush: false, result: f32Bits(kBit.f32.infinity.positive) },
-    // prettier-ignore
-    { val: Number.POSITIVE_INFINITY, dir: false, flush: true, result: f32Bits(kBit.f32.infinity.positive) },
-    // prettier-ignore
-    { val: Number.POSITIVE_INFINITY, dir: false, flush: false, result: f32Bits(kBit.f32.infinity.positive) },
-    // prettier-ignore
-    { val: Number.NEGATIVE_INFINITY, dir: true, flush: true, result: f32Bits(kBit.f32.infinity.negative) },
-    // prettier-ignore
-    { val: Number.NEGATIVE_INFINITY, dir: true, flush: false, result: f32Bits(kBit.f32.infinity.negative) },
-    // prettier-ignore
-    { val: Number.NEGATIVE_INFINITY, dir: false, flush: true, result: f32Bits(kBit.f32.infinity.negative) },
-    // prettier-ignore
-    { val: Number.NEGATIVE_INFINITY, dir: false, flush: false, result: f32Bits(kBit.f32.infinity.negative) },
+    { val: Number.NaN, dir: true, result: f32Bits(0x7fffffff) },
+    { val: Number.NaN, dir: false, result: f32Bits(0x7fffffff) },
+    { val: Number.POSITIVE_INFINITY, dir: true, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: Number.POSITIVE_INFINITY, dir: false, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: Number.NEGATIVE_INFINITY, dir: true, result: f32Bits(kBit.f32.infinity.negative) },
+    { val: Number.NEGATIVE_INFINITY, dir: false, result: f32Bits(kBit.f32.infinity.negative) },
 
     // Zeroes
-    { val: +0, dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
-    { val: +0, dir: true, flush: false, result: f32Bits(kBit.f32.subnormal.positive.min) },
-    { val: +0, dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
-    { val: +0, dir: false, flush: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
-    { val: -0, dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
-    { val: -0, dir: true, flush: false, result: f32Bits(kBit.f32.subnormal.positive.min) },
-    { val: -0, dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
-    { val: -0, dir: false, flush: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
+    { val: +0, dir: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: +0, dir: false, result: f32Bits(kBit.f32.negative.max) },
+    { val: -0, dir: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: -0, dir: false, result: f32Bits(kBit.f32.negative.max) },
 
     // Subnormals
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, flush: false, result: f32Bits(0x00000002) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, flush: true, result:  f32Bits(kBit.f32.negative.max) },
-    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, flush: false, result: f32(0) },
-
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, flush: false, result: f32Bits(kBit.f32.positive.min) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, flush: false, result: f32Bits(0x007ffffe) },
-
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, flush: false, result: f32Bits(0x807ffffe) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, flush: false, result: f32Bits(kBit.f32.negative.max) },
-
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, flush: true, result: f32Bits(kBit.f32.positive.min) },
-    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, flush: false, result: f32(0) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, flush: true, result: f32Bits(kBit.f32.negative.max) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, flush: false, result: f32Bits(0x80000002) },
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, result: f32Bits(kBit.f32.negative.max) },
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, result: f32Bits(kBit.f32.negative.max) },
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, result: f32Bits(kBit.f32.negative.max) },
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, result: f32Bits(kBit.f32.negative.max) },
 
     // Normals
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.positive.max), dir: true, flush: true, result: f32Bits(kBit.f32.infinity.positive) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.positive.max), dir: true, flush: false, result: f32Bits(kBit.f32.infinity.positive) },
-    { val: hexToF32(kBit.f32.positive.max), dir: false, flush: true, result: f32Bits(0x7f7ffffe) },
-    { val: hexToF32(kBit.f32.positive.max), dir: false, flush: false, result: f32Bits(0x7f7ffffe) },
-
-    { val: hexToF32(kBit.f32.positive.min), dir: true, flush: true, result: f32Bits(0x00800001) },
-    { val: hexToF32(kBit.f32.positive.min), dir: true, flush: false, result: f32Bits(0x00800001) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.positive.min), dir: false, flush: true, result: f32(0) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.positive.min), dir: false, flush: false, result: f32Bits(kBit.f32.subnormal.positive.max) },
-
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.negative.max), dir: true, flush: true, result: f32(0) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.negative.max), dir: true, flush: false, result: f32Bits(kBit.f32.subnormal.negative.min) },
-    { val: hexToF32(kBit.f32.negative.max), dir: false, flush: true, result: f32Bits(0x80800001) },
-    { val: hexToF32(kBit.f32.negative.max), dir: false, flush: false, result: f32Bits(0x80800001) },
-
-    { val: hexToF32(kBit.f32.negative.min), dir: true, flush: true, result: f32Bits(0xff7ffffe) },
-    { val: hexToF32(kBit.f32.negative.min), dir: true, flush: false, result: f32Bits(0xff7ffffe) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.negative.min), dir: false, flush: true, result: f32Bits(kBit.f32.infinity.negative) },
-    // prettier-ignore
-    { val: hexToF32(kBit.f32.negative.min), dir: false, flush: false, result: f32Bits(kBit.f32.infinity.negative) },
-
-    { val: hexToF32(0x03800000), dir: true, flush: true, result: f32Bits(0x03800001) },
-    { val: hexToF32(0x03800000), dir: true, flush: false, result: f32Bits(0x03800001) },
-    { val: hexToF32(0x03800000), dir: false, flush: true, result: f32Bits(0x037fffff) },
-    { val: hexToF32(0x03800000), dir: false, flush: false, result: f32Bits(0x037fffff) },
-    { val: hexToF32(0x83800000), dir: true, flush: true, result: f32Bits(0x837fffff) },
-    { val: hexToF32(0x83800000), dir: true, flush: false, result: f32Bits(0x837fffff) },
-    { val: hexToF32(0x83800000), dir: false, flush: true, result: f32Bits(0x83800001) },
-    { val: hexToF32(0x83800000), dir: false, flush: false, result: f32Bits(0x83800001) },
+    { val: hexToF32(kBit.f32.positive.max), dir: true, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: hexToF32(kBit.f32.positive.max), dir: false, result: f32Bits(0x7f7ffffe) },
+    { val: hexToF32(kBit.f32.positive.min), dir: true, result: f32Bits(0x00800001) },
+    { val: hexToF32(kBit.f32.positive.min), dir: false, result: f32(0) },
+    { val: hexToF32(kBit.f32.negative.max), dir: true, result: f32(0) },
+    { val: hexToF32(kBit.f32.negative.max), dir: false, result: f32Bits(0x80800001) },
+    { val: hexToF32(kBit.f32.negative.min), dir: true, result: f32Bits(0xff7ffffe) },
+    { val: hexToF32(kBit.f32.negative.min), dir: false, result: f32Bits(kBit.f32.infinity.negative) },
+    { val: hexToF32(0x03800000), dir: true, result: f32Bits(0x03800001) },
+    { val: hexToF32(0x03800000), dir: false, result: f32Bits(0x037fffff) },
+    { val: hexToF32(0x83800000), dir: true, result: f32Bits(0x837fffff) },
+    { val: hexToF32(0x83800000), dir: false, result: f32Bits(0x83800001) },
   ])
   .fn(t => {
     const val = t.params.val;
     const dir = t.params.dir;
-    const flush = t.params.flush;
     const expect = t.params.result;
     const expect_type = typeof expect;
-    const got = nextAfter(val, dir, flush);
+    const got = nextAfter(val, dir, true);
     const got_type = typeof got;
     t.expect(
       got.value === expect.value || (Number.isNaN(got.value) && Number.isNaN(expect.value)),
-      `nextAfter(${val}, ${dir}, ${flush}) returned ${got} (${got_type}). Expected ${expect} (${expect_type})`
+      `nextAfter(${val}, ${dir}, true) returned ${got} (${got_type}). Expected ${expect} (${expect_type})`
+    );
+  });
+
+g.test('test,math,nextAfterNoFlush')
+  .paramsSubcasesOnly<nextAfterCase>([
+    // Edge Cases
+    { val: Number.NaN, dir: true, result: f32Bits(0x7fffffff) },
+    { val: Number.NaN, dir: false, result: f32Bits(0x7fffffff) },
+    { val: Number.POSITIVE_INFINITY, dir: true, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: Number.POSITIVE_INFINITY, dir: false, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: Number.NEGATIVE_INFINITY, dir: true, result: f32Bits(kBit.f32.infinity.negative) },
+    { val: Number.NEGATIVE_INFINITY, dir: false, result: f32Bits(kBit.f32.infinity.negative) },
+
+    // Zeroes
+    { val: +0, dir: true, result: f32Bits(kBit.f32.subnormal.positive.min) },
+    { val: +0, dir: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
+    { val: -0, dir: true, result: f32Bits(kBit.f32.subnormal.positive.min) },
+    { val: -0, dir: false, result: f32Bits(kBit.f32.subnormal.negative.max) },
+
+    // Subnormals
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: true, result: f32Bits(0x00000002) },
+    { val: hexToF32(kBit.f32.subnormal.positive.min), dir: false, result: f32(0) },
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: true, result: f32Bits(kBit.f32.positive.min) },
+    { val: hexToF32(kBit.f32.subnormal.positive.max), dir: false, result: f32Bits(0x007ffffe) },
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: true, result: f32Bits(0x807ffffe) },
+    { val: hexToF32(kBit.f32.subnormal.negative.min), dir: false, result: f32Bits(kBit.f32.negative.max) },
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: true, result: f32(0) },
+    { val: hexToF32(kBit.f32.subnormal.negative.max), dir: false, result: f32Bits(0x80000002) },
+
+    // Normals
+    { val: hexToF32(kBit.f32.positive.max), dir: true, result: f32Bits(kBit.f32.infinity.positive) },
+    { val: hexToF32(kBit.f32.positive.max), dir: false, result: f32Bits(0x7f7ffffe) },
+    { val: hexToF32(kBit.f32.positive.min), dir: true, result: f32Bits(0x00800001) },
+    { val: hexToF32(kBit.f32.positive.min), dir: false, result: f32Bits(kBit.f32.subnormal.positive.max) },
+    { val: hexToF32(kBit.f32.negative.max), dir: true, result: f32Bits(kBit.f32.subnormal.negative.min) },
+    { val: hexToF32(kBit.f32.negative.max), dir: false, result: f32Bits(0x80800001) },
+    { val: hexToF32(kBit.f32.negative.min), dir: true, result: f32Bits(0xff7ffffe) },
+    { val: hexToF32(kBit.f32.negative.min), dir: false, result: f32Bits(kBit.f32.infinity.negative) },
+    { val: hexToF32(0x03800000), dir: true, result: f32Bits(0x03800001) },
+    { val: hexToF32(0x03800000), dir: false, result: f32Bits(0x037fffff) },
+    { val: hexToF32(0x83800000), dir: true, result: f32Bits(0x837fffff) },
+    { val: hexToF32(0x83800000), dir: false, result: f32Bits(0x83800001) },
+  ])
+  .fn(t => {
+    const val = t.params.val;
+    const dir = t.params.dir;
+    const expect = t.params.result;
+    const expect_type = typeof expect;
+    const got = nextAfter(val, dir, false);
+    const got_type = typeof got;
+    t.expect(
+      got.value === expect.value || (Number.isNaN(got.value) && Number.isNaN(expect.value)),
+      `nextAfter(${val}, ${dir}, false) returned ${got} (${got_type}). Expected ${expect} (${expect_type})`
     );
   });
 

--- a/src/webgpu/shader/execution/builtin/float_built_functions.spec.ts
+++ b/src/webgpu/shader/execution/builtin/float_built_functions.spec.ts
@@ -170,21 +170,6 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
   .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
   .unimplemented();
 
-g.test('float_builtin_functions,fract')
-  .uniqueId('58222ecf6f963798')
-  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#float-builtin-functions')
-  .desc(
-    `
-fract:
-T is f32 or vecN<f32> fract(e: T ) -> T Returns the fractional bits of e (e.g. e - floor(e)). Component-wise when T is a vector. (GLSLstd450Fract)
-
-Please read the following guidelines before contributing:
-https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
-`
-  )
-  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
-  .unimplemented();
-
 g.test('float_builtin_functions,scalar_case_frexp')
   .uniqueId('c5df46977f5b77a0')
   .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#float-builtin-functions')

--- a/src/webgpu/shader/execution/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/builtin/fract.spec.ts
@@ -1,0 +1,63 @@
+export const description = `
+Execution Tests for the 'fract' builtin function
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+import { f32, f32Bits, TypeF32 } from '../../../util/conversion.js';
+
+import { anyOf, Config, correctlyRoundedThreshold, kBit, kValue, run } from './builtin.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('float_builtin_functions,fract')
+  .uniqueId('58222ecf6f963798')
+  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#float-builtin-functions')
+  .desc(
+    `
+fract:
+T is f32 or vecN<f32> fract(e: T ) -> T Returns the fractional bits of e (e.g. e - floor(e)). Component-wise when T is a vector. (GLSLstd450Fract)
+`
+  )
+  .params(u =>
+    u
+     .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+     .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cfg: Config = t.params;
+    cfg.cmpFloats = correctlyRoundedThreshold();
+    run(t, 'fract', [TypeF32], TypeF32, cfg, [
+      // Positive numbers
+      { input: f32Bits(0x3dcccccd), expected: f32Bits(0x3dcccccd) }, // ~0.1 -> ~0.1
+      { input: f32(0.5), expected: f32(0.5) }, // 0.5 -> 0.5
+      { input: f32Bits(0x3f666666), expected: f32Bits(0x3f666666) }, // ~0.9 -> ~0.9
+      { input: f32Bits(0x3f800000), expected: f32(0) }, // 1 -> 0
+      { input: f32Bits(0x40000000), expected: f32(0) }, // 2 -> 0
+      { input: f32Bits(0x3f8e147b), expected: f32Bits(0x3de147b0) }, // ~1.11 -> ~0.11
+      { input: f32Bits(0x41200069), expected: f32Bits(0x38d20000) }, // ~10.0001 -> ~0.0001
+
+      // Negative numbers
+      { input: f32Bits(0xbdcccccd), expected: f32Bits(0x3f666666) }, // ~-0.1 -> ~0.9
+      { input: f32(-0.5), expected: f32(0.5) }, // -0.5 -> 0.5
+      { input: f32Bits(0xbf666666), expected: f32Bits(0x3dccccd0) }, // ~-0.9 -> ~0.1
+      { input: f32Bits(0xbf800000), expected: f32(0) }, // -1 -> 0
+      { input: f32Bits(0xc0000000), expected: f32(0) }, // -2 -> 0
+      { input: f32Bits(0xbf8e147b), expected: f32Bits(0x3f63d70a) }, // ~-1.11 -> ~0.89
+      { input: f32Bits(0xc1200419), expected: f32Bits(0x3f7fbe70) }, // ~-10.0001 -> ~0.999
+
+      // Min and Max f32
+      { input: f32Bits(kBit.f32.positive.min), expected: f32Bits(kBit.f32.positive.min) },
+      { input: f32Bits(kBit.f32.positive.max), expected: f32(0) },
+      { input: f32Bits(kBit.f32.negative.max), expected: f32Bits(0x3f7fffff) },
+      { input: f32Bits(kBit.f32.negative.min), expected: f32(0) },
+
+      // Subnormal f32
+      // prettier-ignore
+      { input: f32Bits(kBit.f32.subnormal.positive.max), expected: f32Bits(kBit.f32.subnormal.positive.max) },
+      // prettier-ignore
+      { input: f32Bits(kBit.f32.subnormal.positive.min), expected: f32Bits(kBit.f32.subnormal.positive.min) },
+      { input: f32Bits(kBit.f32.subnormal.negative.max), expected: f32Bits(0x3f7fffff) },
+      { input: f32Bits(kBit.f32.subnormal.negative.min), expected: f32Bits(0x3f7fffff) },
+    ]);
+  });

--- a/src/webgpu/shader/execution/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/builtin/fract.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { f32, f32Bits, TypeF32 } from '../../../util/conversion.js';
 
-import { Config, correctlyRoundedThreshold, kBit, run } from './builtin.js';
+import { anyOf, Config, correctlyRoundedThreshold, kBit, run } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -49,15 +49,17 @@ T is f32 or vecN<f32> fract(e: T ) -> T Returns the fractional bits of e (e.g. e
       // Min and Max f32
       { input: f32Bits(kBit.f32.positive.min), expected: f32Bits(kBit.f32.positive.min) },
       { input: f32Bits(kBit.f32.positive.max), expected: f32(0) },
-      { input: f32Bits(kBit.f32.negative.max), expected: f32Bits(0x3f7fffff) },
+      { input: f32Bits(kBit.f32.negative.max), expected: anyOf(f32Bits(0x3f7fffff), f32(1)) },
       { input: f32Bits(kBit.f32.negative.min), expected: f32(0) },
 
       // Subnormal f32
       // prettier-ignore
-      { input: f32Bits(kBit.f32.subnormal.positive.max), expected: f32Bits(kBit.f32.subnormal.positive.max) },
+      { input: f32Bits(kBit.f32.subnormal.positive.max), expected: anyOf(f32(0), f32Bits(kBit.f32.subnormal.positive.max)) },
       // prettier-ignore
-      { input: f32Bits(kBit.f32.subnormal.positive.min), expected: f32Bits(kBit.f32.subnormal.positive.min) },
-      { input: f32Bits(kBit.f32.subnormal.negative.max), expected: f32Bits(0x3f7fffff) },
-      { input: f32Bits(kBit.f32.subnormal.negative.min), expected: f32Bits(0x3f7fffff) },
+      { input: f32Bits(kBit.f32.subnormal.positive.min), expected: anyOf(f32(0), f32Bits(kBit.f32.subnormal.positive.min)) },
+      // prettier-ignore
+      { input: f32Bits(kBit.f32.subnormal.negative.max), expected: anyOf(f32(0), f32Bits(0x3f7fffff), f32(1)) },
+      // prettier-ignore
+      { input: f32Bits(kBit.f32.subnormal.negative.min), expected: anyOf(f32(0), f32Bits(0x3f7fffff), f32(1)) },
     ]);
   });

--- a/src/webgpu/shader/execution/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/builtin/fract.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { f32, f32Bits, TypeF32 } from '../../../util/conversion.js';
 
-import { anyOf, Config, correctlyRoundedThreshold, kBit, kValue, run } from './builtin.js';
+import { Config, correctlyRoundedThreshold, kBit, run } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -21,8 +21,8 @@ T is f32 or vecN<f32> fract(e: T ) -> T Returns the fractional bits of e (e.g. e
   )
   .params(u =>
     u
-     .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
-     .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;

--- a/src/webgpu/shader/execution/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/builtin/fract.spec.ts
@@ -28,6 +28,10 @@ T is f32 or vecN<f32> fract(e: T ) -> T Returns the fractional bits of e (e.g. e
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
     run(t, 'fract', [TypeF32], TypeF32, cfg, [
+      // Zeroes
+      { input: f32Bits(kBit.f32.positive.zero), expected: f32(0) },
+      { input: f32Bits(kBit.f32.negative.zero), expected: f32(0) },
+
       // Positive numbers
       { input: f32Bits(0x3dcccccd), expected: f32Bits(0x3dcccccd) }, // ~0.1 -> ~0.1
       { input: f32(0.5), expected: f32(0.5) }, // 0.5 -> 0.5
@@ -49,6 +53,10 @@ T is f32 or vecN<f32> fract(e: T ) -> T Returns the fractional bits of e (e.g. e
       // Min and Max f32
       { input: f32Bits(kBit.f32.positive.min), expected: f32Bits(kBit.f32.positive.min) },
       { input: f32Bits(kBit.f32.positive.max), expected: f32(0) },
+      // For negative numbers on the extremes, here and below, different backends disagree on if this should be 1
+      // exactly vs very close to 1. I think what is occurring is that if the calculation is internally done in f32,
+      // i.e. rounding/flushing each step, you end up with one value, but if all of the math is done in a higher
+      // precision, and then converted at the end, you end up with a different value.
       { input: f32Bits(kBit.f32.negative.max), expected: anyOf(f32Bits(0x3f7fffff), f32(1)) },
       { input: f32Bits(kBit.f32.negative.min), expected: f32(0) },
 
@@ -57,6 +65,8 @@ T is f32 or vecN<f32> fract(e: T ) -> T Returns the fractional bits of e (e.g. e
       { input: f32Bits(kBit.f32.subnormal.positive.max), expected: anyOf(f32(0), f32Bits(kBit.f32.subnormal.positive.max)) },
       // prettier-ignore
       { input: f32Bits(kBit.f32.subnormal.positive.min), expected: anyOf(f32(0), f32Bits(kBit.f32.subnormal.positive.min)) },
+      // Similar to above when these values are not immediately flushed to zero, how the back end internally calculates
+      // the value will dictate if the end value is 1 or very close to 1.
       // prettier-ignore
       { input: f32Bits(kBit.f32.subnormal.negative.max), expected: anyOf(f32(0), f32Bits(0x3f7fffff), f32(1)) },
       // prettier-ignore

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -67,13 +67,45 @@ export function diffULP(a: number, b: number): number {
 }
 
 /**
+ * @returns 0 if |val| is a subnormal f32 number, otherwise returns |val|
+ */
+function flushSubnormalNumber(val: number): number {
+  const u32_val = new Uint32Array(new Float32Array([val]).buffer)[0];
+  return (u32_val & 0x7f800000) === 0 ? 0 : val;
+}
+
+/**
+ * @returns 0 if |val| is a bit field for a subnormal f32 number, otherwise
+ * returns |val|
+ * |val| is assumed to be a u32 value representing a f32
+ */
+function flushSubnormalBits(val: number): number {
+  return (val & 0x7f800000) === 0 ? 0 : val;
+}
+
+/**
+ * @returns 0 if |val| is a subnormal f32 number, otherwise returns |val|
+ */
+function flushSubnormalScalar(val: Scalar): Scalar {
+  if (val.type.kind !== 'f32') {
+    return val;
+  }
+
+  const u32_val = new Uint32Array(new Float32Array([val.value.valueOf() as number]).buffer)[0];
+  return (u32_val & 0x7f800000) === 0 ? f32(0) : val;
+}
+
+/**
  * @returns the next single precision floating point value after |val|,
  * towards +inf if |dir| is true, otherwise towards -inf.
- * For -/+0 the nextAfter will be the closest subnormal in the correct
- * direction, since -0 === +0.
+ * If |flush_| is true, all subnormal values will be flushed to 0,
+ * before processing.
+ * If |flush| is false, the next subnormal will be calculated when appropriate,
+ * and for -/+0 the nextAfter will be the closest subnormal in the correct
+ * direction.
  * |val| must be expressible as a f32.
  */
-export function nextAfter(val: number, dir: boolean = true): Scalar {
+export function nextAfter(val: number, dir: boolean = true, flush: boolean): Scalar {
   if (Number.isNaN(val)) {
     return f32Bits(kBit.f32.nan.positive.s);
   }
@@ -86,12 +118,14 @@ export function nextAfter(val: number, dir: boolean = true): Scalar {
     return f32Bits(kBit.f32.infinity.negative);
   }
 
+  val = flush ? flushSubnormalNumber(val) : val;
+
   // -/+0 === 0 returns true
   if (val === 0) {
     if (dir) {
-      return f32Bits(kBit.f32.subnormal.positive.min);
+      return flush ? f32Bits(kBit.f32.positive.min) : f32Bits(kBit.f32.subnormal.positive.min);
     } else {
-      return f32Bits(kBit.f32.subnormal.negative.max);
+      return flush ? f32Bits(kBit.f32.negative.max) : f32Bits(kBit.f32.subnormal.negative.max);
     }
   }
 
@@ -107,6 +141,7 @@ export function nextAfter(val: number, dir: boolean = true): Scalar {
   } else {
     result -= 1;
   }
+  result = flush ? flushSubnormalBits(result) : result;
 
   // Checking for overflow
   if ((result & 0x7f800000) === 0x7f800000) {
@@ -125,10 +160,20 @@ export function nextAfter(val: number, dir: boolean = true): Scalar {
  *
  * Correctly rounded means that if the target value is precisely expressible
  * as a float32, then |test_value| === |target|.
- * Otherwise |test_value| needs to be either the closest expressible number greater
- * or less than |target|.
+ * Otherwise |test_value| needs to be either the closest expressible number
+ * greater or less than |target|.
+ *
+ * Internally tests with both subnormals being flushed to 0 and not being
+ * flushed.
  */
 export function correctlyRounded(test_value: Scalar, target: number): boolean {
+  return (
+    correctlyRoundedImpl(test_value, target, true) ||
+    correctlyRoundedImpl(test_value, target, false)
+  );
+}
+
+function correctlyRoundedImpl(test_value: Scalar, target: number, flush: boolean = true): boolean {
   assert(test_value.type.kind === 'f32', `${test_value} is expected to be a 'f32'`);
 
   if (Number.isNaN(target)) {
@@ -143,6 +188,9 @@ export function correctlyRounded(test_value: Scalar, target: number): boolean {
     return test_value.value === f32Bits(kBit.f32.infinity.negative).value;
   }
 
+  test_value = flush ? flushSubnormalScalar(test_value) : test_value;
+  target = flush ? flushSubnormalNumber(target) : target;
+
   const target32 = new Float32Array([target])[0];
   const converted: number = target32;
   if (target === converted) {
@@ -156,10 +204,10 @@ export function correctlyRounded(test_value: Scalar, target: number): boolean {
   if (converted > target) {
     // target32 is rounded towards +inf, so is after_target
     after_target = f32(target32);
-    before_target = nextAfter(target32, false);
+    before_target = nextAfter(target32, false, flush);
   } else {
     // target32 is rounded towards -inf, so is before_target
-    after_target = nextAfter(target32, true);
+    after_target = nextAfter(target32, true, flush);
     before_target = f32(target32);
   }
 

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -98,7 +98,7 @@ function flushSubnormalScalar(val: Scalar): Scalar {
 /**
  * @returns the next single precision floating point value after |val|,
  * towards +inf if |dir| is true, otherwise towards -inf.
- * If |flush_| is true, all subnormal values will be flushed to 0,
+ * If |flush| is true, all subnormal values will be flushed to 0,
  * before processing.
  * If |flush| is false, the next subnormal will be calculated when appropriate,
  * and for -/+0 the nextAfter will be the closest subnormal in the correct

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -163,17 +163,32 @@ export function nextAfter(val: number, dir: boolean = true, flush: boolean): Sca
  * Otherwise |test_value| needs to be either the closest expressible number
  * greater or less than |target|.
  *
- * Internally tests with both subnormals being flushed to 0 and not being
- * flushed.
+ * By default internally tests with both subnormals being flushed to 0 and not
+ * being flushed, but |accept_to_zero| and |accept_no_flush| can be used to
+ * control that behaviour. At least one accept flag must be true.
  */
-export function correctlyRounded(test_value: Scalar, target: number): boolean {
-  return (
-    correctlyRoundedImpl(test_value, target, true) ||
-    correctlyRoundedImpl(test_value, target, false)
+export function correctlyRounded(
+  test_value: Scalar,
+  target: number,
+  accept_to_zero: boolean = true,
+  accept_no_flush: boolean = true
+): boolean {
+  assert(
+    accept_to_zero || accept_no_flush,
+    `At least one of |accept_to_zero| & |accept_no_flush| must be true`
   );
+
+  let result: boolean = false;
+  if (accept_to_zero) {
+    result = result || correctlyRoundedImpl(test_value, target, true);
+  }
+  if (accept_no_flush) {
+    result = result || correctlyRoundedImpl(test_value, target, false);
+  }
+  return result;
 }
 
-function correctlyRoundedImpl(test_value: Scalar, target: number, flush: boolean = true): boolean {
+function correctlyRoundedImpl(test_value: Scalar, target: number, flush: boolean): boolean {
   assert(test_value.type.kind === 'f32', `${test_value} is expected to be a 'f32'`);
 
   if (Number.isNaN(target)) {


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.
