### PR TITLE
Fix a validation error caused by WriteTexture bytesPerRow: t.width

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -101,16 +101,7 @@ g.test('depth_stencil_format,copy_usage_and_aspect')
     {
       const success = depthStencilBufferTextureCopySupported('WriteTexture', format, aspect);
       const uploadData = new Uint8Array(uploadBufferSize);
-      t.testWriteTexture(
-        { texture, aspect },
-        uploadData,
-        {
-          bytesPerRow: textureSize.width,
-          rowsPerImage: textureSize.height,
-        },
-        textureSize,
-        success
-      );
+      t.testWriteTexture({ texture, aspect }, uploadData, {}, textureSize, success);
     }
   });
 


### PR DESCRIPTION
Specifying the bytesPerRow is not necessary in this test so it is just
removed.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
