### PR TITLE
Test view format reinterpretation

### DIFF
--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -64,6 +64,8 @@ Whenever a new generally-useful helper is added, it should be indexed here.
     (like in copyBufferToTexture, copyTextureToBuffer, writeTexture).
 - {@link webgpu/util/texture/subresource}: Helpers for working with texture subresource ranges.
 - {@link webgpu/util/texture/texel_data}: Helpers encoding/decoding texel formats.
+- {@link webgpu/util/texture/texel_view}: Helper class to create and view texture data through various representations.
+- {@link webgpu/util/texture/texture_ok}: Helpers for checking texture contents.
 - {@link webgpu/shader/types}: Helpers for WGSL data types.
 - {@link webgpu/shader/execution/expression/expression}: Helpers for WGSL expression execution tests.
 - {@link webgpu/web_platform/util}: Helpers for web platform features (e.g. video elements).

--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -45,6 +45,7 @@ Whenever a new generally-useful helper is added, it should be indexed here.
 - {@link webgpu/constants}:
     Constant values (needed anytime a WebGPU constant is needed outside of a test function).
 - {@link webgpu/util/buffer}: Helpers for GPUBuffers.
+- {@link webgpu/util/texture}: Helpers for GPUTextures.
 - {@link webgpu/util/unions}: Helpers for various union typedefs in the WebGPU spec.
 - {@link webgpu/util/math}: Helpers for common math operations.
 - {@link webgpu/util/check_contents}: Check the contents of TypedArrays, with nice messages.

