### PR TITLE
Fix RenderBundle read-only state mismatch test

### DIFF
--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -163,68 +163,25 @@ g.test('depth_stencil_readonly_mismatch')
     `
   )
   .params(u =>
-    u.combine('depthStencilFormat', kDepthStencilFormats).combineWithParams([
-      {
-        bundleDepthReadOnly: false,
-        bundleStencilReadOnly: false,
-        passDepthReadOnly: false,
-        passStencilReadOnly: false,
-      },
-      {
-        bundleDepthReadOnly: true,
-        bundleStencilReadOnly: false,
-        passDepthReadOnly: true,
-        passStencilReadOnly: false,
-      },
-      {
-        bundleDepthReadOnly: false,
-        bundleStencilReadOnly: true,
-        passDepthReadOnly: false,
-        passStencilReadOnly: true,
-      },
-      {
-        bundleDepthReadOnly: true,
-        bundleStencilReadOnly: true,
-        passDepthReadOnly: true,
-        passStencilReadOnly: true,
-      },
-      {
-        bundleDepthReadOnly: true,
-        bundleStencilReadOnly: false,
-        passDepthReadOnly: true,
-        passStencilReadOnly: true,
-      },
-      {
-        bundleDepthReadOnly: false,
-        bundleStencilReadOnly: true,
-        passDepthReadOnly: true,
-        passStencilReadOnly: true,
-      },
-      {
-        bundleDepthReadOnly: false,
-        bundleStencilReadOnly: false,
-        passDepthReadOnly: true,
-        passStencilReadOnly: true,
-      },
-      {
-        bundleDepthReadOnly: true,
-        bundleStencilReadOnly: true,
-        passDepthReadOnly: false,
-        passStencilReadOnly: true,
-      },
-      {
-        bundleDepthReadOnly: true,
-        bundleStencilReadOnly: true,
-        passDepthReadOnly: true,
-        passStencilReadOnly: false,
-      },
-      {
-        bundleDepthReadOnly: true,
-        bundleStencilReadOnly: true,
-        passDepthReadOnly: false,
-        passStencilReadOnly: false,
-      },
-    ])
+    u
+      .combine('depthStencilFormat', kDepthStencilFormats)
+      .beginSubcases()
+      .combine('bundleDepthReadOnly', [false, true])
+      .combine('bundleStencilReadOnly', [false, true])
+      .combine('passDepthReadOnly', [false, true])
+      .combine('passStencilReadOnly', [false, true])
+      .filter(p => {
+        // For combined depth/stencil formats the depth and stencil read only state must match
+        // in order to create a valid render bundle or render pass.
+        const depthStencilInfo = kTextureFormatInfo[p.depthStencilFormat];
+        if (depthStencilInfo.depth && depthStencilInfo.stencil) {
+          return (
+            p.passDepthReadOnly === p.passStencilReadOnly &&
+            p.bundleDepthReadOnly === p.bundleStencilReadOnly
+          );
+        }
+        return true;
+      })
   )
   .fn(async t => {
     const {
@@ -236,13 +193,9 @@ g.test('depth_stencil_readonly_mismatch')
     } = t.params;
     await t.selectDeviceForTextureFormatOrSkipTestCase(depthStencilFormat);
 
-    let compatible =
-      bundleDepthReadOnly === passDepthReadOnly && bundleStencilReadOnly === passStencilReadOnly;
-
-    const depthStencilInfo = kTextureFormatInfo[depthStencilFormat];
-    if (depthStencilInfo.depth && depthStencilInfo.stencil) {
-      compatible = compatible && bundleDepthReadOnly === bundleStencilReadOnly;
-    }
+    const compatible =
+      (!passDepthReadOnly || bundleDepthReadOnly === passDepthReadOnly) &&
+      (!passStencilReadOnly || bundleStencilReadOnly === passStencilReadOnly);
 
     const bundleEncoder = t.device.createRenderBundleEncoder({
       colorFormats: [],


### PR DESCRIPTION
Fixes an erroneous interpretation of the spec text. States don't
need to match exactly between the render bundle and the pass, but
the render bundle needs to be at least as strict as the pass.

Also, the test was creating invalid passes/bundles for combined
depth/stencil formats. Those are now filtered out. Gets the test
passing on Chrome (assuming [the "stencil8" enum](https://chromium-review.googlesource.com/c/chromium/src/+/3554880) is available)

Issue: #1011

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
