### PR TITLE
Add variants of canvas_composite_alpha reftests that use a copy

### DIFF
--- a/src/webgpu/web_platform/reftests/README.txt
+++ b/src/webgpu/web_platform/reftests/README.txt
@@ -10,7 +10,6 @@ This tests things like:
 
 TODO(#915): canvas_complex: test rgba8unorm and rgba16float
 TODO(#916): canvas_complex: Test all ways to write into textures (currently only testing copy methods).
-TODO(#917): Test compositingAlphaMode options
 TODO(#918): Test all possible color spaces (once we have more than 1)
 
 TODO(#921): Why is there sometimes a difference of 1 (e.g. 3f vs 40) in canvas_size_different_with_back_buffer_size?

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -5,7 +5,13 @@ import { runRefTest } from './gpu_ref_test.js';
 // <canvas> element from html page
 declare const cvs: HTMLCanvasElement;
 
-export function run(format: GPUTextureFormat, compositingAlphaMode: GPUCanvasCompositingAlphaMode) {
+type WriteCanvasMethod = 'draw' | 'copy';
+
+export function run(
+  format: GPUTextureFormat,
+  compositingAlphaMode: GPUCanvasCompositingAlphaMode,
+  writeCanvasMethod: WriteCanvasMethod
+) {
   runRefTest(async t => {
     const ctx = cvs.getContext('webgpu');
     assert(ctx !== null, 'Failed to get WebGPU context from canvas');
@@ -23,10 +29,19 @@ export function run(format: GPUTextureFormat, compositingAlphaMode: GPUCanvasCom
     // This is mimic globalAlpha in 2d context blending behavior
     const a = compositingAlphaMode === 'opaque' ? (1.0).toFixed(1) : (0.5).toFixed(1);
 
+    let usage = 0;
+    switch (writeCanvasMethod) {
+      case 'draw':
+        usage = GPUTextureUsage.RENDER_ATTACHMENT;
+        break;
+      case 'copy':
+        usage = GPUTextureUsage.COPY_DST;
+        break;
+    }
     ctx.configure({
       device: t.device,
       format,
-      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      usage,
       compositingAlphaMode,
     });
 
@@ -109,10 +124,23 @@ return fragColor;
       },
     });
 
+    let renderTarget: GPUTexture;
+    switch (writeCanvasMethod) {
+      case 'draw':
+        renderTarget = ctx.getCurrentTexture();
+        break;
+      case 'copy':
+        renderTarget = t.device.createTexture({
+          size: [ctx.canvas.width, ctx.canvas.height],
+          format,
+          usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+        });
+        break;
+    }
     const renderPassDescriptor: GPURenderPassDescriptor = {
       colorAttachments: [
         {
-          view: ctx.getCurrentTexture().createView(),
+          view: renderTarget.createView(),
           clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
           loadOp: 'clear',
           storeOp: 'store',
@@ -128,6 +156,23 @@ return fragColor;
     passEncoder.draw(6, 1, 12, 0);
     passEncoder.draw(6, 1, 18, 0);
     passEncoder.end();
+
+    switch (writeCanvasMethod) {
+      case 'draw':
+        break;
+      case 'copy':
+        commandEncoder.copyTextureToTexture(
+          {
+            texture: renderTarget,
+          },
+          {
+            texture: ctx.getCurrentTexture(),
+          },
+          [ctx.canvas.width, ctx.canvas.height]
+        );
+        break;
+    }
+
     t.device.queue.submit([commandEncoder.finish()]);
   });
 }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
@@ -1,0 +1,20 @@
+<html class="reftest-wait">
+  <title>WebGPU canvas_composite_alpha_bgra8unorm_opaque</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta
+    name="assert"
+    content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
+  />
+  <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
+  <style>
+    body { background-color: #F0E68C; }
+  </style>
+  <canvas id="cvs" width="4" height="4" style="width: 20px; height: 20px;"></canvas>
+  <script src="/common/reftest-wait.js"></script>
+  <script type="module">
+    cvs.style.imageRendering = 'pixelated';
+    import { run } from './canvas_composite_alpha.html.js';
+    run('bgra8unorm', 'opaque', 'copy');
+  </script>
+</html>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
@@ -1,0 +1,20 @@
+<html class="reftest-wait">
+  <title>WebGPU canvas_composite_alpha_bgra8unorm_opaque</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta
+    name="assert"
+    content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
+  />
+  <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
+  <style>
+    body { background-color: #F0E68C; }
+  </style>
+  <canvas id="cvs" width="4" height="4" style="width: 20px; height: 20px;"></canvas>
+  <script src="/common/reftest-wait.js"></script>
+  <script type="module">
+    cvs.style.imageRendering = 'pixelated';
+    import { run } from './canvas_composite_alpha.html.js';
+    run('bgra8unorm', 'opaque', 'draw');
+  </script>
+</html>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
@@ -15,6 +15,6 @@
   <script type="module">
     cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
-    run('bgra8unorm', 'premultiplied');
+    run('bgra8unorm', 'premultiplied', 'copy');
   </script>
 </html>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
@@ -1,12 +1,12 @@
 <html class="reftest-wait">
-  <title>WebGPU canvas_composite_alpha_bgra8unorm_opaque</title>
+  <title>WebGPU canvas_composite_alpha_bgra8unorm_premultiplied</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta
     name="assert"
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
-  <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
+  <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
   <style>
     body { background-color: #F0E68C; }
   </style>
@@ -15,6 +15,6 @@
   <script type="module">
     cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
-    run('bgra8unorm', 'opaque');
+    run('bgra8unorm', 'premultiplied', 'draw');
   </script>
 </html>


### PR DESCRIPTION
This is to add coverage where the implementation may use a
render pass to clear alpha to 1.0 to implement "opaque". So
internally, the canvas texture should be made renderable.


Issue: #917

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
