### PR TITLE
Add validation tests on resolve target formats

### DIFF
--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -6,10 +6,7 @@ TODO: review for completeness
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import {
-  kRenderableColorTextureFormats,
-  kTextureFormatInfo,
-} from '../../capability_info.js';
+import { kRenderableColorTextureFormats, kTextureFormatInfo } from '../../capability_info.js';
 
 import { ValidationTest } from './validation_test.js';
 

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -6,6 +6,10 @@ TODO: review for completeness
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import {
+  kRenderableColorTextureFormats,
+  kTextureFormatInfo,
+} from '../../capability_info.js';
 
 import { ValidationTest } from './validation_test.js';
 
@@ -579,3 +583,22 @@ g.test('check_depth_stencil_attachment_sample_counts_mismatch').fn(async t => {
     t.tryRenderPass(true, descriptor);
   }
 });
+
+g.test('resolve_target_formats_must_support_resolve')
+  .params(u =>
+    u
+      .combine('format', kRenderableColorTextureFormats)
+      .filter(t => kTextureFormatInfo[t.format].multisample)
+  )
+  .fn(async t => {
+    const { format } = t.params;
+    const multisampledColorTexture = t.createTexture({ format, sampleCount: 4 });
+    const resolveTarget = t.createTexture({ format });
+
+    const colorAttachment = t.getColorAttachment(multisampledColorTexture);
+    colorAttachment.resolveTarget = resolveTarget.createView();
+
+    t.tryRenderPass(kTextureFormatInfo[format].resolve, {
+      colorAttachments: [colorAttachment],
+    });
+  });

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -581,7 +581,7 @@ g.test('check_depth_stencil_attachment_sample_counts_mismatch').fn(async t => {
   }
 });
 