--- a/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
+++ b/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
@@ -1,0 +1,68 @@
+export const description = `
+Test texture views can reinterpret the format of the original texture.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import {
+  kRenderableColorTextureFormats,
+  kRegularTextureFormats,
+} from '../../../capability_info.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+function supportsReinterpretation(a: GPUTextureFormat, b: GPUTextureFormat) {
+  return a + '-srgb' === b || b + '-srgb' === a;
+}
+
+g.test('texture_binding')
+  .desc(`Test that a regular texture allocated as 'format' may be sampled as 'viewFormat'.`)
+  .params(u =>
+    u //
+      .combine('format', kRegularTextureFormats)
+      .combine('viewFormat', kRegularTextureFormats)
+      .filter(({ format, viewFormat }) => supportsReinterpretation(format, viewFormat))
+  )
+  .unimplemented();
+
+g.test('render_attachment')
+  .desc(
+    `Test that a renderable color texture allocated as 'format' may be rendered to as 'viewFormat'.`
+  )
+  .params(u =>
+    u //
+      .combine('format', kRenderableColorTextureFormats)
+      .combine('viewFormat', kRenderableColorTextureFormats)
+      .filter(({ format, viewFormat }) => supportsReinterpretation(format, viewFormat))
+  )
+  .unimplemented();
+
+g.test('resolve_attachment')
+  .desc(
+    `
+Test that a color render attachment allocated as 'renderFormat' may be rendered to as 'renderViewFormat',
+and resolved to an attachment allocated as 'resolveFormat' viewed as 'resolveViewFormat'.`
+  )
+  .params(u =>
+    u //
+      .combine('renderFormat', kRenderableColorTextureFormats)
+      .combine('renderViewFormat', kRenderableColorTextureFormats)
+      .filter(
+        ({ renderFormat, renderViewFormat }) =>
+          // Allow formats to be the same since reinterpretation may instead occur for the resolve format.
+          renderFormat === renderViewFormat ||
+          supportsReinterpretation(renderFormat, renderViewFormat)
+      )
+      .combine('resolveFormat', kRenderableColorTextureFormats)
+      .combine('resolveViewFormat', kRenderableColorTextureFormats)
+      .filter(
+        ({ renderFormat, renderViewFormat, resolveFormat, resolveViewFormat }) =>
+          renderViewFormat === resolveViewFormat && // Required by validation to match.
+          // At least one of the views should be reinterpreted.
+          (renderFormat !== renderViewFormat || resolveFormat !== resolveViewFormat) &&
+          // Allow formats to be the same since reinterpretation may occur for the render format.
+          (resolveFormat === resolveViewFormat ||
+            supportsReinterpretation(resolveFormat, resolveViewFormat))
+      )
+  )
+  .unimplemented();

--- a/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
+++ b/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
@@ -4,15 +4,97 @@ Test texture views can reinterpret the format of the original texture.
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import {
+  EncodableTextureFormat,
+  kTextureFormatInfo,
   kRenderableColorTextureFormats,
   kRegularTextureFormats,
 } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
+import { TexelView } from '../../../util/texture/texel_view.js';
+import { textureContentIsOKByT2B } from '../../../util/texture/texture_ok.js';
 
 export const g = makeTestGroup(GPUTest);
 
+const kColors = [
+  { R: 1.0, G: 0.0, B: 0.0, A: 0.8 },
+  { R: 0.0, G: 1.0, B: 0.0, A: 0.7 },
+  { R: 0.0, G: 0.0, B: 0.0, A: 0.6 },
+  { R: 0.0, G: 0.0, B: 0.0, A: 0.5 },
+  { R: 1.0, G: 1.0, B: 1.0, A: 0.4 },
+  { R: 0.7, G: 0.0, B: 0.0, A: 0.3 },
+  { R: 0.0, G: 0.8, B: 0.0, A: 0.2 },
+  { R: 0.0, G: 0.0, B: 0.9, A: 0.1 },
+  { R: 0.1, G: 0.2, B: 0.0, A: 0.3 },
+  { R: 0.4, G: 0.3, B: 0.6, A: 0.8 },
+];
+
+const kTextureSize = 16;
+
 function supportsReinterpretation(a: GPUTextureFormat, b: GPUTextureFormat) {
   return a + '-srgb' === b || b + '-srgb' === a;
+}
+
+function makeInputTexelView(format: EncodableTextureFormat) {
+  return TexelView.fromTexelsAsColors(
+    format,
+    coords => {
+      const pixelPos = coords.y * kTextureSize + coords.x;
+      return kColors[pixelPos % kColors.length];
+    },
+    { clampToFormatRange: true }
+  );
+}
+
+function makeBlitPipeline(
+  device: GPUDevice,
+  format: GPUTextureFormat,
+  multisample: { sample: number; render: number }
+) {
+  return device.createRenderPipeline({
+    vertex: {
+      module: device.createShaderModule({
+        code: `
+          @stage(vertex) fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
+            var pos = array<vec2<f32>, 6>(
+                                        vec2<f32>(-1.0, -1.0),
+                                        vec2<f32>(-1.0,  1.0),
+                                        vec2<f32>( 1.0, -1.0),
+                                        vec2<f32>(-1.0,  1.0),
+                                        vec2<f32>( 1.0, -1.0),
+                                        vec2<f32>( 1.0,  1.0));
+            return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+          }`,
+      }),
+      entryPoint: 'main',
+    },
+    fragment: {
+      module:
+        multisample.sample > 1
+          ? device.createShaderModule({
+              code: `
+            @group(0) @binding(0) var src: texture_multisampled_2d<f32>;
+            @stage(fragment) fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+              var result : vec4<f32>;
+              for (var i = 0; i < ${multisample.sample}; i = i + 1) {
+                result = result + textureLoad(src, vec2<i32>(coord.xy), i);
+              }
+              return result * ${1 / multisample.sample};
+            }`,
+            })
+          : device.createShaderModule({
+              code: `
+            @group(0) @binding(0) var src: texture_2d<f32>;
+            @stage(fragment) fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+              return textureLoad(src, vec2<i32>(coord.xy), 0);
+            }`,
+            }),
+      entryPoint: 'main',
+      targets: [{ format }],
+    },
+    multisample: {
+      count: multisample.render,
+    },
+  });
 }
 
 g.test('texture_binding')
@@ -23,24 +105,111 @@ g.test('texture_binding')
       .combine('viewFormat', kRegularTextureFormats)
       .filter(({ format, viewFormat }) => supportsReinterpretation(format, viewFormat))
   )
-  .unimplemented();
+  .fn(async t => {
+    const { format, viewFormat } = t.params;
 
-g.test('render_attachment')
-  .desc(
-    `Test that a renderable color texture allocated as 'format' may be rendered to as 'viewFormat'.`
-  )
-  .params(u =>
-    u //
-      .combine('format', kRenderableColorTextureFormats)
-      .combine('viewFormat', kRenderableColorTextureFormats)
-      .filter(({ format, viewFormat }) => supportsReinterpretation(format, viewFormat))
-  )
-  .unimplemented();
+    // Make an input texel view.
+    const inputTexelView = makeInputTexelView(format);
 
-g.test('resolve_attachment')
+    // Write data out to bytes.
+    const texelSize = kTextureFormatInfo[format].bytesPerBlock;
+    const textureData = new Uint8ClampedArray(texelSize * kTextureSize * kTextureSize);
+    inputTexelView.writeTextureData(textureData, {
+      bytesPerRow: texelSize * kTextureSize,
+      rowsPerImage: kTextureSize,
+      subrectOrigin: [0, 0],
+      subrectSize: [kTextureSize, kTextureSize],
+    });
+
+    // Create and upload data to the texture.
+    const texture = t.device.createTexture({
+      format,
+      size: [kTextureSize, kTextureSize],
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      viewFormats: [viewFormat],
+    });
+
+    t.device.queue.writeTexture(
+      { texture },
+      textureData,
+      {
+        bytesPerRow: texelSize * kTextureSize,
+      },
+      [kTextureSize, kTextureSize]
+    );
+
+    // Reinterepret the texture as the view format.
+    // Make a texel view of the format that also reinterprets the data.
+    const reinterpretedView = texture.createView({ format: viewFormat });
+    const reinterpretedTexelView = TexelView.fromTexelsAsBytes(viewFormat, inputTexelView.bytes);
+
+    // Create a pipeline to write data out to rgba8unorm.
+    const pipeline = t.device.createComputePipeline({
+      compute: {
+        module: t.device.createShaderModule({
+          code: `
+          @group(0) @binding(0) var src: texture_2d<f32>;
+          @group(0) @binding(1) var dst: texture_storage_2d<rgba8unorm, write>;
+          @stage(compute) @workgroup_size(1, 1) fn main(
+            @builtin(global_invocation_id) global_id: vec3<u32>,
+          ) {
+            var coord = vec2<i32>(global_id.xy);
+            textureStore(dst, coord, textureLoad(src, coord, 0));
+          }`,
+        }),
+        entryPoint: 'main',
+      },
+    });
+
+    // Create an rgba8unorm output texture.
+    const outputTexture = t.device.createTexture({
+      format: 'rgba8unorm',
+      size: [kTextureSize, kTextureSize],
+      usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC,
+    });
+
+    // Execute a compute pass to load data from the reinterpreted view and
+    // write out to the rgba8unorm texture.
+    const commandEncoder = t.device.createCommandEncoder();
+    const pass = commandEncoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(
+      0,
+      t.device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [
+          {
+            binding: 0,
+            resource: reinterpretedView,
+          },
+          {
+            binding: 1,
+            resource: outputTexture.createView(),
+          },
+        ],
+      })
+    );
+    pass.dispatch(kTextureSize, kTextureSize);
+    pass.end();
+    t.device.queue.submit([commandEncoder.finish()]);
+
+    const result = await textureContentIsOKByT2B(
+      t,
+      { texture: outputTexture },
+      [kTextureSize, kTextureSize],
+      {
+        expTexelView: TexelView.fromTexelsAsColors('rgba8unorm', reinterpretedTexelView.color, {
+          clampToFormatRange: true,
+        }),
+      },
+      { maxDiffULPsForNormFormat: 1 }
+    );
+    t.expectOK(result);
+  });
+
+g.test('render_or_resolve_attachment')
   .desc(
-    `
-Test that a color render attachment allocated as 'renderFormat' may be rendered to as 'renderViewFormat',
+    `Test that a color render attachment allocated as 'renderFormat' may be rendered to as 'renderViewFormat',
 and resolved to an attachment allocated as 'resolveFormat' viewed as 'resolveViewFormat'.`
   )
   .params(u =>
@@ -53,16 +222,192 @@ and resolved to an attachment allocated as 'resolveFormat' viewed as 'resolveVie
           renderFormat === renderViewFormat ||
           supportsReinterpretation(renderFormat, renderViewFormat)
       )
