### PR TITLE
Fix api,operation,programmable,state_tracking - again

### DIFF
--- a/src/webgpu/api/operation/command_buffer/programmable/state_tracking.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/state_tracking.spec.ts
@@ -39,20 +39,24 @@ g.test('bind_group_indices')
     const pipeline = t.createBindingStatePipeline(encoderType, groupIndices);
 
     const out = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroupFactories = {
-      a: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
-      b: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
-      out: (i: number) => t.createBindGroup(out, i),
+    const bindGroups = {
+      a: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([3]), kBufferUsage),
+        'read-only-storage'
+      ),
+      b: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([2]), kBufferUsage),
+        'read-only-storage'
+      ),
+      out: t.createBindGroup(out, 'storage'),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
 
     t.setPipeline(encoder, pipeline);
-    t.setBindGroup(encoder, groupIndices.a, bindGroupFactories.a);
-    t.setBindGroup(encoder, groupIndices.b, bindGroupFactories.b);
-    t.setBindGroup(encoder, groupIndices.out, bindGroupFactories.out);
+    encoder.setBindGroup(groupIndices.a, bindGroups.a);
+    encoder.setBindGroup(groupIndices.b, bindGroups.b);
+    encoder.setBindGroup(groupIndices.out, bindGroups.out);
     t.dispatchOrDraw(encoder);
     validateFinishAndSubmit(true, true);
 
@@ -85,19 +89,23 @@ g.test('bind_group_order')
     const pipeline = t.createBindingStatePipeline(encoderType, groupIndices);
 
     const out = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroupFactories = {
-      a: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
-      b: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
-      out: (i: number) => t.createBindGroup(out, i),
+    const bindGroups = {
+      a: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([3]), kBufferUsage),
+        'read-only-storage'
+      ),
+      b: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([2]), kBufferUsage),
+        'read-only-storage'
+      ),
+      out: t.createBindGroup(out, 'storage'),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
     t.setPipeline(encoder, pipeline);
 
     for (let i = 0; i < setOrder.length; ++i) {
-      t.setBindGroup(encoder, groupIndices[setOrder[i]], bindGroupFactories[setOrder[i]]);
+      encoder.setBindGroup(groupIndices[setOrder[i]], bindGroups[setOrder[i]]);
     }
 
     t.dispatchOrDraw(encoder);
@@ -129,24 +137,28 @@ g.test('bind_group_before_pipeline')
     const pipeline = t.createBindingStatePipeline(encoderType, groupIndices);
 
     const out = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroupFactories = {
-      a: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
-      b: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
-      out: (i: number) => t.createBindGroup(out, i),
+    const bindGroups = {
+      a: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([3]), kBufferUsage),
+        'read-only-storage'
+      ),
+      b: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([2]), kBufferUsage),
+        'read-only-storage'
+      ),
+      out: t.createBindGroup(out, 'storage'),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
 
     for (let i = 0; i < setBefore.length; ++i) {
-      t.setBindGroup(encoder, groupIndices[setBefore[i]], bindGroupFactories[setBefore[i]]);
+      encoder.setBindGroup(groupIndices[setBefore[i]], bindGroups[setBefore[i]]);
     }
 
     t.setPipeline(encoder, pipeline);
 
     for (let i = 0; i < setAfter.length; ++i) {
-      t.setBindGroup(encoder, groupIndices[setAfter[i]], bindGroupFactories[setAfter[i]]);
+      encoder.setBindGroup(groupIndices[setAfter[i]], bindGroups[setAfter[i]]);
     }
 
     t.dispatchOrDraw(encoder);
@@ -170,18 +182,20 @@ g.test('one_bind_group_multiple_slots')
     const pipeline = t.createBindingStatePipeline(encoderType, { a: 0, b: 1, out: 2 });
 
     const out = t.makeBufferWithContents(new Int32Array([1]), kBufferUsage);
-    const bindGroupFactories = {
-      ab: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
-      out: (i: number) => t.createBindGroup(out, i),
+    const bindGroups = {
+      ab: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([3]), kBufferUsage),
+        'read-only-storage'
+      ),
+      out: t.createBindGroup(out, 'storage'),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
     t.setPipeline(encoder, pipeline);
 
