### PR TITLE
Fix floating point arithmetic tests so they actually run

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -16,16 +16,20 @@ export const g = makeTestGroup(GPUTest);
 
 /* Generates an array of numbers spread over the entire range of 32-bit floats */
 function fullNumericRange(): Array<number> {
-  const numeric_range = Array<number>();
-  numeric_range.concat(biasedRange(kValue.f32.negative.max, kValue.f32.negative.min, 100));
-  numeric_range.concat(
-    linearRange(kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max, 100)
+  let numeric_range = Array<number>();
+  numeric_range = numeric_range.concat(
+    biasedRange(kValue.f32.negative.max, kValue.f32.negative.min, 50)
   );
-  numeric_range.concat(0.0);
-  numeric_range.concat(
-    linearRange(kValue.f32.subnormal.positive.min, kValue.f32.subnormal.positive.max, 100)
+  numeric_range = numeric_range.concat(
+    linearRange(kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max, 10)
   );
-  numeric_range.concat(biasedRange(kValue.f32.positive.min, kValue.f32.positive.max, 100));
+  numeric_range = numeric_range.concat(0.0);
+  numeric_range = numeric_range.concat(
+    linearRange(kValue.f32.subnormal.positive.min, kValue.f32.subnormal.positive.max, 10)
+  );
+  numeric_range = numeric_range.concat(
+    biasedRange(kValue.f32.positive.min, kValue.f32.positive.max, 50)
+  );
   return numeric_range;
 }
 

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -38,16 +38,20 @@ Accuracy: Correctly rounded
     };
 
     let cases: Array<Case> = [];
-    const numeric_range = Array<number>();
-    numeric_range.concat(biasedRange(kValue.f32.negative.max, kValue.f32.negative.min, 100));
-    numeric_range.concat(
-      linearRange(kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max, 100)
+    let numeric_range = Array<number>();
+    numeric_range = numeric_range.concat(
+      biasedRange(kValue.f32.negative.max, kValue.f32.negative.min, 50)
     );
-    numeric_range.concat(0.0);
-    numeric_range.concat(
-      linearRange(kValue.f32.subnormal.positive.min, kValue.f32.subnormal.positive.max, 100)
+    numeric_range = numeric_range.concat(
+      linearRange(kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max, 10)
     );
-    numeric_range.concat(biasedRange(kValue.f32.positive.min, kValue.f32.positive.max, 100));
+    numeric_range = numeric_range.concat(0.0);
+    numeric_range = numeric_range.concat(
+      linearRange(kValue.f32.subnormal.positive.min, kValue.f32.subnormal.positive.max, 10)
+    );
+    numeric_range = numeric_range.concat(
+      biasedRange(kValue.f32.positive.min, kValue.f32.positive.max, 10)
+    );
     numeric_range.forEach(x => {
       cases = cases.concat(makeCase(x));
     });


### PR DESCRIPTION
Previously the numeric range was actually an empty array, so no tests
of interest were being run for many cases. Also reduces the number of
entries being used to keep run time manageable.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
