### PR TITLE
Ensure lost device messages output the error message and reason.

### DIFF
--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -55,7 +55,10 @@ export class DevicePool {
       // (Hopefully if the device was lost, it has been reported by the time endErrorScopes()
       // has finished (or timed out). If not, it could cause a finite number of extra test
       // failures following this one (but should recover eventually).)
-      assert(holder.lostInfo === undefined, `Device was unexpectedly lost: ${holder.lostInfo}`);
+      assert(
+        holder.lostInfo === undefined,
+        `Device was unexpectedly lost. Reason: ${holder.lostInfo?.reason}, Message: ${holder.lostInfo?.message}`
+      );
     } catch (ex) {
       // Any error that isn't explicitly TestFailedButDeviceReusable forces a new device to be
       // created for the next test.


### PR DESCRIPTION
Found that lost device messages in the CTS were simply printing:

`Device was unexpectedly lost: [object GPUDeviceLostInfo]`

This updates the error to include the lost info reason and message, which makes debugging failures easier.