### PR TITLE
wgsl: Remove usage of @stride attribute

### DIFF
--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -563,7 +563,7 @@ struct OutPrimitive {
 ${vertexInputShaderLocations.map(i => `  attrib${i} : ${wgslFormat};`).join('\n')}
 };
 struct OutBuffer {
-  primitives : @stride(${vertexInputShaderLocations.length * 4}) array<OutPrimitive>;
+  primitives : array<OutPrimitive>;
 };
 @group(0) @binding(0) var<storage, read_write> outBuffer : OutBuffer;
 

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -64,7 +64,7 @@ export const checkContentsBySampling: CheckContents = (
             @group(0) @binding(1) var myTexture : texture${_multisampled}${_xd}<${shaderType}>;
 
             struct Result {
-              values : @stride(4) array<${shaderType}>;
+              values : array<${shaderType}>;
             };
             @group(0) @binding(3) var<storage, read_write> result : Result;
 

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -310,7 +310,13 @@ g.test('linear_memory')
           switch (access) {
             case 'read':
               {
-                const exprLoadElement = isAtomic ? `atomicLoad(&${exprElement})` : exprElement;
+                let exprLoadElement = isAtomic ? `atomicLoad(&${exprElement})` : exprElement;
+                if (storageClass === 'uniform' && containerType === 'array') {
+                  // Scalar types will be wrapped in a vec4 to satisfy array element size
+                  // requirements for the uniform address space, so we need an additional index
+                  // accessor expression.
+                  exprLoadElement += '[0]';
+                }
                 let condition = `${exprLoadElement} != ${exprZeroElement}`;
                 if (containerType === 'matrix') condition = `any(${condition})`;
                 testFunctionSource += `

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -134,7 +134,7 @@ export function* generateTypes({
     // Sized
     if (storageClass === 'uniform') {
       yield {
-        type: `@stride(16) array<${scalarType},${kArrayLength}>`,
+        type: `array<vec4<${scalarType}>,${kArrayLength}>`,
         _kTypeInfo: arrayTypeInfo,
       };
     } else {

--- a/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0035: The access decoration is required for 'particles'.
 
 struct Particles {
-  particles : @stride(16) array<f32, 4>;
+  particles : array<f32, 4>;
 };
 
 @group(0) @binding(1) var<storage> particles : Particles;

--- a/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
@@ -2,7 +2,7 @@
 // 'particles', which is in 'storage' storage class.
 
 struct Particles {
-  particles : @stride(16) array<f32, 4>;
+  particles : array<f32, 4>;
 };
 
 @group(1) @binding(0) var<storage, read_write> particles : Particles;

--- a/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
@@ -2,7 +2,7 @@
 // 'particles', which is in the 'uniform' storage class.
 
 struct Particles {
-  particles : @stride(16) array<f32, 4>;
+  particles : array<f32, 4>;
 };
 
 @group(0) @binding(0) var<uniform, read_write> particles : Particles;

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0031: in 'y = x', x is a runtime array and it's used as an expression.
 
-type RTArr = @stride(16) array<i32>;
+type RTArr = array<i32>;
 struct S{
   data : RTArr;
 };

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type-v2.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0030 - This fails because 'RTArr' is a runtime array alias and it is used as store type.
 
-type RTArr = @stride(4) array<f32>;
+type RTArr = array<f32>;
 @group(0) @binding(1) var<storage> x : RTArr;
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0015: variable 's' store type is struct 'SArr' that has a runtime-sized member but its storage class is not 'storage'.
 
-type RTArr = @stride(16) array<vec4<f32>>;
+type RTArr = array<vec4<f32>>;
 struct SArr{
   data : RTArr;
 };

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0031: struct 'S' has runtime-sized member but it's storage class is not 'storage'.
 
-type RTArr = @stride(16) array<vec4<f32>>;
+type RTArr = array<vec4<f32>>;
 struct S{
   data : RTArr;
 };

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0015 - This fails because of the aliased runtime array is not last member of the struct.
 
-type RTArr = @stride(16) array<vec4<f32>>;
+type RTArr = array<vec4<f32>>;
 struct S {
   data : RTArr;
   b : f32;

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v3.fail.wgsl
@@ -1,6 +1,6 @@
 // v-0030 - This fails because the runtime array must not be used as a store type.
 
-type RTArr = @stride(16) array<vec4<f32>>;
+type RTArr = array<vec4<f32>>;
 
 @stage(fragment)
 fn main() {

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0015 - This fails because of the runtime array is not last member of the struct.
 
 struct Foo {
-  a : @stride(16) array<f32>;
+  a : array<f32>;
   b : f32;
 };
 


### PR DESCRIPTION
The `@stride` attribute has been removed from WGSL, so we either need to
rely on the implict array stride or wrap the element type in a vec4 to
satisfy array element stride requirements for the uniform address
space.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
