### PR TITLE
wgsl: Test that integral user-defined IO requires flat interpolation

### DIFF
--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -86,4 +86,26 @@ g.test('require_location')
 
 g.test('integral_types')
   .desc(`Test that the implementation requires @interpolate(flat) for integral user-defined IO.`)
-  .unimplemented();
+  .params(u =>
+    u
+      .combine('stage', ['vertex', 'fragment'] as const)
+      .combine('type', ['i32', 'u32', 'vec2<i32>', 'vec4<u32>'] as const)
+      .combine('use_struct', [true, false] as const)
+      .combine('attribute', kValidInterpolationAttributes)
+      .beginSubcases()
+  )
+  .fn(t => {
+    if (t.params.stage === 'vertex' && t.params.use_struct === false) {
+      t.skip('vertex output must include a position builtin, so must use a struct');
+    }
+
+    const code = generateShader({
+      attribute: '@location(0)' + t.params.attribute,
+      type: t.params.type,
+      stage: t.params.stage,
+      io: t.params.stage === 'vertex' ? 'out' : 'in',
+      use_struct: t.params.use_struct,
+    });
+
+    t.expectCompileResult(t.params.attribute === '@interpolate(flat)', code);
+  });


### PR DESCRIPTION
Tested with ToT Dawn+Tint.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
