### PR TITLE
depth_compare_func: Don't use 0.5 as depth16unorm rounds either way

### DIFF
--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -23,6 +23,10 @@ g.test('depth_write_disabled')
   .desc(`Tests render results with depth write disabled`)
   .unimplemented();
 
+// Use a depth value that's not exactly 0.5 because it is exactly between two depth16unorm value and
+// can get rounded either way (and a different way between shaders and clearDepthValue).
+const kMiddleDepthValue = 0.5001;
+
 g.test('depth_compare_func')
   .desc(
     `Tests each depth compare function works properly. Clears the depth attachment to various values, and renders a point at depth 0.5 with various depthCompare modes.`
@@ -35,28 +39,40 @@ g.test('depth_compare_func')
       )
       .combineWithParams([
         { depthCompare: 'never', depthClearValue: 1.0, _expected: backgroundColor },
-        { depthCompare: 'never', depthClearValue: 0.5, _expected: backgroundColor },
+        { depthCompare: 'never', depthClearValue: kMiddleDepthValue, _expected: backgroundColor },
         { depthCompare: 'never', depthClearValue: 0.0, _expected: backgroundColor },
         { depthCompare: 'less', depthClearValue: 1.0, _expected: triangleColor },
-        { depthCompare: 'less', depthClearValue: 0.5, _expected: backgroundColor },
+        { depthCompare: 'less', depthClearValue: kMiddleDepthValue, _expected: backgroundColor },
         { depthCompare: 'less', depthClearValue: 0.0, _expected: backgroundColor },
         { depthCompare: 'less-equal', depthClearValue: 1.0, _expected: triangleColor },
-        { depthCompare: 'less-equal', depthClearValue: 0.5, _expected: triangleColor },
+        {
+          depthCompare: 'less-equal',
+          depthClearValue: kMiddleDepthValue,
+          _expected: triangleColor,
+        },
         { depthCompare: 'less-equal', depthClearValue: 0.0, _expected: backgroundColor },
         { depthCompare: 'equal', depthClearValue: 1.0, _expected: backgroundColor },
-        { depthCompare: 'equal', depthClearValue: 0.5, _expected: triangleColor },
+        { depthCompare: 'equal', depthClearValue: kMiddleDepthValue, _expected: triangleColor },
         { depthCompare: 'equal', depthClearValue: 0.0, _expected: backgroundColor },
         { depthCompare: 'not-equal', depthClearValue: 1.0, _expected: triangleColor },
-        { depthCompare: 'not-equal', depthClearValue: 0.5, _expected: backgroundColor },
+        {
+          depthCompare: 'not-equal',
+          depthClearValue: kMiddleDepthValue,
+          _expected: backgroundColor,
+        },
         { depthCompare: 'not-equal', depthClearValue: 0.0, _expected: triangleColor },
         { depthCompare: 'greater-equal', depthClearValue: 1.0, _expected: backgroundColor },
-        { depthCompare: 'greater-equal', depthClearValue: 0.5, _expected: triangleColor },
+        {
+          depthCompare: 'greater-equal',
+          depthClearValue: kMiddleDepthValue,
+          _expected: triangleColor,
+        },
         { depthCompare: 'greater-equal', depthClearValue: 0.0, _expected: triangleColor },
         { depthCompare: 'greater', depthClearValue: 1.0, _expected: backgroundColor },
-        { depthCompare: 'greater', depthClearValue: 0.5, _expected: backgroundColor },
+        { depthCompare: 'greater', depthClearValue: kMiddleDepthValue, _expected: backgroundColor },
         { depthCompare: 'greater', depthClearValue: 0.0, _expected: triangleColor },
         { depthCompare: 'always', depthClearValue: 1.0, _expected: triangleColor },
-        { depthCompare: 'always', depthClearValue: 0.5, _expected: triangleColor },
+        { depthCompare: 'always', depthClearValue: kMiddleDepthValue, _expected: triangleColor },
         { depthCompare: 'always', depthClearValue: 0.0, _expected: triangleColor },
       ] as const)
   )
@@ -85,7 +101,7 @@ g.test('depth_compare_func')
           code: `
             @stage(vertex) fn main(
               @builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
-              return vec4<f32>(0.5, 0.5, 0.5, 1.0);
+              return vec4<f32>(0.5, 0.5, ${kMiddleDepthValue}, 1.0);
             }
             `,
         }),


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
