### PR TITLE
Update to latest WebGPU CTS API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/offscreencanvas": "^2019.6.2",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.22.0",
-        "@webgpu/types": "0.1.11",
+        "@webgpu/types": "0.1.12",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.0.1",
@@ -1374,9 +1374,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.11.tgz",
-      "integrity": "sha512-hz4skElgAhpWOWWDCJSGVlzTAcJ3TBuIA+NI4VZNI13yfm+zhgOg5lTTw5YaYhxWcS3dsLNd7xmNoLkeksW9fQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.12.tgz",
+      "integrity": "sha512-sHz9jNT6QbgjwGiiU9FRWtJxvGNVPqWnAGNxlsIq63w8539du1vcJ2Rq5Pl6LYdqw1FcVfrLO/93/vtQl4TYrA==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10591,9 +10591,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.11.tgz",
-      "integrity": "sha512-hz4skElgAhpWOWWDCJSGVlzTAcJ3TBuIA+NI4VZNI13yfm+zhgOg5lTTw5YaYhxWcS3dsLNd7xmNoLkeksW9fQ==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.12.tgz",
+      "integrity": "sha512-sHz9jNT6QbgjwGiiU9FRWtJxvGNVPqWnAGNxlsIq63w8539du1vcJ2Rq5Pl6LYdqw1FcVfrLO/93/vtQl4TYrA==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/offscreencanvas": "^2019.6.2",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.22.0",
-    "@webgpu/types": "0.1.11",
+    "@webgpu/types": "0.1.12",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.0.1",

--- a/src/stress/adapter/device_allocation.spec.ts
+++ b/src/stress/adapter/device_allocation.spec.ts
@@ -80,7 +80,7 @@ class DeviceAllocationTests extends Fixture {
           DefaultLimits.maxComputeWorkgroupSizeX,
           DefaultLimits.maxComputeWorkgroupSizeY
         );
-        pass.endPass();
+        pass.end();
         commands.push(encoder.finish());
       }
     }
@@ -170,7 +170,7 @@ class DeviceAllocationTests extends Fixture {
           colorAttachments: [
             {
               view: texture.createView(),
-              loadValue: 'load',
+              loadOp: 'load',
               storeOp: 'store',
             },
           ],
@@ -178,7 +178,7 @@ class DeviceAllocationTests extends Fixture {
         pass.setPipeline(pipeline);
         pass.setBindGroup(0, bindgroup);
         pass.draw(kSize * kSize);
-        pass.endPass();
+        pass.end();
         commands.push(encoder.finish());
       }
     }

--- a/src/stress/compute/compute_pass.spec.ts
+++ b/src/stress/compute/compute_pass.spec.ts
@@ -43,7 +43,7 @@ GPUComputePipeline.`
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
       pass.dispatch(kNumElements);
-      pass.endPass();
+      pass.end();
       t.device.queue.submit([encoder.finish()]);
     }
     t.expectGPUBufferValuesEqual(
@@ -86,7 +86,7 @@ GPUComputePipeline.`
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
       pass.dispatch(1);
-      pass.endPass();
+      pass.end();
       t.device.queue.submit([encoder.finish()]);
     }
     t.expectGPUBufferValuesEqual(buffer, new Uint32Array([kNumIterations]));
@@ -138,7 +138,7 @@ groups.`
       pass.setBindGroup(0, bindGroup);
       pass.dispatch(kNumElements);
     }
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     const kTotalAddition = (kNumIterations / 2) * 3;
     t.expectGPUBufferValuesEqual(
@@ -180,7 +180,7 @@ g.test('many_dispatches')
     for (let i = 0; i < kNumIterations; ++i) {
       pass.dispatch(kNumElements);
     }
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.expectGPUBufferValuesEqual(
       buffer,
@@ -222,7 +222,7 @@ g.test('huge_dispatches')
       pass.setBindGroup(0, bindGroup);
       pass.setPipeline(pipeline);
       pass.dispatch(kDimensions[0], kDimensions[1], kDimensions[2]);
-      pass.endPass();
+      pass.end();
       t.device.queue.submit([encoder.finish()]);
       await t.device.queue.onSubmittedWorkDone();
     }

--- a/src/stress/queue/submit.spec.ts
+++ b/src/stress/queue/submit.spec.ts
@@ -44,7 +44,7 @@ results verified at the end of the test.`
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
       pass.dispatch(kNumElements);
-      pass.endPass();
+      pass.end();
     }
     t.device.queue.submit([encoder.finish()]);
     t.expectGPUBufferValuesEqual(
@@ -89,7 +89,7 @@ submit() call.`
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
       pass.dispatch(kNumElements);
-      pass.endPass();
+      pass.end();
       buffers.push(encoder.finish());
     }
     t.device.queue.submit(buffers);

--- a/src/stress/render/render_pass.spec.ts
+++ b/src/stress/render/render_pass.spec.ts
@@ -48,7 +48,7 @@ a single render pass for every output fragment, with each pass executing a one-v
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
@@ -58,7 +58,7 @@ a single render pass for every output fragment, with each pass executing a one-v
       const pass = encoder.beginRenderPass(renderPassDescriptor);
       pass.setPipeline(pipeline);
       pass.draw(1, 1, i);
-      pass.endPass();
+      pass.end();
     });
     t.device.queue.submit([encoder.finish()]);
     t.expectSingleColor(renderTarget, 'rgba8unorm', {
@@ -105,15 +105,15 @@ pass does a single draw call, with one pass per output fragment.`
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
       depthStencilAttachment: {
         view: depthTarget.createView(),
-        depthLoadValue: 'load',
+        depthLoadOp: 'load',
         depthStoreOp: 'store',
-        stencilLoadValue: 'load',
+        stencilLoadOp: 'load',
         stencilStoreOp: 'discard',
       },
     };
@@ -137,7 +137,7 @@ pass does a single draw call, with one pass per output fragment.`
       const pass = encoder.beginRenderPass(renderPassDescriptor);
       pass.setPipeline(pipeline);
       pass.draw(1, 1, i);
-      pass.endPass();
+      pass.end();
     });
     t.device.queue.submit([encoder.finish()]);
     t.expectSingleColor(renderTarget, 'rgba8unorm', {
@@ -200,7 +200,7 @@ buffer.`
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
@@ -222,7 +222,7 @@ buffer.`
       );
       pass.draw(1, 1);
     });
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.expectSingleColor(renderTarget, 'rgba8unorm', {
       size: [kSize, kSize, 1],
@@ -270,7 +270,7 @@ render pass with a single pipeline, and one draw call per fragment of the output
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
@@ -279,7 +279,7 @@ render pass with a single pipeline, and one draw call per fragment of the output
     const pass = encoder.beginRenderPass(renderPassDescriptor);
     pass.setPipeline(pipeline);
     range(kSize * kSize, i => pass.draw(1, 1, i));
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.expectSingleColor(renderTarget, 'rgba8unorm', {
       size: [kSize, kSize, 1],
@@ -330,7 +330,7 @@ call which draws multiple vertices for each fragment of a large output texture.`
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
@@ -340,7 +340,7 @@ call which draws multiple vertices for each fragment of a large output texture.`
     const pass = encoder.beginRenderPass(renderPassDescriptor);
     pass.setPipeline(pipeline);
     pass.draw(kSize * kSize);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.expectSingleColor(renderTarget, 'rgba8unorm', {
       size: [kTextureSize, kTextureSize, 1],

--- a/src/stress/render/vertex_buffers.spec.ts
+++ b/src/stress/render/vertex_buffers.spec.ts
@@ -45,7 +45,7 @@ function createHugeVertexBuffer(t: GPUTest, size: number) {
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, bindGroup);
   pass.dispatch(size);
-  pass.endPass();
+  pass.end();
 
   const vertexBuffer = t.device.createBuffer({
     size: kBufferSize,
@@ -108,7 +108,7 @@ g.test('many')
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
@@ -119,7 +119,7 @@ g.test('many')
     pass.setPipeline(pipeline);
     pass.setVertexBuffer(0, buffer);
     pass.draw(kSize * kSize);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.expectSingleColor(renderTarget, 'rgba8unorm', {
       size: [kSize, kSize, 1],

--- a/src/stress/shaders/entry_points.spec.ts
+++ b/src/stress/shaders/entry_points.spec.ts
@@ -70,7 +70,7 @@ a shader, in which case this would become a validation test instead.`
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
       pass.dispatch(1);
-      pass.endPass();
+      pass.end();
     });
 
     t.device.queue.submit([encoder.finish()]);

