### PR TITLE
Helper for robust texture content checking

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -246,9 +246,9 @@ export class Fixture {
     return cond;
   }
 
-  /** If the argument is an Error, fail (or warn). Otherwise, no-op. */
+  /** If the argument is an `Error`, fail (or warn). If it's `undefined`, no-op. */
   expectOK(
-    error: Error | unknown,
+    error: Error | undefined,
     { mode = 'fail', niceStack }: { mode?: 'fail' | 'warn'; niceStack?: Error } = {}
   ): void {
     if (error instanceof Error) {
@@ -263,5 +263,14 @@ export class Fixture {
         unreachable();
       }
     }
+  }
+
+  eventualExpectOK(
+    error: Promise<Error | undefined>,
+    { mode = 'fail' }: { mode?: 'fail' | 'warn' } = {}
+  ) {
+    this.eventualAsyncExpectation(async niceStack => {
+      this.expectOK(await error, { mode, niceStack });
+    });
   }
 }

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -762,7 +762,7 @@ class ImageCopyTest extends GPUTest {
     this.expectGPUBufferValuesEqual(outputBuffer, expectedData);
   }
 
-  // MAINTENANCE_TODO(crbug.com/dawn/868): Revisit this when consolidating texture helpers.
+  // MAINTENANCE_TODO(#881): Migrate this into the texture_ok helpers.
   async checkStencilTextureContent(
     stencilTexture: GPUTexture,
     stencilTextureSize: readonly [number, number, number],
@@ -984,7 +984,7 @@ class ImageCopyTest extends GPUTest {
     }
   }
 