-      .combine('resolveFormat', kRenderableColorTextureFormats)
-      .combine('resolveViewFormat', kRenderableColorTextureFormats)
+      .combine('resolveFormat', [undefined, ...kRenderableColorTextureFormats])
+      .combine('resolveViewFormat', [undefined, ...kRenderableColorTextureFormats])
       .filter(
         ({ renderFormat, renderViewFormat, resolveFormat, resolveViewFormat }) =>
-          renderViewFormat === resolveViewFormat && // Required by validation to match.
+          (renderViewFormat === resolveViewFormat || resolveViewFormat === undefined) && // Required by validation to match.
           // At least one of the views should be reinterpreted.
           (renderFormat !== renderViewFormat || resolveFormat !== resolveViewFormat) &&
           // Allow formats to be the same since reinterpretation may occur for the render format.
           (resolveFormat === resolveViewFormat ||
-            supportsReinterpretation(resolveFormat, resolveViewFormat))
+            supportsReinterpretation(resolveFormat!, resolveViewFormat!))
       )
   )
-  .unimplemented();
+  .fn(async t => {
+    const { renderFormat, renderViewFormat, resolveFormat, resolveViewFormat } = t.params;
+
+    // Make an input texel view.
+    const inputTexelView = makeInputTexelView(renderFormat);
+
+    const sampleCount = resolveFormat !== undefined ? 4 : 1;
+
+    // Create the renderTexture as |renderFormat|.
+    const renderTexture = t.device.createTexture({
+      format: renderFormat,
+      size: [kTextureSize, kTextureSize],
+      usage:
+        GPUTextureUsage.RENDER_ATTACHMENT |
+        (sampleCount > 1 ? GPUTextureUsage.TEXTURE_BINDING : GPUTextureUsage.COPY_SRC),
+      viewFormats: [renderViewFormat],
+      sampleCount,
+    });
+
+    const resolveTexture =
+      resolveFormat &&
+      t.device.createTexture({
+        format: resolveFormat,
+        size: [kTextureSize, kTextureSize],
+        usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+        viewFormats: [resolveViewFormat!],
+      });
+
+    // Also create the sample source as |renderFormat|. We will sample this texture
+    // into |renderTexture|. Using the same format keeps the same number of bits of precision.
+    const sampleSource = t.device.createTexture({
+      format: renderFormat,
+      size: [kTextureSize, kTextureSize],
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    });
+
+    // Write data out to bytes.
+    const inputTexelSize = kTextureFormatInfo[renderFormat].bytesPerBlock;
+    const inputTextureData = new Uint8ClampedArray(inputTexelSize * kTextureSize * kTextureSize);
+    inputTexelView.writeTextureData(inputTextureData, {
+      bytesPerRow: inputTexelSize * kTextureSize,
+      rowsPerImage: kTextureSize,
+      subrectOrigin: [0, 0],
+      subrectSize: [kTextureSize, kTextureSize],
+    });
+
+    // Upload into the sample source.
+    t.device.queue.writeTexture(
+      { texture: sampleSource },
+      inputTextureData,
+      {
+        bytesPerRow: inputTexelSize * kTextureSize,
+      },
+      [kTextureSize, kTextureSize]
+    );
+
+    // Reinterpret the renderTexture as |renderViewFormat|.
+    const reinterpretedRenderView = renderTexture.createView({ format: renderViewFormat });
+    const reinterpretedResolveView =
+      resolveTexture && resolveTexture.createView({ format: resolveViewFormat });
+
+    // Create a pipeline to blit a src texture to the render attachment.
+    const pipeline = makeBlitPipeline(t.device, renderViewFormat, {
+      sample: 1,
+      render: sampleCount,
+    });
+
+    // Execute a render pass to sample |sampleSource| into |texture| viewed as |viewFormat|.
+    const commandEncoder = t.device.createCommandEncoder();
+    const pass = commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: reinterpretedRenderView,
+          resolveTarget: reinterpretedResolveView,
+          loadOp: 'load',
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(
+      0,
+      t.device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [
+          {
+            binding: 0,
+            resource: sampleSource.createView(),
+          },
+        ],
+      })
+    );
+    pass.draw(6);
+    pass.end();
+
+    // If the render target is multisampled, we'll manually resolve it to check
+    // the contents.
+    const singleSampleRenderTexture = resolveTexture
+      ? t.device.createTexture({
+          format: renderFormat,
+          size: [kTextureSize, kTextureSize],
+          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+        })
+      : renderTexture;
+
+    if (resolveTexture) {
+      // Create a pipeline to blit the multisampled render texture to a non-multisample texture.
+      // We are basically performing a manual resolve step to the same format as the original
+      // render texture to check its contents.
+      const pipeline = makeBlitPipeline(t.device, renderFormat, { sample: sampleCount, render: 1 });
+      const pass = commandEncoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: singleSampleRenderTexture.createView(),
+            loadOp: 'load',
+            storeOp: 'store',
+          },
+        ],
+      });
+      pass.setPipeline(pipeline);
+      pass.setBindGroup(
+        0,
+        t.device.createBindGroup({
+          layout: pipeline.getBindGroupLayout(0),
+          entries: [
+            {
+              binding: 0,
+              resource: renderTexture.createView(),
+            },
+          ],
+        })
+      );
+      pass.draw(6);
+      pass.end();
+    }
+
+    // Submit the commands.
+    t.device.queue.submit([commandEncoder.finish()]);
+
+    // Check the rendered contents.
+    const renderViewTexels = TexelView.fromTexelsAsColors(renderViewFormat, inputTexelView.color, {
+      clampToFormatRange: true,
+    });
+    t.expectOK(
+      await textureContentIsOKByT2B(
+        t,
+        { texture: singleSampleRenderTexture },
+        [kTextureSize, kTextureSize],
+        { expTexelView: renderViewTexels },
+        { maxDiffULPsForNormFormat: 2 }
+      )
+    );
+
+    // Check the resolved contents.
+    if (resolveTexture) {
+      // Vulkan behavior:
+      // const renderView = TexelView.fromTexelsAsBytes(renderFormat, renderViewTexels.bytes);
+      // const expTexelView = TexelView.fromTexelsAsColors(resolveFormat!, renderTexels.color, {
+      //   clampToFormatRange: true,
+      // });
+
+      // Metal behavior:
+      const resolveView = TexelView.fromTexelsAsColors(resolveViewFormat!, renderViewTexels.color, {
+        clampToFormatRange: true,
+      });
+      const expTexelView = TexelView.fromTexelsAsBytes(resolveFormat!, resolveView.bytes);
+
+      const result = await textureContentIsOKByT2B(
+        t,
+        { texture: resolveTexture },
+        [kTextureSize, kTextureSize],
+        { expTexelView },
+        { maxDiffULPsForNormFormat: 2 }
+      );
+      t.expectOK(result);
+    }
+  });

