### PR TITLE
Revert "Implement validation tests on pipeline_output_targets,format_blendable"

### DIFF
--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -559,43 +559,8 @@ g.test('pipeline_output_targets,blend')
   });
 
 g.test('pipeline_output_targets,format_blendable')
-  .desc(
-    `
-  Tests if blending is used, the target's format must be blendable (support "float" sample type).
-  - For all the formats, test that blending can be enabled if and only if the format is blendable.`
-  )
-  .params(u =>
-    u.combine('isAsync', [false, true]).combine('format', kRenderableColorTextureFormats)
-  )
-  .fn(async t => {
-    const { isAsync, format } = t.params;
-    const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
-
-    const _success = info.sampleType === 'float';
-
-    const blendComponent: GPUBlendComponent = {
-      srcFactor: 'src-alpha',
-      dstFactor: 'dst-alpha',
-      operation: 'add',
-    };
-    t.doCreateRenderPipelineTest(
-      isAsync,
-      _success,
-      t.getDescriptor({
-        targets: [
-          {
-            format,
-            blend: {
-              color: blendComponent,
-              alpha: blendComponent,
-            },
-          },
-        ],
-        fragmentShaderCode: t.getFragmentShaderCode('float', 4),
-      })
-    );
-  });
+  .desc(`If blending is used, the target's format must be blendable (support "float" sample type).`)
+  .unimplemented();
 
 g.test('pipeline_output_targets,blend_min_max')
   .desc(

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -84,7 +84,7 @@ const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
   // 32-bit formats
   'r32uint':               [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               4],
   'r32sint':               [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               4],
-  'r32float':              [        true,          true,        ,        ,          ,      true,          ,          ,      'unfilterable-float',               4],
+  'r32float':              [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               4],
   'rg16uint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               4],
   'rg16sint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               4],
   'rg16float':             [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
@@ -102,14 +102,14 @@ const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
   // 64-bit formats
   'rg32uint':              [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               8],
   'rg32sint':              [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               8],
-  'rg32float':             [        true,          true,        ,        ,          ,      true,          ,          ,      'unfilterable-float',               8],
+  'rg32float':             [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               8],
   'rgba16uint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               8],
   'rgba16sint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               8],
   'rgba16float':           [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               8],
   // 128-bit formats
   'rgba32uint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',              16],
   'rgba32sint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',              16],
-  'rgba32float':           [        true,          true,        ,        ,          ,      true,          ,          ,      'unfilterable-float',              16],
+  'rgba32float':           [        true,          true,        ,        ,          ,      true,          ,          ,      'float',              16],
 } as const);
 /* prettier-ignore */
 const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature', 'baseFormat'] as const;


### PR DESCRIPTION
Reverts gpuweb/cts#990

> hitting an unreachable() inside getFragmentShaderCode
> https://chromium-review.googlesource.com/c/chromium/src/+/3462090
