### PR TITLE
update git attributes to check out text files with lf eol regardless …

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
…of platform

> The ESLint rules warn if the line endings are not LF. On systems (e.g. windows) where autocrlf is set to true, files will be checked out as CRLF and every line will warn. To fix this, add a .gitattributes file which forces files to be checked out as LF always.
> 
> After pulling this change, you can update existing working copies (after ensuring your working copy is clean) by using:
> 
> ```
> git rm --cached -r .
> git reset --hard
> ```

Fixes #1047