### PR TITLE
Remove test leading to FXC compile failure

### DIFF
--- a/src/webgpu/shader/execution/evaluation_order.spec.ts
+++ b/src/webgpu/shader/execution/evaluation_order.spec.ts
@@ -319,13 +319,6 @@ g.test('assignment')
       _result: 4,
     },
     {
-      name: 'ToArray4D',
-      _body:
-        'arr3D_zero[mul(&a, 2)][mul(&a, 2)][mul(&a, 2)] = mul(&a, 2);' +
-        'return arr3D_zero[8][16][32];',
-      _result: 4,
-    },
-    {
       name: 'ToArrayFromArray',
       _body:
         'arr2D_zero[4][8] = 123;' +


### PR DESCRIPTION
ToArray4D allocates a fairly large 4D array that resulted in FXC
failure: error X3059: array dimension must be between 1 and 65536

Removing this test as it doesn't add much value.
