### PR TITLE
color_space_conversion: use exact rational matrix formulations

### DIFF
--- a/src/webgpu/util/color_space_conversion.ts
+++ b/src/webgpu/util/color_space_conversion.ts
@@ -4,10 +4,11 @@ import { multiplyMatrices } from './math.js';
 
 // These color space conversion function definitions are copied directly from
 // CSS Color Module Level 4 Sample Code: https://drafts.csswg.org/css-color/#color-conversion-code
-// *EXCEPT* the conversion matrices are replaced with exact rational forms computed using
-// this Rust crate: https://crates.io/crates/rgb_derivation
-// as described for sRGB on this page: https://mina86.com/2019/srgb-xyz-matrix/
-// but using the numbers from the CSS spec: https://github.com/kainino0x/exact_css_xyz_matrices
+// *EXCEPT* the conversion matrices are replaced with exact rational forms computed here:
+// https://github.com/kainino0x/exact_css_xyz_matrices
+//   using this Rust crate: https://crates.io/crates/rgb_derivation
+//   as described for sRGB on this page: https://mina86.com/2019/srgb-xyz-matrix/
+//   but using the numbers from the CSS spec: https://www.w3.org/TR/css-color-4/#predefined
 
 // Sample code for color conversions
 // Conversion can also be done using ICC profiles and a Color Management System

--- a/src/webgpu/util/color_space_conversion.ts
+++ b/src/webgpu/util/color_space_conversion.ts
@@ -109,7 +109,7 @@ function gam_P3(RGB: Array<number>) {
  * using display-p3's D65 (no chromatic adaptation)
  */
 function lin_P3_to_XYZ(rgb: Array<Array<number>>) {
-  const M = [
+  const M = /* prettier-ignore */ [
     [608311 / 1250200, 189793 / 714400,  198249 / 1000160],
     [ 35783 /  156275, 247089 / 357200,  198249 / 2500400],
     [     0 /       1,  32229 / 714400, 5220557 / 5000800],
@@ -123,7 +123,7 @@ function lin_P3_to_XYZ(rgb: Array<Array<number>>) {
  * using display-p3's own white, D65 (no chromatic adaptation)
  */
 function XYZ_to_lin_P3(XYZ: Array<Array<number>>) {
-  const M = [
+  const M = /* prettier-ignore */ [
     [446124 / 178915, -333277 / 357830, -72051 / 178915],
     [-14852 /  17905,   63121 /  35810,    423 /  17905],
     [ 11844 / 330415,  -50337 / 660830, 316169 / 330415],

--- a/src/webgpu/util/color_space_conversion.ts
+++ b/src/webgpu/util/color_space_conversion.ts
@@ -4,6 +4,10 @@ import { multiplyMatrices } from './math.js';
 
 // These color space conversion function definitions are copied directly from
 // CSS Color Module Level 4 Sample Code: https://drafts.csswg.org/css-color/#color-conversion-code
+// *EXCEPT* the conversion matrices are replaced with exact rational forms computed using
+// this Rust crate: https://crates.io/crates/rgb_derivation
+// as described for sRGB on this page: https://mina86.com/2019/srgb-xyz-matrix/
+// but using the numbers from the CSS spec: https://github.com/kainino0x/exact_css_xyz_matrices
 
 // Sample code for color conversions
 // Conversion can also be done using ICC profiles and a Color Management System
@@ -59,10 +63,10 @@ function gam_sRGB(RGB: Array<number>) {
  * using sRGB's own white, D65 (no chromatic adaptation)
  */
 function lin_sRGB_to_XYZ(rgb: Array<Array<number>>) {
-  const M = [
-    [0.41239079926595934, 0.357584339383878, 0.1804807884018343],
-    [0.21263900587151027, 0.715168678767756, 0.07219231536073371],
-    [0.01933081871559182, 0.11919477979462598, 0.9505321522496607],
+  const M = /* prettier-ignore */ [
+    [506752 / 1228815,  87881 / 245763,   12673 /   70218],
+    [ 87098 /  409605, 175762 / 245763,   12673 /  175545],
+    [  7918 /  409605,  87881 / 737289, 1001167 / 1053270],
   ];
   return multiplyMatrices(M, rgb);
 }
@@ -72,10 +76,10 @@ function lin_sRGB_to_XYZ(rgb: Array<Array<number>>) {
  * using sRGB's own white, D65 (no chromatic adaptation)
  */
 function XYZ_to_lin_sRGB(XYZ: Array<Array<number>>) {
-  const M = [
-    [3.2409699419045226, -1.537383177570094, -0.4986107602930034],
-    [-0.9692436362808796, 1.8759675015077202, 0.04155505740717559],
-    [0.05563007969699366, -0.20397695888897652, 1.0569715142428786],
+  const M = /* prettier-ignore */ [
+    [  12831 /   3959,    -329 /    214, -1974 /   3959],
+    [-851781 / 878810, 1648619 / 878810, 36519 / 878810],
+    [    705 /  12673,   -2585 /  12673,   705 /    667],
   ];
 
   return multiplyMatrices(M, XYZ);
@@ -102,15 +106,13 @@ function gam_P3(RGB: Array<number>) {
 /**
  * convert an array of linear-light display-p3 values to CIE XYZ
  * using display-p3's D65 (no chromatic adaptation)
- * http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
  */
 function lin_P3_to_XYZ(rgb: Array<Array<number>>) {
   const M = [
-    [0.4865709486482162, 0.26566769316909306, 0.1982172852343625],
-    [0.2289745640697488, 0.6917385218365064, 0.079286914093745],
-    [0.0, 0.04511338185890264, 1.043944368900976],
+    [608311 / 1250200, 189793 / 714400,  198249 / 1000160],
+    [ 35783 /  156275, 247089 / 357200,  198249 / 2500400],
+    [     0 /       1,  32229 / 714400, 5220557 / 5000800],
   ];
-  // 0 was computed as -3.972075516933488e-17
 
   return multiplyMatrices(M, rgb);
 }
@@ -121,9 +123,9 @@ function lin_P3_to_XYZ(rgb: Array<Array<number>>) {
  */
 function XYZ_to_lin_P3(XYZ: Array<Array<number>>) {
   const M = [
-    [2.493496911941425, -0.9313836179191239, -0.40271078445071684],
-    [-0.8294889695615747, 1.7626640603183463, 0.023624685841943577],
-    [0.03584583024378447, -0.07617238926804182, 0.9568845240076872],
+    [446124 / 178915, -333277 / 357830, -72051 / 178915],
+    [-14852 /  17905,   63121 /  35810,    423 /  17905],
+    [ 11844 / 330415,  -50337 / 660830, 316169 / 330415],
   ];
 
   return multiplyMatrices(M, XYZ);


### PR DESCRIPTION
On a few tests, the conversion result was exactly the same down to the ULP. But these make a nice reference implementation since they can be copied to other contexts with arbitrary precisions.

Unfortunately, since the results didn't change, this didn't fix relatively large deltas I saw in the G channel of these tests (not huge, 0.0007). It's unclear whether we can fix that or if we'll keep those thresholds (in #1055).


Issue: #913

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