-    t.setBindGroup(encoder, 0, bindGroupFactories.ab);
-    t.setBindGroup(encoder, 1, bindGroupFactories.ab);
-    t.setBindGroup(encoder, 2, bindGroupFactories.out);
+    encoder.setBindGroup(0, bindGroups.ab);
+    encoder.setBindGroup(1, bindGroups.ab);
+    encoder.setBindGroup(2, bindGroups.out);
 
     t.dispatchOrDraw(encoder);
     validateFinishAndSubmit(true, true);
@@ -205,30 +219,36 @@ g.test('bind_group_multiple_sets')
 
     const badOut = t.makeBufferWithContents(new Int32Array([-1]), kBufferUsage);
     const out = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroupFactories = {
-      a: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
-      b: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
-      c: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([5]), kBufferUsage), i),
-      badOut: (i: number) => t.createBindGroup(badOut, i),
-      out: (i: number) => t.createBindGroup(out, i),
+    const bindGroups = {
+      a: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([3]), kBufferUsage),
+        'read-only-storage'
+      ),
+      b: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([2]), kBufferUsage),
+        'read-only-storage'
+      ),
+      c: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([5]), kBufferUsage),
+        'read-only-storage'
+      ),
+      badOut: t.createBindGroup(badOut, 'storage'),
+      out: t.createBindGroup(out, 'storage'),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
 
-    t.setBindGroup(encoder, 1, bindGroupFactories.c);
+    encoder.setBindGroup(1, bindGroups.c);
 
     t.setPipeline(encoder, pipeline);
 
-    t.setBindGroup(encoder, 0, bindGroupFactories.c);
-    t.setBindGroup(encoder, 0, bindGroupFactories.a);
+    encoder.setBindGroup(0, bindGroups.c);
+    encoder.setBindGroup(0, bindGroups.a);
 
-    t.setBindGroup(encoder, 2, bindGroupFactories.badOut);
+    encoder.setBindGroup(2, bindGroups.badOut);
 
-    t.setBindGroup(encoder, 1, bindGroupFactories.b);
-    t.setBindGroup(encoder, 2, bindGroupFactories.out);
+    encoder.setBindGroup(1, bindGroups.b);
+    encoder.setBindGroup(2, bindGroups.out);
 
     t.dispatchOrDraw(encoder);
     validateFinishAndSubmit(true, true);
@@ -254,25 +274,29 @@ g.test('compatible_pipelines')
 
     const outA = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
     const outB = t.makeBufferWithContents(new Int32Array([0]), kBufferUsage);
-    const bindGroupFactories = {
-      a: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([3]), kBufferUsage), i),
-      b: (i: number) =>
-        t.createBindGroup(t.makeBufferWithContents(new Int32Array([2]), kBufferUsage), i),
-      outA: (i: number) => t.createBindGroup(outA, i),
-      outB: (i: number) => t.createBindGroup(outB, i),
+    const bindGroups = {
+      a: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([3]), kBufferUsage),
+        'read-only-storage'
+      ),
+      b: t.createBindGroup(
+        t.makeBufferWithContents(new Int32Array([2]), kBufferUsage),
+        'read-only-storage'
+      ),
+      outA: t.createBindGroup(outA, 'storage'),
+      outB: t.createBindGroup(outB, 'storage'),
     };
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
-    t.setBindGroup(encoder, 0, bindGroupFactories.a);
-    t.setBindGroup(encoder, 1, bindGroupFactories.b);
+    encoder.setBindGroup(0, bindGroups.a);
+    encoder.setBindGroup(1, bindGroups.b);
 
     t.setPipeline(encoder, pipelineA);
-    t.setBindGroup(encoder, 2, bindGroupFactories.outA);
+    encoder.setBindGroup(2, bindGroups.outA);
     t.dispatchOrDraw(encoder);
 
     t.setPipeline(encoder, pipelineB);
-    t.setBindGroup(encoder, 2, bindGroupFactories.outB);
+    encoder.setBindGroup(2, bindGroups.outB);
     t.dispatchOrDraw(encoder);
 
     validateFinishAndSubmit(true, true);


### PR DESCRIPTION
The previous PR #1037 assumed bind groups in the test had a fixed indices. 
This was not true for `webgpu:api,operation,command_buffer,programmable,state_tracking:bind_group_indices:*`.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
