### PR TITLE
Make things work on Node 12.x, and test it on presubmit.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
           git checkout ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: "15.x"
+          node-version: "12.x"
       - run: npm ci
       - run: npm test
       - run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: "15.x"
+          node-version: "12.x"
       - run: npm ci
       - run: |
           npm test


### PR DESCRIPTION
Events aren't implemented on Node 12.x, so just stub out the necessary interfaces and skip the relevant tests.

Issue: none

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [n/a] Tests are properly located in the test tree.
- [n/a] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [n/a] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
