### PR TITLE
Add validation,resource_usages,texture,in_render_common:* - Part II

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -20,6 +20,7 @@ subresources, one for same draw/same pass/different pass, one for visibilities).
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { unreachable } from '../../../../../common/util/util.js';
 import { ValidationTest } from '../../validation_test.js';
 
 class F extends ValidationTest {
@@ -40,9 +41,13 @@ class F extends ValidationTest {
 
 export const g = makeTestGroup(F);
 
+const kTextureSize = 16;
+const kTextureLevels = 3;
+const kTextureLayers = 3;
+
 // Test that the different subresource of the same texture are allowed to be used as color
-// attachments in same / different render passes, while the same subresource is only allowed to be
-// used as different color attachments in different render passes.
+// attachments in same / different render pass encoder, while the same subresource is only allowed
+// to be used as different color attachments in different render pass encoders.
 g.test('subresources_from_same_texture_as_color_attachments')
   .params(u =>
     u
@@ -59,12 +64,13 @@ g.test('subresources_from_same_texture_as_color_attachments')
     const texture = t.device.createTexture({
       format: 'rgba8unorm',
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
-      size: [16, 16, 2],
-      mipLevelCount: 2,
+      size: [kTextureSize, kTextureSize, kTextureLayers],
+      mipLevelCount: kTextureLevels,
     });
 
     const colorAttachment1 = t.getColorAttachment(texture, {
       baseArrayLayer: baseLayer0,
+      arrayLayerCount: 1,
       baseMipLevel: baseLevel0,
       mipLevelCount: 1,
     });
@@ -91,6 +97,131 @@ g.test('subresources_from_same_texture_as_color_attachments')
     }
 
     const success = inSamePass ? baseLayer0 !== baseLayer1 : true;
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, !success);
+  });
+
+// Test that when one subresource of a texture is used as a color attachment, it cannot be used in a
+// bind group simultaneously in the same render pass encoder. It is allowed when the bind group is
+// used in another render pass encoder instead of the same one.
+g.test('subresources_from_same_texture_as_color_attachment_and_in_bind_group')
+  .params(u =>
+    u
+      .combine('colorAttachmentBaseLevel', [0, 1])
+      .combine('colorAttachmentBaseLayer', [0, 1])
+      .combine('bindGroupViewBaseLevel', [0, 1, 2])
+      .combine('bindGroupViewLevelCount', [1, 2])
+      .combine('bindGroupViewBaseLayer', [0, 1, 2])
+      .combine('bindGroupViewLayerCount', [1, 2])
+      .combine('bindGroupUsage', ['texture', 'storage'])
+      .unless(
+        t =>
+          t.bindGroupViewBaseLevel + t.bindGroupViewLevelCount >= kTextureLevels ||
+          t.bindGroupViewBaseLayer + t.bindGroupViewLayerCount >= kTextureLayers ||
+          (t.bindGroupUsage === 'storage' && t.bindGroupViewLevelCount > 0)
+      )
+      .combine('inSamePass', [true, false])
+  )
+  .fn(async t => {
+    const {
+      colorAttachmentBaseLevel,
+      colorAttachmentBaseLayer,
+      bindGroupViewBaseLevel,
+      bindGroupViewLevelCount,
+      bindGroupViewBaseLayer,
+      bindGroupViewLayerCount,
+      bindGroupUsage,
+      inSamePass,
+    } = t.params;
+
+    const bindGroupLayoutEntry: GPUBindGroupLayoutEntry = {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT,
+    };
+    let textureUsage = GPUTextureUsage.RENDER_ATTACHMENT;
+    const viewDimension = bindGroupViewLayerCount > 1 ? '2d-array' : '2d';
+    switch (bindGroupUsage) {
+      case 'texture':
+        bindGroupLayoutEntry.texture = { viewDimension };
+        textureUsage |= GPUTextureUsage.TEXTURE_BINDING;
+        break;
+      case 'storage':
+        bindGroupLayoutEntry.storageTexture = {
+          access: 'write-only',
+          format: 'rgba8unorm',
+          viewDimension,
+        };
+        textureUsage |= GPUTextureUsage.STORAGE_BINDING;
+        break;
+      default:
+        unreachable();
+        break;
+    }
+
+    const texture = t.device.createTexture({
+      format: 'rgba8unorm',
+      usage: textureUsage,
+      size: [kTextureSize, kTextureSize, kTextureLayers],
+      mipLevelCount: kTextureLevels,
+    });
+    const bindGroupView = texture.createView({
+      dimension: bindGroupViewLayerCount > 1 ? '2d-array' : '2d',
+      baseArrayLayer: bindGroupViewBaseLayer,
+      arrayLayerCount: bindGroupViewLayerCount,
+      baseMipLevel: bindGroupViewBaseLevel,
+      mipLevelCount: bindGroupViewLevelCount,
+    });
+
+    const bindGroupLayout = t.device.createBindGroupLayout({
+      entries: [bindGroupLayoutEntry],
+    });
+    const bindGroup = t.device.createBindGroup({
+      layout: bindGroupLayout,
+      entries: [{ binding: 0, resource: bindGroupView }],
+    });
+
+    const colorAttachment = t.getColorAttachment(texture, {
+      baseArrayLayer: colorAttachmentBaseLayer,
+      arrayLayerCount: 1,
+      baseMipLevel: colorAttachmentBaseLevel,
+      mipLevelCount: 1,
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const renderPass = encoder.beginRenderPass({
+      colorAttachments: [colorAttachment],
+    });
+    if (inSamePass) {
+      renderPass.setBindGroup(0, bindGroup);
+      renderPass.end();
+    } else {
+      renderPass.end();
+
+      const texture2 = t.device.createTexture({
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        size: [kTextureSize, kTextureSize, 1],
+        mipLevelCount: 1,
+      });
+      const colorAttachment2 = t.getColorAttachment(texture2);
+      const renderPass2 = encoder.beginRenderPass({
+        colorAttachments: [colorAttachment2],
+      });
+      renderPass2.setBindGroup(0, bindGroup);
+      renderPass2.end();
+    }
+
+    const colorAttachmentBaseLevelSuccess =
+      colorAttachmentBaseLevel < bindGroupViewBaseLevel ||
+      colorAttachmentBaseLevel >= bindGroupViewBaseLevel + bindGroupViewLevelCount;
+    const colorAttachmentBaseLayerSuccess =
+      colorAttachmentBaseLayer < bindGroupViewBaseLayer ||
+      colorAttachmentBaseLayer >= bindGroupViewBaseLayer + bindGroupViewLayerCount;
+
+    const success = inSamePass
+      ? colorAttachmentBaseLevelSuccess || colorAttachmentBaseLayerSuccess
+      : true;
     t.expectValidationError(() => {
       encoder.finish();
     }, !success);


### PR DESCRIPTION
This PR adds the 2nd part of validation,resource_usages,texture,*:
- in_render_common:subresources_from_same_texture_as_color_attachments




Issue: #905

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
