### PR TITLE
Update image copy validation tests for 1D / 3D textures

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -1,39 +1,5 @@
 export const description = `
 copyTextureToTexture tests.
-
-Test Plan: (TODO(jiawei.shao@intel.com): add tests on 1D/3D textures)
-* the source and destination texture
-  - the {source, destination} texture is {invalid, valid}.
-  - mipLevel {>, =, <} the mipmap level count of the {source, destination} texture.
-  - the source texture is created {with, without} GPUTextureUsage::CopySrc.
-  - the destination texture is created {with, without} GPUTextureUsage::CopyDst.
-* sample count
-  - the sample count of the source texture {is, isn't} equal to the one of the destination texture
-  - when the sample count is greater than 1:
-    - it {is, isn't} a copy of the whole subresource of the source texture.
-    - it {is, isn't} a copy of the whole subresource of the destination texture.
-* texture format
-  - the format of the source texture {is, isn't} equal to the one of the destination texture.
-    - including: depth24plus-stencil8 to/from {depth24plus, stencil8}.
-  - for each depth and/or stencil format: a copy between two textures with same format:
-    - it {is, isn't} a copy of the whole subresource of the {source, destination} texture.
-* copy ranges
-  - if the texture dimension is 2D:
-    - (srcOrigin.x + copyExtent.width) {>, =, <} the width of the subresource size of source
-      textureCopyView.
-    - (srcOrigin.y + copyExtent.height) {>, =, <} the height of the subresource size of source
-      textureCopyView.
-    - (srcOrigin.z + copyExtent.depthOrArrayLayers) {>, =, <} the depthOrArrayLayers of the subresource size of source
-      textureCopyView.
-    - (dstOrigin.x + copyExtent.width) {>, =, <} the width of the subresource size of destination
-      textureCopyView.
-    - (dstOrigin.y + copyExtent.height) {>, =, <} the height of the subresource size of destination
-      textureCopyView.
-    - (dstOrigin.z + copyExtent.depthOrArrayLayers) {>, =, <} the depthOrArrayLayers of the subresource size of destination
-      textureCopyView.
-* when the source and destination texture are the same one:
-  - the set of source texture subresources {has, doesn't have} overlaps with the one of destination
-    texture subresources.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
@@ -43,6 +9,8 @@ import {
   kCompressedTextureFormats,
   kDepthStencilFormats,
   kTextureUsages,
+  textureDimensionAndFormatCompatible,
+  kTextureDimensions,
 } from '../../../../capability_info.js';
 import { align } from '../../../../util/math.js';
 import { ValidationTest } from '../../validation_test.js';
@@ -63,6 +31,7 @@ class F extends ValidationTest {
   }
 
   GetPhysicalSubresourceSize(
+    dimension: GPUTextureDimension,
     textureSize: Required<GPUExtent3DDict>,
     format: GPUTextureFormat,
     mipLevel: number
@@ -74,42 +43,56 @@ class F extends ValidationTest {
       virtualHeightAtLevel,
       kTextureFormatInfo[format].blockHeight
     );
-    return {
-      width: physicalWidthAtLevel,
-      height: physicalHeightAtLevel,
-      depthOrArrayLayers: textureSize.depthOrArrayLayers,
-    };
+
+    switch (dimension) {
+      case '1d':
+        return { width: physicalWidthAtLevel, height: 1, depthOrArrayLayers: 1 };
+      case '2d':
+        return {
+          width: physicalWidthAtLevel,
+          height: physicalHeightAtLevel,
+          depthOrArrayLayers: textureSize.depthOrArrayLayers,
+        };
+      case '3d':
+        return {
+          width: physicalWidthAtLevel,
+          height: physicalHeightAtLevel,
+          depthOrArrayLayers: Math.max(textureSize.depthOrArrayLayers >> mipLevel, 1),
+        };
+    }
   }
 }
 
 export const g = makeTestGroup(F);
 
-g.test('copy_with_invalid_texture').fn(async t => {
-  const validTexture = t.device.createTexture({
-    size: { width: 4, height: 4, depthOrArrayLayers: 1 },
-    format: 'rgba8unorm',
-    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+g.test('copy_with_invalid_texture')
+  .desc('Test copyTextureToTexture is an error when one of the textures is invalid.')
+  .fn(async t => {
+    const validTexture = t.device.createTexture({
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+    });
+
+    const errorTexture = t.getErrorTexture();
+
+    t.TestCopyTextureToTexture(
+      { texture: errorTexture },
+      { texture: validTexture },
+      { width: 1, height: 1, depthOrArrayLayers: 1 },
+      false
+    );
+    t.TestCopyTextureToTexture(
+      { texture: validTexture },
+      { texture: errorTexture },
+      { width: 1, height: 1, depthOrArrayLayers: 1 },
+      false
+    );
   });
-
-  const errorTexture = t.getErrorTexture();
-
-  t.TestCopyTextureToTexture(
-    { texture: errorTexture },
-    { texture: validTexture },
-    { width: 1, height: 1, depthOrArrayLayers: 1 },
-    false
-  );
-  t.TestCopyTextureToTexture(
-    { texture: validTexture },
-    { texture: errorTexture },
-    { width: 1, height: 1, depthOrArrayLayers: 1 },
-    false
-  );
-});
 
 g.test('texture,device_mismatch')
   .desc(
-    'Tests copyTextureToTexture cannot be called with src texture or dst texture created from another device'
+    'Tests copyTextureToTexture cannot be called with src texture or dst texture created from another device.'
   )
   .paramsSubcasesOnly([
     { srcMismatched: false, dstMismatched: false }, // control case
@@ -119,28 +102,44 @@ g.test('texture,device_mismatch')
   .unimplemented();
 
 g.test('mipmap_level')
-  .paramsSubcasesOnly([
-    { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 0 },
-    { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 1, dstCopyLevel: 0 },
-    { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 1 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 0 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 2, dstCopyLevel: 0 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 3, dstCopyLevel: 0 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 2 },
-    { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 3 },
-  ] as const)
+  .desc(
+    `
+Test copyTextureToTexture must specify mipLevels that are in range.
+- for various dimensions
+- for varioues mip level count in the texture
+- for various copy target mip level (in range and not in range)
+`
+  )
+  .params(u =>
+    u //
+      .combine('dimension', kTextureDimensions)
+      .beginSubcases()
+      .combineWithParams([
+        { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 0 },
+        { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 1, dstCopyLevel: 0 },
+        { srcLevelCount: 1, dstLevelCount: 1, srcCopyLevel: 0, dstCopyLevel: 1 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 0 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 2, dstCopyLevel: 0 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 3, dstCopyLevel: 0 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 2 },
+        { srcLevelCount: 3, dstLevelCount: 3, srcCopyLevel: 0, dstCopyLevel: 3 },
+      ] as const)
+      .unless(p => p.dimension === '1d' && (p.srcLevelCount !== 1 || p.dstLevelCount !== 1))
+  )
 
   .fn(async t => {
-    const { srcLevelCount, dstLevelCount, srcCopyLevel, dstCopyLevel } = t.params;
+    const { srcLevelCount, dstLevelCount, srcCopyLevel, dstCopyLevel, dimension } = t.params;
 
     const srcTexture = t.device.createTexture({
-      size: { width: 32, height: 32, depthOrArrayLayers: 1 },
+      size: { width: 32, height: 1, depthOrArrayLayers: 1 },
+      dimension,
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC,
       mipLevelCount: srcLevelCount,
     });
     const dstTexture = t.device.createTexture({
-      size: { width: 32, height: 32, depthOrArrayLayers: 1 },
+      size: { width: 32, height: 1, depthOrArrayLayers: 1 },
+      dimension,
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_DST,
       mipLevelCount: dstLevelCount,
@@ -156,6 +155,13 @@ g.test('mipmap_level')
   });
 
 g.test('texture_usage')
+  .desc(
+    `
+Test that copyTextureToTexture source/destination need COPY_SRC/COPY_DST usages.
+- for all possible source texture usages
+- for all possible destination texture usages
+`
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('srcUsage', kTextureUsages)
@@ -187,6 +193,13 @@ g.test('texture_usage')
   });
 
 g.test('sample_count')
+  .desc(
+    `
+Test that textures in copyTextureToTexture must have the same sample count.
+- for various source texture sample count
+- for various destination texture sample count
+`
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('srcSampleCount', [1, 4])
@@ -218,6 +231,15 @@ g.test('sample_count')
   });
 
 g.test('multisampled_copy_restrictions')
+  .desc(
+    `
+Test that copyTextureToTexture of multisampled texture must copy a whole subresource to a whole subresource.
+- for various origin for the source and destination of the copies.
+
+Note: this is only tested for 2D textures as it is the only dimension compatible with multisampling.
+TODO: Check the source and destination constraints separately.
+`
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('srcCopyOrigin', [
@@ -266,6 +288,15 @@ g.test('multisampled_copy_restrictions')
   });
 
 g.test('texture_format_equality')
+  .desc(
+    `
+Test the formats of textures in copyTextureToTexture must be copy-compatible.
+- for all source texture formats
+- for all destination texture formats
+
+TODO: Update with SRGBness now being compatible.
+`
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('srcFormat', kTextureFormats)
@@ -301,6 +332,17 @@ g.test('texture_format_equality')
   });
 
 g.test('depth_stencil_copy_restrictions')
+  .desc(
+    `
+Test that depth textures subresources must be entirely copied in copyTextureToTexture
+- for various depth-stencil formats
+- for various copy origin and size offsets
+- for various source and destination texture sizes
+- for various source and destination mip levels
+
+Note: this is only tested for 2D textures as it is the only dimension compatible with depth-stencil.
+`
+  )
   .params(u =>
     u
       .combine('format', kDepthStencilFormats)
@@ -351,8 +393,8 @@ g.test('depth_stencil_copy_restrictions')
       usage: GPUTextureUsage.COPY_DST,
     });
 
-    const srcSizeAtLevel = t.GetPhysicalSubresourceSize(srcTextureSize, format, srcCopyLevel);
-    const dstSizeAtLevel = t.GetPhysicalSubresourceSize(dstTextureSize, format, dstCopyLevel);
+    const srcSizeAtLevel = t.GetPhysicalSubresourceSize('2d', srcTextureSize, format, srcCopyLevel);
+    const dstSizeAtLevel = t.GetPhysicalSubresourceSize('2d', dstTextureSize, format, dstCopyLevel);
 
     const copyOrigin = { x: copyBoxOffsets.x, y: copyBoxOffsets.y, z: 0 };
 
@@ -384,8 +426,18 @@ g.test('depth_stencil_copy_restrictions')
   });
 
 g.test('copy_ranges')
-  .paramsSubcasesOnly(u =>
-    u //
+  .desc(
+    `
+Test that copyTextureToTexture copy boxes must be in range of the subresource.
+- for various dimensions
+- for various offsets to a full copy for the copy origin/size
+- for various copy mip levels
+`
+  )
+  .params(u =>
+    u
+      .combine('dimension', kTextureDimensions)
+      //.beginSubcases()
       .combine('copyBoxOffsets', [
         { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
         { x: 1, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
@@ -401,31 +453,57 @@ g.test('copy_ranges')
         { x: 0, y: 0, z: 1, width: 0, height: 0, depthOrArrayLayers: -1 },
         { x: 0, y: 0, z: 2, width: 0, height: 0, depthOrArrayLayers: -1 },
       ])
+      .unless(
+        p =>
+          p.dimension === '1d' &&
+          (p.copyBoxOffsets.y !== 0 ||
+            p.copyBoxOffsets.z !== 0 ||
+            p.copyBoxOffsets.height !== 0 ||
+            p.copyBoxOffsets.depthOrArrayLayers !== 0)
+      )
       .combine('srcCopyLevel', [0, 1, 3])
       .combine('dstCopyLevel', [0, 1, 3])
+      .unless(p => p.dimension === '1d' && (p.srcCopyLevel !== 0 || p.dstCopyLevel !== 0))
   )
   .fn(async t => {
-    const { copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const { dimension, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
 
-    const kTextureSize = { width: 16, height: 8, depthOrArrayLayers: 3 };
-    const kMipLevelCount = 4;
+    const textureSize = { width: 16, height: 8, depthOrArrayLayers: 3 };
+    let mipLevelCount = 4;
+    if (dimension === '1d') {
+      mipLevelCount = 1;
+      textureSize.height = 1;
+      textureSize.depthOrArrayLayers = 1;
+    }
     const kFormat = 'rgba8unorm';
 
     const srcTexture = t.device.createTexture({
-      size: kTextureSize,
+      size: textureSize,
       format: kFormat,
-      mipLevelCount: kMipLevelCount,
+      dimension,
+      mipLevelCount,
       usage: GPUTextureUsage.COPY_SRC,
     });
     const dstTexture = t.device.createTexture({
-      size: kTextureSize,
+      size: textureSize,
       format: kFormat,
-      mipLevelCount: kMipLevelCount,
+      dimension,
+      mipLevelCount,
       usage: GPUTextureUsage.COPY_DST,
     });
 
-    const srcSizeAtLevel = t.GetPhysicalSubresourceSize(kTextureSize, kFormat, srcCopyLevel);
-    const dstSizeAtLevel = t.GetPhysicalSubresourceSize(kTextureSize, kFormat, dstCopyLevel);
+    const srcSizeAtLevel = t.GetPhysicalSubresourceSize(
+      dimension,
+      textureSize,
+      kFormat,
+      srcCopyLevel
+    );
+    const dstSizeAtLevel = t.GetPhysicalSubresourceSize(
+      dimension,
+      textureSize,
+      kFormat,
+      dstCopyLevel
+    );
 
     const copyOrigin = { x: copyBoxOffsets.x, y: copyBoxOffsets.y, z: copyBoxOffsets.z };
 
@@ -438,15 +516,26 @@ g.test('copy_ranges')
       0
     );
     const copyDepth =
-      kTextureSize.depthOrArrayLayers + copyBoxOffsets.depthOrArrayLayers - copyOrigin.z;
+      textureSize.depthOrArrayLayers + copyBoxOffsets.depthOrArrayLayers - copyOrigin.z;
 
     {
-      const isSuccess =
+      let isSuccess =
         copyWidth <= srcSizeAtLevel.width &&
         copyHeight <= srcSizeAtLevel.height &&
         copyOrigin.x + copyWidth <= dstSizeAtLevel.width &&
-        copyOrigin.y + copyHeight <= dstSizeAtLevel.height &&
-        copyOrigin.z + copyDepth <= kTextureSize.depthOrArrayLayers;
+        copyOrigin.y + copyHeight <= dstSizeAtLevel.height;
+
+      if (dimension === '3d') {
+        isSuccess =
+          isSuccess &&
+          copyDepth <= srcSizeAtLevel.depthOrArrayLayers &&
+          copyOrigin.z + copyDepth <= dstSizeAtLevel.depthOrArrayLayers;
+      } else {
+        isSuccess =
+          isSuccess &&
+          copyDepth <= textureSize.depthOrArrayLayers &&
+          copyOrigin.z + copyDepth <= textureSize.depthOrArrayLayers;
+      }
 
       t.TestCopyTextureToTexture(
         { texture: srcTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: srcCopyLevel },
@@ -457,12 +546,23 @@ g.test('copy_ranges')
     }
 
     {
-      const isSuccess =
+      let isSuccess =
         copyOrigin.x + copyWidth <= srcSizeAtLevel.width &&
         copyOrigin.y + copyHeight <= srcSizeAtLevel.height &&
         copyWidth <= dstSizeAtLevel.width &&
-        copyHeight <= dstSizeAtLevel.height &&
-        copyOrigin.z + copyDepth <= kTextureSize.depthOrArrayLayers;
+        copyHeight <= dstSizeAtLevel.height;
+
+      if (dimension === '3d') {
+        isSuccess =
+          isSuccess &&
+          copyDepth <= dstSizeAtLevel.depthOrArrayLayers &&
+          copyOrigin.z + copyDepth <= srcSizeAtLevel.depthOrArrayLayers;
+      } else {
+        isSuccess =
+          isSuccess &&
+          copyDepth <= textureSize.depthOrArrayLayers &&
+          copyOrigin.z + copyDepth <= textureSize.depthOrArrayLayers;
+      }
 
       t.TestCopyTextureToTexture(
         { texture: srcTexture, origin: copyOrigin, mipLevel: srcCopyLevel },
@@ -474,6 +574,15 @@ g.test('copy_ranges')
   });
 
 g.test('copy_within_same_texture')
+  .desc(
+    `
+Test that it is an error to use copyTextureToTexture from one subresource to itself.
+- for various starting source/destination array layers.
+- for various copy sizes in number of array layers
+
+TODO: Extend to check the copy is allowed between different mip levels.
+TODO: Extend to 1D and 3D textures.`
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('srcCopyOriginZ', [0, 2, 4])
@@ -563,9 +672,21 @@ Test the validations on the member 'aspect' of GPUImageCopyTexture in CopyTextur
   });
 
 g.test('copy_ranges_with_compressed_texture_formats')
+  .desc(
+    `
+Test that copyTextureToTexture copy boxes must be in range of the subresource and aligned to the block size
+- for various dimensions
+- for various offsets to a full copy for the copy origin/size
+- for various copy mip levels
+
+TODO: Express the offsets in "block size" so as to be able to test non-4x4 compressed formats
+`
+  )
   .params(u =>
     u
       .combine('format', kCompressedTextureFormats)
+      .combine('dimension', kTextureDimensions)
+      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
       .beginSubcases()
       .combine('copyBoxOffsets', [
         { x: 0, y: 0, z: 0, width: 0, height: 0, depthOrArrayLayers: -2 },
@@ -584,7 +705,7 @@ g.test('copy_ranges_with_compressed_texture_formats')
       .combine('dstCopyLevel', [0, 1, 2])
   )
   .fn(async t => {
-    const { format, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
+    const { format, dimension, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
     const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
@@ -598,18 +719,30 @@ g.test('copy_ranges_with_compressed_texture_formats')
     const srcTexture = t.device.createTexture({
       size: kTextureSize,
       format,
+      dimension,
       mipLevelCount: kMipLevelCount,
       usage: GPUTextureUsage.COPY_SRC,
     });
     const dstTexture = t.device.createTexture({
       size: kTextureSize,
       format,
+      dimension,
       mipLevelCount: kMipLevelCount,
       usage: GPUTextureUsage.COPY_DST,
     });
 
-    const srcSizeAtLevel = t.GetPhysicalSubresourceSize(kTextureSize, format, srcCopyLevel);
-    const dstSizeAtLevel = t.GetPhysicalSubresourceSize(kTextureSize, format, dstCopyLevel);
+    const srcSizeAtLevel = t.GetPhysicalSubresourceSize(
+      dimension,
+      kTextureSize,
+      format,
+      srcCopyLevel
+    );
+    const dstSizeAtLevel = t.GetPhysicalSubresourceSize(
+      dimension,
+      kTextureSize,
+      format,
+      dstCopyLevel
+    );
 
     const copyOrigin = { x: copyBoxOffsets.x, y: copyBoxOffsets.y, z: copyBoxOffsets.z };
 

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -129,7 +129,7 @@ export class ImageCopyTest extends ValidationTest {
       method: ImageCopyType;
       dataSize: number;
       success: boolean;
-      /** If submit is true, the validaton error is expected to come from the submit and encoding
+      /** If submit is true, the validation error is expected to come from the submit and encoding
        * should succeed. */
       submit?: boolean;
     }


### PR DESCRIPTION
Also updated all the descriptions in the touched files to be following
the "test plan" convention.

Issue: #872, #876, #892, #893

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

Tested against https://dawn-review.googlesource.com/c/dawn/+/64544, passes both on Metal and Vulkan (didn't try D3D12 yet). I you don't mind I'll land the Dawn CL before this, so that there aren't 1000 suppressions to add in Chromium.

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
