### PR TITLE
operation,image_copy: Add support for depth16unorm

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -39,7 +39,7 @@ TODO: Fix this test for the various skipped formats [2]:
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { assert, memcpy, unreachable } from '../../../../common/util/util.js';
+import { assert, memcpy, TypedArrayBufferView, unreachable } from '../../../../common/util/util.js';
 import {
   kTextureFormatInfo,
   SizedTextureFormat,
@@ -1109,9 +1109,9 @@ class ImageCopyTest extends GPUTest {
     // [2]: need to convert the float32 values in initialData into the ones compatible
     // to the depth aspect of depthFormats when depth16unorm and depth24unorm-stencil8 are supported
     // by the browsers.
-    assert(format !== 'depth16unorm' && format !== 'depth24unorm-stencil8');
+    assert(format !== 'depth24unorm-stencil8');
 
-    // Generate the initial depth data
+    // Generate the initial depth data uploaded to the texture as float32.
     const initialData = new Float32Array(copySize[0] * copySize[1] * copySize[2]);
     for (let i = 0; i < initialData.length; ++i) {
       const baseValue = 0.05 * i;
@@ -1119,6 +1119,20 @@ class ImageCopyTest extends GPUTest {
       // We expect there are both 1's and 0's in initialData.
       initialData[i] = i % 40 === 0 ? 1 : baseValue - Math.floor(baseValue);
       assert(initialData[i] >= 0 && initialData[i] <= 1);
+    }
+
+    // The data uploaded to the texture, using the byte pattern of the format.
+    let formatInitialData: TypedArrayBufferView = initialData;
+
+    // For unorm depth formats, replace the uploaded depth data with quantized data to avoid
+    // rounding issues when converting from 32float to 16unorm.
+    if (format === 'depth16unorm') {
+      const u16Data = new Uint16Array(initialData.length);
+      for (let i = 0; i < initialData.length; i++) {
+        u16Data[i] = initialData[i] * 65535;
+        initialData[i] = u16Data[i] / 65535.0;
+      }
+      formatInitialData = u16Data;
     }
 
     // Initialize the depth aspect of the source texture
@@ -1173,7 +1187,7 @@ class ImageCopyTest extends GPUTest {
       for (let y = 0; y < copySize[1]; ++y) {
         memcpy(
           {
-            src: initialData,
+            src: formatInitialData,
             start: baseInitialDataOffset + y * copySize[0],
             length: copySize[0],
           },


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
