### PR TITLE
Add cts for copy between non-srgb format texture and srgb format texture

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -69,7 +69,8 @@ class F extends GPUTest {
   DoCopyTextureToTextureTest(
     srcTextureSize: Required<GPUExtent3DDict>,
     dstTextureSize: Required<GPUExtent3DDict>,
-    format: SizedTextureFormat,
+    srcFormat: SizedTextureFormat,
+    dstFormat: SizedTextureFormat,
     copyBoxOffsets: {
       srcOffset: { x: number; y: number; z: number };
       dstOffset: { x: number; y: number; z: number };
@@ -83,25 +84,25 @@ class F extends GPUTest {
     // Create srcTexture and dstTexture
     const srcTextureDesc: GPUTextureDescriptor = {
       size: srcTextureSize,
-      format,
+      format: srcFormat,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
       mipLevelCount: kMipLevelCount,
     };
     const srcTexture = this.device.createTexture(srcTextureDesc);
     const dstTextureDesc: GPUTextureDescriptor = {
       size: dstTextureSize,
-      format,
+      format: dstFormat,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
       mipLevelCount: kMipLevelCount,
     };
     const dstTexture = this.device.createTexture(dstTextureDesc);
 
     // Fill the whole subresource of srcTexture at srcCopyLevel with initialSrcData.
-    const initialSrcData = this.GetInitialDataPerMipLevel(srcTextureSize, format, srcCopyLevel);
-    const srcTextureSizeAtLevel = physicalMipSize(srcTextureSize, format, '2d', srcCopyLevel);
-    const bytesPerBlock = kTextureFormatInfo[format].bytesPerBlock;
-    const blockWidth = kTextureFormatInfo[format].blockWidth;
-    const blockHeight = kTextureFormatInfo[format].blockHeight;
+    const initialSrcData = this.GetInitialDataPerMipLevel(srcTextureSize, srcFormat, srcCopyLevel);
+    const srcTextureSizeAtLevel = physicalMipSize(srcTextureSize, srcFormat, '2d', srcCopyLevel);
+    const bytesPerBlock = kTextureFormatInfo[srcFormat].bytesPerBlock;
+    const blockWidth = kTextureFormatInfo[srcFormat].blockWidth;
+    const blockHeight = kTextureFormatInfo[srcFormat].blockHeight;
     const srcBlocksPerRow = srcTextureSizeAtLevel.width / blockWidth;
     const srcBlockRowsPerImage = srcTextureSizeAtLevel.height / blockHeight;
     this.device.queue.writeTexture(
@@ -115,7 +116,7 @@ class F extends GPUTest {
     );
 
     // Copy the region specified by copyBoxOffsets from srcTexture to dstTexture.
-    const dstTextureSizeAtLevel = physicalMipSize(dstTextureSize, format, '2d', dstCopyLevel);
+    const dstTextureSizeAtLevel = physicalMipSize(dstTextureSize, dstFormat, '2d', dstCopyLevel);
     const minWidth = Math.min(srcTextureSizeAtLevel.width, dstTextureSizeAtLevel.width);
     const minHeight = Math.min(srcTextureSizeAtLevel.height, dstTextureSizeAtLevel.height);
 
@@ -618,7 +619,18 @@ g.test('color_textures,non_compressed,non_array')
   )
   .params(u =>
     u
-      .combine('format', kRegularTextureFormats)
+      .combine('srcFormat', kRegularTextureFormats)
+      .combine('dstFormat', kRegularTextureFormats)
+      .filter(({ srcFormat, dstFormat }) => {
+        const srcBaseFormat = kTextureFormatInfo[srcFormat].baseFormat;
+        const dstBaseFormat = kTextureFormatInfo[dstFormat].baseFormat;
+        return (
+          srcFormat === dstFormat ||
+          (srcBaseFormat !== undefined &&
+            dstBaseFormat !== undefined &&
+            srcBaseFormat === dstBaseFormat)
+        );
+      })
       .beginSubcases()
       .combine('textureSize', [
         {
@@ -643,12 +655,20 @@ g.test('color_textures,non_compressed,non_array')
       .combine('dstCopyLevel', [0, 3])
   )
   .fn(async t => {
-    const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const {
+      textureSize,
+      srcFormat,
+      dstFormat,
+      copyBoxOffsets,
+      srcCopyLevel,
+      dstCopyLevel,
+    } = t.params;
 
     t.DoCopyTextureToTextureTest(
       textureSize.srcTextureSize,
       textureSize.dstTextureSize,
-      format,
+      srcFormat,
+      dstFormat,
       copyBoxOffsets,
       srcCopyLevel,
       dstCopyLevel
@@ -665,7 +685,18 @@ g.test('color_textures,compressed,non_array')
   )
   .params(u =>
     u
-      .combine('format', kCompressedTextureFormats)
+      .combine('srcFormat', kCompressedTextureFormats)
+      .combine('dstFormat', kCompressedTextureFormats)
+      .filter(({ srcFormat, dstFormat }) => {
+        const srcBaseFormat = kTextureFormatInfo[srcFormat].baseFormat;
+        const dstBaseFormat = kTextureFormatInfo[dstFormat].baseFormat;
+        return (
+          srcFormat === dstFormat ||
+          (srcBaseFormat !== undefined &&
+            dstBaseFormat !== undefined &&
+            srcBaseFormat === dstBaseFormat)
+        );
+      })
       .beginSubcases()
       .combine('textureSizeInBlocks', [
         // The heights and widths in blocks are all power of 2
@@ -688,22 +719,36 @@ g.test('color_textures,compressed,non_array')
       .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
-    const { textureSizeInBlocks, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
-    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
+    const {
+      textureSizeInBlocks,
+      srcFormat,
+      dstFormat,
+      copyBoxOffsets,
+      srcCopyLevel,
+      dstCopyLevel,
+    } = t.params;
+    await t.selectDeviceOrSkipTestCase([
+      kTextureFormatInfo[srcFormat].feature,
+      kTextureFormatInfo[dstFormat].feature,
+    ]);
+    const srcBlockWidth = kTextureFormatInfo[srcFormat].blockWidth;
+    const srcBlockHeight = kTextureFormatInfo[srcFormat].blockHeight;
+    const dstBlockWidth = kTextureFormatInfo[dstFormat].blockWidth;
+    const dstBlockHeight = kTextureFormatInfo[dstFormat].blockHeight;
 
     t.DoCopyTextureToTextureTest(
       {
-        width: textureSizeInBlocks.src.width * blockWidth,
-        height: textureSizeInBlocks.src.height * blockHeight,
+        width: textureSizeInBlocks.src.width * srcBlockWidth,
+        height: textureSizeInBlocks.src.height * srcBlockHeight,
         depthOrArrayLayers: 1,
       },
       {
-        width: textureSizeInBlocks.dst.width * blockWidth,
-        height: textureSizeInBlocks.dst.height * blockHeight,
+        width: textureSizeInBlocks.dst.width * dstBlockWidth,
+        height: textureSizeInBlocks.dst.height * dstBlockHeight,
         depthOrArrayLayers: 1,
       },
-      format,
+      srcFormat,
+      dstFormat,
       copyBoxOffsets,
       srcCopyLevel,
       dstCopyLevel
@@ -720,7 +765,18 @@ g.test('color_textures,non_compressed,array')
   )
   .params(u =>
     u
-      .combine('format', kRegularTextureFormats)
+      .combine('srcFormat', kRegularTextureFormats)
+      .combine('dstFormat', kRegularTextureFormats)
+      .filter(({ srcFormat, dstFormat }) => {
+        const srcBaseFormat = kTextureFormatInfo[srcFormat].baseFormat;
+        const dstBaseFormat = kTextureFormatInfo[dstFormat].baseFormat;
+        return (
+          srcFormat === dstFormat ||
+          (srcBaseFormat !== undefined &&
+            dstBaseFormat !== undefined &&
+            srcBaseFormat === dstBaseFormat)
+        );
+      })
       .beginSubcases()
       .combine('textureSize', [
         {
@@ -738,12 +794,20 @@ g.test('color_textures,non_compressed,array')
       .combine('dstCopyLevel', [0, 3])
   )
   .fn(async t => {
-    const { textureSize, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const {
+      textureSize,
+      srcFormat,
+      dstFormat,
+      copyBoxOffsets,
+      srcCopyLevel,
+      dstCopyLevel,
+    } = t.params;
 
     t.DoCopyTextureToTextureTest(
       textureSize.srcTextureSize,
       textureSize.dstTextureSize,
-      format,
+      srcFormat,
+      dstFormat,
       copyBoxOffsets,
       srcCopyLevel,
       dstCopyLevel
@@ -760,7 +824,18 @@ g.test('color_textures,compressed,array')
   )
   .params(u =>
     u
-      .combine('format', kCompressedTextureFormats)
+      .combine('srcFormat', kCompressedTextureFormats)
+      .combine('dstFormat', kCompressedTextureFormats)
+      .filter(({ srcFormat, dstFormat }) => {
+        const srcBaseFormat = kTextureFormatInfo[srcFormat].baseFormat;
+        const dstBaseFormat = kTextureFormatInfo[dstFormat].baseFormat;
+        return (
+          srcFormat === dstFormat ||
+          (srcBaseFormat !== undefined &&
+            dstBaseFormat !== undefined &&
+            srcBaseFormat === dstBaseFormat)
+        );
+      })
       .beginSubcases()
       .combine('textureSizeInBlocks', [
         // The heights and widths in blocks are all power of 2
@@ -773,22 +848,36 @@ g.test('color_textures,compressed,array')
       .combine('dstCopyLevel', [0, 2])
   )
   .fn(async t => {
-    const { textureSizeInBlocks, format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
-    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
+    const {
+      textureSizeInBlocks,
+      srcFormat,
+      dstFormat,
+      copyBoxOffsets,
+      srcCopyLevel,
+      dstCopyLevel,
+    } = t.params;
+    await t.selectDeviceOrSkipTestCase([
+      kTextureFormatInfo[srcFormat].feature,
+      kTextureFormatInfo[dstFormat].feature,
+    ]);
+    const srcBlockWidth = kTextureFormatInfo[srcFormat].blockWidth;
+    const srcBlockHeight = kTextureFormatInfo[srcFormat].blockHeight;
+    const dstBlockWidth = kTextureFormatInfo[dstFormat].blockWidth;
+    const dstBlockHeight = kTextureFormatInfo[dstFormat].blockHeight;
 
     t.DoCopyTextureToTextureTest(
       {
-        width: textureSizeInBlocks.src.width * blockWidth,
-        height: textureSizeInBlocks.src.height * blockHeight,
+        width: textureSizeInBlocks.src.width * srcBlockWidth,
+        height: textureSizeInBlocks.src.height * srcBlockHeight,
         depthOrArrayLayers: 5,
       },
       {
-        width: textureSizeInBlocks.dst.width * blockWidth,
-        height: textureSizeInBlocks.dst.height * blockHeight,
+        width: textureSizeInBlocks.dst.width * dstBlockWidth,
+        height: textureSizeInBlocks.dst.height * dstBlockHeight,
         depthOrArrayLayers: 5,
       },
-      format,
+      srcFormat,
+      dstFormat,
       copyBoxOffsets,
       srcCopyLevel,
       dstCopyLevel
@@ -868,13 +957,15 @@ g.test('zero_sized')
   .fn(async t => {
     const { copyBoxOffset, srcCopyLevel, dstCopyLevel } = t.params;
 
-    const format = 'rgba8unorm';
+    const srcFormat = 'rgba8unorm';
+    const dstFormat = 'rgba8unorm';
     const textureSize = { width: 64, height: 32, depthOrArrayLayers: 5 };
 
     t.DoCopyTextureToTextureTest(
       textureSize,
       textureSize,
-      format,
+      srcFormat,
+      dstFormat,
       copyBoxOffset,
       srcCopyLevel,
       dstCopyLevel

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -62,8 +62,8 @@ export const kBufferUsages = numericKeysOf<GPUBufferUsageFlags>(kBufferUsageInfo
 
 // Note that we repeat the header multiple times in order to make it easier to read.
 const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
-                           ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature'] as const,
-                           [            ,              ,    true,   false,     false,          ,      true,      true,             ,                ,            1,             1,                         ] as const, {
+                           ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature', 'baseFormat'] as const,
+                           [            ,              ,    true,   false,     false,          ,      true,      true,             ,                ,            1,             1,                         ,   undefined ] as const, {
   // 8-bit formats
   'r8unorm':               [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               1],
   'r8snorm':               [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               1],
@@ -84,13 +84,13 @@ const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
   'rg16uint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               4],
   'rg16sint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               4],
   'rg16float':             [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
-  'rgba8unorm':            [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               4],
-  'rgba8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'rgba8unorm':            [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               4,            ,                ,                          , 'rgba8unorm'],
+  'rgba8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4,            ,                ,                          , 'rgba8unorm'],
   'rgba8snorm':            [       false,         false,        ,        ,          ,      true,          ,          ,      'float',               4],
   'rgba8uint':             [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               4],
   'rgba8sint':             [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               4],
-  'bgra8unorm':            [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
-  'bgra8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'bgra8unorm':            [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4,            ,                ,                          , 'bgra8unorm'],
+  'bgra8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4,            ,                ,                          , 'bgra8unorm'],
   // Packed 32-bit formats
   'rgb10a2unorm':          [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
   'rg11b10ufloat':         [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               4],
@@ -108,9 +108,9 @@ const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
   'rgba32float':           [        true,          true,        ,        ,          ,      true,          ,          ,      'float',              16],
 } as const);
 /* prettier-ignore */
-const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature'] as const;
+const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature', 'baseFormat'] as const;
 const kSizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [        true,          true,   false,        ,          ,     false,     false,     false,             ,                ,            1,             1,                         ] as const, {
+                           [        true,          true,   false,        ,          ,     false,     false,     false,             ,                ,            1,             1,                         ,   undefined ] as const, {
   'depth32float':          [            ,              ,        ,    true,     false,          ,          ,          ,      'depth',               4],
   'depth16unorm':          [            ,              ,        ,    true,     false,          ,          ,          ,      'depth',               2],
   'stencil8':              [            ,              ,        ,   false,      true,          ,          ,          ,       'uint',               1],
@@ -118,7 +118,7 @@ const kSizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfo
 
 // Multi aspect sample type are now set to their first aspect
 const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [        true,          true,   false,        ,          ,     false,     false,     false,             ,       undefined,            1,             1,                         ] as const, {
+                           [        true,          true,   false,        ,          ,     false,     false,     false,             ,       undefined,            1,             1,                         ,   undefined ] as const, {
   'depth24plus':           [            ,              ,        ,    true,     false,          ,          ,          ,      'depth'],
   'depth24plus-stencil8':  [            ,              ,        ,    true,      true,          ,          ,          ,      'depth'],
   // MAINTENANCE_TODO: These should really be sized formats; see below MAINTENANCE_TODO about multi-aspect formats.
@@ -128,68 +128,68 @@ const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtIn
 
 // Separated compressed formats by type
 const kBCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                         ] as const, {
+                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                         ,  undefined ] as const, {
   // Block Compression (BC) formats
-  'bc1-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
-  'bc1-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
-  'bc2-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
-  'bc2-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
-  'bc3-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
-  'bc3-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc1-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc', 'bc1-rgba-unorm'],
+  'bc1-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc', 'bc1-rgba-unorm'],
+  'bc2-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc2-rgba-unorm'],
+  'bc2-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc2-rgba-unorm'],
+  'bc3-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc3-rgba-unorm'],
+  'bc3-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc3-rgba-unorm'],
   'bc4-r-unorm':           [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
   'bc4-r-snorm':           [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
   'bc5-rg-unorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
   'bc5-rg-snorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
   'bc6h-rgb-ufloat':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
   'bc6h-rgb-float':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
-  'bc7-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
-  'bc7-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc7-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc7-rgba-unorm'],
+  'bc7-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc7-rgba-unorm'],
 } as const);
 const kETC2TextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                           ] as const, {
+                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                          , undefined ] as const, {
   // Ericsson Compression (ETC2) formats
-  'etc2-rgb8unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgb8unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgb8a1unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgb8a1unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgba8unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
-  'etc2-rgba8unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgb8unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2',  'etc2-rgb8unorm'],
+  'etc2-rgb8unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2',  'etc2-rgb8unorm'],
+  'etc2-rgb8a1unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2', 'etc2-rgb8a1unorm'],
+  'etc2-rgb8a1unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2', 'etc2-rgb8a1unorm'],
+  'etc2-rgba8unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2', 'etc2-rgba8unorm'],
+  'etc2-rgba8unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2', 'etc2-rgba8unorm'],
   'eac-r11unorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
   'eac-r11snorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
   'eac-rg11unorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
   'eac-rg11snorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
 } as const);
 const kASTCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,             ,              ,                           ] as const, {
+                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,             ,              ,                           , undefined] as const, {
   // Adaptable Scalable Compression (ASTC) formats
-  'astc-4x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc'],
-  'astc-4x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc'],
-  'astc-5x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc'],
-  'astc-5x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc'],
-  'astc-5x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc'],
-  'astc-5x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc'],
-  'astc-6x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc'],
-  'astc-6x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc'],
-  'astc-6x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc'],
-  'astc-6x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc'],
-  'astc-8x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc'],
-  'astc-8x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc'],
-  'astc-8x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc'],
-  'astc-8x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc'],
-  'astc-8x8-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc'],
-  'astc-8x8-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc'],
-  'astc-10x5-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc'],
-  'astc-10x5-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc'],
-  'astc-10x6-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc'],
-  'astc-10x6-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc'],
-  'astc-10x8-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc'],
-  'astc-10x8-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc'],
-  'astc-10x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc'],
-  'astc-10x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc'],
-  'astc-12x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc'],
-  'astc-12x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc'],
-  'astc-12x12-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc'],
-  'astc-12x12-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc'],
+  'astc-4x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc', 'astc-4x4-unorm'],
+  'astc-4x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc', 'astc-4x4-unorm'],
+  'astc-5x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc', 'astc-5x4-unorm'],
+  'astc-5x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc', 'astc-5x4-unorm'],
+  'astc-5x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc', 'astc-5x5-unorm'],
+  'astc-5x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc', 'astc-5x5-unorm'],
+  'astc-6x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc', 'astc-6x5-unorm'],
+  'astc-6x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc', 'astc-6x5-unorm'],
+  'astc-6x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc', 'astc-6x6-unorm'],
+  'astc-6x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc', 'astc-6x6-unorm'],
+  'astc-8x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc', 'astc-8x5-unorm'],
+  'astc-8x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc', 'astc-8x5-unorm'],
+  'astc-8x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc', 'astc-8x6-unorm'],
+  'astc-8x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc', 'astc-8x6-unorm'],
+  'astc-8x8-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc', 'astc-8x8-unorm'],
+  'astc-8x8-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc', 'astc-8x8-unorm'],
+  'astc-10x5-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc', 'astc-10x5-unorm'],
+  'astc-10x5-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc', 'astc-10x5-unorm'],
+  'astc-10x6-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc', 'astc-10x6-unorm'],
+  'astc-10x6-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc', 'astc-10x6-unorm'],
+  'astc-10x8-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc', 'astc-10x8-unorm'],
+  'astc-10x8-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc', 'astc-10x8-unorm'],
+  'astc-10x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc', 'astc-10x10-unorm'],
+  'astc-10x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc', 'astc-10x10-unorm'],
+  'astc-12x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc', 'astc-12x10-unorm'],
+  'astc-12x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc', 'astc-12x10-unorm'],
+  'astc-12x12-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc', 'astc-12x12-unorm'],
+  'astc-12x12-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc', 'astc-12x12-unorm'],
 } as const);
 
 // Definitions for use locally. To access the table entries, use `kTextureFormatInfo`.


### PR DESCRIPTION
This PR expand the texture compatiblity table with 'baseFormat' attribute
and use this new attribute to expand current copyTextureToTexture tests to
cover T2T copy between non-srgb format texture and srgb format texture




Issue: #935

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
