### PR TITLE
map_ArrayBuffer.spec.ts: initialize contents before mapping

### DIFF
--- a/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
@@ -6,7 +6,6 @@ TODO: Add tests for any other Web APIs that can detach ArrayBuffers.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { memcpy } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { checkElementsEqual } from '../../../util/check_contents.js';
 
@@ -27,20 +26,20 @@ g.test('postMessage')
     const { transfer, mapMode } = t.params;
     const kSize = 1024;
 
-    const buf = t.device.createBuffer({
-      size: kSize,
-      usage: mapMode === 'WRITE' ? GPUBufferUsage.MAP_WRITE : GPUBufferUsage.MAP_READ,
-    });
-    await buf.mapAsync(GPUMapMode[mapMode]);
-    let ab1 = buf.getMappedRange();
-    t.expect(ab1.byteLength === kSize, 'ab1 should have the size of the buffer');
-
     // Populate initial data.
     const initialData = new Uint32Array(new ArrayBuffer(kSize));
     for (let i = 0; i < initialData.length; ++i) {
       initialData[i] = i;
     }
-    memcpy({ src: initialData }, { dst: ab1 });
+
+    const buf = t.makeBufferWithContents(
+      initialData,
+      mapMode === 'WRITE' ? GPUBufferUsage.MAP_WRITE : GPUBufferUsage.MAP_READ
+    );
+
+    await buf.mapAsync(GPUMapMode[mapMode]);
+    let ab1 = buf.getMappedRange();
+    t.expect(ab1.byteLength === kSize, 'ab1 should have the size of the buffer');
 
     const mc = new MessageChannel();
     const ab2Promise = new Promise<ArrayBuffer>(resolve => {


### PR DESCRIPTION
So that remapping after transfer will yield the same mapped
contents. This was already the case for MapWrite, but not for
MapRead, since MapRead may flush buffer updates into the mapping.




Issue: #1033

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