--- a/src/stress/shaders/non_halting.spec.ts
+++ b/src/stress/shaders/non_halting.spec.ts
@@ -41,7 +41,7 @@ device loss.`
     });
     pass.setBindGroup(0, bindGroup);
     pass.dispatch(1);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     await t.device.lost;
   });
@@ -103,7 +103,8 @@ device loss.`
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -111,7 +112,7 @@ device loss.`
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.draw(1);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     await t.device.lost;
   });
@@ -173,7 +174,8 @@ device loss.`
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -181,7 +183,7 @@ device loss.`
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.draw(1);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     await t.device.lost;
   });

--- a/src/stress/shaders/slow.spec.ts
+++ b/src/stress/shaders/slow.spec.ts
@@ -38,7 +38,7 @@ g.test('compute')
     });
     pass.setBindGroup(0, bindGroup);
     pass.dispatch(kDispatchSize);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.expectGPUBufferValuesEqual(buffer, new Uint32Array(new Array(kDispatchSize).fill(1000000)));
   });
@@ -95,7 +95,8 @@ g.test('vertex')
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -103,7 +104,7 @@ g.test('vertex')
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.draw(1);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.expectSinglePixelIn2DTexture(
       renderTarget,
@@ -167,7 +168,8 @@ g.test('fragment')
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -175,7 +177,7 @@ g.test('fragment')
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.draw(1);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.expectSinglePixelIn2DTexture(
       renderTarget,

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -446,16 +446,17 @@ class F extends GPUTest {
             baseMipLevel: srcCopyLevel,
             mipLevelCount: 1,
           }),
-          depthLoadValue: 0.0,
+          depthClearValue: 0.0,
+          depthLoadOp: 'clear',
           depthStoreOp: 'store',
-          stencilLoadValue: 'load',
+          stencilLoadOp: 'load',
           stencilStoreOp: 'store',
         },
       });
       renderPass.setBindGroup(0, bindGroup, [srcCopyLayer * kMinDynamicBufferOffsetAlignment]);
       renderPass.setPipeline(renderPipeline);
       renderPass.draw(6);
-      renderPass.endPass();
+      renderPass.end();
     }
     this.queue.submit([encoder.finish()]);
   }
@@ -493,7 +494,8 @@ class F extends GPUTest {
               baseArrayLayer: dstCopyLayer,
               arrayLayerCount: 1,
             }),
-            loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+            clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+            loadOp: 'clear',
             storeOp: 'store',
           },
         ],
@@ -504,16 +506,16 @@ class F extends GPUTest {
             baseMipLevel: dstCopyLevel,
             mipLevelCount: 1,
           }),
-          depthLoadValue: 'load',
+          depthLoadOp: 'load',
           depthStoreOp: 'store',
-          stencilLoadValue: 'load',
+          stencilLoadOp: 'load',
           stencilStoreOp: 'store',
         },
       });
       renderPass.setBindGroup(0, bindGroup, [dstCopyLayer * kMinDynamicBufferOffsetAlignment]);
       renderPass.setPipeline(renderPipeline);
       renderPass.draw(6);
-      renderPass.endPass();
+      renderPass.end();
     }
     this.queue.submit([encoder.finish()]);
 
@@ -1266,14 +1268,15 @@ g.test('copy_multisampled_color')
       colorAttachments: [
         {
           view: sourceTexture.createView(),
-          loadValue: [1.0, 0.0, 0.0, 1.0],
+          clearValue: [1.0, 0.0, 0.0, 1.0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
     });
     renderPassForInit.setPipeline(renderPipelineForInit);
     renderPassForInit.draw(3);
-    renderPassForInit.endPass();
+    renderPassForInit.end();
     t.queue.submit([initEncoder.finish()]);
 
     // Do the texture-to-texture copy
@@ -1357,7 +1360,8 @@ g.test('copy_multisampled_color')
       colorAttachments: [
         {
           view: expectedOutputTexture.createView(),
-          loadValue: [1.0, 0.0, 0.0, 1.0],
+          clearValue: [1.0, 0.0, 0.0, 1.0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -1365,7 +1369,7 @@ g.test('copy_multisampled_color')
     renderPassForValidation.setPipeline(renderPipelineForValidation);
     renderPassForValidation.setBindGroup(0, bindGroup);
     renderPassForValidation.draw(6);
-    renderPassForValidation.endPass();
+    renderPassForValidation.end();
     t.queue.submit([validationEncoder.finish()]);
 
     t.expectSingleColor(expectedOutputTexture, 'rgba8unorm', {
@@ -1440,15 +1444,17 @@ g.test('copy_multisampled_depth')
       colorAttachments: [],
       depthStencilAttachment: {
         view: sourceTexture.createView(),
-        depthLoadValue: 0.0,
+        depthClearValue: 0.0,
+        depthLoadOp: 'clear',
         depthStoreOp: 'store',
-        stencilLoadValue: 0,
+        stencilClearValue: 0,
+        stencilLoadOp: 'clear',
         stencilStoreOp: 'store',
       },
     });
     renderPassForInit.setPipeline(renderPipelineForInit);
     renderPassForInit.draw(6);
-    renderPassForInit.endPass();
+    renderPassForInit.end();
     t.queue.submit([encoderForInit.finish()]);
 
     // Do the texture-to-texture copy
@@ -1506,22 +1512,24 @@ g.test('copy_multisampled_depth')
       colorAttachments: [
         {
           view: multisampledColorTexture.createView(),
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'discard',
           resolveTarget: colorTextureAsResolveTarget.createView(),
         },
       ],
       depthStencilAttachment: {
         view: destinationTexture.createView(),
-        depthLoadValue: 'load',
+        depthLoadOp: 'load',
         depthStoreOp: 'store',
-        stencilLoadValue: 0,
+        stencilClearValue: 0,
+        stencilLoadOp: 'clear',
         stencilStoreOp: 'store',
       },
     });
     renderPassForVerify.setPipeline(renderPipelineForVerify);
     renderPassForVerify.draw(6);
-    renderPassForVerify.endPass();
+    renderPassForVerify.end();
     t.queue.submit([encoderForVerify.finish()]);
 
     t.expectSingleColor(colorTextureAsResolveTarget, kColorFormat, {

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -909,7 +909,8 @@ class ImageCopyTest extends GPUTest {
         colorAttachments: [
           {
             view: outputTexture.createView(),
-            loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+            clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+            loadOp: 'clear',
             storeOp: 'store',
           },
         ],
@@ -920,9 +921,9 @@ class ImageCopyTest extends GPUTest {
             baseArrayLayer: stencilTextureLayer,
             arrayLayerCount: 1,
           }),
-          stencilLoadValue: 'load',
+          stencilLoadOp: 'load',
           stencilStoreOp: 'store',
-          depthLoadValue: 0,
+          depthClearValue: 0,
           depthStoreOp: 'store',
         },
       });
@@ -938,7 +939,7 @@ class ImageCopyTest extends GPUTest {
         renderPass.setBindGroup(0, bindGroup, [stencilBitIndex * kMinDynamicBufferOffsetAlignment]);
         renderPass.draw(6);
       }
-      renderPass.endPass();
+      renderPass.end();
 
       // Check outputTexture by copying the content of outputTexture into outputStagingBuffer and
       // checking all the data in outputStagingBuffer.
@@ -1054,9 +1055,9 @@ class ImageCopyTest extends GPUTest {
             baseMipLevel: copyMipLevel,
             mipLevelCount: 1,
           }),
-          depthLoadValue: 0.0,
+          depthClearValue: 0.0,
           depthStoreOp: 'store',
-          stencilLoadValue: 'load',
+          stencilLoadOp: 'load',
           stencilStoreOp: 'store',
         },
       });
@@ -1078,7 +1079,7 @@ class ImageCopyTest extends GPUTest {
       });
       renderPass.setBindGroup(0, bindGroup);
       renderPass.draw(6);
-      renderPass.endPass();
+      renderPass.end();
     }
 
     this.queue.submit([encoder.finish()]);

--- a/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
@@ -139,7 +139,8 @@ g.test('set_index_buffer_without_changing_buffer')
       colorAttachments: [
         {
           view: outputTexture.createView(),
-          loadValue: [0, 0, 0, 1],
+          clearValue: [0, 0, 0, 1],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -165,7 +166,7 @@ g.test('set_index_buffer_without_changing_buffer')
     renderPass.setIndexBuffer(indexBuffer, 'uint16', 6, 4);
     renderPass.drawIndexed(2);
 
-    renderPass.endPass();
+    renderPass.end();
     t.queue.submit([encoder.finish()]);
 
     for (let i = 0; i < kPositions.length - 1; ++i) {
@@ -233,7 +234,8 @@ g.test('set_vertex_buffer_without_changing_buffer')
       colorAttachments: [
         {
           view: outputTexture.createView(),
-          loadValue: [0, 0, 0, 1],
+          clearValue: [0, 0, 0, 1],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -269,7 +271,7 @@ g.test('set_vertex_buffer_without_changing_buffer')
     );
     renderPass.draw(4);
 
-    renderPass.endPass();
+    renderPass.end();
     t.queue.submit([encoder.finish()]);
 
     for (let i = 0; i < kPositions.length; ++i) {
@@ -335,7 +337,8 @@ g.test('change_pipeline_before_and_after_vertex_buffer')
       colorAttachments: [
         {
           view: outputTexture.createView(),
-          loadValue: [0, 0, 0, 1],
+          clearValue: [0, 0, 0, 1],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -354,7 +357,7 @@ g.test('change_pipeline_before_and_after_vertex_buffer')
     renderPass.setPipeline(renderPipeline1);
     renderPass.draw(2);
 
-    renderPass.endPass();
+    renderPass.end();
 
     t.queue.submit([encoder.finish()]);
 
@@ -509,7 +512,8 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
       colorAttachments: [
         {
           view: outputTexture.createView(),
-          loadValue: [0, 0, 0, 1],
+          clearValue: [0, 0, 0, 1],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -523,7 +527,7 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
     renderPass.setPipeline(renderPipeline2);
     renderPass.draw(2);
 
-    renderPass.endPass();
+    renderPass.end();
 
     t.queue.submit([encoder.finish()]);
 
@@ -593,7 +597,8 @@ g.test('set_index_buffer_before_non_indexed_draw')
       colorAttachments: [
         {
           view: outputTexture.createView(),
-          loadValue: [0, 0, 0, 1],
+          clearValue: [0, 0, 0, 1],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -608,7 +613,7 @@ g.test('set_index_buffer_before_non_indexed_draw')
     // The second draw call is a non-indexed one (the first and second color are involved)
     renderPass.draw(2);
 
-    renderPass.endPass();
+    renderPass.end();
 
     t.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -59,7 +59,7 @@ g.test('memcpy').fn(async t => {
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, bg);
   pass.dispatch(1);
-  pass.endPass();
+  pass.end();
   t.device.queue.submit([encoder.finish()]);
 
   t.expectGPUBufferValuesEqual(dst, data);
@@ -149,7 +149,7 @@ g.test('large_dispatch')
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bg);
     pass.dispatch(dims[0], dims[1], dims[2]);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     t.expectGPUBufferValuesPassCheck(dst, a => checkElementsEqualGenerated(a, i => val), {

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -126,7 +126,8 @@ export class BufferSyncTest extends GPUTest {
       colorAttachments: [
         {
           view,
-          loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -152,7 +153,7 @@ export class BufferSyncTest extends GPUTest {
     renderer.draw(1, 1, 0, 0);
 
     if (inBundle) pass.executeBundles([(renderer as GPURenderBundleEncoder).finish()]);
-    pass.endPass();
+    pass.end();
   }
 
   // Write buffer via dispatch call in compute pass.
@@ -167,7 +168,7 @@ export class BufferSyncTest extends GPUTest {
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.dispatch(1);
-    pass.endPass();
+    pass.end();
   }
 
   /** Write buffer via BufferToBuffer copy. */

--- a/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/ww.spec.ts
@@ -109,7 +109,7 @@ g.test('two_draws_in_the_same_render_pass')
         passEncoder.executeBundles([(renderEncoder as GPURenderBundleEncoder).finish()]);
     }
 
-    passEncoder.endPass();
+    passEncoder.end();
     t.device.queue.submit([encoder.finish()]);
     t.verifyDataTwoValidValues(buffer, 1, 2);
   });
@@ -137,7 +137,7 @@ g.test('two_draws_in_the_same_render_bundle')
     }
 
     passEncoder.executeBundles([renderEncoder.finish()]);
-    passEncoder.endPass();
+    passEncoder.end();
     t.device.queue.submit([encoder.finish()]);
     t.verifyDataTwoValidValues(buffer, 1, 2);
   });
@@ -161,7 +161,7 @@ g.test('two_dispatches_in_the_same_compute_pass')
       pass.dispatch(1);
     }
 
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.verifyData(buffer, 2);
   });

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -133,7 +133,8 @@ g.test('render_pass_resolve')
         // will be white and the bottom right half will be black.
         renderPassColorAttachments.push({
           view: colorAttachment.createView(),
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          loadOp: 'clear',
           storeOp: t.params.storeOperation,
           resolveTarget: resolveTarget.createView({
             baseMipLevel: t.params.resolveTargetBaseMipLevel,
@@ -145,7 +146,8 @@ g.test('render_pass_resolve')
       } else {
         renderPassColorAttachments.push({
           view: colorAttachment.createView(),
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          loadOp: 'clear',
           storeOp: t.params.storeOperation,
         });
       }
@@ -158,7 +160,7 @@ g.test('render_pass_resolve')
     });
     pass.setPipeline(pipeline);
     pass.draw(3);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     // Verify the resolve targets contain the correct values.

--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -89,19 +89,22 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
       colorAttachments: [
         {
           view: colorAttachmentView,
-          loadValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: t.params.colorStoreOperation,
         },
       ],
       depthStencilAttachment: {
         view: depthStencilAttachment.createView(),
-        depthLoadValue: 1.0,
+        depthClearValue: 1.0,
+        depthLoadOp: 'clear',
         depthStoreOp: t.params.depthStencilStoreOperation,
-        stencilLoadValue: 1.0,
+        stencilClearValue: 1.0,
+        stencilLoadOp: 'clear',
         stencilStoreOp: t.params.depthStencilStoreOperation,
       },
     });
-    pass.endPass();
+    pass.end();
 
     t.device.queue.submit([encoder.finish()]);
 
@@ -176,12 +179,13 @@ g.test('render_pass_store_op,color_attachment_only')
       colorAttachments: [
         {
           view: colorAttachmentView,
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: t.params.storeOperation,
         },
       ],
     });
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     // Check that the correct store operation occurred.
@@ -232,7 +236,8 @@ g.test('render_pass_store_op,multiple_color_attachments')
     for (let i = 0; i < t.params.colorAttachments; i++) {
       renderPassColorAttachments.push({
         view: colorAttachments[i].createView(),
-        loadValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
+        clearValue: { r: 1.0, g: 1.0, b: 1.0, a: 1.0 },
+        loadOp: 'clear',
         storeOp: i % 2 === 0 ? t.params.storeOperation1 : t.params.storeOperation2,
       });
     }
@@ -241,7 +246,7 @@ g.test('render_pass_store_op,multiple_color_attachments')
     const pass = encoder.beginRenderPass({
       colorAttachments: renderPassColorAttachments,
     });
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     // Check that the correct store operation occurred.
@@ -304,13 +309,15 @@ TODO: Also test unsized depth/stencil formats [1]
       colorAttachments: [],
       depthStencilAttachment: {
         view: depthStencilAttachmentView,
-        depthLoadValue: 1.0,
+        depthClearValue: 1.0,
+        depthLoadOp: 'clear',
         depthStoreOp: t.params.storeOperation,
-        stencilLoadValue: 1.0,
+        stencilClearValue: 1.0,
+        stencilLoadOp: 'clear',
         stencilStoreOp: t.params.storeOperation,
       },
     });
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     let expectedValue: PerTexelComponent<number> = {};

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -64,13 +64,14 @@ TODO: needs review and rename
         {
           view: renderTexture.createView(),
           storeOp: t.params.storeOp,
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          loadOp: 'clear',
         },
       ],
     });
     pass.setPipeline(renderPipeline);
     pass.draw(3);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     // expect the buffer to be clear

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -83,16 +83,19 @@ TODO: check the contents of the depth and stencil outputs [2]
       colorAttachments: [
         {
           view: texture.createView(),
-          loadValue: { r: 0.0, g: 0.0, b: 1.0, a: 1.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 1.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
       depthStencilAttachment: depthTexture
         ? {
             view: depthTexture.createView(),
-            depthLoadValue: 1.0,
+            depthClearValue: 1.0,
+            depthLoadOp: 'clear',
             depthStoreOp: 'store',
-            stencilLoadValue: 0,
+            stencilClearValue: 0,
+            stencilLoadOp: 'clear',
             stencilStoreOp: 'store',
           }
         : undefined,
@@ -151,7 +154,7 @@ TODO: check the contents of the depth and stencil outputs [2]
     );
 
     pass.draw(6, 1, 0, 0);
-    pass.endPass();
+    pass.end();
 
     t.device.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -128,13 +128,14 @@ g.test('color,component_count')
         {
           view: renderTarget.createView(),
           storeOp: 'store',
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
         },
       ],
     });
     pass.setPipeline(pipeline);
     pass.draw(3);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     t.expectSingleColor(renderTarget, format, {
@@ -354,13 +355,14 @@ The attachment has a load value of [1, 0, 0, 1]
         {
           view: renderTarget.createView(),
           storeOp: 'store',
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
         },
       ],
     });
     pass.setPipeline(pipeline);
     pass.draw(3);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     t.expectSingleColor(renderTarget, format, {

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -311,7 +311,8 @@ class PrimitiveTopologyTest extends GPUTest {
       colorAttachments: [
         {
           view: colorAttachment.createView(),
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -407,7 +408,7 @@ class PrimitiveTopologyTest extends GPUTest {
       }
     }
 
-    renderPass.endPass();
+    renderPass.end();
 
     this.device.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -27,12 +27,13 @@ g.test('clear').fn(async t => {
     colorAttachments: [
       {
         view: colorAttachmentView,
-        loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+        clearValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+        loadOp: 'clear',
         storeOp: 'store',
       },
     ],
   });
-  pass.endPass();
+  pass.end();
   encoder.copyTextureToBuffer(
     { texture: colorAttachment, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
     { buffer: dst, bytesPerRow: 256 },
@@ -93,13 +94,14 @@ g.test('fullscreen_quad').fn(async t => {
       {
         view: colorAttachmentView,
         storeOp: 'store',
-        loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        loadOp: 'clear',
       },
     ],
   });
   pass.setPipeline(pipeline);
   pass.draw(3);
-  pass.endPass();
+  pass.end();
   encoder.copyTextureToBuffer(
     { texture: colorAttachment, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
     { buffer: dst, bytesPerRow: 256 },
@@ -261,7 +263,8 @@ g.test('large_draw')
           {
             view: colorAttachmentView,
             storeOp: 'store',
-            loadValue: { r: 0.0, g: 0.0, b: 1.0, a: 1.0 },
+            clearValue: { r: 0.0, g: 0.0, b: 1.0, a: 1.0 },
+            loadOp: 'clear',
           },
         ],
       });
@@ -286,7 +289,7 @@ g.test('large_draw')
           pass.draw(numVertices, numInstances);
         }
       }
-      pass.endPass();
+      pass.end();
       encoder.copyTextureToBuffer(
         { texture: colorAttachment, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
         { buffer: dst, bytesPerRow: kBytesPerRow },

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -217,7 +217,8 @@ struct Uniform {
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: dstColor,
+          clearValue: dstColor,
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -244,7 +245,7 @@ struct Uniform {
       })
     );
     renderPass.draw(1);
-    renderPass.endPass();
+    renderPass.end();
 
     t.device.queue.submit([commandEncoder.finish()]);
 

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -34,34 +34,34 @@ g.test('depth_compare_func')
         kDepthStencilFormats.filter(format => format !== 'stencil8')
       )
       .combineWithParams([
-        { depthCompare: 'never', depthLoadValue: 1.0, _expected: backgroundColor },
-        { depthCompare: 'never', depthLoadValue: 0.5, _expected: backgroundColor },
-        { depthCompare: 'never', depthLoadValue: 0.0, _expected: backgroundColor },
-        { depthCompare: 'less', depthLoadValue: 1.0, _expected: triangleColor },
-        { depthCompare: 'less', depthLoadValue: 0.5, _expected: backgroundColor },
-        { depthCompare: 'less', depthLoadValue: 0.0, _expected: backgroundColor },
-        { depthCompare: 'less-equal', depthLoadValue: 1.0, _expected: triangleColor },
-        { depthCompare: 'less-equal', depthLoadValue: 0.5, _expected: triangleColor },
-        { depthCompare: 'less-equal', depthLoadValue: 0.0, _expected: backgroundColor },
-        { depthCompare: 'equal', depthLoadValue: 1.0, _expected: backgroundColor },
-        { depthCompare: 'equal', depthLoadValue: 0.5, _expected: triangleColor },
-        { depthCompare: 'equal', depthLoadValue: 0.0, _expected: backgroundColor },
-        { depthCompare: 'not-equal', depthLoadValue: 1.0, _expected: triangleColor },
-        { depthCompare: 'not-equal', depthLoadValue: 0.5, _expected: backgroundColor },
-        { depthCompare: 'not-equal', depthLoadValue: 0.0, _expected: triangleColor },
-        { depthCompare: 'greater-equal', depthLoadValue: 1.0, _expected: backgroundColor },
-        { depthCompare: 'greater-equal', depthLoadValue: 0.5, _expected: triangleColor },
-        { depthCompare: 'greater-equal', depthLoadValue: 0.0, _expected: triangleColor },
-        { depthCompare: 'greater', depthLoadValue: 1.0, _expected: backgroundColor },
-        { depthCompare: 'greater', depthLoadValue: 0.5, _expected: backgroundColor },
-        { depthCompare: 'greater', depthLoadValue: 0.0, _expected: triangleColor },
-        { depthCompare: 'always', depthLoadValue: 1.0, _expected: triangleColor },
-        { depthCompare: 'always', depthLoadValue: 0.5, _expected: triangleColor },
-        { depthCompare: 'always', depthLoadValue: 0.0, _expected: triangleColor },
+        { depthCompare: 'never', depthClearValue: 1.0, _expected: backgroundColor },
+        { depthCompare: 'never', depthClearValue: 0.5, _expected: backgroundColor },
+        { depthCompare: 'never', depthClearValue: 0.0, _expected: backgroundColor },
+        { depthCompare: 'less', depthClearValue: 1.0, _expected: triangleColor },
+        { depthCompare: 'less', depthClearValue: 0.5, _expected: backgroundColor },
+        { depthCompare: 'less', depthClearValue: 0.0, _expected: backgroundColor },
+        { depthCompare: 'less-equal', depthClearValue: 1.0, _expected: triangleColor },
+        { depthCompare: 'less-equal', depthClearValue: 0.5, _expected: triangleColor },
+        { depthCompare: 'less-equal', depthClearValue: 0.0, _expected: backgroundColor },
+        { depthCompare: 'equal', depthClearValue: 1.0, _expected: backgroundColor },
+        { depthCompare: 'equal', depthClearValue: 0.5, _expected: triangleColor },
+        { depthCompare: 'equal', depthClearValue: 0.0, _expected: backgroundColor },
+        { depthCompare: 'not-equal', depthClearValue: 1.0, _expected: triangleColor },
+        { depthCompare: 'not-equal', depthClearValue: 0.5, _expected: backgroundColor },
+        { depthCompare: 'not-equal', depthClearValue: 0.0, _expected: triangleColor },
+        { depthCompare: 'greater-equal', depthClearValue: 1.0, _expected: backgroundColor },
+        { depthCompare: 'greater-equal', depthClearValue: 0.5, _expected: triangleColor },
+        { depthCompare: 'greater-equal', depthClearValue: 0.0, _expected: triangleColor },
+        { depthCompare: 'greater', depthClearValue: 1.0, _expected: backgroundColor },
+        { depthCompare: 'greater', depthClearValue: 0.5, _expected: backgroundColor },
+        { depthCompare: 'greater', depthClearValue: 0.0, _expected: triangleColor },
+        { depthCompare: 'always', depthClearValue: 1.0, _expected: triangleColor },
+        { depthCompare: 'always', depthClearValue: 0.5, _expected: triangleColor },
+        { depthCompare: 'always', depthClearValue: 0.0, _expected: triangleColor },
       ] as const)
   )
   .fn(async t => {
-    const { depthCompare, depthLoadValue, _expected, format } = t.params;
+    const { depthCompare, depthClearValue, _expected, format } = t.params;
     await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const colorAttachmentFormat = 'rgba8unorm';
@@ -117,21 +117,24 @@ g.test('depth_compare_func')
         {
           view: colorAttachmentView,
           storeOp: 'store',
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
         },
       ],
       depthStencilAttachment: {
         view: depthTextureView,
 
-        depthLoadValue,
+        depthClearValue,
+        depthLoadOp: 'clear',
         depthStoreOp: 'store',
-        stencilLoadValue: 0,
+        stencilClearValue: 0,
+        stencilLoadOp: 'clear',
         stencilStoreOp: 'store',
       },
     });
     pass.setPipeline(pipeline);
     pass.draw(1);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     t.expectSinglePixelIn2DTexture(
@@ -229,21 +232,24 @@ g.test('reverse_depth')
         {
           view: colorAttachmentView,
           storeOp: 'store',
-          loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+          clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+          loadOp: 'clear',
         },
       ],
       depthStencilAttachment: {
         view: depthTextureView,
 
-        depthLoadValue: t.params.reversed ? 0.0 : 1.0,
+        depthClearValue: t.params.reversed ? 0.0 : 1.0,
+        depthLoadOp: 'clear',
         depthStoreOp: 'store',
-        stencilLoadValue: 0,
+        stencilClearValue: 0,
+        stencilLoadOp: 'clear',
         stencilStoreOp: 'store',
       },
     });
     pass.setPipeline(pipeline);
     pass.draw(1, 4);
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
 
     t.expectSinglePixelIn2DTexture(

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -255,9 +255,11 @@ have unexpected values then get drawn to the color buffer, which is later checke
         colorAttachments: [],
         depthStencilAttachment: {
           view: dsTextureView,
-          depthLoadValue: 0.5, // Will see this depth value if the fragment was clipped.
+          depthClearValue: 0.5, // Will see this depth value if the fragment was clipped.
+          depthLoadOp: 'clear',
           depthStoreOp: 'store',
-          stencilLoadValue: 0,
+          stencilClearValue: 0,
+          stencilLoadOp: 'clear',
           stencilStoreOp: 'discard',
         },
       });
@@ -265,36 +267,38 @@ have unexpected values then get drawn to the color buffer, which is later checke
       pass.setBindGroup(0, testBindGroup);
       pass.setViewport(0, 0, kNumTestPoints, 1, kViewportMinDepth, kViewportMaxDepth);
       pass.draw(kNumTestPoints);
-      pass.endPass();
+      pass.end();
     }
     if (dsActual) {
       enc.copyTextureToBuffer({ texture: dsTexture }, { buffer: dsActual }, [kNumTestPoints]);
     }
     {
-      const loadValue = [0, 0, 0, 0]; // Will see this color if the check passed.
+      const clearValue = [0, 0, 0, 0]; // Will see this color if the check passed.
       const pass = enc.beginRenderPass({
         colorAttachments: [
           checkTextureMSView
             ? {
                 view: checkTextureMSView,
                 resolveTarget: checkTextureView,
-                loadValue,
+                clearValue,
+                loadOp: 'clear',
                 storeOp: 'discard',
               }
-            : { view: checkTextureView, loadValue, storeOp: 'store' },
+            : { view: checkTextureView, clearValue, loadOp: 'clear', storeOp: 'store' },
         ],
         depthStencilAttachment: {
           view: dsTextureView,
-          depthLoadValue: 'load',
+          depthLoadOp: 'load',
           depthStoreOp: 'store',
-          stencilLoadValue: 0,
+          stencilClearValue: 0,
+          stencilLoadOp: 'clear',
           stencilStoreOp: 'discard',
         },
       });
       pass.setPipeline(checkPipeline);
       pass.setViewport(0, 0, kNumTestPoints, 1, 0.0, 1.0);
       pass.draw(kNumTestPoints);
-      pass.endPass();
+      pass.end();
     }
     enc.copyTextureToBuffer({ texture: checkTexture }, { buffer: checkBuffer }, [kNumTestPoints]);
     if (dsExpected) {
@@ -466,41 +470,45 @@ to be empty.`
         colorAttachments: [],
         depthStencilAttachment: {
           view: dsTextureView,
-          depthLoadValue: 1.0,
+          depthClearValue: 1.0,
+          depthLoadOp: 'clear',
           depthStoreOp: 'store',
-          stencilLoadValue: 0,
+          stencilClearValue: 0,
+          stencilLoadOp: 'clear',
           stencilStoreOp: 'discard',
         },
       });
       pass.setPipeline(initPipeline);
       pass.draw(kNumDepthValues);
