### PR TITLE
texture_zero_init: Expand for 1D textures.

### DIFF
--- a/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
@@ -11,7 +11,6 @@ export const checkContentsByBufferCopy: CheckContents = (
   subresourceRange
 ) => {
   for (const { level: mipLevel, layer } of subresourceRange.each()) {
-    assert(params.dimension !== '1d');
     assert(params.format in kTextureFormatInfo);
     const format = params.format as EncodableTextureFormat;
 
@@ -33,7 +32,6 @@ export const checkContentsByTextureCopy: CheckContents = (
   subresourceRange
 ) => {
   for (const { level, layer } of subresourceRange.each()) {
-    assert(params.dimension !== '1d');
     assert(params.format in kTextureFormatInfo);
     const format = params.format as EncodableTextureFormat;
 

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -15,7 +15,6 @@ export const checkContentsBySampling: CheckContents = (
   state,
   subresourceRange
 ) => {
-  assert(params.dimension !== '1d');
   assert(params.format in kTextureFormatInfo);
   const format = params.format as EncodableTextureFormat;
   const rep = kTexelRepresentationInfo[format];
@@ -44,11 +43,13 @@ export const checkContentsBySampling: CheckContents = (
 
     const _xd = '_' + params.dimension;
     const _multisampled = params.sampleCount > 1 ? '_multisampled' : '';
-    const texelIndexExpresion =
+    const texelIndexExpression =
       params.dimension === '2d'
         ? 'vec2<i32>(GlobalInvocationID.xy)'
         : params.dimension === '3d'
         ? 'vec3<i32>(GlobalInvocationID.xyz)'
+        : params.dimension === '1d'
+        ? 'i32(GlobalInvocationID.x)'
         : unreachable();
     const computePipeline = t.device.createComputePipeline({
       compute: {
@@ -75,7 +76,7 @@ export const checkContentsBySampling: CheckContents = (
                 GlobalInvocationID.x
               );
               let texel : vec4<${shaderType}> = textureLoad(
-                myTexture, ${texelIndexExpresion}, constants.level);
+                myTexture, ${texelIndexExpression}, constants.level);
 
               for (var i : u32 = 0u; i < ${componentCount}u; i = i + 1u) {
                 result.values[flatIndex + i] = texel.${indexExpression};

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -2,9 +2,9 @@ export const description = `
 Test uninitialized textures are initialized to zero when read.
 
 TODO:
-- 1d [1]
-- test by sampling depth/stencil [2]
-- test by copying out of stencil [3]
+- test by sampling depth/stencil [1]
+- test by copying out of stencil [2]
+- test compressed texture formats [3]
 `;
 
 // MAINTENANCE_TODO: This is a test file, it probably shouldn't export anything.
@@ -23,6 +23,8 @@ import {
   kUncompressedTextureFormats,
   EncodableTextureFormat,
   UncompressedTextureFormat,
+  textureDimensionAndFormatCompatible,
+  kTextureDimensions,
 } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import { GPUTest } from '../../../gpu_test.js';
@@ -213,6 +215,10 @@ export class TextureZeroInitTest extends GPUTest {
   }
 
   get textureHeight(): number {
+    if (this.p.dimension === '1d') {
+      return 1;
+    }
+
     let height = 1 << this.p.mipLevelCount;
     if (this.p.nonPowerOfTwo) {
       height = 2 * height - 1;
@@ -331,9 +337,6 @@ export class TextureZeroInitTest extends GPUTest {
     state: InitializedState,
     subresourceRange: SubresourceRange
   ): void {
-    // [1]: 1D texture
-    assert(this.p.dimension !== '1d');
-
     assert(this.p.format in kTextureFormatInfo);
     const format = this.p.format as EncodableTextureFormat;
 
@@ -433,8 +436,7 @@ export class TextureZeroInitTest extends GPUTest {
 }
 
 const kTestParams = kUnitCaseParamsBuilder
-  // [1]: 1d textures
-  .combine('dimension', ['2d', '3d'] as GPUTextureDimension[])
+  .combine('dimension', kTextureDimensions)
   .combine('readMethod', [
     ReadMethod.CopyToBuffer,
     ReadMethod.CopyToTexture,
@@ -442,7 +444,9 @@ const kTestParams = kUnitCaseParamsBuilder
     ReadMethod.DepthTest,
     ReadMethod.StencilTest,
   ])
+  // [3] compressed formats
   .combine('format', kUncompressedTextureFormats)
+  .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
   .beginSubcases()
   .combine('aspect', kTextureAspects)
   .unless(({ readMethod, format, aspect }) => {
@@ -451,18 +455,20 @@ const kTestParams = kUnitCaseParamsBuilder
       (readMethod === ReadMethod.DepthTest && (!info.depth || aspect === 'stencil-only')) ||
       (readMethod === ReadMethod.StencilTest && (!info.stencil || aspect === 'depth-only')) ||
       (readMethod === ReadMethod.ColorBlending && !info.color) ||
-      // [2]: Test with depth/stencil sampling
+      // [1]: Test with depth/stencil sampling
       (readMethod === ReadMethod.Sample && (info.depth || info.stencil)) ||
       (aspect === 'depth-only' && !info.depth) ||
       (aspect === 'stencil-only' && !info.stencil) ||
       (aspect === 'all' && info.depth && info.stencil) ||
       // Cannot copy from a packed depth format.
-      // [3]: Test copying out of the stencil aspect.
+      // [2]: Test copying out of the stencil aspect.
       ((readMethod === ReadMethod.CopyToBuffer || readMethod === ReadMethod.CopyToTexture) &&
         (format === 'depth24plus' || format === 'depth24plus-stencil8'))
     );
   })
   .combine('mipLevelCount', kMipLevelCounts)
+  // 1D texture can only have a single mip level
+  .unless(p => p.dimension === '1d' && p.mipLevelCount !== 1)
   .combine('sampleCount', kSampleCounts)
   .unless(
     ({ readMethod, sampleCount }) =>
@@ -476,7 +482,7 @@ const kTestParams = kUnitCaseParamsBuilder
   .unless(({ dimension, readMethod, uninitializeMethod, format, sampleCount }) => {
     const formatInfo = kTextureFormatInfo[format];
     return (
-      dimension === '3d' &&
+      dimension !== '2d' &&
       (sampleCount > 1 ||
         formatInfo.depth ||
         formatInfo.stencil ||
@@ -492,11 +498,10 @@ const kTestParams = kUnitCaseParamsBuilder
         yield { layerCount: 1 as LayerCounts };
         yield { layerCount: 7 as LayerCounts };
         break;
+      case '1d':
       case '3d':
         yield { layerCount: 1 as LayerCounts };
         break;
-      default:
-        unreachable();
     }
   })
   // Multisampled 3D / 2D array textures not supported.


### PR DESCRIPTION


Issue: #875 #872

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
