### PR TITLE
Update DevicePool to provide multiple devices

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -502,10 +502,6 @@ g.test('bind_group_layout,device_mismatch')
   .fn(async t => {
     const mismatched = t.params.mismatched;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const bgl = device.createBindGroupLayout({
@@ -559,10 +555,6 @@ g.test('binding_resources,device_mismatch')
   )
   .fn(async t => {
     const { entry, resource0Mismatched, resource1Mismatched } = t.params;
-
-    if (resource0Mismatched || resource1Mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
 
     const info = bindingTypeInfo(entry);
 

--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -182,10 +182,6 @@ g.test('pipeline_layout,device_mismatch')
   .fn(async t => {
     const { isAsync, mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const layout = device.createPipelineLayout({ bindGroupLayouts: [] });
@@ -208,10 +204,6 @@ g.test('shader_module,device_mismatch')
   .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
   .fn(async t => {
     const { isAsync, mismatched } = t.params;
-
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
 
     const device = mismatched ? t.mismatchedDevice : t.device;
 

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -122,10 +122,6 @@ g.test('bind_group_layouts,device_mismatch')
 
     const mismatched = layout0Mismatched || layout1Mismatched;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const bglDescriptor: GPUBindGroupLayoutDescriptor = {
       entries: [],
     };

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -664,10 +664,6 @@ g.test('pipeline_layout,device_mismatch')
   .fn(async t => {
     const { isAsync, mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const layout = device.createPipelineLayout({ bindGroupLayouts: [] });
@@ -707,10 +703,6 @@ g.test('shader_module,device_mismatch')
   )
   .fn(async t => {
     const { isAsync, vertex_mismatched, fragment_mismatched, _success } = t.params;
-
-    if (vertex_mismatched || fragment_mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
 
     const code = `
       @stage(vertex) fn main() -> @builtin(position) vec4<f32> {

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -65,10 +65,6 @@ g.test('color_attachments,device_mismatch')
 
     const mismatched = view0Mismatched || target0Mismatched || view1Mismatched || target1Mismatched;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const view0Texture = view0Mismatched
       ? t.getDeviceMismatchedRenderTexture(4)
       : t.getRenderTexture(4);
@@ -114,10 +110,6 @@ g.test('depth_stencil_attachment,device_mismatch')
   .fn(async t => {
     const { mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const descriptor: GPUTextureDescriptor = {
       size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       format: 'depth24plus-stencil8',
@@ -153,10 +145,6 @@ g.test('occlusion_query_set,device_mismatch')
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
   .fn(async t => {
     const { mismatched } = t.params;
-
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
 
     const device = mismatched ? t.mismatchedDevice : t.device;
 

--- a/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
@@ -60,10 +60,6 @@ g.test('buffer,device_mismatch')
   .fn(async t => {
     const { mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
     const size = 8;
 

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -68,10 +68,6 @@ g.test('pipeline,device_mismatch')
   .fn(async t => {
     const { mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const pipeline = device.createComputePipeline({
@@ -183,10 +179,6 @@ g.test('indirect_dispatch_buffer,device_mismatch')
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
   .fn(async t => {
     const { mismatched } = t.params;
-
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
 
     const pipeline = t.createNoOpComputePipeline();
 

--- a/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
@@ -106,10 +106,6 @@ g.test('buffer,device_mismatch')
     const { srcMismatched, dstMismatched } = t.params;
     const mismatched = srcMismatched || dstMismatched;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const srcBuffer = device.createBuffer({

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -121,10 +121,6 @@ g.test('texture,device_mismatch')
     const { srcMismatched, dstMismatched } = t.params;
     const mismatched = srcMismatched || dstMismatched;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
     const size = { width: 4, height: 4, depthOrArrayLayers: 1 };
     const format = 'rgba8unorm';

--- a/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
@@ -58,10 +58,6 @@ g.test('indirect_buffer,device_mismatch')
   .fn(async t => {
     const { encoderType, indexed, mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const indirectBuffer = device.createBuffer({

--- a/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
@@ -36,10 +36,6 @@ g.test('index_buffer,device_mismatch')
   .fn(async t => {
     const { encoderType, mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const indexBuffer = device.createBuffer({

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -34,10 +34,6 @@ g.test('pipeline,device_mismatch')
   .fn(async t => {
     const { encoderType, mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const pipeline = device.createRenderPipeline({

--- a/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
@@ -62,10 +62,6 @@ g.test('vertex_buffer,device_mismatch')
   .fn(async t => {
     const { encoderType, mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const vertexBuffer = device.createBuffer({

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -143,10 +143,6 @@ g.test('bind_group,device_mismatch')
   .fn(async t => {
     const { encoderType, useU32Array, mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const buffer = device.createBuffer({

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -128,7 +128,7 @@ g.test('timestamp_query,device_mismatch')
   .fn(async t => {
     const { mismatched } = t.params;
 
-    await t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
+    await t.selectDeviceOrSkipTestCase('timestamp-query');
 
     if (mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase('timestamp-query');

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -157,10 +157,6 @@ g.test('query_set_buffer,device_mismatch')
     const { querySetMismatched, bufferMismatched } = t.params;
     const mismatched = querySetMismatched || bufferMismatched;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
     const queryCout = 1;
 

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -38,10 +38,6 @@ g.test('device_mismatch')
     const { bundle0Mismatched, bundle1Mismatched } = t.params;
     const mismatched = bundle0Mismatched || bundle1Mismatched;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const descriptor: GPURenderBundleEncoderDescriptor = {

--- a/src/webgpu/api/validation/image_copy/buffer_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/buffer_related.spec.ts
@@ -65,10 +65,6 @@ g.test('buffer,device_mismatch')
   .fn(async t => {
     const { method, mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const buffer = device.createBuffer({

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -73,10 +73,6 @@ g.test('texture,device_mismatch')
   .fn(async t => {
     const { method, mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const texture = device.createTexture({

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -618,10 +618,6 @@ g.test('destination_texture,device_mismatch')
   .fn(async t => {
     const { mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
     const copySize = { width: 1, height: 1, depthOrArrayLayers: 1 };
 

--- a/src/webgpu/api/validation/queue/submit.spec.ts
+++ b/src/webgpu/api/validation/queue/submit.spec.ts
@@ -28,10 +28,6 @@ g.test('command_buffer,device_mismatch')
     const { cb0Mismatched, cb1Mismatched } = t.params;
     const mismatched = cb0Mismatched || cb1Mismatched;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const encoder0 = cb0Mismatched
       ? t.mismatchedDevice.createCommandEncoder()
       : t.device.createCommandEncoder();

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -179,10 +179,6 @@ g.test('buffer,device_mismatch')
   .fn(async t => {
     const { mismatched } = t.params;
 
-    if (mismatched) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-    }
-
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const buffer = device.createBuffer({

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -640,7 +640,6 @@ g.test('copy_contents_from_gpu_context_canvas')
     let device: GPUDevice;
 
     if (!srcAndDstInSameGPUDevice) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
       device = t.mismatchedDevice;
     } else {
       device = t.device;


### PR DESCRIPTION
- Remove mismatched device pool, make the device pool could provide
  multiple devices at once, and reserve a default mismatched device
  at test initialization.
- Cancel selecting the default mismatched device in tests. For
  requesting mismatched device with particular features, we still need
  to call selectMismatchedDeviceOrSkipTestCase.




Issue: #912

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
