### PR TITLE
Attempt to wait for queue idle on release of the device to the pool

### DIFF
--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -297,6 +297,9 @@ class DeviceHolder implements DeviceProvider {
     let gpuValidationError: GPUValidationError | GPUOutOfMemoryError | null;
     let gpuOutOfMemoryError: GPUValidationError | GPUOutOfMemoryError | null;
 
+    // Submit to the queue to attempt to force a GPU flush.
+    this.device.queue.submit([]);
+
     try {
       // May reject if the device was lost.
       gpuValidationError = await this.device.popErrorScope();
@@ -308,6 +311,9 @@ class DeviceHolder implements DeviceProvider {
       );
       throw ex;
     }
+
+    // Attempt to wait for the queue to be idle.
+    await this.device.queue.onSubmittedWorkDone();
 
     await assertReject(
       this.device.popErrorScope(),

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -313,7 +313,9 @@ class DeviceHolder implements DeviceProvider {
     }
 
     // Attempt to wait for the queue to be idle.
-    await this.device.queue.onSubmittedWorkDone();
+    if (this.device.queue.onSubmittedWorkDone) {
+      await this.device.queue.onSubmittedWorkDone();
+    }
 
     await assertReject(
       this.device.popErrorScope(),


### PR DESCRIPTION
Speculative change to make it so device lost events are surfaced by the end of a test.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
