### PR TITLE
Add unicode tests for entryPoint matching.

### DIFF
--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -138,6 +138,7 @@ The entryPoint assigned in descriptor include:
 - Empty string
 - Mistyping
 - Containing invalid char, including space and control codes (Null character)
+- Unicode entrypoints and their ASCIIfied version
 `
   )
   .params(u =>
@@ -157,6 +158,8 @@ The entryPoint assigned in descriptor include:
       { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: 'main_t12V3' },
       { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: 'main_t12V5' },
       { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: '_main_t12V3' },
+      { shaderModuleEntryPoint: 'séquençage', stageEntryPoint: 'séquençage' },
+      { shaderModuleEntryPoint: 'séquençage', stageEntryPoint: 'sequencage' },
     ])
   )
   .fn(async t => {

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -737,3 +737,9 @@ g.test('shader_module,device_mismatch')
 
     t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
   });
+
+g.test('entry_point_name_must_match')
+  .desc(
+    'TODO: Test the matching of entrypoint names for vertex and fragment (see the equivalent test for createComputePipeline).'
+  )
+  .unimplemented();


### PR DESCRIPTION
Also add a TODO to duplicate these tests for createRenderPipeline.

See #1130

Tested on dawn.node (it should fail in Blink)


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
