### PR TITLE
Build out/{stress,manual}/listing.js so they can be run from online

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
       },
       'generate-listings': {
         cmd: 'node',
-        args: ['tools/gen_listings', 'out/', 'src/webgpu', 'src/unittests', 'src/demo'],
+        args: ['tools/gen_listings', 'out/', 'src/webgpu', 'src/stress', 'src/manual', 'src/unittests', 'src/demo'],
       },
       'generate-wpt-cts-html': {
         cmd: 'node',


### PR DESCRIPTION
e.g. https://gpuweb.github.io/cts/standalone/?runnow=0&worker=0&debug=0&q=stress:*
or local non-dev builds.