### PR TITLE
Add validation,resource_usages,texture,in_render_common:* - Part III

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -125,7 +125,7 @@ g.test('subresources_from_same_texture_as_color_attachment_and_in_bind_group')
         { bindGroupViewBaseLayer: 1, bindGroupViewLayerCount: 2 },
       ])
       .combine('bindGroupUsage', ['texture', 'storage'])
-      .unless(t => t.bindGroupUsage === 'storage' && t.bindGroupViewLevelCount > 0)
+      .unless(t => t.bindGroupUsage === 'storage' && t.bindGroupViewLevelCount > 1)
       .combine('inSamePass', [true, false])
   )
   .fn(async t => {
@@ -226,6 +226,127 @@ g.test('subresources_from_same_texture_as_color_attachment_and_in_bind_group')
     const isOverlapped = isMipLevelOverlapped && isArrayLayerOverlapped;
 
     const success = inSamePass ? !isOverlapped : true;
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, !success);
+  });
+
+g.test('subresources_from_same_texture_as_depth_stencil_attachment_and_in_bind_group')
+  .desc(
+    `
+  Test that when one subresource of a texture is used as a depth stencil attachment, it cannot be
+  used in a bind group simultaneously in the same render pass encoder. It is allowed when the bind
+  group is used in another render pass encoder instead of the same one.`
+  )
+  .params(u =>
+    u
+      .combine('depthStencilAttachmentLevel', [0, 1])
+      .combine('depthStencilAttachmentLayer', [0, 1])
+      .combineWithParams([
+        { bindGroupViewBaseLevel: 0, bindGroupViewLevelCount: 1 },
+        { bindGroupViewBaseLevel: 1, bindGroupViewLevelCount: 1 },
+        { bindGroupViewBaseLevel: 1, bindGroupViewLevelCount: 2 },
+      ])
+      .combineWithParams([
+        { bindGroupViewBaseLayer: 0, bindGroupViewLayerCount: 1 },
+        { bindGroupViewBaseLayer: 1, bindGroupViewLayerCount: 1 },
+        { bindGroupViewBaseLayer: 1, bindGroupViewLayerCount: 2 },
+      ])
+      .combine('depthStencilReadOnly', [true, false])
+      .combine('bindGroupAspect', ['depth-only', 'stencil-only'] as const)
+      .combine('inSamePass', [true, false])
+  )
+  .fn(async t => {
+    const {
+      depthStencilAttachmentLevel,
+      depthStencilAttachmentLayer,
+      bindGroupViewBaseLevel,
+      bindGroupViewLevelCount,
+      bindGroupViewBaseLayer,
+      bindGroupViewLayerCount,
+      depthStencilReadOnly,
+      bindGroupAspect,
+      inSamePass,
+    } = t.params;
+
+    const viewDimension = bindGroupViewLayerCount > 1 ? '2d-array' : '2d';
+    const bindGroupLayoutEntry: GPUBindGroupLayoutEntry = {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension, sampleType: bindGroupAspect === 'depth-only' ? 'depth' : 'uint' },
+    };
+    const texture = t.device.createTexture({
+      format: 'depth24plus-stencil8',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+      size: [kTextureSize, kTextureSize, kTextureLayers],
+      mipLevelCount: kTextureLevels,
+    });
+    const bindGroupView = texture.createView({
+      dimension: bindGroupViewLayerCount > 1 ? '2d-array' : '2d',
+      baseArrayLayer: bindGroupViewBaseLayer,
+      arrayLayerCount: bindGroupViewLayerCount,
+      baseMipLevel: bindGroupViewBaseLevel,
+      mipLevelCount: bindGroupViewLevelCount,
+      aspect: bindGroupAspect,
+    });
+    const bindGroupLayout = t.device.createBindGroupLayout({
+      entries: [bindGroupLayoutEntry],
+    });
+    const bindGroup = t.device.createBindGroup({
+      layout: bindGroupLayout,
+      entries: [{ binding: 0, resource: bindGroupView }],
+    });
+
+    const attachmentView = texture.createView({
+      baseArrayLayer: depthStencilAttachmentLayer,
+      arrayLayerCount: 1,
+      baseMipLevel: depthStencilAttachmentLevel,
+      mipLevelCount: 1,
+    });
+    const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
+      view: attachmentView,
+      depthReadOnly: depthStencilReadOnly,
+      depthLoadOp: 'load',
+      depthStoreOp: 'store',
+      stencilReadOnly: depthStencilReadOnly,
+      stencilLoadOp: 'load',
+      stencilStoreOp: 'store',
+    };
+
+    const encoder = t.device.createCommandEncoder();
+    const renderPass = encoder.beginRenderPass({
+      colorAttachments: [],
+      depthStencilAttachment,
+    });
+    if (inSamePass) {
+      renderPass.setBindGroup(0, bindGroup);
+      renderPass.end();
+    } else {
+      renderPass.end();
+
+      const texture2 = t.device.createTexture({
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        size: [kTextureSize, kTextureSize, 1],
+        mipLevelCount: 1,
+      });
+      const colorAttachment2 = t.getColorAttachment(texture2);
+      const renderPass2 = encoder.beginRenderPass({
+        colorAttachments: [colorAttachment2],
+      });
+      renderPass2.setBindGroup(0, bindGroup);
+      renderPass2.end();
+    }
+
+    const isMipLevelOverlapped =
+      depthStencilAttachmentLevel >= bindGroupViewBaseLevel &&
+      depthStencilAttachmentLevel < bindGroupViewBaseLevel + bindGroupViewLevelCount;
+    const isArrayLayerOverlapped =
+      depthStencilAttachmentLayer >= bindGroupViewBaseLayer &&
+      depthStencilAttachmentLayer < bindGroupViewBaseLayer + bindGroupViewLayerCount;
+    const isOverlapped = isMipLevelOverlapped && isArrayLayerOverlapped;
+
+    const success = !inSamePass || !isOverlapped || depthStencilReadOnly;
     t.expectValidationError(() => {
       encoder.finish();
     }, !success);

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -145,17 +145,16 @@ g.test('subresources_from_same_texture_as_color_attachment_and_in_bind_group')
       visibility: GPUShaderStage.FRAGMENT,
     };
     let textureUsage = GPUTextureUsage.RENDER_ATTACHMENT;
