### PR TITLE
Await on runBufferDependencyTest, copyBufferToBuffer

### DIFF
--- a/src/webgpu/api/validation/queue/buffer_mapped.spec.ts
+++ b/src/webgpu/api/validation/queue/buffer_mapped.spec.ts
@@ -129,7 +129,7 @@ g.test('copyBufferToBuffer')
       }
     );
 
-    t.runBufferDependencyTest(
+    await t.runBufferDependencyTest(
       GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
       (buffer: GPUBuffer) => {
         const commandEncoder = t.device.createCommandEncoder();


### PR DESCRIPTION
Issue: https://github.com/gpuweb/cts/issues/903

Followup fix for #1013 

Somehow missed adding await on one appearance of runBufferDependencyTest
