### PR TITLE
Add presubmit check for long test names

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -90,6 +90,10 @@ module.exports = function (grunt) {
         cmd: 'node',
         args: ['node_modules/eslint/bin/eslint', 'src/**/*.ts', '--max-warnings=0'],
       },
+      presubmit: {
+        cmd: 'node',
+        args: ['tools/presubmit'],
+      },
       fix: {
         cmd: 'node',
         args: ['node_modules/eslint/bin/eslint', 'src/**/*.ts', '--fix'],
@@ -184,6 +188,7 @@ module.exports = function (grunt) {
     'run:build-out-node',
     'build-done-message',
     'ts:check',
+    'run:presubmit',
     'run:unittest',
     'run:lint',
     'run:tsdoc-treatWarningsAsErrors',

--- a/src/common/tools/presubmit.ts
+++ b/src/common/tools/presubmit.ts
@@ -1,0 +1,19 @@
+import { DefaultTestFileLoader } from '../internal/file_loader.js';
+import { parseQuery } from '../internal/query/parseQuery.js';
+import { assert } from '../util/util.js';
+
+(async () => {
+  for (const suite of ['unittests', 'webgpu']) {
+    const loader = new DefaultTestFileLoader();
+    const filterQuery = parseQuery(`${suite}:*`);
+    const testcases = await loader.loadCases(filterQuery);
+    for (const testcase of testcases) {
+      const name = testcase.query.toString();
+      const maxLength = 375;
+      assert(
+        name.length <= maxLength,
+        `Testcase ${name} is too long. Max length is ${maxLength} characters. Please shorten names or reduce parameters.`
+      );
+    }
+  }
+})();

--- a/tools/presubmit
+++ b/tools/presubmit
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('../src/common/tools/setup-ts-in-node.js');
+require('../src/common/tools/presubmit.ts');


### PR DESCRIPTION
Very long test names cause problems on Chrome's infrastructure.
And, long test names probbably imply that the test has been
overparamterized and should be split.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
