### PR TITLE
Don't set depth/stencil load/store ops if the aspect doesn't exist

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1447,9 +1447,6 @@ g.test('copy_multisampled_depth')
         depthClearValue: 0.0,
         depthLoadOp: 'clear',
         depthStoreOp: 'store',
-        stencilClearValue: 0,
-        stencilLoadOp: 'clear',
-        stencilStoreOp: 'store',
       },
     });
     renderPassForInit.setPipeline(renderPipelineForInit);
@@ -1522,9 +1519,6 @@ g.test('copy_multisampled_depth')
         view: destinationTexture.createView(),
         depthLoadOp: 'load',
         depthStoreOp: 'store',
-        stencilClearValue: 0,
-        stencilLoadOp: 'clear',
-        stencilStoreOp: 'store',
       },
     });
     renderPassForVerify.setPipeline(renderPipelineForVerify);

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -19,6 +19,7 @@ Use 2 triangles with different winding orders:
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { kTextureFormatInfo } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
 
 function faceIsCulled(face: 'cw' | 'ccw', frontFace: GPUFrontFace, cullMode: GPUCullMode): boolean {
@@ -70,13 +71,28 @@ TODO: check the contents of the depth and stencil outputs [2]
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
 
-    const depthTexture = t.params.depthStencilFormat
-      ? t.device.createTexture({
-          size: { width: size, height: size, depthOrArrayLayers: 1 },
-          format: t.params.depthStencilFormat,
-          usage: GPUTextureUsage.RENDER_ATTACHMENT,
-        })
-      : null;
+    let depthTexture: GPUTexture | undefined = undefined;
+    let depthStencilAttachment: GPURenderPassDepthStencilAttachment | undefined = undefined;
+    if (t.params.depthStencilFormat) {
+      depthTexture = t.device.createTexture({
+        size: { width: size, height: size, depthOrArrayLayers: 1 },
+        format: t.params.depthStencilFormat,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      });
+
+      depthStencilAttachment = {
+        view: depthTexture.createView(),
+        depthClearValue: 1.0,
+        depthLoadOp: 'clear',
+        depthStoreOp: 'store',
+      };
+
+      if (t.params.depthStencilFormat && kTextureFormatInfo[t.params.depthStencilFormat].stencil) {
+        depthStencilAttachment.stencilClearValue = 0;
+        depthStencilAttachment.stencilLoadOp = 'clear';
+        depthStencilAttachment.stencilStoreOp = 'store';
+      }
+    }
 
     const encoder = t.device.createCommandEncoder();
     const pass = encoder.beginRenderPass({
@@ -88,17 +104,7 @@ TODO: check the contents of the depth and stencil outputs [2]
           storeOp: 'store',
         },
       ],
-      depthStencilAttachment: depthTexture
-        ? {
-            view: depthTexture.createView(),
-            depthClearValue: 1.0,
-            depthLoadOp: 'clear',
-            depthStoreOp: 'store',
-            stencilClearValue: 0,
-            stencilLoadOp: 'clear',
-            stencilStoreOp: 'store',
-          }
-        : undefined,
+      depthStencilAttachment,
     });
 
     // Draw two triangles with different winding orders:

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -3,7 +3,7 @@ Test related to depth buffer, depth op, compare func, etc.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { kDepthStencilFormats } from '../../../capability_info.js';
+import { kDepthStencilFormats, kTextureFormatInfo } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
 
 const backgroundColor = [0x00, 0x00, 0x00, 0xff];
@@ -31,7 +31,7 @@ g.test('depth_compare_func')
     u
       .combine(
         'format',
-        kDepthStencilFormats.filter(format => format !== 'stencil8')
+        kDepthStencilFormats.filter(format => kTextureFormatInfo[format].depth)
       )
       .combineWithParams([
         { depthCompare: 'never', depthClearValue: 1.0, _expected: backgroundColor },
@@ -112,6 +112,17 @@ g.test('depth_compare_func')
     const pipeline = t.device.createRenderPipeline(pipelineDescriptor);
 
     const encoder = t.device.createCommandEncoder();
+    const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
+      view: depthTextureView,
+      depthClearValue,
+      depthLoadOp: 'clear',
+      depthStoreOp: 'store',
+    };
+    if (kTextureFormatInfo[format].stencil) {
+      depthStencilAttachment.stencilClearValue = 0;
+      depthStencilAttachment.stencilLoadOp = 'clear';
+      depthStencilAttachment.stencilStoreOp = 'store';
+    }
     const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
@@ -121,16 +132,7 @@ g.test('depth_compare_func')
           loadOp: 'clear',
         },
       ],
