### PR TITLE
val/copyT2T,format_compat: Don't assume compressed is always 4x4

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -13,7 +13,7 @@ import {
   kTextureDimensions,
 } from '../../../../capability_info.js';
 import { kResourceStates } from '../../../../gpu_test.js';
-import { align } from '../../../../util/math.js';
+import { align, lcm } from '../../../../util/math.js';
 import { ValidationTest } from '../../validation_test.js';
 
 class F extends ValidationTest {
@@ -356,16 +356,20 @@ Test the formats of textures in copyTextureToTexture must be copy-compatible.
     const dstFormatInfo = kTextureFormatInfo[dstFormat];
     await t.selectDeviceOrSkipTestCase([srcFormatInfo.feature, dstFormatInfo.feature]);
 
-    const kTextureSize = { width: 16, height: 16, depthOrArrayLayers: 1 };
+    const textureSize = {
+      width: lcm(srcFormatInfo.blockWidth, dstFormatInfo.blockWidth),
+      height: lcm(srcFormatInfo.blockHeight, dstFormatInfo.blockHeight),
+      depthOrArrayLayers: 1,
+    };
 
     const srcTexture = t.device.createTexture({
-      size: kTextureSize,
+      size: textureSize,
       format: srcFormat,
       usage: GPUTextureUsage.COPY_SRC,
     });
 
     const dstTexture = t.device.createTexture({
-      size: kTextureSize,
+      size: textureSize,
       format: dstFormat,
       usage: GPUTextureUsage.COPY_DST,
     });
@@ -378,7 +382,7 @@ Test the formats of textures in copyTextureToTexture must be copy-compatible.
     t.TestCopyTextureToTexture(
       { texture: srcTexture },
       { texture: dstTexture },
-      kTextureSize,
+      textureSize,
       isSuccess ? 'Success' : 'FinishError'
     );
   });

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -349,3 +349,22 @@ export function isPowerOfTwo(n: number): boolean {
   }
   return n !== 0 && (n & (n - 1)) === 0;
 }
+
+/** @returns the Greatest Common Divisor (GCD) of the inputs */
+export function gcd(a: number, b: number): number {
+  assert(Number.isInteger(a) && a > 0);
+  assert(Number.isInteger(b) && b > 0);
+
+  while (b !== 0) {
+    const bTemp = b;
+    b = a % b;
+    a = bTemp;
+  }
+
+  return a;
+}
+
+/** @returns the Least Common Multiplier (LCM) of the inputs */
+export function lcm(a: number, b: number): number {
+  return (a * b) / gcd(a, b);
+}


### PR DESCRIPTION
The ASTC texture compression format has a lot of different block sizes
so using 16x16 for the test might not work. Instead use the LCM of the
block size.

(and add GCD and LCD util functions)




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
