### PR TITLE
Add additional memory model tests and refactor setup code

### DIFF
--- a/src/webgpu/shader/execution/memory_model/atomicity.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/atomicity.spec.ts
@@ -6,8 +6,10 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildStorageClassMemoryTestShader,
   buildFourResultShader,
+  buildTestShader,
+  MemoryType,
+  TestType
 } from './memory_model_setup.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -49,22 +51,10 @@ g.test('atomicity')
   )
   .fn(async t => {
     const testCode = `
-        let total_ids = u32(workgroupXSize) * stress_params.testing_workgroups;
-        let id_0 = shuffled_workgroup * u32(workgroupXSize) + local_invocation_id[0];
-        let new_workgroup = stripe_workgroup(shuffled_workgroup, local_invocation_id[0]);
-        let id_1 = new_workgroup * u32(workgroupXSize) + permute_id(local_invocation_id[0], stress_params.permute_first, u32(workgroupXSize));
-        let x_0 = (id_0) * stress_params.mem_stride * 2u;
-        let x_1 = (id_1) * stress_params.mem_stride * 2u;
-        if (stress_params.pre_stress == 1u) {
-          do_stress(stress_params.pre_stress_iterations, stress_params.pre_stress_pattern, shuffled_workgroup);
-        }
-        if (stress_params.do_barrier == 1u) {
-          spin(u32(workgroupXSize) * stress_params.testing_workgroups);
-        }
-        let r0 = atomicAdd(&test_locations.value[x_0], 0u);
-        atomicStore(&test_locations.value[x_1], 2u);
-        workgroupBarrier();
-        atomicStore(&results.value[id_0].r0, r0);
+      let r0 = atomicAdd(&test_locations.value[x_0], 0u);
+      atomicStore(&test_locations.value[x_1], 2u);
+      workgroupBarrier();
+      atomicStore(&results.value[id_0].r0, r0);
     `;
     const resultCode = `
       let id_0 = workgroup_id[0] * u32(workgroupXSize) + local_invocation_id[0];
@@ -80,7 +70,7 @@ g.test('atomicity')
       }
     `;
 
-    const testShader = buildStorageClassMemoryTestShader(testCode);
+    const testShader = buildTestShader(testCode, MemoryType.AtomicStorageClass, TestType.InterWorkgroup);
     const resultShader = buildFourResultShader(resultCode);
     const memModelTester = new MemoryModelTester(
       t,

--- a/src/webgpu/shader/execution/memory_model/atomicity.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/atomicity.spec.ts
@@ -6,7 +6,7 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildInterWorkgroupTestShader,
+  buildStorageClassMemoryTestShader,
   buildFourResultShader,
 } from './memory_model_setup.js';
 
@@ -80,7 +80,7 @@ g.test('atomicity')
       }
     `;
 
-    const testShader = buildInterWorkgroupTestShader(testCode);
+    const testShader = buildStorageClassMemoryTestShader(testCode);
     const resultShader = buildFourResultShader(resultCode);
     const memModelTester = new MemoryModelTester(
       t,

--- a/src/webgpu/shader/execution/memory_model/atomicity.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/atomicity.spec.ts
@@ -7,10 +7,10 @@ import {
   MemoryModelTestParams,
   MemoryModelTester,
   buildTestShader,
-  MemoryType,
   TestType,
   buildResultShader,
   ResultType,
+  MemoryType,
 } from './memory_model_setup.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -43,6 +43,30 @@ const memoryModelTestParams: MemoryModelTestParams = {
   numBehaviors: 4,
 };
 
+const storageMemoryTestCode = `
+  let r0 = atomicAdd(&test_locations.value[x_0], 0u);
+  atomicStore(&test_locations.value[x_1], 2u);
+  atomicStore(&results.value[id_0].r0, r0);
+`;
+
+const workgroupMemoryTestCode = `
+  let r0 = atomicAdd(&wg_test_locations[x_0], 0u);
+  atomicStore(&wg_test_locations[x_1], 2u);
+  workgroupBarrier();
+  atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_0].r0, r0);
+  atomicStore(&test_locations.value[shuffled_workgroup * workgroupXSize * stress_params.mem_stride * 2u + x_1], atomicLoad(&wg_test_locations[x_1]));
+`;
+
+const resultCode = `
+  if ((r0 == 0u && mem_x_0 == 2u)) {
+    atomicAdd(&test_results.seq0, 1u);
+  } else if ((r0 == 2u && mem_x_0 == 1u)) {
+    atomicAdd(&test_results.seq1, 1u);
+  } else if ((r0 == 0u && mem_x_0 == 1u)) {
+    atomicAdd(&test_results.weak, 1u);
+  }
+`;
+
 g.test('atomicity')
   .desc(
     `Checks whether a store on one thread can interrupt an atomic RMW on a second thread. If the read returned by
