### PR TITLE
Add sparse color attachments operation tests

### DIFF
--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -139,7 +139,8 @@ g.test('color,attachments')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    const writeValue = { R: 0.125, G: 0.25, B: 0.5, A: 1 };
+    const writeValue =
+      info.sampleType === 'float' ? { R: 0.2, G: 0.6, B: 0.8, A: 1 } : { R: 2, G: 4, B: 8, A: 16 };
 
     const renderTargets = range(attachmentCount, () =>
       t.device.createTexture({

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -139,7 +139,7 @@ g.test('color,attachments')
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
 
-    const writeValue = { R: 1, G: 1, B: 1, A: 1 };
+    const writeValue = { R: 0.125, G: 0.25, B: 0.5, A: 1 };
 
     const renderTargets = range(attachmentCount, () =>
       t.device.createTexture({

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -1,74 +1,208 @@
 export const description = `
-- Test pipeline outputs with different color target formats.
+- Test pipeline outputs with different color attachment number, formats, component counts, etc.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { unreachable } from '../../../../common/util/util.js';
+import { range, unreachable } from '../../../../common/util/util.js';
 import { kRenderableColorTextureFormats, kTextureFormatInfo } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { kTexelRepresentationInfo } from '../../../util/texture/texel_data.js';
 
+const kVertexShader = `
+@stage(vertex) fn main(
+@builtin(vertex_index) VertexIndex : u32
+) -> @builtin(position) vec4<f32> {
+  var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
+      vec2<f32>(-1.0, -3.0),
+      vec2<f32>(3.0, 1.0),
+      vec2<f32>(-1.0, 1.0));
+  return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+}
+`;
+
 class F extends GPUTest {
+  // Build fragment shader based on output value and types
+  // e.g. write to color target 0 a vec4<f32>(1.0, 0.0, 1.0, 1.0) and color target 2 a vec2<u32>(1, 2)
+  // outputs: [
+  //   {
+  //     values: [1, 0, 1, 1],,
+  //     sampleType: 'float',
+  //     componentCount: 4,
+  //   },
+  //   null,
+  //   {
+  //     values: [1, 2],
+  //     sampleType: 'uint',
+  //     componentCount: 2,
+  //   },
+  // ]
+  //
+  // return:
+  // struct Outputs {
+  //     @location(0) o1 : vec4<f32>;
+  //     @location(2) o3 : vec2<u32>;
+  // }
+  // @stage(fragment) fn main() -> Outputs {
+  //     return Outputs(vec4<f32>(1.0, 0.0, 1.0, 1.0), vec4<u32>(1, 2));
+  // }
   getFragmentShaderCode(
-    output: readonly number[],
-    sampleType: GPUTextureSampleType,
-    componentCount: number
+    outputs: ({
+      values: readonly number[];
+      sampleType: GPUTextureSampleType;
+      componentCount: number;
+    } | null)[]
   ): string {
-    let fragColorType;
-    let suffix;
-    let fractionDigits = 0;
-    switch (sampleType) {
-      case 'sint':
-        fragColorType = 'i32';
-        suffix = '';
-        break;
-      case 'uint':
-        fragColorType = 'u32';
-        suffix = 'u';
-        break;
-      case 'float':
-      case 'unfilterable-float':
-        fragColorType = 'f32';
-        suffix = '';
-        fractionDigits = 4;
-        break;
-      default:
-        unreachable();
-    }
+    const resultStrings = [] as string[];
+    let outputStructString = '';
 
-    const v = output.map(n => n.toFixed(fractionDigits));
+    for (let i = 0; i < outputs.length; i++) {
+      const o = outputs[i];
+      if (o === null) {
+        continue;
+      }
 
-    let outputType;
-    let result;
-    switch (componentCount) {
-      case 1:
-        outputType = fragColorType;
-        result = `${v[0]}${suffix}`;
-        break;
-      case 2:
-        outputType = `vec2<${fragColorType}>`;
-        result = `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix})`;
-        break;
-      case 3:
-        outputType = `vec3<${fragColorType}>`;
-        result = `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix})`;
-        break;
-      case 4:
-        outputType = `vec4<${fragColorType}>`;
-        result = `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix}, ${v[3]}${suffix})`;
-        break;
-      default:
-        unreachable();
+      let fragColorType;
+      let suffix;
+      let fractionDigits = 0;
+      switch (o.sampleType) {
+        case 'sint':
+          fragColorType = 'i32';
+          suffix = '';
+          break;
+        case 'uint':
+          fragColorType = 'u32';
+          suffix = 'u';
+          break;
+        case 'float':
+        case 'unfilterable-float':
+          fragColorType = 'f32';
+          suffix = '';
+          fractionDigits = 4;
+          break;
+        default:
+          unreachable();
+      }
+
+      let outputType;
+      const v = o.values.map(n => n.toFixed(fractionDigits));
+      switch (o.componentCount) {
+        case 1:
+          outputType = fragColorType;
+          resultStrings.push(`${v[0]}${suffix}`);
+          break;
+        case 2:
+          outputType = `vec2<${fragColorType}>`;
+          resultStrings.push(`${outputType}(${v[0]}${suffix}, ${v[1]}${suffix})`);
+          break;
+        case 3:
+          outputType = `vec3<${fragColorType}>`;
+          resultStrings.push(`${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix})`);
+          break;
+        case 4:
+          outputType = `vec4<${fragColorType}>`;
+          resultStrings.push(
+            `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix}, ${v[3]}${suffix})`
+          );
+          break;
+        default:
+          unreachable();
+      }
+
+      outputStructString += `@location(${i}) o${i} : ${outputType},\n`;
     }
 
     return `