--- a/src/webgpu/api/operation/texture_view/read.spec.ts
+++ b/src/webgpu/api/operation/texture_view/read.spec.ts
@@ -8,6 +8,9 @@ All x= every possible view read method: {
   - depth comparison
   - stencil comparison
 }
+
+Format reinterpretation is not tested here. It is in format_reinterpretation.spec.ts.
+
 TODO: Write helper for this if not already available (see resource_init, buffer_sync_test for related code).
 `;
 
@@ -21,8 +24,8 @@ g.test('format')
     `Views of every allowed format.
 
 - x= every texture format
-- x= every valid view format (including same)
 - x= sampleCount {1, 4} if valid
+- x= every possible view read method (see above)
 `
   )
   .unimplemented();
@@ -35,6 +38,7 @@ g.test('dimension')
 - x= {every texture dimension} x {every valid view dimension}
   (per gpuweb#79 no dimension-count reinterpretations, like 2d-array <-> 3d, are possible)
 - x= sampleCount {1, 4} if valid
+- x= every possible view read method (see above)
 `
   )
   .unimplemented();
@@ -46,6 +50,7 @@ g.test('aspect')
 - x= every depth/stencil format
 - x= {"all", "stencil-only", "depth-only"} where valid for the format
 - x= sampleCount {1, 4} if valid
