### PR TITLE
Show some loading progress

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -405,6 +405,12 @@ let lastQueryLevelToExpand: TestQueryLevel = 2;
   if (rootQuery.level > lastQueryLevelToExpand) {
     lastQueryLevelToExpand = rootQuery.level;
   }
+  loader.addEventListener('import', ev => {
+    $('#info')[0].textContent = `loading: ${ev.data.url}`;
+  });
+  loader.addEventListener('finish', () => {
+    $('#info')[0].textContent = '';
+  });
   const tree = await loader.loadTree(rootQuery);
 
   tree.dissolveSingleChildTrees();

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -110,10 +110,21 @@ class FakeTestFileLoader extends TestFileLoader {
 }
 
 class LoadingTest extends UnitTest {
-  static readonly loader = new FakeTestFileLoader();
+  loader: FakeTestFileLoader = new FakeTestFileLoader();
+  events: (string | null)[] = [];
+  private isListenersAdded = false;
+
+  collectEvents(): void {
+    this.events = [];
+    if (!this.isListenersAdded) {
+      this.isListenersAdded = true;
+      this.loader.addEventListener('import', ev => this.events.push(ev.data.url));
+      this.loader.addEventListener('finish', ev => this.events.push(null));
+    }
+  }
 
   async load(query: string): Promise<TestTreeLeaf[]> {
-    return Array.from(await LoadingTest.loader.loadCases(parseQuery(query)));
+    return Array.from(await this.loader.loadCases(parseQuery(query)));
   }
 
   async loadNames(query: string): Promise<string[]> {
@@ -129,16 +140,39 @@ g.test('suite').fn(async t => {
 });
 
 g.test('group').fn(async t => {
+  t.collectEvents();
   t.expect((await t.load('suite1:*')).length === 8);
+  t.expect(
+    objectEquals(t.events, [
+      'suite1/foo.spec.js',
+      'suite1/bar/biz.spec.js',
+      'suite1/bar/buzz/buzz.spec.js',
+      'suite1/baz.spec.js',
+      null,
+    ])
+  );
+
+  t.collectEvents();
   t.expect((await t.load('suite1:foo,*')).length === 3); // x:foo,* matches x:foo:
+  t.expect(objectEquals(t.events, ['suite1/foo.spec.js', null]));
+
+  t.collectEvents();
   t.expect((await t.load('suite1:bar,*')).length === 1);
+  t.expect(
+    objectEquals(t.events, ['suite1/bar/biz.spec.js', 'suite1/bar/buzz/buzz.spec.js', null])
+  );
+
+  t.collectEvents();
   t.expect((await t.load('suite1:bar,buzz,buzz,*')).length === 1);
+  t.expect(objectEquals(t.events, ['suite1/bar/buzz/buzz.spec.js', null]));
 
   t.shouldReject('Error', t.load('suite1:f*'));
 
   {
     const s = new TestQueryMultiFile('suite1', ['bar', 'buzz']).toString();
+    t.collectEvents();
     t.expect((await t.load(s)).length === 1);
+    t.expect(objectEquals(t.events, ['suite1/bar/buzz/buzz.spec.js', null]));
   }
 });
 
@@ -652,10 +686,7 @@ async function testIterateCollapsed(
   includeEmptySubtrees = false
 ) {
   t.debug(`expandThrough=${alwaysExpandThroughLevel} expectations=${expectations}`);
-  const treePromise = LoadingTest.loader.loadTree(
-    new TestQueryMultiFile('suite1', []),
-    expectations
-  );
+  const treePromise = t.loader.loadTree(new TestQueryMultiFile('suite1', []), expectations);
   if (expectedResult === 'throws') {
     t.shouldReject('Error', treePromise, 'loadTree should have thrown Error');
     return;
@@ -679,8 +710,8 @@ ${tree.toString()}`
   }
 }
 
-g.test('print').fn(async () => {
-  const tree = await LoadingTest.loader.loadTree(new TestQueryMultiFile('suite1', []));
+g.test('print').fn(async t => {
+  const tree = await t.loader.loadTree(new TestQueryMultiFile('suite1', []));
   tree.toString();
 });
 


### PR DESCRIPTION
It's a little disconcerting that the live CTS takes so long to load.
Here's one idea for putting something in that would let some progress
show.

Maybe we should also not add the buttons, or make them unclickable,
until loading has finished?

Note: I was going to use CustomEvent instead of MessageEvent but
CustomEvent does not exist in node 😭




Issue: #1079

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
