### PR TITLE
buffers,map_ArrayBuffer:* fake transfer of mapped array buffers

### DIFF
--- a/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
@@ -1,72 +1,81 @@
 export const description = `
 Tests for the behavior of ArrayBuffers returned by getMappedRange.
 
-TODO: Update these tests if we make this not an error, but instead "fake" the transfer:
-  https://github.com/gpuweb/gpuweb/issues/747#issuecomment-623712878
 TODO: Add tests that transfer to another thread instead of just using MessageChannel.
 TODO: Add tests for any other Web APIs that can detach ArrayBuffers.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { resolveOnTimeout } from '../../../../common/util/util.js';
+import { memcpy } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
+import { checkElementsEqual } from '../../../util/check_contents.js';
 
 export const g = makeTestGroup(GPUTest);
 
 g.test('postMessage')
   .desc(
-    `Using postMessage to send a getMappedRange-returned ArrayBuffer should throw an exception iff
-    the ArrayBuffer is in the transfer list (x= map read, map write).
-
-  TODO: Determine what the exception.name is expected to be. [1]`
+    `Using postMessage to send a getMappedRange-returned ArrayBuffer always make a copy of
+    the ArrayBuffer. It should detach it if it is in the transfer list.
+    Test combinations of transfer={false, true}, mapMode={read,write}.`
   )
   .params(u =>
     u //
       .combine('transfer', [false, true])
-      .combine('mapWrite', [false, true])
+      .combine('mapMode', ['READ', 'WRITE'] as const)
   )
   .fn(async t => {
-    const { transfer, mapWrite } = t.params;
+    const { transfer, mapMode } = t.params;
     const kSize = 1024;
 
     const buf = t.device.createBuffer({
       size: kSize,
-      usage: mapWrite ? GPUBufferUsage.MAP_WRITE : GPUBufferUsage.MAP_READ,
+      usage: mapMode === 'WRITE' ? GPUBufferUsage.MAP_WRITE : GPUBufferUsage.MAP_READ,
     });
-    await buf.mapAsync(mapWrite ? GPUMapMode.WRITE : GPUMapMode.READ);
-    const ab1 = buf.getMappedRange();
-    t.expect(ab1.byteLength === kSize, 'ab1 should have size of buffer');
+    await buf.mapAsync(GPUMapMode[mapMode]);
+    let ab1 = buf.getMappedRange();
+    t.expect(ab1.byteLength === kSize, 'ab1 should have the size of the buffer');
+
+    // Populate initial data.
+    const initialData = new Uint32Array(new ArrayBuffer(kSize));
+    for (let i = 0; i < initialData.length; ++i) {
+      initialData[i] = i;
+    }
+    memcpy({ src: initialData }, { dst: ab1 });
 
     const mc = new MessageChannel();
     const ab2Promise = new Promise<ArrayBuffer>(resolve => {
       mc.port2.onmessage = ev => resolve(ev.data);
     });
-    // [1]: Pass an exception name here instead of `true`, once we figure out what the exception
-    // is supposed to be.
-    t.shouldThrow(
-      transfer ? true : false,
-      () => {
-        mc.port1.postMessage(ab1, transfer ? [ab1] : undefined);
-      },
-      'in postMessage'
-    );
-    t.expect(ab1.byteLength === kSize, 'after postMessage, ab1 should not be detached');
+
+    mc.port1.postMessage(ab1, transfer ? [ab1] : undefined);
+    if (transfer) {
+      t.expect(ab1.byteLength === 0, 'after postMessage, ab1 should be detached');
+      // Get the mapped range - again. So we can check that the data is not aliased
+      // with ab2. To do this, we need to unmap to reset the mapping state, and map
+      // again.
+      buf.unmap();
+      await buf.mapAsync(GPUMapMode[mapMode]);
+      ab1 = buf.getMappedRange();
+      t.expect(ab1.byteLength === kSize, 'ab1 should have the size of the buffer');
+    } else {
+      t.expect(ab1.byteLength === kSize, 'after postMessage, ab1 should not be detached');
+    }
+
+    const ab2 = await ab2Promise;
+    t.expect(ab2.byteLength === kSize, 'ab2 should be the same size');
+    const ab2Data = new Uint32Array(ab2, 0, initialData.length);
+    // ab2 should have the same initial contents.
+    checkElementsEqual(ab2Data, initialData);
+
+    // Mutations to ab2 should not be visible in ab1.
+    const ab1Data = new Uint32Array(ab1, 0, initialData.length);
+    const abs2NewData = initialData.slice().reverse();
+    for (let i = 0; i < ab2Data.length; ++i) {
+      ab2Data[i] = abs2NewData[i];
+    }
+    checkElementsEqual(ab1Data, initialData);
+    checkElementsEqual(ab2Data, abs2NewData);
 
     buf.unmap();
     t.expect(ab1.byteLength === 0, 'after unmap, ab1 should be detached');
-
-    const ab2 = await Promise.race([
-      // If `transfer` is true, this resolveOnTimeout is _supposed_ to win the race, because the
-      // postMessage should have errored and no message should have been received.
-      resolveOnTimeout(100),
-      // Either way, if postMessage succeeded, then we'll receive an ArrayBuffer on port2, and this
-      // will win the race.
-      ab2Promise,
-    ]);
-
-    if (ab2) {
-      t.expect(!transfer, 'postMessage should have failed if it transferred ab1');
-      // If `transfer` is false, this is a deep copy, and it shouldn't be affected by the unmap.
-      t.expect(ab2.byteLength === kSize, 'ab2 should be the same size');
-    }
   });

--- a/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
@@ -65,7 +65,7 @@ g.test('postMessage')
     t.expect(ab2.byteLength === kSize, 'ab2 should be the same size');
     const ab2Data = new Uint32Array(ab2, 0, initialData.length);
     // ab2 should have the same initial contents.
-    checkElementsEqual(ab2Data, initialData);
+    t.expectOK(checkElementsEqual(ab2Data, initialData));
 
     // Mutations to ab2 should not be visible in ab1.
     const ab1Data = new Uint32Array(ab1, 0, initialData.length);

--- a/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
@@ -73,8 +73,8 @@ g.test('postMessage')
     for (let i = 0; i < ab2Data.length; ++i) {
       ab2Data[i] = abs2NewData[i];
     }
-    checkElementsEqual(ab1Data, initialData);
-    checkElementsEqual(ab2Data, abs2NewData);
+    t.expectOK(checkElementsEqual(ab1Data, initialData));
+    t.expectOK(checkElementsEqual(ab2Data, abs2NewData));
 
     buf.unmap();
     t.expect(ab1.byteLength === 0, 'after unmap, ab1 should be detached');


### PR DESCRIPTION
Passes with updated Chromium implementation in https://chromium-review.googlesource.com/c/chromium/src/+/3496685

Issue: #1033

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