-      depthStencilAttachment: {
-        view: depthTextureView,
-
-        depthClearValue,
-        depthLoadOp: 'clear',
-        depthStoreOp: 'store',
-        stencilClearValue: 0,
-        stencilLoadOp: 'clear',
-        stencilStoreOp: 'store',
-      },
+      depthStencilAttachment,
     });
     pass.setPipeline(pipeline);
     pass.draw(1);
@@ -242,9 +244,6 @@ g.test('reverse_depth')
         depthClearValue: t.params.reversed ? 0.0 : 1.0,
         depthLoadOp: 'clear',
         depthStoreOp: 'store',
-        stencilClearValue: 0,
-        stencilLoadOp: 'clear',
-        stencilStoreOp: 'store',
       },
     });
     pass.setPipeline(pipeline);

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -316,18 +316,23 @@ export class TextureZeroInitTest extends GPUTest {
           })
           .end();
       } else {
+        const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
+          view: texture.createView(viewDescriptor),
+        };
+        if (kTextureFormatInfo[this.p.format].depth) {
+          depthStencilAttachment.depthClearValue = initializedStateAsDepth[state];
+          depthStencilAttachment.depthLoadOp = 'clear';
+          depthStencilAttachment.depthStoreOp = 'store';
+        }
+        if (kTextureFormatInfo[this.p.format].stencil) {
+          depthStencilAttachment.stencilClearValue = initializedStateAsStencil[state];
+          depthStencilAttachment.stencilLoadOp = 'clear';
+          depthStencilAttachment.stencilStoreOp = 'store';
+        }
         commandEncoder
           .beginRenderPass({
             colorAttachments: [],
-            depthStencilAttachment: {
-              view: texture.createView(viewDescriptor),
-              depthStoreOp: 'store',
-              depthClearValue: initializedStateAsDepth[state],
-              depthLoadOp: 'clear',
-              stencilStoreOp: 'store',
-              stencilClearValue: initializedStateAsStencil[state],
-              stencilLoadOp: 'clear',
-            },
+            depthStencilAttachment,
           })
           .end();
       }
@@ -420,16 +425,21 @@ export class TextureZeroInitTest extends GPUTest {
           })
           .end();
       } else {
+        const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
+          view: texture.createView(desc),
+        };
+        if (kTextureFormatInfo[this.p.format].depth) {
+          depthStencilAttachment.depthLoadOp = 'load';
+          depthStencilAttachment.depthStoreOp = 'discard';
+        }
+        if (kTextureFormatInfo[this.p.format].stencil) {
+          depthStencilAttachment.stencilLoadOp = 'load';
+          depthStencilAttachment.stencilStoreOp = 'discard';
+        }
         commandEncoder
           .beginRenderPass({
             colorAttachments: [],
-            depthStencilAttachment: {
-              view: texture.createView(desc),
-              depthStoreOp: 'discard',
-              depthLoadOp: 'load',
-              stencilStoreOp: 'discard',
-              stencilLoadOp: 'load',
-            },
+            depthStencilAttachment,
           })
           .end();
       }

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -677,10 +677,12 @@ g.test('subresources_and_binding_types_combination_for_aspect')
           depthStencilAttachment: depthStencilFormat
             ? {
                 view: view1,
-                depthStoreOp: 'discard',
-                depthLoadOp: 'load',
-                stencilStoreOp: 'discard',
-                stencilLoadOp: 'load',
+                depthStoreOp: kTextureFormatInfo[depthStencilFormat].depth ? 'discard' : undefined,
+                depthLoadOp: kTextureFormatInfo[depthStencilFormat].depth ? 'load' : undefined,
+                stencilStoreOp: kTextureFormatInfo[depthStencilFormat].stencil
+                  ? 'discard'
+                  : undefined,
+                stencilLoadOp: kTextureFormatInfo[depthStencilFormat].stencil ? 'load' : undefined,
               }
             : undefined,
         });

