### PR TITLE
Make cmdline.ts runnable when compiled as cmdline.js as well

### DIFF
--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -28,7 +28,15 @@ function usage(rc: number): never {
   return sys.exit(rc);
 }
 
-if (!sys.existsSync('src/common/runtime/cmdline.ts')) {
+function selfFileExtension() {
+  if (sys.type === 'deno' || __filename.endsWith('.ts')) {
+    return 'ts';
+  } else {
+    return 'js';
+  }
+}
+
+if (!sys.existsSync(`src/common/runtime/cmdline.${selfFileExtension()}`)) {
   console.log('Must be run from repository root');
   usage(1);
 }


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
