### PR TITLE
memory model shuffle_workgroups shader var should be read-only

### DIFF
--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -76,7 +76,7 @@ type MemoryModelBuffers = {
   readResults: BufferWithSource;
   /** This buffer is the aggregated results of every testing thread, and is used to check for test success/failure. */
   testResults: BufferWithSource;
-  /** This buffer stores the shuffled workgroup ids for use during testing. */
+  /** This buffer stores the shuffled workgroup ids for use during testing. Read-only in the shader. */
   shuffledWorkgroups: BufferWithSource;
   /** This is the bounded spin-loop barrier, used to temporally align testing threads. */
   barrier: BufferWithSource;
@@ -255,7 +255,7 @@ export class MemoryModelTester {
       entries: [
         { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
         { binding: 1, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
-        { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
+        { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage' } },
         { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
         { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
         { binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage' } },
@@ -619,7 +619,7 @@ const twoBehaviorTestResultStructure = `
 const testShaderBindings = `
   @group(0) @binding(0) var<storage, read_write> test_locations : AtomicMemory;
   @group(0) @binding(1) var<storage, read_write> results : ReadResults;
-  @group(0) @binding(2) var<storage, read_write> shuffled_workgroups : Memory;
+  @group(0) @binding(2) var<storage, read> shuffled_workgroups : Memory;
   @group(0) @binding(3) var<storage, read_write> barrier : AtomicMemory;
   @group(0) @binding(4) var<storage, read_write> scratchpad : Memory;
   @group(0) @binding(5) var<storage, read_write> scratch_locations : Memory;


### PR DESCRIPTION

Issue: #1015

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
