### PR TITLE
Fix tests about multisampled textures based on latest SPEC changes

### DIFF
--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -512,7 +512,8 @@ const kTestParams = kUnitCaseParamsBuilder
 
     return (
       ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 && !info.renderable) ||
-      ((usage & GPUConst.TextureUsage.STORAGE_BINDING) !== 0 && !info.storage)
+      ((usage & GPUConst.TextureUsage.STORAGE_BINDING) !== 0 && !info.storage) ||
+      (sampleCount > 1 && !info.multisample)
     );
   })
   .combine('nonPowerOfTwo', [false, true])

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -290,12 +290,13 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
       .combine('usage', kTextureUsages)
       // Filter out incompatible dimension type and format combinations.
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
-      .unless(({ usage, format, mipLevelCount, dimension }) => {
+      .unless(({ sampleCount, usage, format, mipLevelCount, dimension }) => {
         const info = kTextureFormatInfo[format];
         return (
           ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 && !info.renderable) ||
           ((usage & GPUConst.TextureUsage.STORAGE_BINDING) !== 0 && !info.storage) ||
-          (mipLevelCount !== 1 && dimension === '1d')
+          (mipLevelCount !== 1 && dimension === '1d') ||
+          (sampleCount > 1 && !info.multisample)
         );
       })
   )

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -82,8 +82,8 @@ const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
   'rg8uint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               2],
   'rg8sint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               2],
   // 32-bit formats
-  'r32uint':               [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               4],
-  'r32sint':               [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               4],
+  'r32uint':               [        true,         false,        ,        ,          ,      true,          ,          ,       'uint',               4],
+  'r32sint':               [        true,         false,        ,        ,          ,      true,          ,          ,       'sint',               4],
   'r32float':              [        true,          true,        ,        ,          ,      true,          ,          ,      'unfilterable-float',               4],
   'rg16uint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               4],
   'rg16sint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               4],
@@ -100,16 +100,16 @@ const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
   'rg11b10ufloat':         [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               4],
   'rgb9e5ufloat':          [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               4],
   // 64-bit formats
-  'rg32uint':              [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               8],
-  'rg32sint':              [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               8],
-  'rg32float':             [        true,          true,        ,        ,          ,      true,          ,          ,      'unfilterable-float',               8],
+  'rg32uint':              [        true,         false,        ,        ,          ,      true,          ,          ,       'uint',               8],
+  'rg32sint':              [        true,         false,        ,        ,          ,      true,          ,          ,       'sint',               8],
+  'rg32float':             [        true,         false,        ,        ,          ,      true,          ,          ,      'unfilterable-float',               8],
   'rgba16uint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               8],
   'rgba16sint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               8],
   'rgba16float':           [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               8],
   // 128-bit formats
-  'rgba32uint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',              16],
-  'rgba32sint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',              16],
-  'rgba32float':           [        true,          true,        ,        ,          ,      true,          ,          ,      'unfilterable-float',              16],
+  'rgba32uint':            [        true,         false,        ,        ,          ,      true,          ,          ,       'uint',              16],
+  'rgba32sint':            [        true,         false,        ,        ,          ,      true,          ,          ,       'sint',              16],
+  'rgba32float':           [        true,         false,        ,        ,          ,      true,          ,          ,      'unfilterable-float',              16],
 } as const);
 /* prettier-ignore */
 const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature', 'baseFormat'] as const;


### PR DESCRIPTION
This patch fixes the tests about multisampled textures according to
the latest changes in WebGPU SPEC. In latest WebGPU SPEC more texture
formats are not allowed to be used to create multisampled textures.




Issue: #940 

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
