### PR TITLE
webgpu: Remove use of `isNan` and `isInf`

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -173,18 +173,6 @@ fn check(success : bool) {
 }
 
 fn floatsSimilar(a : f32, b : f32, tolerance : f32) -> bool {
-  if (isNan(a) && isNan(b)) {
-    return true;
-  }
-
-  if (isInf(a) && isInf(b) && sign(a) == sign(b)) {
-    return true;
-  }
-
-  if (isInf(a) || isInf(b)) {
-    return false;
-  }
-
   // TODO do we check for + and - 0?
   return abs(a - b) < tolerance;
 }


### PR DESCRIPTION
These were removed with https://github.com/gpuweb/gpuweb/pull/2311

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
