### PR TITLE
Skip new depth/stencil tests that require optional formats

### DIFF
--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -70,6 +70,7 @@ g.test('valid_texture_formats')
   )
   .fn(async t => {
     const { format, attachment } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const colorRenderable =
       kTextureFormatInfo[format].renderable && kTextureFormatInfo[format].color;
@@ -117,6 +118,7 @@ g.test('depth_stencil_readonly')
   )
   .fn(async t => {
     const { depthStencilFormat, depthReadOnly, stencilReadOnly } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(depthStencilFormat);
 
     let shouldError = false;
     if (

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -137,6 +137,7 @@ g.test('depth_stencil_formats_mismatch')
   )
   .fn(async t => {
     const { bundleFormat, passFormat } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase([bundleFormat, passFormat]);
 
     const compatible = bundleFormat === passFormat;
 
@@ -236,6 +237,7 @@ g.test('depth_stencil_readonly_mismatch')
       passDepthReadOnly,
       passStencilReadOnly,
     } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(depthStencilFormat);
 
     let compatible =
       bundleDepthReadOnly === passDepthReadOnly && bundleStencilReadOnly === passStencilReadOnly;


### PR DESCRIPTION
Missed in the review of #1057.

Issue: #1011 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
