### PR TITLE
Add checkbox to auto-close subtrees when they pass

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -29,6 +29,7 @@ setBaseResourcePath('../out/resources');
 
 const worker = optionEnabled('worker') ? new TestWorker(debug) : undefined;
 
+const autoCloseOnPass = document.getElementById('autoCloseOnPass') as HTMLInputElement;
 const resultsVis = document.getElementById('resultsVis')!;
 
 interface SubtreeResult {
@@ -240,6 +241,9 @@ function makeSubtreeHTML(n: TestSubtree, parentLevel: TestQueryLevel): Visualize
         status += 'fail';
       }
       div.setAttribute('data-status', status);
+      if (autoCloseOnPass.checked && status === 'pass') {
+        div.firstElementChild!.removeAttribute('open');
+      }
     };
 
     updateRenderedResult();

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -271,6 +271,7 @@
     <h1><img class="logo" src="webgpu-logo-notext.svg">WebGPU Conformance Test Suite</h1>
     <p>
       <input type=button id=expandall value="Expand All (slow!)">
+      <label><input type=checkbox id=autoCloseOnPass> Auto-close each subtree when it passes</label>
     </p>
 
     <div id="info"></div>


### PR DESCRIPTION
Small change, when a node gets turned green, this collapses it. Makes it easier to run some tests and filter down to what's failing. (Not perfect - have to have the box checked while running the tests, it doesn't apply afterward. But easier to have a tiny change.)
