### PR TITLE
Fix readSinglePixelFrom2DTexture helper

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -30,6 +30,7 @@ import {
 import { align, roundDown } from './util/math.js';
 import {
   getTextureCopyLayout,
+  getTextureSubCopyLayout,
   LayoutOptions as TextureLayoutOptions,
 } from './util/texture/layout.js';
 import { PerTexelComponent, kTexelRepresentationInfo } from './util/texture/texel_data.js';
@@ -596,12 +597,7 @@ export class GPUTest extends Fixture {
     { x, y }: { x: number; y: number },
     { slice = 0, layout }: { slice?: number; layout?: TextureLayoutOptions }
   ): GPUBuffer {
-    const { byteLength, bytesPerRow, rowsPerImage, mipSize } = getTextureCopyLayout(
-      format,
-      '2d',
-      [1, 1, 1],
-      layout
-    );
+    const { byteLength, bytesPerRow, rowsPerImage } = getTextureSubCopyLayout(format, [1, 1]);
     const buffer = this.device.createBuffer({
       size: byteLength,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
@@ -612,7 +608,7 @@ export class GPUTest extends Fixture {
     commandEncoder.copyTextureToBuffer(
       { texture: src, mipLevel: layout?.mipLevel, origin: { x, y, z: slice } },
       { buffer, bytesPerRow, rowsPerImage },
-      mipSize
+      [1, 1]
     );
     this.queue.submit([commandEncoder.finish()]);
 

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -43,11 +43,15 @@ export function physicalMipSize(
 ): Required<GPUExtent3DDict> {
   switch (dimension) {
     case '1d':
-      assert(level === 0 && baseSize.height === 1 && baseSize.depthOrArrayLayers === 1);
+      assert(level === 0, '1d textures cannot be mipmapped');
+      assert(baseSize.height === 1 && baseSize.depthOrArrayLayers === 1, '1d texture not Wx1x1');
       return { width: baseSize.width, height: 1, depthOrArrayLayers: 1 };
 
     case '2d': {
-      assert(Math.max(baseSize.width, baseSize.height) >> level > 0);
+      assert(
+        Math.max(baseSize.width, baseSize.height) >> level > 0,
+        () => `level (${level}) too large for base size (${baseSize.width}x${baseSize.height})`
+      );
 
       const virtualWidthAtLevel = Math.max(baseSize.width >> level, 1);
       const virtualHeightAtLevel = Math.max(baseSize.height >> level, 1);
@@ -67,9 +71,14 @@ export function physicalMipSize(
     }
 
     case '3d': {
-      assert(Math.max(baseSize.width, baseSize.height, baseSize.depthOrArrayLayers) >> level > 0);
       assert(
-        kTextureFormatInfo[format].blockWidth === 1 && kTextureFormatInfo[format].blockHeight === 1
+        Math.max(baseSize.width, baseSize.height, baseSize.depthOrArrayLayers) >> level > 0,
+        () =>
+          `level (${level}) too large for base size (${baseSize.width}x${baseSize.height}x${baseSize.depthOrArrayLayers})`
+      );
+      assert(
+        kTextureFormatInfo[format].blockWidth === 1 && kTextureFormatInfo[format].blockHeight === 1,
+        'not implemented for 3d block formats'
       );
       return {
         width: Math.max(baseSize.width >> level, 1),


### PR DESCRIPTION
Since it reads only one pixel, this should use the new
getTextureSubCopyLayout instead of getTextureCopyLayout.

Tested in render_pass,resolve:render_pass_resolve tests.

Issue: another followup to #1068 and #1077

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
