### PR TITLE
Validation test for GPURenderPassDepthStencilAttachment usage

### DIFF
--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -6,7 +6,11 @@ TODO: review for completeness
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { kRenderableColorTextureFormats, kTextureFormatInfo } from '../../capability_info.js';
+import {
+  kDepthStencilFormats,
+  kRenderableColorTextureFormats,
+  kTextureFormatInfo,
+} from '../../capability_info.js';
 
 import { ValidationTest } from './validation_test.js';
 
@@ -584,6 +588,74 @@ g.test('check_depth_stencil_attachment_sample_counts_mismatch').fn(async t => {
     t.tryRenderPass(true, descriptor);
   }
 });
+
+g.test('depth_stencil_attachment')
+  .desc(
+    `
+  Test GPURenderPassDepthStencilAttachment Usage:
+  - depthReadOnly and stencilReadOnly must match if the format is a combined depth-stencil format.
+  - depthLoadOp and depthStoreOp must be provided iff the format has a depth aspect and depthReadOnly is not true.
+  - stencilLoadOp and stencilStoreOp must be provided iff the format has a stencil aspect and stencilReadOnly is not true.
+  `
+  )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('format', kDepthStencilFormats)
+      .combine('depthReadOnly', [false, true])
+      .combine('stencilReadOnly', [false, true])
+      .combine('setDepthLoadStoreOp', [false, true])
+      .combine('setStencilLoadStoreOp', [false, true])
+  )
+  .fn(async t => {
+    const {
+      format,
+      depthReadOnly,
+      stencilReadOnly,
+      setDepthLoadStoreOp,
+      setStencilLoadStoreOp,
+    } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
+
+    let isValid = true;
+    const info = kTextureFormatInfo[format];
+    if (info.depth && info.stencil) {
+      isValid &&= depthReadOnly === stencilReadOnly;
+    }
+
+    if (info.depth && !depthReadOnly) {
+      isValid &&= setDepthLoadStoreOp;
+    } else {
+      isValid &&= !setDepthLoadStoreOp;
+    }
+
+    if (info.stencil && !stencilReadOnly) {
+      isValid &&= setStencilLoadStoreOp;
+    } else {
+      isValid &&= !setStencilLoadStoreOp;
+    }
+
+    const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
+      view: t.createTexture({ format }).createView(),
+      depthReadOnly,
+      stencilReadOnly,
+    };
+
+    if (setDepthLoadStoreOp) {
+      depthStencilAttachment.depthLoadOp = 'clear';
+      depthStencilAttachment.depthStoreOp = 'store';
+    }
+    if (setStencilLoadStoreOp) {
+      depthStencilAttachment.stencilLoadOp = 'clear';
+      depthStencilAttachment.stencilStoreOp = 'store';
+    }
+
+    const descriptor = {
+      colorAttachments: [t.getColorAttachment(t.createTexture())],
+      depthStencilAttachment,
+    };
+
+    t.tryRenderPass(isValid, descriptor);
+  });
 
 g.test('multisample_render_target_formats_support_resolve')
   .params(u =>


### PR DESCRIPTION

Issue: #927

Sort of related to https://github.com/gpuweb/cts/pull/1057

This one passed

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
