### PR TITLE
Await on runBufferDependencyTest

### DIFF
--- a/src/webgpu/api/validation/queue/buffer_mapped.spec.ts
+++ b/src/webgpu/api/validation/queue/buffer_mapped.spec.ts
@@ -95,7 +95,7 @@ g.test('writeBuffer')
   .fn(async t => {
     const data = new Uint32Array([42]);
 
-    t.runBufferDependencyTest(
+    await t.runBufferDependencyTest(
       GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
       (buffer: GPUBuffer) => {
         t.queue.writeBuffer(buffer, 0, data);
@@ -120,7 +120,7 @@ g.test('copyBufferToBuffer')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.runBufferDependencyTest(
+    await t.runBufferDependencyTest(
       GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
       (buffer: GPUBuffer) => {
         const commandEncoder = t.device.createCommandEncoder();
@@ -152,7 +152,7 @@ g.test('copyBufferToTexture')
       usage: GPUTextureUsage.COPY_DST,
     });
 
-    t.runBufferDependencyTest(
+    await t.runBufferDependencyTest(
       GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC,
       (buffer: GPUBuffer) => {
         const commandEncoder = t.device.createCommandEncoder();
@@ -175,7 +175,7 @@ g.test('copyTextureToBuffer')
       usage: GPUTextureUsage.COPY_SRC,
     });
 
-    t.runBufferDependencyTest(
+    await t.runBufferDependencyTest(
       GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
       (buffer: GPUBuffer) => {
         const commandEncoder = t.device.createCommandEncoder();


### PR DESCRIPTION


Issue: #903 

Followup fix for https://github.com/gpuweb/cts/commit/91a1259873e35add48059cb836c88e656aa94459

Fixing
```
Uncaught (in promise) Error: No provider available right now; did you "await" selectDeviceOrSkipTestCase?
    at assert (util.ts:34:11)
    at F.get device [as device] (gpu_test.ts:77:5)
    at F.expectValidationError (gpu_test.ts:768:12)
    at F.runBufferDependencyTest (buffer_mapped.spec.ts:56:10)
```

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