+- x= every possible view read method (see above)
 `
   )
   .unimplemented();

--- a/src/webgpu/api/operation/texture_view/read.spec.ts
+++ b/src/webgpu/api/operation/texture_view/read.spec.ts
@@ -23,7 +23,6 @@ g.test('format')
 - x= every texture format
 - x= every valid view format (including same)
 - x= sampleCount {1, 4} if valid
-- x= every possible view read method (see above)
 `
   )
   .unimplemented();
@@ -36,7 +35,6 @@ g.test('dimension')
 - x= {every texture dimension} x {every valid view dimension}
   (per gpuweb#79 no dimension-count reinterpretations, like 2d-array <-> 3d, are possible)
 - x= sampleCount {1, 4} if valid
-- x= every possible view read method (see above)
 `
   )
   .unimplemented();
@@ -48,7 +46,6 @@ g.test('aspect')
 - x= every depth/stencil format
 - x= {"all", "stencil-only", "depth-only"} where valid for the format
 - x= sampleCount {1, 4} if valid
-- x= every possible view read method (see above)
 `
   )
   .unimplemented();

--- a/src/webgpu/api/operation/texture_view/write.spec.ts
+++ b/src/webgpu/api/operation/texture_view/write.spec.ts
@@ -21,7 +21,6 @@ g.test('format')
 - x= every texture format
 - x= every valid view format (including same)
 - x= sampleCount {1, 4} if valid
