### PR TITLE
Add validation tests for render bundle creation and usage

### DIFF
--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -1,0 +1,161 @@
+export const description = `
+createRenderBundleEncoder validation tests.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import {
+  kAllTextureFormats,
+  kDepthStencilFormats,
+  kTextureFormatInfo,
+  kMaxColorAttachments,
+} from '../../../capability_info.js';
+import { ValidationTest } from '../validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('attachment_state')
+  .desc(
+    `
+    Tests that createRenderBundleEncoder correctly validates the attachment state passed to it.
+      - Must be <= kMaxColorAttachments (8) colorFormats
+      - Must have a depthStencilFormat if no colorFormats are given
+    `
+  )
+  .params(u =>
+    u //
+      .combine('colorFormatCount', [...Array(kMaxColorAttachments + 2).keys()]) // 0-9
+      .beginSubcases()
+      .combine('colorFormat', [undefined, 'bgra8unorm'])
+      .combine('depthStencilFormat', [undefined, 'depth24plus-stencil8'] as const)
+      .filter(({ colorFormat, colorFormatCount }) => {
+        // Only run the test with 0 colorFormats once.
+        return (
+          (colorFormat !== undefined && colorFormatCount > 0) ||
+          (colorFormat === undefined && colorFormatCount === 0)
+        );
+      })
+  )
+  .fn(async t => {
+    const { colorFormat, depthStencilFormat, colorFormatCount } = t.params;
+
+    // Ensure up to kMaxColorAttachments (8) color formats are allowed.
+    let shouldError = colorFormatCount > kMaxColorAttachments;
+
+    // Zero color formats are only allowed if a depthStencilFormat is provided.
+    if (depthStencilFormat === undefined && colorFormatCount === 0) {
+      shouldError = true;
+    }
+
+    t.expectValidationError(() => {
+      t.device.createRenderBundleEncoder({
+        colorFormats: Array(colorFormatCount).fill(colorFormat),
+        depthStencilFormat,
+      });
+    }, shouldError);
+  });
+
+g.test('valid_texture_formats')
+  .desc(
+    `
+    Tests that createRenderBundleEncoder only accepts valid formats for its attachments.
+      - colorFormats
+      - depthStencilFormat
+    `
+  )
+  .params(u =>
+    u //
+      .combine('format', kAllTextureFormats)
+      .beginSubcases()
+      .combine('attachment', ['color', 'depthStencil'])
+  )
+  .fn(async t => {
+    const { format, attachment } = t.params;
+
+    const colorRenderable =
+      kTextureFormatInfo[format].renderable && kTextureFormatInfo[format].color;
+
+    const depthStencil = kTextureFormatInfo[format].depth || kTextureFormatInfo[format].stencil;
+
+    switch (attachment) {
+      case 'color': {
+        t.expectValidationError(() => {
+          t.device.createRenderBundleEncoder({
+            colorFormats: [format],
+          });
+        }, !colorRenderable);
+
+        break;
+      }
+      case 'depthSencil': {
+        t.expectValidationError(() => {
+          t.device.createRenderBundleEncoder({
+            colorFormats: [],
+            depthStencilFormat: format,
+          });
+        }, !depthStencil);
+
+        break;
+      }
+    }
+  });
+
+g.test('depth_stencil_readonly')
+  .desc(
+    `
+    Tests that createRenderBundleEncoder validation of depthReadOnly and stencilReadOnly
+      - With depth-only formats
+      - With stencil-only formats
+      - With depth-stencil-combined formats
+    `
+  )
+  .params(u =>
+    u //
+      .combine('depthStencilFormat', kDepthStencilFormats)
+      .beginSubcases()
+      .combine('depthReadOnly', [false, true])
+      .combine('stencilReadOnly', [false, true])
+  )
+  .fn(async t => {
+    const { depthStencilFormat, depthReadOnly, stencilReadOnly } = t.params;
+
+    let shouldError = false;
+    if (
+      kTextureFormatInfo[depthStencilFormat].depth &&
+      kTextureFormatInfo[depthStencilFormat].stencil &&
+      depthReadOnly !== stencilReadOnly
+    ) {
+      shouldError = true;
+    }
+
+    t.expectValidationError(() => {
+      t.device.createRenderBundleEncoder({
+        colorFormats: [],
+        depthStencilFormat,
+        depthReadOnly,
+        stencilReadOnly,
+      });
+    }, shouldError);
+  });
+
+g.test('depth_stencil_readonly_with_undefined_depth')
+  .desc(
+    `
+    Tests that createRenderBundleEncoder validation of depthReadOnly and stencilReadOnly is ignored
+    if there is no depthStencilFormat set.
+    `
+  )
+  .params(u =>
+    u //
+      .beginSubcases()
+      .combine('depthReadOnly', [false, true])
+      .combine('stencilReadOnly', [false, true])
+  )
+  .fn(async t => {
+    const { depthReadOnly, stencilReadOnly } = t.params;
+
+    t.device.createRenderBundleEncoder({
+      colorFormats: ['bgra8unorm'],
+      depthReadOnly,
+      stencilReadOnly,
+    });
+  });

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -1,17 +1,26 @@
 export const description = `