-    const viewDimension = bindGroupViewLayerCount > 1 ? '2d-array' : '2d';
     switch (bindGroupUsage) {
       case 'texture':
-        bindGroupLayoutEntry.texture = { viewDimension };
+        bindGroupLayoutEntry.texture = { viewDimension: '2d-array' };
         textureUsage |= GPUTextureUsage.TEXTURE_BINDING;
         break;
       case 'storage':
         bindGroupLayoutEntry.storageTexture = {
           access: 'write-only',
           format: 'rgba8unorm',
-          viewDimension,
+          viewDimension: '2d-array',
         };
         textureUsage |= GPUTextureUsage.STORAGE_BINDING;
         break;
@@ -171,7 +170,7 @@ g.test('subresources_from_same_texture_as_color_attachment_and_in_bind_group')
       mipLevelCount: kTextureLevels,
     });
     const bindGroupView = texture.createView({
-      dimension: bindGroupViewLayerCount > 1 ? '2d-array' : '2d',
+      dimension: '2d-array',
       baseArrayLayer: bindGroupViewBaseLayer,
       arrayLayerCount: bindGroupViewLayerCount,
       baseMipLevel: bindGroupViewBaseLevel,
@@ -269,12 +268,14 @@ g.test('subresources_from_same_texture_as_depth_stencil_attachment_and_in_bind_g
       inSamePass,
     } = t.params;
 
-    const viewDimension = bindGroupViewLayerCount > 1 ? '2d-array' : '2d';
-    const bindGroupLayoutEntry: GPUBindGroupLayoutEntry = {
+    const bindGroupLayoutEntry = {
       binding: 0,
       visibility: GPUShaderStage.FRAGMENT,
-      texture: { viewDimension, sampleType: bindGroupAspect === 'depth-only' ? 'depth' : 'uint' },
-    };
+      texture: {
+        viewDimension: '2d-array',
+        sampleType: bindGroupAspect === 'depth-only' ? 'depth' : 'uint',
+      },
+    } as const;
     const texture = t.device.createTexture({
       format: 'depth24plus-stencil8',
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
@@ -282,7 +283,7 @@ g.test('subresources_from_same_texture_as_depth_stencil_attachment_and_in_bind_g
       mipLevelCount: kTextureLevels,
     });
     const bindGroupView = texture.createView({
-      dimension: bindGroupViewLayerCount > 1 ? '2d-array' : '2d',
+      dimension: '2d-array',
       baseArrayLayer: bindGroupViewBaseLayer,
       arrayLayerCount: bindGroupViewLayerCount,
       baseMipLevel: bindGroupViewBaseLevel,


### PR DESCRIPTION
Issue: #905

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
