### PR TITLE
Update deprecated WGSL struct syntax (";" -> ",")

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -334,7 +334,7 @@ class F extends GPUTest {
         module: this.device.createShaderModule({
           code: `
             struct Params {
-              copyLayer: f32;
+              copyLayer: f32
             };
             @group(0) @binding(0) var<uniform> param: Params;
             @stage(vertex)

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -826,7 +826,7 @@ class ImageCopyTest extends GPUTest {
         module: this.device.createShaderModule({
           code: `
             struct Params {
-              stencilBitIndex: u32;
+              stencilBitIndex: u32
             };
             @group(0) @binding(0) var<uniform> param: Params;
             @stage(fragment)

--- a/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
@@ -62,7 +62,7 @@ export class ProgrammableStateTest extends GPUTest {
     switch (encoderType) {
       case 'compute pass': {
         const wgsl = `struct Data {
-            value : i32;
+            value : i32
           };
 
           @group(${groups.a}) @binding(0) var<storage> a : Data;
@@ -98,7 +98,7 @@ export class ProgrammableStateTest extends GPUTest {
 
           fragment: `
             struct Data {
-              value : i32;
+              value : i32
             };
 
             @group(${groups.a}) @binding(0) var<storage> a : Data;

--- a/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
@@ -15,12 +15,12 @@ class VertexAndIndexStateTrackingTest extends GPUTest {
         module: this.device.createShaderModule({
           code: `
         struct Inputs {
-          @location(0) vertexPosition : f32;
-          @location(1) vertexColor : vec4<f32>;
+          @location(0) vertexPosition : f32,
+          @location(1) vertexColor : vec4<f32>,
         };
         struct Outputs {
-          @builtin(position) position : vec4<f32>;
-          @location(0) color : vec4<f32>;
+          @builtin(position) position : vec4<f32>,
+          @location(0) color : vec4<f32>,
         };
         @stage(vertex)
         fn main(input : Inputs)-> Outputs {
@@ -54,7 +54,7 @@ class VertexAndIndexStateTrackingTest extends GPUTest {
         module: this.device.createShaderModule({
           code: `
         struct Input {
-          @location(0) color : vec4<f32>;
+          @location(0) color : vec4<f32>
         };
         @stage(fragment)
         fn main(input : Input) -> @location(0) vec4<f32> {
@@ -395,7 +395,7 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
       module: t.device.createShaderModule({
         code: `
       struct Input {
-        @location(0) color : vec4<f32>;
+        @location(0) color : vec4<f32>
       };
       @stage(fragment)
       fn main(input : Input) -> @location(0) vec4<f32> {
@@ -412,12 +412,12 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
         module: t.device.createShaderModule({
           code: `
         struct Inputs {
-          @location(0) vertexColor : vec4<f32>;
-          @location(1) vertexPosition : f32;
+          @location(0) vertexColor : vec4<f32>,
+          @location(1) vertexPosition : f32,
         };
         struct Outputs {
-          @builtin(position) position : vec4<f32>;
-          @location(0) color : vec4<f32>;
+          @builtin(position) position : vec4<f32>,
+          @location(0) color : vec4<f32>,
         };
         @stage(vertex)
         fn main(input : Inputs)-> Outputs {
@@ -463,12 +463,12 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
         module: t.device.createShaderModule({
           code: `
         struct Inputs {
-          @builtin(vertex_index) vertexIndex : u32;
-          @location(0) vertexColor : vec4<f32>;
+          @builtin(vertex_index) vertexIndex : u32,
+          @location(0) vertexColor : vec4<f32>,
         };
         struct Outputs {
-          @builtin(position) position : vec4<f32>;
-          @location(0) color : vec4<f32>;
+          @builtin(position) position : vec4<f32>,
+          @location(0) color : vec4<f32>,
         };
         @stage(vertex)
         fn main(input : Inputs)-> Outputs {

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -30,7 +30,7 @@ g.test('memcpy').fn(async t => {
       module: t.device.createShaderModule({
         code: `
           struct Data {
-              value : u32;
+              value : u32
           };
 
           @group(0) @binding(0) var<storage, read> src : Data;
@@ -108,7 +108,7 @@ g.test('large_dispatch')
         module: t.device.createShaderModule({
           code: `
             struct OutputBuffer {
-              value : array<u32>;
+              value : array<u32>
             };
 
             @group(0) @binding(0) var<storage, read_write> dst : OutputBuffer;

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -315,7 +315,7 @@ export class BufferSyncTest extends GPUTest {
   createStorageWriteComputePipeline(value: number): GPUComputePipeline {
     const wgslCompute = `
       struct Data {
-        a : u32;
+        a : u32
       };
 
       @group(0) @binding(0) var<storage, read_write> data : Data;
@@ -359,7 +359,7 @@ export class BufferSyncTest extends GPUTest {
       vertex: kDummyVertexShader,
       fragment: `
       struct Data {
-        a : u32;
+        a : u32
       };
 
       @group(0) @binding(0) var<storage, read_write> data : Data;
@@ -496,7 +496,7 @@ export class BufferSyncTest extends GPUTest {
   createStorageReadComputePipeline(): GPUComputePipeline {
     const wgslCompute = `
       struct Data {
-        a : u32;
+        a : u32
       };
 
       @group(0) @binding(0) var<storage, read> srcData : Data;
@@ -536,8 +536,8 @@ export class BufferSyncTest extends GPUTest {
     const wgslShaders = {
       vertex: `
       struct VertexOutput {
-        @builtin(position) position : vec4<f32>;
-        @location(0) @interpolate(flat) data : u32;
+        @builtin(position) position : vec4<f32>,
+        @location(0) @interpolate(flat) data : u32,
       };
       
       @stage(vertex) fn vert_main(@location(0) input: u32) -> VertexOutput {
@@ -549,7 +549,7 @@ export class BufferSyncTest extends GPUTest {
       `,
       fragment: `
       struct Data {
-        a : u32;
+        a : u32
       };
       
       @group(0) @binding(0) var<storage, read_write> data : Data;
@@ -597,7 +597,7 @@ export class BufferSyncTest extends GPUTest {
       vertex: kDummyVertexShader,
       fragment: `
       struct Data {
-        a : u32;
+        a : u32
       };
       
       @group(0) @binding(0) var<uniform> constant: Data;
@@ -619,7 +619,7 @@ export class BufferSyncTest extends GPUTest {
       vertex: kDummyVertexShader,
       fragment: `
         struct Data {
-          a : u32;
+          a : u32
         };
 
         @group(0) @binding(0) var<storage, read> srcData : Data;

--- a/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
@@ -35,7 +35,7 @@ export const g = makeTestGroup(GPUTest);
 
 const fullscreenQuadWGSL = `
   struct VertexOutput {
-    @builtin(position) Position : vec4<f32>;
+    @builtin(position) Position : vec4<f32>
   };
 
   @stage(vertex) fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -68,10 +68,10 @@ g.test('render_pass_resolve')
         module: t.device.createShaderModule({
           code: `
             struct Output {
-              @location(0) fragColor0 : vec4<f32>;
-              @location(1) fragColor1 : vec4<f32>;
-              @location(2) fragColor2 : vec4<f32>;
-              @location(3) fragColor3 : vec4<f32>;
+              @location(0) fragColor0 : vec4<f32>,
+              @location(1) fragColor1 : vec4<f32>,
+              @location(2) fragColor2 : vec4<f32>,
+              @location(3) fragColor3 : vec4<f32>,
             };
 
             @stage(fragment) fn main() -> Output {

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -219,8 +219,8 @@ g.test('large_draw')
         module: t.device.createShaderModule({
           code: `
           struct Params {
-            numVertices: u32;
-            numInstances: u32;
+            numVertices: u32,
+            numInstances: u32,
           };
 
           fn selectValue(index: u32, maxIndex: u32) -> f32 {

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -180,7 +180,7 @@ g.test('GPUBlendComponent')
         module: t.device.createShaderModule({
           code: `
 struct Uniform {
-  color: vec4<f32>;
+  color: vec4<f32>
 };
 @group(0) @binding(0) var<uniform> u : Uniform;
 

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -176,8 +176,8 @@ g.test('reverse_depth')
         module: t.device.createShaderModule({
           code: `
             struct Output {
-              @builtin(position) Position : vec4<f32>;
-              @location(0) color : vec4<f32>;
+              @builtin(position) Position : vec4<f32>,
+              @location(0) color : vec4<f32>,
             };
 
             @stage(vertex) fn main(

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -85,8 +85,8 @@ have unexpected values then get drawn to the color buffer, which is later checke
       //////// "Test" entry points
 
       struct VFTest {
-        @builtin(position) pos: vec4<f32>;
-        @location(0) @interpolate(flat) vertexIndex: u32;
+        @builtin(position) pos: vec4<f32>,
+        @location(0) @interpolate(flat) vertexIndex: u32,
       };
 
       @stage(vertex)
@@ -100,7 +100,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
       struct Output {
         // Each fragment (that didn't get clipped) writes into one element of this output.
         // (Anything that doesn't get written is already zero.)
-        fragInputZDiff: array<f32, ${kNumTestPoints}>;
+        fragInputZDiff: array<f32, ${kNumTestPoints}>
       };
       @group(0) @binding(0) var <storage, read_write> output: Output;
 
@@ -122,8 +122,8 @@ have unexpected values then get drawn to the color buffer, which is later checke
       //////// "Check" entry points
 
       struct VFCheck {
-        @builtin(position) pos: vec4<f32>;
-        @location(0) @interpolate(flat) vertexIndex: u32;
+        @builtin(position) pos: vec4<f32>,
+        @location(0) @interpolate(flat) vertexIndex: u32,
       };
 
       @stage(vertex)
@@ -136,8 +136,8 @@ have unexpected values then get drawn to the color buffer, which is later checke
       }
 
       struct FCheck {
-        @builtin(frag_depth) depth: f32;
-        @location(0) color: f32;
+        @builtin(frag_depth) depth: f32,
+        @location(0) color: f32,
       };
 
       @stage(fragment)
@@ -375,8 +375,8 @@ to be empty.`
       }
 
       struct VF {
-        @builtin(position) pos: vec4<f32>;
-        @location(0) @interpolate(flat) vertexIndex: u32;
+        @builtin(position) pos: vec4<f32>,
+        @location(0) @interpolate(flat) vertexIndex: u32,
       };
 
       @stage(vertex)
@@ -395,8 +395,8 @@ to be empty.`
       }
 
       struct FTest {
-        @builtin(frag_depth) depth: f32;
-        @location(0) color: f32;
+        @builtin(frag_depth) depth: f32,
+        @location(0) color: f32,
       };
 
       @stage(fragment)

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -85,9 +85,9 @@ Params:
     const vertexModule = t.device.createShaderModule({
       code: `
 struct Inputs {
-  @builtin(vertex_index) vertex_index : u32;
-  @builtin(instance_index) instance_id : u32;
-  @location(0) vertexPosition : vec2<f32>;
+  @builtin(vertex_index) vertex_index : u32,
+  @builtin(instance_index) instance_id : u32,
+  @location(0) vertexPosition : vec2<f32>,
 };
 
 @stage(vertex) fn vert_main(input : Inputs
@@ -110,7 +110,7 @@ struct Inputs {
     const fragmentModule = t.device.createShaderModule({
       code: `
 struct Output {
-  value : u32;
+  value : u32
 };
 
 @group(0) @binding(0) var<storage, read_write> output : Output;
@@ -520,17 +520,17 @@ g.test('vertex_attributes,basic')
         module: t.device.createShaderModule({
           code: `
 struct Inputs {
-  @builtin(vertex_index) vertexIndex : u32;
-  @builtin(instance_index) instanceIndex : u32;
-${vertexInputShaderLocations.map(i => `  @location(${i}) attrib${i} : ${wgslFormat};`).join('\n')}
+  @builtin(vertex_index) vertexIndex : u32,
+  @builtin(instance_index) instanceIndex : u32,
+${vertexInputShaderLocations.map(i => `  @location(${i}) attrib${i} : ${wgslFormat},`).join('\n')}
 };
 
 struct Outputs {
-  @builtin(position) Position : vec4<f32>;
+  @builtin(position) Position : vec4<f32>,
 ${interStageScalarShaderLocations
-  .map(i => `  @location(${i}) @interpolate(flat) outAttrib${i} : ${wgslFormat};`)
+  .map(i => `  @location(${i}) @interpolate(flat) outAttrib${i} : ${wgslFormat},`)
   .join('\n')}
-  @location(${interStageScalarShaderLocations.length}) @interpolate(flat) primitiveId : u32;
+  @location(${interStageScalarShaderLocations.length}) @interpolate(flat) primitiveId : u32,
 ${accumulateVariableDeclarationsInVertexShader}
 };
 
@@ -553,17 +553,17 @@ ${accumulateVariableAssignmentsInVertexShader}
           code: `
 struct Inputs {
 ${interStageScalarShaderLocations
-  .map(i => `  @location(${i}) @interpolate(flat) attrib${i} : ${wgslFormat};`)
+  .map(i => `  @location(${i}) @interpolate(flat) attrib${i} : ${wgslFormat},`)
   .join('\n')}
-  @location(${interStageScalarShaderLocations.length}) @interpolate(flat) primitiveId : u32;
+  @location(${interStageScalarShaderLocations.length}) @interpolate(flat) primitiveId : u32,
 ${accumulateVariableDeclarationsInFragmentShader}
 };
 
 struct OutPrimitive {
-${vertexInputShaderLocations.map(i => `  attrib${i} : ${wgslFormat};`).join('\n')}
+${vertexInputShaderLocations.map(i => `  attrib${i} : ${wgslFormat},`).join('\n')}
 };
 struct OutBuffer {
-  primitives : array<OutPrimitive>;
+  primitives : array<OutPrimitive>
 };
 @group(0) @binding(0) var<storage, read_write> outBuffer : OutBuffer;
 

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -507,7 +507,7 @@ g.test('uniform_buffer')
     const computeShaderModule = t.device.createShaderModule({
       code: `
   struct UBO {
-      value : vec4<u32>;
+      value : vec4<u32>
   };
   @group(0) @binding(0) var<uniform> ubo : UBO;
   @group(0) @binding(1) var outImage : texture_storage_2d<rgba8unorm, write>;
@@ -542,7 +542,7 @@ g.test('readonly_storage_buffer')
     const computeShaderModule = t.device.createShaderModule({
       code: `
     struct SSBO {
-        value : vec4<u32>;
+        value : vec4<u32>
     };
     @group(0) @binding(0) var<storage, read> ssbo : SSBO;
     @group(0) @binding(1) var outImage : texture_storage_2d<rgba8unorm, write>;
@@ -577,7 +577,7 @@ g.test('storage_buffer')
     const computeShaderModule = t.device.createShaderModule({
       code: `
     struct SSBO {
-        value : vec4<u32>;
+        value : vec4<u32>
     };
     @group(0) @binding(0) var<storage, read_write> ssbo : SSBO;
     @group(0) @binding(1) var outImage : texture_storage_2d<rgba8unorm, write>;
@@ -608,8 +608,8 @@ g.test('vertex_buffer')
       t.device.createShaderModule({
         code: `
       struct VertexOut {
-        @location(0) color : vec4<f32>;
-        @builtin(position) position : vec4<f32>;
+        @location(0) color : vec4<f32>,
+        @builtin(position) position : vec4<f32>,
       };
 
       @stage(vertex) fn main(@location(0) pos : vec4<f32>) -> VertexOut {
@@ -671,8 +671,8 @@ GPUBuffer, all the contents in that GPUBuffer have been initialized to 0.`
       t.device.createShaderModule({
         code: `
     struct VertexOut {
-      @location(0) color : vec4<f32>;
-      @builtin(position) position : vec4<f32>;
+      @location(0) color : vec4<f32>,
+      @builtin(position) position : vec4<f32>,
     };
 
     @stage(vertex)
@@ -739,8 +739,8 @@ have been initialized to 0.`
       t.device.createShaderModule({
         code: `
     struct VertexOut {
-      @location(0) color : vec4<f32>;
-      @builtin(position) position : vec4<f32>;
+      @location(0) color : vec4<f32>,
+      @builtin(position) position : vec4<f32>,
     };
 
     @stage(vertex) fn main() -> VertexOut {

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -35,8 +35,8 @@ function getDepthTestEqualPipeline(
       module: t.device.createShaderModule({
         code: `
         struct Outputs {
-          @builtin(frag_depth) FragDepth : f32;
-          @location(0) outSuccess : f32;
+          @builtin(frag_depth) FragDepth : f32,
+          @location(0) outSuccess : f32,
         };
 
         @stage(fragment)

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -57,14 +57,14 @@ export const checkContentsBySampling: CheckContents = (
         module: t.device.createShaderModule({
           code: `
             struct Constants {
-              level : i32;
+              level : i32
             };
 
             @group(0) @binding(0) var<uniform> constants : Constants;
             @group(0) @binding(1) var myTexture : texture${_multisampled}${_xd}<${shaderType}>;
 
             struct Result {
-              values : array<${shaderType}>;
+              values : array<${shaderType}>
             };
             @group(0) @binding(3) var<storage, read_write> result : Result;
 

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -59,8 +59,8 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
         module: this.device.createShaderModule({
           code: `
             struct Outputs {
-              @builtin(position) Position : vec4<f32>;
-              @location(0) fragUV : vec2<f32>;
+              @builtin(position) Position : vec4<f32>,
+              @location(0) fragUV : vec2<f32>,
             };
 
             @stage(vertex) fn main(

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -126,8 +126,8 @@ class VertexStateTest extends GPUTest {
           storageType = 'storage, read';
         }
 
-        vsInputs += `  @location(${i}) attrib${i} : ${shaderType};\n`;
-        vsBindings += `struct S${i} { data : array<vec4<${a.shaderBaseType}>, ${maxCount}>; };\n`;
+        vsInputs += `  @location(${i}) attrib${i} : ${shaderType},\n`;
+        vsBindings += `struct S${i} { data : array<vec4<${a.shaderBaseType}>, ${maxCount}> };\n`;
         vsBindings += `@group(0) @binding(${i}) var<${storageType}> providedData${i} : S${i};\n`;
 
         // Generate the all the checks for the attributes.
@@ -157,8 +157,8 @@ class VertexStateTest extends GPUTest {
     return `
 struct Inputs {
 ${vsInputs}
-  @builtin(vertex_index) vertexIndex: u32;
-  @builtin(instance_index) instanceIndex: u32;
+  @builtin(vertex_index) vertexIndex: u32,
+  @builtin(instance_index) instanceIndex: u32,
 };
 
 ${vsBindings}
@@ -182,8 +182,8 @@ ${vsChecks}
 }
 
 struct VSOutputs {
-  @location(0) @interpolate(flat) result : i32;
-  @builtin(position) position : vec4<f32>;
+  @location(0) @interpolate(flat) result : i32,
+  @builtin(position) position : vec4<f32>,
 };
 
 @stage(vertex) fn vsMain(input : Inputs) -> VSOutputs {

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -20,7 +20,7 @@ class F extends ValidationTest {
         module: this.device.createShaderModule({
           code: `
             struct Inputs {
-            ${range(bufferCount, i => `\n@location(${i}) a_position${i} : vec3<f32>;`).join('')}
+            ${range(bufferCount, i => `\n@location(${i}) a_position${i} : vec3<f32>,`).join('')}
             };
             @stage(vertex) fn main(input : Inputs
               ) -> @builtin(position) vec4<f32> {

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -118,7 +118,7 @@ class F extends ValidationTest {
 
     let count = 0;
     for (const input of inputs) {
-      interfaces += `@location(${input.location}) input${count} : ${input.type};\n`;
+      interfaces += `@location(${input.location}) input${count} : ${input.type},\n`;
       body += `var i${count} : ${input.type} = input.input${count};\n`;
       count++;
     }

--- a/src/webgpu/shader/execution/evaluation_order.spec.ts
+++ b/src/webgpu/shader/execution/evaluation_order.spec.ts
@@ -33,9 +33,9 @@ var<private> arr3D_zero : array<array<array<i32, 50>, 50>, 50>;
 var<private> vec4_zero : vec4<i32>;
 
 struct S {
-  x : i32;
-  y : i32;
-  z : i32;
+  x : i32,
+  y : i32,
+  z : i32,
 }
 
 fn mul(p1 : ptr<private, i32>, multiplicand : i32) -> i32 {

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -184,12 +184,12 @@ function runBatch(
   const source = `
 struct Input {
 ${parameterTypes
-  .map((ty, i) => `  @size(${kValueStride}) param${i} : ${storageType(ty)};`)
+  .map((ty, i) => `  @size(${kValueStride}) param${i} : ${storageType(ty)},`)
   .join('\n')}
 };
 
 struct Output {
-  @size(${kValueStride}) value : ${storageType(returnType)};
+  @size(${kValueStride}) value : ${storageType(returnType)}
 };
 
 @group(0) @binding(0)

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -554,35 +554,35 @@ export class MemoryModelTester {
 /** Defines common data structures used in memory model test shaders. */
 const shaderMemStructures = `
   struct Memory {
-    value: array<u32>;
+    value: array<u32>
   };
 
   struct AtomicMemory {
-    value: array<atomic<u32>>;
+    value: array<atomic<u32>>
   };
 
   struct ReadResult {
-    r0: atomic<u32>;
-    r1: atomic<u32>;
+    r0: atomic<u32>,
+    r1: atomic<u32>,
   };
 
   struct ReadResults {
-    value: array<ReadResult>;
+    value: array<ReadResult>
   };
 
   struct StressParamsMemory {
-    do_barrier: u32;
-    mem_stress: u32;
-    mem_stress_iterations: u32;
-    mem_stress_pattern: u32;
-    pre_stress: u32;
-    pre_stress_iterations: u32;
-    pre_stress_pattern: u32;
-    permute_first: u32;
-    permute_second: u32;
-    testing_workgroups: u32;
-    mem_stride: u32;
-    location_offset: u32;
+    do_barrier: u32,
+    mem_stress: u32,
+    mem_stress_iterations: u32,
+    mem_stress_pattern: u32,
+    pre_stress: u32,
+    pre_stress_iterations: u32,
+    pre_stress_pattern: u32,
+    permute_first: u32,
+    permute_second: u32,
+    testing_workgroups: u32,
+    mem_stride: u32,
+    location_offset: u32,
   };
 `;
 
@@ -595,10 +595,10 @@ const shaderMemStructures = `
  */
 const fourBehaviorTestResultStructure = `
   struct TestResults {
-    seq0: atomic<u32>;
-    seq1: atomic<u32>;
-    interleaved: atomic<u32>;
-    weak: atomic<u32>;
+    seq0: atomic<u32>,
+    seq1: atomic<u32>,
+    interleaved: atomic<u32>,
+    weak: atomic<u32>,
   };
 `;
 
@@ -610,8 +610,8 @@ const fourBehaviorTestResultStructure = `
  */
 const twoBehaviorTestResultStructure = `
   struct TestResults {
-    seq: atomic<u32>;
-    weak: atomic<u32>;
+    seq: atomic<u32>,
+    weak: atomic<u32>,
   };
 `;
 

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -42,12 +42,12 @@ function runShaderTest(
 
   const source = `
     struct Constants {
-      zero: u32;
+      zero: u32
     };
     @group(1) @binding(0) var<uniform> constants: Constants;
 
     struct Result {
-      value: u32;
+      value: u32
     };
     @group(1) @binding(1) var<storage, write> result: Result;
 
@@ -196,9 +196,9 @@ g.test('linear_memory')
     // in the global scope or inside the test function itself.
     const structDecl = `
       struct S {
-        startCanary: array<u32, 10>;
-        data: ${type};
-        endCanary: array<u32, 10>;
+        startCanary: array<u32, 10>,
+        data: ${type},
+        endCanary: array<u32, 10>,
       };`;
 
     const testGroupBGLEntires: GPUBindGroupLayoutEntry[] = [];
@@ -212,7 +212,7 @@ g.test('linear_memory')
           const qualifiers = storageClass === 'storage' ? `storage, ${storageMode}` : storageClass;
           globalSource += `
           struct TestData {
-            data: ${type};
+            data: ${type},
           };
           @group(0) @binding(0) var<${qualifiers}> s: TestData;`;
 

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -351,7 +351,7 @@ class F extends GPUTest {
       let currAttribute = 0;
       for (let i = 0; i < bufferCount; i++) {
         for (let j = 0; j < attributesPerBuffer; j++) {
-          layoutStr += `@location(${currAttribute}) a_${currAttribute} : ${typeInfo.wgslType};\n`;
+          layoutStr += `@location(${currAttribute}) a_${currAttribute} : ${typeInfo.wgslType},\n`;
           attributeNames.push(`a_${currAttribute}`);
           currAttribute++;
         }

--- a/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
+++ b/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
@@ -42,8 +42,8 @@ class DerivativesTest extends GPUTest {
         module: this.device.createShaderModule({
           code: `
             struct Outputs {
-              @builtin(position) Position : vec4<f32>;
-              @location(0) fragUV : vec2<f32>;
+              @builtin(position) Position : vec4<f32>,
+              @location(0) fragUV : vec2<f32>,
             };
 
             @stage(vertex) fn main(
@@ -82,7 +82,7 @@ class DerivativesTest extends GPUTest {
         module: this.device.createShaderModule({
           code: `
             struct Uniforms {
-              numIterations : i32;
+              numIterations : i32
             };
             @binding(0) @group(0) var<uniform> uniforms : Uniforms;
 

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -63,11 +63,11 @@ g.test('inputs')
         break;
       case 'struct':
         structures = `struct Inputs {
-            @builtin(local_invocation_id) local_id : vec3<u32>;
-            @builtin(local_invocation_index) local_index : u32;
-            @builtin(global_invocation_id) global_id : vec3<u32>;
-            @builtin(workgroup_id) group_id : vec3<u32>;
-            @builtin(num_workgroups) num_groups : vec3<u32>;
+            @builtin(local_invocation_id) local_id : vec3<u32>,
+            @builtin(local_invocation_index) local_index : u32,
+            @builtin(global_invocation_id) global_id : vec3<u32>,
+            @builtin(workgroup_id) group_id : vec3<u32>,
+            @builtin(num_workgroups) num_groups : vec3<u32>,
           };`;
         params = `inputs : Inputs`;
         local_id = 'inputs.local_id';
@@ -78,11 +78,11 @@ g.test('inputs')
         break;
       case 'mixed':
         structures = `struct InputsA {
-          @builtin(local_invocation_index) local_index : u32;
-          @builtin(global_invocation_id) global_id : vec3<u32>;
+          @builtin(local_invocation_index) local_index : u32,
+          @builtin(global_invocation_id) global_id : vec3<u32>,
         };
         struct InputsB {
-          @builtin(workgroup_id) group_id : vec3<u32>;
+          @builtin(workgroup_id) group_id : vec3<u32>
         };`;
         params = `@builtin(local_invocation_id) local_id : vec3<u32>,
                   inputsA : InputsA,
@@ -99,10 +99,10 @@ g.test('inputs')
     // WGSL shader that stores every builtin value to a buffer, for every invocation in the grid.
     const wgsl = `
       struct S {
-        data : array<u32>;
+        data : array<u32>
       };
       struct V {
-        data : array<vec3<u32>>;
+        data : array<vec3<u32>>
       };
       @group(0) @binding(0) var<storage, write> local_id_out : V;
       @group(0) @binding(1) var<storage, write> local_index_out : S;

--- a/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
@@ -29,9 +29,9 @@ g.test('shared_with_buffer')
     // attributes, and also layout attributes for the storage buffer.
     const wgsl = `
       struct S {
-        /* byte offset:  0 */ @size(32)  @builtin(workgroup_id) group_id : vec3<u32>;
-        /* byte offset: 32 */            @builtin(local_invocation_index) local_index : u32;
-        /* byte offset: 64 */ @align(64) @builtin(num_workgroups) numGroups : vec3<u32>;
+        /* byte offset:  0 */ @size(32)  @builtin(workgroup_id) group_id : vec3<u32>,
+        /* byte offset: 32 */            @builtin(local_invocation_index) local_index : u32,
+        /* byte offset: 64 */ @align(64) @builtin(num_workgroups) numGroups : vec3<u32>,
       };
 
       @group(0) @binding(0)
@@ -118,8 +118,8 @@ g.test('shared_between_stages')
     const size = [31, 31];
     const wgsl = `
       struct Interface {
-        @builtin(position) position : vec4<f32>;
-        @location(0) color : f32;
+        @builtin(position) position : vec4<f32>,
+        @location(0) color : f32,
       };
 
       var<private> vertices : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
@@ -234,12 +234,12 @@ g.test('shared_with_non_entry_point_function')
     // functions.
     const wgsl = `
       struct Inputs {
-        @builtin(vertex_index) index : u32;
-        @location(0) color : vec4<f32>;
+        @builtin(vertex_index) index : u32,
+        @location(0) color : vec4<f32>,
       };
       struct Outputs {
-        @builtin(position) position : vec4<f32>;
-        @location(0) color : vec4<f32>;
+        @builtin(position) position : vec4<f32>,
+        @location(0) color : vec4<f32>,
       };
 
       var<private> vertices : array<vec2<f32>, 3> = array<vec2<f32>, 3>(

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -232,7 +232,7 @@ g.test('compute,zero_init')
   .fn(async t => {
     let moduleScope = `
       struct Output {
-        failed : atomic<u32>;
+        failed : atomic<u32>
       };
       @group(0) @binding(0) var <storage, read_write> output : Output;
     `;
@@ -264,7 +264,7 @@ g.test('compute,zero_init')
                     `${typeName}_Member${i}`,
                     member,
                     depth + 1
-                  )};`;
+                  )},`;
                 })
                 .join('');
               declaredStructTypes.set(type, typeName);

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -111,7 +111,7 @@ g.test('type')
     if (t.params.target_type === 'MyStruct') {
       // Generate a struct that contains the correct built-in type.
       code += 'struct MyStruct {\n';
-      code += `  value : ${t.params.type};\n`;
+      code += `  value : ${t.params.type}\n`;
       code += '};\n\n';
     }
 
@@ -146,10 +146,10 @@ g.test('nesting')
     // Generate a struct that contains a sample_mask builtin, nested inside another struct.
     let code = `
     struct Inner {
-      @builtin(sample_mask) value : u32;
+      @builtin(sample_mask) value : u32
     };
     struct Outer {
-      inner : Inner;
+      inner : Inner
     };`;
 
     code += generateShader({
@@ -198,16 +198,16 @@ g.test('duplicates')
       t.params.second === 'rb' ? '@builtin(sample_mask)' : '@location(2) @interpolate(flat)';
     const code = `
     struct S1 {
-      ${s1a} a : u32;
-      ${s1b} b : u32;
+      ${s1a} a : u32,
+      ${s1b} b : u32,
     };
     struct S2 {
-      ${s2a} a : u32;
-      ${s2b} b : u32;
+      ${s2a} a : u32,
+      ${s2b} b : u32,
     };
     struct R {
-      ${ra} a : u32;
-      ${rb} b : u32;
+      ${ra} a : u32,
+      ${rb} b : u32,
     };
     @stage(fragment)
     fn main(${p1} p1 : u32,
@@ -238,7 +238,7 @@ g.test('missing_vertex_position')
   .fn(t => {
     const code = `
     struct S {
-      ${t.params.attribute} value : vec4<f32>;
+      ${t.params.attribute} value : vec4<f32>
     };
 
     @stage(vertex)

--- a/src/webgpu/shader/validation/shader_io/generic.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/generic.spec.ts
@@ -50,19 +50,19 @@ g.test('missing_attribute_on_param_struct')
     const compute_attr = t.params.target_stage === 'compute' ? '' : '@builtin(workgroup_id)';
     const code = `
 struct VertexInputs {
-  @location(0) a : f32;
-  ${vertex_attr}  b : f32;
-@  location(2) c : f32;
+  @location(0) a : f32,
+  ${vertex_attr}  b : f32,
+@  location(2) c : f32,
 };
 struct FragmentInputs {
-  @location(0)  a : f32;
-  ${fragment_attr} b : f32;
-@  location(2)  c : f32;
+  @location(0)  a : f32,
+  ${fragment_attr} b : f32,
+@  location(2)  c : f32,
 };
 struct ComputeInputs {
-  @builtin(global_invocation_id) a : vec3<u32>;
-  ${compute_attr}                   b : vec3<u32>;
-  @builtin(local_invocation_id)  c : vec3<u32>;
+  @builtin(global_invocation_id) a : vec3<u32>,
+  ${compute_attr}                   b : vec3<u32>,
+  @builtin(local_invocation_id)  c : vec3<u32>,
 };
 
 @stage(vertex)
@@ -111,14 +111,14 @@ g.test('missing_attribute_on_return_type_struct')
     const fragment_attr = t.params.target_stage === 'fragment' ? '' : '@location(1)';
     const code = `
 struct VertexOutputs {
-  @location(0)       a : f32;
-  ${vertex_attr}        b : f32;
-  @builtin(position) c : vec4<f32>;
+  @location(0)       a : f32,
+  ${vertex_attr}        b : f32,
+  @builtin(position) c : vec4<f32>,
 };
 struct FragmentOutputs {
-  @location(0)  a : f32;
-  ${fragment_attr} b : f32;
-@  location(2)  c : f32;
+  @location(0)  a : f32,
+  ${fragment_attr} b : f32,
+@  location(2)  c : f32,
 };
 
 @stage(vertex)

--- a/src/webgpu/shader/validation/shader_io/invariant.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/invariant.spec.ts
@@ -35,8 +35,8 @@ g.test('not_valid_on_user_defined_io')
     const invariant = t.params.use_invariant ? '@invariant' : '';
     const code = `
     struct VertexOut {
-      @location(0) ${invariant} loc0 : vec4<f32>;
-      @builtin(position) position : vec4<f32>;
+      @location(0) ${invariant} loc0 : vec4<f32>,
+      @builtin(position) position : vec4<f32>,
     };
     @stage(vertex)
     fn main() -> VertexOut {
@@ -52,7 +52,7 @@ g.test('invalid_use_of_parameters')
   .fn(t => {
     const code = `
     struct VertexOut {
-      @builtin(position) @invariant${t.params.suffix} position : vec4<f32>;
+      @builtin(position) @invariant${t.params.suffix} position : vec4<f32>
     };
     @stage(vertex)
     fn main() -> VertexOut {

--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -83,7 +83,7 @@ g.test('type')
     if (t.params.type === 'MyStruct') {
       // Generate a struct that contains a valid type.
       code += 'struct MyStruct {\n';
-      code += `  value : f32;\n`;
+      code += `  value : f32\n`;
       code += '};\n\n';
     }
 
@@ -112,10 +112,10 @@ g.test('nesting')
 
     // Generate a struct that contains a valid type.
     code += 'struct Inner {\n';
-    code += `  @location(0) value : f32;\n`;
+    code += `  @location(0) value : f32\n`;
     code += '};\n\n';
     code += 'struct Outer {\n';
-    code += `  inner : Inner;\n`;
+    code += `  inner : Inner\n`;
     code += '};\n\n';
 
     code += generateShader({
@@ -155,16 +155,16 @@ g.test('duplicates')
     const rb = t.params.second === 'rb' ? '0' : '2';
     const code = `
     struct S1 {
-      @location(${s1a}) a : f32;
-      @location(${s1b}) b : f32;
+      @location(${s1a}) a : f32,
+      @location(${s1b}) b : f32,
     };
     struct S2 {
-      @location(${s2a}) a : f32;
-      @location(${s2b}) b : f32;
+      @location(${s2a}) a : f32,
+      @location(${s2b}) b : f32,
     };
     struct R {
-      @location(${ra}) a : f32;
-      @location(${rb}) b : f32;
+      @location(${ra}) a : f32,
+      @location(${rb}) b : f32,
     };
     @stage(fragment)
     fn main(@location(${p1}) p1 : f32,

--- a/src/webgpu/shader/validation/shader_io/util.ts
+++ b/src/webgpu/shader/validation/shader_io/util.ts
@@ -27,10 +27,10 @@ export function generateShader({
   if (use_struct) {
     // Generate a struct that wraps the entry point IO variable.
     code += 'struct S {\n';
-    code += `  ${attribute} value : ${type};\n`;
+    code += `  ${attribute} value : ${type},\n`;
     if (stage === 'vertex' && io === 'out' && !attribute.includes('builtin(position)')) {
       // Add position builtin for vertex outputs.
-      code += `  @builtin(position) position : vec4<f32>;\n`;
+      code += `  @builtin(position) position : vec4<f32>,\n`;
     }
     code += '};\n\n';
   }

--- a/src/webgpu/shader/validation/variable_and_const.spec.ts
+++ b/src/webgpu/shader/validation/variable_and_const.spec.ts
@@ -105,7 +105,7 @@ g.test('io_shareable_type')
     if (`${storageClass}` === 'in') {
       code = `
         struct MyInputs {
-          @location(0) @interpolate(flat) a : ${type};
+          @location(0) @interpolate(flat) a : ${type}
         };
 
         @stage(fragment)
@@ -115,7 +115,7 @@ g.test('io_shareable_type')
     } else if (`${storageClass}` === 'out') {
       code = `
         struct MyOutputs {
-          @location(0) a : ${type};
+          @location(0) a : ${type}
         };
 
         @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-is-required.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0035: The access decoration is required for 'particles'.
 
 struct Particles {
-  particles : array<f32, 4>;
+  particles : array<f32, 4>
 };
 
 @group(0) @binding(1) var<storage> particles : Particles;

--- a/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-storage-storage-class.pass.wgsl
@@ -2,7 +2,7 @@
 // 'particles', which is in 'storage' storage class.
 
 struct Particles {
-  particles : array<f32, 4>;
+  particles : array<f32, 4>
 };
 
 @group(1) @binding(0) var<storage, read_write> particles : Particles;

--- a/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/access-decoration-uniform-storage-class.fail.wgsl
@@ -2,7 +2,7 @@
 // 'particles', which is in the 'uniform' storage class.
 
 struct Particles {
-  particles : array<f32, 4>;
+  particles : array<f32, 4>
 };
 
 @group(0) @binding(0) var<uniform, read_write> particles : Particles;

--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name-v2.fail.wgsl
@@ -2,7 +2,7 @@
 // the same name |Foo|.
 
 struct Foo {
-  b : f32;
+  b : f32
 };
 
 fn Foo() {

--- a/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/duplicate-stuct-name.fail.wgsl
@@ -1,11 +1,11 @@
 // v-0012 - This fails because of the duplicated `foo` structure.
 
 struct foo {
-  a : i32;
+  a : i32
 };
 
 struct foo {
-  b : f32;
+  b : f32
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-expression-type.fail.wgsl
@@ -1,8 +1,8 @@
 // v-0031: in 'y = x', x is a runtime array and it's used as an expression.
 
 type RTArr = array<i32>;
-struct S{
-  data : RTArr;
+struct S {
+  data : RTArr
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-is-store-type.fail.wgsl
@@ -1,8 +1,8 @@
 // v-0015: variable 's' store type is struct 'SArr' that has a runtime-sized member but its storage class is not 'storage'.
 
 type RTArr = array<vec4<f32>>;
-struct SArr{
-  data : RTArr;
+struct SArr {
+  data : RTArr
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-block-decorated.fail.wgsl
@@ -1,8 +1,8 @@
 // v-0031: struct 'S' has runtime-sized member but it's storage class is not 'storage'.
 
 type RTArr = array<vec4<f32>>;
-struct S{
-  data : RTArr;
+struct S {
+  data : RTArr
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last-v2.fail.wgsl
@@ -2,8 +2,8 @@
 
 type RTArr = array<vec4<f32>>;
 struct S {
-  data : RTArr;
-  b : f32;
+  data : RTArr,
+  b : f32,
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-not-last.fail.wgsl
@@ -1,8 +1,8 @@
 // v-0015 - This fails because of the runtime array is not last member of the struct.
 
 struct Foo {
-  a : array<f32>;
-  b : f32;
+  a : array<f32>,
+  b : f32,
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/runtime-array-without-stride.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0032 - This fails because the runtime array does not have a stride attribute.
 
 struct Foo {
-  a : array<f32>;
+  a : array<f32>
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v2.fail.wgsl
@@ -1,15 +1,15 @@
 // v-0007 - Fails because struct 'boo' does not have a member 't'.
 
 struct boo {
-  z : f32;
+  z : f32
 };
 
 struct goo {
-  y : boo;
+  y : boo
 };
 
 struct foo {
-  x : goo;
+  x : goo
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v3.fail.wgsl
@@ -2,7 +2,7 @@
 // have a member `s.z`.
 
 struct goo {
-  s : vec2<i32>;
+  s : vec2<i32>
 };
 
 fn Foo() -> goo {

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v4.fail.wgsl
@@ -2,8 +2,8 @@
 // is used.
 
 struct foo {
-  b : f32;
-  a : array<f32>;
+  b : f32
+  a : array<f32>
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-member-def-before-use-v5.fail.wgsl
@@ -2,11 +2,11 @@
 // used.
 
 struct goo {
-  b : f32;
+  b : f32
 };
 
 struct foo {
-  a : f32;
+  a : f32
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/struct-use-before-def.fail.wgsl
@@ -3,7 +3,7 @@
 let a : Foo;
 
 struct Foo {
-  a : i32;
+  a : i32
 };
 
 @stage(fragment)

--- a/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-storage-group-binding-decoration.fail.wgsl
@@ -2,7 +2,7 @@
 # decoration.
 
 struct PositionBuffer {
-  pos: vec2<f32>;
+  pos: vec2<f32>
 };
 
 var<storage> s : PositionBuffer;

--- a/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-uniform-group-binding-decoration.fail.wgsl
@@ -2,7 +2,7 @@
 # decoration.
 
 struct Params {
-  count: i32;
+  count: i32
 };
 
 var<uniform> u : Params;

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-storage.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0032: variable 'u' has an initializer, however its storage class is 'storage'.
 
 struct PositionBuffer {
-  pos: vec2<f32>;
+  pos: vec2<f32>
 };
 
 @group(0) @binding(0)

--- a/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
+++ b/src/webgpu/shader/validation/wgsl/variable-with-initilizer-uniform.fail.wgsl
@@ -1,7 +1,7 @@
 // v-0032: variable 'u' has an initializer, however its storage class is 'uniform'.
 
 struct Params {
-  count: i32;
+  count: i32
 };
 
 @group(0) @binding(0)


### PR DESCRIPTION
Unfortunately large change, but it's all just replacing ";" in WGSL structs. The deprecation messages generated by this are causing an awful lot of log spam when running the CTS as part of the Chrome commit queue.

This CL removes the ";" from any struct with a single member, and replaces all ";" with "," for any struct with multiple members, including a trailing comma. There may be some shader snippets I missed, as this isn't something that's trivial to search and replace, but hopefully it addresses the majority of cases.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
