### PR TITLE
Sparse color attachments validation tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/offscreencanvas": "^2019.6.4",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "0.1.13",
+        "@webgpu/types": "0.1.14",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1227,9 +1227,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.13.tgz",
-      "integrity": "sha512-SAq8FRONvMANQi/eXw5ArKfSvih6am/EC+5y7+du2xf1VyprtKn4ylUPKGW4T6ZkDogtH3xZgGE+J/cx601L5w==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.14.tgz",
+      "integrity": "sha512-+zUQ4FmzZTPHLAm7Fjggtb/qqlDrpdBDuCjaWx82dbZNYRKiGRFWw2bYPHYXSSWHQak48KGQEKWxRWCaZiwemg==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10483,9 +10483,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.13.tgz",
-      "integrity": "sha512-SAq8FRONvMANQi/eXw5ArKfSvih6am/EC+5y7+du2xf1VyprtKn4ylUPKGW4T6ZkDogtH3xZgGE+J/cx601L5w==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.14.tgz",
+      "integrity": "sha512-+zUQ4FmzZTPHLAm7Fjggtb/qqlDrpdBDuCjaWx82dbZNYRKiGRFWw2bYPHYXSSWHQak48KGQEKWxRWCaZiwemg==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/offscreencanvas": "^2019.6.4",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "0.1.13",
+    "@webgpu/types": "0.1.14",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -1,7 +1,5 @@
 export const description = `
 Validation for attachment compatibility between render passes, bundles, and pipelines
-
-TODO: Add sparse color attachment compatibility test when defined by specification
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
@@ -92,11 +90,11 @@ class F extends ValidationTest {
   }
 
   createColorAttachment(
-    format: GPUTextureFormat | undefined,
+    format: GPUTextureFormat | null,
     sampleCount?: number
-  ): GPURenderPassColorAttachment | undefined {
-    return format === undefined
-      ? undefined
+  ): GPURenderPassColorAttachment | null {
+    return format === null
+      ? null
       : {
           view: this.createAttachmentTextureView(format, sampleCount),
           clearValue: [0, 0, 0, 0],
@@ -126,7 +124,7 @@ class F extends ValidationTest {
   }
 
   createRenderPipeline(
-    targets: Iterable<GPUColorTargetState | undefined>,
+    targets: Iterable<GPUColorTargetState | null>,
     depthStencil?: GPUDepthStencilState,
     sampleCount?: number
   ) {
@@ -232,7 +230,7 @@ g.test('render_pass_and_bundle,color_sparse')
   )
   .fn(t => {
     const { passAttachments, bundleAttachments } = t.params;
-    const colorFormats = bundleAttachments.map(i => (i === 1 ? 'rgba8unorm' : undefined));
+    const colorFormats = bundleAttachments.map(i => (i === 1 ? 'rgba8unorm' : null));
     const bundleEncoder = t.device.createRenderBundleEncoder({
       colorFormats,
     });
@@ -240,7 +238,7 @@ g.test('render_pass_and_bundle,color_sparse')
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder('non-pass');
     const colorAttachments = passAttachments.map(i =>
-      t.createColorAttachment(i === 1 ? 'rgba8unorm' : undefined)
+      t.createColorAttachment(i === 1 ? 'rgba8unorm' : null)
     );
     const pass = encoder.beginRenderPass({
       colorAttachments,
@@ -379,11 +377,11 @@ Test that each of color attachments in render passes or bundles match that of th
     const { encoderType, encoderAttachments, pipelineAttachments } = t.params;
 
     const colorTargets = pipelineAttachments.map(i =>
-      i === 1 ? ({ format: 'rgba8unorm', writeMask: 0 } as GPUColorTargetState) : undefined
+      i === 1 ? ({ format: 'rgba8unorm', writeMask: 0 } as GPUColorTargetState) : null
     );
     const pipeline = t.createRenderPipeline(colorTargets);
 
-    const colorFormats = encoderAttachments.map(i => (i === 1 ? 'rgba8unorm' : undefined));
+    const colorFormats = encoderAttachments.map(i => (i === 1 ? 'rgba8unorm' : null));
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
       attachmentInfo: { colorFormats },
     });

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -997,7 +997,7 @@ export class GPUTest extends Fixture {
                   loadOp: 'clear',
                   storeOp: 'store',
                 }
-              : undefined
+              : null
           ),
           depthStencilAttachment,
           occlusionQuerySet,

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -989,12 +989,16 @@ export class GPUTest extends Fixture {
           }
         }
         const passDesc: GPURenderPassDescriptor = {
-          colorAttachments: Array.from(fullAttachmentInfo.colorFormats, format => ({
-            view: makeAttachmentView(format),
-            clearValue: [0, 0, 0, 0],
-            loadOp: 'clear',
-            storeOp: 'store',
-          })),
+          colorAttachments: Array.from(fullAttachmentInfo.colorFormats, format =>
+            format
+              ? {
+                  view: makeAttachmentView(format),
+                  clearValue: [0, 0, 0, 0],
+                  loadOp: 'clear',
+                  storeOp: 'store',
+                }
+              : undefined
+          ),
           depthStencilAttachment,
           occlusionQuerySet,
         };

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -223,6 +223,7 @@ function canonicalizeDescriptor(
   const descriptorCanonicalized: CanonicalDeviceDescriptor = {
     requiredFeatures: featuresCanonicalized,
     requiredLimits: limitsCanonicalized,
+    defaultQueue: {},
   };
   return [descriptorCanonicalized, JSON.stringify(descriptorCanonicalized)];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
-    "lib": ["dom", "es2016"],
+    "lib": ["dom", "es2019"],
     "module": "esnext",
     /* Output options */
     "noEmit": true,


### PR DESCRIPTION

Issue: #901

WIP: need to land chromium change and npm publish updated types first

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
