### PR TITLE
Remove deprecated copyImageBitmapToTexture from comments and readme

### DIFF
--- a/src/webgpu/api/validation/queue/README.txt
+++ b/src/webgpu/api/validation/queue/README.txt
@@ -1,5 +1,5 @@
 Tests for validation that occurs inside queued operations
-(submit, writeBuffer, writeTexture, copyImageBitmapToTexture).
+(submit, writeBuffer, writeTexture, copyExternalImageToTexture).
 
 BufferMapStatesToTest = {
   mapped -> unmapped,

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-copyImageBitmapToTexture from ImageBitmaps created from various sources.
+copyExternalImageToTexture from ImageBitmaps created from various sources.
 
 TODO: Test ImageBitmap generated from all possible ImageBitmapSource, relevant ImageBitmapOptions
     (https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#images-2)


### PR DESCRIPTION
`copyImageBitmapToTexture` is deprecated API and it has been removed from cts tests. But the word `copyImageBitmapToTexture` remains in comments and readme. This commit replaces it with `copyExternalImageToTexture`.

This PR just updates comments and readme, doesn't change the tests at all.

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
