### PR TITLE
val: depth/stencil readOnly states of render pass/bundle VS wrtie states of render pipeline

### DIFF
--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -128,7 +128,8 @@ class F extends ValidationTest {
   createRenderPipeline(
     targets: Iterable<GPUColorTargetState | null>,
     depthStencil?: GPUDepthStencilState,
-    sampleCount?: number
+    sampleCount?: number,
+    cullMode?: GPUCullMode
   ) {
     return this.device.createRenderPipeline({
       vertex: {
@@ -147,7 +148,7 @@ class F extends ValidationTest {
         entryPoint: 'main',
         targets,
       },
-      primitive: { topology: 'triangle-list' },
+      primitive: { topology: 'triangle-list', cullMode },
       depthStencil,
       multisample: { count: sampleCount },
     });
@@ -421,6 +422,128 @@ Test that the depth attachment format in render passes or bundles match the pipe
     });
     encoder.setPipeline(pipeline);
     validateFinishAndSubmit(encoderFormat === pipelineFormat, true);
+  });
+
+const kStencilFaceStates = [
+  { failOp: 'keep', depthFailOp: 'keep', passOp: 'keep' },
+  { failOp: 'zero', depthFailOp: 'zero', passOp: 'zero' },
+] as GPUStencilFaceState[];
+
+g.test('render_pass_or_bundle_and_pipeline,depth_stencil_read_only_write_state')
+  .desc(
+    `
+Test that the depth stencil read only state in render passes or bundles is compatible with the depth stencil write state of the pipeline.
+`
+  )
+  .params(u =>
+    u
+      .combine('encoderType', ['render pass', 'render bundle'] as const)
+      .combine('format', kDepthStencilAttachmentFormats)
+      .beginSubcases()
+      // pass/bundle state
+      .combine('depthReadOnly', [false, true])
+      .combine('stencilReadOnly', [false, true])
+      .combine('stencilFront', kStencilFaceStates)
+      .combine('stencilBack', kStencilFaceStates)
+      // pipeline state
+      .combine('depthWriteEnabled', [false, true])
+      .combine('stencilWriteMask', [0, 0xffffffff])
+      .combine('cullMode', ['none', 'front', 'back'] as const)
+      .filter(p => {
+        if (p.format) {
+          const depthStencilInfo = kTextureFormatInfo[p.format];
+          // For combined depth/stencil formats the depth and stencil read only state must match
+          // in order to create a valid render bundle or render pass.
+          if (depthStencilInfo.depth && depthStencilInfo.stencil) {
+            if (p.depthReadOnly !== p.stencilReadOnly) {
+              return false;
+            }
+          }
+          // If the format has no depth aspect, the depthReadOnly, depthWriteEnabled of the pipeline must not be true
+          // in order to create a valid render pipeline.
+          if (!depthStencilInfo.depth && p.depthWriteEnabled) {
+            return false;
+          }
+          // If the format has no stencil aspect, the stencil state operation must be 'keep'
+          // in order to create a valid render pipeline.
+          if (
+            !depthStencilInfo.stencil &&
+            (p.stencilFront.failOp !== 'keep' || p.stencilBack.failOp !== 'keep')
+          ) {
+            return false;
+          }
+        }
+        // No depthStencil attachment
+        return true;
+      })
+  )
+  .fn(async t => {
+    const {
+      encoderType,
+      format,
+      depthReadOnly,
+      stencilReadOnly,
+      depthWriteEnabled,
+      stencilWriteMask,
+      cullMode,
+      stencilFront,
+      stencilBack,
+    } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
+
+    const pipeline = t.createRenderPipeline(
+      [{ format: 'rgba8unorm', writeMask: 0 }],
+      format === undefined
+        ? undefined
+        : {
+            format,
+            depthWriteEnabled,
+            stencilWriteMask,
+            stencilFront,
+            stencilBack,
+          },
+      1,
+      cullMode
+    );
+
+    const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
+      attachmentInfo: { colorFormats: ['rgba8unorm'], depthStencilFormat: format },
+    });
+    encoder.setPipeline(pipeline);
+
+    let writesDepth = false;
+    let writesStencil = false;
+    if (format) {
+      writesDepth = depthWriteEnabled;
+      if (stencilWriteMask !== 0) {
+        if (
+          cullMode !== 'front' &&
+          (stencilFront.passOp !== 'keep' ||
+            stencilFront.depthFailOp !== 'keep' ||
+            stencilFront.failOp !== 'keep')
+        ) {
+          writesStencil = true;
+        }
+        if (
+          cullMode !== 'back' &&
+          (stencilBack.passOp !== 'keep' ||
+            stencilBack.depthFailOp !== 'keep' ||
+            stencilBack.failOp !== 'keep')
+        ) {
+          writesStencil = true;
+        }
+      }
+    }
+
+    let isValid = true;
+    if (writesDepth) {
+      isValid &&= !depthReadOnly;
+    }
+    if (writesStencil) {
+      isValid &&= !stencilReadOnly;
+    }
+
+    validateFinishAndSubmit(isValid, true);
   });
 
 g.test('render_pass_or_bundle_and_pipeline,sample_count')


### PR DESCRIPTION
Issue: #927

Some validation fails for current chrome canary (https://crbug.com/dawn/1325). Basically under these two conditions:
- pass/bundle state `depthReadOnly=true` vs pipeline state: `depthWriteEnabled=true`
- pass/bundle state `stencilReadOnly=true` vs pipeline state: any of the stencil op is not "keep" (`failOp`/`depthFailOp`/`passOp`) + that face is not culled (related to `stencilFront`/`stencilBack` and `cullMode`)

The render pass/bundle vs pass/bundle test is added in `render_bundle.spec.ts` at #1057
Some tests in that file duplicate with tests in `attachment_compatibility.spec.ts`.
e.g.
`color_formats_mismatch` vs `render_pass_and_bundle,color_format` + `render_pass_and_bundle,color_count`
`sample_count_mismatch` vs `render_pass_and_bundle,sample_count`
We might want to merge them into `attachment_compatibility.spec.ts` to keep them in one place and to reduce overall cts running time.



<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
