### PR TITLE
Better check for presence of the Web platform

### DIFF
--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -914,7 +914,11 @@ Tests copyExternalImageToTexture from canvas on queue on destroyed device.
   .params(u => u.beginSubcases().combine('awaitLost', [true, false]))
   .fn(async t => {
     const { awaitLost } = t.params;
+    if (typeof createImageBitmap === 'undefined') {
+      t.skip('Creating ImageBitmaps is not supported.');
+    }
     const imageBitmap = await createImageBitmap(new ImageData(new Uint8ClampedArray(4), 1, 1));
+
     const texture = t.device.createTexture({
       size: { width: 1, height: 1 },
       format: 'bgra8unorm',

--- a/src/webgpu/util/create_elements.ts
+++ b/src/webgpu/util/create_elements.ts
@@ -44,7 +44,11 @@ export function createCanvas(
       test.skip('Cannot create HTMLCanvasElement');
     }
   } else if (canvasType === 'offscreen') {
-    canvas = createOffscreenCanvas(test, width, height);
+    if (typeof OffscreenCanvas !== 'undefined') {
+      canvas = createOffscreenCanvas(test, width, height);
+    } else {
+      test.skip('Cannot create an OffscreenCanvas');
+    }
   } else {
     unreachable();
   }


### PR DESCRIPTION
This makes more tests correctly skip themselves when parts of the Web
platform isn't present, like OffscreenCanvas, ImageData, or
createImageBitmap.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
