### PR TITLE
Add handling subnormals to f32 arithmetic tests

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -4,10 +4,15 @@ Execution Tests for the f32 arithmetic binary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { correctlyRoundedThreshold, ulpThreshold } from '../../../../util/compare.js';
+import { anyOf, correctlyRoundedThreshold, ulpThreshold } from '../../../../util/compare.js';
 import { kValue } from '../../../../util/constants.js';
-import { f32, TypeF32 } from '../../../../util/conversion.js';
-import { biasedRange, linearRange, quantizeToF32 } from '../../../../util/math.js';
+import { f32, Scalar, TypeF32 } from '../../../../util/conversion.js';
+import {
+  biasedRange,
+  isSubnormalNumber,
+  linearRange,
+  quantizeToF32,
+} from '../../../../util/math.js';
 import { Case, Config, run } from '../expression.js';
 
 import { binary } from './binary.js';
@@ -23,6 +28,61 @@ function fullNumericRange(): Array<number> {
     ...linearRange(kValue.f32.subnormal.positive.min, kValue.f32.subnormal.positive.max, 10),
     ...biasedRange(kValue.f32.positive.min, kValue.f32.positive.max, 50),
   ];
+}
+
+/**
+ * Produces all of the results for a binary op and a specific pair of params, accounting for if subnormal results can be
+ * flushed to zero.
+ * Does not account for the inputs being flushed.
+ * @param lhs the left hand side to pass into the binary operation
+ * @param rhs the rhs hand side to pass into the binary operation
+ * @param op callback that implements the truth function for the binary operation
+ */
+function calculateResults(
+  lhs: number,
+  rhs: number,
+  op: (l: number, r: number) => number
+): Array<Scalar> {
+  const results: Array<Scalar> = [];
+  const value = op(lhs, rhs);
+  results.push(f32(value));
+  if (isSubnormalNumber(value)) {
+    results.push(f32(0.0));
+  }
+  return results;
+}
+
+/**
+ * Generates a Case for the params and binary op provide.
+ * @param lhs the left hand side to pass into the binary operation
+ * @param rhs the rhs hand side to pass into the binary operation
+ * @param op callback that implements the truth function for the binary operation
+ * @param skip_rhs_zero_flush should the builder skip cases where the rhs would be flushed to 0, this is primarily for
+ *                            avoid doing division by 0. The caller is responsible for making sure the initial rhs isn't
+ *                            0.
+ */
+function makeCaseImpl(
+  lhs: number,
+  rhs: number,
+  op: (l: number, r: number) => number,
+  skip_rhs_zero_flush: boolean = false
+): Case {
+  const f32_lhs = quantizeToF32(lhs);
+  const f32_rhs = quantizeToF32(rhs);
+  const is_lhs_subnormal = isSubnormalNumber(f32_lhs);
+  const is_rhs_subnormal = isSubnormalNumber(f32_rhs);
+  const expected = calculateResults(f32_lhs, f32_rhs, op);
+  if (is_lhs_subnormal) {
+    expected.push(...calculateResults(0.0, f32_rhs, op));
+  }
+  if (!skip_rhs_zero_flush && is_rhs_subnormal) {
+    expected.push(...calculateResults(f32_lhs, 0.0, op));
+  }
+  if (!skip_rhs_zero_flush && is_lhs_subnormal && is_rhs_subnormal) {
+    expected.push(...calculateResults(0.0, 0.0, op));
+  }
+
+  return { input: [f32(lhs), f32(rhs)], expected: anyOf(...expected) };
 }
 
 g.test('addition')
@@ -44,9 +104,9 @@ Accuracy: Correctly rounded
     cfg.cmpFloats = correctlyRoundedThreshold();
 
     const makeCase = (lhs: number, rhs: number): Case => {
-      const f32_lhs = quantizeToF32(lhs);
-      const f32_rhs = quantizeToF32(rhs);
-      return { input: [f32(lhs), f32(rhs)], expected: f32(f32_lhs + f32_rhs) };
+      return makeCaseImpl(lhs, rhs, (l: number, r: number): number => {
+        return l + r;
+      });
     };
 
     const cases: Array<Case> = [];
