### PR TITLE
Fix test of BGL binding limits to correctly check limits

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -7,7 +7,6 @@ TODO: make sure tests are complete.
 import { kUnitCaseParamsBuilder } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
-  kMaxBindingsPerBindGroup,
   kShaderStages,
   kShaderStageCombinations,
   kTextureViewDimensions,
@@ -200,6 +199,7 @@ g.test('max_resources_per_stage,in_bind_group_layout')
     const { maxedEntry, extraEntry, maxedVisibility, extraVisibility } = t.params;
     const maxedTypeInfo = bindingTypeInfo(maxedEntry);
     const maxedCount = maxedTypeInfo.perStageLimitClass.max;
+    const extraTypeInfo = bindingTypeInfo(extraEntry);
 
     const maxResourceBindings: GPUBindGroupLayoutEntry[] = [];
     for (let i = 0; i < maxedCount; i++) {
@@ -215,6 +215,7 @@ g.test('max_resources_per_stage,in_bind_group_layout')
     // Control
     t.device.createBindGroupLayout(goodDescriptor);
 
+    // Add an entry counting towards the same limit. It should produce a validation error.
     const newDescriptor = clone(goodDescriptor);
     newDescriptor.entries.push({
       binding: maxedCount,
@@ -222,11 +223,13 @@ g.test('max_resources_per_stage,in_bind_group_layout')
       ...extraEntry,
     });
 
-    const shouldError = maxedCount >= kMaxBindingsPerBindGroup;
+    const newBindingCountsTowardSamePerStageLimit =
+      (maxedVisibility & extraVisibility) !== 0 &&
+      maxedTypeInfo.perStageLimitClass.class === extraTypeInfo.perStageLimitClass.class;
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout(newDescriptor);
-    }, shouldError);
+    }, newBindingCountsTowardSamePerStageLimit);
   });
 
 // One pipeline layout can have a maximum number of each type of binding *per stage* (which is
@@ -277,9 +280,8 @@ g.test('max_resources_per_stage,in_pipeline_layout')
     const newBindingCountsTowardSamePerStageLimit =
       (maxedVisibility & extraVisibility) !== 0 &&
       maxedTypeInfo.perStageLimitClass.class === extraTypeInfo.perStageLimitClass.class;
-    const layoutExceedsPerStageLimit = newBindingCountsTowardSamePerStageLimit;
 
     t.expectValidationError(() => {
       t.device.createPipelineLayout({ bindGroupLayouts: [goodLayout, extraLayout] });
-    }, layoutExceedsPerStageLimit);
+    }, newBindingCountsTowardSamePerStageLimit);
   });

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -648,9 +648,6 @@ assertTypeTrue<TypeEqual<BindableResource, typeof kBindableResources[number]>>()
 /** Dynamic buffer offsets require offset to be divisible by 256, by spec. */
 export const kMinDynamicBufferOffsetAlignment = 256;
 
-/** Maximum number of bindings per GPUBindGroup(Layout), by spec. */
-export const kMaxBindingsPerBindGroup = 16;
-
 /** Default `PerShaderStage` binding limits, by spec. */
 export const kPerStageBindingLimits: {
   readonly [k in PerStageBindingLimitClass]: {


### PR DESCRIPTION
It seems was used a very deprecated kMaxBindingsPerGroup constant that
doesn't exist in the spec anymore, and didn't account for binding limits
being per-stage for the most part.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
