### PR TITLE
Partially implement memory_sync,texture,*

### DIFF
--- a/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
@@ -2,10 +2,20 @@ export const description = `
 Memory Synchronization Tests for Texture: read before write, read after write, and write after write to the same subresource.
 
 - TODO: Test synchronization between multiple queues.
+- TODO: Test depth/stencil attachments.
 `;
 
+import { SkipTestCase } from '../../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { assert, memcpy, unreachable } from '../../../../../common/util/util.js';
+import { EncodableTextureFormat } from '../../../../capability_info.js';
 import { GPUTest } from '../../../../gpu_test.js';
+import { align } from '../../../../util/math.js';
+import { getTextureCopyLayout } from '../../../../util/texture/layout.js';
+import {
+  kTexelRepresentationInfo,
+  PerTexelComponent,
+} from '../../../../util/texture/texel_data.js';
 
 import {
   kOperationBoundaries,
@@ -13,9 +23,443 @@ import {
   kAllReadOps,
   kAllWriteOps,
   checkOpsValidForContext,
+  Op,
+  OperationBoundary,
+  OperationContext,
+  kOpInfo,
+  kOperationContexts,
 } from './texture_sync_test.js';
 
 export const g = makeTestGroup(GPUTest);
+
+class TextureSyncTestHelper {
+  // We start at the queue context which is top-level.
+  private currentContext: OperationContext = 'queue';
+
+  // Set based on the current context.
+  private queue: GPUQueue;
+  private commandEncoder?: GPUCommandEncoder;
+  private computePassEncoder?: GPUComputePassEncoder;
+  private renderPassEncoder?: GPURenderPassEncoder;
+  private renderBundleEncoder?: GPURenderBundleEncoder;
+
+  private device: GPUDevice;
+  private texture: GPUTexture;
+
+  private encodedCommands: GPURenderBundle[] | GPUCommandBuffer[] = [];
+
+  public readonly kTextureSize = [4, 4] as const;
+  public readonly kTextureFormat: EncodableTextureFormat = 'rgba8unorm';
+
+  constructor(
+    device: GPUDevice,
+    textureCreationParams: {
+      usage: GPUTextureUsageFlags;
+    }
+  ) {
+    this.device = device;
+    this.queue = device.queue;
+    this.texture = device.createTexture({
+      size: this.kTextureSize,
+      format: this.kTextureFormat,
+      ...textureCreationParams,
+    });
+  }
+
+  /**
+   * Perform a read operation on the test texture.
+   * @return GPUTexture copy containing the contents.
+   */
+  performReadOp({ op, in: context }: { op: Op; in: OperationContext }): GPUTexture {
+    this.ensureContext(context);
+    switch (op) {
+      case 't2t-copy': {
+        const texture = this.device.createTexture({
+          size: this.kTextureSize,
+          format: this.kTextureFormat,
+          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+        });
+
+        assert(this.commandEncoder !== undefined);
+        this.commandEncoder.copyTextureToTexture(
+          {
+            texture: this.texture,
+          },
+          { texture },
+          this.kTextureSize
+        );
+        return texture;
+      }
+      case 't2b-copy': {
+        const { byteLength, bytesPerRow } = getTextureCopyLayout(this.kTextureFormat, '2d', [
+          ...this.kTextureSize,
+          1,
+        ]);
+        const buffer = this.device.createBuffer({
+          size: byteLength,
+          usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+        });
+
+        const texture = this.device.createTexture({
+          size: this.kTextureSize,
+          format: this.kTextureFormat,
+          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+        });
+
+        assert(this.commandEncoder !== undefined);
+        this.commandEncoder.copyTextureToBuffer(
+          {
+            texture: this.texture,
+          },
+          { buffer, bytesPerRow },
+          this.kTextureSize
+        );
+        this.commandEncoder.copyBufferToTexture(
+          { buffer, bytesPerRow },
+          { texture },
+          this.kTextureSize
+        );
+        return texture;
+      }
+      case 'sample':
+      case 'storage':
+        // [1] Finish implementation
+        throw new SkipTestCase('unimplemented');
+        break;
+      case 'b2t-copy':
+      case 'attachment-resolve':
+      case 'attachment-store':
+        unreachable();
+    }
+    unreachable();
+  }
+
+  performWriteOp(
+    { op, in: context }: { op: Op; in: OperationContext },
+    data: PerTexelComponent<number>
+  ) {
+    this.ensureContext(context);
+    switch (op) {
+      case 'attachment-store': {
+        assert(this.commandEncoder !== undefined);
+        this.renderPassEncoder = this.commandEncoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view: this.texture.createView(),
+              // [2] Use non-uniform texture values
+              loadValue: [data.R ?? 0, data.G ?? 0, data.B ?? 0, data.A ?? 0],
+              storeOp: 'store',
+            },
+          ],
+        });
+        this.currentContext = 'render-pass-encoder';
+        break;
+      }
+      case 'write-texture': {
+        // [2] Use non-uniform texture values
+        const rep = kTexelRepresentationInfo[this.kTextureFormat];
+        const texelData = rep.pack(rep.encode(data));
+        const numTexels = this.kTextureSize[0] * this.kTextureSize[1];
+        const fullTexelData = new ArrayBuffer(texelData.byteLength * numTexels);
+        for (let i = 0; i < numTexels; ++i) {
+          memcpy({ src: texelData }, { dst: fullTexelData, start: i * texelData.byteLength });
+        }
+
+        this.queue.writeTexture(
+          { texture: this.texture },
+          fullTexelData,
+          {
+            bytesPerRow: texelData.byteLength * this.kTextureSize[0],
+          },
+          this.kTextureSize
+        );
+        break;
+      }
+      case 't2t-copy': {
+        const texture = this.device.createTexture({
+          size: this.kTextureSize,
+          format: this.kTextureFormat,
+          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+        });
+
+        // [2] Use non-uniform texture values
+        const rep = kTexelRepresentationInfo[this.kTextureFormat];
+        const texelData = rep.pack(rep.encode(data));
+        const numTexels = this.kTextureSize[0] * this.kTextureSize[1];
+        const fullTexelData = new ArrayBuffer(texelData.byteLength * numTexels);
+        for (let i = 0; i < numTexels; ++i) {
+          memcpy({ src: texelData }, { dst: fullTexelData, start: i * texelData.byteLength });
+        }
+
+        this.queue.writeTexture(
+          { texture },
+          fullTexelData,
+          {
+            bytesPerRow: texelData.byteLength * this.kTextureSize[0],
+          },
+          this.kTextureSize
+        );
+
+        assert(this.commandEncoder !== undefined);
+        this.commandEncoder.copyTextureToTexture(
+          { texture },
+          { texture: this.texture },
+          this.kTextureSize
+        );
+        break;
+      }
+      case 'b2t-copy': {
+        // [2] Use non-uniform texture values
+        const rep = kTexelRepresentationInfo[this.kTextureFormat];
+        const texelData = rep.pack(rep.encode(data));
+        const bytesPerRow = align(texelData.byteLength, 256);
+        const fullTexelData = new ArrayBuffer(bytesPerRow * this.kTextureSize[1]);
+        for (let i = 0; i < this.kTextureSize[1]; ++i) {
+          for (let j = 0; j < this.kTextureSize[0]; ++j) {
+            memcpy(
+              { src: texelData },
+              {
+                dst: fullTexelData,
+                start: i * bytesPerRow + j * texelData.byteLength,
+              }
+            );
+          }
+        }
+
+        const buffer = this.device.createBuffer({
+          size: fullTexelData.byteLength,
+          usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+        });
+
+        this.queue.writeBuffer(buffer, 0, fullTexelData);
+
+        assert(this.commandEncoder !== undefined);
+        this.commandEncoder.copyBufferToTexture(
+          { buffer, bytesPerRow },
+          { texture: this.texture },
+          this.kTextureSize
+        );
+        break;
+      }
+      case 'attachment-resolve':
+      case 'storage':
+        // [1] Finish implementation
+        throw new SkipTestCase('unimplemented');
+      case 't2b-copy':
+      case 'sample':
+        unreachable();
+    }
+  }
+
+  // Ensure that all encoded commands are finished and subitted.
+  ensureSubmit() {
+    this.ensureContext('queue');
+    this.flushEncodedCommands();
+  }
+
+  private popContext(): GPURenderBundle | GPUCommandBuffer | null {
+    switch (this.currentContext) {
+      case 'queue':
+        unreachable();
+        break;
+      case 'command-encoder': {
+        assert(this.commandEncoder !== undefined);
+        const commandBuffer = this.commandEncoder.finish();
+        this.commandEncoder = undefined;
+        this.currentContext = 'queue';
+        return commandBuffer;
+      }
+      case 'compute-pass-encoder':
+        assert(this.computePassEncoder !== undefined);
+        this.computePassEncoder.endPass();
+        this.computePassEncoder = undefined;
+        this.currentContext = 'command-encoder';
+        break;
+      case 'render-pass-encoder':
+        assert(this.renderPassEncoder !== undefined);
+        this.renderPassEncoder.endPass();
+        this.renderPassEncoder = undefined;
+        this.currentContext = 'command-encoder';
+        break;
+      case 'render-bundle-encoder': {
+        assert(this.renderBundleEncoder !== undefined);
+        const renderBundle = this.renderBundleEncoder.finish();
+        this.renderBundleEncoder = undefined;
+        this.currentContext = 'render-pass-encoder';
+        return renderBundle;
+      }
+    }
+    return null;
+  }
+
+  private makeDummyAttachment(): GPURenderPassColorAttachment {
+    const texture = this.device.createTexture({
+      format: this.kTextureFormat,
+      size: this.kTextureSize,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    return {
+      view: texture.createView(),
+      loadValue: 'load',
+      storeOp: 'store',
+    };
+  }
+
+  private ensureContext(context: OperationContext) {
+    // Find the common ancestor. So we can transition from currentContext -> context.
+    const ancestorContext =
+      kOperationContexts[
+        Math.min(
+          kOperationContexts.indexOf(context),
+          kOperationContexts.indexOf(this.currentContext)
+        )
+      ];
+
+    // Pop the context until we're at the common ancestor.
+    while (this.currentContext !== ancestorContext) {
+      // We're about to pop another context. Make sure we've
+      // executed any previous render bundles / command buffers.
+      this.flushEncodedCommands();
+
+      const result = this.popContext();
+      if (result) {
+        if (result instanceof GPURenderBundle) {
+          this.encodedCommands = [result];
+        } else {
+          this.encodedCommands = [result];
+        }
+      }
+    }
+
+    if (this.currentContext === context) {
+      return;
+    }
+
+    switch (context) {
+      case 'queue':
+        unreachable();
+        break;
+      case 'command-encoder':
+        assert(this.currentContext === 'queue');
+        this.commandEncoder = this.device.createCommandEncoder();
+        break;
+      case 'compute-pass-encoder':
+        switch (this.currentContext) {
+          case 'queue':
+            this.commandEncoder = this.device.createCommandEncoder();
+            this.computePassEncoder = this.commandEncoder.beginComputePass();
+            break;
+          case 'command-encoder':
+            assert(this.commandEncoder !== undefined);
+            this.computePassEncoder = this.commandEncoder.beginComputePass();
+            break;
+          case 'compute-pass-encoder':
+          case 'render-bundle-encoder':
+          case 'render-pass-encoder':
+            unreachable();
+        }
+        break;
+      case 'render-pass-encoder':
+        switch (this.currentContext) {
+          case 'queue':
+            this.commandEncoder = this.device.createCommandEncoder();
+            this.renderPassEncoder = this.commandEncoder.beginRenderPass({
+              colorAttachments: [this.makeDummyAttachment()],
+            });
+            break;
+          case 'command-encoder':
+            assert(this.commandEncoder !== undefined);
+            this.renderPassEncoder = this.commandEncoder.beginRenderPass({
+              colorAttachments: [this.makeDummyAttachment()],
+            });
+            break;
+          case 'render-pass-encoder':
+          case 'render-bundle-encoder':
+          case 'compute-pass-encoder':
+            unreachable();
+        }
+        break;
+      case 'render-bundle-encoder':
+        switch (this.currentContext) {
+          case 'queue':
+            this.commandEncoder = this.device.createCommandEncoder();
+            this.renderPassEncoder = this.commandEncoder.beginRenderPass({
+              colorAttachments: [this.makeDummyAttachment()],
+            });
+            this.renderBundleEncoder = this.device.createRenderBundleEncoder({
+              colorFormats: [this.kTextureFormat],
+            });
+            break;
+          case 'command-encoder':
+            assert(this.commandEncoder !== undefined);
+            this.renderPassEncoder = this.commandEncoder.beginRenderPass({
+              colorAttachments: [this.makeDummyAttachment()],
+            });
+            this.renderBundleEncoder = this.device.createRenderBundleEncoder({
+              colorFormats: [this.kTextureFormat],
+            });
+            break;
+          case 'render-pass-encoder':
+            this.renderBundleEncoder = this.device.createRenderBundleEncoder({
+              colorFormats: [this.kTextureFormat],
+            });
+            break;
+          case 'render-bundle-encoder':
+          case 'compute-pass-encoder':
+            unreachable();
+        }
+        break;
+    }
+    this.currentContext = context;
+  }
+
+  private flushEncodedCommands() {
+    if (this.encodedCommands.length > 0) {
+      if (this.encodedCommands[0] instanceof GPURenderBundle) {
+        assert(this.renderPassEncoder !== undefined);
+        this.renderPassEncoder.executeBundles(this.encodedCommands as GPURenderBundle[]);
+      } else {
+        this.queue.submit(this.encodedCommands as GPUCommandBuffer[]);
+      }
+    }
+    this.encodedCommands = [];
+  }
+
+  ensureBoundary(boundary: OperationBoundary) {
+    switch (boundary) {
+      case 'command-buffer':
+        this.ensureContext('queue');
+        break;
+      case 'queue-op':
+        this.ensureContext('queue');
+        // Submit any GPUCommandBuffers so the next one is in a separate submit.
+        this.flushEncodedCommands();
+        break;
+      case 'dispatch':
+        // Nothing to do to separate dispatches.
+        assert(this.currentContext === 'compute-pass-encoder');
+        break;
+      case 'draw':
+        // Nothing to do to separate draws.
+        assert(
+          this.currentContext === 'render-pass-encoder' ||
+            this.currentContext === 'render-bundle-encoder'
+        );
+        break;
+      case 'pass':
+        this.ensureContext('command-encoder');
+        break;
+      case 'render-bundle':
+        this.ensureContext('render-pass-encoder');
+        break;
+      case 'execute-bundles':
+        this.ensureContext('render-pass-encoder');
+        // Execute any GPURenderBundles so the next one is in a separate executeBundles.
+        this.flushEncodedCommands();
+        break;
+    }
+  }
+}
 
 g.test('rw')
   .desc(
@@ -42,7 +486,30 @@ g.test('rw')
         }
       })
   )
