### PR TITLE
Fuzzy canvas reftests

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html
@@ -7,7 +7,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_complex-ref.html" />
-  <meta name=fuzzy content="maxDifference=2;totalPixels=10">
+  <meta name=fuzzy content="maxDifference=2;totalPixels=50">
 
   <canvas id="cvs_copy_buffer_to_texture" width="2" height="2" style="width: 20px; height: 20px;"></canvas>
   <canvas id="cvs_copy_texture_to_texture" width="2" height="2" style="width: 20px; height: 20px;"></canvas>

--- a/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html
@@ -7,6 +7,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_complex-ref.html" />
+  <meta name=fuzzy content="maxDifference=2;totalPixels=10">
 
   <canvas id="cvs_copy_buffer_to_texture" width="2" height="2" style="width: 20px; height: 20px;"></canvas>
   <canvas id="cvs_copy_texture_to_texture" width="2" height="2" style="width: 20px; height: 20px;"></canvas>

--- a/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html
@@ -7,6 +7,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_complex-ref.html" />
+  <meta name=fuzzy content="maxDifference=2;totalPixels=10">
 
   <canvas id="cvs_draw_texture_sample" width="2" height="2" style="width: 20px; height: 20px;"></canvas>
   <canvas id="cvs_draw_vertex_color" width="2" height="2" style="width: 20px; height: 20px;"></canvas>

--- a/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html
@@ -7,7 +7,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_complex-ref.html" />
-  <meta name=fuzzy content="maxDifference=2;totalPixels=10">
+  <meta name=fuzzy content="maxDifference=2;totalPixels=50">
 
   <canvas id="cvs_draw_texture_sample" width="2" height="2" style="width: 20px; height: 20px;"></canvas>
   <canvas id="cvs_draw_vertex_color" width="2" height="2" style="width: 20px; height: 20px;"></canvas>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
@@ -7,6 +7,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
+  <meta name=fuzzy content="maxDifference=2;totalPixels=400">
   <style>
     body { background-color: #F0E68C; }
   </style>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
@@ -7,6 +7,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
+  <meta name=fuzzy content="maxDifference=2;totalPixels=400">
   <style>
     body { background-color: #F0E68C; }
   </style>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
@@ -7,6 +7,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
+  <meta name=fuzzy content="maxDifference=2;totalPixels=400">
   <style>
     body { background-color: #F0E68C; }
   </style>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
@@ -7,6 +7,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
+  <meta name=fuzzy content="maxDifference=2;totalPixels=400">
   <style>
     body { background-color: #F0E68C; }
   </style>


### PR DESCRIPTION
Adding fuzziness to the canvas reference tests. There can be some small missmatching in the rgb values but not visual difference when comparing these tests with the 2d canvas reference.

Issue: #1045

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
