### PR TITLE
Fix validation errors with depth/StencilLoad/StoreOp set when not all…

### DIFF
--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -130,6 +130,8 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
     }
 
     const commandEncoder = t.device.createCommandEncoder();
+    commandEncoder.pushDebugGroup('checkContentsWithDepthStencil');
+
     const pass = commandEncoder.beginRenderPass({
       colorAttachments: [
         {
@@ -142,10 +144,10 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
       ],
       depthStencilAttachment: {
         view: texture.createView(viewDescriptor),
-        depthStoreOp: 'store',
-        depthLoadOp: 'load',
-        stencilStoreOp: 'store',
-        stencilLoadOp: 'load',
+        depthStoreOp: type === 'depth' ? 'store' : undefined,
+        depthLoadOp: type === 'depth' ? 'load' : undefined,
+        stencilStoreOp: type === 'stencil' ? 'store' : undefined,
+        stencilLoadOp: type === 'stencil' ? 'load' : undefined,
       },
     });
 
@@ -173,6 +175,7 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
     pass.draw(3);
     pass.end();
 
+    commandEncoder.popDebugGroup();
     t.queue.submit([commandEncoder.finish()]);
 
     t.expectSingleColor(resolveTexture || renderTexture, 'r8unorm', {

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -298,6 +298,8 @@ export class TextureZeroInitTest extends GPUTest {
     subresourceRange?: SubresourceRange
   ): void {
     const commandEncoder = this.device.createCommandEncoder();
+    commandEncoder.pushDebugGroup('initializeWithStoreOp');
+
     for (const viewDescriptor of this.generateTextureViewDescriptorsForRendering(
       this.p.aspect,
       subresourceRange
@@ -319,12 +321,12 @@ export class TextureZeroInitTest extends GPUTest {
         const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
           view: texture.createView(viewDescriptor),
         };
-        if (kTextureFormatInfo[this.p.format].depth) {
+        if (kTextureFormatInfo[this.p.format].depth && this.p.aspect !== 'stencil-only') {
           depthStencilAttachment.depthClearValue = initializedStateAsDepth[state];
           depthStencilAttachment.depthLoadOp = 'clear';
           depthStencilAttachment.depthStoreOp = 'store';
         }
-        if (kTextureFormatInfo[this.p.format].stencil) {
+        if (kTextureFormatInfo[this.p.format].stencil && this.p.aspect !== 'depth-only') {
           depthStencilAttachment.stencilClearValue = initializedStateAsStencil[state];
           depthStencilAttachment.stencilLoadOp = 'clear';
           depthStencilAttachment.stencilStoreOp = 'store';
@@ -337,6 +339,8 @@ export class TextureZeroInitTest extends GPUTest {
           .end();
       }
     }
+
+    commandEncoder.popDebugGroup();
     this.queue.submit([commandEncoder.finish()]);
   }
 
@@ -407,6 +411,7 @@ export class TextureZeroInitTest extends GPUTest {
 
   discardTexture(texture: GPUTexture, subresourceRange: SubresourceRange): void {
     const commandEncoder = this.device.createCommandEncoder();
+    commandEncoder.pushDebugGroup('discardTexture');
 
     for (const desc of this.generateTextureViewDescriptorsForRendering(
       this.p.aspect,
@@ -428,11 +433,11 @@ export class TextureZeroInitTest extends GPUTest {
         const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
           view: texture.createView(desc),
         };
-        if (kTextureFormatInfo[this.p.format].depth) {
+        if (kTextureFormatInfo[this.p.format].depth && this.p.aspect !== 'stencil-only') {
           depthStencilAttachment.depthLoadOp = 'load';
           depthStencilAttachment.depthStoreOp = 'discard';
         }
-        if (kTextureFormatInfo[this.p.format].stencil) {
+        if (kTextureFormatInfo[this.p.format].stencil && this.p.aspect !== 'depth-only') {
           depthStencilAttachment.stencilLoadOp = 'load';
           depthStencilAttachment.stencilStoreOp = 'discard';
         }
@@ -444,6 +449,8 @@ export class TextureZeroInitTest extends GPUTest {
           .end();
       }
     }
+
+    commandEncoder.popDebugGroup();
     this.queue.submit([commandEncoder.finish()]);
   }
 }


### PR DESCRIPTION
…owed.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
