### PR TITLE
depth_clip_clamp: only set stencilLoadOp and friends when needed.

### DIFF
--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -43,11 +43,12 @@ have unexpected values then get drawn to the color buffer, which is later checke
   )
   .fn(async t => {
     const { format, unclippedDepth, writeDepth, multisampled } = t.params;
+    const info = kTextureFormatInfo[format];
+
     await t.selectDeviceOrSkipTestCase([
       unclippedDepth ? 'depth-clip-control' : undefined,
-      kTextureFormatInfo[format].feature,
+      info.feature,
     ]);
-    const info = kTextureFormatInfo[format];
 
     /** Number of depth values to test for both vertex output and frag_depth output. */
     const kNumDepthValues = 8;
@@ -252,9 +253,9 @@ have unexpected values then get drawn to the color buffer, which is later checke
           depthClearValue: 0.5, // Will see this depth value if the fragment was clipped.
           depthLoadOp: 'clear',
           depthStoreOp: 'store',
-          stencilClearValue: 0,
-          stencilLoadOp: 'clear',
-          stencilStoreOp: 'discard',
+          stencilClearValue: info.stencil ? 0 : undefined,
+          stencilLoadOp: info.stencil ? 'clear' : undefined,
+          stencilStoreOp: info.stencil ? 'discard' : undefined,
         },
       });
       pass.setPipeline(testPipeline);
@@ -284,9 +285,9 @@ have unexpected values then get drawn to the color buffer, which is later checke
           view: dsTextureView,
           depthLoadOp: 'load',
           depthStoreOp: 'store',
-          stencilClearValue: 0,
-          stencilLoadOp: 'clear',
-          stencilStoreOp: 'discard',
+          stencilClearValue: info.stencil ? 0 : undefined,
+          stencilLoadOp: info.stencil ? 'clear' : undefined,
+          stencilStoreOp: info.stencil ? 'discard' : undefined,
         },
       });
       pass.setPipeline(checkPipeline);
@@ -352,9 +353,11 @@ to be empty.`
   )
   .fn(async t => {
     const { format, unclippedDepth, multisampled } = t.params;
+    const info = kTextureFormatInfo[format];
+
     await t.selectDeviceOrSkipTestCase([
       unclippedDepth ? 'depth-clip-control' : undefined,
-      kTextureFormatInfo[format].feature,
+      info.feature,
     ]);
 
     const kNumDepthValues = 8;
@@ -492,9 +495,9 @@ to be empty.`
           view: dsTextureView,
           depthLoadOp: 'load',
           depthStoreOp: 'store',
-          stencilClearValue: 0,
-          stencilLoadOp: 'clear',
-          stencilStoreOp: 'discard',
+          stencilClearValue: info.stencil ? 0 : undefined,
+          stencilLoadOp: info.stencil ? 'clear' : undefined,
+          stencilStoreOp: info.stencil ? 'discard' : undefined,
         },
       });
       pass.setPipeline(testPipeline);


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
