### PR TITLE
Update createTexture tests with 1D + mipLevelCount > 0 being invalid

### DIFF
--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -15,10 +15,19 @@ export function maxMipLevelCount({
 }): number {
   const sizeDict = reifyExtent3D(size);
 
-  let maxMippedDimension = sizeDict.width;
-  if (dimension !== '1d') maxMippedDimension = Math.max(maxMippedDimension, sizeDict.height);
-  if (dimension === '3d')
-    maxMippedDimension = Math.max(maxMippedDimension, sizeDict.depthOrArrayLayers);
+  let maxMippedDimension = 0;
+  switch (dimension) {
+    case '1d':
+      maxMippedDimension = 1; // No mipmaps allowed.
+      break;
+    case '2d':
+      maxMippedDimension = Math.max(sizeDict.width, sizeDict.height);
+      break;
+    case '3d':
+      maxMippedDimension = Math.max(sizeDict.width, sizeDict.height, sizeDict.depthOrArrayLayers);
+      break;
+  }
+
   return Math.floor(Math.log2(maxMippedDimension)) + 1;
 }
 


### PR DESCRIPTION
This also makes the texture1d size tests avoid depth-stencil formats
because they are not valid for 1D textures.

Also improves the coverage of mipLevelCount validation a bit.

Linked to #872

This is the test coverage for Dawn CL: https://dawn-review.googlesource.com/c/dawn/+/64542
That Dawn CL plus a WIP stencil8 CL passes all the createTexture tests in the CTS.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.
