### PR TITLE
Add an option to run subcases in parallel

### DIFF
--- a/src/common/framework/execution_context.ts
+++ b/src/common/framework/execution_context.ts
@@ -1,0 +1,6 @@
+import { TestQueryWithExpectation } from '../internal/query/query.js';
+
+export type ExecutionContext = {
+  expectations: TestQueryWithExpectation[];
+  parallelSubcases: boolean;
+};

--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -36,6 +36,7 @@ let verbose = false;
 let listTestcases = false;
 let debug = false;
 let printJSON = false;
+let parallelSubcases = false;
 let loadWebGPUExpectations: Promise<unknown> | undefined = undefined;
 let gpuProviderModule: GPUProviderModule | undefined = undefined;
 
@@ -55,6 +56,8 @@ for (let i = 0; i < sys.args.length; ++i) {
     } else if (a === '--expectations') {
       const expectationsFile = new URL(sys.args[++i], `file://${sys.cwd()}`).pathname;
       loadWebGPUExpectations = import(expectationsFile).then(m => m.expectations);
+    } else if (a === '--parallelSubcases') {
+      parallelSubcases = true;
     } else if (a === '--gpu-provider') {
       const modulePath = sys.args[++i];
       gpuProviderModule = require(modulePath);
@@ -105,7 +108,7 @@ if (queries.length === 0) {
     }
 
     const [rec, res] = log.record(name);
-    await testcase.run(rec, expectations);
+    await testcase.run(rec, { expectations, parallelSubcases });
 
     if (verbose) {
       printResults([[name, res]]);

--- a/src/common/runtime/helper/test_worker-worker.ts
+++ b/src/common/runtime/helper/test_worker-worker.ts
@@ -1,8 +1,8 @@
+import { ExecutionContext } from '../../framework/execution_context.js';
 import { setBaseResourcePath } from '../../framework/resources.js';
 import { DefaultTestFileLoader } from '../../internal/file_loader.js';
 import { Logger } from '../../internal/logging/logger.js';
 import { parseQuery } from '../../internal/query/parseQuery.js';
-import { TestQueryWithExpectation } from '../../internal/query/query.js';
 import { assert } from '../../util/util.js';
 
 // Should be DedicatedWorkerGlobalScope, but importing lib "webworker" conflicts with lib "dom".
@@ -15,7 +15,7 @@ setBaseResourcePath('../../../resources');
 
 self.onmessage = async (ev: MessageEvent) => {
   const query: string = ev.data.query;
-  const expectations: TestQueryWithExpectation[] = ev.data.expectations;
+  const ctx: ExecutionContext = ev.data.ctx;
   const debug: boolean = ev.data.debug;
 
   Logger.globalDebugMode = debug;
@@ -26,7 +26,7 @@ self.onmessage = async (ev: MessageEvent) => {
 
   const testcase = testcases[0];
   const [rec, result] = log.record(testcase.query.toString());
-  await testcase.run(rec, expectations);
+  await testcase.run(rec, ctx);
 
   self.postMessage({ query, result });
 };

--- a/src/common/runtime/helper/test_worker.ts
+++ b/src/common/runtime/helper/test_worker.ts
@@ -1,7 +1,7 @@
+import { ExecutionContext } from '../../framework/execution_context.js';
 import { LogMessageWithStack } from '../../internal/logging/log_message.js';
 import { TransferredTestCaseResult, LiveTestCaseResult } from '../../internal/logging/result.js';
 import { TestCaseRecorder } from '../../internal/logging/test_case_recorder.js';
-import { TestQueryWithExpectation } from '../../internal/query/query.js';
 
 export class TestWorker {
   private readonly debug: boolean;
@@ -30,12 +30,8 @@ export class TestWorker {
     };
   }
 
-  async run(
-    rec: TestCaseRecorder,
-    query: string,
-    expectations: TestQueryWithExpectation[] = []
-  ): Promise<void> {
-    this.worker.postMessage({ query, expectations, debug: this.debug });
+  async run(rec: TestCaseRecorder, query: string, ctx: ExecutionContext): Promise<void> {
+    this.worker.postMessage({ query, ctx, debug: this.debug });
     const workerResult = await new Promise<LiveTestCaseResult>(resolve => {
       this.resolvers.set(query, resolve);
     });

--- a/src/common/runtime/server.ts
+++ b/src/common/runtime/server.ts
@@ -46,6 +46,7 @@ if (!sys.existsSync('src/common/runtime/cmdline.ts')) {
 
 let debug = false;
 let gpuProviderModule: GPUProviderModule | undefined = undefined;
+let parallelSubcases = false;
 
 const gpuProviderFlags: string[] = [];
 for (let i = 0; i < sys.args.length; ++i) {
@@ -54,6 +55,8 @@ for (let i = 0; i < sys.args.length; ++i) {
     if (a === '--gpu-provider') {
       const modulePath = sys.args[++i];
       gpuProviderModule = require(modulePath);
+    } else if (a === '--parallelSubcases') {
+      parallelSubcases = true;
     } else if (a === '--gpu-provider-flag') {
       gpuProviderFlags.push(sys.args[++i]);
     } else if (a === '--help') {
@@ -90,7 +93,7 @@ if (gpuProviderModule) {
   ): Promise<LiveTestCaseResult> {
     const name = testcase.query.toString();
     const [rec, res] = log.record(name);
-    await testcase.run(rec, expectations);
+    await testcase.run(rec, { expectations, parallelSubcases });
     return res;
   }
 

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -21,6 +21,7 @@ let haveSomeResults = false;
 
 const runnow = optionEnabled('runnow');
 const debug = optionEnabled('debug');
+const parallelSubcases = optionEnabled('parallelSubcases');
 
 Logger.globalDebugMode = debug;
 const logger = new Logger();
@@ -113,9 +114,9 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
     const [rec, res] = logger.record(name);
     caseResult = res;
     if (worker) {
-      await worker.run(rec, name);
+      await worker.run(rec, name, { expectations: [], parallelSubcases });
     } else {
-      await t.run(rec);
+      await t.run(rec, { expectations: [], parallelSubcases });
     }
 
     result.total++;
@@ -313,7 +314,9 @@ function makeTreeNodeHeaderHTML(
     onChange(true);
   };
 
-  const href = `?${worker ? 'worker&' : ''}${debug ? 'debug&' : ''}q=${n.query.toString()}`;
+  const href = `?${worker ? 'worker&' : ''}${debug ? 'debug&' : ''}${
+    parallelSubcases ? 'parallelSubcases&' : ''
+  }q=${n.query.toString()}`;
   if (onChange) {
     div.on('toggle', function (this) {
       onChange((this as HTMLDetailsElement).open);
@@ -398,6 +401,7 @@ let lastQueryLevelToExpand: TestQueryLevel = 2;
         ['runnow', runnow ? '1' : '0'],
         ['worker', worker ? '1' : '0'],
         ['debug', debug ? '1' : '0'],
+        ['parallelSubcases', parallelSubcases ? '1' : '0'],
       ]).toString() +
       '&' +
       qs.map(q => 'q=' + q).join('&');

--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -61,9 +61,9 @@ setup({
     const wpt_fn = async () => {
       const [rec, res] = log.record(name);
       if (worker) {
-        await worker.run(rec, name, expectations);
+        await worker.run(rec, name, { expectations, parallelSubcases: false });
       } else {
-        await testcase.run(rec, expectations);
+        await testcase.run(rec, { expectations, parallelSubcases: false });
       }
 
       // Unfortunately, it seems not possible to surface any logs for warn/skip.

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -251,7 +251,7 @@ async function runTestcase(
   t.expect(objectEquals(testcases[i].query, query));
   const name = testcases[i].query.toString();
   const [rec, res] = log.record(name);
-  await testcases[i].run(rec, expectations);
+  await testcases[i].run(rec, { expectations, parallelSubcases: false });
 
   t.expect(log.results.get(name) === res);
   t.expect(res.status === status);

--- a/src/unittests/test_group_test.ts
+++ b/src/unittests/test_group_test.ts
@@ -12,7 +12,7 @@ export class TestGroupTest extends UnitTest {
       for (const rc of t.iterate()) {
         const query = new TestQuerySingleCase('xx', ['yy'], rc.id.test, rc.id.params);
         const [rec] = logger.record(query.toString());
-        await rc.run(rec, query, []);
+        await rc.run(rec, query, { expectations: [], parallelSubcases: false });
       }
     }
     return logger.results;


### PR DESCRIPTION
Setting parallelSubcases=true in the standalone runner or passing
--parallel-subcases on the command line will cause subcases to not
wait for each other to complete before continuing to the next
subcases. When there is a lot of async behavior, this should yield
better test throughput.

Currently defaults to false.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