-  .unimplemented();
+  .fn(t => {
+    const helper = new TextureSyncTestHelper(t.device, {
+      usage:
+        GPUTextureUsage.COPY_DST |
+        kOpInfo[t.params.read.op].readUsage |
+        kOpInfo[t.params.write.op].writeUsage,
+    });
+    // [2] Use non-uniform texture value.
+    const texelValue1 = { R: 0, G: 1, B: 0, A: 1 } as const;
+    const texelValue2 = { R: 1, G: 0, B: 0, A: 1 } as const;
+
+    // Initialize the texture with something.
+    helper.performWriteOp({ op: 'write-texture', in: 'queue' }, texelValue1);
+    const readbackTexture = helper.performReadOp(t.params.read);
+    helper.ensureBoundary(t.params.boundary);
+    helper.performWriteOp(t.params.write, texelValue2);
+    helper.ensureSubmit();
+
+    // Contents should be the first value written, not the second.
+    t.expectSingleColor(readbackTexture, helper.kTextureFormat, {
+      size: [...helper.kTextureSize, 1],
+      exp: texelValue1,
+    });
+  });
 
 g.test('wr')
   .desc(
@@ -50,7 +517,10 @@ g.test('wr')
     Perform a 'write' operation on a texture subresource, followed by a 'read' operation.
     Operations are separated by a 'boundary' (pass, encoder, queue-op, etc.).
     Test that the results are synchronized.
-    The read should see exactly the contents written by the previous write.`
+    The read should see exactly the contents written by the previous write.
+
+    - TODO: Finish implementation [1]
+    - TODO: Use non-uniform texture contents [2]`
   )
   .params(u =>
     u
@@ -69,7 +539,24 @@ g.test('wr')
         }
       })
   )
