### PR TITLE
Implementing `min` tests

### DIFF
--- a/src/webgpu/shader/execution/builtin/float_built_functions.spec.ts
+++ b/src/webgpu/shader/execution/builtin/float_built_functions.spec.ts
@@ -292,21 +292,6 @@ https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
   .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
   .unimplemented();
 
-g.test('float_builtin_functions,min')
-  .uniqueId('53efc46faad0f380')
-  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#float-builtin-functions')
-  .desc(
-    `
-min:
-T is f32 or vecN<f32> min(e1: T ,e2: T ) -> T Returns e2 if e2 is less than e1, and e1 otherwise. If one operand is a NaN, the other is returned. If both operands are NaNs, a NaN is returned. Component-wise when T is a vector. (GLSLstd450NMin)
-
-Please read the following guidelines before contributing:
-https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
-`
-  )
-  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
-  .unimplemented();
-
 g.test('float_builtin_functions,mix_all_same_type_operands')
   .uniqueId('f17861e71386bb59')
   .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#float-builtin-functions')

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -87,12 +87,24 @@ function flushSubnormalBits(val: number): number {
  * @returns 0 if |val| is a subnormal f32 number, otherwise returns |val|
  */
 function flushSubnormalScalar(val: Scalar): Scalar {
+  return isSubnormalScalar(val) ? f32(0) : val;
+}
+
+/**
+ * @returns true if |val| is a subnormal f32 number, otherwise returns false
+ * 0 is considered a non-subnormal number by this function.
+ */
+export function isSubnormalScalar(val: Scalar): boolean {
   if (val.type.kind !== 'f32') {
-    return val;
+    return false;
+  }
+
+  if (val === f32(0)) {
+    return false;
   }
 
   const u32_val = new Uint32Array(new Float32Array([val.value.valueOf() as number]).buffer)[0];
-  return (u32_val & 0x7f800000) === 0 ? f32(0) : val;
+  return (u32_val & 0x7f800000) === 0;
 }
 
 /**


### PR DESCRIPTION
These tests are for the builtin float function `min`.
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