-    @stage(fragment) fn main() -> @location(0) ${outputType} {
-        return ${result};
+    struct Outputs {
+      ${outputStructString}
+    }
+
+    @stage(fragment) fn main() -> Outputs {
+        return Outputs(${resultStrings.join(',')});
     }`;
   }
 }
 
 export const g = makeTestGroup(F);
+
+g.test('color,attachments')
+  .desc(`Test that pipeline with  sparse color attachments write values correctly.`)
+  .params(u =>
+    u
+      .combine('format', kRenderableColorTextureFormats)
+      .beginSubcases()
+      .combine('attachmentCount', [2, 3, 4])
+      .expand('emptyAttachmentId', p => range(p.attachmentCount, i => i))
+  )
+  .fn(async t => {
+    const { format, attachmentCount, emptyAttachmentId } = t.params;
+    const componentCount = kTexelRepresentationInfo[format].componentOrder.length;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+
+    const writeValue = { R: 1, G: 1, B: 1, A: 1 };
+
+    const renderTargets = range(attachmentCount, () =>
+      t.device.createTexture({
+        format,
+        size: { width: 1, height: 1, depthOrArrayLayers: 1 },
+        usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+      })
+    );
+    const pipeline = t.device.createRenderPipeline({
+      vertex: {
+        module: t.device.createShaderModule({
+          code: kVertexShader,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: t.getFragmentShaderCode(
+            range(attachmentCount, i =>
+              i === emptyAttachmentId
+                ? null
+                : {
+                    values: [writeValue.R, writeValue.G, writeValue.B, writeValue.A],
+                    sampleType: info.sampleType,
+                    componentCount,
+                  }
+            )
+          ),
+        }),
+        entryPoint: 'main',
+        targets: range(attachmentCount, i => (i === emptyAttachmentId ? null : { format })),
+      },
+      primitive: { topology: 'triangle-list' },
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: range(attachmentCount, i =>
+        i === emptyAttachmentId
+          ? null
+          : {
+              view: renderTargets[i].createView(),
+              storeOp: 'store',
+              clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 0.5 },
+              loadOp: 'clear',
+            }
+      ),
+    });
+    pass.setPipeline(pipeline);
+    pass.draw(3);
+    pass.end();
+    t.device.queue.submit([encoder.finish()]);
+
+    for (let i = 0; i < attachmentCount; i++) {
+      if (i === emptyAttachmentId) {
+        continue;
+      }
+      t.expectSingleColor(renderTargets[i], format, {
+        size: [1, 1, 1],
+        exp: writeValue,
+      });
+    }
+  });
 
 g.test('color,component_count')
   .desc(
@@ -88,7 +222,7 @@ g.test('color,component_count')
 
     // expected RGBA values
     // extra channels are discarded
-    const result = [0, 1, 0, 1];
+    const values = [0, 1, 0, 1];
 
     const renderTarget = t.device.createTexture({
       format,
@@ -99,23 +233,19 @@ g.test('color,component_count')
     const pipeline = t.device.createRenderPipeline({
       vertex: {
         module: t.device.createShaderModule({
-          code: `
-            @stage(vertex) fn main(
-              @builtin(vertex_index) VertexIndex : u32
-              ) -> @builtin(position) vec4<f32> {
-                var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
-                    vec2<f32>(-1.0, -3.0),
-                    vec2<f32>(3.0, 1.0),
-                    vec2<f32>(-1.0, 1.0));
-                return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-              }
-              `,
+          code: kVertexShader,
         }),
         entryPoint: 'main',
       },
       fragment: {
         module: t.device.createShaderModule({
-          code: t.getFragmentShaderCode(result, info.sampleType, componentCount),
+          code: t.getFragmentShaderCode([
+            {
+              values,
+              sampleType: info.sampleType,
+              componentCount,
+            },
+          ]),
         }),
         entryPoint: 'main',
         targets: [{ format }],
@@ -141,7 +271,7 @@ g.test('color,component_count')
 
     t.expectSingleColor(renderTarget, format, {
       size: [1, 1, 1],
-      exp: { R: result[0], G: result[1], B: result[2], A: result[3] },
+      exp: { R: values[0], G: values[1], B: values[2], A: values[3] },
     });
   });
 
@@ -310,23 +440,19 @@ The attachment has a load value of [1, 0, 0, 1]
     const pipeline = t.device.createRenderPipeline({
       vertex: {
         module: t.device.createShaderModule({
-          code: `
-            @stage(vertex) fn main(
-              @builtin(vertex_index) VertexIndex : u32
-              ) -> @builtin(position) vec4<f32> {
-                var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
-                    vec2<f32>(-1.0, -3.0),
-                    vec2<f32>(3.0, 1.0),
-                    vec2<f32>(-1.0, 1.0));
-                return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
-              }
-              `,
+          code: kVertexShader,
         }),
         entryPoint: 'main',
       },
       fragment: {
         module: t.device.createShaderModule({
-          code: t.getFragmentShaderCode(output, info.sampleType, componentCount),
+          code: t.getFragmentShaderCode([
+            {
+              values: output,
+              sampleType: info.sampleType,
+              componentCount,
+            },
+          ]),
         }),
         entryPoint: 'main',
         targets: [


### PR DESCRIPTION


Following #1149 (to use new webgpu types)

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
