### PR TITLE
Enable multi-planar-formats ImportExternalTexture tests

### DIFF
--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -101,14 +101,17 @@ g.test('importExternalTexture,sample')
 Tests that we can import an HTMLVideoElement into a GPUExternalTexture, sample from it for all
 supported video formats {vp8, vp9, ogg, mp4}, and ensure the GPUExternalTexture is destroyed by
 a microtask.
-TODO: Multiplanar scenarios
 `
   )
   .params(u =>
     u //
+      .combine('multiPlanarFormats', [false, true])
       .combine('videoSource', kVideoSources)
   )
   .fn(async t => {
+    if (t.params.multiPlanarFormats) {
+      await t.selectDeviceOrSkipTestCase('multi-planar-formats');
+    }
     const videoUrl = getResourcePath(t.params.videoSource);
     const video = document.createElement('video');
     video.src = videoUrl;


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
