### PR TITLE
Fix tests trying to copy aspects of depth-stencil textures.

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -43,7 +43,6 @@ import { assert, memcpy, unreachable } from '../../../../common/util/util.js';
 import {
   kTextureFormatInfo,
   SizedTextureFormat,
-  kSizedTextureFormats,
   kDepthStencilFormats,
   kMinDynamicBufferOffsetAlignment,
   kBufferSizeAlignment,
@@ -52,6 +51,7 @@ import {
   depthStencilFormatAspectSize,
   kTextureDimensions,
   textureDimensionAndFormatCompatible,
+  kColorTextureFormats,
 } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { makeBufferWithContents } from '../../../util/buffer.js';
@@ -119,7 +119,7 @@ const kExcludedFormats: Set<SizedTextureFormat> = new Set([
   'rg32float',
   'rgba32float',
 ]);
-const kWorkingTextureFormats = kSizedTextureFormats.filter(x => !kExcludedFormats.has(x));
+const kWorkingColorTextureFormats = kColorTextureFormats.filter(x => !kExcludedFormats.has(x));
 
 class ImageCopyTest extends GPUTest {
   /** Offset for a particular texel in the linear texture data */
@@ -881,11 +881,12 @@ class ImageCopyTest extends GPUTest {
     // will "Copy" one bit of the stencil value into the color attachment. The bit of the stencil
     // value is specified by setStencilReference().
     const copyFromOutputTextureLayout = getTextureCopyLayout(
-      'stencil8',
+      stencilTextureFormat,
       '2d',
       [stencilTextureSize[0], stencilTextureSize[1], 1],
       {
         mipLevel: stencilTextureMipLevel,
+        aspect: 'stencil-only',
       }
     );
     const outputTextureSize = [
@@ -1154,6 +1155,7 @@ class ImageCopyTest extends GPUTest {
       {
         texture: depthTexture,
         mipLevel,
+        aspect: 'depth-only',
       },
       {
         buffer: destinationBuffer,
@@ -1256,7 +1258,7 @@ bytes in copy works for every format.
   .params(u =>
     u
       .combineWithParams(kMethodsToTest)
-      .combine('format', kWorkingTextureFormats)
+      .combine('format', kWorkingColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', kTextureDimensions)
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
@@ -1348,12 +1350,13 @@ works for every format with 2d and 2d-array textures.
     offset > bytesInACompleteCopyImage
 
   TODO: Cover the special code paths for 3D textures in D3D12.
+  TODO: Make a variant for depth-stencil formats.
 `
   )
   .params(u =>
     u
       .combineWithParams(kMethodsToTest)
-      .combine('format', kWorkingTextureFormats)
+      .combine('format', kWorkingColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', kTextureDimensions)
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
@@ -1422,7 +1425,7 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
   .params(u =>
     u
       .combineWithParams(kMethodsToTest)
-      .combine('format', kWorkingTextureFormats)
+      .combine('format', kWorkingColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', kTextureDimensions)
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
@@ -1576,12 +1579,14 @@ g.test('mip_levels')
   - For 3D textures test copying to a sub-range of the depth.
 
 Tests both 2D and 3D textures. 1D textures are skipped because they can only have one mip level.
+
+TODO: Make a variant for depth-stencil formats.
   `
   )
   .params(u =>
     u
       .combineWithParams(kMethodsToTest)
-      .combine('format', kWorkingTextureFormats)
+      .combine('format', kWorkingColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', ['2d', '3d'] as const)
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))

--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -133,6 +133,7 @@ g.test('render_pass_store_op,color_attachment_with_depth_stencil_attachment')
     t.expectSingleColor(depthStencilAttachment, kDepthStencilFormat, {
       size: [kHeight, kWidth, 1],
       exp: expectedDepthValue,
+      layout: { mipLevel: 0, aspect: 'depth-only' },
     });
   });
 
@@ -322,19 +323,32 @@ TODO: Also test unsized depth/stencil formats [1]
     pass.end();
     t.device.queue.submit([encoder.finish()]);
 
-    let expectedValue: PerTexelComponent<number> = {};
+    let expectedDepthValue: PerTexelComponent<number> = {};
+    let expectedStencilValue: PerTexelComponent<number> = {};
     if (t.params.storeOperation === 'discard') {
-      // If depthStencilStoreOperation was clear, the texture's depth component should be 0.0,
-      expectedValue = { Depth: 0.0 };
+      // If depthStencilStoreOperation was clear, the texture's depth/stencil component should be 0,
+      expectedDepthValue = { Depth: 0.0 };
+      expectedStencilValue = { Stencil: 0 };
     } else if (t.params.storeOperation === 'store') {
-      // If depthStencilStoreOperation was store, the texture's depth component should be 1.0,
-      expectedValue = { Depth: 1.0 };
+      // If depthStencilStoreOperation was store, the texture's depth/stencil components should be 1,
+      expectedDepthValue = { Depth: 1.0 };
+      expectedStencilValue = { Stencil: 1 };
     }
 
-    t.expectSingleColor(depthStencilTexture, t.params.depthStencilFormat, {
-      size: [kHeight, kWidth, 1],
-      slice: t.params.arrayLayer,
-      exp: expectedValue,
-      layout: { mipLevel: t.params.mipLevel },
-    });
+    if (kTextureFormatInfo[t.params.depthStencilFormat].depth) {
+      t.expectSingleColor(depthStencilTexture, t.params.depthStencilFormat, {
+        size: [kHeight, kWidth, 1],
+        slice: t.params.arrayLayer,
+        exp: expectedDepthValue,
+        layout: { mipLevel: t.params.mipLevel, aspect: 'depth-only' },
+      });
+    }
+    if (kTextureFormatInfo[t.params.depthStencilFormat].stencil) {
+      t.expectSingleColor(depthStencilTexture, t.params.depthStencilFormat, {
+        size: [kHeight, kWidth, 1],
+        slice: t.params.arrayLayer,
+        exp: expectedStencilValue,
+        layout: { mipLevel: t.params.mipLevel, aspect: 'stencil-only' },
+      });
+    }
   });

--- a/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
@@ -18,7 +18,7 @@ export const checkContentsByBufferCopy: CheckContents = (
       size: [t.textureWidth, t.textureHeight, t.textureDepth],
       dimension: params.dimension,
       slice: layer,
-      layout: { mipLevel },
+      layout: { mipLevel, aspect: params.aspect },
       exp: t.stateToTexelComponents[state],
     });
   }
@@ -59,6 +59,7 @@ export const checkContentsByTextureCopy: CheckContents = (
     t.expectSingleColor(dst, format, {
       size: [width, height, depth],
       exp: t.stateToTexelComponents[state],
+      layout: { mipLevel: 0, aspect: params.aspect },
     });
   }
 };

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -1,4 +1,5 @@
 import { assert } from '../../../../../common/util/util.js';
