### PR TITLE
Add validation,resource_usages,texture,in_render_common:* - Part IV

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -18,7 +18,7 @@ subresources, one for same draw/same pass/different pass, one for visibilities).
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { unreachable } from '../../../../../common/util/util.js';
+import { assert, unreachable } from '../../../../../common/util/util.js';
 import { ValidationTest } from '../../validation_test.js';
 
 class F extends ValidationTest {
@@ -34,6 +34,47 @@ class F extends ValidationTest {
       loadOp: 'clear',
       storeOp: 'store',
     };
+  }
+
+  createBindGroupForTest(
+    textureView: GPUTextureView,
+    textureUsage: 'texture' | 'storage',
+    sampleType: 'float' | 'depth' | 'uint'
+  ) {
+    const bindGroupLayoutEntry: GPUBindGroupLayoutEntry = {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT,
+    };
+    switch (textureUsage) {
+      case 'texture':
+        bindGroupLayoutEntry.texture = { viewDimension: '2d-array', sampleType };
+        break;
+      case 'storage':
+        bindGroupLayoutEntry.storageTexture = {
+          access: 'write-only',
+          format: 'rgba8unorm',
+          viewDimension: '2d-array',
+        };
+        break;
+      default:
+        unreachable();
+        break;
+    }
+    const layout = this.device.createBindGroupLayout({
+      entries: [bindGroupLayoutEntry],
+    });
+    return this.device.createBindGroup({
+      layout,
+      entries: [{ binding: 0, resource: textureView }],
+    });
+  }
+
+  isRangeNotOverlapped(start0: number, end0: number, start1: number, end1: number): boolean {
+    assert(start0 <= end0 && start1 <= end1);
+    // There are only two possibilities for two non-overlapped ranges:
+    // [start0, end0] [start1, end1] or
+    // [start1, end1] [start0, end0]
+    return end0 < start1 || end1 < start0;
   }
 }
 
@@ -124,7 +165,7 @@ g.test('subresources_from_same_texture_as_color_attachment_and_in_bind_group')
         { bindGroupViewBaseLayer: 1, bindGroupViewLayerCount: 1 },
         { bindGroupViewBaseLayer: 1, bindGroupViewLayerCount: 2 },
       ])
-      .combine('bindGroupUsage', ['texture', 'storage'])
+      .combine('bindGroupUsage', ['texture', 'storage'] as const)
       .unless(t => t.bindGroupUsage === 'storage' && t.bindGroupViewLevelCount > 1)
       .combine('inSamePass', [true, false])
   )
@@ -140,32 +181,12 @@ g.test('subresources_from_same_texture_as_color_attachment_and_in_bind_group')
       inSamePass,
     } = t.params;
 
-    const bindGroupLayoutEntry: GPUBindGroupLayoutEntry = {
-      binding: 0,
-      visibility: GPUShaderStage.FRAGMENT,
-    };
-    let textureUsage = GPUTextureUsage.RENDER_ATTACHMENT;
-    switch (bindGroupUsage) {
-      case 'texture':
-        bindGroupLayoutEntry.texture = { viewDimension: '2d-array' };
-        textureUsage |= GPUTextureUsage.TEXTURE_BINDING;
-        break;
-      case 'storage':
-        bindGroupLayoutEntry.storageTexture = {
-          access: 'write-only',
-          format: 'rgba8unorm',
-          viewDimension: '2d-array',
-        };
-        textureUsage |= GPUTextureUsage.STORAGE_BINDING;
-        break;
-      default:
-        unreachable();
-        break;
-    }
-
     const texture = t.device.createTexture({
       format: 'rgba8unorm',
-      usage: textureUsage,
+      usage:
+        GPUTextureUsage.RENDER_ATTACHMENT |
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.STORAGE_BINDING,
       size: [kTextureSize, kTextureSize, kTextureLayers],
       mipLevelCount: kTextureLevels,
     });