-TODO:
-- test creating a render bundle, and if it's valid, test that executing it is not an error
-    - color formats {all possible formats} {zero, one, multiple}
-    - depth/stencil format {unset, all possible formats}
-- ?
+Tests execution of render bundles.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { kDepthStencilFormats, kTextureFormatInfo } from '../../../capability_info.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
 
-g.test('render_bundles,device_mismatch')
+g.test('empty_bundle_list')
+  .desc(
+    `
+    Test that it is valid to execute an empty list of render bundles
+    `
+  )
+  .fn(async t => {
+    const encoder = t.createEncoder('render pass');
+    encoder.encoder.executeBundles([]);
+    encoder.validateFinish(true);
+  });
+
+g.test('device_mismatch')
   .desc(
     `
     Tests executeBundles cannot be called with render bundles created from another device
@@ -50,4 +59,246 @@ g.test('render_bundles,device_mismatch')
     encoder.encoder.executeBundles([bundle0, bundle1]);
 
     encoder.validateFinish(!mismatched);
+  });
+
+g.test('color_formats_mismatch')
+  .desc(
+    `
+    Tests executeBundles cannot be called with render bundles that do match the colorFormats of the
+    render pass. This includes:
+    - formats don't match
+    - formats match but are in a different order
+    - formats match but there is a different count
+    `
+  )
+  .params(u =>
+    u.combineWithParams([
+      {
+        bundleFormats: ['bgra8unorm', 'rg8unorm'] as const,
+        passFormats: ['bgra8unorm', 'rg8unorm'] as const,
+        _compatible: true,
+      }, // control case
+      {
+        bundleFormats: ['bgra8unorm', 'rg8unorm'] as const,
+        passFormats: ['bgra8unorm', 'bgra8unorm'] as const,
+        _compatible: false,
+      },
+      {
+        bundleFormats: ['bgra8unorm', 'rg8unorm'] as const,
+        passFormats: ['rg8unorm', 'bgra8unorm'] as const,
+        _compatible: false,
+      },
+      {
+        bundleFormats: ['bgra8unorm', 'rg8unorm', 'rgba8unorm'] as const,
+        passFormats: ['rg8unorm', 'bgra8unorm'] as const,
+        _compatible: false,
+      },
+      {
+        bundleFormats: ['bgra8unorm', 'rg8unorm'] as const,
+        passFormats: ['rg8unorm', 'bgra8unorm', 'rgba8unorm'] as const,
+        _compatible: false,
+      },
+    ])
+  )
+  .fn(async t => {
+    const { bundleFormats, passFormats, _compatible } = t.params;
+
+    const bundleEncoder = t.device.createRenderBundleEncoder({
+      colorFormats: bundleFormats,
+    });
+    const bundle = bundleEncoder.finish();
+
+    const encoder = t.createEncoder('render pass', {
+      attachmentInfo: {
+        colorFormats: passFormats,
+      },
+    });
+    encoder.encoder.executeBundles([bundle]);
+
+    encoder.validateFinish(_compatible);
+  });
+
+g.test('depth_stencil_formats_mismatch')
+  .desc(
+    `
+    Tests executeBundles cannot be called with render bundles that do match the depthStencil of the
+    render pass. This includes:
+    - formats don't match
+    - formats have matching depth or stencil aspects, but other aspects are missing
+    `
+  )
+  .params(u =>
+    u.combineWithParams([
+      { bundleFormat: 'depth24plus', passFormat: 'depth24plus' }, // control case
+      { bundleFormat: 'depth24plus', passFormat: 'depth16unorm' },
+      { bundleFormat: 'depth24plus', passFormat: 'depth24plus-stencil8' },
+      { bundleFormat: 'stencil8', passFormat: 'depth24plus-stencil8' },
+    ] as const)
+  )
+  .fn(async t => {
+    const { bundleFormat, passFormat } = t.params;
+
+    const compatible = bundleFormat === passFormat;
+
+    const bundleEncoder = t.device.createRenderBundleEncoder({
+      colorFormats: [],
+      depthStencilFormat: bundleFormat,
+    });
+    const bundle = bundleEncoder.finish();
+
+    const encoder = t.createEncoder('render pass', {
+      attachmentInfo: {
+        colorFormats: [],
+        depthStencilFormat: passFormat,
+      },
+    });
+    encoder.encoder.executeBundles([bundle]);
+
+    encoder.validateFinish(compatible);
+  });
+
+g.test('depth_stencil_readonly_mismatch')
+  .desc(
+    `
+    Tests executeBundles cannot be called with render bundles that do match the depthStencil
+    readonly state of the render pass.
+    `
+  )
+  .params(u =>
+    u.combine('depthStencilFormat', kDepthStencilFormats).combineWithParams([
+      {
+        bundleDepthReadOnly: false,
+        bundleStencilReadOnly: false,
+        passDepthReadOnly: false,
+        passStencilReadOnly: false,
+      },
+      {
+        bundleDepthReadOnly: true,
+        bundleStencilReadOnly: false,
+        passDepthReadOnly: true,
+        passStencilReadOnly: false,
+      },
+      {
+        bundleDepthReadOnly: false,
+        bundleStencilReadOnly: true,
+        passDepthReadOnly: false,
+        passStencilReadOnly: true,
+      },
+      {
+        bundleDepthReadOnly: true,
+        bundleStencilReadOnly: true,
+        passDepthReadOnly: true,
+        passStencilReadOnly: true,
+      },
+      {
+        bundleDepthReadOnly: true,
+        bundleStencilReadOnly: false,
+        passDepthReadOnly: true,
+        passStencilReadOnly: true,
+      },
+      {
+        bundleDepthReadOnly: false,
+        bundleStencilReadOnly: true,
+        passDepthReadOnly: true,
+        passStencilReadOnly: true,
+      },
+      {
+        bundleDepthReadOnly: false,
+        bundleStencilReadOnly: false,
+        passDepthReadOnly: true,
+        passStencilReadOnly: true,
+      },
+      {
+        bundleDepthReadOnly: true,
+        bundleStencilReadOnly: true,
+        passDepthReadOnly: false,
+        passStencilReadOnly: true,
+      },
+      {
+        bundleDepthReadOnly: true,
+        bundleStencilReadOnly: true,
+        passDepthReadOnly: true,
+        passStencilReadOnly: false,
+      },
+      {
+        bundleDepthReadOnly: true,
+        bundleStencilReadOnly: true,
+        passDepthReadOnly: false,
+        passStencilReadOnly: false,
+      },
+    ])
+  )
+  .fn(async t => {
+    const {
+      depthStencilFormat,
+      bundleDepthReadOnly,
+      bundleStencilReadOnly,
+      passDepthReadOnly,
+      passStencilReadOnly,
+    } = t.params;
+
+    let compatible =
+      bundleDepthReadOnly === passDepthReadOnly && bundleStencilReadOnly === passStencilReadOnly;
+
+    const depthStencilInfo = kTextureFormatInfo[depthStencilFormat];
+    if (depthStencilInfo.depth && depthStencilInfo.stencil) {
+      compatible = compatible && bundleDepthReadOnly === bundleStencilReadOnly;
+    }
+
+    const bundleEncoder = t.device.createRenderBundleEncoder({
+      colorFormats: [],
+      depthStencilFormat,
+      depthReadOnly: bundleDepthReadOnly,
+      stencilReadOnly: bundleStencilReadOnly,
+    });
+    const bundle = bundleEncoder.finish();
+
+    const encoder = t.createEncoder('render pass', {
+      attachmentInfo: {
+        colorFormats: [],
+        depthStencilFormat,
+        depthReadOnly: passDepthReadOnly,
+        stencilReadOnly: passStencilReadOnly,
+      },
+    });
+    encoder.encoder.executeBundles([bundle]);
+
+    encoder.validateFinish(compatible);
+  });
+
+g.test('sample_count_mismatch')
+  .desc(
+    `
+    Tests executeBundles cannot be called with render bundles that do match the sampleCount of the
+    render pass.
+    `
+  )
+  .params(u =>
+    u.combineWithParams([
+      { bundleSamples: 1, passSamples: 1 }, // control case
+      { bundleSamples: 4, passSamples: 4 }, // control case
+      { bundleFormat: 4, passFormat: 1 },
+      { bundleFormat: 1, passFormat: 4 },
+    ])
+  )
+  .fn(async t => {
+    const { bundleSamples, passSamples } = t.params;
+
+    const compatible = bundleSamples === passSamples;
+
+    const bundleEncoder = t.device.createRenderBundleEncoder({
+      colorFormats: ['bgra8unorm'],
+      sampleCount: bundleSamples,
+    });
+    const bundle = bundleEncoder.finish();
+
+    const encoder = t.createEncoder('render pass', {
+      attachmentInfo: {
+        colorFormats: ['bgra8unorm'],
+        sampleCount: passSamples,
+      },
+    });
+    encoder.encoder.executeBundles([bundle]);
+
+    encoder.validateFinish(compatible);
   });

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -952,13 +952,21 @@ export class GPUTest extends Fixture {
         if (fullAttachmentInfo.depthStencilFormat !== undefined) {
           depthStencilAttachment = {
             view: makeAttachmentView(fullAttachmentInfo.depthStencilFormat),
+            depthReadOnly: fullAttachmentInfo.depthReadOnly,
+            stencilReadOnly: fullAttachmentInfo.stencilReadOnly,
           };
-          if (kTextureFormatInfo[fullAttachmentInfo.depthStencilFormat].depth) {
+          if (
+            kTextureFormatInfo[fullAttachmentInfo.depthStencilFormat].depth &&
+            !fullAttachmentInfo.depthReadOnly
+          ) {
             depthStencilAttachment.depthClearValue = 0;
             depthStencilAttachment.depthLoadOp = 'clear';
             depthStencilAttachment.depthStoreOp = 'discard';
           }
-          if (kTextureFormatInfo[fullAttachmentInfo.depthStencilFormat].stencil) {
+          if (
+            kTextureFormatInfo[fullAttachmentInfo.depthStencilFormat].stencil &&
+            !fullAttachmentInfo.stencilReadOnly
+          ) {
             depthStencilAttachment.stencilClearValue = 1;
             depthStencilAttachment.stencilLoadOp = 'clear';
             depthStencilAttachment.stencilStoreOp = 'discard';


### PR DESCRIPTION
Issue: #1011

Some tests are not passing in Chrome due to lack of the `stencil8` enum. Also, turns out that Chrome doesn't implement tracking of `depthReadOnly` and `stencilReadOnly` for render bundles, so validation of those fields fails as well.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
