### PR TITLE
Match layout and shader in command_buffer,programmable,state_tracking

### DIFF
--- a/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
@@ -9,29 +9,45 @@ interface BindGroupIndices {
 }
 
 export class ProgrammableStateTest extends GPUTest {
-  private commonBindGroupLayout: GPUBindGroupLayout | undefined;
-  private encoder: GPUCommandEncoder | null = null;
+  private commonBindGroupLayouts: Map<string, GPUBindGroupLayout> = new Map();
 
-  get bindGroupLayout(): GPUBindGroupLayout {
-    if (!this.commonBindGroupLayout) {
-      this.commonBindGroupLayout = this.device.createBindGroupLayout({
-        entries: [
-          {
-            binding: 0,
-            visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
-            buffer: { type: 'storage' },
-          },
-        ],
-      });
+  private storageTypes: ('storage' | 'read-only-storage')[] = [
+    'read-only-storage',
+    'read-only-storage',
+    'storage',
+  ];
+  getBindGroupLayout(index: number): GPUBindGroupLayout {
+    const type = this.storageTypes[index];
+    if (!this.commonBindGroupLayouts.has(type)) {
+      this.commonBindGroupLayouts.set(
+        type,
+        this.device.createBindGroupLayout({
+          entries: [
+            {
+              binding: 0,
+              visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+              buffer: { type },
+            },
+          ],
+        })
+      );
     }
-    return this.commonBindGroupLayout;
+    return this.commonBindGroupLayouts.get(type)!;
   }
 
-  createBindGroup(buffer: GPUBuffer): GPUBindGroup {
+  createBindGroup(buffer: GPUBuffer, index: number): GPUBindGroup {
     return this.device.createBindGroup({
-      layout: this.bindGroupLayout,
+      layout: this.getBindGroupLayout(index),
       entries: [{ binding: 0, resource: { buffer } }],
     });
+  }
+
+  setBindGroup(
+    encoder: GPUProgrammablePassEncoder,
+    index: number,
+    factory: (index: number) => GPUBindGroup
+  ) {
+    encoder.setBindGroup(index, factory(index));
   }
 
   // Create a compute pipeline that performs an operation on data from two bind groups,
@@ -59,7 +75,11 @@ export class ProgrammableStateTest extends GPUTest {
 
         return this.device.createComputePipeline({
           layout: this.device.createPipelineLayout({
-            bindGroupLayouts: [this.bindGroupLayout, this.bindGroupLayout, this.bindGroupLayout],
+            bindGroupLayouts: [
+              this.getBindGroupLayout(0),
+              this.getBindGroupLayout(1),
+              this.getBindGroupLayout(2),
+            ],
           }),
           compute: {
             module: this.device.createShaderModule({
@@ -96,7 +116,11 @@ export class ProgrammableStateTest extends GPUTest {
 
         return this.device.createRenderPipeline({
           layout: this.device.createPipelineLayout({
-            bindGroupLayouts: [this.bindGroupLayout, this.bindGroupLayout, this.bindGroupLayout],
+            bindGroupLayouts: [
+              this.getBindGroupLayout(0),
+              this.getBindGroupLayout(1),
+              this.getBindGroupLayout(2),
+            ],
           }),
           vertex: {
             module: this.device.createShaderModule({

--- a/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
@@ -11,6 +11,7 @@ interface BindGroupIndices {
 export class ProgrammableStateTest extends GPUTest {
   private commonBindGroupLayouts: Map<string, GPUBindGroupLayout> = new Map();
 
+  // These types match the shader types in createBindingStatePipeline, below.
   private storageTypes: ('storage' | 'read-only-storage')[] = [
     'read-only-storage',
     'read-only-storage',

--- a/src/webgpu/api/operation/command_buffer/programmable/state_tracking.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/state_tracking.spec.ts
@@ -39,18 +39,20 @@ g.test('bind_group_indices')
     const pipeline = t.createBindingStatePipeline(encoderType, groupIndices);
 
     const out = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroups = {
-      a: t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage)),
-      b: t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage)),
-      out: t.createBindGroup(out),
+    const bindGroupFactories = {
+      a: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
+      b: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
+      out: (i: number) => t.createBindGroup(out, i),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
 
     t.setPipeline(encoder, pipeline);
-    encoder.setBindGroup(groupIndices.a, bindGroups.a);
-    encoder.setBindGroup(groupIndices.b, bindGroups.b);
-    encoder.setBindGroup(groupIndices.out, bindGroups.out);
+    t.setBindGroup(encoder, groupIndices.a, bindGroupFactories.a);
+    t.setBindGroup(encoder, groupIndices.b, bindGroupFactories.b);
+    t.setBindGroup(encoder, groupIndices.out, bindGroupFactories.out);
     t.dispatchOrDraw(encoder);
     validateFinishAndSubmit(true, true);
 
@@ -83,17 +85,19 @@ g.test('bind_group_order')
     const pipeline = t.createBindingStatePipeline(encoderType, groupIndices);
 
     const out = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroups = {
-      a: t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage)),
-      b: t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage)),
-      out: t.createBindGroup(out),
+    const bindGroupFactories = {
+      a: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
+      b: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
+      out: (i: number) => t.createBindGroup(out, i),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
     t.setPipeline(encoder, pipeline);
 
-    for (const group of setOrder) {
-      encoder.setBindGroup(groupIndices[group], bindGroups[group]);
+    for (let i = 0; i < setOrder.length; ++i) {
+      t.setBindGroup(encoder, groupIndices[setOrder[i]], bindGroupFactories[setOrder[i]]);
     }
 
     t.dispatchOrDraw(encoder);
@@ -125,22 +129,24 @@ g.test('bind_group_before_pipeline')
     const pipeline = t.createBindingStatePipeline(encoderType, groupIndices);
 
     const out = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroups = {
-      a: t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage)),
-      b: t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage)),
-      out: t.createBindGroup(out),
+    const bindGroupFactories = {
+      a: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
+      b: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
+      out: (i: number) => t.createBindGroup(out, i),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
 
-    for (const group of setBefore) {
-      encoder.setBindGroup(groupIndices[group], bindGroups[group]);
+    for (let i = 0; i < setBefore.length; ++i) {
+      t.setBindGroup(encoder, groupIndices[setBefore[i]], bindGroupFactories[setBefore[i]]);
     }
 
     t.setPipeline(encoder, pipeline);
 
-    for (const group of setAfter) {
-      encoder.setBindGroup(groupIndices[group], bindGroups[group]);
+    for (let i = 0; i < setAfter.length; ++i) {
+      t.setBindGroup(encoder, groupIndices[setAfter[i]], bindGroupFactories[setAfter[i]]);
     }
 
     t.dispatchOrDraw(encoder);
@@ -164,17 +170,18 @@ g.test('one_bind_group_multiple_slots')
     const pipeline = t.createBindingStatePipeline(encoderType, { a: 0, b: 1, out: 2 });
 
     const out = t.makeBufferWithContents(new Int32Array([1]), kBufferUsage);
-    const bindGroups = {
-      ab: t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage)),
-      out: t.createBindGroup(out),
+    const bindGroupFactories = {
+      ab: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
+      out: (i: number) => t.createBindGroup(out, i),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
     t.setPipeline(encoder, pipeline);
 
-    encoder.setBindGroup(0, bindGroups.ab);
-    encoder.setBindGroup(1, bindGroups.ab);
-    encoder.setBindGroup(2, bindGroups.out);
+    t.setBindGroup(encoder, 0, bindGroupFactories.ab);
+    t.setBindGroup(encoder, 1, bindGroupFactories.ab);
+    t.setBindGroup(encoder, 2, bindGroupFactories.out);
 
     t.dispatchOrDraw(encoder);
     validateFinishAndSubmit(true, true);
@@ -198,27 +205,30 @@ g.test('bind_group_multiple_sets')
 
     const badOut = t.makeBufferWithContents(new Int32Array([-1]), kBufferUsage);
     const out = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroups = {
-      a: t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage)),
-      b: t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage)),
-      c: t.createBindGroup(t.makeBufferWithContents(new Int32Array([5]), kBufferUsage)),
-      badOut: t.createBindGroup(badOut),
-      out: t.createBindGroup(out),
+    const bindGroupFactories = {
+      a: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
+      b: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
+      c: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([5]), kBufferUsage), i),
+      badOut: (i: number) => t.createBindGroup(badOut, i),
+      out: (i: number) => t.createBindGroup(out, i),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
 
-    encoder.setBindGroup(1, bindGroups.c);
+    t.setBindGroup(encoder, 1, bindGroupFactories.c);
 
     t.setPipeline(encoder, pipeline);
 
-    encoder.setBindGroup(0, bindGroups.c);
-    encoder.setBindGroup(0, bindGroups.a);
+    t.setBindGroup(encoder, 0, bindGroupFactories.c);
+    t.setBindGroup(encoder, 0, bindGroupFactories.a);
 
-    encoder.setBindGroup(2, bindGroups.badOut);
+    t.setBindGroup(encoder, 2, bindGroupFactories.badOut);
 
-    encoder.setBindGroup(1, bindGroups.b);
-    encoder.setBindGroup(2, bindGroups.out);
+    t.setBindGroup(encoder, 1, bindGroupFactories.b);
+    t.setBindGroup(encoder, 2, bindGroupFactories.out);
 
     t.dispatchOrDraw(encoder);
     validateFinishAndSubmit(true, true);
@@ -244,23 +254,25 @@ g.test('compatible_pipelines')
 
     const outA = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
     const outB = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroups = {
-      a: t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage)),
-      b: t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage)),
-      outA: t.createBindGroup(outA),
-      outB: t.createBindGroup(outB),
+    const bindGroupFactories = {
+      a: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
+      b: (i: number) =>
+        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
+      outA: (i: number) => t.createBindGroup(outA, i),
+      outB: (i: number) => t.createBindGroup(outB, i),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
-    encoder.setBindGroup(0, bindGroups.a);
-    encoder.setBindGroup(1, bindGroups.b);
+    t.setBindGroup(encoder, 0, bindGroupFactories.a);
+    t.setBindGroup(encoder, 1, bindGroupFactories.b);
 
     t.setPipeline(encoder, pipelineA);
-    encoder.setBindGroup(2, bindGroups.outA);
+    t.setBindGroup(encoder, 2, bindGroupFactories.outA);
     t.dispatchOrDraw(encoder);
 
     t.setPipeline(encoder, pipelineB);
-    encoder.setBindGroup(2, bindGroups.outB);
+    t.setBindGroup(encoder, 2, bindGroupFactories.outB);
     t.dispatchOrDraw(encoder);
 
     validateFinishAndSubmit(true, true);


### PR DESCRIPTION
These tests currently expect readonly storage buffers in the shader
to work with non-readonly storage buffer bindings in the layout. This
is not correct. readonly must match readonly, and read-write must match
read-write.

Found when updating Dawn's implementation to disallow this type of
promotion for crbug.com/dawn/1188

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
