### PR TITLE
wgsl: Add @interpolate(flat) to integral IO

### DIFF
--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -90,7 +90,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
 
       struct VFTest {
         @builtin(position) pos: vec4<f32>;
-        @location(0) vertexIndex: u32;
+        @location(0) @interpolate(flat) vertexIndex: u32;
       };
 
       @stage(vertex)
@@ -127,7 +127,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
 
       struct VFCheck {
         @builtin(position) pos: vec4<f32>;
-        @location(0) vertexIndex: u32;
+        @location(0) @interpolate(flat) vertexIndex: u32;
       };
 
       @stage(vertex)
@@ -378,7 +378,7 @@ to be empty.`
 
       struct VF {
         @builtin(position) pos: vec4<f32>;
-        @location(0) vertexIndex: u32;
+        @location(0) @interpolate(flat) vertexIndex: u32;
       };
 
       @stage(vertex)

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -497,14 +497,14 @@ g.test('vertex_attributes,basic')
     // The remaining 3 vertex attributes
     if (t.params.vertex_attribute_count === 16) {
       accumulateVariableDeclarationsInVertexShader = `
-        @location(13) outAttrib13 : vec4<${wgslFormat}>;
+        @location(13) @interpolate(flat) outAttrib13 : vec4<${wgslFormat}>;
       `;
       accumulateVariableAssignmentsInVertexShader = `
       output.outAttrib13 =
           vec4<${wgslFormat}>(input.attrib12, input.attrib13, input.attrib14, input.attrib15);
       `;
       accumulateVariableDeclarationsInFragmentShader = `
-      @location(13) attrib13 : vec4<${wgslFormat}>;
+      @location(13) @interpolate(flat) attrib13 : vec4<${wgslFormat}>;
       `;
       accumulateVariableAssignmentsInFragmentShader = `
       outBuffer.primitives[input.primitiveId].attrib12 = input.attrib13.x;
@@ -527,9 +527,9 @@ ${vertexInputShaderLocations.map(i => `  @location(${i}) attrib${i} : ${wgslForm
 struct Outputs {
   @builtin(position) Position : vec4<f32>;
 ${interStageScalarShaderLocations
-  .map(i => `  @location(${i}) outAttrib${i} : ${wgslFormat};`)
+  .map(i => `  @location(${i}) @interpolate(flat) outAttrib${i} : ${wgslFormat};`)
   .join('\n')}
-  @location(${interStageScalarShaderLocations.length}) primitiveId : u32;
+  @location(${interStageScalarShaderLocations.length}) @interpolate(flat) primitiveId : u32;
 ${accumulateVariableDeclarationsInVertexShader}
 };
 
@@ -552,9 +552,9 @@ ${accumulateVariableAssignmentsInVertexShader}
           code: `
 struct Inputs {
 ${interStageScalarShaderLocations
-  .map(i => `  @location(${i}) attrib${i} : ${wgslFormat};`)
+  .map(i => `  @location(${i}) @interpolate(flat) attrib${i} : ${wgslFormat};`)
   .join('\n')}
-  @location(${interStageScalarShaderLocations.length}) primitiveId : u32;
+  @location(${interStageScalarShaderLocations.length}) @interpolate(flat) primitiveId : u32;
 ${accumulateVariableDeclarationsInFragmentShader}
 };
 

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -180,14 +180,22 @@ g.test('duplicates')
       .beginSubcases()
   )
   .fn(t => {
-    const p1 = t.params.first === 'p1' ? '@builtin(sample_mask)' : '@location(1)';
-    const p2 = t.params.second === 'p2' ? '@builtin(sample_mask)' : '@location(2)';
-    const s1a = t.params.first === 's1a' ? '@builtin(sample_mask)' : '@location(3)';
-    const s1b = t.params.second === 's1b' ? '@builtin(sample_mask)' : '@location(4)';
-    const s2a = t.params.first === 's2a' ? '@builtin(sample_mask)' : '@location(5)';
-    const s2b = t.params.second === 's2b' ? '@builtin(sample_mask)' : '@location(6)';
-    const ra = t.params.first === 'ra' ? '@builtin(sample_mask)' : '@location(1)';
-    const rb = t.params.second === 'rb' ? '@builtin(sample_mask)' : '@location(2)';
+    const p1 =
+      t.params.first === 'p1' ? '@builtin(sample_mask)' : '@location(1) @interpolate(flat)';
+    const p2 =
+      t.params.second === 'p2' ? '@builtin(sample_mask)' : '@location(2) @interpolate(flat)';
+    const s1a =
+      t.params.first === 's1a' ? '@builtin(sample_mask)' : '@location(3) @interpolate(flat)';
+    const s1b =
+      t.params.second === 's1b' ? '@builtin(sample_mask)' : '@location(4) @interpolate(flat)';
+    const s2a =
+      t.params.first === 's2a' ? '@builtin(sample_mask)' : '@location(5) @interpolate(flat)';
+    const s2b =
+      t.params.second === 's2b' ? '@builtin(sample_mask)' : '@location(6) @interpolate(flat)';
+    const ra =
+      t.params.first === 'ra' ? '@builtin(sample_mask)' : '@location(1) @interpolate(flat)';
+    const rb =
+      t.params.second === 'rb' ? '@builtin(sample_mask)' : '@location(2) @interpolate(flat)';
     const code = `
     struct S1 {
       ${s1a} a : u32;

--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -88,7 +88,7 @@ g.test('type')
     }
 
     code += generateShader({
-      attribute: '@location(0)',
+      attribute: '@location(0) @interpolate(flat)',
       type: t.params.type,
       stage: 'fragment',
       io: 'in',

--- a/src/webgpu/shader/validation/variable_and_const.spec.ts
+++ b/src/webgpu/shader/validation/variable_and_const.spec.ts
@@ -105,7 +105,7 @@ g.test('io_shareable_type')
     if (`${storageClass}` === 'in') {
       code = `
         struct MyInputs {
-          @location(0) a : ${type};
+          @location(0) @interpolate(flat) a : ${type};
         };
 
         @stage(fragment)


### PR DESCRIPTION
This is required by the WGSL spec.

Chromium currently only produces a warning when this is missing, but it will soon become an error. Test coverage for validating that an error is produced will be added in a later PR.


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
