### PR TITLE
writeBuffer: an unaligned bufferOffset is a validation error.

### DIFF
--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -106,7 +106,7 @@ Also verifies that the specified data range:
       t.expectValidationError(() => queue.writeBuffer(buffer, 8, arrayMd));
 
       // Writing the full buffer with a unaligned offset.
-      t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 3, arraySm));
+      t.expectValidationError(() => queue.writeBuffer(buffer, 3, arraySm));
 
       // Writing remainder of buffer from offset.
       queue.writeBuffer(buffer, 0, arraySm, 4);


### PR DESCRIPTION
And not an OperationError exception.

Passes on dawn.node. But will fail in Blink.


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