-- x= every possible view write method (see above)
 `
   )
   .unimplemented();
@@ -34,7 +33,6 @@ g.test('dimension')
 - x= {every texture dimension} x {every valid view dimension}
   (per gpuweb#79 no dimension-count reinterpretations, like 2d-array <-> 3d, are possible)
 - x= sampleCount {1, 4} if valid
-- x= every possible view write method (see above)
 `
   )
   .unimplemented();
@@ -46,7 +44,6 @@ g.test('aspect')
 - x= every depth/stencil format
 - x= {"all", "stencil-only", "depth-only"} where valid for the format
 - x= sampleCount {1, 4} if valid
-- x= every possible view write method (see above)
 `
   )
   .unimplemented();

--- a/src/webgpu/api/operation/texture_view/write.spec.ts
+++ b/src/webgpu/api/operation/texture_view/write.spec.ts
@@ -6,6 +6,9 @@ All x= every possible view write method: {
   - render pass store
   - render pass resolve
 }
+
+Format reinterpretation is not tested here. It is in format_reinterpretation.spec.ts.
+
 TODO: Write helper for this if not already available (see resource_init, buffer_sync_test for related code).
 `;
 
@@ -19,8 +22,8 @@ g.test('format')
     `Views of every allowed format.
 
 - x= every texture format
-- x= every valid view format (including same)
 - x= sampleCount {1, 4} if valid
+- x= every possible view write method (see above)
 `
   )
   .unimplemented();
@@ -33,6 +36,7 @@ g.test('dimension')
 - x= {every texture dimension} x {every valid view dimension}
   (per gpuweb#79 no dimension-count reinterpretations, like 2d-array <-> 3d, are possible)
 - x= sampleCount {1, 4} if valid
+- x= every possible view write method (see above)
 `
   )
   .unimplemented();
@@ -44,6 +48,7 @@ g.test('aspect')
 - x= every depth/stencil format
 - x= {"all", "stencil-only", "depth-only"} where valid for the format
 - x= sampleCount {1, 4} if valid
+- x= every possible view write method (see above)
 `
   )
   .unimplemented();

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -12,6 +12,7 @@ import {
   kRegularTextureFormats,
   textureDimensionAndFormatCompatible,
   kLimitInfo,
+  viewCompatible,
 } from '../../capability_info.js';
 import { GPUConst } from '../../constants.js';
 import { maxMipLevelCount } from '../../util/texture/base.js';
@@ -702,4 +703,49 @@ g.test('texture_usage')
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);
     }, !success);
