### PR TITLE
Add initial test plans for memory model

### DIFF
--- a/src/webgpu/shader/execution/memory_model/coherence.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/coherence.spec.ts
@@ -1,0 +1,14 @@
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+export const description = `
+A suite of tests checking threads all see a sequentially consistent view of the order of memory
+accesses to a single memory location. Uses a parallel testing strategy along with stressing
+threads to increase coverage of possible bugs.`;
+
+export const g = makeTestGroup(GPUTest);
+
+g.test("CoRR")
+  .desc(`
+Ensures two reads on one thread cannot observe an inconsistent view of a write on a second thread.`)
+  .unimplemented();

--- a/src/webgpu/shader/execution/memory_model/litmus.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/litmus.spec.ts
@@ -1,0 +1,15 @@
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+export const description = `
+A suite of tests for properties of the WebGPU memory model involving two memory locations.
+Specifically, we can use the acquire/release ordering provided by WebGPU's barriers to disallow
+weak behaviors in several classic memory model litmus tests.`;
+
+export const g = makeTestGroup(GPUTest);
+
+g.test("Message Passing, workgroup memory")
+  .desc(`
+Checks whether two reads on one thread can observe two writes in another thread in a way
+that is inconsistent with sequential consistency.`)
+  .unimplemented();

--- a/src/webgpu/shader/execution/memory_model/misc.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/misc.spec.ts
@@ -1,0 +1,20 @@
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+export const description = `
+Tests for the memory model that do not fall under other categories. Includes tests for
+non-atomic memory in the presence of a WebGPU barrier, and a test for the atomicity of atomic
+read-modify-write instructions.`;
+
+export const g = makeTestGroup(GPUTest);
+
+g.test("Atomicity")
+  .desc(`
+Checks whether a store on one thread can interrupt an atomic RMW on a second thread.`)
+  .unimplemented();
+
+g.test("Workgroup Barrier Store Load")
+  .desc(`
+Checks whether the workgroup barrier properly synchronizes a non-atomic write and read on
+separate threads`)
+  .unimplemented();


### PR DESCRIPTION


Issue: #963 

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.

### Notes
- I've split the proposed tests into three files, corresponding to the types of tests we want to add.
- One of the main concerns for these types of tests is the time it takes to run them. Our initial goal will be to keep the runtime of all the tests we add below one minute, with the ability to increase the number of iterations to do a more thorough testing campaign when needed.

@dneto0 @alan-baker @tyler-utah
