### PR TITLE
webgpu: Migrate more `endPass()` -> `end()`

### DIFF
--- a/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
@@ -285,13 +285,13 @@ class TextureSyncTestHelper {
       }
       case 'compute-pass-encoder':
         assert(this.computePassEncoder !== undefined);
-        this.computePassEncoder.endPass();
+        this.computePassEncoder.end();
         this.computePassEncoder = undefined;
         this.currentContext = 'command-encoder';
         break;
       case 'render-pass-encoder':
         assert(this.renderPassEncoder !== undefined);
-        this.renderPassEncoder.endPass();
+        this.renderPassEncoder.end();
         this.renderPassEncoder = undefined;
         this.currentContext = 'command-encoder';
         break;

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -343,13 +343,13 @@ export class MemoryModelTester {
       testPass.setPipeline(this.testPipeline);
       testPass.setBindGroup(0, this.testBindGroup);
       testPass.dispatch(numWorkgroups);
-      testPass.endPass();
+      testPass.end();
 
       const resultPass = encoder.beginComputePass();
       resultPass.setPipeline(this.resultPipeline);
       resultPass.setBindGroup(0, this.resultBindGroup);
       resultPass.dispatch(this.params.testingWorkgroups);
-      resultPass.endPass();
+      resultPass.end();
 
       this.test.device.queue.submit([encoder.finish()]);
       this.test.expectGPUBufferValuesPassCheck(
@@ -556,20 +556,20 @@ const shaderMemStructures = `
   struct Memory {
     value: array<u32>;
   };
-    
+
   struct AtomicMemory {
     value: array<atomic<u32>>;
   };
-    
+
   struct ReadResult {
     r0: atomic<u32>;
     r1: atomic<u32>;
   };
-    
+
   struct ReadResults {
     value: array<ReadResult>;
   };
-    
+
   struct StressParamsMemory {
     do_barrier: u32;
     mem_stress: u32;
@@ -676,7 +676,7 @@ const memoryLocationFunctions = `
   fn permute_id(id: u32, factor: u32, mask: u32) -> u32 {
     return (id * factor) % mask;
   }
-    
+
   fn stripe_workgroup(workgroup_id: u32, local_id: u32) -> u32 {
     return (workgroup_id + 1u + local_id % (stress_params.testing_workgroups - 1u)) % stress_params.testing_workgroups;
   }
@@ -699,7 +699,7 @@ const testShaderFunctions = `
       i = i + 1u;
     }
   }
-    
+
   // Perform iterations of stress, depending on the specified pattern. Pattern 0 is store-store, pattern 1 is store-load,
   // pattern 2 is load-store, and pattern 3 is load-load. The extra if condition (if tmpX > 100000u), is used to avoid
   // the compiler optimizing out unused loads, where 100,000 is larger than the maximum number of stress iterations used

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -67,7 +67,7 @@ async function initCanvasContent(
         { view: tempTextureView, clearValue: color, loadOp: 'clear', storeOp: 'store' },
       ],
     });
-    pass.endPass();
+    pass.end();
     encoder.copyTextureToTexture(
       { texture: tempTexture },
       { texture: canvasTexture, origin },


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
