### PR TITLE
Change endPass to end in in_render_common.spec.ts

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -78,16 +78,16 @@ g.test('subresources_from_same_texture_as_color_attachments')
       const renderPass = encoder.beginRenderPass({
         colorAttachments: [colorAttachment1, colorAttachment2],
       });
-      renderPass.endPass();
+      renderPass.end();
     } else {
       const renderPass1 = encoder.beginRenderPass({
         colorAttachments: [colorAttachment1],
       });
-      renderPass1.endPass();
+      renderPass1.end();
       const renderPass2 = encoder.beginRenderPass({
         colorAttachments: [colorAttachment2],
       });
-      renderPass2.endPass();
+      renderPass2.end();
     }
 
     const success = inSamePass ? baseLayer0 !== baseLayer1 : true;


### PR DESCRIPTION
With this PR we have replaced all the places that are using `endPass()`
with `end()`.




Issue: #905

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
