### PR TITLE
Review and expand validation,queue,buffer_mapped

### DIFF
--- a/src/webgpu/api/validation/queue/buffer_mapped.spec.ts
+++ b/src/webgpu/api/validation/queue/buffer_mapped.spec.ts
@@ -1,19 +1,217 @@
 export const description = `
-Tests for map-state of mappable buffers used in submitted command buffers.
+Validation tests for the map-state of mappable buffers used in submitted command buffers.
 
-- x= just before queue op, buffer in {BufferMapStatesToTest}
-- x= in every possible place for mappable buffer:
-  {submit, writeBuffer, copyB2B {src,dst}, copyB2T, copyT2B, ..?}
+Tests every operation that has a dependency on a buffer
+  - writeBuffer
+  - copyB2B {src,dst}
+  - copyB2T
+  - copyT2B
 
-TODO: generalize existing test
+Test those operations against buffers in the following states:
+  - Unmapped
+  - In the process of mapping
+  - mapped
+  - mapped with a mapped range queried
+  - unmapped after mapping
+  - mapped at creation
+
+Also tests every order of operations combination of mapping operations and command recording
+operations to ensure the mapping state is only considered when a command buffer is submitted.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { ValidationTest } from '../validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+class F extends ValidationTest {
+  async runBufferDependencyTest(options: {
+    usage: number;
+    mapMode: number;
+    bufferSize?: number;
+  }, callback : Function): Promise<void> {
+    const { usage, mapMode, bufferSize} = options;
 
-g.test('submit').fn(async t => {
+    const bufferDesc = {
+      usage,
+      size: bufferSize || 8,
+      mappedAtCreation: false,
+    };
+
+    // Create a mappable buffer, and one that will remain unmapped for comparison.
+    const mappableBuffer = this.device.createBuffer(bufferDesc);
+    const unmappedBuffer = this.device.createBuffer(bufferDesc);
+
+    // Run the given operation before the buffer is mapped. Should succeed.
+    callback(mappableBuffer);
+
+    // Map the buffer
+    const mapPromise = mappableBuffer.mapAsync(mapMode);
+
+    // Run the given operation while the buffer is in the process of mapping. Should fail.
+    this.expectValidationError(() => {
+      callback(mappableBuffer);
+    });
+
+    // Run on a different, unmapped buffer. Should succeed.
+    callback(unmappedBuffer);
+
+    await mapPromise;
+
+    // Run the given operation when the buffer is finished mapping with no getMappedRange. Should fail.
+    this.expectValidationError(() => {
+      callback(mappableBuffer);
+    });
+
+    // Run on a different, unmapped buffer. Should succeed.
+    callback(unmappedBuffer);
+
+    // Run the given operation when the buffer is mapped with getMappedRange. Should fail.
+    mappableBuffer.getMappedRange();
+    this.expectValidationError(() => {
+      callback(mappableBuffer);
+    });
+
+    // Unmap the buffer and run the operation. Should succeed.
+    mappableBuffer.unmap();
+    callback(mappableBuffer);
+
+
+    // Create a buffer that's mappedAtCreation.
+    bufferDesc.mappedAtCreation = true;
+    const mappedBuffer = this.device.createBuffer(bufferDesc);
+
+    // Run the operation with the mappedAtCreation buffer. Should fail.
+    this.expectValidationError(() => {
+      callback(mappedBuffer);
+    });
+
+    // Run on a different, unmapped buffer. Should succeed.
+    callback(unmappedBuffer);
+
+    // Unmap the mappedAtCreation buffer and run the operation. Should succeed.
+    mappedBuffer.unmap();
+    callback(mappedBuffer);
+  }
+}
+
+export const g = makeTestGroup(F);
+
+g.test('writeBuffer')
+  .desc(`Test that an outstanding mapping will prevent writeBuffer calls.`)
+  .fn(async t => {
+  const data = new Uint32Array([42]);
+
+  const options = {
+    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    mapMode: GPUMapMode.READ
+  };
+
+  t.runBufferDependencyTest(options, (buffer: GPUBuffer) => {
+    t.queue.writeBuffer(buffer, 0, data);
+  });
+});
+
+g.test('copyBufferToBuffer')
+  .desc(`
+  Test that an outstanding mapping will prevent copyBufferToTexture commands from submitting,
+  both when used as the source and destination.`)
+  .fn(async t => {
+  const sourceBuffer = t.device.createBuffer({
+    size: 8,
+    usage: GPUBufferUsage.COPY_SRC,
+  });
+
+  const destBuffer = t.device.createBuffer({
+    size: 8,
+    usage: GPUBufferUsage.COPY_DST,
+  });
+
+  const srcOptions = {
+    usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
+    mapMode: GPUMapMode.WRITE
+  };
+
+  t.runBufferDependencyTest(srcOptions, (buffer: GPUBuffer) => {
+    const commandEncoder = t.device.createCommandEncoder();
+    commandEncoder.copyBufferToBuffer(buffer, 0, destBuffer, 0, 4);
+    t.queue.submit([commandEncoder.finish()]);
+  });
+
+  const destOptions = {
+    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    mapMode: GPUMapMode.READ
+  };
+
+  t.runBufferDependencyTest(destOptions, (buffer: GPUBuffer) => {
+    const commandEncoder = t.device.createCommandEncoder();
+    commandEncoder.copyBufferToBuffer(sourceBuffer, 0, buffer, 0, 4);
+    t.queue.submit([commandEncoder.finish()]);
+  });
+});
+
+g.test('copyBufferToTexture')
+  .desc(`Test that an outstanding mapping will prevent copyBufferToTexture commands from submitting.`)
+  .fn(async t => {
+  const size = { width: 1, height: 1 };
+
+  const texture = t.device.createTexture({
+    size,
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.COPY_DST
+  });
+
+  const options = {
+    usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
+    mapMode: GPUMapMode.WRITE,
+  };
+
+  t.runBufferDependencyTest(options, (buffer: GPUBuffer) => {
+    const commandEncoder = t.device.createCommandEncoder();
+    commandEncoder.copyBufferToTexture({ buffer }, { texture }, size);
+    t.queue.submit([commandEncoder.finish()]);
+  });
+});
+
+g.test('copyTextureToBuffer')
+  .desc(`Test that an outstanding mapping will prevent copyTextureToBuffer commands from submitting.`)
+  .fn(async t => {
+  const size = { width: 1, height: 1 };
+
+  const texture = t.device.createTexture({
+    size,
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.COPY_SRC
+  });
+
+  const options = {
+    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    mapMode: GPUMapMode.READ,
+  };
+
+  t.runBufferDependencyTest(options, (buffer: GPUBuffer) => {
+    const commandEncoder = t.device.createCommandEncoder();
+    commandEncoder.copyTextureToBuffer({ texture }, { buffer }, size);
+    t.queue.submit([commandEncoder.finish()]);
+  });
+});
+
+g.test('map_command_recording_order')
+  .desc(`
+Test that the order of mapping a buffer relative to when commands are recorded that use it
+  does not matter, as long as the buffer is unmapped when the commands are submitted.
+  `)
+  .paramsSubcasesOnly([
+    { order: ['record', 'map', 'unmap', 'finish', 'submit'], _shouldError: false },
+    { order: ['record', 'map', 'finish', 'unmap', 'submit'], _shouldError: false },
+    { order: ['record', 'finish', 'map', 'unmap', 'submit'], _shouldError: false },
+    { order: ['map', 'record', 'unmap', 'finish', 'submit'], _shouldError: false },
+    { order: ['map', 'record', 'finish', 'unmap', 'submit'], _shouldError: false },
+    { order: ['map', 'record', 'finish', 'submit', 'unmap'], _shouldError: true },
+    { order: ['record', 'map', 'finish', 'submit', 'unmap'], _shouldError: true },
+    { order: ['record', 'finish', 'map', 'submit', 'unmap'], _shouldError: true },
+  ] as const)
+  .fn(async t => {
+    const { order, _shouldError: shouldError } = t.params;
+
   const buffer = t.device.createBuffer({
     size: 4,
     usage: GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
@@ -24,24 +222,30 @@ g.test('submit').fn(async t => {
     usage: GPUBufferUsage.COPY_DST,
   });
 
-  const getCommandBuffer = (): GPUCommandBuffer => {
-    const commandEncoder = t.device.createCommandEncoder();
-    commandEncoder.copyBufferToBuffer(buffer, 0, targetBuffer, 0, 4);
-    return commandEncoder.finish();
-  };
+  let commandEncoder = t.device.createCommandEncoder();
+  let commandBuffer : GPUCommandBuffer;
 
-  // Submitting when the buffer has never been mapped should succeed
-  t.queue.submit([getCommandBuffer()]);
+  const steps = {
+    'record': async () => {
+      commandEncoder.copyBufferToBuffer(buffer, 0, targetBuffer, 0, 4);
+    },
+    'map': async () => {
+      await buffer.mapAsync(GPUMapMode.WRITE);
+    },
+    'unmap': async() => {
+      buffer.unmap();
+    },
+    'finish': async () => {
+      commandBuffer = commandEncoder.finish();
+    },
+    'submit': async () => {
+      t.expectValidationError(() => {
+        t.queue.submit([commandBuffer]);
+      }, shouldError);
+    }
+  }
 
-  // Map the buffer, submitting when the buffer is mapped (even with no getMappedRange) should fail
-  await buffer.mapAsync(GPUMapMode.WRITE);
-  t.queue.submit([]);
-
-  t.expectValidationError(() => {
-    t.queue.submit([getCommandBuffer()]);
-  });
-
-  // Unmap the buffer, queue submit should succeed
-  buffer.unmap();
-  t.queue.submit([getCommandBuffer()]);
+  for (const op of order) {
+    await steps[op]();
+  }
 });


### PR DESCRIPTION
Issue: #903

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