-  // MAINTENANCE_TODO(crbug.com/dawn/868): Revisit this when consolidating texture helpers.
+  // MAINTENANCE_TODO(#881): Consider if this can be simplified/encapsulated using TexelView.
   initializeDepthAspectWithRendering(
     depthTexture: GPUTexture,
     depthFormat: GPUTextureFormat,

--- a/src/webgpu/util/check_contents.ts
+++ b/src/webgpu/util/check_contents.ts
@@ -1,3 +1,9 @@
+// MAINTENANCE_TODO: The "checkThingTrue" naming is confusing; these must be used with `expectOK`
+// or the result is dropped on the floor. Rename these to things like `typedArrayIsOK`(??) to
+// make it clearer.
+// MAINTENANCE_TODO: Also, audit to make sure we aren't dropping any on the floor. Consider a
+// no-ignored-return lint check if we can find one that we can use.
+
 import {
   assert,
   ErrorWithExtra,

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -9,11 +9,11 @@ import { clamp } from './math.js';
  */
 export function floatAsNormalizedInteger(float: number, bits: number, signed: boolean): number {
   if (signed) {
-    assert(float >= -1 && float <= 1);
+    assert(float >= -1 && float <= 1, () => `${float} out of bounds of snorm`);
     const max = Math.pow(2, bits - 1) - 1;
     return Math.round(float * max);
   } else {
-    assert(float >= 0 && float <= 1);
+    assert(float >= 0 && float <= 1, () => `${float} out of bounds of unorm`);
     const max = Math.pow(2, bits) - 1;
     return Math.round(float * max);
   }

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -46,6 +46,8 @@ export function normalizedIntegerAsFloat(integer: number, bits: number, signed: 
  *
  * Does not handle clamping, overflow, or denormal inputs.
  * On underflow (result is subnormal), rounds to (signed) zero.
+ *
+ * MAINTENANCE_TODO: Replace usages of this with numberToFloatBits.
  */
 export function float32ToFloatBits(
   n: number,
@@ -151,6 +153,17 @@ export function floatBitsToNumber(bits: number, fmt: FloatFormat): number {
   f32BitsWithWrongBias |= (bits << (31 - kNonSignBits)) & 0x8000_0000;
   const numberWithWrongBias = float32BitsToNumber(f32BitsWithWrongBias);
   return numberWithWrongBias * 2 ** (kFloat32Format.bias - fmt.bias);
+}
+
+/**
+ * Encodes a JS `number` into an IEEE754 floating point number with the specified format.
+ * Returns the result as an integer-valued JS `number`.
+ *
+ * Does not handle clamping, overflow, or denormal inputs.
+ * On underflow (result is subnormal), rounds to (signed) zero.
+ */
+export function numberToFloatBits(number: number, fmt: FloatFormat): number {
+  return float32ToFloatBits(number, fmt.signed, fmt.exponentBits, fmt.mantissaBits, fmt.bias);
 }
 
 /**

--- a/src/webgpu/util/copy_to_texture.ts
+++ b/src/webgpu/util/copy_to_texture.ts
@@ -1,49 +1,10 @@
-import { assert, memcpy, TypedArrayBufferView, unreachable } from '../../common/util/util.js';
-import { RegularTextureFormat, kTextureFormatInfo } from '../capability_info.js';
+import { assert, memcpy, unreachable } from '../../common/util/util.js';
+import { RegularTextureFormat } from '../capability_info.js';
 import { GPUTest } from '../gpu_test.js';
 
-import { checkElementsEqual, checkElementsBetween } from './check_contents.js';
 import { displayP3ToSrgb } from './color_space_conversion.js';
-import { align } from './math.js';
-import { kBytesPerRowAlignment } from './texture/layout.js';
-import { kTexelRepresentationInfo } from './texture/texel_data.js';
-
-function isFp16Format(format: RegularTextureFormat): boolean {
-  switch (format) {
-    case 'r16float':
-    case 'rg16float':
-    case 'rgba16float':
-      return true;
-    default:
-      return false;
-  }
-}
-
-function isFp32Format(format: RegularTextureFormat): boolean {
-  switch (format) {
-    case 'r32float':
-    case 'rg32float':
-    case 'rgba32float':
-      return true;
-    default:
-      return false;
-  }
-}
-
-function isUnormFormat(format: RegularTextureFormat): boolean {
-  switch (format) {
-    case 'r8unorm':
-    case 'rg8unorm':
-    case 'rgba8unorm':
-    case 'rgba8unorm-srgb':
-    case 'bgra8unorm':
-    case 'bgra8unorm-srgb':
-    case 'rgb10a2unorm':
-      return true;
-    default:
-      return false;
-  }
-}
+import { TexelView } from './texture/texel_view.js';
+import { TexelCompareOptions, textureContentIsOKByT2B } from './texture/texture_ok.js';
 
 export class CopyToTextureUtils extends GPUTest {
   doFlipY(
@@ -71,36 +32,6 @@ export class CopyToTextureUtils extends GPUTest {
     return dstPixels;
   }
 
-  /**
-   * If the destination format specifies a transfer function,
-   * copyExternalImageToTexture (like B2T/T2T copies) should ignore it.
-   */
-  formatForExpectedPixels(format: RegularTextureFormat): RegularTextureFormat {
-    return format === 'rgba8unorm-srgb'
-      ? 'rgba8unorm'
-      : format === 'bgra8unorm-srgb'
-      ? 'bgra8unorm'
-      : format;
-  }
-
-  getSourceImageBitmapPixels(
-    sourcePixels: Uint8ClampedArray,
-    width: number,
-    height: number,
-    isPremultiplied: boolean,
-    isFlipY: boolean
-  ): Uint8ClampedArray {
-    return this.getExpectedPixels(
-      sourcePixels,
-      width,
-      height,
-      'rgba8unorm',
-      false,
-      isPremultiplied,
-      isFlipY
-    );
-  }
-
   getExpectedPixels(
     sourcePixels: Uint8ClampedArray,
     width: number,
@@ -111,217 +42,77 @@ export class CopyToTextureUtils extends GPUTest {
     isFlipY: boolean,
     srcColorSpace: PredefinedColorSpace = 'srgb',
     dstColorSpace: GPUPredefinedColorSpace = 'srgb'
-  ): Uint8ClampedArray {
-    const bytesPerPixel = kTextureFormatInfo[format].bytesPerBlock;
-
-    const orientedPixels = isFlipY ? this.doFlipY(sourcePixels, width, height, 4) : sourcePixels;
-    const expectedPixels = new Uint8ClampedArray(bytesPerPixel * width * height);
-
-    // Generate expectedPixels
-    // Use getImageData and readPixels to get canvas contents.
-    const rep = kTexelRepresentationInfo[format];
-    const divide = 255.0;
-    let rgba: { R: number; G: number; B: number; A: number };
+  ): TexelView {
     const requireColorSpaceConversion = srcColorSpace !== dstColorSpace;
     const requireUnpremultiplyAlpha =
       requireColorSpaceConversion || (srcPremultiplied && !dstPremultiplied);
     const requirePremultiplyAlpha =
       requireColorSpaceConversion || (!srcPremultiplied && dstPremultiplied);
-    for (let i = 0; i < height; ++i) {
-      for (let j = 0; j < width; ++j) {
-        const pixelPos = i * width + j;
 
-        rgba = {
-          R: orientedPixels[pixelPos * 4] / divide,
-          G: orientedPixels[pixelPos * 4 + 1] / divide,
-          B: orientedPixels[pixelPos * 4 + 2] / divide,
-          A: orientedPixels[pixelPos * 4 + 3] / divide,
-        };
+    const divide = 255.0;
+    return TexelView.fromTexelsAsColors(format, coords => {
+      assert(coords.x < width && coords.y < height && coords.z === 0, 'out of bounds');
+      const y = isFlipY ? height - coords.y - 1 : coords.y;
+      const pixelPos = y * width + coords.x;
 
-        if (requireUnpremultiplyAlpha) {
-          if (rgba.A !== 0.0) {
-            rgba.R /= rgba.A;
-            rgba.G /= rgba.A;
-            rgba.B /= rgba.A;
-          } else {
-            assert(
-              rgba.R === 0.0 && rgba.G === 0.0 && rgba.B === 0.0 && rgba.A === 0.0,
-              'Unpremultiply ops with alpha value 0.0 requires all channels equals to 0.0'
-            );
-          }
+      let rgba = {
+        R: sourcePixels[pixelPos * 4] / divide,
+        G: sourcePixels[pixelPos * 4 + 1] / divide,
+        B: sourcePixels[pixelPos * 4 + 2] / divide,
+        A: sourcePixels[pixelPos * 4 + 3] / divide,
+      };
+
+      if (requireUnpremultiplyAlpha) {
+        if (rgba.A !== 0.0) {
+          rgba.R /= rgba.A;
+          rgba.G /= rgba.A;
+          rgba.B /= rgba.A;
+        } else {
+          assert(
+            rgba.R === 0.0 && rgba.G === 0.0 && rgba.B === 0.0 && rgba.A === 0.0,
+            'Unpremultiply ops with alpha value 0.0 requires all channels equals to 0.0'
+          );
         }
-
-        if (requireColorSpaceConversion) {
-          // WebGPU support 'srgb' as dstColorSpace only.
-          if (srcColorSpace === 'display-p3' && dstColorSpace === 'srgb') {
-            rgba = displayP3ToSrgb(rgba);
-          } else {
-            unreachable();
-          }
-        }
-
-        if (requirePremultiplyAlpha) {
-          rgba.R *= rgba.A;
-          rgba.G *= rgba.A;
-          rgba.B *= rgba.A;
-        }
-
-        // Clamp 0.0 around floats to 0.0
-        if ((rgba.R > 0.0 && rgba.R < 1.0e-8) || (rgba.R < 0.0 && rgba.R > -1.0e-8)) {
-          rgba.R = 0.0;
-        }
-
-        if ((rgba.G > 0.0 && rgba.G < 1.0e-8) || (rgba.G < 0.0 && rgba.G > -1.0e-8)) {
-          rgba.G = 0.0;
-        }
-
-        if ((rgba.B > 0.0 && rgba.B < 1.0e-8) || (rgba.B < 0.0 && rgba.B > -1.0e-8)) {
-          rgba.B = 0.0;
-        }
-
-        if (isUnormFormat(format)) {
-          rgba.R = Math.max(0.0, Math.min(rgba.R, 1.0));
-          rgba.G = Math.max(0.0, Math.min(rgba.G, 1.0));
-          rgba.B = Math.max(0.0, Math.min(rgba.B, 1.0));
-        }
-
-        memcpy(
-          { src: rep.pack(rep.encode(rgba)) },
-          { dst: expectedPixels, start: pixelPos * bytesPerPixel }
-        );
       }
-    }
 
-    return expectedPixels;
-  }
+      if (requireColorSpaceConversion) {
+        // WebGPU support 'srgb' as dstColorSpace only.
+        if (srcColorSpace === 'display-p3' && dstColorSpace === 'srgb') {
+          rgba = displayP3ToSrgb(rgba);
+        } else {
+          unreachable();
+        }
+      }
 
-  // MAINTENANCE_TODO(crbug.com/dawn/868): Should be possible to consolidate this along with texture checking
-  checkCopyExternalImageResult(
-    src: GPUBuffer,
-    expected: TypedArrayBufferView,
-    width: number,
-    height: number,
-    bytesPerPixel: number,
-    dstFormat: RegularTextureFormat
-  ): void {
-    const rowPitch = align(width * bytesPerPixel, kBytesPerRowAlignment);
+      if (requirePremultiplyAlpha) {
+        rgba.R *= rgba.A;
+        rgba.G *= rgba.A;
+        rgba.B *= rgba.A;
+      }
 
-    const readbackPromise = this.readGPUBufferRangeTyped(src, {
-      type: Uint8Array,
-      typedLength: rowPitch * height,
+      // Clamp 0.0 around floats to 0.0
+      if ((rgba.R > 0.0 && rgba.R < 1.0e-8) || (rgba.R < 0.0 && rgba.R > -1.0e-8)) {
+        rgba.R = 0.0;
+      }
+
+      if ((rgba.G > 0.0 && rgba.G < 1.0e-8) || (rgba.G < 0.0 && rgba.G > -1.0e-8)) {
+        rgba.G = 0.0;
+      }
+
+      if ((rgba.B > 0.0 && rgba.B < 1.0e-8) || (rgba.B < 0.0 && rgba.B > -1.0e-8)) {
+        rgba.B = 0.0;
+      }
+
+      return rgba;
     });
-
-    this.eventualAsyncExpectation(async niceStack => {
-      const readback = await readbackPromise;
-      const check = this.checkBufferWithRowPitch(
-        readback.data,
-        expected,
-        width,
-        height,
-        rowPitch,
-        bytesPerPixel,
-        dstFormat
-      );
-      if (check !== undefined) {
-        niceStack.message = check;
-        this.rec.expectationFailed(niceStack);
-      }
-      readback.cleanup();
-    });
-  }
-
-  // MAINTENANCE_TODO(crbug.com/dawn/868): Should be possible to consolidate this along with texture checking
-  checkBufferWithRowPitch(
-    actual: TypedArrayBufferView,
-    expected: TypedArrayBufferView,
-    width: number,
-    height: number,
-    rowPitch: number,
-    bytesPerPixel: number,
-    dstFormat: RegularTextureFormat
-  ): string | undefined {
-    const bytesPerRow = width * bytesPerPixel;
-
-    if (isFp16Format(dstFormat)) {
-      const expF16bits = new Uint16Array(
-        expected.buffer,
-        expected.byteOffset / Uint16Array.BYTES_PER_ELEMENT,
-        expected.byteLength / Uint16Array.BYTES_PER_ELEMENT
-      );
-      const checkF16bits = new Uint16Array(
-        actual.buffer,
-        actual.byteOffset / Uint16Array.BYTES_PER_ELEMENT,
-        actual.byteLength / Uint16Array.BYTES_PER_ELEMENT
-      );
-
-      for (let y = 0; y < height; ++y) {
-        const expRowF16bits = expF16bits.subarray(
-          (y * bytesPerRow) / expF16bits.BYTES_PER_ELEMENT,
-          bytesPerRow / expF16bits.BYTES_PER_ELEMENT
-        );
-
-        const checkRowF16bits = checkF16bits.subarray(
-          (y * bytesPerRow) / checkF16bits.BYTES_PER_ELEMENT,
-          bytesPerRow / checkF16bits.BYTES_PER_ELEMENT
-        );
-
-        // 2701 is 0.0002 in float16. If the result is smaller than this, we
-        // treat the value as 0;
-        const checkResult = checkElementsBetween(checkRowF16bits, [
-          i => (expRowF16bits[i] === 0 ? 0 : expRowF16bits[i] - 1),
-          i => (expRowF16bits[i] === 0 ? 2701 : expRowF16bits[i] + 1),
-        ]);
-        if (checkResult !== undefined) return `on row ${y}: ${checkResult}`;
-      }
-    } else if (isFp32Format(dstFormat)) {
-      const expF32 = new Float32Array(
-        expected.buffer,
-        expected.byteOffset / Float32Array.BYTES_PER_ELEMENT,
-        expected.byteLength / Float32Array.BYTES_PER_ELEMENT
-      );
-      const checkF32 = new Float32Array(
-        actual.buffer,
-        actual.byteOffset / Float32Array.BYTES_PER_ELEMENT,
-        actual.byteLength / Float32Array.BYTES_PER_ELEMENT
-      );
-
-      for (let y = 0; y < height; ++y) {
-        const expRowF32 = expF32.subarray(
-          (y * bytesPerRow) / expF32.BYTES_PER_ELEMENT,
-          bytesPerRow / expF32.BYTES_PER_ELEMENT
-        );
-        const checkRowF32 = checkF32.subarray(
-          (y * bytesPerRow) / checkF32.BYTES_PER_ELEMENT,
-          bytesPerRow / checkF32.BYTES_PER_ELEMENT
-        );
-        const checkResult = checkElementsBetween(checkRowF32, [
-          i => expRowF32[i] - 0.001,
-          i => expRowF32[i] + 0.001,
-        ]);
-        if (checkResult !== undefined) return `on row ${y}: ${checkResult}`;
-      }
-    } else {
-      for (let y = 0; y < height; ++y) {
-        const exp = new Uint8Array(expected.buffer, expected.byteOffset, expected.byteLength);
-        const check = new Uint8Array(actual.buffer, actual.byteOffset, actual.byteLength);
-
-        const checkResult = checkElementsEqual(
-          check.subarray(y * rowPitch, bytesPerRow),
-          exp.subarray(y * bytesPerRow, bytesPerRow)
-        );
-        if (checkResult !== undefined) return `on row ${y}: ${checkResult}`;
-      }
-    }
-    return undefined;
   }
 
   doTestAndCheckResult(
     imageCopyExternalImage: GPUImageCopyExternalImage,
     dstTextureCopyView: GPUImageCopyTextureTagged,
-    copySize: GPUExtent3DDict,
-    bytesPerPixel: number,
-    expectedData: Uint8ClampedArray,
-    dstFormat: RegularTextureFormat
+    expTexelView: TexelView,
+    copySize: Required<GPUExtent3DDict>,
+    texelCompareOptions: TexelCompareOptions
   ): void {
     this.device.queue.copyExternalImageToTexture(
       imageCopyExternalImage,
@@ -329,32 +120,13 @@ export class CopyToTextureUtils extends GPUTest {
       copySize
     );
 
-    const externalImage = imageCopyExternalImage.source;
-    const dstTexture = dstTextureCopyView.texture;
-
-    const bytesPerRow = align(externalImage.width * bytesPerPixel, kBytesPerRowAlignment);
-    const testBuffer = this.device.createBuffer({
-      size: bytesPerRow * externalImage.height,
-      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
-    });
-    this.trackForCleanup(testBuffer);
-
-    const encoder = this.device.createCommandEncoder();
-
-    encoder.copyTextureToBuffer(
-      { texture: dstTexture, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
-      { buffer: testBuffer, bytesPerRow },
-      { width: externalImage.width, height: externalImage.height, depthOrArrayLayers: 1 }
+    const resultPromise = textureContentIsOKByT2B(
+      this,
+      { texture: dstTextureCopyView.texture },
+      copySize,
+      { expTexelView },
+      texelCompareOptions
     );
-    this.device.queue.submit([encoder.finish()]);
-
-    this.checkCopyExternalImageResult(
-      testBuffer,
-      expectedData,
-      externalImage.width,
-      externalImage.height,
-      bytesPerPixel,
-      dstFormat
-    );
+    this.eventualExpectOK(resultPromise);
   }
 }

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -16,6 +16,7 @@ import {
   kFloat16Format,
   numberToFloat32Bits,
   float32BitsToNumber,
+  numberToFloatBits,
 } from '../conversion.js';
 import { clamp, signExtend } from '../math.js';
 
@@ -684,9 +685,9 @@ export const kTexelRepresentationInfo: {
       },
       unpackBits: (data: Uint8Array) => unpackComponentsBits(kRGB, data, { R: 11, G: 11, B: 10 }),
       numberToBits: components => ({
-        R: float32ToFloatBits(components.R ?? unreachable(), 0, 5, 6, 15),
-        G: float32ToFloatBits(components.G ?? unreachable(), 0, 5, 6, 15),
-        B: float32ToFloatBits(components.B ?? unreachable(), 0, 5, 5, 15),
+        R: numberToFloatBits(components.R ?? unreachable(), kFloat11Format),
+        G: numberToFloatBits(components.G ?? unreachable(), kFloat11Format),
+        B: numberToFloatBits(components.B ?? unreachable(), kFloat10Format),
       }),
       bitsToNumber: components => ({
         R: floatBitsToNumber(components.R!, kFloat11Format),

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -1,5 +1,5 @@
 import { assert, unreachable } from '../../../common/util/util.js';
-import { UncompressedTextureFormat } from '../../capability_info.js';
+import { EncodableTextureFormat, UncompressedTextureFormat } from '../../capability_info.js';
 import {
   assertInIntegerRange,
   float32ToFloatBits,
@@ -9,7 +9,15 @@ import {
   gammaDecompress,
   normalizedIntegerAsFloat,
   packRGB9E5UFloat,
+  floatBitsToNumber,
+  float16BitsToFloat32,
+  floatBitsToNormalULPFromZero,
+  kFloat32Format,
+  kFloat16Format,
+  numberToFloat32Bits,
+  float32BitsToNumber,
 } from '../conversion.js';
+import { clamp, signExtend } from '../math.js';
 
 /** A component of a texture format: R, G, B, A, Depth, or Stencil. */
 export const enum TexelComponent {
@@ -40,6 +48,9 @@ type ComponentMapFn = (components: PerTexelComponent<number>) => PerTexelCompone
  * @returns {ArrayBuffer} The packed data.
  */
 type ComponentPackFn = (components: PerTexelComponent<number>) => ArrayBuffer;
+
+/** Unpacks component values from a Uint8Array */
+type ComponentUnpackFn = (data: Uint8Array) => PerTexelComponent<number>;
 
 /**
  * Create a PerTexelComponent object filled with the same value for all components.
@@ -100,6 +111,15 @@ const decodeSRGB: ComponentMapFn = components => {
   );
   return applyEach(gammaDecompress, kRGB)(components);
 };
+
+/**
+ * Makes a `ComponentMapFn` for clamping values to the specified range.
+ */
+export function makeClampToRange(format: EncodableTextureFormat): ComponentMapFn {
+  const repr = kTexelRepresentationInfo[format];
+  assert(repr.numericRange !== null, 'Format has unknown numericRange');
+  return applyEach(x => clamp(x, repr.numericRange!), repr.componentOrder);
+}
 
 /**
  * Helper function to pack components as an ArrayBuffer.
@@ -226,6 +246,66 @@ function packComponents(
 }
 
 /**
+ * Unpack substrings of bits from a Uint8Array, e.g. [8,8,8,8] or [9,9,9,5].
+ *
+ * MAINTENANCE_TODO: Pretty slow. Could significantly optimize when `bitLengths` is 8, 16, or 32.
+ */
+function unpackComponentsBits(
+  componentOrder: TexelComponent[],
+  byteView: Uint8Array,
+  bitLengths: number | PerTexelComponent<number>
+): PerTexelComponent<number> {
+  const bitLengthMap =
+    typeof bitLengths === 'number' ? makePerTexelComponent(componentOrder, bitLengths) : bitLengths;
+
+  const totalBitLength = Object.entries(bitLengthMap).reduce((acc, [, value]) => {
+    assert(value !== undefined);
+    return acc + value;
+  }, 0);
+  assert(totalBitLength % 8 === 0);
+
+  const components = makePerTexelComponent(componentOrder, 0);
+  let bitOffset = 0;
+  for (const c of componentOrder) {
+    const bitLength = bitLengthMap[c];
+    assert(bitLength !== undefined);
+
+    let value: number;
+
+    const byteOffset = Math.floor(bitOffset / 8);
+    const byteLength = Math.ceil(bitLength / 8);
+    if (byteOffset === bitOffset / 8 && byteLength === bitLength / 8) {
+      const dataView = new DataView(byteView.buffer, byteView.byteOffset + byteOffset, byteLength);
+      switch (byteLength) {
+        case 1:
+          value = dataView.getUint8(0);
+          break;
+        case 2:
+          value = dataView.getUint16(0, true);
+          break;
+        case 4:
+          value = dataView.getUint32(0, true);
+          break;
+        default:
+          unreachable();
+      }
+    } else {
+      // Packed representations are all 32-bit and use Uint as the data type.
+      // ex.) rg10b11float, rgb10a2unorm
+      const view = new DataView(byteView.buffer, byteView.byteOffset, byteView.byteLength);
+      assert(view.byteLength === 4);
+      const word = view.getUint32(0, true);
+      value = (word >>> bitOffset) & ((1 << bitLength) - 1);
+    }
+
+    bitOffset += bitLength;
+    components[c] = value;
+  }
+
+  return components;
+}
+
+/**
  * Create an entry in `kTexelRepresentationInfo` for normalized integer texel data with constant
  * bitlength.
  * @param {TexelComponent[]} componentOrder - The order of the component data.
@@ -236,7 +316,7 @@ function makeNormalizedInfo(
   componentOrder: TexelComponent[],
   bitLength: number,
   opt: { signed: boolean; sRGB: boolean }
-) {
+): TexelRepresentationInfo {
   const encodeNonSRGB = applyEach(
     (n: number) => floatAsNormalizedInteger(n, bitLength, opt.signed),
     componentOrder
@@ -246,17 +326,51 @@ function makeNormalizedInfo(
     componentOrder
   );
 
+  const numberToBitsNonSRGB = applyEach(
+    n => floatAsNormalizedInteger(n, bitLength, opt.signed),
+    componentOrder
+  );
+  let bitsToNumberNonSRGB: ComponentMapFn;
+  if (opt.signed) {
+    bitsToNumberNonSRGB = applyEach(
+      n => normalizedIntegerAsFloat(signExtend(n, bitLength), bitLength, opt.signed),
+      componentOrder
+    );
+  } else {
+    bitsToNumberNonSRGB = applyEach(
+      n => normalizedIntegerAsFloat(n, bitLength, opt.signed),
+      componentOrder
+    );
+  }
+
   let encode: ComponentMapFn;
   let decode: ComponentMapFn;
+  let numberToBits: ComponentMapFn;
+  let bitsToNumber: ComponentMapFn;
   if (opt.sRGB) {
     encode = components => encodeNonSRGB(encodeSRGB(components));
     decode = components => decodeSRGB(decodeNonSRGB(components));
+    numberToBits = components => numberToBitsNonSRGB(encodeSRGB(components));
+    bitsToNumber = components => decodeSRGB(bitsToNumberNonSRGB(components));
   } else {
     encode = encodeNonSRGB;
     decode = decodeNonSRGB;
+    numberToBits = numberToBitsNonSRGB;
+    bitsToNumber = bitsToNumberNonSRGB;
   }
 
-  const dataType = opt.signed ? 'snorm' : ('unorm' as ComponentDataType);
+  let bitsToULPFromZero: ComponentMapFn;
+  if (opt.signed) {
+    const maxValue = (1 << (bitLength - 1)) - 1; // e.g. 127 for snorm8
+    bitsToULPFromZero = applyEach(
+      n => Math.max(-maxValue, signExtend(n, bitLength)),
+      componentOrder
+    );
+  } else {
+    bitsToULPFromZero = components => components;
+  }
+
+  const dataType: ComponentDataType = opt.signed ? 'snorm' : 'unorm';
   return {
     componentOrder,
     componentInfo: makePerTexelComponent(componentOrder, {
@@ -267,6 +381,11 @@ function makeNormalizedInfo(
     decode,
     pack: (components: PerTexelComponent<number>) =>
       packComponents(componentOrder, components, bitLength, dataType),
+    unpackBits: (data: Uint8Array) => unpackComponentsBits(componentOrder, data, bitLength),
+    numberToBits,
+    bitsToNumber,
+    bitsToULPFromZero,
+    numericRange: { min: opt.signed ? -1 : 0, max: 1 },
   };
 }
 
@@ -280,7 +399,8 @@ function makeIntegerInfo(
   componentOrder: TexelComponent[],
   bitLength: number,
   opt: { signed: boolean }
-) {
+): TexelRepresentationInfo {
+  assert(bitLength <= 32);
   const encode = applyEach(
     (n: number) => (assertInIntegerRange(n, bitLength, opt.signed), n),
     componentOrder
@@ -290,7 +410,15 @@ function makeIntegerInfo(
     componentOrder
   );
 
-  const dataType = opt.signed ? 'sint' : ('uint' as ComponentDataType);
+  let bitsToULPFromZero: ComponentMapFn;
+  if (opt.signed) {
+    bitsToULPFromZero = applyEach(n => signExtend(n, bitLength), componentOrder);
+  } else {
+    bitsToULPFromZero = components => components;
+  }
+
+  const dataType: ComponentDataType = opt.signed ? 'sint' : 'uint';
+  const bitMask = (1 << bitLength) - 1;
   return {
     componentOrder,
     componentInfo: makePerTexelComponent(componentOrder, {
@@ -301,6 +429,13 @@ function makeIntegerInfo(
     decode,
     pack: (components: PerTexelComponent<number>) =>
       packComponents(componentOrder, components, bitLength, dataType),
+    unpackBits: (data: Uint8Array) => unpackComponentsBits(componentOrder, data, bitLength),
+    numberToBits: applyEach(v => v & bitMask, componentOrder),
+    bitsToNumber: decode,
+    bitsToULPFromZero,
+    numericRange: opt.signed
+      ? { min: -(2 ** (bitLength - 1)), max: 2 ** (bitLength - 1) - 1 }
+      : { min: 0, max: 2 ** bitLength - 1 },
   };
 }
 
@@ -310,15 +445,57 @@ function makeIntegerInfo(
  * @param {TexelComponent[]} componentOrder - The order of the component data.
  * @param {number} bitLength - The number of bits in each component.
  */
-function makeFloatInfo(componentOrder: TexelComponent[], bitLength: number) {
-  // MAINTENANCE_TODO: Use |bitLength| to round float values based on precision.
-  const encode = applyEach(identity, componentOrder);
+function makeFloatInfo(
+  componentOrder: TexelComponent[],
+  bitLength: number,
+  { restrictedDepth = false }: { restrictedDepth?: boolean } = {}
+): TexelRepresentationInfo {
+  let encode: ComponentMapFn;
+  let numberToBits;
+  let bitsToNumber;
+  let bitsToULPFromZero;
+  switch (bitLength) {
+    case 32:
+      if (restrictedDepth) {
+        encode = applyEach(v => {
+          assert(v >= 0.0 && v <= 1.0, 'depth out of range');
+          return new Float32Array([v])[0];
+        }, componentOrder);
+      } else {
+        encode = applyEach(v => new Float32Array([v])[0], componentOrder);
+      }
+      numberToBits = applyEach(numberToFloat32Bits, componentOrder);
+      bitsToNumber = applyEach(float32BitsToNumber, componentOrder);
+      bitsToULPFromZero = applyEach(
+        v => floatBitsToNormalULPFromZero(v, kFloat32Format),
+        componentOrder
+      );
+      break;
+    case 16:
+      if (restrictedDepth) {
+        encode = applyEach(v => {
+          assert(v >= 0.0 && v <= 1.0, 'depth out of range');
+          return float16BitsToFloat32(float32ToFloat16Bits(v));
+        }, componentOrder);
+      } else {
+        encode = applyEach(v => float16BitsToFloat32(float32ToFloat16Bits(v)), componentOrder);
+      }
+      numberToBits = applyEach(float32ToFloat16Bits, componentOrder);
+      bitsToNumber = applyEach(float16BitsToFloat32, componentOrder);
+      bitsToULPFromZero = applyEach(
+        v => floatBitsToNormalULPFromZero(v, kFloat16Format),
+        componentOrder
+      );
+      break;
+    default:
+      unreachable();
+  }
   const decode = applyEach(identity, componentOrder);
 
   return {
     componentOrder,
     componentInfo: makePerTexelComponent(componentOrder, {
-      dataType: 'float' as ComponentDataType,
+      dataType: 'float' as const,
       bitLength,
     }),
     encode,
@@ -326,10 +503,7 @@ function makeFloatInfo(componentOrder: TexelComponent[], bitLength: number) {
     pack: (components: PerTexelComponent<number>) => {
       switch (bitLength) {
         case 16:
-          components = applyEach(
-            (n: number) => float32ToFloat16Bits(n),
-            componentOrder
-          )(components);
+          components = applyEach(float32ToFloat16Bits, componentOrder)(components);
           return packComponents(componentOrder, components, 16, 'uint');
         case 32:
           return packComponents(componentOrder, components, bitLength, 'float');
@@ -337,6 +511,13 @@ function makeFloatInfo(componentOrder: TexelComponent[], bitLength: number) {
           unreachable();
       }
     },
+    unpackBits: (data: Uint8Array) => unpackComponentsBits(componentOrder, data, bitLength),
+    numberToBits,
+    bitsToNumber,
+    bitsToULPFromZero,
+    numericRange: restrictedDepth
+      ? { min: 0, max: 1 }
+      : { min: Number.NEGATIVE_INFINITY, max: Number.POSITIVE_INFINITY },
   };
 }
 
@@ -348,6 +529,10 @@ const kBGRA = [TexelComponent.B, TexelComponent.G, TexelComponent.R, TexelCompon
 
 const identity = (n: number) => n;
 
+const kFloat11Format = { signed: 0, exponentBits: 5, mantissaBits: 6, bias: 15 } as const;
+const kFloat10Format = { signed: 0, exponentBits: 5, mantissaBits: 5, bias: 15 } as const;
+const kFloat9e5Format = { signed: 0, exponentBits: 5, mantissaBits: 9, bias: 15 } as const;
+
 export type TexelRepresentationInfo = {
   /** Order of components in the packed representation. */
   readonly componentOrder: TexelComponent[];
@@ -357,11 +542,26 @@ export type TexelRepresentationInfo = {
     bitLength: number;
   }>;
   /** Encode shader values into their data representation. ex.) float 1.0 -> unorm8 255 */
+  // MAINTENANCE_TODO: Replace with numberToBits?
   readonly encode: ComponentMapFn;
   /** Decode the data representation into the shader values. ex.) unorm8 255 -> float 1.0 */
+  // MAINTENANCE_TODO: Replace with bitsToNumber?
   readonly decode: ComponentMapFn;
-  /** Pack texel component values into an ArrayBuffer. ex.) rg8unorm {r: 0, g:255} -> 0xFF00 */
+  /** Pack texel component values into an ArrayBuffer. ex.) rg8unorm {r: 0, g: 255} -> 0xFF00 */
+  // MAINTENANCE_TODO: Replace with packBits?
   readonly pack: ComponentPackFn;
+
+  /** Convert integer bit representations into numeric values, e.g. unorm8 255 -> numeric 1.0 */
+  readonly bitsToNumber: ComponentMapFn;
+  /** Convert numeric values into integer bit representations, e.g. numeric 1.0 -> unorm8 255 */
+  readonly numberToBits: ComponentMapFn;
+  /** Unpack integer bit representations from an ArrayBuffer, e.g. 0xFF00 -> rg8unorm [0,255] */
+  readonly unpackBits: ComponentUnpackFn;
+  /** Convert integer bit representations into ULPs-from-zero, e.g. unorm8 255 -> 255 ULPs */
+  readonly bitsToULPFromZero: ComponentMapFn;
+  /** The valid range of numeric "color" values, e.g. [0, Infinity] for ufloat. */
+  readonly numericRange: null | { min: number; max: number };
+
   // Add fields as needed
 };
 export const kTexelRepresentationInfo: {
@@ -439,6 +639,22 @@ export const kTexelRepresentationInfo: {
           },
           'uint'
         ),
+      unpackBits: (data: Uint8Array) =>
+        unpackComponentsBits(kRGBA, data, { R: 10, G: 10, B: 10, A: 2 }),
+      numberToBits: components => ({
+        R: floatAsNormalizedInteger(components.R ?? unreachable(), 10, false),
+        G: floatAsNormalizedInteger(components.G ?? unreachable(), 10, false),
+        B: floatAsNormalizedInteger(components.B ?? unreachable(), 10, false),
+        A: floatAsNormalizedInteger(components.A ?? unreachable(), 2, false),
+      }),
+      bitsToNumber: components => ({
+        R: normalizedIntegerAsFloat(components.R!, 10, false),
+        G: normalizedIntegerAsFloat(components.G!, 10, false),
+        B: normalizedIntegerAsFloat(components.B!, 10, false),
+        A: normalizedIntegerAsFloat(components.A!, 2, false),
+      }),
+      bitsToULPFromZero: components => components,
+      numericRange: { min: 0, max: 1 },
     },
     rg11b10ufloat: {
       componentOrder: kRGB,
@@ -450,14 +666,14 @@ export const kTexelRepresentationInfo: {
         B: { dataType: 'ufloat', bitLength: 10 },
       },
       pack: components => {
-        components = {
+        const componentsBits = {
           R: float32ToFloatBits(components.R ?? unreachable(), 0, 5, 6, 15),
           G: float32ToFloatBits(components.G ?? unreachable(), 0, 5, 6, 15),
           B: float32ToFloatBits(components.B ?? unreachable(), 0, 5, 5, 15),
         };
         return packComponents(
           kRGB,
-          components,
+          componentsBits,
           {
             R: 11,
             G: 11,
@@ -466,6 +682,23 @@ export const kTexelRepresentationInfo: {
           'uint'
         );
       },
+      unpackBits: (data: Uint8Array) => unpackComponentsBits(kRGB, data, { R: 11, G: 11, B: 10 }),
+      numberToBits: components => ({
+        R: float32ToFloatBits(components.R ?? unreachable(), 0, 5, 6, 15),
+        G: float32ToFloatBits(components.G ?? unreachable(), 0, 5, 6, 15),
+        B: float32ToFloatBits(components.B ?? unreachable(), 0, 5, 5, 15),
+      }),
+      bitsToNumber: components => ({
+        R: floatBitsToNumber(components.R!, kFloat11Format),
+        G: floatBitsToNumber(components.G!, kFloat11Format),
+        B: floatBitsToNumber(components.B!, kFloat10Format),
+      }),
+      bitsToULPFromZero: components => ({
+        R: floatBitsToNormalULPFromZero(components.R!, kFloat11Format),
+        G: floatBitsToNormalULPFromZero(components.G!, kFloat11Format),
+        B: floatBitsToNormalULPFromZero(components.B!, kFloat10Format),
+      }),
+      numericRange: { min: 0, max: Number.POSITIVE_INFINITY },
     },
     rgb9e5ufloat: {
       componentOrder: kRGB,
@@ -483,14 +716,34 @@ export const kTexelRepresentationInfo: {
             components.B ?? unreachable()
           ),
         ]).buffer,
+      // For the purpose of unpacking, expand into three "ufloat14" values.
+      unpackBits: (data: Uint8Array) => {
+        // Pretend the exponent part is A so we can use unpackComponentsBits.
+        const parts = unpackComponentsBits(kRGBA, data, { R: 9, G: 9, B: 9, A: 5 });
+        return {
+          R: (parts.A! << 9) | parts.R!,
+          G: (parts.A! << 9) | parts.G!,
+          B: (parts.A! << 9) | parts.B!,
+        };
+      },
+      numberToBits: components => ({
+        R: float32ToFloatBits(components.R ?? unreachable(), 0, 5, 9, 15),
+        G: float32ToFloatBits(components.G ?? unreachable(), 0, 5, 9, 15),
+        B: float32ToFloatBits(components.B ?? unreachable(), 0, 5, 9, 15),
+      }),
+      bitsToNumber: components => ({
+        R: floatBitsToNumber(components.R!, kFloat9e5Format),
+        G: floatBitsToNumber(components.G!, kFloat9e5Format),
+        B: floatBitsToNumber(components.B!, kFloat9e5Format),
+      }),
+      bitsToULPFromZero: components => ({
+        R: floatBitsToNormalULPFromZero(components.R!, kFloat9e5Format),
+        G: floatBitsToNormalULPFromZero(components.G!, kFloat9e5Format),
+        B: floatBitsToNormalULPFromZero(components.B!, kFloat9e5Format),
+      }),
+      numericRange: { min: 0, max: Number.POSITIVE_INFINITY },
     },
-    depth32float: {
-      componentOrder: [TexelComponent.Depth],
-      encode: applyEach((n: number) => (assert(n >= 0 && n <= 1.0), n), [TexelComponent.Depth]),
-      decode: applyEach((n: number) => (assert(n >= 0 && n <= 1.0), n), [TexelComponent.Depth]),
-      componentInfo: { Depth: { dataType: 'float', bitLength: 32 } },
-      pack: components => packComponents([TexelComponent.Depth], components, 32, 'float'),
-    },
+    depth32float: makeFloatInfo([TexelComponent.Depth], 32, { restrictedDepth: true }),
     depth16unorm: makeNormalizedInfo([TexelComponent.Depth], 16, { signed: false, sRGB: false }),
     depth24plus: {
       componentOrder: [TexelComponent.Depth],
@@ -498,22 +751,13 @@ export const kTexelRepresentationInfo: {
       encode: applyEach(() => unreachable('depth24plus cannot be encoded'), [TexelComponent.Depth]),
       decode: applyEach(() => unreachable('depth24plus cannot be decoded'), [TexelComponent.Depth]),
       pack: () => unreachable('depth24plus data cannot be packed'),
+      unpackBits: () => unreachable('depth24plus data cannot be unpacked'),
+      numberToBits: () => unreachable('depth24plus has no representation'),
+      bitsToNumber: () => unreachable('depth24plus has no representation'),
+      bitsToULPFromZero: () => unreachable('depth24plus has no representation'),
+      numericRange: { min: 0, max: 1 },
     },
-    stencil8: {
-      componentOrder: [TexelComponent.Stencil],
-      componentInfo: { Stencil: { dataType: 'uint', bitLength: 8 } },
-      encode: components => {
-        assert(components.Stencil !== undefined);
-        assertInIntegerRange(components.Stencil, 8, false);
-        return components;
-      },
-      decode: components => {
-        assert(components.Stencil !== undefined);
-        assertInIntegerRange(components.Stencil, 8, false);
-        return components;
-      },
-      pack: components => packComponents([TexelComponent.Stencil], components, 8, 'uint'),
-    },
+    stencil8: makeIntegerInfo([TexelComponent.Stencil], 8, { signed: false }),
     'depth24unorm-stencil8': {
       componentOrder: [TexelComponent.Depth, TexelComponent.Stencil],
       componentInfo: {
@@ -543,6 +787,11 @@ export const kTexelRepresentationInfo: {
         };
       },
       pack: () => unreachable('depth24unorm-stencil8 data cannot be packed'),
+      unpackBits: () => unreachable('depth24unorm-stencil8 data cannot be unpacked'),
+      numberToBits: () => unreachable('not implemented'),
+      bitsToNumber: () => unreachable('not implemented'),
+      bitsToULPFromZero: () => unreachable('not implemented'),
+      numericRange: null,
     },
     'depth32float-stencil8': {
       componentOrder: [TexelComponent.Depth, TexelComponent.Stencil],
@@ -567,6 +816,11 @@ export const kTexelRepresentationInfo: {
         return components;
       },
       pack: () => unreachable('depth32float-stencil8 data cannot be packed'),
+      unpackBits: () => unreachable('depth32float-stencil8 data cannot be unpacked'),
+      numberToBits: () => unreachable('not implemented'),
+      bitsToNumber: () => unreachable('not implemented'),
+      bitsToULPFromZero: () => unreachable('not implemented'),
+      numericRange: null,
     },
     'depth24plus-stencil8': {
       componentOrder: [TexelComponent.Depth, TexelComponent.Stencil],
@@ -593,6 +847,11 @@ export const kTexelRepresentationInfo: {
         return components;
       },
       pack: () => unreachable('depth24plus-stencil8 data cannot be packed'),
+      unpackBits: () => unreachable('depth24plus-stencil8 data cannot be unpacked'),
+      numberToBits: () => unreachable('depth24plus-stencil8 has no representation'),
+      bitsToNumber: () => unreachable('depth24plus-stencil8 has no representation'),
+      bitsToULPFromZero: () => unreachable('depth24plus-stencil8 has no representation'),
+      numericRange: null,
     },
   },
 };

--- a/src/webgpu/util/texture/texel_view.ts
+++ b/src/webgpu/util/texture/texel_view.ts
@@ -1,0 +1,160 @@
+import { assert, memcpy } from '../../../common/util/util.js';
+import { EncodableTextureFormat, kTextureFormatInfo } from '../../capability_info.js';
+import { reifyExtent3D, reifyOrigin3D } from '../unions.js';
+
+import { kTexelRepresentationInfo, makeClampToRange, PerTexelComponent } from './texel_data.js';
+
+/** Function taking some x,y,z coordinates and returning `Readonly<T>`. */
+export type PerPixelAtLevel<T> = (coords: Required<GPUOrigin3DDict>) => Readonly<T>;
+
+/**
+ * Wrapper to view various representations of texture data in other ways. E.g., can:
+ * - Provide a mapped buffer, containing copied texture data, and read color values.
+ * - Provide a function that generates color values by coordinate, and convert to ULPs-from-zero.
+ *
+ * MAINTENANCE_TODO: Would need some refactoring to support block formats, which could be partially
+ * supported if useful.
+ */
+export class TexelView {
+  /** The GPUTextureFormat of the TexelView. */
+  readonly format: EncodableTextureFormat;
+  /** Generates the bytes for the texel at the given coordinates. */
+  readonly bytes: PerPixelAtLevel<Uint8Array>;
+  /** Generates the ULPs-from-zero for the texel at the given coordinates. */
+  readonly ulpFromZero: PerPixelAtLevel<PerTexelComponent<number>>;
+  /** Generates the color for the texel at the given coordinates. */
+  readonly color: PerPixelAtLevel<PerTexelComponent<number>>;
+
+  private constructor(
+    format: EncodableTextureFormat,
+    {
+      bytes,
+      ulpFromZero,
+      color,
+    }: {
+      bytes: PerPixelAtLevel<Uint8Array>;
+      ulpFromZero: PerPixelAtLevel<PerTexelComponent<number>>;
+      color: PerPixelAtLevel<PerTexelComponent<number>>;
+    }
+  ) {
+    this.format = format;
+    this.bytes = bytes;
+    this.ulpFromZero = ulpFromZero;
+    this.color = color;
+  }
+
+  /**
+   * Produces a TexelView from "linear image data", i.e. the `writeTexture` format. Takes a
+   * reference to the input `subrectData`, so any changes to it will be visible in the TexelView.
+   */
+  static fromTextureDataByReference(
+    format: EncodableTextureFormat,
+    subrectData: Uint8Array | Uint8ClampedArray,
+    {
+      bytesPerRow,
+      rowsPerImage,
+      subrectOrigin,
+      subrectSize,
+    }: {
+      bytesPerRow: number;
+      rowsPerImage: number;
+      subrectOrigin: GPUOrigin3D;
+      subrectSize: GPUExtent3D;
+    }
+  ) {
+    const origin = reifyOrigin3D(subrectOrigin);
+    const size = reifyExtent3D(subrectSize);
+
+    const info = kTextureFormatInfo[format];
+    assert(info.blockWidth === 1 && info.blockHeight === 1, 'unimplemented for block formats');
+
+    return TexelView.fromTexelsAsBytes(format, coords => {
+      assert(
+        coords.x >= origin.x &&
+          coords.y >= origin.y &&
+          coords.z >= origin.z &&
+          coords.x < size.width &&
+          coords.y < size.height &&
+          coords.z < size.depthOrArrayLayers,
+        'coordinate out of bounds'
+      );
+
+      const imageOffsetInRows = (coords.z - origin.z) * rowsPerImage;
+      const rowOffset = (imageOffsetInRows + (coords.y - origin.y)) * bytesPerRow;
+      const offset = rowOffset + (coords.x - origin.x) * info.bytesPerBlock;
+
+      // MAINTENANCE_TODO: To support block formats, decode the block and then index into the result.
+      return subrectData.subarray(offset, offset + info.bytesPerBlock) as Uint8Array;
+    });
+  }
+
+  /** Produces a TexelView from a generator of bytes for individual texel blocks. */
+  static fromTexelsAsBytes(
+    format: EncodableTextureFormat,
+    generator: PerPixelAtLevel<Uint8Array>
+  ): TexelView {
+    const info = kTextureFormatInfo[format];
+    assert(info.blockWidth === 1 && info.blockHeight === 1, 'unimplemented for block formats');
+
+    const repr = kTexelRepresentationInfo[format];
+    return new TexelView(format, {
+      bytes: generator,
+      ulpFromZero: coords => repr.bitsToULPFromZero(repr.unpackBits(generator(coords))),
+      color: coords => repr.bitsToNumber(repr.unpackBits(generator(coords))),
+    });
+  }
+
+  /** Produces a TexelView from a generator of numeric "color" values for each texel. */
+  static fromTexelsAsColors(
+    format: EncodableTextureFormat,
+    generator: PerPixelAtLevel<PerTexelComponent<number>>,
+    { clampToFormatRange = false }: { clampToFormatRange?: boolean } = {}
+  ): TexelView {
+    const info = kTextureFormatInfo[format];
+    assert(info.blockWidth === 1 && info.blockHeight === 1, 'unimplemented for block formats');
+
+    if (clampToFormatRange) {
+      const applyClamp = makeClampToRange(format);
+      const oldGenerator = generator;
+      generator = coords => applyClamp(oldGenerator(coords));
+    }
+
+    const repr = kTexelRepresentationInfo[format];
+    return new TexelView(format, {
+      bytes: coords => new Uint8Array(repr.pack(repr.encode(generator(coords)))),
+      ulpFromZero: coords => repr.bitsToULPFromZero(repr.numberToBits(generator(coords))),
+      color: generator,
+    });
+  }
+
+  /** Writes the contents of a TexelView as "linear image data", i.e. the `writeTexture` format. */
+  writeTextureData(
+    subrectData: Uint8Array | Uint8ClampedArray,
+    {
+      bytesPerRow,
+      rowsPerImage,
+      subrectOrigin: subrectOrigin_,
+      subrectSize: subrectSize_,
+    }: {
+      bytesPerRow: number;
+      rowsPerImage: number;
+      subrectOrigin: GPUOrigin3D;
+      subrectSize: GPUExtent3D;
+    }
+  ): void {
+    const subrectOrigin = reifyOrigin3D(subrectOrigin_);
+    const subrectSize = reifyExtent3D(subrectSize_);
+
+    const info = kTextureFormatInfo[this.format];
+    assert(info.blockWidth === 1 && info.blockHeight === 1, 'unimplemented for block formats');
+
+    for (let z = subrectOrigin.z; z < subrectOrigin.z + subrectSize.depthOrArrayLayers; ++z) {
+      for (let y = subrectOrigin.y; y < subrectOrigin.y + subrectSize.height; ++y) {
+        for (let x = subrectOrigin.x; x < subrectOrigin.x + subrectSize.width; ++x) {
+          const start = (z * rowsPerImage + y) * bytesPerRow + x * info.bytesPerBlock;
+          memcpy({ src: this.bytes({ x, y, z }) }, { dst: subrectData, start });
+        }
+      }
+    }
+  }
+}

--- a/src/webgpu/util/texture/texture_ok.spec.ts
+++ b/src/webgpu/util/texture/texture_ok.spec.ts
@@ -1,0 +1,159 @@
+export const description = 'checkPixels helpers behave as expected against real textures';
+
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { GPUTest } from '../../gpu_test.js';
+
+import { TexelView } from './texel_view.js';
+import { textureContentIsOKByT2B } from './texture_ok.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('float32')
+  .desc(`Basic test that actual/expected must match, for float32.`)
+  .params(u =>
+    u
+      .combineWithParams([
+        { format: 'rgba32float' }, //
+        { format: 'rg32float' },
+      ] as const)
+      .beginSubcases()
+      .combineWithParams([
+        // Expected data is 0.6 in all channels
+        { data: 0.6, opts: { maxFractionalDiff: 0.0000001 }, _ok: true },
+        { data: 0.6, opts: { maxDiffULPsForFloatFormat: 1 }, _ok: true },
+
+        { data: 0.5999, opts: { maxFractionalDiff: 0 }, _ok: false },
+        { data: 0.5999, opts: { maxFractionalDiff: 0.0001001 }, _ok: true },
+
+        { data: 0.6001, opts: { maxFractionalDiff: 0 }, _ok: false },
+        { data: 0.6001, opts: { maxFractionalDiff: 0.0001001 }, _ok: true },
+
+        { data: 0.5999, opts: { maxDiffULPsForFloatFormat: 1677 }, _ok: false },
+        { data: 0.5999, opts: { maxDiffULPsForFloatFormat: 1678 }, _ok: true },
+
+        { data: 0.6001, opts: { maxDiffULPsForFloatFormat: 1676 }, _ok: false },
+        { data: 0.6001, opts: { maxDiffULPsForFloatFormat: 1677 }, _ok: true },
+      ])
+  )
+  .fn(async t => {
+    const { format, data, opts, _ok } = t.params;
+
+    const size = [1, 1];
+    const texture = t.device.createTexture({
+      format,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+    });
+    t.trackForCleanup(texture);
+    t.device.queue.writeTexture({ texture }, new Float32Array([data, data, data, data]), {}, size);
+
+    const expColor = { R: 0.6, G: 0.6, B: 0.6, A: 0.6 };
+    const expTexelView = TexelView.fromTexelsAsColors(format, coords => expColor);
+
+    const result = await textureContentIsOKByT2B(t, { texture }, size, { expTexelView }, opts);
+    t.expect((result === undefined) === _ok, `expected ${_ok}, got ${result === undefined}`);
+  });
+
+g.test('norm')
+  .desc(`Basic test that actual/expected must match, for unorm/snorm.`)
+  .params(u =>
+    u
+      .combine('mode', ['bytes', 'colors'] as const)
+      .combineWithParams([
+        { format: 'r8unorm', _maxValue: 255 },
+        { format: 'r8snorm', _maxValue: 127 },
+      ] as const)
+      .beginSubcases()
+      .combineWithParams([
+        // Expected data is [10, 10]
+        { data: [10, 10], _ok: true },
+        { data: [10, 11], _ok: false },
+        { data: [11, 10], _ok: false },
+        { data: [11, 11], _ok: false },
+      ])
+  )
+  .fn(async t => {
+    const { mode, format, _maxValue, data, _ok } = t.params;
+
+    const size = [2, 1];
+    const texture = t.device.createTexture({
+      format,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+    });
+    t.trackForCleanup(texture);
+    t.device.queue.writeTexture({ texture }, new Int8Array(data), {}, size);
+
+    let expTexelView;
+    switch (mode) {
+      case 'bytes':
+        expTexelView = TexelView.fromTexelsAsBytes(format, coords => new Uint8Array([10]));
+        break;
+      case 'colors':
+        expTexelView = TexelView.fromTexelsAsColors(format, coords => ({ R: 10 / _maxValue }));
+        break;
+    }
+
+    const result = await textureContentIsOKByT2B(
+      t,
+      { texture },
+      size,
+      { expTexelView },
+      { maxDiffULPsForNormFormat: 0 }
+    );
+    t.expect((result === undefined) === _ok, result?.message);
+  });
+
+g.test('snorm_min')
+  .desc(
+    `The minimum snorm value has two possible representations (e.g. -127 and -128). Ensure that
+    actual/expected can mismatch in both directions and pass the test.`
+  )
+  .params(u =>
+    u //
+      .combine('mode', ['bytes', 'colors'] as const)
+      .combineWithParams([
+        //
+        { format: 'r8snorm', _maxValue: 127 },
+      ] as const)
+  )
+  .fn(async t => {
+    const { mode, format, _maxValue } = t.params;
+
+    const data = [-_maxValue, -_maxValue - 1];
+
+    const size = [2, 1];
+    const texture = t.device.createTexture({
+      format,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+    });
+    t.trackForCleanup(texture);
+    t.device.queue.writeTexture({ texture }, new Int8Array(data), {}, size);
+
+    let expTexelView;
+    switch (mode) {
+      case 'bytes':
+        {
+          // Actual value should be [-127,-128], expected value is [-128,-127], both should pass.
+          const exp = [-_maxValue - 1, -_maxValue];
+          expTexelView = TexelView.fromTexelsAsBytes(
+            format,
+            coords => new Uint8Array([exp[coords.x]])
+          );
+        }
+        break;
+      case 'colors':
+        expTexelView = TexelView.fromTexelsAsColors(format, coords => ({ R: -1 }));
+        break;
+    }
+
+    const result = await textureContentIsOKByT2B(
+      t,
+      { texture },
+      size,
+      { expTexelView },
+      { maxDiffULPsForNormFormat: 0 }
+    );
+    t.expectOK(result);
+  });

--- a/src/webgpu/util/texture/texture_ok.ts
+++ b/src/webgpu/util/texture/texture_ok.ts
@@ -1,0 +1,339 @@
+import { assert, ErrorWithExtra, unreachable } from '../../../common/util/util.js';
+import { EncodableTextureFormat, kTextureFormatInfo } from '../../capability_info.js';
+import { GPUTest } from '../../gpu_test.js';
+import { generatePrettyTable } from '../pretty_diff_tables.js';
+import { reifyExtent3D, reifyOrigin3D } from '../unions.js';
+
+import { getTextureSubCopyLayout } from './layout.js';
+import { kTexelRepresentationInfo, PerTexelComponent, TexelComponent } from './texel_data.js';
+import { TexelView } from './texel_view.js';
+
+type PerPixelAtLevel<T> = (coords: Required<GPUOrigin3DDict>) => T;
+
+/** Threshold options for comparing texels of different formats (norm/float/int). */
+export type TexelCompareOptions = {
+  /** Threshold for integer texture formats. Defaults to 0. */
+  maxIntDiff?: number;
+  /** Threshold for non-integer (norm/float) texture formats, if not overridden. */
+  maxFractionalDiff?: number;
+  /** Threshold in ULPs for unorm/snorm texture formats. Overrides `maxFractionalDiff`. */
+  maxDiffULPsForNormFormat?: number;
+  /** Threshold in ULPs for float/ufloat texture formats. Overrides `maxFractionalDiff`. */
+  maxDiffULPsForFloatFormat?: number;
+};
+
+type TexelViewComparer = {
+  /** Given coords, returns whether the two texel views are considered matching at that point. */
+  predicate: PerPixelAtLevel<boolean>;
+  /**
+   * Given a list of failed coords, returns table rows for `generatePrettyTable` that
+   * display the actual/expected values and diffs for debugging.
+   */
+  tableRows: (failedCoords: readonly Required<GPUOrigin3DDict>[]) => Iterable<string>[];
+};
+
+function makeTexelViewComparer(
+  format: EncodableTextureFormat,
+  { actTexelView, expTexelView }: { actTexelView: TexelView; expTexelView: TexelView },
+  opts: TexelCompareOptions
+): TexelViewComparer {
+  const {
+    maxIntDiff = 0,
+    maxFractionalDiff,
+    maxDiffULPsForNormFormat,
+    maxDiffULPsForFloatFormat,
+  } = opts;
+
+  assert(maxIntDiff >= 0, 'threshold must be non-negative');
+  if (maxFractionalDiff !== undefined) {
+    assert(maxFractionalDiff >= 0, 'threshold must be non-negative');
+  }
+  if (maxDiffULPsForFloatFormat !== undefined) {
+    assert(maxDiffULPsForFloatFormat >= 0, 'threshold must be non-negative');
+  }
+  if (maxDiffULPsForNormFormat !== undefined) {
+    assert(maxDiffULPsForNormFormat >= 0, 'threshold must be non-negative');
+  }
+
+  const fmtIsInt = format.includes('int');
+  const fmtIsNorm = format.includes('norm');
+  const fmtIsFloat = format.includes('float');
+
+  const tvc = {} as TexelViewComparer;
+  if (fmtIsInt) {
+    tvc.predicate = coords =>
+      comparePerComponent(actTexelView.color(coords), expTexelView.color(coords), maxIntDiff);
+  } else if (fmtIsNorm && maxDiffULPsForNormFormat !== undefined) {
+    tvc.predicate = coords =>
+      comparePerComponent(
+        actTexelView.ulpFromZero(coords),
+        expTexelView.ulpFromZero(coords),
+        maxDiffULPsForNormFormat
+      );
+  } else if (fmtIsFloat && maxDiffULPsForFloatFormat !== undefined) {
+    tvc.predicate = coords =>
+      comparePerComponent(
+        actTexelView.ulpFromZero(coords),
+        expTexelView.ulpFromZero(coords),
+        maxDiffULPsForFloatFormat
+      );
+  } else if (maxFractionalDiff !== undefined) {
+    tvc.predicate = coords =>
+      comparePerComponent(
+        actTexelView.color(coords),
+        expTexelView.color(coords),
+        maxFractionalDiff
+      );
+  } else {
+    if (fmtIsNorm) {
+      unreachable('need maxFractionalDiff or maxDiffULPsForNormFormat to compare norm textures');
+    } else if (fmtIsFloat) {
+      unreachable('need maxFractionalDiff or maxDiffULPsForFloatFormat to compare float textures');
+    } else {
+      unreachable();
+    }
+  }
+
+  const repr = kTexelRepresentationInfo[format];
+  if (fmtIsInt) {
+    tvc.tableRows = failedCoords => [
+      [`tolerance ± ${maxIntDiff}`],
+      (function* () {
+        yield* [` diff (act - exp)`, '==', ''];
+        for (const coords of failedCoords) {
+          const act = actTexelView.color(coords);
+          const exp = expTexelView.color(coords);
+          yield repr.componentOrder.map(ch => act[ch]! - exp[ch]!).join(',');
+        }
+      })(),
+    ];
+  } else if (
+    (fmtIsNorm && maxDiffULPsForNormFormat !== undefined) ||
+    (fmtIsFloat && maxDiffULPsForFloatFormat !== undefined)
+  ) {
+    const toleranceULPs = fmtIsNorm ? maxDiffULPsForNormFormat! : maxDiffULPsForFloatFormat!;
+    tvc.tableRows = failedCoords => [
+      [`tolerance ± ${toleranceULPs} normal-ULPs`],
+      (function* () {
+        yield* [` diff (act - exp) in normal-ULPs`, '==', ''];
+        for (const coords of failedCoords) {
+          const act = actTexelView.ulpFromZero(coords);
+          const exp = expTexelView.ulpFromZero(coords);
+          yield repr.componentOrder.map(ch => act[ch]! - exp[ch]!).join(',');
+        }
+      })(),
+    ];
+  } else {
+    assert(maxFractionalDiff !== undefined);
+    tvc.tableRows = failedCoords => [
+      [`tolerance ± ${maxFractionalDiff}`],
+      (function* () {
+        yield* [` diff (act - exp)`, '==', ''];
+        for (const coords of failedCoords) {
+          const act = actTexelView.color(coords);
+          const exp = expTexelView.color(coords);
+          yield repr.componentOrder.map(ch => (act[ch]! - exp[ch]!).toPrecision(4)).join(',');
+        }
+      })(),
+    ];
+  }
+
+  return tvc;
+}
+
+function comparePerComponent(
+  actual: PerTexelComponent<number>,
+  expected: PerTexelComponent<number>,
+  maxDiff: number
+) {
+  return Object.keys(actual).every(key => {
+    const k = key as TexelComponent;
+    const act = actual[k]!;
+    const exp = expected[k];
+    if (exp === undefined) return false;
+    return Math.abs(act - exp) <= maxDiff;
+  });
+}
+
+/** Create a new mappable GPUBuffer, and copy a subrectangle of GPUTexture data into it. */
+function createTextureCopyForMapRead(
+  t: GPUTest,
+  source: GPUImageCopyTexture,
+  copySize: GPUExtent3D,
+  { format }: { format: EncodableTextureFormat }
+): { buffer: GPUBuffer; bytesPerRow: number; rowsPerImage: number } {
+  const { byteLength, bytesPerRow, rowsPerImage } = getTextureSubCopyLayout(format, copySize);
+
+  const buffer = t.device.createBuffer({
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+    size: byteLength,
+  });
+  t.trackForCleanup(buffer);
+
+  const cmd = t.device.createCommandEncoder();
+  cmd.copyTextureToBuffer(source, { buffer, bytesPerRow, rowsPerImage }, copySize);
+  t.device.queue.submit([cmd.finish()]);
+
+  return { buffer, bytesPerRow, rowsPerImage };
+}
+
+function findFailedPixels(
+  format: EncodableTextureFormat,
+  subrectOrigin: Required<GPUOrigin3DDict>,
+  subrectSize: Required<GPUExtent3DDict>,
+  { actTexelView, expTexelView }: { actTexelView: TexelView; expTexelView: TexelView },
+  texelCompareOptions: TexelCompareOptions
+) {
+  const comparer = makeTexelViewComparer(
+    format,
+    { actTexelView, expTexelView },
+    texelCompareOptions
+  );
+
+  const lowerCorner = [subrectSize.width, subrectSize.height, subrectSize.depthOrArrayLayers];
+  const upperCorner = [0, 0, 0];
+  const failedPixels: Required<GPUOrigin3DDict>[] = [];
+  for (let z = subrectOrigin.z; z < subrectOrigin.z + subrectSize.depthOrArrayLayers; ++z) {
+    for (let y = subrectOrigin.y; y < subrectOrigin.y + subrectSize.height; ++y) {
+      for (let x = subrectOrigin.x; x < subrectOrigin.x + subrectSize.width; ++x) {
+        const coords = { x, y, z };
+
+        if (!comparer.predicate(coords)) {
+          failedPixels.push(coords);
+          lowerCorner[0] = Math.min(lowerCorner[0], x);
+          lowerCorner[1] = Math.min(lowerCorner[1], y);
+          lowerCorner[2] = Math.min(lowerCorner[2], z);
+          upperCorner[0] = Math.max(upperCorner[0], x);
+          upperCorner[1] = Math.max(upperCorner[1], y);
+          upperCorner[2] = Math.max(upperCorner[2], z);
+        }
+      }
+    }
+  }
+  if (failedPixels.length === 0) {
+    return undefined;
+  }
+
+  const info = kTextureFormatInfo[format];
+  const repr = kTexelRepresentationInfo[format];
+
+  const integerSampleType = info.sampleType === 'uint' || info.sampleType === 'sint';
+  const numberToString = integerSampleType
+    ? (n: number) => n.toFixed()
+    : (n: number) => n.toPrecision(6);
+
+  const componentOrderStr = repr.componentOrder.join(',') + ':';
+
+  const printCoords = (function* () {
+    yield* [' coords', '==', 'X,Y,Z:'];
+    for (const coords of failedPixels) yield `${coords.x},${coords.y},${coords.z}`;
+  })();
+  const printActualBytes = (function* () {
+    yield* [' act. texel bytes (little-endian)', '==', '0x:'];
+    for (const coords of failedPixels) {
+      yield Array.from(actTexelView.bytes(coords), b => b.toString(16).padStart(2, '0')).join(' ');
+    }
+  })();
+  const printActualColors = (function* () {
+    yield* [' act. colors', '==', componentOrderStr];
+    for (const coords of failedPixels) {
+      const pixel = actTexelView.color(coords);
+      yield `${repr.componentOrder.map(ch => numberToString(pixel[ch]!)).join(',')}`;
+    }
+  })();
+  const printExpectedColors = (function* () {
+    yield* [' exp. colors', '==', componentOrderStr];
+    for (const coords of failedPixels) {
+      const pixel = expTexelView.color(coords);
+      yield `${repr.componentOrder.map(ch => numberToString(pixel[ch]!)).join(',')}`;
+    }
+  })();
+  const printActualULPs = (function* () {
+    yield* [' act. normal-ULPs-from-zero', '==', componentOrderStr];
+    for (const coords of failedPixels) {
+      const pixel = actTexelView.ulpFromZero(coords);
+      yield `${repr.componentOrder.map(ch => pixel[ch]).join(',')}`;
+    }
+  })();
+  const printExpectedULPs = (function* () {
+    yield* [` exp. normal-ULPs-from-zero`, '==', componentOrderStr];
+    for (const coords of failedPixels) {
+      const pixel = expTexelView.ulpFromZero(coords);
+      yield `${repr.componentOrder.map(ch => pixel[ch]).join(',')}`;
+    }
+  })();
+
+  const opts = {
+    fillToWidth: 120,
+    numberToString,
+  };
+  return `\
+ between ${lowerCorner} and ${upperCorner} inclusive:
+${generatePrettyTable(opts, [
+  printCoords,
+  printActualBytes,
+  printActualColors,
+  printExpectedColors,
+  printActualULPs,
+  printExpectedULPs,
+  ...comparer.tableRows(failedPixels),
+])}`;
+}
+
+/**
+ * Check the contents of a GPUTexture by reading it back (with copyTextureToBuffer+mapAsync), then
+ * comparing the data with the data in `expTexelView`.
+ *
+ * The actual and expected texture data are both converted to the "NormalULPFromZero" format,
+ * which is a signed number representing how far the number is from zero, in ULPs, skipping
+ * subnormal numbers (where ULP is defined for float, normalized, and integer formats).
+ */
+export async function textureContentIsOKByT2B(
+  t: GPUTest,
+  source: GPUImageCopyTexture,
+  copySize_: GPUExtent3D,
+  { expTexelView }: { expTexelView: TexelView },
+  texelCompareOptions: TexelCompareOptions
+): Promise<ErrorWithExtra | undefined> {
+  const subrectOrigin = reifyOrigin3D(source.origin ?? [0, 0, 0]);
+  const subrectSize = reifyExtent3D(copySize_);
+  const format = expTexelView.format;
+
+  const { buffer, bytesPerRow, rowsPerImage } = createTextureCopyForMapRead(
+    t,
+    source,
+    subrectSize,
+    { format }
+  );
+
+  await buffer.mapAsync(GPUMapMode.READ);
+  const data = new Uint8Array(buffer.getMappedRange());
+
+  const texelViewConfig = {
+    bytesPerRow,
+    rowsPerImage,
+    subrectOrigin,
+    subrectSize,
+  } as const;
+
+  const actTexelView = TexelView.fromTextureDataByReference(format, data, texelViewConfig);
+
+  const failedPixelsMessage = findFailedPixels(
+    format,
+    subrectOrigin,
+    subrectSize,
+    { actTexelView, expTexelView },
+    texelCompareOptions
+  );
+
+  if (failedPixelsMessage === undefined) {
+    return undefined;
+  }
+
+  const msg = 'Texture level had unexpected contents:\n' + failedPixelsMessage;
+  return new ErrorWithExtra(msg, () => ({
+    expTexelView,
+    // Make a new TexelView with a copy of the data so we can unmap the buffer (debug mode only).
+    actTexelView: TexelView.fromTextureDataByReference(format, data.slice(), texelViewConfig),
+  }));
+}

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -11,107 +11,68 @@ TODO: Test zero-sized copies from all sources (just make sure params cover it) (
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { unreachable } from '../../../common/util/util.js';
 import {
-  RegularTextureFormat,
   kTextureFormatInfo,
   kValidTextureFormatsForCopyE2T,
+  EncodableTextureFormat,
 } from '../../capability_info.js';
 import { CopyToTextureUtils } from '../../util/copy_to_texture.js';
-import { kTexelRepresentationInfo } from '../../util/texture/texel_data.js';
+import { PerTexelComponent } from '../../util/texture/texel_data.js';
+import { TexelView } from '../../util/texture/texel_view.js';
 
-enum Color {
-  Red,
-  Green,
-  Blue,
-  Black,
-  White,
-  SemitransparentWhite,
+type TestColor = PerTexelComponent<number>;
+// None of the dst texture format is 'uint' or 'sint', so we can always use float value.
+const kColors = {
+  Red: { R: 1.0, G: 0.0, B: 0.0, A: 1.0 },
+  Green: { R: 0.0, G: 1.0, B: 0.0, A: 1.0 },
+  Blue: { R: 0.0, G: 0.0, B: 1.0, A: 1.0 },
+  Black: { R: 0.0, G: 0.0, B: 0.0, A: 1.0 },
+  White: { R: 1.0, G: 1.0, B: 1.0, A: 1.0 },
+  SemitransparentWhite: { R: 1.0, G: 1.0, B: 1.0, A: 0.6 },
+} as const;
+const kTestColorsOpaque = [
+  kColors.Red,
+  kColors.Green,
+  kColors.Blue,
+  kColors.Black,
+  kColors.White,
+] as const;
+const kTestColorsAll = [...kTestColorsOpaque, kColors.SemitransparentWhite] as const;
+
+function makeTestColorsTexelView({
+  testColors,
+  format,
+  width,
+  height,
+  premultiplied,
+  flipY,
+}: {
+  testColors: readonly TestColor[];
+  format: EncodableTextureFormat;
+  width: number;
+  height: number;
+  premultiplied: boolean;
+  flipY: boolean;
+}) {
+  return TexelView.fromTexelsAsColors(format, coords => {
+    const y = flipY ? height - coords.y - 1 : coords.y;
+    const pixelPos = y * width + coords.x;
+    const currentPixel = testColors[pixelPos % testColors.length];
+
+    if (premultiplied && currentPixel.A !== 1.0) {
+      return {
+        R: currentPixel.R! * currentPixel.A!,
+        G: currentPixel.G! * currentPixel.A!,
+        B: currentPixel.B! * currentPixel.A!,
+        A: currentPixel.A,
+      };
+    } else {
+      return currentPixel;
+    }
+  });
 }
 
-// Cache for generated pixels.
-const generatedPixelCache: Map<RegularTextureFormat, Map<Color, Uint8Array>> = new Map();
-
-class F extends CopyToTextureUtils {
-  generatePixel(
-    color: Color,
-    format: RegularTextureFormat,
-    hasTransparentPixels: boolean
-  ): Uint8Array {
-    let formatEntry = generatedPixelCache.get(format);
-    if (formatEntry === undefined) {
-      formatEntry = new Map();
-      generatedPixelCache.set(format, formatEntry);
-    }
-
-    const colorEntry = formatEntry.get(color);
-    if (colorEntry === undefined) {
-      // None of the dst texture format is 'uint' or 'sint', so we can always use float value.
-      const rep = kTexelRepresentationInfo[format];
-      let rgba: { R: number; G: number; B: number; A: number };
-      switch (color) {
-        case Color.Red:
-          rgba = { R: 1.0, G: 0.0, B: 0.0, A: 1.0 };
-          break;
-        case Color.Green:
-          rgba = { R: 0.0, G: 1.0, B: 0.0, A: 1.0 };
-          break;
-        case Color.Blue:
-          rgba = { R: 0.0, G: 0.0, B: 1.0, A: 1.0 };
-          break;
-        case Color.Black:
-          rgba = { R: 0.0, G: 0.0, B: 0.0, A: 1.0 };
-          break;
-        case Color.White:
-          rgba = { R: 1.0, G: 1.0, B: 1.0, A: 1.0 };
-          break;
-        case Color.SemitransparentWhite:
-          rgba = { R: 1.0, G: 1.0, B: 1.0, A: 0.6 };
-          break;
-        default:
-          unreachable();
-      }
-
-      const pixels = new Uint8Array(rep.pack(rep.encode(rgba)));
-      formatEntry.set(color, pixels);
-    }
-
-    return formatEntry.get(color)!;
-  }
-
-  // Helper functions to generate imagePixels based input configs.
-  getImagePixels({
-    format,
-    width,
-    height,
-    hasTransparentPixels,
-  }: {
-    format: RegularTextureFormat;
-    width: number;
-    height: number;
-    hasTransparentPixels: boolean;
-  }): Uint8ClampedArray {
-    const bytesPerPixel = kTextureFormatInfo[format].bytesPerBlock;
-
-    // Generate input contents by iterating 'Color' enum
-    const imagePixels = new Uint8ClampedArray(bytesPerPixel * width * height);
-    const testColors = [Color.Red, Color.Green, Color.Blue, Color.Black, Color.White];
-    if (hasTransparentPixels) testColors.push(Color.SemitransparentWhite);
-
-    for (let i = 0; i < height; ++i) {
-      for (let j = 0; j < width; ++j) {
-        const pixelPos = i * width + j;
-        const currentPixel = testColors[pixelPos % testColors.length];
-        const pixelData = this.generatePixel(currentPixel, format, hasTransparentPixels);
-        imagePixels.set(pixelData, pixelPos * bytesPerPixel);
-      }
-    }
-
-    return imagePixels;
-  }
-}
-
-export const g = makeTestGroup(F);
+export const g = makeTestGroup(CopyToTextureUtils);
 
 g.test('from_ImageData')
   .desc(
@@ -167,54 +128,47 @@ g.test('from_ImageData')
       srcDoFlipYDuringCopy,
     } = t.params;
 
-    // Generate input contents by iterating 'Color' enum
-    const imagePixels = t.getImagePixels({
-      format: 'rgba8unorm',
-      width,
-      height,
-      hasTransparentPixels: true,
-    });
+    const testColors = kTestColorsAll;
 
     // Generate correct expected values
-    const imageData = new ImageData(imagePixels, width, height);
+    const texelViewSource = makeTestColorsTexelView({
+      testColors,
+      format: 'rgba8unorm', // ImageData is always in rgba8unorm format.
+      width,
+      height,
+      flipY: false,
+      premultiplied: false,
+    });
+    const imageData = new ImageData(width, height);
+    texelViewSource.writeTextureData(imageData.data, {
+      bytesPerRow: width * 4,
+      rowsPerImage: height,
+      subrectOrigin: [0, 0],
+      subrectSize: { width, height },
+    });
+
     const imageBitmap = await createImageBitmap(imageData, {
       premultiplyAlpha: alpha,
       imageOrientation: orientation,
     });
 
     const dst = t.device.createTexture({
-      size: {
-        width: imageBitmap.width,
-        height: imageBitmap.height,
-        depthOrArrayLayers: 1,
-      },
+      size: { width, height },
       format: dstColorFormat,
       usage:
         GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
-    // Construct expected value for different dst color format
-    const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
-    const srcPremultiplied = alpha === 'premultiply';
-    const sourceImageBitmapPixels = t.getSourceImageBitmapPixels(
-      imagePixels,
+    const expFormat = kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat;
+    const expectFlipped = srcDoFlipYDuringCopy !== (orientation === 'flipY');
+    const texelViewExpected = makeTestColorsTexelView({
+      testColors,
+      format: expFormat,
       width,
       height,
-      srcPremultiplied,
-      orientation === 'flipY'
-    );
-
-    const format = kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat;
-
-    const expectedPixels = t.getExpectedPixels(
-      sourceImageBitmapPixels,
-      width,
-      height,
-      format,
-      srcPremultiplied,
-      dstPremultiplied,
-      srcDoFlipYDuringCopy
-    );
+      flipY: expectFlipped,
+      premultiplied: dstPremultiplied,
+    });
 
     t.doTestAndCheckResult(
       { source: imageBitmap, origin: { x: 0, y: 0 }, flipY: srcDoFlipYDuringCopy },
@@ -224,10 +178,9 @@ g.test('from_ImageData')
         colorSpace: 'srgb',
         premultipliedAlpha: dstPremultiplied,
       },
-      { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 },
-      dstBytesPerPixel,
-      expectedPixels,
-      dstColorFormat
+      texelViewExpected,
+      { width, height, depthOrArrayLayers: 1 },
+      { maxDiffULPsForFloatFormat: 0, maxDiffULPsForNormFormat: 0 }
     );
   });
 
@@ -307,14 +260,22 @@ g.test('from_canvas')
     // Generate non-transparent pixel data to avoid canvas
     // different opt behaviour on putImageData()
     // from browsers.
-    const imagePixels = t.getImagePixels({
-      format: 'rgba8unorm',
+    const texelViewSource = makeTestColorsTexelView({
+      testColors: kTestColorsOpaque,
+      format: 'rgba8unorm', // ImageData is always in rgba8unorm format.
       width,
       height,
-      hasTransparentPixels: false,
+      flipY: false,
+      premultiplied: false,
     });
-
-    const imageData = new ImageData(imagePixels, width, height);
+    // Generate correct expected values
+    const imageData = new ImageData(width, height);
+    texelViewSource.writeTextureData(imageData.data, {
+      bytesPerRow: width * 4,
+      rowsPerImage: height,
+      subrectOrigin: [0, 0],
+      subrectSize: { width, height },
+    });
 
     // Use putImageData to prevent color space conversion.
     imageCanvasContext.putImageData(imageData, 0, 0);
@@ -327,37 +288,22 @@ g.test('from_canvas')
     });
 
     const dst = t.device.createTexture({
-      size: {
-        width: imageBitmap.width,
-        height: imageBitmap.height,
-        depthOrArrayLayers: 1,
-      },
+      size: { width, height },
       format: dstColorFormat,
       usage:
         GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
-    const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
-
-    const sourceImageBitmapPixels = t.getSourceImageBitmapPixels(
-      imagePixels,
+    const expFormat = kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat;
+    const expectFlipped = srcDoFlipYDuringCopy !== (orientation === 'flipY');
+    const texelViewExpected = makeTestColorsTexelView({
+      testColors: kTestColorsOpaque,
+      format: expFormat,
       width,
       height,
-      true,
-      orientation === 'flipY'
-    );
-
-    const format = kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat;
-
-    const expectedPixels = t.getExpectedPixels(
-      sourceImageBitmapPixels,
-      width,
-      height,
-      format,
-      true,
-      dstPremultiplied,
-      srcDoFlipYDuringCopy
-    );
+      flipY: expectFlipped,
+      premultiplied: dstPremultiplied,
+    });
 
     t.doTestAndCheckResult(
       { source: imageBitmap, origin: { x: 0, y: 0 }, flipY: srcDoFlipYDuringCopy },
@@ -367,9 +313,8 @@ g.test('from_canvas')
         colorSpace: 'srgb',
         premultipliedAlpha: dstPremultiplied,
       },
-      { width: imageBitmap.width, height: imageBitmap.height, depthOrArrayLayers: 1 },
-      dstBytesPerPixel,
-      expectedPixels,
-      dstColorFormat
+      texelViewExpected,
+      { width, height, depthOrArrayLayers: 1 },
+      { maxDiffULPsForFloatFormat: 0, maxDiffULPsForNormFormat: 0 }
     );
   });

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -1,19 +1,12 @@
 export const description = `
 copyToTexture with HTMLCanvasElement and OffscreenCanvas sources.
-
-TODO: Add tests for flipY
 `;
 
-import { getResourcePath } from '../../../common/framework/resources.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { unreachable } from '../../../common/util/util.js';
-import {
-  RegularTextureFormat,
-  kTextureFormatInfo,
-  kValidTextureFormatsForCopyE2T,
-} from '../../capability_info.js';
+import { kTextureFormatInfo, kValidTextureFormatsForCopyE2T } from '../../capability_info.js';
 import { CopyToTextureUtils } from '../../util/copy_to_texture.js';
 import { CanvasType, kAllCanvasTypes, createCanvas } from '../../util/create_elements.js';
+import { TexelCompareOptions } from '../../util/texture/texture_ok.js';
 
 class F extends CopyToTextureUtils {
   init2DCanvasContentWithColorSpace({
@@ -398,17 +391,6 @@ class F extends CopyToTextureUtils {
 
     return rgbaPixels;
   }
-
-  getTestImageURLByColorSpace(colorSpace: 'srgb' | 'display-p3'): string {
-    switch (colorSpace) {
-      case 'srgb':
-        return getResourcePath('Webkit-logo-sRGB.png');
-      case 'display-p3':
-        return getResourcePath('Webkit-logo-P3.png');
-      default:
-        unreachable();
-    }
-  }
 }
 
 export const g = makeTestGroup(F);
@@ -492,20 +474,17 @@ g.test('copy_contents_from_2d_context_canvas')
     });
 
     // Construct expected value for different dst color format
-    const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
-    const format: RegularTextureFormat =
-      kTextureFormatInfo[dstColorFormat].baseFormat !== undefined
-        ? kTextureFormatInfo[dstColorFormat].baseFormat!
-        : dstColorFormat;
+    const info = kTextureFormatInfo[dstColorFormat];
+    const expFormat = info.baseFormat ?? dstColorFormat;
 
     // For 2d canvas, get expected pixels with getImageData(), which returns unpremultiplied
     // values.
     const sourcePixels = t.getSourceCanvas2DContent(canvasContext, width, height);
-    const expectedPixels = t.getExpectedPixels(
+    const expTexelView = t.getExpectedPixels(
       sourcePixels,
       width,
       height,
-      format,
+      expFormat,
       false,
       dstPremultiplied,
       srcDoFlipYDuringCopy
@@ -519,10 +498,11 @@ g.test('copy_contents_from_2d_context_canvas')
         colorSpace: 'srgb',
         premultipliedAlpha: dstPremultiplied,
       },
-      { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
-      dstBytesPerPixel,
-      expectedPixels,
-      dstColorFormat
+      expTexelView,
+      { width, height, depthOrArrayLayers: 1 },
+      // 1.0 and 0.6 are representable precisely by all formats except rgb10a2unorm, but
+      // allow diffs of 1ULP since that's the generally-appropriate threshold.
+      { maxDiffULPsForNormFormat: 1, maxDiffULPsForFloatFormat: 1 }
     );
   });
 
@@ -603,28 +583,21 @@ g.test('copy_contents_from_gl_context_canvas')
     });
 
     const dst = t.device.createTexture({
-      size: {
-        width,
-        height,
-        depthOrArrayLayers: 1,
-      },
+      size: { width, height },
       format: dstColorFormat,
       usage:
         GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
     // Construct expected value for different dst color format
-    const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
-    const format: RegularTextureFormat =
-      kTextureFormatInfo[dstColorFormat].baseFormat !== undefined
-        ? kTextureFormatInfo[dstColorFormat].baseFormat!
-        : dstColorFormat;
+    const info = kTextureFormatInfo[dstColorFormat];
+    const expFormat = info.baseFormat ?? dstColorFormat;
     const sourcePixels = t.getSourceCanvasGLContent(canvasContext, width, height);
-    const expectedPixels = t.getExpectedPixels(
+    const expTexelView = t.getExpectedPixels(
       sourcePixels,
       width,
       height,
-      format,
+      expFormat,
       srcPremultiplied,
       dstPremultiplied,
       srcDoFlipYDuringCopy
@@ -638,10 +611,11 @@ g.test('copy_contents_from_gl_context_canvas')
         colorSpace: 'srgb',
         premultipliedAlpha: dstPremultiplied,
       },
-      { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
-      dstBytesPerPixel,
-      expectedPixels,
-      dstColorFormat
+      expTexelView,
+      { width, height, depthOrArrayLayers: 1 },
+      // 1.0 and 0.6 are representable precisely by all formats except rgb10a2unorm, but
+      // allow diffs of 1ULP since that's the generally-appropriate threshold.
+      { maxDiffULPsForNormFormat: 1, maxDiffULPsForFloatFormat: 1 }
     );
   });
 
@@ -744,19 +718,19 @@ g.test('copy_contents_from_gpu_context_canvas')
     });
 
     // Construct expected value for different dst color format
-    const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
-    const format = kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat;
+    const info = kTextureFormatInfo[dstColorFormat];
+    const expFormat = info.baseFormat ?? dstColorFormat;
     const sourcePixels = t.calculateSourceContentOnCPU(
       width,
       height,
       srcPremultiplied,
       dstColorFormat === 'rgb10a2unorm'
     );
-    const expectedPixels = t.getExpectedPixels(
+    const expTexelView = t.getExpectedPixels(
       sourcePixels,
       width,
       height,
-      format,
+      expFormat,
       srcPremultiplied,
       dstPremultiplied,
       srcDoFlipYDuringCopy
@@ -770,10 +744,11 @@ g.test('copy_contents_from_gpu_context_canvas')
         colorSpace: 'srgb',
         premultipliedAlpha: dstPremultiplied,
       },
+      expTexelView,
       { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
-      dstBytesPerPixel,
-      expectedPixels,
-      dstColorFormat
+      // 1.0 and 0.6 are representable precisely by all formats except rgb10a2unorm, but
+      // allow diffs of 1ULP since that's the generally-appropriate threshold.
+      { maxDiffULPsForNormFormat: 1, maxDiffULPsForFloatFormat: 1 }
     );
   });
 
@@ -783,31 +758,33 @@ g.test('color_space_conversion')
     Test HTMLCanvasElement with 2d context can created with 'colorSpace' attribute.
     Using CopyExternalImageToTexture to copy from such type of canvas needs
     to do color space converting correctly.
-  
+
     It creates HTMLCanvasElement/OffscreenCanvas with '2d' and 'colorSpace' attributes.
     Use fillRect(2d context) to render red rect for top-left,
     green rect for top-right, blue rect for bottom-left and white for bottom-right.
-  
+
     Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
     of dst texture, and read the contents out to compare with the canvas contents.
-  
+
     Provide premultiplied input if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
     is set to 'true' and unpremultiplied input if it is set to 'false'.
-  
+
     If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
     is flipped.
 
     If color space from source input and user defined dstTexture color space are different, the
     result must convert the content to user defined color space
-  
+
     The tests covers:
     - Valid dstColorFormat of copyExternalImageToTexture()
     - Valid dest alphaMode
     - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
     - Valid 'colorSpace' config in 'dstColorSpace'
-    - TODO: Add error tolerance for rgb10a2unorm dst texture format
-  
+
     And the expected results are all passed.
+
+    TODO: Enhance test data with colors that aren't always opaque and fully saturated.
+    TODO: Consider refactoring src data setup with TexelView.writeTextureData.
   `
   )
   .params(u =>
@@ -839,11 +816,7 @@ g.test('color_space_conversion')
     });
 
     const dst = t.device.createTexture({
-      size: {
-        width,
-        height,
-        depthOrArrayLayers: 1,
-      },
+      size: { width, height },
       format: dstColorFormat,
       usage:
         GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
@@ -851,9 +824,7 @@ g.test('color_space_conversion')
 
     const sourcePixels = t.getSourceCanvas2DContent(canvasContext, width, height);
 
-    const dstBytesPerPixel = kTextureFormatInfo[dstColorFormat].bytesPerBlock;
-
-    const expectedPixels = t.getExpectedPixels(
+    const expTexelView = t.getExpectedPixels(
       sourcePixels,
       width,
       height,
@@ -865,6 +836,17 @@ g.test('color_space_conversion')
       dstColorSpace
     );
 
+    const texelCompareOptions: TexelCompareOptions = {
+      maxFractionalDiff: 0,
+      maxDiffULPsForNormFormat: 1,
+    };
+    if (srcColorSpace !== dstColorSpace) {
+      // Color space conversion seems prone to errors up to about 0.0003 on f32, 0.0007 on f16.
+      texelCompareOptions.maxFractionalDiff = 0.001;
+    } else if (dstPremultiplied) {
+      texelCompareOptions.maxDiffULPsForFloatFormat = 1;
+    }
+
     t.doTestAndCheckResult(
       { source: canvas, origin: { x: 0, y: 0 }, flipY: srcDoFlipYDuringCopy },
       {
@@ -873,9 +855,8 @@ g.test('color_space_conversion')
         colorSpace: dstColorSpace,
         premultipliedAlpha: dstPremultiplied,
       },
-      { width: canvas.width, height: canvas.height, depthOrArrayLayers: 1 },
-      dstBytesPerPixel,
-      expectedPixels,
-      dstColorFormat
+      expTexelView,
+      { width, height, depthOrArrayLayers: 1 },
+      texelCompareOptions
     );
   });

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -485,9 +485,11 @@ g.test('copy_contents_from_2d_context_canvas')
       width,
       height,
       expFormat,
-      false,
-      dstPremultiplied,
-      srcDoFlipYDuringCopy
+      srcDoFlipYDuringCopy,
+      {
+        srcPremultiplied: false,
+        dstPremultiplied,
+      }
     );
 
     t.doTestAndCheckResult(
@@ -598,9 +600,11 @@ g.test('copy_contents_from_gl_context_canvas')
       width,
       height,
       expFormat,
-      srcPremultiplied,
-      dstPremultiplied,
-      srcDoFlipYDuringCopy
+      srcDoFlipYDuringCopy,
+      {
+        srcPremultiplied,
+        dstPremultiplied,
+      }
     );
 
     t.doTestAndCheckResult(
@@ -731,9 +735,11 @@ g.test('copy_contents_from_gpu_context_canvas')
       width,
       height,
       expFormat,
-      srcPremultiplied,
-      dstPremultiplied,
-      srcDoFlipYDuringCopy
+      srcDoFlipYDuringCopy,
+      {
+        srcPremultiplied,
+        dstPremultiplied,
+      }
     );
 
     t.doTestAndCheckResult(
@@ -829,11 +835,13 @@ g.test('color_space_conversion')
       width,
       height,
       dstColorFormat,
-      false,
-      dstPremultiplied,
       srcDoFlipYDuringCopy,
-      srcColorSpace,
-      dstColorSpace
+      {
+        srcPremultiplied: false,
+        dstPremultiplied,
+        srcColorSpace,
+        dstColorSpace,
+      }
     );
 
     const texelCompareOptions: TexelCompareOptions = {

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -12,12 +12,10 @@ class F extends CopyToTextureUtils {
   init2DCanvasContentWithColorSpace({
     width,
     height,
-    paintOpaqueRects,
     colorSpace,
   }: {
     width: number;
     height: number;
-    paintOpaqueRects: boolean;
     colorSpace: 'srgb' | 'display-p3';
   }): {
     canvas: HTMLCanvasElement | OffscreenCanvas;
@@ -45,7 +43,7 @@ class F extends CopyToTextureUtils {
     const rectWidth = Math.floor(width / 2);
     const rectHeight = Math.floor(height / 2);
 
-    const alphaValue = paintOpaqueRects ? 255 : 153;
+    const alphaValue = 153;
 
     let pixelStartPos = 0;
     // Red;
@@ -110,12 +108,10 @@ class F extends CopyToTextureUtils {
     canvasType,
     width,
     height,
-    paintOpaqueRects,
   }: {
     canvasType: CanvasType;
     width: number;
     height: number;
-    paintOpaqueRects: boolean;
   }): {
     canvas: HTMLCanvasElement | OffscreenCanvas;
     canvasContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
@@ -132,12 +128,8 @@ class F extends CopyToTextureUtils {
       this.skip(canvasType + ' canvas 2d context not available');
     }
 
-    // The rgb10a2unorm dst texture will have tiny errors when we compare actual and expectation.
-    // This is due to the convert from 8-bit to 10-bit combined with alpha value ops. So for
-    // rgb10a2unorm dst textures, we'll set alphaValue to 1.0 to test.
-    const alphaValue = paintOpaqueRects ? 1.0 : 0.6;
     const ctx = canvasContext as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
-    this.paint2DCanvas(ctx, width, height, alphaValue);
+    this.paint2DCanvas(ctx, width, height, 0.6);
 
     return { canvas, canvasContext };
   }
@@ -172,14 +164,12 @@ class F extends CopyToTextureUtils {
     width,
     height,
     premultiplied,
-    paintOpaqueRects,
   }: {
     canvasType: CanvasType;
     contextName: 'webgl' | 'webgl2';
     width: number;
     height: number;
     premultiplied: boolean;
-    paintOpaqueRects: boolean;
   }): {
     canvas: HTMLCanvasElement | OffscreenCanvas;
     canvasContext: WebGLRenderingContext | WebGL2RenderingContext;
@@ -200,7 +190,7 @@ class F extends CopyToTextureUtils {
     const rectWidth = Math.floor(width / 2);
     const rectHeight = Math.floor(height / 2);
 
-    const alphaValue = paintOpaqueRects ? 1.0 : 0.6;
+    const alphaValue = 0.6;
     const colorValue = premultiplied ? alphaValue : 1.0;
 
     // For webgl/webgl2 context canvas, if the context created with premultipliedAlpha attributes,
@@ -227,16 +217,11 @@ class F extends CopyToTextureUtils {
     return { canvas, canvasContext: gl };
   }
 
-  getInitGPUCanvasData(
-    width: number,
-    height: number,
-    premultiplied: boolean,
-    paintOpaqueRects: boolean
-  ): Uint8ClampedArray {
+  getInitGPUCanvasData(width: number, height: number, premultiplied: boolean): Uint8ClampedArray {
     const rectWidth = Math.floor(width / 2);
     const rectHeight = Math.floor(height / 2);
 
-    const alphaValue = paintOpaqueRects ? 255 : 153;
+    const alphaValue = 153;
     const colorValue = premultiplied ? alphaValue : 255;
 
     // BGRA8Unorm texture
@@ -287,14 +272,12 @@ class F extends CopyToTextureUtils {
     width,
     height,
     premultiplied,
-    paintOpaqueRects,
   }: {
     device: GPUDevice;
     canvasType: CanvasType;
     width: number;
     height: number;
     premultiplied: boolean;
-    paintOpaqueRects: boolean;
   }): {
     canvas: HTMLCanvasElement | OffscreenCanvas;
   } {
@@ -316,7 +299,7 @@ class F extends CopyToTextureUtils {
     });
 
     // BGRA8Unorm texture
-    const initialData = this.getInitGPUCanvasData(width, height, premultiplied, paintOpaqueRects);
+    const initialData = this.getInitGPUCanvasData(width, height, premultiplied);
     const canvasTexture = gpuContext.getCurrentTexture();
     device.queue.writeTexture(
       { texture: canvasTexture },
@@ -360,17 +343,11 @@ class F extends CopyToTextureUtils {
   calculateSourceContentOnCPU(
     width: number,
     height: number,
-    premultipliedAlpha: boolean,
-    paintOpaqueRects: boolean
+    premultipliedAlpha: boolean
   ): Uint8ClampedArray {
     const bytesPerPixel = 4;
 
-    const rgbaPixels = this.getInitGPUCanvasData(
-      width,
-      height,
-      premultipliedAlpha,
-      paintOpaqueRects
-    );
+    const rgbaPixels = this.getInitGPUCanvasData(width, height, premultipliedAlpha);
 
     // The source canvas has bgra8unorm back resource. We
     // swizzle the channels to align with 2d/webgl canvas and
@@ -421,7 +398,6 @@ g.test('copy_contents_from_2d_context_canvas')
   - Valid dest alphaMode
   - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
   - TODO(#913): color space tests need to be added
-  - TODO: Add error tolerance for rgb10a2unorm dst texture format
 
   And the expected results are all passed.
   `
@@ -446,20 +422,10 @@ g.test('copy_contents_from_2d_context_canvas')
       srcDoFlipYDuringCopy,
     } = t.params;
 
-    // When dst texture format is rgb10a2unorm, the generated expected value of the result
-    // may have tiny errors compared to the actual result when the channel value is
-    // not 1.0 or 0.0.
-    // For example, we init the pixel with r channel to 0.6. And the denormalized value for
-    // 10-bit channel is 613.8, which needs to call "round" or other function to get an integer.
-    // It is possible that gpu adopt different "round" as our cpu implementation(we use Math.round())
-    // and it will generate tiny errors.
-    // So the cases with rgb10a2unorm dst texture format are handled specially by painting opaque rects
-    // to ensure they will have stable result after alphaOps(should keep the same value).
     const { canvas, canvasContext } = t.init2DCanvasContent({
       canvasType,
       width,
       height,
-      paintOpaqueRects: dstColorFormat === 'rgb10a2unorm',
     });
 
     const dst = t.device.createTexture({
@@ -537,7 +503,6 @@ g.test('copy_contents_from_gl_context_canvas')
   - Valid dest alphaMode
   - Valid 'flipY' config in 'GPUImageCopyExternalImage'(named 'srcDoFlipYDuringCopy' in cases)
   - TODO: color space tests need to be added
-  - TODO: Add error tolerance for rgb10a2unorm dst texture format
 
   And the expected results are all passed.
   `
@@ -566,22 +531,12 @@ g.test('copy_contents_from_gl_context_canvas')
       srcDoFlipYDuringCopy,
     } = t.params;
 
-    // When dst texture format is rgb10a2unorm, the generated expected value of the result
-    // may have tiny errors compared to the actual result when the channel value is
-    // not 1.0 or 0.0.
-    // For example, we init the pixel with r channel to 0.6. And the denormalized value for
-    // 10-bit channel is 613.8, which needs to call "round" or other function to get an integer.
-    // It is possible that gpu adopt different "round" as our cpu implementation(we use Math.round())
-    // and it will generate tiny errors.
-    // So the cases with rgb10a2unorm dst texture format are handled specially by by painting opaque rects
-    // to ensure they will have stable result after alphaOps(should keep the same value).
     const { canvas, canvasContext } = t.initGLCanvasContent({
       canvasType,
       contextName,
       width,
       height,
       premultiplied: srcPremultiplied,
-      paintOpaqueRects: dstColorFormat === 'rgb10a2unorm',
     });
 
     const dst = t.device.createTexture({
@@ -654,7 +609,6 @@ g.test('copy_contents_from_gpu_context_canvas')
   - Valid dest alphaMode
   - Valid 'flipY' config in 'GPUImageCopyExternalImage'(named 'srcDoFlipYDuringCopy' in cases)
   - TODO: color space tests need to be added
-  - TODO: Add error tolerance for rgb10a2unorm dst texture format
 
   And the expected results are all passed.
   `
@@ -692,22 +646,12 @@ g.test('copy_contents_from_gpu_context_canvas')
       device = t.device;
     }
 
-    // When dst texture format is rgb10a2unorm, the generated expected value of the result
-    // may have tiny errors compared to the actual result when the channel value is
-    // not 1.0 or 0.0.
-    // For example, we init the pixel with r channel to 0.6. And the denormalized value for
-    // 10-bit channel is 613.8, which needs to call "round" or other function to get an integer.
-    // It is possible that gpu adopt different "round" as our cpu implementation(we use Math.round())
-    // and it will generate tiny errors.
-    // So the cases with rgb10a2unorm dst texture format are handled specially by by painting opaque rects
-    // to ensure they will have stable result after alphaOps(should keep the same value).
     const { canvas } = t.initGPUCanvasContent({
       device,
       canvasType,
       width,
       height,
       premultiplied: srcPremultiplied,
-      paintOpaqueRects: dstColorFormat === 'rgb10a2unorm',
     });
 
     const dst = t.device.createTexture({
@@ -724,12 +668,7 @@ g.test('copy_contents_from_gpu_context_canvas')
     // Construct expected value for different dst color format
     const info = kTextureFormatInfo[dstColorFormat];
     const expFormat = info.baseFormat ?? dstColorFormat;
-    const sourcePixels = t.calculateSourceContentOnCPU(
-      width,
-      height,
-      srcPremultiplied,
-      dstColorFormat === 'rgb10a2unorm'
-    );
+    const sourcePixels = t.calculateSourceContentOnCPU(width, height, srcPremultiplied);
     const expTexelView = t.getExpectedPixels(
       sourcePixels,
       width,
@@ -817,7 +756,6 @@ g.test('color_space_conversion')
     const { canvas, canvasContext } = t.init2DCanvasContentWithColorSpace({
       width,
       height,
-      paintOpaqueRects: true,
       colorSpace: srcColorSpace,
     });
 
@@ -834,7 +772,8 @@ g.test('color_space_conversion')
       sourcePixels,
       width,
       height,
-      dstColorFormat,
+      // copyExternalImageToTexture does not perform gamma-encoding into `-srgb` formats.
+      kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat,
       srcDoFlipYDuringCopy,
       {
         srcPremultiplied: false,
@@ -851,7 +790,7 @@ g.test('color_space_conversion')
     if (srcColorSpace !== dstColorSpace) {
       // Color space conversion seems prone to errors up to about 0.0003 on f32, 0.0007 on f16.
       texelCompareOptions.maxFractionalDiff = 0.001;
-    } else if (dstPremultiplied) {
+    } else {
       texelCompareOptions.maxDiffULPsForFloatFormat = 1;
     }
 


### PR DESCRIPTION
The commits in this PR can be reviewed separately (likely helpful for some of them).

- Add new interfaces to texel_data to use for texture checking
- Add TexelView helper which exposes an underlying generator or data as texels in various representations
- Add textureContentIsOKByT2B helper to compare an "expected" TexelView with a GPUTexture
- Update the copyToTexture tests to use these (see #1068 for some test performance measurements)

Issue: #881

Dry run against Chromium:
https://chromium-review.googlesource.com/c/chromium/src/+/3531550/5
(The only failures are a flake and a simple precision issue, fixed in https://github.com/gpuweb/cts/compare/759728c63c54c9aef1eed66079882c50eaf816d0...dc82768bd0cbb7183889dea50c2f7353d1435dd3)

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
