### PR TITLE
Add rgba16float support for canvas context

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -246,7 +246,7 @@ export const kRenderableColorTextureFormats = kRegularTextureFormats.filter(
 );
 
 // The formats of GPUTextureFormat for canvas context.
-export const kCanvasTextureFormats = ['bgra8unorm', 'rgba8unorm'] as const;
+export const kCanvasTextureFormats = ['bgra8unorm', 'rgba8unorm', 'rgba16float'] as const;
 
 /** Per-GPUTextureFormat info. */
 // Exists just for documentation. Otherwise could be inferred by `makeTable`.

--- a/src/webgpu/web_platform/reftests/README.txt
+++ b/src/webgpu/web_platform/reftests/README.txt
@@ -8,7 +8,8 @@ This tests things like:
 - The canvas renders with the correct transfer function.
 - The canvas blends and interpolates in the correct color encoding.
 
-TODO(#916): Test all possible ways to write into those formats (currently only testing B2T copy).
+TODO(#915): canvas_complex: test rgba8unorm and rgba16float
+TODO(#916): canvas_complex: Test all ways to write into textures (currently only testing copy methods).
 TODO(#917): Test compositingAlphaMode options
 TODO(#918): Test all possible color spaces (once we have more than 1)
 

--- a/src/webgpu/web_platform/reftests/README.txt
+++ b/src/webgpu/web_platform/reftests/README.txt
@@ -8,7 +8,6 @@ This tests things like:
 - The canvas renders with the correct transfer function.
 - The canvas blends and interpolates in the correct color encoding.
 
-TODO(#915): Test all possible output texture formats (currently only needs rgba16float).
 TODO(#916): Test all possible ways to write into those formats (currently only testing B2T copy).
 TODO(#917): Test compositingAlphaMode options
 TODO(#918): Test all possible color spaces (once we have more than 1)

--- a/src/webgpu/web_platform/reftests/canvas_clear.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_clear.html.ts
@@ -29,4 +29,5 @@ runRefTest(async t => {
 
   draw('cvs0', 'bgra8unorm');
   draw('cvs1', 'rgba8unorm');
+  draw('cvs2', 'rgba16float');
 });

--- a/src/webgpu/web_platform/reftests/canvas_clear.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_clear.https.html
@@ -6,6 +6,7 @@
   <link rel="match" href="./ref/canvas_clear-ref.html" />
   <canvas id="cvs0" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <canvas id="cvs1" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="cvs2" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module" src="canvas_clear.html.js"></script>
 </html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_clear-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_clear-ref.html
@@ -4,6 +4,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <canvas id="cvs0" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <canvas id="cvs1" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="cvs2" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script>
     function draw(canvas) {
       var c = document.getElementById(canvas);
@@ -14,6 +15,7 @@
 
     draw('cvs0');
     draw('cvs1');
+    draw('cvs2');
 
  </script>
 </html>


### PR DESCRIPTION
This extends the readbackFromWebGPUCanvas and canvas_clear tests to cover rgba16float.




Issue: #915

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
