### PR TITLE
Remove test stubs for `isInfinite` and `isNormal`

### DIFF
--- a/src/webgpu/shader/execution/builtin/value_testing_built_in_functions.spec.ts
+++ b/src/webgpu/shader/execution/builtin/value_testing_built_in_functions.spec.ts
@@ -5,36 +5,6 @@ import { GPUTest } from '../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('value_testing_builtin_functions,isFinite')
-  .uniqueId('bf8ee3764330ceb4')
-  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#value-testing-builtin-functions')
-  .desc(
-    `
-isFinite:
-isFinite(e: I ) -> T Test a finite value according to IEEE-754. Component-wise when I is a vector.
-
-Please read the following guidelines before contributing:
-https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
-`
-  )
-  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
-  .unimplemented();
-
-g.test('value_testing_builtin_functions,isNormal')
-  .uniqueId('ea51009a88a27a15')
-  .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#value-testing-builtin-functions')
-  .desc(
-    `
-isNormal:
-isNormal(e: I ) -> T Test a normal value according to IEEE-754. Component-wise when I is a vector.
-
-Please read the following guidelines before contributing:
-https://github.com/gpuweb/cts/blob/main/docs/plan_autogen.md
-`
-  )
-  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
-  .unimplemented();
-
 g.test('value_testing_builtin_functions,runtime_sized_array_length')
   .uniqueId('8089b54fa4eeaa0b')
   .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#value-testing-builtin-functions')


### PR DESCRIPTION
These were removed from the spec

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
