### PR TITLE
Implements remaining device.destroy validation tests.

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -165,7 +165,7 @@ export function* iterRange<T>(n: number, fn: (i: number) => T): Iterable<T> {
   }
 }
 
-const TypedArrayBufferViewTypes = [
+const TypedArrayBufferViewInstances = [
   new Uint8Array(),
   new Uint8ClampedArray(),
   new Uint16Array(),
@@ -177,7 +177,7 @@ const TypedArrayBufferViewTypes = [
   new Float64Array(),
 ] as const;
 
-export type TypedArrayBufferView = typeof TypedArrayBufferViewTypes[number];
+export type TypedArrayBufferView = typeof TypedArrayBufferViewInstances[number];
 
 export type TypedArrayBufferViewConstructor<
   A extends TypedArrayBufferView = TypedArrayBufferView
@@ -206,7 +206,7 @@ export const kTypedArrayBufferViews: {
   ...(() => {
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
     const result: { [k: string]: any } = {};
-    for (const v of TypedArrayBufferViewTypes) {
+    for (const v of TypedArrayBufferViewInstances) {
       result[v.constructor.name] = v.constructor;
     }
     return result;

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -1,5 +1,6 @@
 import { Logger } from '../internal/logging/logger.js';
 
+import { keysOf } from './data_tables.js';
 import { timeout } from './timeout.js';
 
 /**
@@ -164,16 +165,19 @@ export function* iterRange<T>(n: number, fn: (i: number) => T): Iterable<T> {
   }
 }
 
-export type TypedArrayBufferView =
-  | Uint8Array
-  | Uint8ClampedArray
-  | Uint16Array
-  | Uint32Array
-  | Int8Array
-  | Int16Array
-  | Int32Array
-  | Float32Array
-  | Float64Array;
+const TypedArrayBufferViewTypes = [
+  new Uint8Array(),
+  new Uint8ClampedArray(),
+  new Uint16Array(),
+  new Uint32Array(),
+  new Int8Array(),
+  new Int16Array(),
+  new Int32Array(),
+  new Float32Array(),
+  new Float64Array(),
+] as const;
+
+export type TypedArrayBufferView = typeof TypedArrayBufferViewTypes[number];
 
 export type TypedArrayBufferViewConstructor<
   A extends TypedArrayBufferView = TypedArrayBufferView
@@ -195,6 +199,21 @@ export type TypedArrayBufferViewConstructor<
   from<T>(arrayLike: ArrayLike<T>, mapfn: (v: T, k: number) => number, thisArg?: any): A;
   of(...items: number[]): A;
 };
+
+export const kTypedArrayBufferViews: {
+  readonly [k: string]: TypedArrayBufferViewConstructor;
+} = {
+  ...(() => {
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    const result: { [k: string]: any } = {};
+    for (const v of TypedArrayBufferViewTypes) {
+      result[v.constructor.name] = v.constructor;
+    }
+    return result;
+  })(),
+};
+export const kTypedArrayBufferViewKeys = keysOf(kTypedArrayBufferViews);
+export const kTypedArrayBufferViewConstructors = Object.values(kTypedArrayBufferViews);
 
 function subarrayAsU8(
   buf: ArrayBuffer | TypedArrayBufferView,

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -13,10 +13,12 @@ import {
 } from '../../../../capability_info.js';
 import { kResourceStates } from '../../../../gpu_test.js';
 import {
-  canvasTypes,
+  CanvasType,
+  canCopyFromCanvasContext,
   createCanvas,
   createOnscreenCanvas,
   createOffscreenCanvas,
+  kValidCanvasContextIds,
 } from '../../../../util/create_elements.js';
 import { ValidationTest } from '../../validation_test.js';
 
@@ -25,11 +27,6 @@ const kDefaultWidth = 32;
 const kDefaultHeight = 32;
 const kDefaultDepth = 1;
 const kDefaultMipLevelCount = 6;
-
-/** Valid contextId for HTMLCanvasElement/OffscreenCanvas,
- *  spec: https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext
- */
-export const kValidContextId = ['2d', 'bitmaprenderer', 'webgl', 'webgl2', 'webgpu'] as const;
 
 function computeMipMapSize(width: number, height: number, mipLevel: number) {
   return {
@@ -123,18 +120,6 @@ function generateCopySizeForDstOOB({ mipLevel, dstOrigin }: WithDstOriginMipLeve
   ];
 }
 
-function canCopyFromContextType(contextName: string) {
-  switch (contextName) {
-    case '2d':
-    case 'webgl':
-    case 'webgl2':
-    case 'webgpu':
-      return true;
-    default:
-      return false;
-  }
-}
-
 class CopyExternalImageToTextureTest extends ValidationTest {
   getImageData(width: number, height: number): ImageData {
     const pixelSize = kDefaultBytesPerPixel * width * height;
@@ -143,7 +128,7 @@ class CopyExternalImageToTextureTest extends ValidationTest {
   }
 
   getCanvasWithContent(
-    canvasType: canvasTypes,
+    canvasType: CanvasType,
     width: number,
     height: number,
     content: HTMLImageElement | HTMLCanvasElement | OffscreenCanvas | ImageBitmap
@@ -201,7 +186,7 @@ g.test('source_canvas,contexts')
   )
   .params(u =>
     u //
-      .combine('contextType', kValidContextId)
+      .combine('contextType', kValidCanvasContextIds)
       .beginSubcases()
       .combine('copySize', [
         { width: 0, height: 0, depthOrArrayLayers: 0 },
@@ -229,7 +214,7 @@ g.test('source_canvas,contexts')
       { texture: dstTexture },
       copySize,
       true, // No validation errors.
-      canCopyFromContextType(contextType) ? '' : 'OperationError'
+      canCopyFromCanvasContext(contextType) ? '' : 'OperationError'
     );
   });
 
@@ -246,7 +231,7 @@ g.test('source_offscreenCanvas,contexts')
   )
   .params(u =>
     u //
-      .combine('contextType', kValidContextId)
+      .combine('contextType', kValidCanvasContextIds)
       .beginSubcases()
       .combine('copySize', [
         { width: 0, height: 0, depthOrArrayLayers: 0 },
@@ -277,7 +262,7 @@ g.test('source_offscreenCanvas,contexts')
       { texture: dstTexture },
       copySize,
       true, // No validation errors.
-      canCopyFromContextType(contextType) ? '' : 'OperationError'
+      canCopyFromCanvasContext(contextType) ? '' : 'OperationError'
     );
   });
 

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -7,6 +7,7 @@ Note: buffer map state is tested in ./buffer_mapped.spec.ts.
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import {
+  kTypedArrayBufferViewConstructors,
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
 } from '../../../../common/util/util.js';
@@ -117,21 +118,9 @@ Also verifies that the specified data range:
       t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, arraySm, undefined, 12));
     }
 
-    const arrayTypes = [
-      Uint8Array,
-      Uint8ClampedArray,
-      Int8Array,
-      Uint16Array,
-      Int16Array,
-      Uint32Array,
-      Int32Array,
-      Float32Array,
-      Float64Array,
-    ];
-
     runTest(Uint8Array, true);
 
-    for (const arrayType of arrayTypes) {
+    for (const arrayType of kTypedArrayBufferViewConstructors) {
       runTest(arrayType, false);
     }
   });

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -6,10 +6,6 @@ Tests for device lost induced via destroy.
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import {
-  kTypedArrayBufferViewKeys,
-  kTypedArrayBufferViews,
-} from '../../../../../common/util/util.js';
-import {
   allBindingEntries,
   bindingTypeInfo,
   kBindableResources,
@@ -794,22 +790,15 @@ Tests writeBuffer on queue on destroyed device.
   `
   )
   .params(u =>
-    u
-      .combine('arrayType', kTypedArrayBufferViewKeys)
-      .beginSubcases()
-      .combine('numElements', [4, 8, 16])
-      .combine('awaitLost', [true, false])
+    u.combine('numElements', [4, 8, 16]).beginSubcases().combine('awaitLost', [true, false])
   )
   .fn(async t => {
-    const { arrayType, numElements, awaitLost } = t.params;
-    const array = kTypedArrayBufferViews[arrayType];
-    const elementSize = array.BYTES_PER_ELEMENT;
-    const bufferSize = numElements * elementSize;
+    const { numElements, awaitLost } = t.params;
     const buffer = t.device.createBuffer({
-      size: bufferSize,
+      size: numElements,
       usage: GPUBufferUsage.COPY_DST,
     });
-    const data = new array(numElements);
+    const data = new Uint8Array(numElements);
     await t.executeAfterDestroy(() => {
       t.device.queue.writeBuffer(buffer, 0, data);
     }, awaitLost);

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -6,6 +6,10 @@ Tests for device lost induced via destroy.
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import {
+  kTypedArrayBufferViewKeys,
+  kTypedArrayBufferViews,
+} from '../../../../../common/util/util.js';
+import {
   allBindingEntries,
   bindingTypeInfo,
   kBindableResources,
@@ -14,6 +18,7 @@ import {
   kBufferUsageCopy,
   kBufferUsageCopyInfo,
   kCompressedTextureFormats,
+  kQueryTypes,
   kTextureUsageType,
   kTextureUsageTypeInfo,
   kTextureUsageCopy,
@@ -22,9 +27,18 @@ import {
   kRenderableColorTextureFormats,
   kShaderStageKeys,
   kTextureFormatInfo,
-  kQueryTypes,
 } from '../../../../capability_info.js';
+import { CommandBufferMaker, EncoderType } from '../../../../util/command_buffer_maker.js';
+import {
+  canCopyFromCanvasContext,
+  createCanvas,
+  kAllCanvasTypes,
+  kValidCanvasContextIds,
+} from '../../../../util/create_elements.js';
 import { ValidationTest } from '../../validation_test.js';
+
+const kCommandValidationStages = ['finish', 'submit'];
+type CommandValidationStage = typeof kCommandValidationStages[number];
 
 class DeviceDestroyTests extends ValidationTest {
   /**
@@ -42,6 +56,46 @@ class DeviceDestroyTests extends ValidationTest {
       this.expect(lostInfo.reason === 'destroyed');
     }
     fn();
+  }
+
+  /**
+   * Expects that encoders can finish and submit the resulting commands before the device is
+   * destroyed, then repeats the same process after the device is destroyed without any specific
+   * expectations.
+   * There are two valid stages: 'finish' and 'submit'.
+   *   'finish': Tests [encode, finish] and [encoder, destroy, finish]
+   *   'submit': Tests [encoder, finish, submit] and [encoder, finish, destroy, submit]
+   */
+  async executeCommandsAfterDestroy<T extends EncoderType>(
+    stage: CommandValidationStage,
+    awaitLost: boolean,
+    encoderType: T,
+    fn: (maker: CommandBufferMaker<T>) => CommandBufferMaker<T>
+  ): Promise<void> {
+    this.expectDeviceLost('destroyed');
+
+    switch (stage) {
+      case 'finish': {
+        // Control case
+        fn(this.createEncoder(encoderType)).validateFinish(true);
+        // Validation case
+        const encoder = fn(this.createEncoder(encoderType));
+        await this.executeAfterDestroy(() => {
+          encoder.finish();
+        }, awaitLost);
+        break;
+      }
+      case 'submit': {
+        // Control case
+        fn(this.createEncoder(encoderType)).validateFinishAndSubmit(true, true);
+        // Validation case
+        const commands = fn(this.createEncoder(encoderType)).validateFinish(true);
+        await this.executeAfterDestroy(() => {
+          this.queue.submit([commands]);
+        }, awaitLost);
+        break;
+      }
+    }
   }
 }
 
@@ -443,126 +497,446 @@ Tests creating query sets on destroyed device.
 g.test('command,copyBufferToBuffer')
   .desc(
     `
-Tests copyBufferToBuffer command on destroyed device fails.
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+Tests copyBufferToBuffer command with various uncompressed formats on destroyed device.
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.beginSubcases().combine('stage', kCommandValidationStages).combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { stage, awaitLost } = t.params;
+    const kBufferSize = 16;
+    const src = t.device.createBuffer({
+      size: kBufferSize,
+      usage: GPUBufferUsage.COPY_SRC,
+    });
+    const dst = t.device.createBuffer({
+      size: kBufferSize,
+      usage: GPUBufferUsage.COPY_DST,
+    });
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'non-pass', maker => {
+      maker.encoder.copyBufferToBuffer(src, 0, dst, 0, kBufferSize);
+      return maker;
+    });
+  });
 
 g.test('command,copyBufferToTexture')
   .desc(
     `
-Tests copyBufferToTexture command on destroyed device fails.
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+Tests copyBufferToTexture command on destroyed device.
+  - Tests finishing encoding on destroyed device
+  - Tests submitting command on destroyed device
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.beginSubcases().combine('stage', kCommandValidationStages).combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { stage, awaitLost } = t.params;
+    const format = 'rgba32uint';
+    const { bytesPerBlock, blockWidth, blockHeight } = kTextureFormatInfo[format];
+    const src = {
+      buffer: t.device.createBuffer({
+        size: bytesPerBlock,
+        usage: GPUBufferUsage.COPY_SRC,
+      }),
+    };
+    const dst = {
+      texture: t.device.createTexture({
+        size: { width: blockWidth, height: blockHeight },
+        usage: GPUTextureUsage.COPY_DST,
+        format,
+      }),
+    };
+    const copySize = { width: blockWidth, height: blockHeight };
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'non-pass', maker => {
+      maker.encoder.copyBufferToTexture(src, dst, copySize);
+      return maker;
+    });
+  });
 
 g.test('command,copyTextureToBuffer')
   .desc(
     `
-Tests copyTextureToBuffer command on destroyed device fails.
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+Tests copyTextureToBuffer command on destroyed device.
+  - Tests finishing encoding on destroyed device
+  - Tests submitting command on destroyed device
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.beginSubcases().combine('stage', kCommandValidationStages).combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { stage, awaitLost } = t.params;
+    const format = 'rgba32uint';
+    const { bytesPerBlock, blockWidth, blockHeight } = kTextureFormatInfo[format];
+    const src = {
+      texture: t.device.createTexture({
+        size: { width: blockWidth, height: blockHeight },
+        usage: GPUTextureUsage.COPY_SRC,
+        format,
+      }),
+    };
+    const dst = {
+      buffer: t.device.createBuffer({
+        size: bytesPerBlock,
+        usage: GPUBufferUsage.COPY_DST,
+      }),
+    };
+    const copySize = { width: blockWidth, height: blockHeight };
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'non-pass', maker => {
+      maker.encoder.copyTextureToBuffer(src, dst, copySize);
+      return maker;
+    });
+  });
 
 g.test('command,copyTextureToTexture')
   .desc(
     `
-Tests copyTextureToTexture command on destroyed device fails.
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+Tests copyTextureToTexture command on destroyed device.
+  - Tests finishing encoding on destroyed device
+  - Tests submitting command on destroyed device
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.beginSubcases().combine('stage', kCommandValidationStages).combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { stage, awaitLost } = t.params;
+    const format = 'rgba32uint';
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
+    const src = {
+      texture: t.device.createTexture({
+        size: { width: blockWidth, height: blockHeight },
+        usage: GPUTextureUsage.COPY_SRC,
+        format,
+      }),
+    };
+    const dst = {
+      texture: t.device.createTexture({
+        size: { width: blockWidth, height: blockHeight },
+        usage: GPUBufferUsage.COPY_DST,
+        format,
+      }),
+    };
+    const copySize = { width: blockWidth, height: blockHeight };
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'non-pass', maker => {
+      maker.encoder.copyTextureToTexture(src, dst, copySize);
+      return maker;
+    });
+  });
 
 g.test('command,clearBuffer')
   .desc(
     `
-Tests encoding and finishing a clearBuffer command on destroyed device fails.
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+Tests encoding and finishing a clearBuffer command on destroyed device.
+  - Tests finishing encoding on destroyed device
+  - Tests submitting command on destroyed device
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.beginSubcases().combine('stage', kCommandValidationStages).combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { stage, awaitLost } = t.params;
+    const kBufferSize = 16;
+    const buffer = t.device.createBuffer({
+      size: kBufferSize,
+      usage: GPUBufferUsage.COPY_SRC,
+    });
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'non-pass', maker => {
+      maker.encoder.clearBuffer(buffer, 0, kBufferSize);
+      return maker;
+    });
+  });
 
 g.test('command,writeTimestamp')
   .desc(
     `
-Tests encoding and finishing a writeTimestamp command on destroyed device fails.
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+Tests encoding and finishing a writeTimestamp command on destroyed device.
+  - Tests finishing encoding on destroyed device
+  - Tests submitting command on destroyed device
   `
   )
