### PR TITLE
Fix a bug in validation,createTexture,texture_usage:dimension=undef

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -695,7 +695,7 @@ g.test('texture_usage')
     };
 
     let success = true;
-    const appliedDimension = dimension === undefined ? '2d' : dimension;
+    const appliedDimension = dimension ?? '2d';
     // Note that we unconditionally test copy usages for all formats. We don't check copySrc/copyDst in kTextureFormatInfo in capability_info.js
     // if (!info.copySrc && (usage & GPUTextureUsage.COPY_SRC) !== 0) success = false;
     // if (!info.copyDst && (usage & GPUTextureUsage.COPY_DST) !== 0) success = false;

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -695,12 +695,13 @@ g.test('texture_usage')
     };
 
     let success = true;
+    const appliedDimension = dimension === undefined ? '2d' : dimension;
     // Note that we unconditionally test copy usages for all formats. We don't check copySrc/copyDst in kTextureFormatInfo in capability_info.js
     // if (!info.copySrc && (usage & GPUTextureUsage.COPY_SRC) !== 0) success = false;
     // if (!info.copyDst && (usage & GPUTextureUsage.COPY_DST) !== 0) success = false;
     if (!info.storage && (usage & GPUTextureUsage.STORAGE_BINDING) !== 0) success = false;
     if (
-      (!info.renderable || dimension !== '2d') &&
+      (!info.renderable || appliedDimension !== '2d') &&
       (usage & GPUTextureUsage.RENDER_ATTACHMENT) !== 0
     )
       success = false;


### PR DESCRIPTION
This patch fixes a bug in the below test by treating "undefined"
texture dimension as 2D when deciding if the texture dimension is
compatible with the texture usage.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