-      pass.endPass();
+      pass.end();
     }
     {
-      const loadValue = [0, 0, 0, 0]; // Will see this color if the test passed.
+      const clearValue = [0, 0, 0, 0]; // Will see this color if the test passed.
       const pass = enc.beginRenderPass({
         colorAttachments: [
           testTextureMSView
             ? {
                 view: testTextureMSView,
                 resolveTarget: testTextureView,
-                loadValue,
+                clearValue,
+                loadOp: 'clear',
                 storeOp: 'discard',
               }
-            : { view: testTextureView, loadValue, storeOp: 'store' },
+            : { view: testTextureView, clearValue, loadOp: 'clear', storeOp: 'store' },
         ],
         depthStencilAttachment: {
           view: dsTextureView,
-          depthLoadValue: 'load',
+          depthLoadOp: 'load',
           depthStoreOp: 'store',
-          stencilLoadValue: 0,
+          stencilClearValue: 0,
+          stencilLoadOp: 'clear',
           stencilStoreOp: 'discard',
         },
       });
       pass.setPipeline(testPipeline);
       pass.setViewport(0, 0, kNumDepthValues, 1, kViewportMinDepth, kViewportMaxDepth);
       pass.draw(kNumDepthValues);
-      pass.endPass();
+      pass.end();
     }
     enc.copyTextureToBuffer({ texture: testTexture }, { buffer: resultBuffer }, [kNumDepthValues]);
     t.device.queue.submit([enc.finish()]);

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -172,7 +172,8 @@ struct Output {
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -276,7 +277,7 @@ struct Output {
       }
     }
 
