### PR TITLE
Fix numeric array sort in WGSL clamp tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -47,7 +47,9 @@ function calculateMinMaxClamp(ei: number, fi: number, gi: number): number {
  * @returns the index of the clamped value
  */
 function calculateMedianClamp(ei: number, fi: number, gi: number): number {
-  return [ei, fi, gi].sort()[1];
+  return [ei, fi, gi].sort((a, b) => {
+    return a - b;
+  })[1];
 }
 
 /** @returns a set of clamp test cases from an ascending list of integer values */


### PR DESCRIPTION
Array.sort() defaults to sorting elements by converting them to
strings and sorting them alphabetically. To sort numerically, we need
to define the comparator function manually.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
