### PR TITLE
Implement Basic Worker WebGPU Test

### DIFF
--- a/node.tsconfig.json
+++ b/node.tsconfig.json
@@ -11,6 +11,7 @@
   "exclude": [
     "src/common/runtime/wpt.ts",
     "src/common/runtime/standalone.ts",
-    "src/common/runtime/helper/test_worker.ts"
+    "src/common/runtime/helper/test_worker.ts",
+    "src/webgpu/web_platform/worker/worker_launcher.ts"
   ]
 }

--- a/src/webgpu/web_platform/worker/worker.spec.ts
+++ b/src/webgpu/web_platform/worker/worker.spec.ts
@@ -1,0 +1,35 @@
+export const description = `
+Tests WebGPU is available in a worker.
+
+Note: The CTS test can be run in a worker by passing in worker=1 as
+a query parameter. This test is specifically to check that WebGPU
+is available in a worker.
+`;
+
+import { Fixture } from '../../../common/framework/fixture.js';
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { assert } from '../../../common/util/util.js';
+
+export const g = makeTestGroup(Fixture);
+
+function isNode(): boolean {
+  return typeof process !== 'undefined' && process?.versions?.node !== undefined;
+}
+
+g.test('worker')
+  .desc(`test WebGPU is available in DedicatedWorkers and check for basic functionality`)
+  .fn(async t => {
+    if (isNode()) {
+      t.skip('node does not support 100% compatible workers');
+      return;
+    }
+    // Note: we load worker_launcher dynamically because ts-node support
+    // is using commonjs which doesn't support import.meta. Further,
+    // we need to put the url in a string add pass the string to import
+    // otherwise typescript tries to parse the file which again, fails.
+    // worker_launcher.js is excluded in node.tsconfig.json.
+    const url = './worker_launcher.js';
+    const { launchWorker } = await import(url);
+    const result = await launchWorker();
+    assert(result.error === undefined, `should be no error from worker but was: ${result.error}`);
+  });

--- a/src/webgpu/web_platform/worker/worker.ts
+++ b/src/webgpu/web_platform/worker/worker.ts
@@ -1,0 +1,78 @@
+import { getGPU } from '../../../common/util/navigator_gpu.js';
+import { assert, objectEquals, iterRange } from '../../../common/util/util.js';
+
+async function basicTest() {
+  const adapter = await getGPU().requestAdapter();
+  assert(adapter !== null, 'Failed to get adapter.');
+
+  const device = await adapter.requestDevice();
+  assert(device !== null, 'Failed to get device.');
+
+  const kOffset = 1230000;
+  const pipeline = await device.createComputePipeline({
+    compute: {
+      module: device.createShaderModule({
+        code: `
+          struct Buffer { data: array<u32>; };
+
+          @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
+          @stage(compute) @workgroup_size(1u) fn main(
+              @builtin(global_invocation_id) id: vec3<u32>) {
+            buffer.data[id.x] = id.x + ${kOffset}u;
+          }
+        `,
+      }),
+      entryPoint: 'main',
+    },
+  });
+
+  const kNumElements = 64;
+  const kBufferSize = kNumElements * 4;
+  const buffer = device.createBuffer({
+    size: kBufferSize,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+  });
+
+  const resultBuffer = device.createBuffer({
+    size: kBufferSize,
+    usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+  });
+
+  const bindGroup = device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [{ binding: 0, resource: { buffer } }],
+  });
+
+  const encoder = device.createCommandEncoder();
+
+  const pass = encoder.beginComputePass();
+  pass.setPipeline(pipeline);
+  pass.setBindGroup(0, bindGroup);
+  pass.dispatch(kNumElements);
+  pass.end();
+
+  encoder.copyBufferToBuffer(buffer, 0, resultBuffer, 0, kBufferSize);
+
+  device.queue.submit([encoder.finish()]);
+
+  const expected = new Uint32Array([...iterRange(kNumElements, x => x + kOffset)]);
+
+  await resultBuffer.mapAsync(GPUMapMode.READ);
+  const actual = new Uint32Array(resultBuffer.getMappedRange());
+
+  assert(objectEquals(actual, expected), 'compute pipeline ran');
+
+  resultBuffer.destroy();
+  buffer.destroy();
+  device.destroy();
+}
+
+self.onmessage = async (ev: MessageEvent) => {
+  let error = undefined;
+  try {
+    await basicTest();
+  } catch (err: unknown) {
+    error = (err as Error).toString();
+  }
+  self.postMessage({ error });
+};

--- a/src/webgpu/web_platform/worker/worker_launcher.ts
+++ b/src/webgpu/web_platform/worker/worker_launcher.ts
@@ -1,0 +1,16 @@
+export type TestResult = {
+  error: String | undefined;
+};
+
+export async function launchWorker() {
+  const selfPath = import.meta.url;
+  const selfPathDir = selfPath.substring(0, selfPath.lastIndexOf('/'));
+  const workerPath = selfPathDir + '/worker.js';
+  const worker = new Worker(workerPath, { type: 'module' });
+
+  const promise = new Promise<TestResult>(resolve => {
+    worker.addEventListener('message', ev => resolve(ev.data as TestResult), { once: true });
+  });
+  worker.postMessage({});
+  return await promise;
+}


### PR DESCRIPTION
A Basic Worker Test

Issue: #1066

Notes: There's a bunch of issues with finding the path to the worker. The issue is the code is mostly converted to forms that do not support `import.meta` when run in node via ts-node. This works for test_worker.js because it is excluded from conversion via node.tsconfig.json. Trying to exclude worker_launcher.ts failed because tsc sees what was a static import and imports it anyway. It works for `test_worker.js` because `standalone.js` is also excluded in node.tsconfig.json

Other solutions tried:

Tried solutions listed here: https://github.com/TypeStrong/ts-node/discussions/1290, No luck but maybe I just did something wrong.

Tried switching ts-node to use esm instead of commonjs. That included writing a custom resolver and/or using ts-node's resolver as in `node --loader ts-node/esm`. Failed for various reasons.

Tried putting the contents of `worker.js` in a string and creating a dataUrl or Blob url. It got further than the previous solutions but both failed because node doesn't support Blob and Worker as globals. Tried making them globals via setup-ts-in-node.js but it still failed because node's Worker doesn't support dataUrls and/or Blobs as input unless you pass in special flags. Tried setting the special flags but typescript complains that those special flags are invalid.

Rather than spending a bunch of time trying to make cross platform worker wrappers I just made it so the test is skipped in node.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