+import { resolvePerAspectFormat } from '../../../../capability_info.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { virtualMipSize } from '../../../../util/texture/base.js';
 import { CheckContents } from '../texture_zero.spec.js';
@@ -149,13 +150,14 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
       },
     });
 
+    const pipelineDSFormat = resolvePerAspectFormat(params.format, params.aspect);
     switch (type) {
       case 'depth': {
         const expectedDepth = t.stateToTexelComponents[state].Depth;
         assert(expectedDepth !== undefined);
 
         pass.setPipeline(
-          getDepthTestEqualPipeline(t, params.format, params.sampleCount, expectedDepth)
+          getDepthTestEqualPipeline(t, pipelineDSFormat, params.sampleCount, expectedDepth)
         );
         break;
       }
@@ -164,7 +166,7 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
         const expectedStencil = t.stateToTexelComponents[state].Stencil;
         assert(expectedStencil !== undefined);
 
-        pass.setPipeline(getStencilTestEqualPipeline(t, params.format, params.sampleCount));
+        pass.setPipeline(getStencilTestEqualPipeline(t, pipelineDSFormat, params.sampleCount));
         pass.setStencilReference(expectedStencil);
         break;
       }

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -119,10 +119,10 @@ const kRegularTextureFormatInfo = /* prettier-ignore */ makeTable(
 /* prettier-ignore */
 const kTexFmtInfoHeader =  ['renderable', 'multisample', 'resolve', 'color', 'depth', 'stencil', 'storage', 'copySrc', 'copyDst', 'sampleType', 'bytesPerBlock', 'blockWidth', 'blockHeight',                'feature', 'baseFormat'] as const;
 const kSizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtInfoHeader,
-                           [        true,          true,     false,   false,        ,          ,     false,     false,     false,             ,                ,            1,             1,                         ,   undefined ] as const, {
-  'depth32float':          [            ,              ,          ,        ,    true,     false,          ,          ,          ,      'depth',               4],
-  'depth16unorm':          [            ,              ,          ,        ,    true,     false,          ,          ,          ,      'depth',               2],
-  'stencil8':              [            ,              ,          ,        ,   false,      true,          ,          ,          ,       'uint',               1],
+                           [        true,          true,     false,   false,        ,          ,     false,          ,          ,             ,                ,            1,             1,                         ,   undefined ] as const, {
+  'depth32float':          [            ,              ,          ,        ,    true,     false,          ,      true,     false,      'depth',               4],
+  'depth16unorm':          [            ,              ,          ,        ,    true,     false,          ,      true,      true,      'depth',               2],
+  'stencil8':              [            ,              ,          ,        ,   false,      true,          ,      true,      true,       'uint',               1],
 } as const);
 
 // Multi aspect sample type are now set to their first aspect
@@ -458,6 +458,28 @@ export const kDepthStencilFormatResolvedAspect: {
     'stencil-only': 'stencil8',
   },
 } as const;
