### PR TITLE
Adds some device.destroy and lost tests.

### DIFF
--- a/src/webgpu/api/operation/device/lost.spec.ts
+++ b/src/webgpu/api/operation/device/lost.spec.ts
@@ -2,28 +2,24 @@ export const description = `
 Tests for GPUDevice.lost.
 `;
 
+import { Fixture } from '../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { attemptGarbageCollection } from '../../../../common/util/collect_garbage.js';
 import { getGPU } from '../../../../common/util/navigator_gpu.js';
 import { assert, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
-import { GPUTest } from '../../../gpu_test.js';
 
-class DeviceLostTests extends GPUTest {
+class DeviceLostTests extends Fixture {
   // Default timeout for waiting for device lost is 2 seconds.
   readonly kDeviceLostTimeoutMS = 2000;
 
-  getDeviceLostWithTimeout(device: GPUDevice = this.device): Promise<GPUDeviceLostInfo> {
-    return raceWithRejectOnTimeout(
-      this.device.lost,
-      this.kDeviceLostTimeoutMS,
-      'device was not lost'
-    );
+  getDeviceLostWithTimeout(lost: Promise<GPUDeviceLostInfo>): Promise<GPUDeviceLostInfo> {
+    return raceWithRejectOnTimeout(lost, this.kDeviceLostTimeoutMS, 'device was not lost');
   }
 
-  expectDeviceDestroyed(): void {
+  expectDeviceDestroyed(device: GPUDevice): void {
     this.eventualAsyncExpectation(async niceStack => {
       try {
-        const lost = await this.getDeviceLostWithTimeout();
+        const lost = await this.getDeviceLostWithTimeout(device.lost);
         this.expect(lost.reason === 'destroyed', 'device was lost from destroy');
       } catch (ex) {
         niceStack.message = 'device was not lost';
@@ -40,44 +36,49 @@ g.test('not_lost_on_gc')
     `'lost' is never resolved by GPUDevice being garbage collected (with attemptGarbageCollection).`
   )
   .fn(async t => {
-    // Create a new device for this because it is hard to lose all refs to the test fixture device.
-    const adapter = await getGPU().requestAdapter();
-    assert(adapter !== null);
-    let device: GPUDevice | undefined = await adapter.requestDevice();
-    assert(device !== null);
+    // Wraps a lost promise object creation in a function scope so that the device has the best
+    // chance of being gone and ready for GC before trying to resolve the lost promise.
+    const { lost } = await (async () => {
+      const adapter = await getGPU().requestAdapter();
+      assert(adapter !== null);
+      const lost = (await adapter.requestDevice()).lost;
+      return { lost };
+    })();
+    t.shouldReject('Error', t.getDeviceLostWithTimeout(lost), 'device was unexpectedly lost');
 
-    t.shouldReject('Error', t.getDeviceLostWithTimeout(device), 'device was unexpectedly lost');
-
-    device = undefined;
     await attemptGarbageCollection();
   });
 
 g.test('lost_on_destroy')
   .desc(`'lost' is resolved, with reason='destroyed', on GPUDevice.destroy().`)
   .fn(async t => {
-    t.expectDeviceDestroyed();
-    t.device.destroy();
+    const adapter = await getGPU().requestAdapter();
+    assert(adapter !== null);
+    const device: GPUDevice = await adapter.requestDevice();
+    t.expectDeviceDestroyed(device);
+    device.destroy();
   });
 
 g.test('same_object')
   .desc(`'lost' provides the same Promise and GPUDeviceLostInfo objects each time it's accessed.`)
   .fn(async t => {
+    const adapter = await getGPU().requestAdapter();
+    assert(adapter !== null);
+    const device: GPUDevice = await adapter.requestDevice();
+
     // The promises should be the same promise object.
-    const lostPromise1 = t.device.lost;
-    const lostPromise2 = t.device.lost;
+    const lostPromise1 = device.lost;
+    const lostPromise2 = device.lost;
     t.expect(lostPromise1 === lostPromise2);
 
     // The results should also be the same result object.
-    t.device.destroy();
-    const lost1 = await raceWithRejectOnTimeout(
-      lostPromise1,
-      t.kDeviceLostTimeoutMS,
-      'device was not lost'
-    );
-    const lost2 = await raceWithRejectOnTimeout(
-      lostPromise2,
-      t.kDeviceLostTimeoutMS,
-      'device was not lost'
-    );
-    t.expect(lost1 === lost2);
+    device.destroy();
+    const lostPromise3 = device.lost;
+    t.expect(lostPromise1 === lostPromise3);
+
+    const lost1 = await t.getDeviceLostWithTimeout(lostPromise1);
+    const lost2 = await t.getDeviceLostWithTimeout(lostPromise2);
+    const lost3 = await t.getDeviceLostWithTimeout(lostPromise3);
+    const lost4 = await t.getDeviceLostWithTimeout(device.lost);
+    t.expect(lost1 === lost2 && lost2 === lost3 && lost3 === lost4);
   });

--- a/src/webgpu/api/operation/device/lost.spec.ts
+++ b/src/webgpu/api/operation/device/lost.spec.ts
@@ -2,24 +2,82 @@ export const description = `
 Tests for GPUDevice.lost.
 `;
 
-import { Fixture } from '../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { attemptGarbageCollection } from '../../../../common/util/collect_garbage.js';
+import { getGPU } from '../../../../common/util/navigator_gpu.js';
+import { assert, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
+import { GPUTest } from '../../../gpu_test.js';
 
-export const g = makeTestGroup(Fixture);
+class DeviceLostTests extends GPUTest {
+  // Default timeout for waiting for device lost is 2 seconds.
+  readonly kDeviceLostTimeoutMS = 2000;
+
+  getDeviceLostWithTimeout(device: GPUDevice = this.device): Promise<GPUDeviceLostInfo> {
+    return raceWithRejectOnTimeout(
+      this.device.lost,
+      this.kDeviceLostTimeoutMS,
+      'device was not lost'
+    );
+  }
+
+  expectDeviceDestroyed(): void {
+    this.eventualAsyncExpectation(async niceStack => {
+      try {
+        const lost = await this.getDeviceLostWithTimeout();
+        this.expect(lost.reason === 'destroyed', 'device was lost from destroy');
+      } catch (ex) {
+        niceStack.message = 'device was not lost';
+        this.rec.expectationFailed(niceStack);
+      }
+    });
+  }
+}
+
+export const g = makeTestGroup(DeviceLostTests);
 
 g.test('not_lost_on_gc')
   .desc(
     `'lost' is never resolved by GPUDevice being garbage collected (with attemptGarbageCollection).`
   )
-  .unimplemented();
+  .fn(async t => {
+    // Create a new device for this because it is hard to lose all refs to the test fixture device.
+    const adapter = await getGPU().requestAdapter();
+    assert(adapter !== null);
+    let device: GPUDevice | undefined = await adapter.requestDevice();
+    assert(device !== null);
+
+    t.shouldReject('Error', t.getDeviceLostWithTimeout(device), 'device was unexpectedly lost');
+
+    device = undefined;
+    await attemptGarbageCollection();
+  });
 
 g.test('lost_on_destroy')
   .desc(`'lost' is resolved, with reason='destroyed', on GPUDevice.destroy().`)
-  .unimplemented();
+  .fn(async t => {
+    t.expectDeviceDestroyed();
+    t.device.destroy();
+  });
 
 g.test('same_object')
-  .desc(
-    `'lost' provides a [new? same?] Promise object with a [new? same?] GPUDeviceLostInfo object
-each time it's accessed. (Not sure what the semantic is supposed to be, need to investigate.)`
-  )
-  .unimplemented();
+  .desc(`'lost' provides the same Promise and GPUDeviceLostInfo objects each time it's accessed.`)
+  .fn(async t => {
+    // The promises should be the same promise object.
+    const lostPromise1 = t.device.lost;
+    const lostPromise2 = t.device.lost;
+    t.expect(lostPromise1 === lostPromise2);
+
+    // The results should also be the same result object.
+    t.device.destroy();
+    const lost1 = await raceWithRejectOnTimeout(
+      lostPromise1,
+      t.kDeviceLostTimeoutMS,
+      'device was not lost'
+    );
+    const lost2 = await raceWithRejectOnTimeout(
+      lostPromise2,
+      t.kDeviceLostTimeoutMS,
+      'device was not lost'
+    );
+    t.expect(lost1 === lost2);
+  });

--- a/src/webgpu/api/operation/device/lost.spec.ts
+++ b/src/webgpu/api/operation/device/lost.spec.ts
@@ -71,14 +71,18 @@ g.test('same_object')
     const lostPromise2 = device.lost;
     t.expect(lostPromise1 === lostPromise2);
 
-    // The results should also be the same result object.
+    // Promise object should still be the same after destroy.
     device.destroy();
     const lostPromise3 = device.lost;
     t.expect(lostPromise1 === lostPromise3);
 
+    // The results should also be the same result object.
     const lost1 = await t.getDeviceLostWithTimeout(lostPromise1);
     const lost2 = await t.getDeviceLostWithTimeout(lostPromise2);
     const lost3 = await t.getDeviceLostWithTimeout(lostPromise3);
-    const lost4 = await t.getDeviceLostWithTimeout(device.lost);
+    // Promise object should still be the same after we've been notified about device loss.
+    const lostPromise4 = device.lost;
+    t.expect(lostPromise1 === lostPromise4);
+    const lost4 = await t.getDeviceLostWithTimeout(lostPromise4);
     t.expect(lost1 === lost2 && lost2 === lost3 && lost3 === lost4);
   });


### PR DESCRIPTION
- Changes the tests to save the entire lost info interface instead of just the message so that we can identify the reason for device lost and suppress failures when tests expect devices to be destroyed.

- Tested in local chromium build with changes:
   - https://dawn-review.googlesource.com/c/dawn/+/77200
   - https://chromium-review.googlesource.com/c/chromium/src/+/3388269

Issue: https://github.com/gpuweb/cts/issues/882