-  .unimplemented();
+  .params(u =>
+    u
+      .combine('type', kQueryTypes)
+      .beginSubcases()
+      .combine('stage', kCommandValidationStages)
+      .combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { type, stage, awaitLost } = t.params;
+    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
+    const querySet = t.device.createQuerySet({ type, count: 2 });
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'non-pass', maker => {
+      maker.encoder.writeTimestamp(querySet, 0);
+      return maker;
+    });
+  });
 
 g.test('command,resolveQuerySet')
   .desc(
     `
-Tests encoding and finishing a resolveQuerySet command on destroyed device fails.
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+Tests encoding and finishing a resolveQuerySet command on destroyed device.
+  - Tests finishing encoding on destroyed device
+  - Tests submitting command on destroyed device
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.beginSubcases().combine('stage', kCommandValidationStages).combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { stage, awaitLost } = t.params;
+    const kQueryCount = 2;
+    const querySet = t.createQuerySetWithState('valid');
+    const destination = t.createBufferWithState('valid', {
+      size: kQueryCount * 8,
+      usage: GPUBufferUsage.QUERY_RESOLVE,
+    });
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'non-pass', maker => {
+      maker.encoder.resolveQuerySet(querySet, 0, 1, destination, 0);
+      return maker;
+    });
+  });
 
 g.test('command,computePass,dispatch')
   .desc(
     `
-Tests encoding and dispatching a simple valid compute pass on destroyed device fails.
+Tests encoding and dispatching a simple valid compute pass on destroyed device.
   - Binds valid pipeline and bindgroups, then dispatches
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+  - Tests finishing encoding on destroyed device
+  - Tests submitting command on destroyed device
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.beginSubcases().combine('stage', kCommandValidationStages).combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { stage, awaitLost } = t.params;
+    const cShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('COMPUTE') });
+    const pipeline = t.device.createComputePipeline({
+      compute: { module: cShader, entryPoint: 'main' },
+    });
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'compute pass', maker => {
+      maker.encoder.setPipeline(pipeline);
+      maker.encoder.dispatch(1);
+      return maker;
+    });
+  });
 
 g.test('command,renderPass,draw')
   .desc(
     `
-Tests encoding and finishing a simple valid render pass on destroyed device fails.
+Tests encoding and finishing a simple valid render pass on destroyed device.
   - Binds valid pipeline and bindgroups, then draws
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+  - Tests finishing encoding on destroyed device
+  - Tests submitting command on destroyed device
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.beginSubcases().combine('stage', kCommandValidationStages).combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { stage, awaitLost } = t.params;
+    const vShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('VERTEX') });
+    const fShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('FRAGMENT') });
+    const pipeline = t.device.createRenderPipeline({
+      vertex: { module: vShader, entryPoint: 'main' },
+      fragment: {
+        module: fShader,
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm', writeMask: 0 }],
+      },
+    });
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'render pass', maker => {
+      maker.encoder.setPipeline(pipeline);
+      maker.encoder.draw(0);
+      return maker;
+    });
+  });
 
 g.test('command,renderPass,renderBundle')
   .desc(
     `
-Tests encoding and drawing a render pass including a render bundle on destroyed device fails.
+Tests encoding and drawing a render pass including a render bundle on destroyed device.
   - Binds valid pipeline and bindgroups, executes render bundle, then draws
-  - Tests that finishing encoding fails on destroyed device
-  - Tests that submitting command fails on destroyed device
+  - Tests finishing encoding on destroyed device
+  - Tests submitting command on destroyed device
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.beginSubcases().combine('stage', kCommandValidationStages).combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { stage, awaitLost } = t.params;
+    const vShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('VERTEX') });
+    const fShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('FRAGMENT') });
+    const pipeline = t.device.createRenderPipeline({
+      vertex: { module: vShader, entryPoint: 'main' },
+      fragment: {
+        module: fShader,
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm', writeMask: 0 }],
+      },
+    });
+    await t.executeCommandsAfterDestroy(stage, awaitLost, 'render bundle', maker => {
+      maker.encoder.setPipeline(pipeline);
+      maker.encoder.draw(0);
+      return maker;
+    });
+  });
 
 g.test('queue,writeBuffer')
   .desc(
     `
-Tests writeBuffer on queue on destroyed device fails.
+Tests writeBuffer on queue on destroyed device.
   `
   )