-  .unimplemented();
+  .fn(t => {
+    const helper = new TextureSyncTestHelper(t.device, {
+      usage: kOpInfo[t.params.read.op].readUsage | kOpInfo[t.params.write.op].writeUsage,
+    });
+    // [2] Use non-uniform texture value.
+    const texelValue = { R: 0, G: 1, B: 0, A: 1 } as const;
+
+    helper.performWriteOp(t.params.write, texelValue);
+    helper.ensureBoundary(t.params.boundary);
+    const readbackTexture = helper.performReadOp(t.params.read);
+    helper.ensureSubmit();
+
+    // Contents should be exactly the values written.
+    t.expectSingleColor(readbackTexture, helper.kTextureFormat, {
+      size: [...helper.kTextureSize, 1],
+      exp: texelValue,
+    });
+  });
 
 g.test('ww')
   .desc(
@@ -95,5 +582,44 @@ g.test('ww')
           }
         }
       })
+  )
+  .fn(t => {
+    const helper = new TextureSyncTestHelper(t.device, {
+      usage:
+        GPUTextureUsage.COPY_SRC |
+        kOpInfo[t.params.first.op].writeUsage |
+        kOpInfo[t.params.second.op].writeUsage,
+    });
+    // [2] Use non-uniform texture value.
+    const texelValue1 = { R: 1, G: 0, B: 0, A: 1 } as const;
+    const texelValue2 = { R: 0, G: 1, B: 0, A: 1 } as const;
+
+    helper.performWriteOp(t.params.first, texelValue1);
+    helper.ensureBoundary(t.params.boundary);
+    helper.performWriteOp(t.params.second, texelValue2);
+    helper.ensureSubmit();
+
+    // Read back the contents so we can test the result.
+    const readbackTexture = helper.performReadOp({ op: 't2t-copy', in: 'command-encoder' });
+    helper.ensureSubmit();
+
+    // Contents should be the second value written.
+    t.expectSingleColor(readbackTexture, helper.kTextureFormat, {
+      size: [...helper.kTextureSize, 1],
+      exp: texelValue2,
+    });
+  });
+
+g.test('rw,single_pass,load_store')
+  .desc(
+    `
+    TODO: Test memory synchronization when loading from a texture subresource in a single pass and storing to it.`
+  )
+  .unimplemented();
+
+g.test('rw,single_pass,load_resolve')
+  .desc(
+    `
+    TODO: Test memory synchronization when loading from a texture subresource in a single pass and resolving to it.`
   )
   .unimplemented();