@@ -50,33 +74,26 @@ g.test('atomicity')
     in the second thread occurred in between the read and the write of the RMW.
     `
   )
+  .paramsSimple([
+    {
+      memType: MemoryType.AtomicStorageClass,
+      testType: TestType.InterWorkgroup,
+      _testCode: storageMemoryTestCode,
+    },
+    {
+      memType: MemoryType.AtomicStorageClass,
+      testType: TestType.IntraWorkgroup,
+      _testCode: storageMemoryTestCode,
+    },
+    {
+      memType: MemoryType.AtomicWorkgroupClass,
+      testType: TestType.IntraWorkgroup,
+      _testCode: workgroupMemoryTestCode,
+    },
+  ])
   .fn(async t => {
-    const testCode = `
-      let r0 = atomicAdd(&test_locations.value[x_0], 0u);
-      atomicStore(&test_locations.value[x_1], 2u);
-      workgroupBarrier();
-      atomicStore(&results.value[id_0].r0, r0);
-    `;
-    const resultCode = `
-      if ((r0 == 0u && mem_x_0 == 2u)) {
-        atomicAdd(&test_results.seq0, 1u);
-      } else if ((r0 == 2u && mem_x_0 == 1u)) {
-        atomicAdd(&test_results.seq1, 1u);
-      } else if ((r0 == 0u && mem_x_0 == 1u)) {
-        atomicAdd(&test_results.weak, 1u);
-      }
-    `;
-
-    const testShader = buildTestShader(
-      testCode,
-      MemoryType.AtomicStorageClass,
-      TestType.InterWorkgroup
-    );
-    const resultShader = buildResultShader(
-      resultCode,
-      TestType.InterWorkgroup,
-      ResultType.FourBehavior
-    );
+    const testShader = buildTestShader(t.params._testCode, t.params.memType, t.params.testType);
+    const resultShader = buildResultShader(resultCode, t.params.testType, ResultType.FourBehavior);
     const memModelTester = new MemoryModelTester(
       t,
       memoryModelTestParams,

--- a/src/webgpu/shader/execution/memory_model/atomicity.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/atomicity.spec.ts
@@ -6,10 +6,11 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildFourResultShader,
   buildTestShader,
   MemoryType,
-  TestType
+  TestType,
+  buildResultShader,
+  ResultType,
 } from './memory_model_setup.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -57,10 +58,6 @@ g.test('atomicity')
       atomicStore(&results.value[id_0].r0, r0);
     `;
     const resultCode = `
-      let id_0 = workgroup_id[0] * u32(workgroupXSize) + local_invocation_id[0];
-      let r0 = atomicLoad(&read_results.value[id_0].r0);
-      let x_0 = (id_0) * stress_params.mem_stride * 2u;
-      let mem_x_0 = atomicLoad(&test_locations.value[x_0]);
       if ((r0 == 0u && mem_x_0 == 2u)) {
         atomicAdd(&test_results.seq0, 1u);
       } else if ((r0 == 2u && mem_x_0 == 1u)) {
@@ -70,8 +67,16 @@ g.test('atomicity')
       }
     `;
 
-    const testShader = buildTestShader(testCode, MemoryType.AtomicStorageClass, TestType.InterWorkgroup);
-    const resultShader = buildFourResultShader(resultCode);
+    const testShader = buildTestShader(
+      testCode,
+      MemoryType.AtomicStorageClass,
+      TestType.InterWorkgroup
+    );
+    const resultShader = buildResultShader(
+      resultCode,
+      TestType.InterWorkgroup,
+      ResultType.FourBehavior
+    );
     const memModelTester = new MemoryModelTester(
       t,
       memoryModelTestParams,

--- a/src/webgpu/shader/execution/memory_model/barrier.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/barrier.spec.ts
@@ -7,10 +7,11 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildTwoResultShader,
   buildTestShader,
   MemoryType,
   TestType,
+  buildResultShader,
+  ResultType,
 } from './memory_model_setup.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -60,16 +61,22 @@ g.test('workgroup_barrier_store_load')
     `;
 
     const resultCode = `