-g.test('resolve_target_formats_must_support_resolve')
+g.test('multisample_render_target_formats_support_resolve')
   .params(u =>
     u
       .combine('format', kRenderableColorTextureFormats)

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -66,134 +66,134 @@ export const kAllBufferUsageBits = kBufferUsages.reduce(
 
 // Note that we repeat the header multiple times in order to make it easier to read.
 const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
-                           ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature', 'baseFormat'] as const,
-                           [            ,              ,    true,   false,     false,          ,      true,      true,             ,                ,            1,             1,                         ,   undefined ] as const, {
+                           ['renderable', 'multisample', 'resolve', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature', 'baseFormat'] as const,
+                           [            ,              ,          ,    true,   false,     false,          ,      true,      true,             ,                ,            1,             1,                         ,   undefined ] as const, {
   // 8-bit formats
-  'r8unorm':               [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               1],
-  'r8snorm':               [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               1],
-  'r8uint':                [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               1],
-  'r8sint':                [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               1],
+  'r8unorm':               [        true,          true,      true,        ,        ,          ,     false,          ,          ,      'float',               1],
+  'r8snorm':               [       false,         false,     false,        ,        ,          ,     false,          ,          ,      'float',               1],
+  'r8uint':                [        true,          true,     false,        ,        ,          ,     false,          ,          ,       'uint',               1],
+  'r8sint':                [        true,          true,     false,        ,        ,          ,     false,          ,          ,       'sint',               1],
   // 16-bit formats
-  'r16uint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               2],
-  'r16sint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               2],
-  'r16float':              [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               2],
-  'rg8unorm':              [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               2],
-  'rg8snorm':              [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               2],
-  'rg8uint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               2],
-  'rg8sint':               [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               2],
+  'r16uint':               [        true,          true,     false,        ,        ,          ,     false,          ,          ,       'uint',               2],
+  'r16sint':               [        true,          true,     false,        ,        ,          ,     false,          ,          ,       'sint',               2],
+  'r16float':              [        true,          true,      true,        ,        ,          ,     false,          ,          ,      'float',               2],
+  'rg8unorm':              [        true,          true,      true,        ,        ,          ,     false,          ,          ,      'float',               2],
+  'rg8snorm':              [       false,         false,     false,        ,        ,          ,     false,          ,          ,      'float',               2],
+  'rg8uint':               [        true,          true,     false,        ,        ,          ,     false,          ,          ,       'uint',               2],
+  'rg8sint':               [        true,          true,     false,        ,        ,          ,     false,          ,          ,       'sint',               2],
   // 32-bit formats
-  'r32uint':               [        true,         false,        ,        ,          ,      true,          ,          ,       'uint',               4],
-  'r32sint':               [        true,         false,        ,        ,          ,      true,          ,          ,       'sint',               4],
-  'r32float':              [        true,          true,        ,        ,          ,      true,          ,          ,      'unfilterable-float',               4],
-  'rg16uint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'uint',               4],
-  'rg16sint':              [        true,          true,        ,        ,          ,     false,          ,          ,       'sint',               4],
-  'rg16float':             [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
-  'rgba8unorm':            [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               4,            ,                ,                          , 'rgba8unorm'],
-  'rgba8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4,            ,                ,                          , 'rgba8unorm'],
-  'rgba8snorm':            [       false,         false,        ,        ,          ,      true,          ,          ,      'float',               4],
-  'rgba8uint':             [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               4],
-  'rgba8sint':             [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               4],
-  'bgra8unorm':            [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4,            ,                ,                          , 'bgra8unorm'],
-  'bgra8unorm-srgb':       [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4,            ,                ,                          , 'bgra8unorm'],
+  'r32uint':               [        true,         false,     false,        ,        ,          ,      true,          ,          ,       'uint',               4],
+  'r32sint':               [        true,         false,     false,        ,        ,          ,      true,          ,          ,       'sint',               4],
+  'r32float':              [        true,          true,     false,        ,        ,          ,      true,          ,          ,      'unfilterable-float',               4],
+  'rg16uint':              [        true,          true,     false,        ,        ,          ,     false,          ,          ,       'uint',               4],
+  'rg16sint':              [        true,          true,     false,        ,        ,          ,     false,          ,          ,       'sint',               4],
+  'rg16float':             [        true,          true,      true,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'rgba8unorm':            [        true,          true,      true,        ,        ,          ,      true,          ,          ,      'float',               4,            ,                ,                          , 'rgba8unorm'],
+  'rgba8unorm-srgb':       [        true,          true,      true,        ,        ,          ,     false,          ,          ,      'float',               4,            ,                ,                          , 'rgba8unorm'],
+  'rgba8snorm':            [       false,         false,     false,        ,        ,          ,      true,          ,          ,      'float',               4],
+  'rgba8uint':             [        true,          true,     false,        ,        ,          ,      true,          ,          ,       'uint',               4],
+  'rgba8sint':             [        true,          true,     false,        ,        ,          ,      true,          ,          ,       'sint',               4],
+  'bgra8unorm':            [        true,          true,      true,        ,        ,          ,     false,          ,          ,      'float',               4,            ,                ,                          , 'bgra8unorm'],
+  'bgra8unorm-srgb':       [        true,          true,      true,        ,        ,          ,     false,          ,          ,      'float',               4,            ,                ,                          , 'bgra8unorm'],
   // Packed 32-bit formats
-  'rgb10a2unorm':          [        true,          true,        ,        ,          ,     false,          ,          ,      'float',               4],
-  'rg11b10ufloat':         [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               4],
-  'rgb9e5ufloat':          [       false,         false,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'rgb10a2unorm':          [        true,          true,      true,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'rg11b10ufloat':         [       false,         false,     false,        ,        ,          ,     false,          ,          ,      'float',               4],
+  'rgb9e5ufloat':          [       false,         false,     false,        ,        ,          ,     false,          ,          ,      'float',               4],
   // 64-bit formats
-  'rg32uint':              [        true,         false,        ,        ,          ,      true,          ,          ,       'uint',               8],
-  'rg32sint':              [        true,         false,        ,        ,          ,      true,          ,          ,       'sint',               8],
-  'rg32float':             [        true,         false,        ,        ,          ,      true,          ,          ,      'unfilterable-float',               8],
-  'rgba16uint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'uint',               8],
-  'rgba16sint':            [        true,          true,        ,        ,          ,      true,          ,          ,       'sint',               8],
-  'rgba16float':           [        true,          true,        ,        ,          ,      true,          ,          ,      'float',               8],
+  'rg32uint':              [        true,         false,     false,        ,        ,          ,      true,          ,          ,       'uint',               8],
+  'rg32sint':              [        true,         false,     false,        ,        ,          ,      true,          ,          ,       'sint',               8],
+  'rg32float':             [        true,         false,     false,        ,        ,          ,      true,          ,          ,      'unfilterable-float',               8],
+  'rgba16uint':            [        true,          true,     false,        ,        ,          ,      true,          ,          ,       'uint',               8],
+  'rgba16sint':            [        true,          true,     false,        ,        ,          ,      true,          ,          ,       'sint',               8],
+  'rgba16float':           [        true,          true,      true,        ,        ,          ,      true,          ,          ,      'float',               8],
   // 128-bit formats
-  'rgba32uint':            [        true,         false,        ,        ,          ,      true,          ,          ,       'uint',              16],
-  'rgba32sint':            [        true,         false,        ,        ,          ,      true,          ,          ,       'sint',              16],
-  'rgba32float':           [        true,         false,        ,        ,          ,      true,          ,          ,      'unfilterable-float',              16],
+  'rgba32uint':            [        true,         false,     false,        ,        ,          ,      true,          ,          ,       'uint',              16],
+  'rgba32sint':            [        true,         false,     false,        ,        ,          ,      true,          ,          ,       'sint',              16],
+  'rgba32float':           [        true,         false,     false,        ,        ,          ,      true,          ,          ,      'unfilterable-float',              16],
 } as const);
 /* prettier-ignore */
-const kTexFmtInfoHeader =  ['renderable', 'multisample', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature', 'baseFormat'] as const;
+const kTexFmtInfoHeader =  ['renderable', 'multisample', 'resolve', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature', 'baseFormat'] as const;
 const kSizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [        true,          true,   false,        ,          ,     false,     false,     false,             ,                ,            1,             1,                         ,   undefined ] as const, {
-  'depth32float':          [            ,              ,        ,    true,     false,          ,          ,          ,      'depth',               4],
-  'depth16unorm':          [            ,              ,        ,    true,     false,          ,          ,          ,      'depth',               2],
-  'stencil8':              [            ,              ,        ,   false,      true,          ,          ,          ,       'uint',               1],
+                           [        true,          true,     false,   false,        ,          ,     false,     false,     false,             ,                ,            1,             1,                         ,   undefined ] as const, {
+  'depth32float':          [            ,              ,          ,        ,    true,     false,          ,          ,          ,      'depth',               4],
+  'depth16unorm':          [            ,              ,          ,        ,    true,     false,          ,          ,          ,      'depth',               2],
+  'stencil8':              [            ,              ,          ,        ,   false,      true,          ,          ,          ,       'uint',               1],
 } as const);
 
 // Multi aspect sample type are now set to their first aspect
 const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [        true,          true,   false,        ,          ,     false,     false,     false,             ,       undefined,            1,             1,                         ,   undefined ] as const, {
-  'depth24plus':           [            ,              ,        ,    true,     false,          ,          ,          ,      'depth'],
-  'depth24plus-stencil8':  [            ,              ,        ,    true,      true,          ,          ,          ,      'depth'],
+                           [        true,          true,     false,   false,        ,          ,     false,     false,     false,             ,       undefined,            1,             1,                         ,   undefined ] as const, {
+  'depth24plus':           [            ,              ,          ,        ,    true,     false,          ,          ,          ,      'depth'],
+  'depth24plus-stencil8':  [            ,              ,          ,        ,    true,      true,          ,          ,          ,      'depth'],
   // MAINTENANCE_TODO: These should really be sized formats; see below MAINTENANCE_TODO about multi-aspect formats.
-  'depth24unorm-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth24unorm-stencil8'],
-  'depth32float-stencil8': [            ,              ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth32float-stencil8'],
+  'depth24unorm-stencil8': [            ,              ,          ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth24unorm-stencil8'],
+  'depth32float-stencil8': [            ,              ,          ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth32float-stencil8'],
 } as const);
 
 // Separated compressed formats by type
 const kBCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                         ,  undefined ] as const, {
+                           [       false,         false,     false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                         ,  undefined ] as const, {
   // Block Compression (BC) formats
-  'bc1-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc', 'bc1-rgba-unorm'],
-  'bc1-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc', 'bc1-rgba-unorm'],
-  'bc2-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc2-rgba-unorm'],
-  'bc2-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc2-rgba-unorm'],
-  'bc3-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc3-rgba-unorm'],
-  'bc3-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc3-rgba-unorm'],
-  'bc4-r-unorm':           [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
-  'bc4-r-snorm':           [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
-  'bc5-rg-unorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
-  'bc5-rg-snorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
-  'bc6h-rgb-ufloat':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
-  'bc6h-rgb-float':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
-  'bc7-rgba-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc7-rgba-unorm'],
-  'bc7-rgba-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc7-rgba-unorm'],
+  'bc1-rgba-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc', 'bc1-rgba-unorm'],
+  'bc1-rgba-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc', 'bc1-rgba-unorm'],
+  'bc2-rgba-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc2-rgba-unorm'],
+  'bc2-rgba-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc2-rgba-unorm'],
+  'bc3-rgba-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc3-rgba-unorm'],
+  'bc3-rgba-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc3-rgba-unorm'],
+  'bc4-r-unorm':           [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
+  'bc4-r-snorm':           [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-bc'],
+  'bc5-rg-unorm':          [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc5-rg-snorm':          [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc6h-rgb-ufloat':       [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc6h-rgb-float':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc'],
+  'bc7-rgba-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc7-rgba-unorm'],
+  'bc7-rgba-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-bc', 'bc7-rgba-unorm'],
 } as const);
 const kETC2TextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                          , undefined ] as const, {
+                           [       false,         false,     false,    true,   false,     false,     false,      true,      true,             ,                ,            4,             4,                          , undefined ] as const, {
   // Ericsson Compression (ETC2) formats
-  'etc2-rgb8unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2',  'etc2-rgb8unorm'],
-  'etc2-rgb8unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2',  'etc2-rgb8unorm'],
-  'etc2-rgb8a1unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2', 'etc2-rgb8a1unorm'],
-  'etc2-rgb8a1unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2', 'etc2-rgb8a1unorm'],
-  'etc2-rgba8unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2', 'etc2-rgba8unorm'],
-  'etc2-rgba8unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2', 'etc2-rgba8unorm'],
-  'eac-r11unorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'eac-r11snorm':          [            ,              ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
-  'eac-rg11unorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
-  'eac-rg11snorm':         [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+  'etc2-rgb8unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2',  'etc2-rgb8unorm'],
+  'etc2-rgb8unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2',  'etc2-rgb8unorm'],
+  'etc2-rgb8a1unorm':      [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2', 'etc2-rgb8a1unorm'],
+  'etc2-rgb8a1unorm-srgb': [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2', 'etc2-rgb8a1unorm'],
+  'etc2-rgba8unorm':       [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2', 'etc2-rgba8unorm'],
+  'etc2-rgba8unorm-srgb':  [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2', 'etc2-rgba8unorm'],
+  'eac-r11unorm':          [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'eac-r11snorm':          [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',               8,            4,             4, 'texture-compression-etc2'],
+  'eac-rg11unorm':         [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
+  'eac-rg11snorm':         [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-etc2'],
 } as const);
 const kASTCTextureFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [       false,         false,    true,   false,     false,     false,      true,      true,             ,                ,             ,              ,                           , undefined] as const, {
+                           [       false,         false,     false,    true,   false,     false,     false,      true,      true,             ,                ,             ,              ,                           , undefined] as const, {
   // Adaptable Scalable Compression (ASTC) formats
-  'astc-4x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc', 'astc-4x4-unorm'],
-  'astc-4x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc', 'astc-4x4-unorm'],
-  'astc-5x4-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc', 'astc-5x4-unorm'],
-  'astc-5x4-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc', 'astc-5x4-unorm'],
-  'astc-5x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc', 'astc-5x5-unorm'],
-  'astc-5x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc', 'astc-5x5-unorm'],
-  'astc-6x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc', 'astc-6x5-unorm'],
-  'astc-6x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc', 'astc-6x5-unorm'],
-  'astc-6x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc', 'astc-6x6-unorm'],
-  'astc-6x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc', 'astc-6x6-unorm'],
-  'astc-8x5-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc', 'astc-8x5-unorm'],
-  'astc-8x5-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc', 'astc-8x5-unorm'],
-  'astc-8x6-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc', 'astc-8x6-unorm'],
-  'astc-8x6-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc', 'astc-8x6-unorm'],
-  'astc-8x8-unorm':        [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc', 'astc-8x8-unorm'],
-  'astc-8x8-unorm-srgb':   [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc', 'astc-8x8-unorm'],
-  'astc-10x5-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc', 'astc-10x5-unorm'],
-  'astc-10x5-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc', 'astc-10x5-unorm'],
-  'astc-10x6-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc', 'astc-10x6-unorm'],
-  'astc-10x6-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc', 'astc-10x6-unorm'],
-  'astc-10x8-unorm':       [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc', 'astc-10x8-unorm'],
-  'astc-10x8-unorm-srgb':  [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc', 'astc-10x8-unorm'],
-  'astc-10x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc', 'astc-10x10-unorm'],
-  'astc-10x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc', 'astc-10x10-unorm'],
-  'astc-12x10-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc', 'astc-12x10-unorm'],
-  'astc-12x10-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc', 'astc-12x10-unorm'],
-  'astc-12x12-unorm':      [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc', 'astc-12x12-unorm'],
-  'astc-12x12-unorm-srgb': [            ,              ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc', 'astc-12x12-unorm'],
+  'astc-4x4-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc', 'astc-4x4-unorm'],
+  'astc-4x4-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            4,             4, 'texture-compression-astc', 'astc-4x4-unorm'],
+  'astc-5x4-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc', 'astc-5x4-unorm'],
+  'astc-5x4-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             4, 'texture-compression-astc', 'astc-5x4-unorm'],
+  'astc-5x5-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc', 'astc-5x5-unorm'],
+  'astc-5x5-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            5,             5, 'texture-compression-astc', 'astc-5x5-unorm'],
+  'astc-6x5-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc', 'astc-6x5-unorm'],
+  'astc-6x5-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             5, 'texture-compression-astc', 'astc-6x5-unorm'],
+  'astc-6x6-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc', 'astc-6x6-unorm'],
+  'astc-6x6-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            6,             6, 'texture-compression-astc', 'astc-6x6-unorm'],
+  'astc-8x5-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc', 'astc-8x5-unorm'],
+  'astc-8x5-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             5, 'texture-compression-astc', 'astc-8x5-unorm'],
+  'astc-8x6-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc', 'astc-8x6-unorm'],
+  'astc-8x6-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             6, 'texture-compression-astc', 'astc-8x6-unorm'],
+  'astc-8x8-unorm':        [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc', 'astc-8x8-unorm'],
+  'astc-8x8-unorm-srgb':   [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,            8,             8, 'texture-compression-astc', 'astc-8x8-unorm'],
+  'astc-10x5-unorm':       [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc', 'astc-10x5-unorm'],
+  'astc-10x5-unorm-srgb':  [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             5, 'texture-compression-astc', 'astc-10x5-unorm'],
+  'astc-10x6-unorm':       [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc', 'astc-10x6-unorm'],
+  'astc-10x6-unorm-srgb':  [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             6, 'texture-compression-astc', 'astc-10x6-unorm'],
+  'astc-10x8-unorm':       [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc', 'astc-10x8-unorm'],
+  'astc-10x8-unorm-srgb':  [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,             8, 'texture-compression-astc', 'astc-10x8-unorm'],
+  'astc-10x10-unorm':      [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc', 'astc-10x10-unorm'],
+  'astc-10x10-unorm-srgb': [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           10,            10, 'texture-compression-astc', 'astc-10x10-unorm'],
+  'astc-12x10-unorm':      [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc', 'astc-12x10-unorm'],
+  'astc-12x10-unorm-srgb': [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            10, 'texture-compression-astc', 'astc-12x10-unorm'],
+  'astc-12x12-unorm':      [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc', 'astc-12x12-unorm'],
+  'astc-12x12-unorm-srgb': [            ,              ,          ,        ,        ,          ,          ,          ,          ,      'float',              16,           12,            12, 'texture-compression-astc', 'astc-12x12-unorm'],
 } as const);
 
 // Definitions for use locally. To access the table entries, use `kTextureFormatInfo`.
@@ -258,6 +258,8 @@ export type TextureFormatInfo = {
   renderable: boolean;
   /** Whether the format can be used in a multisample texture. */
   multisample: boolean;
+  /** Whether the texture with the format can be used as a resolve target. */
+  resolve: boolean;
   /** Whether the format has a color aspect. */
   color: boolean;
   /** Whether the format has a depth aspect. */


### PR DESCRIPTION


Issue: #940
Fixes: #940 

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
