### PR TITLE
Use globalThis instead of self.

### DIFF
--- a/src/common/util/collect_garbage.ts
+++ b/src/common/util/collect_garbage.ts
@@ -10,7 +10,7 @@ declare const Components: any;
  */
 export async function attemptGarbageCollection(): Promise<void> {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  const w: any = self;
+  const w: any = globalThis;
   if (w.GCController) {
     w.GCController.collect();
     return;


### PR DESCRIPTION
The `self` global variable seems to only be available in browsers. Use
`globalThis` instead that is available everywhere.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