-      let id_0 = workgroup_id[0] * u32(workgroupXSize) + local_invocation_id[0];
-      let r0 = atomicLoad(&read_results.value[id_0].r0);
       if (r0 == 1u) {
         atomicAdd(&test_results.seq, 1u);
       } else if (r0 == 0u) {
         atomicAdd(&test_results.weak, 1u);
       }
     `;
-    const testShader = buildTestShader(testCode, MemoryType.NonAtomicWorkgroupClass, TestType.IntraWorkgroup);
-    const resultShader = buildTwoResultShader(resultCode);
+    const testShader = buildTestShader(
+      testCode,
+      MemoryType.NonAtomicWorkgroupClass,
+      TestType.IntraWorkgroup
+    );
+    const resultShader = buildResultShader(
+      resultCode,
+      TestType.IntraWorkgroup,
+      ResultType.TwoBehavior
+    );
     const memModelTester = new MemoryModelTester(
       t,
       memoryModelTestParams,

--- a/src/webgpu/shader/execution/memory_model/barrier.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/barrier.spec.ts
@@ -7,7 +7,7 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildIntraWorkgroupTestShader,
+  buildWorkgroupClassMemoryTestShader,
   buildTwoResultShader,
 } from './memory_model_setup.js';
 
@@ -77,7 +77,7 @@ g.test('workgroup_barrier_store_load')
         atomicAdd(&test_results.weak, 1u);
       }
     `;
-    const testShader = buildIntraWorkgroupTestShader(testCode, false);
+    const testShader = buildWorkgroupClassMemoryTestShader(testCode, false);
     const resultShader = buildTwoResultShader(resultCode);
     const memModelTester = new MemoryModelTester(
       t,

--- a/src/webgpu/shader/execution/memory_model/coherence.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/coherence.spec.ts
@@ -9,7 +9,7 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildInterWorkgroupTestShader,
+  buildStorageClassMemoryTestShader,
   buildFourResultShader,
 } from './memory_model_setup.js';
 
@@ -87,7 +87,7 @@ g.test('corr')
       }
     `;
 
-    const testShader = buildInterWorkgroupTestShader(testCode);
+    const testShader = buildStorageClassMemoryTestShader(testCode);
     const resultShader = buildFourResultShader(resultCode);
     const memModelTester = new MemoryModelTester(
       t,

--- a/src/webgpu/shader/execution/memory_model/coherence.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/coherence.spec.ts
@@ -9,8 +9,10 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildStorageClassMemoryTestShader,
   buildFourResultShader,
+  buildTestShader,
+  MemoryType,
+  TestType,
 } from './memory_model_setup.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -52,25 +54,12 @@ g.test('corr')
   )
   .fn(async t => {
     const testCode = `
-        let total_ids = u32(workgroupXSize) * stress_params.testing_workgroups;
-        let id_0 = shuffled_workgroup * u32(workgroupXSize) + local_invocation_id[0];
-        let new_workgroup = stripe_workgroup(shuffled_workgroup, local_invocation_id[0]);
-        let id_1 = new_workgroup * u32(workgroupXSize) + permute_id(local_invocation_id[0], stress_params.permute_first, u32(workgroupXSize));
-        let x_0 = (id_0) * stress_params.mem_stride * 2u;
-        let x_1 = (id_1) * stress_params.mem_stride * 2u;
-        let y_1 = (permute_id(id_1, stress_params.permute_second, total_ids)) * stress_params.mem_stride * 2u + stress_params.location_offset;
-        if (stress_params.pre_stress == 1u) {
-          do_stress(stress_params.pre_stress_iterations, stress_params.pre_stress_pattern, shuffled_workgroup);
-        }
-        if (stress_params.do_barrier == 1u) {
-          spin(u32(workgroupXSize) * stress_params.testing_workgroups);
-        }
-        atomicStore(&test_locations.value[x_0], 1u);
-        let r0 = atomicLoad(&test_locations.value[x_1]);
-        let r1 = atomicLoad(&test_locations.value[y_1]);
-        workgroupBarrier();
-        atomicStore(&results.value[id_1].r0, r0);
-        atomicStore(&results.value[id_1].r1, r1);
+      atomicStore(&test_locations.value[x_0], 1u);
+      let r0 = atomicLoad(&test_locations.value[x_1]);
+      let r1 = atomicLoad(&test_locations.value[y_1]);
+      workgroupBarrier();
+      atomicStore(&results.value[id_1].r0, r0);
+      atomicStore(&results.value[id_1].r1, r1);
     `;
     const resultCode = `
       let id_0 = workgroup_id[0] * u32(workgroupXSize) + local_invocation_id[0];