--- a/src/webgpu/api/validation/texture/destroy.spec.ts
+++ b/src/webgpu/api/validation/texture/destroy.spec.ts
@@ -3,7 +3,7 @@ Destroying a texture more than once is allowed.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { kTextureAspects } from '../../../capability_info.js';
+import { kTextureAspects, kTextureFormatInfo } from '../../../capability_info.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
@@ -80,6 +80,19 @@ that was destroyed {before, after} encoding finishes.
     }
 
     const commandEncoder = t.device.createCommandEncoder();
+    const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
+      view: depthStencilTexture.createView({ aspect: depthStencilTextureAspect }),
+    };
+    if (kTextureFormatInfo[depthStencilTextureFormat].depth) {
+      depthStencilAttachment.depthClearValue = 0;
+      depthStencilAttachment.depthLoadOp = 'clear';
+      depthStencilAttachment.depthStoreOp = 'discard';
+    }
+    if (kTextureFormatInfo[depthStencilTextureFormat].stencil) {
+      depthStencilAttachment.stencilClearValue = 0;
+      depthStencilAttachment.stencilLoadOp = 'clear';
+      depthStencilAttachment.stencilStoreOp = 'discard';
+    }
     const renderPass = commandEncoder.beginRenderPass({
       colorAttachments: [
         {
@@ -89,13 +102,7 @@ that was destroyed {before, after} encoding finishes.
           storeOp: 'store',
         },
       ],
-      depthStencilAttachment: {
-        view: depthStencilTexture.createView({ aspect: depthStencilTextureAspect }),
-        depthLoadValue: 0,
-        depthStoreOp: 'discard',
-        stencilLoadValue: 0,
-        stencilStoreOp: 'discard',
-      },
+      depthStencilAttachment,
     });
     renderPass.end();
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -944,6 +944,22 @@ export class GPUTest extends Fixture {
             })
           ).createView();
 
+        let depthStencilAttachment: GPURenderPassDepthStencilAttachment | undefined = undefined;
+        if (fullAttachmentInfo.depthStencilFormat !== undefined) {
+          depthStencilAttachment = {
+            view: makeAttachmentView(fullAttachmentInfo.depthStencilFormat),
+          };
+          if (kTextureFormatInfo[fullAttachmentInfo.depthStencilFormat].depth) {
+            depthStencilAttachment.depthClearValue = 0;
+            depthStencilAttachment.depthLoadOp = 'clear';
+            depthStencilAttachment.depthStoreOp = 'discard';
+          }
+          if (kTextureFormatInfo[fullAttachmentInfo.depthStencilFormat].stencil) {
+            depthStencilAttachment.stencilClearValue = 1;
+            depthStencilAttachment.stencilLoadOp = 'clear';
+            depthStencilAttachment.stencilStoreOp = 'discard';
+          }
+        }
         const passDesc: GPURenderPassDescriptor = {
           colorAttachments: Array.from(fullAttachmentInfo.colorFormats, format => ({
             view: makeAttachmentView(format),
@@ -951,18 +967,7 @@ export class GPUTest extends Fixture {
             loadOp: 'clear',
             storeOp: 'store',
           })),
-          depthStencilAttachment:
-            fullAttachmentInfo.depthStencilFormat !== undefined
-              ? {
-                  view: makeAttachmentView(fullAttachmentInfo.depthStencilFormat),
-                  depthClearValue: 0,
-                  depthLoadOp: 'clear',
-                  depthStoreOp: 'discard',
-                  stencilClearValue: 1,
-                  stencilLoadOp: 'clear',
-                  stencilStoreOp: 'discard',
-                }
-              : undefined,
+          depthStencilAttachment,
           occlusionQuerySet,
         };
 


### PR DESCRIPTION
Updates tests to follow spec in https://github.com/gpuweb/gpuweb/pull/2639.
Passes updated implementation in https://dawn-review.googlesource.com/c/dawn/+/82540.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
