### PR TITLE
validation,vertex_state: Only check valid attribute @locations

### DIFF
--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -367,11 +367,11 @@ g.test('vertex_attribute_shaderLocation_unique')
 g.test('vertex_shader_input_location_limit')
   .desc(
     `Test that vertex shader's input's location decoration must be less than maxVertexAttributes.
-   - Test for shaderLocation 0, 1, limit - 1, limit`
+   - Test for shaderLocation 0, 1, limit - 1, limit, MAX_I32 (the WGSL spec requires a non-negative i32)`
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('testLocation', [0, 1, kMaxVertexAttributes - 1, kMaxVertexAttributes, -1, 2 ** 32])
+      .combine('testLocation', [0, 1, kMaxVertexAttributes - 1, kMaxVertexAttributes, 2 ** 31 - 1])
   )
   .fn(t => {
     const { testLocation } = t.params;


### PR DESCRIPTION
The WGSL spec requires that these decorations be non-negative i32, so we
can't test -1 and MAX_U32.

Tested that combined with a Dawn fix the test passes in dawn_node.


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
