### PR TITLE
Bugfix for getTextureCopyLayout

### DIFF
--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -82,6 +82,8 @@ export function physicalMipSize(
 
 /**
  * Compute the "virtual size" of a mip level of a texture (not accounting for texel block rounding).
+ *
+ * MAINTENANCE_TODO: Change input/output to Required<GPUExtent3DDict> for consistency.
  */
 export function virtualMipSize(
   dimension: GPUTextureDimension,

--- a/src/webgpu/util/texture/layout.ts
+++ b/src/webgpu/util/texture/layout.ts
@@ -7,7 +7,7 @@ import {
 import { align } from '../math.js';
 import { reifyExtent3D } from '../unions.js';
 
-import { virtualMipSize } from './base.js';
+import { physicalMipSize, virtualMipSize } from './base.js';
 
 /** The minimum `bytesPerRow` alignment, per spec. */
 export const kBytesPerRowAlignment = 256;
@@ -50,6 +50,8 @@ export interface TextureCopyLayout extends TextureSubCopyLayout {
  * of size `baseSize` with the provided `format` and `dimension`.
  *
  * Computes default values for `bytesPerRow` and `rowsPerImage` if not specified.
+ *
+ * MAINTENANCE_TODO: Change input/output to Required<GPUExtent3DDict> for consistency.
  */
 export function getTextureCopyLayout(
   format: SizedTextureFormat,
@@ -57,10 +59,15 @@ export function getTextureCopyLayout(
   baseSize: readonly [number, number, number],
   { mipLevel, bytesPerRow, rowsPerImage }: LayoutOptions = kDefaultLayoutOptions
 ): TextureCopyLayout {
-  const mipSize = virtualMipSize(dimension, baseSize, mipLevel);
+  const mipSize = physicalMipSize(
+    { width: baseSize[0], height: baseSize[1], depthOrArrayLayers: baseSize[2] },
+    format,
+    dimension,
+    mipLevel
+  );
 
   const layout = getTextureSubCopyLayout(format, mipSize, { bytesPerRow, rowsPerImage });
-  return { ...layout, mipSize };
+  return { ...layout, mipSize: [mipSize.width, mipSize.height, mipSize.depthOrArrayLayers] };
 }
 
 /**


### PR DESCRIPTION
Bug introduced in #1068. getTextureCopyLayout used to implement physicalMipSize itself (by rounding up the virtualMipSize), and I accidentally removed the rounding code instead of switching to physicalMipSize.

Issue: #881

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