-    renderPass.endPass();
+    renderPass.end();
     t.queue.submit([commandEncoder.finish()]);
 
     const green = new Uint8Array([0, 255, 0, 255]);
@@ -617,7 +618,8 @@ ${accumulateVariableAssignmentsInFragmentShader}
               format: 'rgba8unorm',
             })
             .createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -629,7 +631,7 @@ ${accumulateVariableAssignmentsInFragmentShader}
       renderPass.setVertexBuffer(i, vertexBuffers[i]);
     }
     renderPass.draw(vertexCount, instanceCount);
-    renderPass.endPass();
+    renderPass.end();
     t.device.queue.submit([commandEncoder.finish()]);
 
     t.expectGPUBufferValuesEqual(resultBuffer, expectedData);

--- a/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
@@ -215,7 +215,8 @@ Params:
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -229,7 +230,7 @@ Params:
     } else {
       renderPass.drawIndirect(indirectBuffer, indirectOffset);
     }
-    renderPass.endPass();
+    renderPass.end();
     t.queue.submit([commandEncoder.finish()]);
 
     // The bottom left area is filled

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -83,7 +83,7 @@ class F extends GPUTest {
     computePass.setBindGroup(0, bindGroup);
     computePass.setPipeline(computePipeline);
     computePass.dispatch(1);
-    computePass.endPass();
+    computePass.end();
     this.queue.submit([encoder.finish()]);
 
     this.CheckBufferAndOutputTexture(buffer, boundBufferSize + bufferOffset, outputTexture);
@@ -134,12 +134,13 @@ class F extends GPUTest {
       colorAttachments: [
         {
           view: texture.createView(),
-          loadValue: color,
+          clearValue: color,
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
     });
-    renderPass.endPass();
+    renderPass.end();
   }
 
   CheckBufferAndOutputTexture(
@@ -457,12 +458,13 @@ remaining part of it will be initialized to 0.`
               arrayLayerCount: 1,
               baseMipLevel: copyMipLevel,
             }),
-            loadValue: { r: layer + 1, g: 0, b: 0, a: 0 },
+            clearValue: { r: layer + 1, g: 0, b: 0, a: 0 },
+            loadOp: 'clear',
             storeOp: 'store',
           },
         ],
       });
-      renderPass.endPass();
+      renderPass.end();
     }
 
     // Do texture-to-buffer copy
@@ -641,7 +643,8 @@ g.test('vertex_buffer')
       colorAttachments: [
         {
           view: outputTexture.createView(),
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -649,7 +652,7 @@ g.test('vertex_buffer')
     renderPass.setVertexBuffer(0, vertexBuffer, bufferOffset);
     renderPass.setPipeline(renderPipeline);
     renderPass.draw(1);
-    renderPass.endPass();
+    renderPass.end();
     t.queue.submit([encoder.finish()]);
 
     t.CheckBufferAndOutputTexture(vertexBuffer, bufferSize, outputTexture);
@@ -705,7 +708,8 @@ GPUBuffer, all the contents in that GPUBuffer have been initialized to 0.`
       colorAttachments: [
         {
           view: outputTexture.createView(),
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -713,7 +717,7 @@ GPUBuffer, all the contents in that GPUBuffer have been initialized to 0.`
     renderPass.setPipeline(renderPipeline);
     renderPass.setIndexBuffer(indexBuffer, 'uint16', bufferOffset, 4);
     renderPass.drawIndexed(1);
-    renderPass.endPass();
+    renderPass.end();
     t.queue.submit([encoder.finish()]);
 
     t.CheckBufferAndOutputTexture(indexBuffer, bufferSize, outputTexture);
@@ -772,7 +776,7 @@ have been initialized to 0.`
       colorAttachments: [
         {
           view: outputTexture.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
@@ -791,7 +795,7 @@ have been initialized to 0.`
       renderPass.drawIndirect(indirectBuffer, bufferOffset);
     }
 
-    renderPass.endPass();
+    renderPass.end();
     t.queue.submit([encoder.finish()]);
 
     // The indirect buffer should be lazily cleared to 0, so we actually draw nothing and the color
@@ -858,7 +862,7 @@ creation of that GPUBuffer, all the contents in that GPUBuffer have been initial
     computePass.setBindGroup(0, bindGroup);
     computePass.setPipeline(computePipeline);
     computePass.dispatchIndirect(indirectBuffer, bufferOffset);
-    computePass.endPass();
+    computePass.end();
     t.queue.submit([encoder.finish()]);
 
     // The indirect buffer should be lazily cleared to 0, so we actually draw nothing and the color

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -135,16 +135,17 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
         {
           view: renderTexture.createView(),
           resolveTarget,
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
       depthStencilAttachment: {
         view: texture.createView(viewDescriptor),
         depthStoreOp: 'store',
-        depthLoadValue: 'load',
+        depthLoadOp: 'load',
         stencilStoreOp: 'store',
-        stencilLoadValue: 'load',
+        stencilLoadOp: 'load',
       },
     });
 
@@ -170,7 +171,7 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
     }
 
     pass.draw(3);
-    pass.endPass();
+    pass.end();
 
     t.queue.submit([commandEncoder.finish()]);
 

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -131,7 +131,7 @@ export const checkContentsBySampling: CheckContents = (
       pass.setPipeline(computePipeline);
       pass.setBindGroup(0, bindGroup);
       pass.dispatch(width, height, depth);
-      pass.endPass();
+      pass.end();
       t.queue.submit([commandEncoder.finish()]);
       ubo.destroy();
 

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -309,11 +309,12 @@ export class TextureZeroInitTest extends GPUTest {
               {
                 view: texture.createView(viewDescriptor),
                 storeOp: 'store',
-                loadValue: initializedStateAsColor(state, this.p.format),
+                clearValue: initializedStateAsColor(state, this.p.format),
+                loadOp: 'clear',
               },
             ],
           })
-          .endPass();
+          .end();
       } else {
         commandEncoder
           .beginRenderPass({
@@ -321,12 +322,14 @@ export class TextureZeroInitTest extends GPUTest {
             depthStencilAttachment: {
               view: texture.createView(viewDescriptor),
               depthStoreOp: 'store',
-              depthLoadValue: initializedStateAsDepth[state],
+              depthClearValue: initializedStateAsDepth[state],
+              depthLoadOp: 'clear',
               stencilStoreOp: 'store',
-              stencilLoadValue: initializedStateAsStencil[state],
+              stencilClearValue: initializedStateAsStencil[state],
+              stencilLoadOp: 'clear',
             },
           })
-          .endPass();
+          .end();
       }
     }
     this.queue.submit([commandEncoder.finish()]);
@@ -411,11 +414,11 @@ export class TextureZeroInitTest extends GPUTest {
               {
                 view: texture.createView(desc),
                 storeOp: 'discard',
-                loadValue: 'load',
+                loadOp: 'load',
               },
             ],
           })
-          .endPass();
+          .end();
       } else {
         commandEncoder
           .beginRenderPass({
@@ -423,12 +426,12 @@ export class TextureZeroInitTest extends GPUTest {
             depthStencilAttachment: {
               view: texture.createView(desc),
               depthStoreOp: 'discard',
-              depthLoadValue: 'load',
+              depthLoadOp: 'load',
               stencilStoreOp: 'discard',
-              stencilLoadValue: 'load',
+              stencilLoadOp: 'load',
             },
           })
-          .endPass();
+          .end();
       }
     }
     this.queue.submit([commandEncoder.finish()]);

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -143,14 +143,15 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
         {
           view: colorAttachmentView,
           storeOp: 'store',
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
         },
       ],
     });
     pass.setPipeline(this.pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.draw(6);
-    pass.endPass();
+    pass.end();
     this.device.queue.submit([encoder.finish()]);
 
     return colorAttachment;

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -284,7 +284,8 @@ struct VSOutputs {
       colorAttachments: [
         {
           view: testTexture.createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -296,7 +297,7 @@ struct VSOutputs {
       pass.setVertexBuffer(buffer.slot, buffer.buffer, buffer.vbOffset ?? 0);
     }
     pass.draw(vertexCount, instanceCount);
-    pass.endPass();
+    pass.end();
 
     this.device.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -133,13 +133,18 @@ class IndexFormatTest extends GPUTest {
     const encoder = this.device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
       colorAttachments: [
-        { view: colorAttachment.createView(), loadValue: [0, 0, 0, 0], storeOp: 'store' },
+        {
+          view: colorAttachment.createView(),
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
       ],
     });
     pass.setPipeline(pipeline);
     pass.setIndexBuffer(indexBuffer, indexFormat, indexOffset);
     pass.drawIndexed(indexCount);
-    pass.endPass();
+    pass.end();
     encoder.copyTextureToBuffer(
       { texture: colorAttachment },
       { buffer: result, bytesPerRow, rowsPerImage },

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -43,7 +43,8 @@ class F extends ValidationTest {
   ): GPURenderPassColorAttachment {
     return {
       view: this.createAttachmentTextureView(format, sampleCount),
-      loadValue: [0, 0, 0, 0],
+      clearValue: [0, 0, 0, 0],
+      loadOp: 'clear',
       storeOp: 'store',
     };
   }
@@ -54,9 +55,9 @@ class F extends ValidationTest {
   ): GPURenderPassDepthStencilAttachment {
     return {
       view: this.createAttachmentTextureView(format, sampleCount),
-      depthLoadValue: 0,
+      depthClearValue: 0,
       depthStoreOp: 'discard',
-      stencilLoadValue: 1,
+      stencilClearValue: 1,
       stencilStoreOp: 'discard',
     };
   }
@@ -116,7 +117,7 @@ g.test('render_pass_and_bundle,color_format')
       colorAttachments: [t.createColorAttachment(passFormat)],
     });
     pass.executeBundles([bundle]);
-    pass.endPass();
+    pass.end();
     validateFinishAndSubmit(passFormat === bundleFormat, true);
   });
 
@@ -145,7 +146,7 @@ g.test('render_pass_and_bundle,color_count')
       colorAttachments: range(passCount, () => t.createColorAttachment('rgba8unorm')),
     });
     pass.executeBundles([bundle]);
-    pass.endPass();
+    pass.end();
     validateFinishAndSubmit(passCount === bundleCount, true);
   });
 
@@ -173,7 +174,7 @@ g.test('render_pass_and_bundle,depth_format')
         passFormat !== undefined ? t.createDepthAttachment(passFormat) : undefined,
     });
     pass.executeBundles([bundle]);
-    pass.endPass();
+    pass.end();
     validateFinishAndSubmit(passFormat === bundleFormat, true);
   });
 
@@ -196,7 +197,7 @@ g.test('render_pass_and_bundle,sample_count')
       colorAttachments: [t.createColorAttachment('rgba8unorm', renderSampleCount)],
     });
     pass.executeBundles([bundle]);
-    pass.endPass();
+    pass.end();
     validateFinishAndSubmit(renderSampleCount === bundleSampleCount, true);
   });
 

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -87,19 +87,21 @@ g.test('color_attachments,device_mismatch')
       colorAttachments: [
         {
           view: view0Texture.createView(),
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
           resolveTarget: target0Texture.createView(),
         },
         {
           view: view1Texture.createView(),
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
           resolveTarget: target1Texture.createView(),
         },
       ],
     });
-    pass.endPass();
+    pass.end();
 
     encoder.validateFinish(!mismatched);
   });
@@ -131,13 +133,15 @@ g.test('depth_stencil_attachment,device_mismatch')
       colorAttachments: [],
       depthStencilAttachment: {
         view: depthStencilTexture.createView(),
-        depthLoadValue: 0,
+        depthClearValue: 0,
+        depthLoadOp: 'clear',
         depthStoreOp: 'store',
-        stencilLoadValue: 0,
+        stencilClearValue: 0,
+        stencilLoadOp: 'clear',
         stencilStoreOp: 'store',
       },
     });
-    pass.endPass();
+    pass.end();
 
     encoder.validateFinish(!mismatched);
   });

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -49,7 +49,8 @@ class F extends ValidationTest {
       colorAttachments: [
         {
           view: colorAttachment.createView(),
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -72,7 +73,7 @@ class F extends ValidationTest {
     pass.setPipeline(pipeline);
     pass.setIndexBuffer(indexBuffer, 'uint32');
     pass.drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
-    pass.endPass();
+    pass.end();
 
     if (isSuccess) {
       this.device.queue.submit([encoder.finish()]);

--- a/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
@@ -58,13 +58,13 @@ class F extends ValidationTest {
       colorAttachments: [
         {
           view: attachment.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
     });
     pass.setViewport(v.x, v.y, v.w, v.h, v.minDepth, v.maxDepth);
-    pass.endPass();
+    pass.end();
 
     this.expectValidationError(() => {
       encoder.finish();
@@ -87,7 +87,7 @@ class F extends ValidationTest {
       colorAttachments: [
         {
           view: attachment.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
@@ -98,7 +98,7 @@ class F extends ValidationTest {
       });
     } else {
       pass.setScissorRect(s.x, s.y, s.w, s.h);
-      pass.endPass();
+      pass.end();
 
       this.expectValidationError(() => {
         encoder.finish();
@@ -118,7 +118,7 @@ class F extends ValidationTest {
       colorAttachments: [
         {
           view: attachment.createView(),
-          loadValue: 'load',
+          loadOp: 'load',
           storeOp: 'store',
         },
       ],
@@ -298,7 +298,7 @@ g.test('setBlendConstant')
     const { r, g, b, a } = t.params;
     const encoders = t.createDummyRenderPassEncoder();
     encoders.pass.setBlendConstant({ r, g, b, a });
-    encoders.pass.endPass();
+    encoders.pass.end();
     encoders.encoder.finish();
   });
 
@@ -314,6 +314,6 @@ g.test('setStencilReference')
     const { value } = t.params;
     const encoders = t.createDummyRenderPassEncoder();
     encoders.pass.setStencilReference(value);
-    encoders.pass.endPass();
+    encoders.pass.end();
     encoders.encoder.finish();
   });

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -64,7 +64,8 @@ class F extends ValidationTest {
       colorAttachments: [
         {
           view: attachmentTexture.createView(),
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -108,7 +109,7 @@ g.test('vertex_buffers_inherit_from_previous_pipeline').fn(async t => {
     const renderPass = t.beginRenderPass(commandEncoder);
     renderPass.setPipeline(pipeline1);
     renderPass.draw(3);
-    renderPass.endPass();
+    renderPass.end();
 
     t.expectValidationError(() => {
       commandEncoder.finish();
@@ -124,7 +125,7 @@ g.test('vertex_buffers_inherit_from_previous_pipeline').fn(async t => {
     renderPass.draw(3);
     renderPass.setPipeline(pipeline1);
     renderPass.draw(3);
-    renderPass.endPass();
+    renderPass.end();
 
     commandEncoder.finish();
   }
@@ -146,14 +147,14 @@ g.test('vertex_buffers_do_not_inherit_between_render_passes').fn(async t => {
       renderPass.setVertexBuffer(0, vertexBuffer1);
       renderPass.setVertexBuffer(1, vertexBuffer2);
       renderPass.draw(3);
-      renderPass.endPass();
+      renderPass.end();
     }
     {
       const renderPass = t.beginRenderPass(commandEncoder);
       renderPass.setPipeline(pipeline1);
       renderPass.setVertexBuffer(0, vertexBuffer1);
       renderPass.draw(3);
-      renderPass.endPass();
+      renderPass.end();
     }
     commandEncoder.finish();
   }
@@ -166,13 +167,13 @@ g.test('vertex_buffers_do_not_inherit_between_render_passes').fn(async t => {
       renderPass.setVertexBuffer(0, vertexBuffer1);
       renderPass.setVertexBuffer(1, vertexBuffer2);
       renderPass.draw(3);
-      renderPass.endPass();
+      renderPass.end();
     }
     {
       const renderPass = t.beginRenderPass(commandEncoder);
       renderPass.setPipeline(pipeline1);
       renderPass.draw(3);
-      renderPass.endPass();
+      renderPass.end();
     }
 
     t.expectValidationError(() => {

--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -4,7 +4,7 @@ TODO:
 - non-pass command, or beginPass, during {render, compute} pass
 - {before (control case), after} finish()
     - x= {finish(), ... all non-pass commands}
-- {before (control case), after} endPass()
+- {before (control case), after} end()
     - x= {render, compute} pass
     - x= {finish(), ... all relevant pass commands}
     - x= {

--- a/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
@@ -101,13 +101,13 @@ Tests that two disjoint occlusion queries cannot be begun with same query index 
     if (t.params.isOnSameRenderPass) {
       pass.beginOcclusionQuery(0);
       pass.endOcclusionQuery();
-      pass.endPass();
+      pass.end();
     } else {
-      pass.endPass();
+      pass.end();
       const otherPass = beginRenderPassWithQuerySet(t, encoder, querySet);
       otherPass.beginOcclusionQuery(0);
       otherPass.endOcclusionQuery();
-      otherPass.endPass();
+      otherPass.end();
     }
 
     t.expectValidationError(() => {

--- a/src/webgpu/api/validation/encoding/queries/common.ts
+++ b/src/webgpu/api/validation/encoding/queries/common.ts
@@ -29,7 +29,8 @@ export function beginRenderPassWithQuerySet(
     colorAttachments: [
       {
         view,
-        loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+        loadOp: 'clear',
         storeOp: 'store',
       },
     ],

--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -131,7 +131,7 @@ Test various validation behaviors when a resolveTarget is provided.
 
           renderPassColorAttachmentDescriptors.push({
             view: resolveSourceColorAttachment.createView(),
-            loadValue: 'load',
+            loadOp: 'load',
             storeOp: 'discard',
             resolveTarget: resolveTarget.createView({
               dimension: resolveTargetViewArrayLayerCount === 1 ? '2d' : '2d-array',
@@ -168,7 +168,7 @@ Test various validation behaviors when a resolveTarget is provided.
 
           renderPassColorAttachmentDescriptors.push({
             view: colorAttachment.createView(),
-            loadValue: 'load',
+            loadOp: 'load',
             storeOp: 'discard',
             resolveTarget: resolveTarget.createView(),
           });
@@ -178,7 +178,7 @@ Test various validation behaviors when a resolveTarget is provided.
       const pass = encoder.beginRenderPass({
         colorAttachments: renderPassColorAttachmentDescriptors,
       });
-      pass.endPass();
+      pass.end();
 
       t.expectValidationError(() => {
         encoder.finish();

--- a/src/webgpu/api/validation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/validation/render_pass/storeOp.spec.ts
@@ -13,7 +13,7 @@ Test Coverage:
 
   - Tests that depthReadOnly and stencilReadOnly default to false.
 
-TODO: test interactions with depthLoadValue too
+TODO: test interactions with depthClearValue too
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -59,15 +59,15 @@ g.test('store_op_and_read_only')
       colorAttachments: [],
       depthStencilAttachment: {
         view: depthAttachmentView,
-        depthLoadValue: 'load',
+        depthLoadOp: 'load',
         depthStoreOp,
         depthReadOnly,
-        stencilLoadValue: 'load',
+        stencilLoadOp: 'load',
         stencilStoreOp,
         stencilReadOnly,
       },
     });
-    pass.endPass();
+    pass.end();
 
     t.expectValidationError(() => {
       encoder.finish();

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -48,7 +48,8 @@ class F extends ValidationTest {
 
     return {
       view,
-      loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+      clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+      loadOp: 'clear',
       storeOp: 'store',
     };
   }
@@ -61,9 +62,11 @@ class F extends ValidationTest {
 
     return {
       view,
-      depthLoadValue: 1.0,
+      depthClearValue: 1.0,
+      depthLoadOp: 'clear',
       depthStoreOp: 'store',
-      stencilLoadValue: 0,
+      stencilClearValue: 0,
+      stencilLoadOp: 'clear',
       stencilStoreOp: 'store',
     };
   }
@@ -71,7 +74,7 @@ class F extends ValidationTest {
   async tryRenderPass(success: boolean, descriptor: GPURenderPassDescriptor): Promise<void> {
     const commandEncoder = this.device.createCommandEncoder();
     const renderPass = commandEncoder.beginRenderPass(descriptor);
-    renderPass.endPass();
+    renderPass.end();
 
     this.expectValidationError(() => {
       commandEncoder.finish();
@@ -340,7 +343,8 @@ g.test('it_is_invalid_to_set_resolve_target_if_color_attachment_is_non_multisamp
         {
           view: colorTexture.createView(),
           resolveTarget: resolveTargetTexture.createView(),
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -160,7 +160,8 @@ class TextureUsageTracking extends ValidationTest {
       colorAttachments: [
         {
           view,
-          loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -476,17 +477,19 @@ g.test('subresources_and_binding_types_combination_for_color')
         colorAttachments: [
           {
             view: view0,
-            loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+            clearValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+            loadOp: 'clear',
             storeOp: 'store',
           },
           {
             view: view1,
-            loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+            clearValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+            loadOp: 'clear',
             storeOp: 'store',
           },
         ],
       });
-      pass.endPass();
+      pass.end();
     } else {
       const pass = compute
         ? encoder.beginComputePass()
@@ -537,7 +540,7 @@ g.test('subresources_and_binding_types_combination_for_color')
           t.device.createPipelineLayout({ bindGroupLayouts: bgls })
         );
       }
-      pass.endPass();
+      pass.end();
     }
 
     const success = _resourceSuccess || _usageOK;
@@ -666,7 +669,8 @@ g.test('subresources_and_binding_types_combination_for_aspect')
           colorAttachments: [
             {
               view: t.createTexture({ width: size, height: size }).createView(),
-              loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+              clearValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+              loadOp: 'clear',
               storeOp: 'store',
             },
           ],
@@ -674,9 +678,9 @@ g.test('subresources_and_binding_types_combination_for_aspect')
             ? {
                 view: view1,
                 depthStoreOp: 'discard',
-                depthLoadValue: 'load',
+                depthLoadOp: 'load',
                 stencilStoreOp: 'discard',
-                stencilLoadValue: 'load',
+                stencilLoadOp: 'load',
               }
             : undefined,
         });
@@ -718,7 +722,7 @@ g.test('subresources_and_binding_types_combination_for_aspect')
       }
     }
     if (compute) t.setComputePipelineAndCallDispatch(pass as GPUComputePassEncoder);
-    pass.endPass();
+    pass.end();
 
     const disjointAspects =
       (aspect0 === 'depth-only' && aspect1 === 'stencil-only') ||
@@ -794,7 +798,7 @@ g.test('shader_stages_and_visibility')
         })
       );
     }
-    pass.endPass();
+    pass.end();
 
     // Texture usages in bindings with invisible shader stages should be validated. Invisible shader
     // stages include shader stage with visibility none, compute shader stage in render pass, and
@@ -861,7 +865,7 @@ g.test('replaced_binding')
       t.issueDrawOrDispatch(pass, compute);
     }
     pass.setBindGroup(0, bindGroup1);
-    pass.endPass();
+    pass.end();
 
     // MAINTENANCE_TODO: If the Compatible Usage List (https://gpuweb.github.io/gpuweb/#compatible-usage-list)
     // gets programmatically defined in capability_info, use it here, instead of this logic, for clarity.
@@ -976,7 +980,7 @@ g.test('bindings_in_bundle')
       }
     }
 
-    pass.endPass();
+    pass.end();
 
     const isReadOnly = (t: typeof type0 | typeof type1) => {
       switch (t) {
@@ -1088,7 +1092,8 @@ g.test('unused_bindings_in_pipeline')
           colorAttachments: [
             {
               view: t.createTexture().createView(),
-              loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+              clearValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+              loadOp: 'clear',
               storeOp: 'store',
             },
           ],
@@ -1101,7 +1106,7 @@ g.test('unused_bindings_in_pipeline')
     pass.setBindGroup(index1, bindGroup1);
     if (setPipeline === 'after') t.setPipeline(pass, pipeline, compute);
     if (callDrawOrDispatch) t.issueDrawOrDispatch(pass, compute);
-    pass.endPass();
+    pass.end();
 
     // Resource usage validation scope is defined by the whole render pass or by dispatch calls.
     // Regardless of whether or not dispatch is called, in a compute pass, we always succeed
@@ -1129,7 +1134,7 @@ g.test('validation_scope,no_draw_or_dispatch')
     t.setPipeline(pass, pipeline, compute);
     pass.setBindGroup(0, bindGroup0);
     pass.setBindGroup(1, bindGroup1);
-    pass.endPass();
+    pass.end();
 
     // Resource usage validation scope is defined by dispatch calls. If dispatch is not called,
     // we don't need to do resource usage validation and no validation error to be reported.
@@ -1148,7 +1153,7 @@ g.test('validation_scope,same_draw_or_dispatch')
     pass.setBindGroup(0, bindGroup0);
     pass.setBindGroup(1, bindGroup1);
     t.issueDrawOrDispatch(pass, compute);
-    pass.endPass();
+    pass.end();
 
     t.expectValidationError(() => {
       encoder.finish();
@@ -1168,7 +1173,7 @@ g.test('validation_scope,different_draws_or_dispatches')
     pass.setBindGroup(1, bindGroup1);
     t.issueDrawOrDispatch(pass, compute);
 
-    pass.endPass();
+    pass.end();
 
     // Note that bindGroup0 will be inherited in the second draw/dispatch.
     t.expectValidationError(() => {
@@ -1184,7 +1189,7 @@ g.test('validation_scope,different_passes')
     t.setPipeline(pass, pipeline, compute);
     pass.setBindGroup(0, bindGroup0);
     if (compute) t.setComputePipelineAndCallDispatch(pass as GPUComputePassEncoder);
-    pass.endPass();
+    pass.end();
 
     const pass1 = compute
       ? encoder.beginComputePass()
@@ -1192,7 +1197,7 @@ g.test('validation_scope,different_passes')
     t.setPipeline(pass1, pipeline, compute);
     pass1.setBindGroup(1, bindGroup1);
     if (compute) t.setComputePipelineAndCallDispatch(pass1 as GPUComputePassEncoder);
-    pass1.endPass();
+    pass1.end();
 
     // No validation error.
     encoder.finish();

--- a/src/webgpu/api/validation/texture/destroy.spec.ts
+++ b/src/webgpu/api/validation/texture/destroy.spec.ts
@@ -46,12 +46,13 @@ g.test('submit_a_destroyed_texture')
       colorAttachments: [
         {
           view: textureView,
-          loadValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
     });
-    renderPass.endPass();
+    renderPass.end();
     const commandBuffer = commandEncoder.finish();
 
     if (destroyAfterEncode) {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -525,7 +525,7 @@ export class GPUTest extends Fixture {
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.dispatch(numRows);
-    pass.endPass();
+    pass.end();
     this.device.queue.submit([commandEncoder.finish()]);
 
     const expectedResults = new Array(numRows).fill(1);
@@ -929,7 +929,7 @@ export class GPUTest extends Fixture {
         const encoder = commandEncoder.beginComputePass();
 
         return new CommandBufferMaker(this, encoder, (shouldSucceed: boolean) => {
-          encoder.endPass();
+          encoder.end();
           return this.expectGPUError('validation', () => commandEncoder.finish(), !shouldSucceed);
         });
       }
@@ -947,16 +947,19 @@ export class GPUTest extends Fixture {
         const passDesc: GPURenderPassDescriptor = {
           colorAttachments: Array.from(fullAttachmentInfo.colorFormats, format => ({
             view: makeAttachmentView(format),
-            loadValue: [0, 0, 0, 0],
+            clearValue: [0, 0, 0, 0],
+            loadOp: 'clear',
             storeOp: 'store',
           })),
           depthStencilAttachment:
             fullAttachmentInfo.depthStencilFormat !== undefined
               ? {
                   view: makeAttachmentView(fullAttachmentInfo.depthStencilFormat),
-                  depthLoadValue: 0,
+                  depthClearValue: 0,
+                  depthLoadOp: 'clear',
                   depthStoreOp: 'discard',
-                  stencilLoadValue: 1,
+                  stencilClearValue: 1,
+                  stencilLoadOp: 'clear',
                   stencilStoreOp: 'discard',
                 }
               : undefined,
@@ -966,7 +969,7 @@ export class GPUTest extends Fixture {
         const commandEncoder = this.device.createCommandEncoder();
         const encoder = commandEncoder.beginRenderPass(passDesc);
         return new CommandBufferMaker(this, encoder, (shouldSucceed: boolean) => {
-          encoder.endPass();
+          encoder.end();
           return this.expectGPUError('validation', () => commandEncoder.finish(), !shouldSucceed);
         });
       }

--- a/src/webgpu/shader/execution/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/builtin/builtin.ts
@@ -388,7 +388,7 @@ fn main() {
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, group);
   pass.dispatch(1);
-  pass.endPass();
+  pass.end();
 
   t.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -85,7 +85,7 @@ function runShaderTest(
   pass.setBindGroup(0, testGroup, dynamicOffsets);
   pass.setBindGroup(1, group);
   pass.dispatch(1);
-  pass.endPass();
+  pass.end();
 
   t.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -499,7 +499,8 @@ class F extends GPUTest {
         {
           view: colorAttachmentView,
           storeOp: 'store',
-          loadValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 0.0, g: 1.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
         },
       ],
     });
@@ -508,7 +509,7 @@ class F extends GPUTest {
     // Run the draw variant
     drawCall.insertInto(pass, isIndexed, isIndirect);
 
-    pass.endPass();
+    pass.end();
     this.device.queue.submit([encoder.finish()]);
 
     // Validate we see green on the left pixel, showing that no failure case is detected

--- a/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
+++ b/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
@@ -159,14 +159,15 @@ class DerivativesTest extends GPUTest {
         {
           view: colorAttachmentView,
           storeOp: 'store',
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
         },
       ],
     });
     pass.setPipeline(this.pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.draw(6);
-    pass.endPass();
+    pass.end();
     this.device.queue.submit([encoder.finish()]);
 
     return colorAttachment;

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -195,7 +195,7 @@ g.test('inputs')
         break;
       }
     }
-    pass.endPass();
+    pass.end();
     t.queue.submit([encoder.finish()]);
 
     type vec3 = { x: number; y: number; z: number };

--- a/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
@@ -72,7 +72,7 @@ g.test('shared_with_buffer')
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.dispatch(numGroups[0], numGroups[1], numGroups[2]);
-    pass.endPass();
+    pass.end();
     t.queue.submit([encoder.finish()]);
 
     // Check the output values.
@@ -175,14 +175,15 @@ g.test('shared_between_stages')
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
     });
     pass.setPipeline(pipeline);
     pass.draw(3);
-    pass.endPass();
+    pass.end();
     t.queue.submit([encoder.finish()]);
 
     // Test a few points to make sure we rendered a half-red/half-green triangle.
@@ -311,7 +312,8 @@ g.test('shared_with_non_entry_point_function')
       colorAttachments: [
         {
           view: renderTarget.createView(),
-          loadValue: [0, 0, 0, 0],
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -319,7 +321,7 @@ g.test('shared_with_non_entry_point_function')
     pass.setPipeline(pipeline);
     pass.setVertexBuffer(0, vertexBuffer);
     pass.draw(3);
-    pass.endPass();
+    pass.end();
     t.queue.submit([encoder.finish()]);
 
     // Test a few points to make sure we rendered a red triangle.

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -424,7 +424,7 @@ g.test('compute,zero_init')
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
     pass.dispatch(1);
-    pass.endPass();
+    pass.end();
     t.queue.submit([encoder.finish()]);
     t.expectGPUBufferValuesEqual(resultBuffer, new Uint32Array([0]));
   });

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -102,7 +102,7 @@ function doTest(
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, bindGroup);
   pass.dispatch(1);
-  pass.endPass();
+  pass.end();
   t.device.queue.submit([encoder.finish()]);
 
   t.expectGPUBufferValuesEqual(

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -63,7 +63,9 @@ async function initCanvasContent(
 
   const clearOnePixel = (origin: GPUOrigin3D, color: GPUColor) => {
     const pass = encoder.beginRenderPass({
-      colorAttachments: [{ view: tempTextureView, loadValue: color, storeOp: 'store' }],
+      colorAttachments: [
+        { view: tempTextureView, clearValue: color, loadOp: 'clear', storeOp: 'store' },
+      ],
     });
     pass.endPass();
     encoder.copyTextureToTexture(

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -129,7 +129,8 @@ TODO: Multiplanar scenarios
         colorAttachments: [
           {
             view: colorAttachment.createView(),
-            loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+            clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+            loadOp: 'clear',
             storeOp: 'store',
           },
         ],
@@ -137,7 +138,7 @@ TODO: Multiplanar scenarios
       passEncoder.setPipeline(pipeline);
       passEncoder.setBindGroup(0, bindGroup);
       passEncoder.draw(6);
-      passEncoder.endPass();
+      passEncoder.end();
       t.device.queue.submit([commandEncoder.finish()]);
 
       // Top left corner should be red. Sample a few pixels away from the edges to avoid compression
@@ -183,7 +184,12 @@ destroyed results in an error.
     });
     const passDescriptor = {
       colorAttachments: [
-        { view: colorAttachment.createView(), loadValue: [0, 0, 0, 1], storeOp: 'store' },
+        {
+          view: colorAttachment.createView(),
+          clearValue: [0, 0, 0, 1],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
       ],
     } as const;
 
@@ -196,7 +202,7 @@ destroyed results in an error.
       const commandEncoder = t.device.createCommandEncoder();
       const passEncoder = commandEncoder.beginRenderPass(passDescriptor);
       passEncoder.setBindGroup(0, bindGroup);
-      passEncoder.endPass();
+      passEncoder.end();
       return commandEncoder.finish();
     };
 
@@ -285,7 +291,7 @@ Tests that we can import an HTMLVideoElement into a GPUExternalTexture and use i
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bg);
       pass.dispatch(1);
-      pass.endPass();
+      pass.end();
       t.device.queue.submit([encoder.finish()]);
 
       // Pixel loaded from top left corner should be red.

--- a/src/webgpu/web_platform/reftests/canvas_clear.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_clear.html.ts
@@ -18,15 +18,13 @@ runRefTest(async t => {
       colorAttachments: [
         {
           view: colorAttachmentView,
-          loadValue: { r: 0.4, g: 1.0, b: 0.0, a: 1.0 },
+          clearValue: { r: 0.4, g: 1.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
     });
-    pass.endPass();
+    pass.end();
     t.device.queue.submit([encoder.finish()]);
   }
-
-  draw('cvs0', 'bgra8unorm');
-  draw('cvs1', 'rgba8unorm');
 });

--- a/src/webgpu/web_platform/reftests/canvas_complex.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_complex.html.ts
@@ -236,7 +236,8 @@ fn linearMain(@location(0) fragUV: vec2<f32>) -> @location(0) vec4<f32> {
           {
             view: ctx.getCurrentTexture().createView(),
 
-            loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+            clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+            loadOp: 'clear',
             storeOp: 'store',
           },
         ],
@@ -247,7 +248,7 @@ fn linearMain(@location(0) fragUV: vec2<f32>) -> @location(0) vec4<f32> {
       passEncoder.setPipeline(pipeline);
       passEncoder.setBindGroup(0, uniformBindGroup);
       passEncoder.draw(6, 1, 0, 0);
-      passEncoder.endPass();
+      passEncoder.end();
       t.device.queue.submit([commandEncoder.finish()]);
     }
 
@@ -314,7 +315,8 @@ fn main(@location(0) fragColor: vec4<f32>) -> @location(0) vec4<f32> {
           {
             view: ctx.getCurrentTexture().createView(),
 
-            loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+            clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+            loadOp: 'clear',
             storeOp: 'store',
           },
         ],
@@ -324,7 +326,7 @@ fn main(@location(0) fragColor: vec4<f32>) -> @location(0) vec4<f32> {
       const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
       passEncoder.setPipeline(pipeline);
       passEncoder.draw(24, 1, 0, 0);
-      passEncoder.endPass();
+      passEncoder.end();
       t.device.queue.submit([commandEncoder.finish()]);
     }
 
@@ -396,7 +398,8 @@ fn main(@builtin(position) fragcoord: vec4<f32>) -> @location(0) vec4<f32> {
           {
             view: ctx.getCurrentTexture().createView(),
 
-            loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+            clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+            loadOp: 'clear',
             storeOp: 'store',
           },
         ],
@@ -406,7 +409,7 @@ fn main(@builtin(position) fragcoord: vec4<f32>) -> @location(0) vec4<f32> {
       const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
       passEncoder.setPipeline(pipeline);
       passEncoder.draw(6, 1, 0, 0);
-      passEncoder.endPass();
+      passEncoder.end();
       t.device.queue.submit([commandEncoder.finish()]);
     }
 

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -113,8 +113,8 @@ return fragColor;
       colorAttachments: [
         {
           view: ctx.getCurrentTexture().createView(),
-
-          loadValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          loadOp: 'clear',
           storeOp: 'store',
         },
       ],
@@ -127,7 +127,7 @@ return fragColor;
     passEncoder.draw(6, 1, 6, 0);
     passEncoder.draw(6, 1, 12, 0);
     passEncoder.draw(6, 1, 18, 0);
-    passEncoder.endPass();
+    passEncoder.end();
     t.device.queue.submit([commandEncoder.finish()]);
   });
 }


### PR DESCRIPTION
`GPUComputePassEncoder.endPass()` -> `end()`
`GPURenderPassEncoder.endPass()` -> `end()`
`GPURenderPassColorAttachment.loadValue` -> `loadOp` / `clearValue`
`GPURenderPassDepthStencilAttachment.depthLoadValue` -> `depthLoadOp` / `depthClearValue`
`GPURenderPassDepthStencilAttachment.stencilLoadValue` -> `stencilLoadOp` / `stencilClearValue`




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
