### PR TITLE
Don't require offset % 4 == 0 for depth-stencil <-> buffer copies

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -221,9 +221,10 @@ g.test('depth_stencil_format,copy_buffer_size')
 g.test('depth_stencil_format,copy_buffer_offset')
   .desc(
     `
-    Validate for every depth stencil formats the buffer offset must be a multiple of 4 in
-    copyBufferToTexture() and copyTextureToBuffer(), but the offset in writeTexture() doesn't always
-    need to be a multiple of 4.
+    Validate for every depth stencil formats the buffer offset must be a multiple of the block size
+    in copyBufferToTexture() and copyTextureToBuffer(), but the offset in writeTexture() doesn't
+    always need to be a multiple of the block size.
+    TODO: test copying to aspects of depth-stencil formats.
     `
   )
   .params(u =>
@@ -265,7 +266,7 @@ g.test('depth_stencil_format,copy_buffer_offset')
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
 
-    const isSuccess = copyType === 'WriteTexture' ? true : offset % 4 === 0;
+    const isSuccess = copyType === 'WriteTexture' ? true : offset % texelAspectSize === 0;
 
     if (copyType === 'CopyB2T') {
       t.testCopyBufferToTexture(

--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -262,7 +262,7 @@ Test that rowsPerImage has no alignment constraints.
 g.test('offset_alignment')
   .desc(
     `
-Test the alignment requirement on the linear data offset (block size, or 4 for depth-stencil).
+Test the block size alignment requirement on the linear data offset.
 - for various copy methods
 - for all sized formats
 - for all dimensions
@@ -293,11 +293,7 @@ Test the alignment requirement on the linear data offset (block size, or 4 for d
 
     let success = false;
     if (method === 'WriteTexture') success = true;
-    if (info.depth || info.stencil) {
-      if (offset % 4 === 0) success = true;
-    } else {
-      if (offset % info.bytesPerBlock === 0) success = true;
-    }
+    if (offset % info.bytesPerBlock === 0) success = true;
 
     t.testRun({ texture }, { offset, bytesPerRow: 256 }, size, {
       dataSize: offset + info.bytesPerBlock,


### PR DESCRIPTION
This limitation has been removed from the spec for the depth16unorm and
stencil8 formats which don't have this limitation.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