@@ -79,9 +139,9 @@ Accuracy: Correctly rounded
     cfg.cmpFloats = correctlyRoundedThreshold();
 
     const makeCase = (lhs: number, rhs: number): Case => {
-      const f32_lhs = quantizeToF32(lhs);
-      const f32_rhs = quantizeToF32(rhs);
-      return { input: [f32(lhs), f32(rhs)], expected: f32(f32_lhs - f32_rhs) };
+      return makeCaseImpl(lhs, rhs, (l: number, r: number): number => {
+        return l - r;
+      });
     };
 
     const cases: Array<Case> = [];
@@ -114,9 +174,9 @@ Accuracy: Correctly rounded
     cfg.cmpFloats = correctlyRoundedThreshold();
 
     const makeCase = (lhs: number, rhs: number): Case => {
-      const f32_lhs = quantizeToF32(lhs);
-      const f32_rhs = quantizeToF32(rhs);
-      return { input: [f32(lhs), f32(rhs)], expected: f32(f32_lhs * f32_rhs) };
+      return makeCaseImpl(lhs, rhs, (l: number, r: number): number => {
+        return l * r;
+      });
     };
 
     const cases: Array<Case> = [];
@@ -149,14 +209,21 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
     cfg.cmpFloats = ulpThreshold(2.5);
 
     const makeCase = (lhs: number, rhs: number): Case => {
-      const f32_lhs = quantizeToF32(lhs);
-      const f32_rhs = quantizeToF32(rhs);
-      return { input: [f32(lhs), f32(rhs)], expected: f32(f32_lhs / f32_rhs) };
+      return makeCaseImpl(
+        lhs,
+        rhs,
+        (l: number, r: number): number => {
+          return l / r;
+        },
+        true
+      );
     };
 
     const cases: Array<Case> = [];
     const lhs_numeric_range = fullNumericRange();
-    const rhs_numeric_range = biasedRange(2 ** -126, 2 ** 126, 200);
+    const rhs_numeric_range = biasedRange(2 ** -126, 2 ** 126, 200).filter(value => {
+      return value !== 0.0;
+    });
     lhs_numeric_range.forEach(lhs => {
       rhs_numeric_range.forEach(rhs => {
         cases.push(makeCase(lhs, rhs));

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -4,10 +4,15 @@ Execution Tests for the f32 arithmetic unary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { correctlyRoundedThreshold } from '../../../../util/compare.js';
+import { anyOf, correctlyRoundedThreshold } from '../../../../util/compare.js';
 import { kValue } from '../../../../util/constants.js';
 import { f32, TypeF32 } from '../../../../util/conversion.js';
-import { biasedRange, linearRange, quantizeToF32 } from '../../../../util/math.js';
+import {
+  biasedRange,
+  isSubnormalNumber,
+  linearRange,
+  quantizeToF32,
+} from '../../../../util/math.js';
 import { Case, Config, run } from '../expression.js';
 
 import { unary } from './unary.js';
@@ -34,7 +39,11 @@ Accuracy: Correctly rounded
 
     const makeCase = (x: number): Case => {
       const f32_x = quantizeToF32(x);
-      return { input: [f32(x)], expected: f32(-f32_x) };
+      if (isSubnormalNumber(f32_x)) {
+        return { input: [f32(x)], expected: anyOf(f32(-f32_x), f32(0.0)) };
+      } else {
+        return { input: [f32(x)], expected: f32(-f32_x) };
+      }
     };
 
     const numeric_range = [

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -110,6 +110,11 @@ export function isSubnormalScalar(val: Scalar): boolean {
   return (u32_val & 0x7f800000) === 0;
 }
 
+/** Utility to pass TS numbers into |isSubnormalNumber| */
+export function isSubnormalNumber(val: number): boolean {
+  return isSubnormalScalar(f32(val));
+}
+
 /**
  * @returns the next single precision floating point value after |val|,
  * towards +inf if |dir| is true, otherwise towards -inf.


### PR DESCRIPTION
Fixes #1118

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