@@ -87,7 +76,7 @@ g.test('corr')
       }
     `;
 
-    const testShader = buildStorageClassMemoryTestShader(testCode);
+    const testShader = buildTestShader(testCode, MemoryType.AtomicStorageClass, TestType.InterWorkgroup);
     const resultShader = buildFourResultShader(resultCode);
     const memModelTester = new MemoryModelTester(
       t,

--- a/src/webgpu/shader/execution/memory_model/coherence.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/coherence.spec.ts
@@ -9,10 +9,11 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildFourResultShader,
   buildTestShader,
   MemoryType,
   TestType,
+  buildResultShader,
+  ResultType,
 } from './memory_model_setup.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -62,9 +63,6 @@ g.test('corr')
       atomicStore(&results.value[id_1].r1, r1);
     `;
     const resultCode = `
-      let id_0 = workgroup_id[0] * u32(workgroupXSize) + local_invocation_id[0];
-      let r0 = atomicLoad(&read_results.value[id_0].r0);
-      let r1 = atomicLoad(&read_results.value[id_0].r1);
       if ((r0 == 0u && r1 == 0u)) {
         atomicAdd(&test_results.seq0, 1u);
       } else if ((r0 == 1u && r1 == 1u)) {
@@ -76,8 +74,16 @@ g.test('corr')
       }
     `;
 
-    const testShader = buildTestShader(testCode, MemoryType.AtomicStorageClass, TestType.InterWorkgroup);
-    const resultShader = buildFourResultShader(resultCode);
+    const testShader = buildTestShader(
+      testCode,
+      MemoryType.AtomicStorageClass,
+      TestType.InterWorkgroup
+    );
+    const resultShader = buildResultShader(
+      resultCode,
+      TestType.InterWorkgroup,
+      ResultType.FourBehavior
+    );
     const memModelTester = new MemoryModelTester(
       t,
       memoryModelTestParams,

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -922,10 +922,14 @@ const resultShaderCommonCode = [
  * its composite parts.
  */
 export enum MemoryType {
-  AtomicStorageClass,
-  NonAtomicStorageClass,
-  AtomicWorkgroupClass,
-  NonAtomicWorkgroupClass,
+  /** Atomic memory in the storage address space. */
+  AtomicStorageClass = 'atomic_storage',
+  /** Non-atomic memory in the storage address space. */
+  NonAtomicStorageClass = 'non_atomic_storage',
+  /** Atomic memory in the workgroup address space. */
+  AtomicWorkgroupClass = 'atomic_workgroup',
+  /** Non-atomic memory in the workgroup address space. */
+  NonAtomicWorkgroupClass = 'non_atomic_workgroup',
 }
 
 /**
@@ -933,8 +937,10 @@ export enum MemoryType {
  * code from its composite parts.
  */
 export enum TestType {
-  InterWorkgroup,
-  IntraWorkgroup,
+  /** A test consists of two invocations in different workgroups. */
+  InterWorkgroup = 'inter_workgroup',
+  /** A test consists of two invocations in the same workgroup. */
+  IntraWorkgroup = 'intra_workgroup',
 }
 
 /** Defines the number of behaviors a test may have. */

--- a/src/webgpu/shader/execution/memory_model/weak.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/weak.spec.ts
@@ -9,10 +9,11 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildFourResultShader,
   buildTestShader,
   MemoryType,
   TestType,
+  buildResultShader,
+  ResultType,
 } from './memory_model_setup.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -45,10 +46,8 @@ const memoryModelTestParams: MemoryModelTestParams = {
   numBehaviors: 4,
 };
 
