### PR TITLE
Fix infinite recursion in CopyExternalImageToTexture.spec.ts

### DIFF
--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -149,7 +149,7 @@ class CopyExternalImageToTextureTest extends ValidationTest {
     if (typeof createImageBitmap === 'undefined') {
       this.skip('Creating ImageBitmaps is not supported.');
     }
-    return this.createImageBitmap(image);
+    return createImageBitmap(image);
   }
 
   runTest(


### PR DESCRIPTION
Infinite loop accidentally introduced at https://github.com/gpuweb/cts/commit/43ba3cc3a7af99073481ced635a5750c067d6ee9#diff-cec7e2cde939294b3323147877151c20b55a96d45829ff4660409f97b9372c8eR152




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
