### PR TITLE
Fix limits of `log()` and `log2()`

### DIFF
--- a/src/webgpu/shader/execution/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/builtin/log.spec.ts
@@ -4,11 +4,11 @@ Execution Tests for the 'log' builtin function
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { absThreshold, ulpThreshold } from '../../../util/compare.js';
-import { kBit, kValue } from '../../../util/constants.js';
-import { f32, f32Bits, TypeF32 } from '../../../util/conversion.js';
+import { absThreshold, FloatMatch, ulpThreshold } from '../../../util/compare.js';
+import { kValue } from '../../../util/constants.js';
+import { f32, TypeF32 } from '../../../util/conversion.js';
 import { biasedRange, linearRange } from '../../../util/math.js';
-import { builtin, Case, Config, run } from '../expression.js';
+import { builtin, Case, CaseList, Config, run } from '../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -24,11 +24,10 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
   )
   .params(u =>
-    // u
-    //   .combine('storageClass', ['uniform'] as const)
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('range', ['low', 'mid', 'high'] as const)
   )
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
@@ -37,19 +36,31 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       return { input: f32_x, expected: f32(Math.log(f32_x.value as number)) };
     };
 
-    // log's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
-    let cases: Array<Case> = [];
-    cases = cases.concat({ input: f32(0), expected: f32Bits(kBit.f32.infinity.negative) });
-    cases = cases.concat(linearRange(kValue.f32.positive.min, 0.5, 20).map(x => truthFunc(x)));
-    cases = cases.concat(linearRange(0.5, 2.0, 20).map(x => truthFunc(x)));
-    cases = cases.concat(biasedRange(2.0, 2 ** 32, 1000).map(x => truthFunc(x)));
-
-    const cfg: Config = t.params;
-    cfg.cmpFloats = (got: number, expected: number): boolean => {
-      if (expected >= 0.5 && expected <= 2.0) {
-        return absThreshold(2 ** -21)(got, expected);
-      }
-      return ulpThreshold(3)(got, expected);
+    const runRange = (match: FloatMatch, cases: CaseList) => {
+      const cfg: Config = t.params;
+      cfg.cmpFloats = match;
+      run(t, builtin('log'), [TypeF32], TypeF32, cfg, cases);
     };
-    run(t, builtin('log'), [TypeF32], TypeF32, cfg, cases);
+
+    // log's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
+    switch (t.params.range) {
+      case 'low': // [0, 0.5)
+        runRange(
+          ulpThreshold(3),
+          linearRange(kValue.f32.positive.min, 0.5, 20).map(x => truthFunc(x))
+        );
+        break;
+      case 'mid': // [0.5, 2.0]
+        runRange(
+          absThreshold(2 ** -21),
+          linearRange(0.5, 2.0, 20).map(x => truthFunc(x))
+        );
+        break;
+      case 'high': // (2.0, +∞]
+        runRange(
+          ulpThreshold(3),
+          biasedRange(2.0, 2 ** 32, 1000).map(x => truthFunc(x))
+        );
+        break;
+    }
   });


### PR DESCRIPTION
The switch between ULP and absolute error was testing the expected value against the range `[0.5 .. 2.0]`, when this should have been the input value.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