-  .unimplemented();
+  .params(u =>
+    u
+      .combine('arrayType', kTypedArrayBufferViewKeys)
+      .beginSubcases()
+      .combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { arrayType, awaitLost } = t.params;
+    const kNumElements = 16;
+    const array = kTypedArrayBufferViews[arrayType];
+    const elementSize = array.BYTES_PER_ELEMENT;
+    const bufferSize = kNumElements * elementSize;
+    const buffer = t.device.createBuffer({
+      size: bufferSize,
+      usage: GPUBufferUsage.COPY_DST,
+    });
+    const data = new array(kNumElements);
+    await t.executeAfterDestroy(() => {
+      t.device.queue.writeBuffer(buffer, 0, data);
+    }, awaitLost);
+  });
 
-g.test('queue,writeTexture')
+g.test('queue,writeTexture,2d,uncompressed_format')
   .desc(
     `
-Tests writeTexture on queue on destroyed device fails.
+Tests writeTexture on queue on destroyed device with uncompressed formats.
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.combine('format', kRegularTextureFormats).beginSubcases().combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { format, awaitLost } = t.params;
+    const { blockWidth, blockHeight, bytesPerBlock } = kTextureFormatInfo[format];
+    const data = new Uint8Array(bytesPerBlock);
+    const texture = t.device.createTexture({
+      size: { width: blockWidth, height: blockHeight },
+      usage: GPUTextureUsage.COPY_DST,
+      format,
+    });
+    await t.executeAfterDestroy(() => {
+      t.device.queue.writeTexture(
+        { texture },
+        data,
+        {},
+        { width: blockWidth, height: blockHeight }
+      );
+    }, awaitLost);
+  });
 
-g.test('queue,copyExternalImageToTexture')
+g.test('queue,writeTexture,2d,compressed_format')
   .desc(
     `
-Tests copyExternalImageToTexture on queue on destroyed device fails.
+Tests writeTexture on queue on destroyed device with compressed formats.
   `
   )
-  .unimplemented();
+  .params(u =>
+    u
+      .combine('format', kCompressedTextureFormats)
+      .beginSubcases()
+      .combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { format, awaitLost } = t.params;
+    const { blockWidth, blockHeight, bytesPerBlock, feature } = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(feature);
+    const data = new Uint8Array(bytesPerBlock);
+    const texture = t.device.createTexture({
+      size: { width: blockWidth, height: blockHeight },
+      usage: GPUTextureUsage.COPY_DST,
+      format,
+    });
+    await t.executeAfterDestroy(() => {
+      t.device.queue.writeTexture(
+        { texture },
+        data,
+        {},
+        { width: blockWidth, height: blockHeight }
+      );
+    }, awaitLost);
+  });
+
+g.test('queue,copyExternalImageToTexture,canvas')
+  .desc(
+    `
+Tests copyExternalImageToTexture from canvas on queue on destroyed device.
+  `
+  )
+  .params(u =>
+    u
+      .combine('canvasType', kAllCanvasTypes)
+      .combine('contextType', kValidCanvasContextIds)
+      .filter(({ contextType }) => {
+        return canCopyFromCanvasContext(contextType);
+      })
+      .beginSubcases()
+      .combine('awaitLost', [true, false])
+  )
+  .fn(async t => {
+    const { canvasType, contextType, awaitLost } = t.params;
+    const canvas = createCanvas(t, canvasType, 1, 1);
+    const texture = t.device.createTexture({
+      size: { width: 1, height: 1 },
+      format: 'bgra8unorm',
+      usage: GPUTextureUsage.COPY_DST,
+    });
+
+    const ctx = ((canvas as unknown) as HTMLCanvasElement).getContext(contextType);
+    if (ctx === null) {
+      t.skip('Failed to get context for canvas element');
+      return;
+    }
+    t.tryTrackForCleanup(ctx);
+
+    await t.executeAfterDestroy(() => {
+      t.device.queue.copyExternalImageToTexture(
+        { source: canvas },
+        { texture },
+        { width: 1, height: 1 }
+      );
+    }, awaitLost);
+  });
+
+g.test('queue,copyExternalImageToTexture,imageBitmap')
+  .desc(
+    `
+Tests copyExternalImageToTexture from canvas on queue on destroyed device.
+  `
+  )
+  .params(u => u.beginSubcases().combine('awaitLost', [true, false]))
+  .fn(async t => {
+    const { awaitLost } = t.params;
+    const imageBitmap = await createImageBitmap(new ImageData(new Uint8ClampedArray(4), 1, 1));
+    const texture = t.device.createTexture({
+      size: { width: 1, height: 1 },
+      format: 'bgra8unorm',
+      usage: GPUTextureUsage.COPY_DST,
+    });
+
+    await t.executeAfterDestroy(() => {
+      t.device.queue.copyExternalImageToTexture(
+        { source: imageBitmap },
+        { texture },
+        { width: 1, height: 1 }
+      );
+    }, awaitLost);
+  });

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -797,19 +797,19 @@ Tests writeBuffer on queue on destroyed device.
     u
       .combine('arrayType', kTypedArrayBufferViewKeys)
       .beginSubcases()
+      .combine('numElements', [4, 8, 16])
       .combine('awaitLost', [true, false])
   )
   .fn(async t => {
-    const { arrayType, awaitLost } = t.params;
-    const kNumElements = 16;
+    const { arrayType, numElements, awaitLost } = t.params;
     const array = kTypedArrayBufferViews[arrayType];
     const elementSize = array.BYTES_PER_ELEMENT;
-    const bufferSize = kNumElements * elementSize;
+    const bufferSize = numElements * elementSize;
     const buffer = t.device.createBuffer({
       size: bufferSize,
       usage: GPUBufferUsage.COPY_DST,
     });
-    const data = new array(kNumElements);
+    const data = new array(numElements);
     await t.executeAfterDestroy(() => {
       t.device.queue.writeBuffer(buffer, 0, data);
     }, awaitLost);

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -918,30 +918,27 @@ export class GPUTest extends Fixture {
       case 'non-pass': {
         const encoder = this.device.createCommandEncoder();
 
-        return new CommandBufferMaker(this, encoder, (shouldSucceed: boolean) =>
-          this.expectGPUError('validation', () => encoder.finish(), !shouldSucceed)
-        );
+        return new CommandBufferMaker(this, encoder, () => {
+          return encoder.finish();
+        });
       }
       case 'render bundle': {
         const device = this.device;
         const rbEncoder = device.createRenderBundleEncoder(fullAttachmentInfo);
         const pass = this.createEncoder('render pass', { attachmentInfo });
 
-        return new CommandBufferMaker(this, rbEncoder, (shouldSucceed: boolean) => {
-          // If !shouldSucceed, the resulting bundle should be invalid.
-          const rb = this.expectGPUError('validation', () => rbEncoder.finish(), !shouldSucceed);
-          pass.encoder.executeBundles([rb]);
-          // Then, the pass should also be invalid if the bundle was invalid.
-          return pass.validateFinish(shouldSucceed);
+        return new CommandBufferMaker(this, rbEncoder, () => {
+          pass.encoder.executeBundles([rbEncoder.finish()]);
+          return pass.finish();
         });
       }
       case 'compute pass': {
         const commandEncoder = this.device.createCommandEncoder();
         const encoder = commandEncoder.beginComputePass();
 
-        return new CommandBufferMaker(this, encoder, (shouldSucceed: boolean) => {
+        return new CommandBufferMaker(this, encoder, () => {
           encoder.end();
-          return this.expectGPUError('validation', () => commandEncoder.finish(), !shouldSucceed);
+          return commandEncoder.finish();
         });
       }
       case 'render pass': {
@@ -992,9 +989,9 @@ export class GPUTest extends Fixture {
 
         const commandEncoder = this.device.createCommandEncoder();
         const encoder = commandEncoder.beginRenderPass(passDesc);
-        return new CommandBufferMaker(this, encoder, (shouldSucceed: boolean) => {
+        return new CommandBufferMaker(this, encoder, () => {
           encoder.end();
-          return this.expectGPUError('validation', () => commandEncoder.finish(), !shouldSucceed);
+          return commandEncoder.finish();
         });
       }
     }

--- a/src/webgpu/util/create_elements.ts
+++ b/src/webgpu/util/create_elements.ts
@@ -1,8 +1,33 @@
 import { Fixture } from '../../common/framework/fixture.js';
 import { unreachable } from '../../common/util/util.js';
 
-export const allCanvasTypes = ['onscreen', 'offscreen'] as const;
-export type canvasTypes = 'onscreen' | 'offscreen';
+export const kAllCanvasTypes = ['onscreen', 'offscreen'] as const;
+export type CanvasType = typeof kAllCanvasTypes[number];
+
+/** Valid contextId for HTMLCanvasElement/OffscreenCanvas,
+ *  spec: https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext
+ */
+export const kValidCanvasContextIds = [
+  '2d',
+  'bitmaprenderer',
+  'webgl',
+  'webgl2',
+  'webgpu',
+] as const;
+export type CanvasContext = typeof kValidCanvasContextIds[number];
+
+/** Helper(s) to determine if context is copyable. */
+export function canCopyFromCanvasContext(contextName: CanvasContext) {
+  switch (contextName) {
+    case '2d':
+    case 'webgl':
+    case 'webgl2':
+    case 'webgpu':
+      return true;
+    default:
+      return false;
+  }
+}
 
 /** Create HTMLCanvas/OffscreenCanvas. */
 export function createCanvas(

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -8,8 +8,8 @@ import { kCanvasTextureFormats } from '../../capability_info.js';
 import { GPUTest } from '../../gpu_test.js';
 import { checkElementsEqual } from '../../util/check_contents.js';
 import {
-  allCanvasTypes,
-  canvasTypes,
+  kAllCanvasTypes,
+  CanvasType,
   createCanvas,
   createOnscreenCanvas,
 } from '../../util/create_elements.js';
@@ -40,7 +40,7 @@ const webglExpect = /* prettier-ignore */ new Uint8ClampedArray([
 async function initCanvasContent(
   t: GPUTest,
   format: GPUTextureFormat,
-  canvasType: canvasTypes
+  canvasType: CanvasType
 ): Promise<HTMLCanvasElement | OffscreenCanvas> {
   const canvas = createCanvas(t, canvasType, 2, 2);
   const ctx = canvas.getContext('webgpu');
@@ -280,8 +280,8 @@ g.test('drawTo2DCanvas')
   .params(u =>
     u //
       .combine('format', kCanvasTextureFormats)
-      .combine('webgpuCanvasType', allCanvasTypes)
-      .combine('canvas2DType', allCanvasTypes)
+      .combine('webgpuCanvasType', kAllCanvasTypes)
+      .combine('canvas2DType', kAllCanvasTypes)
   )
   .fn(async t => {
     const { format, webgpuCanvasType, canvas2DType } = t.params;

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -13,7 +13,7 @@ import {
   kValidTextureFormatsForCopyE2T,
 } from '../../capability_info.js';
 import { CopyToTextureUtils } from '../../util/copy_to_texture.js';
-import { canvasTypes, allCanvasTypes, createCanvas } from '../../util/create_elements.js';
+import { CanvasType, kAllCanvasTypes, createCanvas } from '../../util/create_elements.js';
 
 class F extends CopyToTextureUtils {
   init2DCanvasContentWithColorSpace({
@@ -119,7 +119,7 @@ class F extends CopyToTextureUtils {
     height,
     paintOpaqueRects,
   }: {
-    canvasType: canvasTypes;
+    canvasType: CanvasType;
     width: number;
     height: number;
     paintOpaqueRects: boolean;
@@ -181,7 +181,7 @@ class F extends CopyToTextureUtils {
     premultiplied,
     paintOpaqueRects,
   }: {
-    canvasType: canvasTypes;
+    canvasType: CanvasType;
     contextName: 'webgl' | 'webgl2';
     width: number;
     height: number;
@@ -297,7 +297,7 @@ class F extends CopyToTextureUtils {
     paintOpaqueRects,
   }: {
     device: GPUDevice;
-    canvasType: canvasTypes;
+    canvasType: CanvasType;
     width: number;
     height: number;
     premultiplied: boolean;
@@ -446,7 +446,7 @@ g.test('copy_contents_from_2d_context_canvas')
   )
   .params(u =>
     u
-      .combine('canvasType', allCanvasTypes)
+      .combine('canvasType', kAllCanvasTypes)
       .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
       .combine('dstPremultiplied', [true, false])
       .combine('srcDoFlipYDuringCopy', [true, false])
@@ -562,7 +562,7 @@ g.test('copy_contents_from_gl_context_canvas')
   )
   .params(u =>
     u
-      .combine('canvasType', allCanvasTypes)
+      .combine('canvasType', kAllCanvasTypes)
       .combine('contextName', ['webgl', 'webgl2'] as const)
       .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
       .combine('srcPremultiplied', [true, false])
@@ -683,7 +683,7 @@ g.test('copy_contents_from_gpu_context_canvas')
   )
   .params(u =>
     u
-      .combine('canvasType', allCanvasTypes)
+      .combine('canvasType', kAllCanvasTypes)
       .combine('srcAndDstInSameGPUDevice', [true, false])
       .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
       .combine('srcPremultiplied', [true])


### PR DESCRIPTION
- Moves some canvas utilities around to be in central location for reuse, and update related tests.
- Moves some array typing around for reuse.
- Adds remaining tests for device destroy.




Issue: #882 

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
