### PR TITLE
image_copy,mip_levels: reduce the mip level count.

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1620,14 +1620,14 @@ Tests both 2D and 3D textures. 1D textures are skipped because they can only hav
           copySizeInBlocks: { width: 5, height: 4, depthOrArrayLayers: 2 },
           originInBlocks: { x: 3, y: 2, z: 1 },
           _mipSizeInBlocks: { width: 9, height: 7, depthOrArrayLayers: 3 },
-          mipLevel: 5,
+          mipLevel: 4,
         },
         // origin + copySize < texturePhysicalSizeAtMipLevel for all coordinates
         {
           copySizeInBlocks: { width: 5, height: 4, depthOrArrayLayers: 2 },
           originInBlocks: { x: 3, y: 2, z: 1 },
           _mipSizeInBlocks: { width: 9, height: 7, depthOrArrayLayers: 4 },
-          mipLevel: 6,
+          mipLevel: 4,
         },
       ])
       .expand('textureSize', generateTestTextureSizes)


### PR DESCRIPTION
Using a mip level of 6 made the test request a 1.2 GB 3d texture, which
shouldn't be something regular tests do, only stress tests.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
