### PR TITLE
CTS: Color space conversion operation test for CopyToTexture

### DIFF
--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -53,6 +53,9 @@ Whenever a new generally-useful helper is added, it should be indexed here.
 - {@link webgpu/util/conversion}: Numeric encoding/decoding for float/unorm/snorm values, etc.
 - {@link webgpu/util/copy_to_texture}:
     Helper class for copyToTexture test suites for execution copy and check results.
+- {@link webgpu/util/color_space_conversion}:
+    Helper functions to do color space conversion. The algorithm is the same as defined in
+    CSS Color Module Level 4.
 - {@link webgpu/util/create_elements}:
     Helpers for creating web elements like HTMLCanvasElement, OffscrrenCanvas, etc.
 - {@link webgpu/util/navigator_gpu}: Finds and returns the `navigator.gpu` object or equivalent.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,9 @@
 {
   "name": "@webgpu/cts",
   "version": "0.1.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
+<<<<<<< HEAD
   "packages": {
     "": {
       "name": "@webgpu/cts",
@@ -9541,6 +9542,8 @@
       }
     }
   },
+=======
+>>>>>>> f1d8e2a3 (WIP: CopyEI2T color space cts)
   "dependencies": {
     "@ampproject/remapping": {
       "version": "2.1.2",
@@ -16162,15 +16165,6 @@
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -16211,6 +16205,15 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/src/webgpu/util/color_space_conversion.ts
+++ b/src/webgpu/util/color_space_conversion.ts
@@ -2,7 +2,7 @@ import { assert } from '../../common/util/util.js';
 
 import { multiplyMatrices } from './math.js';
 
-// The color space conversion function definations copies directly from
+// These color space conversion function definitions are copied directly from
 // CSS Color Module Level 4 Sample Code: https://drafts.csswg.org/css-color/#color-conversion-code
 
 // Sample code for color conversions

--- a/src/webgpu/util/color_space_conversion.ts
+++ b/src/webgpu/util/color_space_conversion.ts
@@ -2,16 +2,12 @@ import { assert } from '../../common/util/util.js';
 
 import { multiplyMatrices } from './math.js';
 
-/**
- * The color space conversion function definations are fully aign with
- * CSS Color Module Level 4 Sample Code: https://drafts.csswg.org/css-color/#color-conversion-code
- */
+// The color space conversion function definations copies directly from
+// CSS Color Module Level 4 Sample Code: https://drafts.csswg.org/css-color/#color-conversion-code
 
-/**
- *  Sample code for color conversions
- * Conversion can also be done using ICC profiles and a Color Management System
- * For clarity, a library is used for matrix multiplication (multiply-matrices.js)
- */
+// Sample code for color conversions
+// Conversion can also be done using ICC profiles and a Color Management System
+// For clarity, a library is used for matrix multiplication (multiply-matrices.js)
 
 // sRGB-related functions
 
@@ -73,6 +69,7 @@ function lin_sRGB_to_XYZ(rgb: Array<Array<number>>) {
 
 /**
  * convert XYZ to linear-light sRGB
+ * using sRGB's own white, D65 (no chromatic adaptation)
  */
 function XYZ_to_lin_sRGB(XYZ: Array<Array<number>>) {
   const M = [
@@ -104,7 +101,7 @@ function gam_P3(RGB: Array<number>) {
 
 /**
  * convert an array of linear-light display-p3 values to CIE XYZ
- * using  D65 (no chromatic adaptation)
+ * using display-p3's D65 (no chromatic adaptation)
  * http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
  */
 function lin_P3_to_XYZ(rgb: Array<Array<number>>) {
@@ -120,6 +117,7 @@ function lin_P3_to_XYZ(rgb: Array<Array<number>>) {
 
 /**
  * convert XYZ to linear-light P3
+ * using display-p3's own white, D65 (no chromatic adaptation)
  */
 function XYZ_to_lin_P3(XYZ: Array<Array<number>>) {
   const M = [

--- a/src/webgpu/util/color_space_conversion.ts
+++ b/src/webgpu/util/color_space_conversion.ts
@@ -1,0 +1,190 @@
+import { assert } from '../../common/util/util.js';
+
+/**
+ * The color space conversion function definations are fully aign with
+ * CSS Color Module Level 4 Sample Code: https://drafts.csswg.org/css-color/#color-conversion-code
+ */
+
+/**
+ * Simple matrix (and vector) multiplication
+ * Warning: No error handling for incompatible dimensions!
+ * @author Lea Verou 2020 MIT License
+ */
+// A is m x n. B is n x p. product is m x p.
+function multiplyMatrices(A: Array<Array<number>>, B: Array<Array<number>>) {
+  const B_cols = B[0].map((_, i) => B.map(x => x[i])); // transpose B
+  const product = A.map(row =>
+    B_cols.map(col => {
+      if (!Array.isArray(row)) {
+        return col.reduce((a, c) => a + c * row, 0);
+      }
+
+      return row.reduce((a, c, i) => a + c * (col[i] || 0), 0);
+    })
+  );
+
+  return product;
+}
+
+// Sample code for color conversions
+// Conversion can also be done using ICC profiles and a Color Management System
+// For clarity, a library is used for matrix multiplication (multiply-matrices.js)
+
+// sRGB-related functions
+
+function lin_sRGB(RGB: Array<number>) {
+  // convert an array of sRGB values
+  // where in-gamut values are in the range [0 - 1]
+  // to linear light (un-companded) form.
+  // https://en.wikipedia.org/wiki/SRGB
+  // Extended transfer function:
+  // for negative values,  linear portion is extended on reflection of axis,
+  // then reflected power function is used.
+  return RGB.map(val => {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    if (abs < 0.04045) {
+      return val / 12.92;
+    }
+
+    return sign * Math.pow((abs + 0.055) / 1.055, 2.4);
+  });
+}
+
+function gam_sRGB(RGB: Array<number>) {
+  // convert an array of linear-light sRGB values in the range 0.0-1.0
+  // to gamma corrected form
+  // https://en.wikipedia.org/wiki/SRGB
+  // Extended transfer function:
+  // For negative values, linear portion extends on reflection
+  // of axis, then uses reflected pow below that
+  return RGB.map(val => {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    if (abs > 0.0031308) {
+      return sign * (1.055 * Math.pow(abs, 1 / 2.4) - 0.055);
+    }
+
+    return 12.92 * val;
+  });
+}
+
+function lin_sRGB_to_XYZ(rgb: Array<Array<number>>) {
+  // convert an array of linear-light sRGB values to CIE XYZ
+  // using sRGB's own white, D65 (no chromatic adaptation)
+
+  const M = [
+    [0.41239079926595934, 0.357584339383878, 0.1804807884018343],
+    [0.21263900587151027, 0.715168678767756, 0.07219231536073371],
+    [0.01933081871559182, 0.11919477979462598, 0.9505321522496607],
+  ];
+  return multiplyMatrices(M, rgb);
+}
+
+function XYZ_to_lin_sRGB(XYZ: Array<Array<number>>) {
+  // convert XYZ to linear-light sRGB
+
+  const M = [
+    [3.2409699419045226, -1.537383177570094, -0.4986107602930034],
+    [-0.9692436362808796, 1.8759675015077202, 0.04155505740717559],
+    [0.05563007969699366, -0.20397695888897652, 1.0569715142428786],
+  ];
+
+  return multiplyMatrices(M, XYZ);
+}
+
+//  display-p3-related functions
+
+function lin_P3(RGB: Array<number>) {
+  // convert an array of display-p3 RGB values in the range 0.0 - 1.0
+  // to linear light (un-companded) form.
+
+  return lin_sRGB(RGB); // same as sRGB
+}
+
+function gam_P3(RGB: Array<number>) {
+  // convert an array of linear-light display-p3 RGB  in the range 0.0-1.0
+  // to gamma corrected form
+
+  return gam_sRGB(RGB); // same as sRGB
+}
+
+function lin_P3_to_XYZ(rgb: Array<Array<number>>) {
+  // convert an array of linear-light display-p3 values to CIE XYZ
+  // using  D65 (no chromatic adaptation)
+  // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+  const M = [
+    [0.4865709486482162, 0.26566769316909306, 0.1982172852343625],
+    [0.2289745640697488, 0.6917385218365064, 0.079286914093745],
+    [0.0, 0.04511338185890264, 1.043944368900976],
+  ];
+  // 0 was computed as -3.972075516933488e-17
+
+  return multiplyMatrices(M, rgb);
+}
+
+function XYZ_to_lin_P3(XYZ: Array<Array<number>>) {
+  // convert XYZ to linear-light P3
+  const M = [
+    [2.493496911941425, -0.9313836179191239, -0.40271078445071684],
+    [-0.8294889695615747, 1.7626640603183463, 0.023624685841943577],
+    [0.03584583024378447, -0.07617238926804182, 0.9568845240076872],
+  ];
+
+  return multiplyMatrices(M, XYZ);
+}
+
+// Follow conversion steps in CSS Color Module Level 4
+// https://drafts.csswg.org/css-color/#predefined-to-predefined
+// display-p3 and sRGB share the same white points.
+export function displayP3ToSrgb(pixel: {
+  R: number;
+  G: number;
+  B: number;
+  A: number;
+}): { R: number; G: number; B: number; A: number } {
+  assert(
+    pixel.R !== undefined && pixel.G !== undefined && pixel.B !== undefined,
+    'color space conversion requires all of R, G and B components'
+  );
+
+  let rgbVec = [pixel.R, pixel.G, pixel.B];
+  rgbVec = lin_P3(rgbVec);
+  let rgbMatrix = [[rgbVec[0]], [rgbVec[1]], [rgbVec[2]]];
+  rgbMatrix = XYZ_to_lin_sRGB(lin_P3_to_XYZ(rgbMatrix));
+  rgbVec = [rgbMatrix[0][0], rgbMatrix[1][0], rgbMatrix[2][0]];
+  rgbVec = gam_sRGB(rgbVec);
+
+  pixel.R = rgbVec[0];
+  pixel.G = rgbVec[1];
+  pixel.B = rgbVec[2];
+
+  return pixel;
+}
+
+export function srgbToDisplayP3(pixel: {
+  R: number;
+  G: number;
+  B: number;
+  A: number;
+}): { R: number; G: number; B: number; A: number } {
+  assert(
+    pixel.R !== undefined && pixel.G !== undefined && pixel.B !== undefined,
+    'color space conversion requires all of R, G and B components'
+  );
+
+  let rgbVec = [pixel.R, pixel.G, pixel.B];
+  rgbVec = lin_sRGB(rgbVec);
+  let rgbMatrix = [[rgbVec[0]], [rgbVec[1]], [rgbVec[2]]];
+  rgbMatrix = XYZ_to_lin_P3(lin_sRGB_to_XYZ(rgbMatrix));
+  rgbVec = [rgbMatrix[0][0], rgbMatrix[1][0], rgbMatrix[2][0]];
+  rgbVec = gam_P3(rgbVec);
+
+  pixel.R = rgbVec[0];
+  pixel.G = rgbVec[1];
+  pixel.B = rgbVec[2];
+
+  return pixel;
+}

--- a/src/webgpu/util/copy_to_texture.ts
+++ b/src/webgpu/util/copy_to_texture.ts
@@ -112,7 +112,7 @@ export class CopyToTextureUtils extends GPUTest {
     srcPremultiplied: boolean,
     dstPremultiplied: boolean,
     isFlipY: boolean,
-    srcColorSpace: GPUPredefinedColorSpace | 'display-p3' = 'srgb',
+    srcColorSpace: PredefinedColorSpace = 'srgb',
     dstColorSpace: GPUPredefinedColorSpace = 'srgb'
   ): Uint8ClampedArray {
     const bytesPerPixel = kTextureFormatInfo[format].bytesPerBlock;

--- a/src/webgpu/util/copy_to_texture.ts
+++ b/src/webgpu/util/copy_to_texture.ts
@@ -1,17 +1,45 @@
-import { assert, memcpy } from '../../common/util/util.js';
+import { memcpy, TypedArrayBufferView, unreachable } from '../../common/util/util.js';
 import { RegularTextureFormat, kTextureFormatInfo } from '../capability_info.js';
 import { GPUTest } from '../gpu_test.js';
 
 import { checkElementsEqual, checkElementsBetween } from './check_contents.js';
+import { displayP3ToSrgb } from './color_space_conversion.js';
+import { float16BitsToFloat32 } from './conversion.js';
 import { align } from './math.js';
 import { kBytesPerRowAlignment } from './texture/layout.js';
 import { kTexelRepresentationInfo } from './texture/texel_data.js';
 
-export function isFp16Format(format: GPUTextureFormat): boolean {
+function isFp16Format(format: RegularTextureFormat): boolean {
   switch (format) {
     case 'r16float':
     case 'rg16float':
     case 'rgba16float':
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isFp32Format(format: RegularTextureFormat): boolean {
+  switch (format) {
+    case 'r32float':
+    case 'rg32float':
+    case 'rgba32float':
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isUnormFormat(format: RegularTextureFormat): boolean {
+  switch (format) {
+    case 'r8unorm':
+    case 'rg8unorm':
+    case 'rgba8unorm':
+    case 'rgba8unorm-srgb':
+    case 'bgra8unorm':
+    case 'bgra8unorm-srgb':
+    case 'rgb10a2unorm':
       return true;
     default:
       return false;
@@ -81,7 +109,9 @@ export class CopyToTextureUtils extends GPUTest {
     format: RegularTextureFormat,
     srcPremultiplied: boolean,
     dstPremultiplied: boolean,
-    isFlipY: boolean
+    isFlipY: boolean,
+    srcColorSpace: 'display-p3' | 'srgb' = 'srgb',
+    dstColorSpace: 'srgb' = 'srgb'
   ): Uint8ClampedArray {
     const bytesPerPixel = kTextureFormatInfo[format].bytesPerBlock;
 
@@ -93,6 +123,11 @@ export class CopyToTextureUtils extends GPUTest {
     const rep = kTexelRepresentationInfo[format];
     const divide = 255.0;
     let rgba: { R: number; G: number; B: number; A: number };
+    const requireColorSpaceConversion = srcColorSpace !== dstColorSpace;
+    const requireUnpremultiplyAlpha =
+      requireColorSpaceConversion || (srcPremultiplied && !dstPremultiplied);
+    const requirePremultiplyAlpha =
+      requireColorSpaceConversion || (!srcPremultiplied && dstPremultiplied);
     for (let i = 0; i < height; ++i) {
       for (let j = 0; j < width; ++j) {
         const pixelPos = i * width + j;
@@ -104,17 +139,44 @@ export class CopyToTextureUtils extends GPUTest {
           A: orientedPixels[pixelPos * 4 + 3] / divide,
         };
 
-        if (!srcPremultiplied && dstPremultiplied) {
+        if (requireUnpremultiplyAlpha && rgba.A !== 0.0) {
+          rgba.R /= rgba.A;
+          rgba.G /= rgba.A;
+          rgba.B /= rgba.A;
+        }
+
+        if (requireColorSpaceConversion) {
+          // WebGPU support 'srgb' as dstColorSpace only.
+          if (srcColorSpace === 'display-p3' && dstColorSpace === 'srgb') {
+            rgba = displayP3ToSrgb(rgba);
+          } else {
+            unreachable();
+          }
+        }
+
+        if (requirePremultiplyAlpha) {
           rgba.R *= rgba.A;
           rgba.G *= rgba.A;
           rgba.B *= rgba.A;
         }
 
-        if (srcPremultiplied && !dstPremultiplied) {
-          assert(rgba.A !== 0.0);
-          rgba.R /= rgba.A;
-          rgba.G /= rgba.A;
-          rgba.B /= rgba.A;
+        // Clamp 0.0 around floats to 0.0
+        if ((rgba.R > 0.0 && rgba.R < 1.0e-8) || (rgba.R < 0.0 && rgba.R > -1.0e-8)) {
+          rgba.R = 0.0;
+        }
+
+        if ((rgba.G > 0.0 && rgba.G < 1.0e-8) || (rgba.G < 0.0 && rgba.G > -1.0e-8)) {
+          rgba.G = 0.0;
+        }
+
+        if ((rgba.B > 0.0 && rgba.B < 1.0e-8) || (rgba.B < 0.0 && rgba.B > -1.0e-8)) {
+          rgba.B = 0.0;
+        }
+
+        if (isUnormFormat(format)) {
+          rgba.R = Math.max(0.0, Math.min(rgba.R, 1.0));
+          rgba.G = Math.max(0.0, Math.min(rgba.G, 1.0));
+          rgba.B = Math.max(0.0, Math.min(rgba.B, 1.0));
         }
 
         memcpy(
@@ -130,13 +192,13 @@ export class CopyToTextureUtils extends GPUTest {
   // MAINTENANCE_TODO(crbug.com/dawn/868): Should be possible to consolidate this along with texture checking
   checkCopyExternalImageResult(
     src: GPUBuffer,
-    expected: ArrayBufferView,
+    expected: TypedArrayBufferView,
     width: number,
     height: number,
     bytesPerPixel: number,
-    isFp16: boolean
+    dstFormat: RegularTextureFormat
   ): void {
-    const exp = new Uint8Array(expected.buffer, expected.byteOffset, expected.byteLength);
+    //const exp = new Uint8Array(expected.buffer, expected.byteOffset, expected.byteLength);
     const rowPitch = align(width * bytesPerPixel, kBytesPerRowAlignment);
 
     const readbackPromise = this.readGPUBufferRangeTyped(src, {
@@ -148,12 +210,12 @@ export class CopyToTextureUtils extends GPUTest {
       const readback = await readbackPromise;
       const check = this.checkBufferWithRowPitch(
         readback.data,
-        exp,
+        expected,
         width,
         height,
         rowPitch,
         bytesPerPixel,
-        isFp16
+        dstFormat
       );
       if (check !== undefined) {
         niceStack.message = check;
@@ -165,31 +227,88 @@ export class CopyToTextureUtils extends GPUTest {
 
   // MAINTENANCE_TODO(crbug.com/dawn/868): Should be possible to consolidate this along with texture checking
   checkBufferWithRowPitch(
-    actual: Uint8Array,
-    exp: Uint8Array,
+    actual: TypedArrayBufferView,
+    expected: TypedArrayBufferView,
     width: number,
     height: number,
     rowPitch: number,
     bytesPerPixel: number,
-    isFp16: boolean
+    dstFormat: RegularTextureFormat
   ): string | undefined {
     const bytesPerRow = width * bytesPerPixel;
+
     // When dst format is fp16 formats, the expectation and real result always has 1 bit difference in the ending
     // (e.g. CC vs CD) if there needs some alpha ops (if alpha channel is not 0.0 or 1.0). Suspect it is errors when
     // doing encoding. We check fp16 dst texture format with 1-bit ULP tolerance.
-    if (isFp16) {
+    if (isFp16Format(dstFormat)) {
+      const exp = new Uint16Array(
+        expected.buffer,
+        expected.byteOffset / Uint16Array.BYTES_PER_ELEMENT,
+        expected.byteLength / Uint16Array.BYTES_PER_ELEMENT
+      );
+      const check = new Uint16Array(
+        actual.buffer,
+        actual.byteOffset / Uint16Array.BYTES_PER_ELEMENT,
+        actual.byteLength / Uint16Array.BYTES_PER_ELEMENT
+      );
+
       for (let y = 0; y < height; ++y) {
-        const expRow = exp.subarray(y * bytesPerRow, bytesPerRow);
-        const checkResult = checkElementsBetween(actual.subarray(y * rowPitch, bytesPerRow), [
-          i => (expRow[i] > 0 ? expRow[i] - 1 : expRow[i]),
-          i => expRow[i] + 1,
+        const expRow = exp.subarray(
+          (y * bytesPerRow) / exp.BYTES_PER_ELEMENT,
+          bytesPerRow / exp.BYTES_PER_ELEMENT
+        );
+        const checkRow = check.subarray(
+          (y * bytesPerRow) / check.BYTES_PER_ELEMENT,
+          bytesPerRow / check.BYTES_PER_ELEMENT
+        );
+        const expRowF32 = new Float32Array(expRow.length);
+        const checkRowF32 = new Float32Array(checkRow.length);
+        checkRow.forEach((v: number, i: number) => {
+          checkRowF32[i] = float16BitsToFloat32(v);
+        });
+        expRow.forEach((v: number, i: number) => {
+          expRowF32[i] = float16BitsToFloat32(v);
+        });
+        const checkResult = checkElementsBetween(checkRowF32, [
+          i => expRowF32[i] - 0.001,
+          i => expRow[i] + 0.001,
+        ]);
+        if (checkResult !== undefined) return `on row ${y}: ${checkResult}`;
+      }
+    } else if (isFp32Format(dstFormat)) {
+      const exp = new Float32Array(
+        expected.buffer,
+        expected.byteOffset / Float32Array.BYTES_PER_ELEMENT,
+        expected.byteLength / Float32Array.BYTES_PER_ELEMENT
+      );
+      const check = new Float32Array(
+        actual.buffer,
+        actual.byteOffset / Float32Array.BYTES_PER_ELEMENT,
+        actual.byteLength / Float32Array.BYTES_PER_ELEMENT
+      );
+
+      for (let y = 0; y < height; ++y) {
+        const expRow = exp.subarray(
+          (y * bytesPerRow) / exp.BYTES_PER_ELEMENT,
+          bytesPerRow / exp.BYTES_PER_ELEMENT
+        );
+        const checkRow = check.subarray(
+          (y * bytesPerRow) / check.BYTES_PER_ELEMENT,
+          bytesPerRow / check.BYTES_PER_ELEMENT
+        );
+        const checkResult = checkElementsBetween(checkRow, [
+          i => expRow[i] - 0.001,
+          i => expRow[i] + 0.001,
         ]);
         if (checkResult !== undefined) return `on row ${y}: ${checkResult}`;
       }
     } else {
       for (let y = 0; y < height; ++y) {
+        const exp = new Uint8Array(expected.buffer, expected.byteOffset, expected.byteLength);
+        const check = new Uint8Array(actual.buffer, actual.byteOffset, actual.byteLength);
+
         const checkResult = checkElementsEqual(
-          actual.subarray(y * rowPitch, bytesPerRow),
+          check.subarray(y * rowPitch, bytesPerRow),
           exp.subarray(y * bytesPerRow, bytesPerRow)
         );
         if (checkResult !== undefined) return `on row ${y}: ${checkResult}`;
@@ -204,7 +323,7 @@ export class CopyToTextureUtils extends GPUTest {
     copySize: GPUExtent3DDict,
     bytesPerPixel: number,
     expectedData: Uint8ClampedArray,
-    isFp16: boolean
+    dstFormat: RegularTextureFormat
   ): void {
     this.device.queue.copyExternalImageToTexture(
       imageCopyExternalImage,
@@ -237,7 +356,7 @@ export class CopyToTextureUtils extends GPUTest {
       externalImage.width,
       externalImage.height,
       bytesPerPixel,
-      isFp16
+      dstFormat
     );
   }
 }

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -289,3 +289,26 @@ export function biasedRange(a: number, b: number, num_steps: number): Array<numb
     lerp(a, b, Math.pow(lerp(0, 1, i / (num_steps - 1)), c))
   );
 }
+
+/**
+ * @returns the result matrix in Array<Array<number>> type.
+ *
+ * Simple matrix (and vector) multiplication
+ * Warning: No error handling for incompatible dimensions!
+ * @author Lea Verou 2020 MIT License
+ */
+// A is m x n. B is n x p. product is m x p.
+export function multiplyMatrices(A: Array<Array<number>>, B: Array<Array<number>>) {
+  const B_cols = B[0].map((_, i) => B.map(x => x[i])); // transpose B
+  const product = A.map(row =>
+    B_cols.map(col => {
+      if (!Array.isArray(row)) {
+        return col.reduce((a, c) => a + c * row, 0);
+      }
+
+      return row.reduce((a, c, i) => a + c * (col[i] || 0), 0);
+    })
+  );
+
+  return product;
+}

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -293,22 +293,27 @@ export function biasedRange(a: number, b: number, num_steps: number): Array<numb
 /**
  * @returns the result matrix in Array<Array<number>> type.
  *
- * Simple matrix (and vector) multiplication
- * Warning: No error handling for incompatible dimensions!
- * @author Lea Verou 2020 MIT License
+ * Matrix multiplication. A is m x n and B is n x p. Returns
+ * m x p result.
  */
 // A is m x n. B is n x p. product is m x p.
-export function multiplyMatrices(A: Array<Array<number>>, B: Array<Array<number>>) {
-  const B_cols = B[0].map((_, i) => B.map(x => x[i])); // transpose B
-  const product = A.map(row =>
-    B_cols.map(col => {
-      if (!Array.isArray(row)) {
-        return col.reduce((a, c) => a + c * row, 0);
-      }
+export function multiplyMatrices(
+  A: Array<Array<number>>,
+  B: Array<Array<number>>
+): Array<Array<number>> {
+  assert(A.length > 0 && B.length > 0 && B[0].length > 0 && A[0].length === B.length);
+  const product = new Array<Array<number>>(A.length);
+  for (let i = 0; i < product.length; ++i) {
+    product[i] = new Array<number>(B[0].length).fill(0);
+  }
 
-      return row.reduce((a, c, i) => a + c * (col[i] || 0), 0);
-    })
-  );
+  for (let m = 0; m < A.length; ++m) {
+    for (let p = 0; p < B[0].length; ++p) {
+      for (let n = 0; n < B.length; ++n) {
+        product[m][p] += A[m][n] * B[n][p];
+      }
+    }
+  }
 
   return product;
 }

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -17,7 +17,7 @@ import {
   kTextureFormatInfo,
   kValidTextureFormatsForCopyE2T,
 } from '../../capability_info.js';
-import { CopyToTextureUtils, isFp16Format } from '../../util/copy_to_texture.js';
+import { CopyToTextureUtils } from '../../util/copy_to_texture.js';
 import { kTexelRepresentationInfo } from '../../util/texture/texel_data.js';
 
 enum Color {
@@ -227,7 +227,7 @@ g.test('from_ImageData')
       { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 },
       dstBytesPerPixel,
       expectedPixels,
-      isFp16Format(dstColorFormat)
+      dstColorFormat
     );
   });
 
@@ -368,6 +368,6 @@ g.test('from_canvas')
       { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 },
       dstBytesPerPixel,
       expectedPixels,
-      isFp16Format(dstColorFormat)
+      dstColorFormat
     );
   });

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -4,16 +4,58 @@ copyToTexture with HTMLCanvasElement and OffscreenCanvas sources.
 TODO: Add tests for flipY
 `;
 
+import { getResourcePath } from '../../../common/framework/resources.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { unreachable } from '../../../common/util/util.js';
 import {
   RegularTextureFormat,
   kTextureFormatInfo,
   kValidTextureFormatsForCopyE2T,
 } from '../../capability_info.js';
-import { CopyToTextureUtils, isFp16Format } from '../../util/copy_to_texture.js';
+import { CopyToTextureUtils } from '../../util/copy_to_texture.js';
 import { canvasTypes, allCanvasTypes, createCanvas } from '../../util/create_elements.js';
 
 class F extends CopyToTextureUtils {
+  init2DCanvasContentWithColorSpace({
+    width,
+    height,
+    paintOpaqueRects,
+    colorSpace,
+  }: {
+    width: number;
+    height: number;
+    paintOpaqueRects: boolean;
+    colorSpace: 'srgb' | 'display-p3';
+  }): {
+    canvas: HTMLCanvasElement | OffscreenCanvas;
+    canvasContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+  } {
+    const canvas = createCanvas(this, 'onscreen', width, height);
+
+    let canvasContext = null;
+    canvasContext = canvas.getContext('2d', { colorSpace }) as CanvasRenderingContext2D | null;
+
+    if (canvasContext === null) {
+      this.skip('onscreen canvas 2d context not available');
+    }
+
+    if (
+      typeof (canvasContext as any).getContextAttributes === 'undefined' ||
+      typeof (canvasContext as any).getContextAttributes().colorSpace === 'undefined'
+    ) {
+      this.skip('color space attr is not supported for canvas 2d context');
+    }
+
+    // The rgb10a2unorm dst texture will have tiny errors when we compare actual and expectation.
+    // This is due to the convert from 8-bit to 10-bit combined with alpha value ops. So for
+    // rgb10a2unorm dst textures, we'll set alphaValue to 1.0 to test.
+    const alphaValue = paintOpaqueRects ? 1.0 : 0.6;
+    const ctx = canvasContext as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    this.paint2DCanvas(ctx, width, height, alphaValue);
+
+    return { canvas, canvasContext };
+  }
+
   // MAINTENANCE_TODO: Cache the generated canvas to avoid duplicated initialization.
   init2DCanvasContent({
     canvasType,
@@ -41,14 +83,25 @@ class F extends CopyToTextureUtils {
       this.skip(canvasType + ' canvas 2d context not available');
     }
 
-    const rectWidth = Math.floor(width / 2);
-    const rectHeight = Math.floor(height / 2);
-
     // The rgb10a2unorm dst texture will have tiny errors when we compare actual and expectation.
     // This is due to the convert from 8-bit to 10-bit combined with alpha value ops. So for
     // rgb10a2unorm dst textures, we'll set alphaValue to 1.0 to test.
     const alphaValue = paintOpaqueRects ? 1.0 : 0.6;
     const ctx = canvasContext as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    this.paint2DCanvas(ctx, width, height, alphaValue);
+
+    return { canvas, canvasContext };
+  }
+
+  paint2DCanvas(
+    ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
+    width: number,
+    height: number,
+    alphaValue: number
+  ) {
+    const rectWidth = Math.floor(width / 2);
+    const rectHeight = Math.floor(height / 2);
+
     // Red
     ctx.fillStyle = `rgba(255, 0, 0, ${alphaValue})`;
     ctx.fillRect(0, 0, rectWidth, rectHeight);
@@ -58,11 +111,9 @@ class F extends CopyToTextureUtils {
     // Blue
     ctx.fillStyle = `rgba(0, 0, 255, ${alphaValue})`;
     ctx.fillRect(0, rectHeight, rectWidth, height - rectHeight);
-    // White
-    ctx.fillStyle = `rgba(255, 255, 255, ${alphaValue})`;
+    // Fuchsia
+    ctx.fillStyle = `rgba(255, 0, 255, ${alphaValue})`;
     ctx.fillRect(rectWidth, rectHeight, width - rectWidth, height - rectHeight);
-
-    return { canvas, canvasContext };
   }
 
   // MAINTENANCE_TODO: Cache the generated canvas to avoid duplicated initialization.
@@ -239,7 +290,8 @@ class F extends CopyToTextureUtils {
     width: number,
     height: number
   ): Uint8ClampedArray {
-    return context.getImageData(0, 0, width, height).data;
+    // Always read back the raw data from canvas
+    return (context as any).getImageData(0, 0, width, height, { colorSpace: 'srgb' }).data;
   }
 
   getSourceCanvasGLContent(
@@ -288,6 +340,17 @@ class F extends CopyToTextureUtils {
     }
 
     return rgbaPixels;
+  }
+
+  getTestImageURLByColorSpace(colorSpace: 'srgb' | 'display-p3'): string {
+    switch (colorSpace) {
+      case 'srgb':
+        return getResourcePath('Webkit-logo-sRGB.png');
+      case 'display-p3':
+        return getResourcePath('Webkit-logo-P3.png');
+      default:
+        unreachable();
+    }
   }
 }
 
@@ -402,7 +465,7 @@ g.test('copy_contents_from_2d_context_canvas')
       { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
       dstBytesPerPixel,
       expectedPixels,
-      isFp16Format(dstColorFormat)
+      dstColorFormat
     );
   });
 
@@ -521,7 +584,7 @@ g.test('copy_contents_from_gl_context_canvas')
       { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
       dstBytesPerPixel,
       expectedPixels,
-      isFp16Format(dstColorFormat)
+      dstColorFormat
     );
   });
 
@@ -653,6 +716,113 @@ g.test('copy_contents_from_gpu_context_canvas')
       { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
       dstBytesPerPixel,
       expectedPixels,
-      isFp16Format(dstColorFormat)
+      dstColorFormat
+    );
+  });
+
+g.test('color_space_conversion')
+  .desc(
+    `
+    Test HTMLCanvasElement with 2d context can created with 'colorSpace' attribute.
+    Using CopyExternalImageToTexture to copy from such type of canvas needs
+    to do color space converting correctly.
+  
+    It creates HTMLCanvasElement/OffscreenCanvas with '2d' and 'colorSpace' attributes.
+    Use fillRect(2d context) to render red rect for top-left,
+    green rect for top-right, blue rect for bottom-left and white for bottom-right.
+  
+    Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
+    of dst texture, and read the contents out to compare with the canvas contents.
+  
+    Do premultiply alpha in advance if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
+    is set to 'ture' and do unpremultiply alpha if it is set to 'false'.
+  
+    If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
+    is flipped.
+
+    If color space from source input and user defined dstTexture color space are different, the
+    result must convert the content to user defined color space
+  
+    The tests covers:
+    - Valid dstColorFormat of copyExternalImageToTexture()
+    - Valid dest alphaMode
+    - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
+    - Valid 'colorSpace' config in 'dstColorSpace'
+    - TODO: Add error tolerance for rgb10a2unorm dst texture format
+  
+    And the expected results are all passed.
+  `
+  )
+  .params(u =>
+    u
+      .combine('srcColorSpace', ['srgb', 'display-p3'] as const)
+      .combine('dstColorSpace', ['srgb'] as const)
+      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstPremultiplied', [true, false])
+      .combine('srcDoFlipYDuringCopy', [true, false])
+      .beginSubcases()
+      .combine('width', [
+        //1,
+        2,
+        //  4, 15, 255, 256
+      ])
+      .combine('height', [1, 2, 4, 15, 255, 256])
+  )
+  .fn(async t => {
+    const {
+      width,
+      height,
+      srcColorSpace,
+      dstColorSpace,
+      dstColorFormat,
+      dstPremultiplied,
+      srcDoFlipYDuringCopy,
+    } = t.params;
+    const { canvas, canvasContext } = t.init2DCanvasContentWithColorSpace({
+      width,
+      height,
+      paintOpaqueRects: true,
+      colorSpace: srcColorSpace,
+    });
+
+    const dst = t.device.createTexture({
+      size: {
+        width,
+        height,
+        depthOrArrayLayers: 1,
+      },
+      format: dstColorFormat,
+      usage:
+        GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const sourcePixels = t.getSourceCanvas2DContent(canvasContext, width, height);
+
+    const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
+
+    const expectedPixels = t.getExpectedPixels(
+      sourcePixels,
+      width,
+      height,
+      dstColorFormat,
+      false,
+      dstPremultiplied,
+      srcDoFlipYDuringCopy,
+      srcColorSpace,
+      dstColorSpace
+    );
+
+    t.doTestAndCheckResult(
+      { source: canvas, origin: { x: 0, y: 0 }, flipY: srcDoFlipYDuringCopy },
+      {
+        texture: dst,
+        origin: { x: 0, y: 0 },
+        colorSpace: dstColorSpace,
+        premultipliedAlpha: dstPremultiplied,
+      },
+      { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
+      dstBytesPerPixel,
+      expectedPixels,
+      dstColorFormat
     );
   });

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -40,8 +40,8 @@ class F extends CopyToTextureUtils {
     }
 
     if (
-      typeof (canvasContext as any).getContextAttributes === 'undefined' ||
-      typeof (canvasContext as any).getContextAttributes().colorSpace === 'undefined'
+      typeof canvasContext.getContextAttributes === 'undefined' ||
+      typeof canvasContext.getContextAttributes().colorSpace === 'undefined'
     ) {
       this.skip('color space attr is not supported for canvas 2d context');
     }
@@ -99,7 +99,9 @@ class F extends CopyToTextureUtils {
       }
     }
 
-    const imageData = new (ImageData as any)(imagePixels, width, height, { colorSpace });
+    const imageData = new ImageData(imagePixels, width, height, { colorSpace });
+    // MAINTENANCE_TODO: Remove as any when tsc support imageData.colorSpace
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     if (typeof (imageData as any).colorSpace === 'undefined') {
       this.skip('color space attr is not supported for ImageData');
     }
@@ -424,8 +426,8 @@ g.test('copy_contents_from_2d_context_canvas')
   Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
   of dst texture, and read the contents out to compare with the canvas contents.
 
-  Do premultiply alpha in advance if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
-  is set to 'ture' and do unpremultiply alpha if it is set to 'false'.
+  Provide premultiplied input if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
+  is set to 'true' and unpremultiplied input if it is set to 'false'.
 
   If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
   is flipped.
@@ -539,8 +541,8 @@ g.test('copy_contents_from_gl_context_canvas')
   Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
   of dst texture, and read the contents out to compare with the canvas contents.
 
-  Do premultiply alpha during copy if  'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
-  is set to 'ture' and do unpremultiply alpha if it is set to 'false'.
+  Provide premultiplied input if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
+  is set to 'true' and unpremultiplied input if it is set to 'false'.
 
   If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
   is flipped.
@@ -660,8 +662,8 @@ g.test('copy_contents_from_gpu_context_canvas')
   Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
   of dst texture, and read the contents out to compare with the canvas contents.
 
-  Do premultiply alpha during copy if  'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
-  is set to 'ture' and do unpremultiply alpha if it is set to 'false'.
+  Provide premultiplied input if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
+  is set to 'true' and unpremultiplied input if it is set to 'false'.
 
   If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
   is flipped.
@@ -789,8 +791,8 @@ g.test('color_space_conversion')
     Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
     of dst texture, and read the contents out to compare with the canvas contents.
   
-    Do premultiply alpha in advance if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
-    is set to 'ture' and do unpremultiply alpha if it is set to 'false'.
+    Provide premultiplied input if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
+    is set to 'true' and unpremultiplied input if it is set to 'false'.
   
     If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
     is flipped.


### PR DESCRIPTION
This PR add cts to test copyExternalImageToTexture() color space
conversion ability.
It creates canvas with color space attr and copy to dst texture in
user defined color space through CopyExternalImageToTexture().





Issue: #913
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