-const messagePassingResultShader = buildFourResultShader(`
-  let id_0 = workgroup_id[0] * workgroupXSize + local_invocation_id[0];
-  let r0 = atomicLoad(&read_results.value[id_0].r0);
-  let r1 = atomicLoad(&read_results.value[id_0].r1);
+const messagePassingResultShader = buildResultShader(
+  `
   if ((r0 == 0u && r1 == 0u)) {
     atomicAdd(&test_results.seq0, 1u);
   } else if ((r0 == 1u && r1 == 1u)) {
@@ -58,7 +57,10 @@ const messagePassingResultShader = buildFourResultShader(`
   } else if ((r0 == 1u && r1 == 0u)) {
     atomicAdd(&test_results.weak, 1u);
   }
-`);
+`,
+  TestType.IntraWorkgroup,
+  ResultType.FourBehavior
+);
 
 g.test('message_passing_workgroup_memory')
   .desc(
@@ -82,7 +84,11 @@ g.test('message_passing_workgroup_memory')
       atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r1, r1);
     `;
 
-    const testShader = buildTestShader(testCode, MemoryType.AtomicWorkgroupClass, TestType.IntraWorkgroup);
+    const testShader = buildTestShader(
+      testCode,
+      MemoryType.AtomicWorkgroupClass,
+      TestType.IntraWorkgroup
+    );
     const memModelTester = new MemoryModelTester(
       t,
       memoryModelTestParams,
@@ -109,7 +115,11 @@ g.test('message_passing_storage_memory')
       atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r1, r1);
     `;
 
-    const testShader = buildTestShader(testCode, MemoryType.AtomicStorageClass, TestType.IntraWorkgroup);
+    const testShader = buildTestShader(
+      testCode,
+      MemoryType.AtomicStorageClass,
+      TestType.IntraWorkgroup
+    );
     const memModelTester = new MemoryModelTester(
       t,
       memoryModelTestParams,

--- a/src/webgpu/shader/execution/memory_model/weak.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/weak.spec.ts
@@ -9,8 +9,9 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
-  buildIntraWorkgroupTestShader,
   buildFourResultShader,
+  buildWorkgroupClassMemoryTestShader,
+  buildStorageClassMemoryTestShader,
 } from './memory_model_setup.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -43,6 +44,37 @@ const memoryModelTestParams: MemoryModelTestParams = {
   numBehaviors: 4,
 };
 
+const commonWeakSetupCode = `
+  let total_ids = workgroupXSize;
+  let id_0 = local_invocation_id[0];
+  let id_1 = permute_id(local_invocation_id[0], stress_params.permute_first, workgroupXSize);
+  let x_0 = (id_0) * stress_params.mem_stride * 2u;
+  let y_0 = (permute_id(id_0, stress_params.permute_second, total_ids)) * stress_params.mem_stride * 2u + stress_params.location_offset;
+  let y_1 = (permute_id(id_1, stress_params.permute_second, total_ids)) * stress_params.mem_stride * 2u + stress_params.location_offset;
+  let x_1 = (id_1) * stress_params.mem_stride * 2u;
+  if (stress_params.pre_stress == 1u) {
+    do_stress(stress_params.pre_stress_iterations, stress_params.pre_stress_pattern, shuffled_workgroup);
+  }
+  if (stress_params.do_barrier == 1u) {
+    spin(workgroupXSize);
+  }
+`;
+
+const messagePassingResultShader = buildFourResultShader(`
+  let id_0 = workgroup_id[0] * workgroupXSize + local_invocation_id[0];
+  let r0 = atomicLoad(&read_results.value[id_0].r0);
+  let r1 = atomicLoad(&read_results.value[id_0].r1);
+  if ((r0 == 0u && r1 == 0u)) {
+    atomicAdd(&test_results.seq0, 1u);
+  } else if ((r0 == 1u && r1 == 1u)) {
+    atomicAdd(&test_results.seq1, 1u);
+  } else if ((r0 == 0u && r1 == 1u)) {
+    atomicAdd(&test_results.interleaved, 1u);
+  } else if ((r0 == 1u && r1 == 0u)) {
+    atomicAdd(&test_results.weak, 1u);
+  }
+`);
+
 g.test('message_passing_workgroup_memory')
   .desc(
     `Checks whether two reads on one thread can observe two writes in another thread in a way
@@ -55,51 +87,49 @@ g.test('message_passing_workgroup_memory')
   )
   .fn(async t => {
     const testCode = `
-        let total_ids = workgroupXSize;
-        let id_0 = local_invocation_id[0];
-        let id_1 = permute_id(local_invocation_id[0], stress_params.permute_first, workgroupXSize);
-        let x_0 = (id_0) * stress_params.mem_stride * 2u;
-        let y_0 = (permute_id(id_0, stress_params.permute_second, total_ids)) * stress_params.mem_stride * 2u + stress_params.location_offset;
-        let y_1 = (permute_id(id_1, stress_params.permute_second, total_ids)) * stress_params.mem_stride * 2u + stress_params.location_offset;
-        let x_1 = (id_1) * stress_params.mem_stride * 2u;
-        if (stress_params.pre_stress == 1u) {
-          do_stress(stress_params.pre_stress_iterations, stress_params.pre_stress_pattern, shuffled_workgroup);
-        }
-        if (stress_params.do_barrier == 1u) {
-          spin(workgroupXSize);
-        }
-        atomicStore(&wg_test_locations[x_0], 1u);
-        workgroupBarrier();
-        atomicStore(&wg_test_locations[y_0], 1u);
-        let r0 = atomicLoad(&wg_test_locations[y_1]);
-        workgroupBarrier();
-        let r1 = atomicLoad(&wg_test_locations[x_1]);
-        workgroupBarrier();
-        atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r0, r0);
-        atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r1, r1);
-    `;
-    const resultCode = `
-      let id_0 = workgroup_id[0] * workgroupXSize + local_invocation_id[0];
-      let r0 = atomicLoad(&read_results.value[id_0].r0);
-      let r1 = atomicLoad(&read_results.value[id_0].r1);
-      if ((r0 == 0u && r1 == 0u)) {
-        atomicAdd(&test_results.seq0, 1u);
-      } else if ((r0 == 1u && r1 == 1u)) {
-        atomicAdd(&test_results.seq1, 1u);
-      } else if ((r0 == 0u && r1 == 1u)) {
-        atomicAdd(&test_results.interleaved, 1u);
-      } else if ((r0 == 1u && r1 == 0u)) {
-        atomicAdd(&test_results.weak, 1u);
-      }
+      atomicStore(&wg_test_locations[x_0], 1u);
+      workgroupBarrier();
+      atomicStore(&wg_test_locations[y_0], 1u);
+      let r0 = atomicLoad(&wg_test_locations[y_1]);
+      workgroupBarrier();
+      let r1 = atomicLoad(&wg_test_locations[x_1]);
+      atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r0, r0);
+      atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r1, r1);
     `;
 
-    const testShader = buildIntraWorkgroupTestShader(testCode);
-    const resultShader = buildFourResultShader(resultCode);
+    const testShader = buildWorkgroupClassMemoryTestShader([commonWeakSetupCode, testCode].join("\n"));
     const memModelTester = new MemoryModelTester(
       t,
       memoryModelTestParams,
       testShader,
-      resultShader
+      messagePassingResultShader
+    );
+    await memModelTester.run(20, 3);
+  });
+
+g.test('message_passing_storage_memory')
+  .desc(
+    `Performs the message passing litmus test using storage class memory.
+    `
+  )
+  .fn(async t => {
+    const testCode = `
+      atomicStore(&test_locations.value[x_0], 1u);
+      storageBarrier();
+      atomicStore(&test_locations.value[y_0], 1u);
+      let r0 = atomicLoad(&test_locations.value[y_1]);
+      storageBarrier();
+      let r1 = atomicLoad(&test_locations.value[x_1]);
+      atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r0, r0);
+      atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r1, r1);
+    `;
+
+    const testShader = buildStorageClassMemoryTestShader([commonWeakSetupCode, testCode].join("\n"));
+    const memModelTester = new MemoryModelTester(
+      t,
+      memoryModelTestParams,
+      testShader,
+      messagePassingResultShader
     );
     await memModelTester.run(20, 3);
   });


### PR DESCRIPTION
- With this PR, there are now 10 total tests
  - Two variants of an intra-workgroup message passing litmus test, operating on the "storage" and "workgroup" address spaces
  - Two variants of an intra-workgroup non-atomic store-load test with a barrier, operating on "storage" and "workgroup" address spaces
  - Three variants of the atomicity of atomic RMW operations, one inter-workgroup variant operating on "storage" address space and two intra-workgroup variants on "storage" and "workgroup"
  - Three variants of the CoRR (coherence of reads) litmus test, one inter-workgroup and two intra-workgroup

I also refactored some of the test generation code to remove more duplication with the addition of these new tests, and added some `enum`s so that tests can be subcased using the `paramsSimple` functionality of the CTS.

I wanted to submit this PR first to get feedback on the setup code and use of params. Once this lands, my next PR will hopefully be the remainder of the conformance tests at https://gpuharbor.ucsc.edu/webgpu-mem-testing/conformance/

Issue: #963 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.

@dneto0 @alan-baker @sorensenucsc
