### PR TITLE
val,buffer,create: Buffer sizes don't have to be multiple of 4.

### DIFF
--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -94,10 +94,6 @@ hidden behind the "more severe" validation error.`
       { usage: BufferUsage.MAP_READ | BufferUsage.UNIFORM, size: 16 },
       { usage: BufferUsage.MAP_READ | BufferUsage.UNIFORM, size: kMaxSafeMultipleOf8 },
       { usage: BufferUsage.MAP_READ | BufferUsage.UNIFORM, size: 0x20_0000_0000 }, // 128 GiB
-      // Invalid because size is not aligned to 4 bytes.
-      { usage: BufferUsage.STORAGE, size: 15 },
-      { usage: BufferUsage.STORAGE, size: kMaxSafeMultipleOf8 - 1 },
-      { usage: BufferUsage.STORAGE, size: 0x20_0000_0000 - 1 }, // 128 GiB - 1
     ] as const)
   )
   .fn(t => {


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