@@ -176,14 +197,7 @@ g.test('subresources_from_same_texture_as_color_attachment_and_in_bind_group')
       baseMipLevel: bindGroupViewBaseLevel,
       mipLevelCount: bindGroupViewLevelCount,
     });
-
-    const bindGroupLayout = t.device.createBindGroupLayout({
-      entries: [bindGroupLayoutEntry],
-    });
-    const bindGroup = t.device.createBindGroup({
-      layout: bindGroupLayout,
-      entries: [{ binding: 0, resource: bindGroupView }],
-    });
+    const bindGroup = t.createBindGroupForTest(bindGroupView, bindGroupUsage, 'float');
 
     const colorAttachment = t.getColorAttachment(texture, {
       baseArrayLayer: colorAttachmentLayer,
@@ -216,15 +230,21 @@ g.test('subresources_from_same_texture_as_color_attachment_and_in_bind_group')
       renderPass2.end();
     }
 
-    const isMipLevelOverlapped =
-      colorAttachmentLevel >= bindGroupViewBaseLevel &&
-      colorAttachmentLevel < bindGroupViewBaseLevel + bindGroupViewLevelCount;
-    const isArrayLayerOverlapped =
-      colorAttachmentLayer >= bindGroupViewBaseLayer &&
-      colorAttachmentLayer < bindGroupViewBaseLayer + bindGroupViewLayerCount;
-    const isOverlapped = isMipLevelOverlapped && isArrayLayerOverlapped;
+    const isMipLevelNotOverlapped = t.isRangeNotOverlapped(
+      colorAttachmentLevel,
+      colorAttachmentLevel,
+      bindGroupViewBaseLevel,
+      bindGroupViewBaseLevel + bindGroupViewLevelCount - 1
+    );
+    const isArrayLayerNotOverlapped = t.isRangeNotOverlapped(
+      colorAttachmentLayer,
+      colorAttachmentLayer,
+      bindGroupViewBaseLayer,
+      bindGroupViewBaseLayer + bindGroupViewLayerCount - 1
+    );
+    const isNotOverlapped = isMipLevelNotOverlapped || isArrayLayerNotOverlapped;
 
-    const success = inSamePass ? !isOverlapped : true;
+    const success = inSamePass ? isNotOverlapped : true;
     t.expectValidationError(() => {
       encoder.finish();
     }, !success);
@@ -235,7 +255,8 @@ g.test('subresources_from_same_texture_as_depth_stencil_attachment_and_in_bind_g
     `
   Test that when one subresource of a texture is used as a depth stencil attachment, it cannot be
   used in a bind group simultaneously in the same render pass encoder. It is allowed when the bind
-  group is used in another render pass encoder instead of the same one.`
+  group is used in another render pass encoder instead of the same one, or the subresource is used
+  as a read-only depth stencil attachment.`
   )
   .params(u =>
     u
@@ -268,14 +289,6 @@ g.test('subresources_from_same_texture_as_depth_stencil_attachment_and_in_bind_g
       inSamePass,
     } = t.params;
 
-    const bindGroupLayoutEntry = {
-      binding: 0,
-      visibility: GPUShaderStage.FRAGMENT,
-      texture: {
-        viewDimension: '2d-array',
-        sampleType: bindGroupAspect === 'depth-only' ? 'depth' : 'uint',
-      },
-    } as const;
     const texture = t.device.createTexture({
       format: 'depth24plus-stencil8',
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
@@ -290,13 +303,8 @@ g.test('subresources_from_same_texture_as_depth_stencil_attachment_and_in_bind_g
       mipLevelCount: bindGroupViewLevelCount,
       aspect: bindGroupAspect,
     });
-    const bindGroupLayout = t.device.createBindGroupLayout({
-      entries: [bindGroupLayoutEntry],
-    });
-    const bindGroup = t.device.createBindGroup({
-      layout: bindGroupLayout,
-      entries: [{ binding: 0, resource: bindGroupView }],
-    });
+    const sampleType = bindGroupAspect === 'depth-only' ? 'depth' : 'uint';
+    const bindGroup = t.createBindGroupForTest(bindGroupView, 'texture', sampleType);
 
     const attachmentView = texture.createView({
       baseArrayLayer: depthStencilAttachmentLayer,
@@ -339,15 +347,145 @@ g.test('subresources_from_same_texture_as_depth_stencil_attachment_and_in_bind_g
       renderPass2.end();
     }
 
-    const isMipLevelOverlapped =
-      depthStencilAttachmentLevel >= bindGroupViewBaseLevel &&
-      depthStencilAttachmentLevel < bindGroupViewBaseLevel + bindGroupViewLevelCount;
-    const isArrayLayerOverlapped =
-      depthStencilAttachmentLayer >= bindGroupViewBaseLayer &&
-      depthStencilAttachmentLayer < bindGroupViewBaseLayer + bindGroupViewLayerCount;
-    const isOverlapped = isMipLevelOverlapped && isArrayLayerOverlapped;
+    const isMipLevelNotOverlapped = t.isRangeNotOverlapped(
+      depthStencilAttachmentLevel,
+      depthStencilAttachmentLevel,
+      bindGroupViewBaseLevel,
+      bindGroupViewBaseLevel + bindGroupViewLevelCount - 1
+    );
+    const isArrayLayerNotOverlapped = t.isRangeNotOverlapped(
+      depthStencilAttachmentLayer,
+      depthStencilAttachmentLayer,
+      bindGroupViewBaseLayer,
+      bindGroupViewBaseLayer + bindGroupViewLayerCount - 1
+    );
+    const isNotOverlapped = isMipLevelNotOverlapped || isArrayLayerNotOverlapped;
 
-    const success = !inSamePass || !isOverlapped || depthStencilReadOnly;
+    const success = !inSamePass || isNotOverlapped || depthStencilReadOnly;
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, !success);
+  });
+
+g.test('subresources_from_same_color_texture_in_bind_groups')
+  .desc(
+    `
+  Test that when one color texture subresource is bound to different bind groups, its list of
+  internal usages within one usage scope can only be a compatible usage list. For texture
+  subresources in bind groups, the compatible usage lists are {TEXTURE_BINDING} and
+  {STORAGE_BINDING}, which means it can only be bound as both TEXTURE_BINDING and STORAGE_BINDING in
+  different render pass encoders, otherwise a validation error will occur.`
+  )
+  .params(u =>
+    u
+      .combineWithParams([
+        { bindGroupView0BaseLevel: 0, bindGroupView0LevelCount: 1 },
+        { bindGroupView0BaseLevel: 1, bindGroupView0LevelCount: 1 },
+        { bindGroupView0BaseLevel: 1, bindGroupView0LevelCount: 2 },
+      ])
+      .combineWithParams([
+        { bindGroupView0BaseLayer: 0, bindGroupView0LayerCount: 1 },
+        { bindGroupView0BaseLayer: 1, bindGroupView0LayerCount: 1 },
+        { bindGroupView0BaseLayer: 1, bindGroupView0LayerCount: 2 },
+      ])
+      .combineWithParams([
+        { bindGroupView1BaseLevel: 0, bindGroupView1LevelCount: 1 },
+        { bindGroupView1BaseLevel: 1, bindGroupView1LevelCount: 1 },
+        { bindGroupView1BaseLevel: 1, bindGroupView1LevelCount: 2 },
+      ])
+      .combineWithParams([
+        { bindGroupView1BaseLayer: 0, bindGroupView1LayerCount: 1 },
+        { bindGroupView1BaseLayer: 1, bindGroupView1LayerCount: 1 },
+        { bindGroupView1BaseLayer: 1, bindGroupView1LayerCount: 2 },
+      ])
+      .combine('bindGroupUsage0', ['texture', 'storage'] as const)
+      .combine('bindGroupUsage1', ['texture', 'storage'] as const)
+      .unless(
+        t =>
+          (t.bindGroupUsage0 === 'storage' && t.bindGroupView0LevelCount > 1) ||
+          (t.bindGroupUsage1 === 'storage' && t.bindGroupView1LevelCount > 1)
+      )
+      .combine('inSamePass', [true, false])
+  )
+  .fn(async t => {
+    const {
+      bindGroupView0BaseLevel,
+      bindGroupView0LevelCount,
+      bindGroupView0BaseLayer,
+      bindGroupView0LayerCount,
+      bindGroupView1BaseLevel,
+      bindGroupView1LevelCount,
+      bindGroupView1BaseLayer,
+      bindGroupView1LayerCount,
+      bindGroupUsage0,
+      bindGroupUsage1,
+      inSamePass,
+    } = t.params;
+
+    const texture = t.device.createTexture({
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+      size: [kTextureSize, kTextureSize, kTextureLayers],
+      mipLevelCount: kTextureLevels,
+    });
+    const bindGroupView0 = texture.createView({
+      dimension: '2d-array',
+      baseArrayLayer: bindGroupView0BaseLayer,
+      arrayLayerCount: bindGroupView0LayerCount,
+      baseMipLevel: bindGroupView0BaseLevel,
+      mipLevelCount: bindGroupView0LevelCount,
+    });
+    const bindGroupView1 = texture.createView({
+      dimension: '2d-array',
+      baseArrayLayer: bindGroupView1BaseLayer,
+      arrayLayerCount: bindGroupView1LayerCount,
+      baseMipLevel: bindGroupView1BaseLevel,
+      mipLevelCount: bindGroupView1LevelCount,
+    });
+    const bindGroup0 = t.createBindGroupForTest(bindGroupView0, bindGroupUsage0, 'float');
+    const bindGroup1 = t.createBindGroupForTest(bindGroupView1, bindGroupUsage1, 'float');
+
+    const colorTexture = t.device.createTexture({
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      size: [kTextureSize, kTextureSize, 1],
+      mipLevelCount: 1,
+    });
+    const colorAttachment = t.getColorAttachment(colorTexture);
+    const encoder = t.device.createCommandEncoder();
+    const renderPass = encoder.beginRenderPass({
+      colorAttachments: [colorAttachment],
+    });
+    if (inSamePass) {
+      renderPass.setBindGroup(0, bindGroup0);
+      renderPass.setBindGroup(1, bindGroup1);
+      renderPass.end();
+    } else {
+      renderPass.setBindGroup(0, bindGroup0);
+      renderPass.end();
+
+      const renderPass2 = encoder.beginRenderPass({
+        colorAttachments: [colorAttachment],
+      });
+      renderPass2.setBindGroup(1, bindGroup1);
+      renderPass2.end();
+    }
+
+    const isMipLevelNotOverlapped = t.isRangeNotOverlapped(
+      bindGroupView0BaseLevel,
+      bindGroupView0BaseLevel + bindGroupView0LevelCount - 1,
+      bindGroupView1BaseLevel,
+      bindGroupView1BaseLevel + bindGroupView1LevelCount - 1
+    );
+    const isArrayLayerNotOverlapped = t.isRangeNotOverlapped(
+      bindGroupView0BaseLayer,
+      bindGroupView0BaseLayer + bindGroupView0LayerCount - 1,
+      bindGroupView1BaseLayer,
+      bindGroupView1BaseLayer + bindGroupView1LayerCount - 1
+    );
+    const isNotOverlapped = isMipLevelNotOverlapped || isArrayLayerNotOverlapped;
+
+    const success = !inSamePass || isNotOverlapped || bindGroupUsage0 === bindGroupUsage1;
     t.expectValidationError(() => {
       encoder.finish();
     }, !success);


### PR DESCRIPTION
This PR implements the 4th part of
Add validation,resource_usages,texture,in_render_common:*:
- subresources_from_same_color_texture_in_bind_groups

Issue: #905 

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