+  });
+
+g.test('viewFormats')
+  .desc(
+    `Test creating a texture with viewFormats list for all {texture format}x{view format}. Only compatible view formats should be valid.`
+  )
+  .params(u =>
+    u.combine('format', kTextureFormats).beginSubcases().combine('viewFormat', kTextureFormats)
+  )
+  .fn(async t => {
+    const { format, viewFormat } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase([format, viewFormat]);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
+
+    const compatible = viewCompatible(format, viewFormat);
+
+    // Test the viewFormat in the list.
+    t.expectValidationError(() => {
+      t.device.createTexture({
+        format,
+        size: [blockWidth, blockHeight],
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+        viewFormats: [viewFormat],
+      });
+    }, !compatible);
+
+    // Test the viewFormat and the texture format in the list.
+    t.expectValidationError(() => {
+      t.device.createTexture({
+        format,
+        size: [blockWidth, blockHeight],
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+        viewFormats: [viewFormat, format],
+      });
+    }, !compatible);
+
+    // Test the viewFormat multiple times in the list.
+    t.expectValidationError(() => {
+      t.device.createTexture({
+        format,
+        size: [blockWidth, blockHeight],
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+        viewFormats: [viewFormat, viewFormat],
+      });
+    }, !compatible);
   });

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -32,7 +32,6 @@ g.test('format')
   .params(u =>
     u
       .combine('textureFormat', kTextureFormats)
-      // If undefined, should default to textureFormat.
       .beginSubcases()
       .combine('viewFormat', [undefined, ...kTextureFormats])
       .combine('useViewFormatList', [false, true])

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -9,6 +9,7 @@ import {
   kTextureFormatInfo,
   kTextureFormats,
   kTextureViewDimensions,
+  viewCompatible,
 } from '../../capability_info.js';
 import { kResourceStates } from '../../gpu_test.js';
 import {
@@ -26,27 +27,38 @@ const kLevels = 6;
 
 g.test('format')
   .desc(
-    `Views must have the same format as the base texture, for all {texture format}x{view format}.`
+    `Views must have the view format compatible with the base texture, for all {texture format}x{view format}.`
   )
   .params(u =>
     u
       .combine('textureFormat', kTextureFormats)
-      .beginSubcases()
       // If undefined, should default to textureFormat.
+      .beginSubcases()
       .combine('viewFormat', [undefined, ...kTextureFormats])
+      .combine('useViewFormatList', [false, true])
   )
   .fn(async t => {
-    const { textureFormat, viewFormat } = t.params;
+    const { textureFormat, viewFormat, useViewFormatList } = t.params;
     await t.selectDeviceForTextureFormatOrSkipTestCase([textureFormat, viewFormat]);
     const { blockWidth, blockHeight } = kTextureFormatInfo[textureFormat];
+
+    const compatible = viewFormat === undefined || viewCompatible(textureFormat, viewFormat);
 
     const texture = t.device.createTexture({
       format: textureFormat,
       size: [blockWidth, blockHeight],
       usage: GPUTextureUsage.TEXTURE_BINDING,
+
+      // This is a test of createView, not createTexture. Don't pass viewFormats here that
+      // are not compatible, as that is tested in createTexture.spec.ts.
+      viewFormats:
+        useViewFormatList && compatible && viewFormat !== undefined ? [viewFormat] : undefined,
     });
 
-    const success = viewFormat === undefined || viewFormat === textureFormat;
+    // Successful if there is no view format, no reinterpretation was required, or the formats are compatible
+    // and is was specified in the viewFormats list.
+    const success =
+      viewFormat === undefined || viewFormat === textureFormat || (compatible && useViewFormatList);
     t.expectValidationError(() => {
       texture.createView({ format: viewFormat });
     }, !success);

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -964,6 +964,11 @@ export const kLimitInfo = /* prettier-ignore */ makeTable(
 /** List of all entries of GPUSupportedLimits. */
 export const kLimits = keysOf(kLimitInfo);
 
+/**
+ * Check if two formats are view format compatible.
+ *
+ * This function may need to be generalized to use `baseFormat` from `kTextureFormatInfo`.
+ */
 export function viewCompatible(a: GPUTextureFormat, b: GPUTextureFormat): boolean {
   return a === b || a + '-srgb' === b || b + '-srgb' === a;
 }

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -963,3 +963,7 @@ export const kLimitInfo = /* prettier-ignore */ makeTable(
 
 /** List of all entries of GPUSupportedLimits. */
 export const kLimits = keysOf(kLimitInfo);
+
+export function viewCompatible(a: GPUTextureFormat, b: GPUTextureFormat): boolean {
+  return a === b || a + '-srgb' === b || b + '-srgb' === a;
+}

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -28,12 +28,14 @@ import {
   UncanonicalizedDeviceDescriptor,
 } from './util/device_pool.js';
 import { align, roundDown } from './util/math.js';
+import { makeTextureWithContents } from './util/texture.js';
 import {
   getTextureCopyLayout,
   getTextureSubCopyLayout,
   LayoutOptions as TextureLayoutOptions,
 } from './util/texture/layout.js';
 import { PerTexelComponent, kTexelRepresentationInfo } from './util/texture/texel_data.js';
+import { TexelView } from './util/texture/texel_view.js';
 
 const devicePool = new DevicePool();
 
@@ -818,6 +820,16 @@ export class GPUTest extends Fixture {
    */
   makeBufferWithContents(dataArray: TypedArrayBufferView, usage: GPUBufferUsageFlags): GPUBuffer {
     return this.trackForCleanup(makeBufferWithContents(this.device, dataArray, usage));
+  }
+
+  /**
+   * Creates a texture with the contents of a TexelView.
+   */
+  makeTextureWithContents(
+    texelView: TexelView,
+    desc: Omit<GPUTextureDescriptor, 'format'>
+  ): GPUTexture {
+    return this.trackForCleanup(makeTextureWithContents(this.device, texelView, desc));
   }
 
   /**

--- a/src/webgpu/util/texture.ts
+++ b/src/webgpu/util/texture.ts
@@ -1,0 +1,61 @@
+import { assert } from '../../common/util/util.js';
+import { kTextureFormatInfo } from '../capability_info.js';
+
+import { align } from './math.js';
+import { TexelView } from './texture/texel_view.js';
+import { reifyExtent3D } from './unions.js';
+
+/**
+ * Creates a texture with the contents of a TexelView.
+ */
+export function makeTextureWithContents(
+  device: GPUDevice,
+  texelView: TexelView,
+  desc: Omit<GPUTextureDescriptor, 'format'>
+): GPUTexture {
+  const { width, height, depthOrArrayLayers } = reifyExtent3D(desc.size);
+
+  const { bytesPerBlock, blockWidth } = kTextureFormatInfo[texelView.format];
+  // Currently unimplemented for compressed textures.
+  assert(blockWidth === 1);
+
+  // Compute bytes per row.
+  const bytesPerRow = align(bytesPerBlock * width, 256);
+
+  // Create a staging buffer to upload the texture contents.
+  const stagingBuffer = device.createBuffer({
+    mappedAtCreation: true,
+    size: bytesPerRow * height * depthOrArrayLayers,
+    usage: GPUBufferUsage.COPY_SRC,
+  });
+
+  // Write the texels into the staging buffer.
+  texelView.writeTextureData(new Uint8Array(stagingBuffer.getMappedRange()), {
+    bytesPerRow,
+    rowsPerImage: height,
+    subrectOrigin: [0, 0, 0],
+    subrectSize: [width, height, depthOrArrayLayers],
+  });
+  stagingBuffer.unmap();
+
+  // Create the texture.
+  const texture = device.createTexture({
+    ...desc,
+    format: texelView.format,
+    usage: desc.usage | GPUTextureUsage.COPY_DST,
+  });
+
+  // Copy from the staging buffer into the texture.
+  const commandEncoder = device.createCommandEncoder();
+  commandEncoder.copyBufferToTexture(
+    { buffer: stagingBuffer, bytesPerRow },
+    { texture },
+    desc.size
+  );
+  device.queue.submit([commandEncoder.finish()]);
+
+  // Clean up the staging buffer.
+  stagingBuffer.destroy();
+
+  return texture;
+}


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
