### PR TITLE
Add rgba8unorm support for swapchain format

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_clear.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_clear.html.ts
@@ -1,27 +1,32 @@
 import { runRefTest } from './gpu_ref_test.js';
 
 runRefTest(async t => {
-  const canvas = document.getElementById('gpucanvas') as HTMLCanvasElement;
+  function draw(canvasId: string, format: GPUTextureFormat) {
+    const canvas = document.getElementById(canvasId) as HTMLCanvasElement;
 
-  const ctx = (canvas.getContext('webgpu') as unknown) as GPUCanvasContext;
-  ctx.configure({
-    device: t.device,
-    format: 'bgra8unorm',
-  });
+    const ctx = (canvas.getContext('webgpu') as unknown) as GPUCanvasContext;
+    ctx.configure({
+      device: t.device,
+      format: format,
+    });
 
-  const colorAttachment = ctx.getCurrentTexture();
-  const colorAttachmentView = colorAttachment.createView();
+    const colorAttachment = ctx.getCurrentTexture();
+    const colorAttachmentView = colorAttachment.createView();
 
-  const encoder = t.device.createCommandEncoder();
-  const pass = encoder.beginRenderPass({
-    colorAttachments: [
-      {
-        view: colorAttachmentView,
-        loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
-        storeOp: 'store',
-      },
-    ],
-  });
-  pass.endPass();
-  t.device.queue.submit([encoder.finish()]);
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: colorAttachmentView,
+          loadValue: {r: 0.5, g: 1.0, b: 0.0, a: 1.0},
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.endPass();
+    t.device.queue.submit([encoder.finish()]);
+  }
+
+  draw('cvs0', 'bgra8unorm');
+  draw('cvs1', 'rgba8unorm');
 });

--- a/src/webgpu/web_platform/reftests/canvas_clear.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_clear.https.html
@@ -4,7 +4,8 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU cleared canvas should be presented correctly" />
   <link rel="match" href="./ref/canvas_clear-ref.html" />
-  <canvas id="gpucanvas" width="10" height="10"></canvas>
+  <canvas id="cvs0" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="cvs1" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module" src="canvas_clear.html.js"></script>
 </html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_clear-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_clear-ref.html
@@ -2,11 +2,18 @@
   <title>WebGPU canvas_clear (ref)</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
-  <canvas id="myCanvas" width="10" height="10"></canvas>
+  <canvas id="cvs0" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="cvs1" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script>
-    var c = document.getElementById('myCanvas');
-    var ctx = c.getContext('2d');
-    ctx.fillStyle = '#00FF00';
-    ctx.fillRect(0, 0, c.width, c.height);
-  </script>
+    function draw(canvas) {
+      var c = document.getElementById(canvas);
+      var ctx = c.getContext('2d');
+      ctx.fillStyle = '#80FF00';
+      ctx.fillRect(0, 0, c.width, c.height);
+    }
+
+    draw('cvs0');
+    draw('cvs1');
+
+ </script>
 </html>


### PR DESCRIPTION
This extends the readbackFromWebGPUCanvas and canvas_clear tests to cover rgba8unorm.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