--- a/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
@@ -3,6 +3,7 @@ Memory Synchronization Tests for Texture: read before write, read after write, a
 
 - TODO: Test synchronization between multiple queues.
 - TODO: Test depth/stencil attachments.
+- TODO: Use non-solid-color texture contents [2]
 `;
 
 import { SkipTestCase } from '../../../../../common/framework/fixture.js';

--- a/src/webgpu/api/operation/memory_sync/texture/texture_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/texture_sync_test.ts
@@ -1,3 +1,5 @@
+import { GPUConst } from '../../../../constants.js';
+
 /**
  * Boundary between the first operation, and the second operation.
  */
@@ -5,6 +7,7 @@ export const kOperationBoundaries = [
   'queue-op', // Operations are performed in different queue operations (submit, writeTexture).
   'command-buffer', // Operations are in different command buffers.
   'pass', // Operations are in different passes.
+  'execute-bundles', // Operations are in different executeBundles(...) calls
   'render-bundle', // Operations are in different render bundles.
   'dispatch', // Operations are in different dispatches.
   'draw', // Operations are in different draws.
@@ -13,6 +16,8 @@ export type OperationBoundary = typeof kOperationBoundaries[number];
 
 /**
  * Context a particular operation is permitted in.
+ * These contexts should be sorted such that the first is the most top-level
+ * context, and the last is most nested (inside a render bundle, in a render pass, ...).
  */
 export const kOperationContexts = [
   'queue', // Operation occurs on the GPUQueue object
@@ -71,6 +76,11 @@ export const kBoundaryInfo: {
       ['render-bundle-encoder', 'render-bundle-encoder'],
     ],
   },
+  'execute-bundles': {
+    contexts: [
+      ['render-bundle-encoder', 'render-bundle-encoder'],
+    ]
+  },
   'render-bundle': {
     contexts: [
       ['render-bundle-encoder', 'render-pass-encoder'],
@@ -101,37 +111,64 @@ export const kAllWriteOps = [
 ] as const;
 export type WriteOp = typeof kAllWriteOps[number];
 
-export const kAllReadOps = [
-  't2b-copy',
-  't2t-copy',
-  'attachment-load',
-  'storage',
-  'sample',
-] as const;
+export const kAllReadOps = ['t2b-copy', 't2t-copy', 'storage', 'sample'] as const;
 export type ReadOp = typeof kAllReadOps[number];
 
 export type Op = ReadOp | WriteOp;
 
 interface OpInfo {
   readonly contexts: OperationContext[];
+  readonly readUsage: GPUTextureUsageFlags;
+  readonly writeUsage: GPUTextureUsageFlags;
   // Add fields as needed
 }
 
 /**
  * Mapping of Op to the OperationContext(s) it is valid in
  */
-const kOpInfo: {
+export const kOpInfo: {
   readonly [k in Op]: OpInfo;
 } = /* prettier-ignore */ {
-  'write-texture': { contexts: [ 'queue' ] },
-  'b2t-copy': { contexts: [ 'command-encoder' ] },
-  't2t-copy': { contexts: [ 'command-encoder' ] },
-  't2b-copy': { contexts: [ 'command-encoder' ] },
-  'storage': { contexts: [ 'compute-pass-encoder', 'render-pass-encoder', 'render-bundle-encoder' ] },
-  'sample': { contexts: [ 'compute-pass-encoder', 'render-pass-encoder', 'render-bundle-encoder' ] },
-  'attachment-store': { contexts: [ 'render-pass-encoder' ] },
-  'attachment-resolve': { contexts: [ 'render-pass-encoder' ] },
-  'attachment-load': { contexts: [ 'render-pass-encoder' ] },
+  'write-texture': {
+    contexts: [ 'queue' ],
+    readUsage: 0,
+    writeUsage: GPUConst.TextureUsage.COPY_DST,
+  },
+  'b2t-copy': {
+    contexts: [ 'command-encoder' ],
+    readUsage: 0,
+    writeUsage: GPUConst.TextureUsage.COPY_DST,
+  },
+  't2t-copy': {
+    contexts: [ 'command-encoder' ],
+    readUsage: GPUConst.TextureUsage.COPY_SRC,
+    writeUsage: GPUConst.TextureUsage.COPY_DST,
+  },
+  't2b-copy': {
+    contexts: [ 'command-encoder' ],
+    readUsage: GPUConst.TextureUsage.COPY_SRC,
+    writeUsage: 0,
+  },
+  'storage': {
+    contexts: [ 'compute-pass-encoder', 'render-pass-encoder', 'render-bundle-encoder' ],
+    readUsage: GPUConst.TextureUsage.STORAGE,
+    writeUsage: GPUConst.TextureUsage.STORAGE,
+  },
+  'sample': {
+    contexts: [ 'compute-pass-encoder', 'render-pass-encoder', 'render-bundle-encoder' ],
+    readUsage: GPUConst.TextureUsage.SAMPLED,
+    writeUsage: 0,
+  },
+  'attachment-store': {
+    contexts: [ 'command-encoder' ],
+    readUsage: 0,
+    writeUsage: GPUConst.TextureUsage.RENDER_ATTACHMENT,
+  },
+  'attachment-resolve': {
+    contexts: [ 'command-encoder' ],
+    readUsage: 0,
+    writeUsage: GPUConst.TextureUsage.RENDER_ATTACHMENT,
+  },
 };
 
 export function checkOpsValidForContext(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,9 @@
     "allowJs": false,
     "strict": true,
     /* tsc lint options */
-    "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
-    /* These should be caught be eslint instead */
+    /* These should be caught by eslint instead */
+    "noFallthroughCasesInSwitch": false,
     "noUnusedLocals": false,
     "allowUnreachableCode": true,
     /* Module Options */


### PR DESCRIPTION
Issue: https://github.com/gpuweb/cts/issues/898, https://github.com/gpuweb/cts/issues/899

Unimplemented parts are tagged with TODOs or marked with
SkipTestCase("unimplemented"). Remaining:
 - single pass load/store, load/resolve
 - read by sample usage
 - read/write by storage usage
 - write by attachment resolve
 - depth/stencil attachments

Could be improved with by using non-uniform texel values.

Currently passing in Google Chrome Canary on Mac.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