+
+/**
+ * @returns the GPUTextureFormat corresponding to the @param aspect of @param format.
+ * This allows choosing the correct format for depth-stencil aspects when creating pipelines that
+ * will have to match the resolved format of views, or to get per-aspect information like the
+ * `blockByteSize`.
+ *
+ * Many helpers use an `undefined` `aspect` to means `'all'` so this is also the default for this
+ * function.
+ */
+export function resolvePerAspectFormat(
+  format: GPUTextureFormat,
+  aspect?: GPUTextureAspect
+): GPUTextureFormat {
+  if (aspect === 'all' || aspect === undefined) {
+    return format;
+  }
+  assert(kTextureFormatInfo[format].depth || kTextureFormatInfo[format].stencil);
+  const resolved = kDepthStencilFormatResolvedAspect[format as DepthStencilFormat][aspect ?? 'all'];
+  assert(resolved !== undefined);
+  return resolved!;
+}
 
 /**
  * Gets all copyable aspects for copies between texture and buffer for specified depth/stencil format and copy type, by spec.

--- a/src/webgpu/util/texture/texture_ok.ts
+++ b/src/webgpu/util/texture/texture_ok.ts
@@ -162,7 +162,9 @@ function createTextureCopyForMapRead(
   copySize: GPUExtent3D,
   { format }: { format: EncodableTextureFormat }
 ): { buffer: GPUBuffer; bytesPerRow: number; rowsPerImage: number } {
-  const { byteLength, bytesPerRow, rowsPerImage } = getTextureSubCopyLayout(format, copySize);
+  const { byteLength, bytesPerRow, rowsPerImage } = getTextureSubCopyLayout(format, copySize, {
+    aspect: source.aspect,
+  });
 
   const buffer = t.device.createBuffer({
     usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,


### PR DESCRIPTION
 - Fixes tests by passing an `aspect` to the copyTextureToBuffer from a
   depth-stencil texture.
 - Adds an aspect to `LayoutOptions` that's used by the various texture
   helpers to copy correctly from depth or stencil aspects. (support for
   the aspect was added to some helpers without tests needing it yet, so
   that hopefully other developers don't have to add it in the future).
 - Adds a resolvePerAspectFormat to factor some got determining the
   per-aspect format, only for depth-stencil textures.
 - Restricts some image-copy tests to only be for color textures because
   copying depth-stencil textures requires copying a whole subresource.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`. <- not sure about this one yet.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
