### PR TITLE
Pipeline gathering subcase results

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -41,7 +41,8 @@ export class Fixture {
   }
 
   /**
-   * Returns the (case+subcase) parameters for this test function invocation.
+   * In a test function invocation, returns the (case+subcase) parameters for the test.
+   * In a before function invocation, returns only the case parameters for the test.
    */
   get params(): unknown {
     return this._params;

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -369,7 +369,7 @@ g.test('test,math,correctlyRounded')
   ]
   )
   .fn(t => {
-    const test_val = t.params.test_val;
+    const test_val = t.params.test_val as Scalar;
     const target = t.params.target;
     const is_correct = t.params.is_correct;
 
@@ -510,7 +510,7 @@ g.test('test,math,correctlyRoundedNoFlushOnly')
   ]
   )
   .fn(t => {
-    const test_val = t.params.test_val;
+    const test_val = t.params.test_val as Scalar;
     const target = t.params.target;
     const is_correct = t.params.is_correct;
 
@@ -651,7 +651,7 @@ g.test('test,math,correctlyRoundedFlushToZeroOnly')
   ]
   )
   .fn(t => {
-    const test_val = t.params.test_val;
+    const test_val = t.params.test_val as Scalar;
     const target = t.params.target;
     const is_correct = t.params.is_correct;
 

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -778,6 +778,13 @@ g.test('color_textures,compressed,non_array')
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])
   )
+  .before(async t => {
+    const { srcFormat, dstFormat } = t.params;
+    await t.selectDeviceOrSkipTestCase([
+      kTextureFormatInfo[srcFormat].feature,
+      kTextureFormatInfo[dstFormat].feature,
+    ]);
+  })
   .fn(async t => {
     const {
       dimension,
@@ -788,10 +795,6 @@ g.test('color_textures,compressed,non_array')
       srcCopyLevel,
       dstCopyLevel,
     } = t.params;
-    await t.selectDeviceOrSkipTestCase([
-      kTextureFormatInfo[srcFormat].feature,
-      kTextureFormatInfo[dstFormat].feature,
-    ]);
     const srcBlockWidth = kTextureFormatInfo[srcFormat].blockWidth;
     const srcBlockHeight = kTextureFormatInfo[srcFormat].blockHeight;
     const dstBlockWidth = kTextureFormatInfo[dstFormat].blockWidth;
@@ -929,6 +932,14 @@ g.test('color_textures,compressed,array')
       .combine('srcCopyLevel', [0, 2])
       .combine('dstCopyLevel', [0, 2])
   )
+  .before(async t => {
+    const { srcFormat, dstFormat } = t.params;
+
+    await t.selectDeviceOrSkipTestCase([
+      kTextureFormatInfo[srcFormat].feature,
+      kTextureFormatInfo[dstFormat].feature,
+    ]);
+  })
   .fn(async t => {
     const {
       dimension,
@@ -939,10 +950,6 @@ g.test('color_textures,compressed,array')
       srcCopyLevel,
       dstCopyLevel,
     } = t.params;
-    await t.selectDeviceOrSkipTestCase([
-      kTextureFormatInfo[srcFormat].feature,
-      kTextureFormatInfo[dstFormat].feature,
-    ]);
     const srcBlockWidth = kTextureFormatInfo[srcFormat].blockWidth;
     const srcBlockHeight = kTextureFormatInfo[srcFormat].blockHeight;
     const dstBlockWidth = kTextureFormatInfo[dstFormat].blockWidth;
@@ -1109,6 +1116,10 @@ g.test('copy_depth_stencil')
         );
       })
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
+  })
   .fn(async t => {
     const {
       format,
@@ -1118,7 +1129,6 @@ g.test('copy_depth_stencil')
       srcCopyBaseArrayLayer,
       dstCopyBaseArrayLayer,
     } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const copySize: [number, number, number] = [
       srcTextureSize.width >> srcCopyLevel,

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1287,6 +1287,10 @@ bytes in copy works for every format.
         return kRowsPerImageAndBytesPerRowParams.copySizes;
       })
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       bytesPerRowPadding,
@@ -1300,8 +1304,6 @@ bytes in copy works for every format.
       checkMethod,
     } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
-
     // For CopyB2T and CopyT2B we need to have bytesPerRow 256-aligned,
     // to make this happen we align the bytesInACompleteRow value and multiply
     // bytesPerRowPadding by 256.
@@ -1381,6 +1383,10 @@ works for every format with 2d and 2d-array textures.
       .combine('copyDepth', kOffsetsAndSizesParams.copyDepth) // 2d and 2d-array textures
       .unless(p => p.dimension === '1d' && p.copyDepth !== 1)
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       offsetInBlocks,
@@ -1392,7 +1398,6 @@ works for every format with 2d and 2d-array textures.
       checkMethod,
     } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const offset = offsetInBlocks * info.bytesPerBlock;
     const copySize = {
@@ -1457,6 +1462,10 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
       .combine('coordinateToTest', [0, 1, 2] as const)
       .unless(p => p.dimension === '1d' && p.coordinateToTest !== 0)
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       originValueInBlocks,
@@ -1468,7 +1477,6 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
       checkMethod,
     } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     let originBlocks = [1, 1, 1];
     let copySizeBlocks = [2, 2, 2];
@@ -1653,6 +1661,10 @@ TODO: Make a variant for depth-stencil formats.
       ])
       .expand('textureSize', generateTestTextureSizes)
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       copySizeInBlocks,
@@ -1665,7 +1677,6 @@ TODO: Make a variant for depth-stencil formats.
       checkMethod,
     } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const origin = {
       x: originInBlocks.x * info.blockWidth,
@@ -1817,6 +1828,10 @@ aspect and copyTextureToBuffer() with depth aspect.
       })
       .combine('mipLevel', [0, 2])
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       format,
@@ -1829,9 +1844,6 @@ aspect and copyTextureToBuffer() with depth aspect.
       copyDepth,
       mipLevel,
     } = t.params;
-
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
-
     const bytesPerBlock = depthStencilFormatAspectSize(format, aspect);
     const rowsPerImage = copyHeightInBlocks + rowsPerImagePadding;
 
@@ -1907,6 +1919,10 @@ copyTextureToBuffer() with depth aspect.
       .combine('copyDepth', kOffsetsAndSizesParams.copyDepth)
       .combine('mipLevel', [0, 2])
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       format,
@@ -1917,8 +1933,6 @@ copyTextureToBuffer() with depth aspect.
       copyDepth,
       mipLevel,
     } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
-
     const bytesPerBlock = depthStencilFormatAspectSize(format, aspect);
     const initialDataOffset = offsetInBlocks * bytesPerBlock;
     const copySize = [3, 3, copyDepth] as const;

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -81,10 +81,13 @@ g.test('color,component_count')
       .combine('componentCount', [1, 2, 3, 4])
       .filter(x => x.componentCount >= kTexelRepresentationInfo[x.format].componentOrder.length)
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { format, componentCount } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     // expected RGBA values
     // extra channels are discarded
@@ -287,6 +290,10 @@ The attachment has a load value of [1, 0, 0, 1]
       ] as const)
       .filter(x => x.output.length >= kTexelRepresentationInfo[x.format].componentOrder.length)
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       format,
@@ -299,7 +306,6 @@ The attachment has a load value of [1, 0, 0, 1]
     } = t.params;
     const componentCount = output.length;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const renderTarget = t.device.createTexture({
       format,

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -76,9 +76,11 @@ g.test('depth_compare_func')
         { depthCompare: 'always', depthClearValue: 0.0, _expected: triangleColor },
       ] as const)
   )
+  .before(async t => {
+    await t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+  })
   .fn(async t => {
     const { depthCompare, depthClearValue, _expected, format } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const colorAttachmentFormat = 'rgba8unorm';
     const colorAttachment = t.device.createTexture({

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -41,14 +41,17 @@ have unexpected values then get drawn to the color buffer, which is later checke
       .combine('writeDepth', [false, true])
       .combine('multisampled', [false, true])
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+
+    await t.selectDeviceOrSkipTestCase([
+      t.params.unclippedDepth ? 'depth-clip-control' : undefined,
+      info.feature,
+    ]);
+  })
   .fn(async t => {
     const { format, unclippedDepth, writeDepth, multisampled } = t.params;
     const info = kTextureFormatInfo[format];
-
-    await t.selectDeviceOrSkipTestCase([
-      unclippedDepth ? 'depth-clip-control' : undefined,
-      info.feature,
-    ]);
 
     /** Number of depth values to test for both vertex output and frag_depth output. */
     const kNumDepthValues = 8;
@@ -351,14 +354,17 @@ to be empty.`
       .combine('unclippedDepth', [false, true])
       .combine('multisampled', [false, true])
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+
+    await t.selectDeviceOrSkipTestCase([
+      t.params.unclippedDepth ? 'depth-clip-control' : undefined,
+      info.feature,
+    ]);
+  })
   .fn(async t => {
     const { format, unclippedDepth, multisampled } = t.params;
     const info = kTextureFormatInfo[format];
-
-    await t.selectDeviceOrSkipTestCase([
-      unclippedDepth ? 'depth-clip-control' : undefined,
-      info.feature,
-    ]);
 
     const kNumDepthValues = 8;
     const kViewportMinDepth = 0.25;

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -50,11 +50,12 @@ Params:
       .expand('index_buffer_offset', p => (p.indexed ? ([0, 16] as const) : [undefined]))
       .expand('base_vertex', p => (p.indexed ? ([0, 9] as const) : [undefined]))
   )
-  .fn(async t => {
+  .before(async t => {
     if (t.params.first_instance > 0 && t.params.indirect) {
       await t.selectDeviceOrSkipTestCase('indirect-first-instance');
     }
-
+  })
+  .fn(async t => {
     const renderTargetSize = [72, 36];
 
     // The test will split up the render target into a grid where triangles of

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -10,7 +10,7 @@ TODO:
 // MAINTENANCE_TODO: This is a test file, it probably shouldn't export anything.
 // Everything that's exported should be moved to another file.
 
-import { TestCaseRecorder, TestParams } from '../../../../common/framework/fixture.js';
+import { CaseRecorder, TestParams } from '../../../../common/framework/fixture.js';
 import {
   kUnitCaseParamsBuilder,
   ParamTypeOf,
@@ -27,7 +27,7 @@ import {
   kTextureDimensions,
 } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
-import { GPUTest } from '../../../gpu_test.js';
+import { GPUTest, GPUTestSharedState } from '../../../gpu_test.js';
 import { virtualMipSize } from '../../../util/texture/base.js';
 import { createTextureUploadBuffer } from '../../../util/texture/layout.js';
 import { BeginEndRange, SubresourceRange } from '../../../util/texture/subresource.js';
@@ -184,8 +184,8 @@ export class TextureZeroInitTest extends GPUTest {
   readonly stateToTexelComponents: { [k in InitializedState]: PerTexelComponent<number> };
 
   private p: TextureZeroParams;
-  constructor(rec: TestCaseRecorder, params: TestParams) {
-    super(rec, params);
+  constructor(sharedState: GPUTestSharedState, rec: CaseRecorder, params: TestParams) {
+    super(sharedState, rec, params);
     this.p = params as TextureZeroParams;
 
     const stateToTexelComponents = (state: InitializedState) => {
@@ -577,9 +577,10 @@ export const g = makeTestGroup(TextureZeroInitTest);
 
 g.test('uninitialized_texture_is_zero')
   .params(kTestParams)
-  .fn(async t => {
+  .before(async t => {
     await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[t.params.format].feature);
-
+  })
+  .fn(async t => {
     const usage = getRequiredTextureUsage(
       t.params.format,
       t.params.sampleCount,

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -256,14 +256,17 @@ g.test('render_pass_and_bundle,color_sparse')
 
 g.test('render_pass_and_bundle,depth_format')
   .desc('Test that the depth attachment format in render passes and bundles must match.')
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u //
       .combine('passFormat', kDepthStencilAttachmentFormats)
       .combine('bundleFormat', kDepthStencilAttachmentFormats)
   )
-  .fn(async t => {
+  .before(async t => {
     const { passFormat, bundleFormat } = t.params;
     await t.selectDeviceForTextureFormatOrSkipTestCase([passFormat, bundleFormat]);
+  })
+  .fn(async t => {
+    const { passFormat, bundleFormat } = t.params;
 
     const bundleEncoder = t.device.createRenderBundleEncoder({
       colorFormats: ['rgba8unorm'],
@@ -404,13 +407,15 @@ Test that the depth attachment format in render passes or bundles match the pipe
   .params(u =>
     u
       .combine('encoderType', ['render pass', 'render bundle'] as const)
-      .beginSubcases()
       .combine('encoderFormat', kDepthStencilAttachmentFormats)
       .combine('pipelineFormat', kDepthStencilAttachmentFormats)
   )
+  .before(async t => {
+    const { encoderFormat, pipelineFormat } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase([encoderFormat, pipelineFormat]);
+  })
   .fn(async t => {
     const { encoderType, encoderFormat, pipelineFormat } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase([encoderFormat, pipelineFormat]);
 
     const pipeline = t.createRenderPipeline(
       [{ format: 'rgba8unorm', writeMask: 0 }],
@@ -477,6 +482,9 @@ Test that the depth stencil read only state in render passes or bundles is compa
         return true;
       })
   )
+  .before(async t => {
+    await t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+  })
   .fn(async t => {
     const {
       encoderType,
@@ -489,7 +497,6 @@ Test that the depth stencil read only state in render passes or bundles is compa
       stencilFront,
       stencilBack,
     } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const pipeline = t.createRenderPipeline(
       [{ format: 'rgba8unorm', writeMask: 0 }],

--- a/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
@@ -25,8 +25,8 @@ As of this writing, the spec needs to be fixed as well.
       .combine('type', ['occlusion', 'timestamp'] as const)
       .combine('timestampQueryEnable', [false, true])
   )
-  .fn(async t => {
-    const { type, timestampQueryEnable } = t.params;
+  .before(async t => {
+    const { timestampQueryEnable } = t.params;
 
     const requiredFeatures: GPUFeatureName[] = [];
     if (timestampQueryEnable) {
@@ -34,6 +34,9 @@ As of this writing, the spec needs to be fixed as well.
     }
 
     await t.selectDeviceOrSkipTestCase({ requiredFeatures });
+  })
+  .fn(async t => {
+    const { type, timestampQueryEnable } = t.params;
 
     const count = 1;
     const shouldError = type === 'timestamp' && !timestampQueryEnable;

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -28,19 +28,20 @@ g.test('texture_descriptor')
   `
   )
   .params(u =>
-    u
-      .combine('format', kOptionalTextureFormats)
-      .beginSubcases()
-      .combine('enable_required_feature', [true, false])
+    u.combine('format', kOptionalTextureFormats).combine('enable_required_feature', [true, false])
   )
-  .fn(async t => {
+  .before(async t => {
     const { format, enable_required_feature } = t.params;
 
     const formatInfo = kTextureFormatInfo[format];
     if (enable_required_feature) {
       await t.selectDeviceOrSkipTestCase(formatInfo.feature);
     }
+  })
+  .fn(async t => {
+    const { format, enable_required_feature } = t.params;
 
+    const formatInfo = kTextureFormatInfo[format];
     t.expectValidationError(() => {
       t.device.createTexture({
         format,
@@ -63,16 +64,18 @@ g.test('storage_texture_binding_layout')
     u
       .combine('format', kOptionalTextureFormats)
       .filter(t => kTextureFormatInfo[t.format].storage)
-      .beginSubcases()
       .combine('enable_required_feature', [true, false])
   )
-  .fn(async t => {
+  .before(async t => {
     const { format, enable_required_feature } = t.params;
 
     const formatInfo = kTextureFormatInfo[format];
     if (enable_required_feature) {
       await t.selectDeviceOrSkipTestCase(formatInfo.feature);
     }
+  })
+  .fn(async t => {
+    const { format, enable_required_feature } = t.params;
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout({
@@ -102,16 +105,18 @@ g.test('color_target_state')
     u
       .combine('format', kOptionalTextureFormats)
       .filter(t => kTextureFormatInfo[t.format].renderable && kTextureFormatInfo[t.format].color)
-      .beginSubcases()
       .combine('enable_required_feature', [true, false])
   )
-  .fn(async t => {
+  .before(async t => {
     const { format, enable_required_feature } = t.params;
 
     const formatInfo = kTextureFormatInfo[format];
     if (enable_required_feature) {
       await t.selectDeviceOrSkipTestCase(formatInfo.feature);
     }
+  })
+  .fn(async t => {
+    const { format, enable_required_feature } = t.params;
 
     t.expectValidationError(() => {
       t.device.createRenderPipeline({
@@ -155,16 +160,18 @@ g.test('depth_stencil_state')
           kTextureFormatInfo[t.format].renderable &&
           (kTextureFormatInfo[t.format].depth || kTextureFormatInfo[t.format].stencil)
       )
-      .beginSubcases()
       .combine('enable_required_feature', [true, false])
   )
-  .fn(async t => {
+  .before(async t => {
     const { format, enable_required_feature } = t.params;
 
     const formatInfo = kTextureFormatInfo[format];
     if (enable_required_feature) {
       await t.selectDeviceOrSkipTestCase(formatInfo.feature);
     }
+  })
+  .fn(async t => {
+    const { format, enable_required_feature } = t.params;
 
     t.expectValidationError(() => {
       t.device.createRenderPipeline({
@@ -209,16 +216,18 @@ g.test('render_bundle_encoder_descriptor_color_format')
     u
       .combine('format', kOptionalTextureFormats)
       .filter(t => kTextureFormatInfo[t.format].renderable && kTextureFormatInfo[t.format].color)
-      .beginSubcases()
       .combine('enable_required_feature', [true, false])
   )
-  .fn(async t => {
+  .before(async t => {
     const { format, enable_required_feature } = t.params;
 
     const formatInfo = kTextureFormatInfo[format];
     if (enable_required_feature) {
       await t.selectDeviceOrSkipTestCase(formatInfo.feature);
     }
+  })
+  .fn(async t => {
+    const { format, enable_required_feature } = t.params;
 
     t.expectValidationError(() => {
       t.device.createRenderBundleEncoder({
@@ -242,16 +251,18 @@ g.test('render_bundle_encoder_descriptor_depth_stencil_format')
           kTextureFormatInfo[t.format].renderable &&
           (kTextureFormatInfo[t.format].depth || kTextureFormatInfo[t.format].stencil)
       )
-      .beginSubcases()
       .combine('enable_required_feature', [true, false])
   )
-  .fn(async t => {
+  .before(async t => {
     const { format, enable_required_feature } = t.params;
 
     const formatInfo = kTextureFormatInfo[format];
     if (enable_required_feature) {
       await t.selectDeviceOrSkipTestCase(formatInfo.feature);
     }
+  })
+  .fn(async t => {
+    const { format, enable_required_feature } = t.params;
 
     t.expectValidationError(() => {
       t.device.createRenderBundleEncoder({

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -498,13 +498,14 @@ g.test('bind_group_layout,device_mismatch')
   .desc(
     'Tests createBindGroup cannot be called with a bind group layout created from another device'
   )
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const mismatched = t.params.mismatched;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const mismatched = t.params.mismatched;
 
     const device = mismatched ? t.mismatchedDevice : t.device;
 
@@ -550,19 +551,21 @@ g.test('binding_resources,device_mismatch')
         { texture: { multisampled: false } },
         { storageTexture: { access: 'write-only', format: 'rgba8unorm' } },
       ] as const)
-      .beginSubcases()
       .combineWithParams([
         { resource0Mismatched: false, resource1Mismatched: false }, //control case
         { resource0Mismatched: true, resource1Mismatched: false },
         { resource0Mismatched: false, resource1Mismatched: true },
       ])
   )
-  .fn(async t => {
-    const { entry, resource0Mismatched, resource1Mismatched } = t.params;
+  .before(async t => {
+    const { resource0Mismatched, resource1Mismatched } = t.params;
 
     if (resource0Mismatched || resource1Mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { entry, resource0Mismatched, resource1Mismatched } = t.params;
 
     const info = bindingTypeInfo(entry);
 

--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -178,14 +178,16 @@ g.test('pipeline_layout,device_mismatch')
   .desc(
     'Tests createComputePipeline(Async) cannot be called with a pipeline layout created from another device'
   )
-  .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { isAsync, mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u =>
+    u.combine('mismatched', [true, false]).beginSubcases().combine('isAsync', [true, false])
+  )
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { isAsync, mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const layout = device.createPipelineLayout({ bindGroupLayouts: [] });
@@ -205,13 +207,16 @@ g.test('shader_module,device_mismatch')
   .desc(
     'Tests createComputePipeline(Async) cannot be called with a shader module created from another device'
   )
-  .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { isAsync, mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u =>
+    u.combine('mismatched', [true, false]).beginSubcases().combine('isAsync', [true, false])
+  )
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { isAsync, mismatched } = t.params;
 
     const device = mismatched ? t.mismatchedDevice : t.device;
 

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -112,12 +112,12 @@ g.test('bind_group_layouts,device_mismatch')
     - layout0 and layout1 from different device
     `
   )
-  .paramsSubcasesOnly([
+  .paramsSimple([
     { layout0Mismatched: false, layout1Mismatched: false }, // control case
     { layout0Mismatched: true, layout1Mismatched: false },
     { layout0Mismatched: false, layout1Mismatched: true },
   ])
-  .fn(async t => {
+  .before(async t => {
     const { layout0Mismatched, layout1Mismatched } = t.params;
 
     const mismatched = layout0Mismatched || layout1Mismatched;
@@ -125,6 +125,11 @@ g.test('bind_group_layouts,device_mismatch')
     if (mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { layout0Mismatched, layout1Mismatched } = t.params;
+
+    const mismatched = layout0Mismatched || layout1Mismatched;
 
     const bglDescriptor: GPUBindGroupLayoutDescriptor = {
       entries: [],

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -248,10 +248,14 @@ g.test('at_least_one_color_state_is_required_for_complete_pipeline')
 g.test('color_formats_must_be_renderable')
   .desc(`TODO: review and add description; shorten name`)
   .params(u => u.combine('isAsync', [false, true]).combine('format', kTextureFormats))
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { isAsync, format } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const descriptor = t.getDescriptor({ targets: [{ format }] });
 
@@ -261,10 +265,14 @@ g.test('color_formats_must_be_renderable')
 g.test('depth_stencil_state,format')
   .desc(`The texture format in depthStencilState must be a depth/stencil format`)
   .params(u => u.combine('isAsync', [false, true]).combine('format', kTextureFormats))
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { isAsync, format } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const descriptor = t.getDescriptor({ depthStencil: { format } });
 
@@ -281,10 +289,14 @@ g.test('depth_stencil_state,depth_aspect,depth_test')
       .combine('format', kDepthStencilFormats)
       .combine('depthCompare', [undefined, ...kCompareFunctions])
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { isAsync, format, depthCompare } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const descriptor = t.getDescriptor({
       depthStencil: { format, depthCompare },
@@ -304,10 +316,14 @@ g.test('depth_stencil_state,depth_aspect,depth_write')
       .combine('format', kDepthStencilFormats)
       .combine('depthWriteEnabled', [false, true])
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { isAsync, format, depthWriteEnabled } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const descriptor = t.getDescriptor({
       depthStencil: { format, depthWriteEnabled },
@@ -326,10 +342,14 @@ g.test('depth_stencil_state,stencil_aspect,stencil_test')
       .combine('face', ['front', 'back'] as const)
       .combine('compare', [undefined, ...kCompareFunctions])
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { isAsync, format, face, compare } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     let descriptor: GPURenderPipelineDescriptor;
     if (face === 'front') {
@@ -360,10 +380,14 @@ g.test('depth_stencil_state,stencil_aspect,stencil_write')
       ] as const)
       .combine('op', [undefined, ...kStencilOperations])
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { isAsync, format, faceAndOpType, op } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     let depthStencil: GPUDepthStencilState;
     switch (faceAndOpType) {
@@ -433,10 +457,14 @@ g.test('pipeline_output_targets')
       .combine('sampleType', ['float', 'uint', 'sint'] as const)
       .combine('componentCount', [1, 2, 3, 4])
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { isAsync, format, sampleType, componentCount } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const descriptor = t.getDescriptor({
       targets: [{ format }],
@@ -518,6 +546,11 @@ g.test('pipeline_output_targets,blend')
         },
       ] as const)
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const sampleType = 'float';
     const {
@@ -530,7 +563,6 @@ g.test('pipeline_output_targets,blend')
       alphaDstFactor,
     } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const descriptor = t.getDescriptor({
       targets: [
@@ -572,10 +604,14 @@ Tests if blending is used, the target's format must be blendable (support "float
   .params(u =>
     u.combine('isAsync', [false, true]).combine('format', kRenderableColorTextureFormats)
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { isAsync, format } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const _success = info.sampleType === 'float';
 
@@ -660,13 +696,16 @@ g.test('pipeline_layout,device_mismatch')
   .desc(
     'Tests createRenderPipeline(Async) cannot be called with a pipeline layout created from another device'
   )
-  .paramsSubcasesOnly(u => u.combine('isAsync', [true, false]).combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { isAsync, mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u =>
+    u.combine('mismatched', [true, false]).beginSubcases().combine('isAsync', [true, false])
+  )
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { isAsync, mismatched } = t.params;
 
     const device = mismatched ? t.mismatchedDevice : t.device;
 
@@ -698,19 +737,25 @@ g.test('shader_module,device_mismatch')
   .desc(
     'Tests createRenderPipeline(Async) cannot be called with a shader module created from another device'
   )
-  .paramsSubcasesOnly(u =>
-    u.combine('isAsync', [true, false]).combineWithParams([
-      { vertex_mismatched: false, fragment_mismatched: false, _success: true },
-      { vertex_mismatched: true, fragment_mismatched: false, _success: false },
-      { vertex_mismatched: false, fragment_mismatched: true, _success: false },
-    ])
+  .params(u =>
+    u
+      .combineWithParams([
+        { vertex_mismatched: false, fragment_mismatched: false, _success: true },
+        { vertex_mismatched: true, fragment_mismatched: false, _success: false },
+        { vertex_mismatched: false, fragment_mismatched: true, _success: false },
+      ])
+      .beginSubcases()
+      .combine('isAsync', [true, false])
   )
-  .fn(async t => {
-    const { isAsync, vertex_mismatched, fragment_mismatched, _success } = t.params;
+  .before(async t => {
+    const { vertex_mismatched, fragment_mismatched } = t.params;
 
     if (vertex_mismatched || fragment_mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { isAsync, vertex_mismatched, fragment_mismatched, _success } = t.params;
 
     const code = `
       @stage(vertex) fn main() -> @builtin(position) vec4<f32> {

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -11,9 +11,11 @@ import {
   kTextureUsages,
   kUncompressedTextureFormats,
   kRegularTextureFormats,
+  kFeaturesForFormats,
   textureDimensionAndFormatCompatible,
   kLimitInfo,
   viewCompatible,
+  filterFormatsByFeature,
 } from '../../capability_info.js';
 import { GPUConst } from '../../constants.js';
 import { maxMipLevelCount } from '../../util/texture/base.js';
@@ -771,10 +773,21 @@ g.test('viewFormats')
   .desc(
     `Test creating a texture with viewFormats list for all {texture format}x{view format}. Only compatible view formats should be valid.`
   )
-  .params(u => u.combine('format', kTextureFormats).combine('viewFormat', kTextureFormats))
+  .params(u =>
+    u
+      .combine('formatFeature', kFeaturesForFormats)
+      .combine('viewFormatFeature', kFeaturesForFormats)
+      .beginSubcases()
+      .expand('format', ({ formatFeature }) =>
+        filterFormatsByFeature(formatFeature, kTextureFormats)
+      )
+      .expand('viewFormat', ({ viewFormatFeature }) =>
+        filterFormatsByFeature(viewFormatFeature, kTextureFormats)
+      )
+  )
   .before(async t => {
-    const { format, viewFormat } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase([format, viewFormat]);
+    const { formatFeature, viewFormatFeature } = t.params;
+    await t.selectDeviceOrSkipTestCase([formatFeature, viewFormatFeature]);
   })
   .fn(async t => {
     const { format, viewFormat } = t.params;

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -1,5 +1,6 @@
 export const description = `createTexture validation tests.`;
 
+import { SkipTestCase } from '../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { assert } from '../../../common/util/util.js';
 import {
@@ -29,6 +30,12 @@ g.test('zero_size')
   .params(u =>
     u
       .combine('dimension', [undefined, ...kTextureDimensions])
+      .combine('format', [
+        'rgba8unorm',
+        'rgb10a2unorm',
+        'bc1-rgba-unorm',
+        'depth24plus-stencil8',
+      ] as const)
       .beginSubcases()
       .combine('zeroArgument', [
         'none',
@@ -37,19 +44,17 @@ g.test('zero_size')
         'depthOrArrayLayers',
         'mipLevelCount',
       ] as const)
-      .combine('format', [
-        'rgba8unorm',
-        'rgb10a2unorm',
-        'bc1-rgba-unorm',
-        'depth24plus-stencil8',
-      ] as const)
       // Filter out incompatible dimension type and format combinations.
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { dimension, zeroArgument, format } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const size = [info.blockWidth, info.blockHeight, 1];
     let mipLevelCount = 1;
@@ -91,15 +96,16 @@ g.test('dimension_type_and_format_compatibility')
     `Test every dimension type on every format. Note that compressed formats and depth/stencil formats are not valid for 1D/3D dimension types.`
   )
   .params(u =>
-    u
-      .combine('dimension', [undefined, ...kTextureDimensions])
-      .beginSubcases()
-      .combine('format', kTextureFormats)
+    u.combine('dimension', [undefined, ...kTextureDimensions]).combine('format', kTextureFormats)
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { dimension, format } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const descriptor: GPUTextureDescriptor = {
       size: [info.blockWidth, info.blockHeight, 1],
@@ -121,18 +127,22 @@ g.test('mipLevelCount,format')
   .params(u =>
     u
       .combine('dimension', [undefined, ...kTextureDimensions])
-      .beginSubcases()
       .combine('format', kTextureFormats)
+      .beginSubcases()
       .combine('mipLevelCount', [1, 2, 3, 6, 7])
       // Filter out incompatible dimension type and format combinations.
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
       .combine('largestDimension', [0, 1, 2])
       .unless(({ dimension, largestDimension }) => dimension === '1d' && largestDimension > 0)
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { dimension, format, mipLevelCount, largestDimension } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     // Compute dimensions such that the dimensions are in range [17, 32] and aligned with the
     // format block size so that there will be exactly 6 mip levels.
@@ -172,9 +182,10 @@ g.test('mipLevelCount,bound_check')
     `Test mip level count bound check upon different texture size and different texture dimension types.
     The cases below test: 1) there must be no mip levels after a 1 level (1D texture), or 1x1 level (2D texture), or 1x1x1 level (3D texture), 2) array layers are not mip-mapped, 3) power-of-two, non-power-of-two, and non-square sizes.`
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u //
       .combine('format', ['rgba8unorm', 'bc1-rgba-unorm'] as const)
+      .beginSubcases()
       .combineWithParams([
         { size: [32, 32] }, // Mip level sizes: 32x32, 16x16, 8x8, 4x4, 2x2, 1x1
         { size: [31, 32] }, // Mip level sizes: 31x32, 15x16, 7x8, 3x4, 1x2, 1x1
@@ -202,9 +213,13 @@ g.test('mipLevelCount,bound_check')
             size[1] % kTextureFormatInfo[format].blockHeight !== 0)
       )
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { format, size, dimension } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const descriptor = {
       size,
@@ -246,13 +261,17 @@ g.test('sampleCount,various_sampleCount_with_all_formats')
   .params(u =>
     u
       .combine('dimension', [undefined, '2d'] as const)
+      .combine('format', kTextureFormats)
       .beginSubcases()
       .combine('sampleCount', [0, 1, 2, 4, 8, 16, 32, 256])
-      .combine('format', kTextureFormats)
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { dimension, sampleCount, format } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
     const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     const descriptor = {
@@ -280,6 +299,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
   .params(u =>
     u
       .combine('dimension', [undefined, ...kTextureDimensions])
+      .combine('format', kTextureFormats)
       .beginSubcases()
       .combine('sampleCount', [1, 4])
       .combine('arrayLayerCount', [1, 2])
@@ -288,7 +308,6 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
           arrayLayerCount === 2 && dimension !== '2d' && dimension !== undefined
       )
       .combine('mipLevelCount', [1, 2])
-      .combine('format', kTextureFormats)
       .combine('usage', kTextureUsages)
       // Filter out incompatible dimension type and format combinations.
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
@@ -303,9 +322,13 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
         );
       })
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { dimension, sampleCount, format, mipLevelCount, arrayLayerCount, usage } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
     const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     const size =
@@ -345,15 +368,19 @@ g.test('texture_size,default_value_and_smallest_size,uncompressed_format')
   .params(u =>
     u
       .combine('dimension', [undefined, ...kTextureDimensions])
-      .beginSubcases()
       .combine('format', kUncompressedTextureFormats)
+      .beginSubcases()
       .combine('size', [[1], [1, 1], [1, 1, 1]])
       // Filter out incompatible dimension type and format combinations.
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { dimension, format, size } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -374,8 +401,8 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
     u
       // Compressed formats are invalid for 1D and 3D.
       .combine('dimension', [undefined, '2d'] as const)
-      .beginSubcases()
       .combine('format', kCompressedTextureFormats)
+      .beginSubcases()
       .expandWithParams(p => {
         const { blockWidth, blockHeight } = kTextureFormatInfo[p.format];
         return [
@@ -388,10 +415,13 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
         ];
       })
   )
-  .fn(async t => {
-    const { dimension, format, size, _success } = t.params;
+  .before(async t => {
+    const { format } = t.params;
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
+  })
+  .fn(async t => {
+    const { dimension, format, size, _success } = t.params;
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -407,10 +437,11 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
 
 g.test('texture_size,1d_texture')
   .desc(`Test texture size requirement for 1D texture`)
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u //
       // Compressed and depth-stencil textures are invalid for 1D.
       .combine('format', kRegularTextureFormats)
+      .beginSubcases()
       .combine('width', [
         kLimitInfo.maxTextureDimension1D.default - 1,
         kLimitInfo.maxTextureDimension1D.default,
@@ -419,9 +450,13 @@ g.test('texture_size,1d_texture')
       .combine('height', [1, 2])
       .combine('depthOrArrayLayers', [1, 2])
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { format, width, height, depthOrArrayLayers } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const descriptor: GPUTextureDescriptor = {
       size: [width, height, depthOrArrayLayers],
@@ -459,9 +494,13 @@ g.test('texture_size,2d_texture,uncompressed_format')
         [1, 1, kLimitInfo.maxTextureArrayLayers.default + 1],
       ])
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { dimension, format, size } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -523,10 +562,14 @@ g.test('texture_size,2d_texture,compressed_format')
         ];
       })
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { dimension, format, size } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -551,9 +594,10 @@ g.test('texture_size,3d_texture,uncompressed_format')
   .desc(
     `Test texture size requirement for 3D texture with uncompressed format. Note that depth/stencil formats are invalid for 3D textures, so we only test regular formats.`
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u //
       .combine('format', kRegularTextureFormats)
+      .beginSubcases()
       .combine('size', [
         // Test the bound of width
         [kLimitInfo.maxTextureDimension3D.default - 1, 1, 1],
@@ -569,9 +613,13 @@ g.test('texture_size,3d_texture,uncompressed_format')
         [1, 1, kLimitInfo.maxTextureDimension3D.default + 1],
       ])
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { format, size } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -592,9 +640,10 @@ g.test('texture_size,3d_texture,uncompressed_format')
 
 g.test('texture_size,3d_texture,compressed_format')
   .desc(`Test texture size requirement for 3D texture with compressed format.`)
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u //
       .combine('format', kCompressedTextureFormats)
+      .beginSubcases()
       .expand('size', p => {
         const { blockWidth, blockHeight } = kTextureFormatInfo[p.format];
         return [
@@ -632,14 +681,17 @@ g.test('texture_size,3d_texture,compressed_format')
         ];
       })
   )
-  .fn(async t => {
-    const { format, size } = t.params;
-
+  .before(async t => {
     // Compressed formats are not supported in 3D in WebGPU v1 because they are complicated but not very useful for now.
-    t.skip('Compressed 3D texture is not supported');
+    throw new SkipTestCase('Comprsesed 3D texture is not supported');
 
+    const { format } = t.params;
     const info = kTextureFormatInfo[format];
     await t.selectDeviceOrSkipTestCase(info.feature);
+  })
+  .fn(async t => {
+    const { format, size } = t.params;
+    const info = kTextureFormatInfo[format];
 
     assert(
       kLimitInfo.maxTextureDimension3D.default % info.blockWidth === 0 &&
@@ -672,18 +724,22 @@ g.test('texture_usage')
   .params(u =>
     u
       .combine('dimension', [undefined, ...kTextureDimensions])
-      .beginSubcases()
       .combine('format', kTextureFormats)
+      .beginSubcases()
       // If usage0 and usage1 are the same, then the usage being test is a single usage. Otherwise, it is a combined usage.
       .combine('usage0', kTextureUsages)
       .combine('usage1', kTextureUsages)
       // Filter out incompatible dimension type and format combinations.
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
   )
+  .before(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { dimension, format, usage0, usage1 } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const size = [info.blockWidth, info.blockHeight, 1];
     const usage = usage0 | usage1;
@@ -715,12 +771,13 @@ g.test('viewFormats')
   .desc(
     `Test creating a texture with viewFormats list for all {texture format}x{view format}. Only compatible view formats should be valid.`
   )
-  .params(u =>
-    u.combine('format', kTextureFormats).beginSubcases().combine('viewFormat', kTextureFormats)
-  )
-  .fn(async t => {
+  .params(u => u.combine('format', kTextureFormats).combine('viewFormat', kTextureFormats))
+  .before(async t => {
     const { format, viewFormat } = t.params;
     await t.selectDeviceForTextureFormatOrSkipTestCase([format, viewFormat]);
+  })
+  .fn(async t => {
+    const { format, viewFormat } = t.params;
     const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     const compatible = viewCompatible(format, viewFormat);

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -32,13 +32,16 @@ g.test('format')
   .params(u =>
     u
       .combine('textureFormat', kTextureFormats)
-      .beginSubcases()
       .combine('viewFormat', [undefined, ...kTextureFormats])
+      .beginSubcases()
       .combine('useViewFormatList', [false, true])
   )
+  .before(async t => {
+    const { textureFormat, viewFormat } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase([textureFormat, viewFormat]);
+  })
   .fn(async t => {
     const { textureFormat, viewFormat, useViewFormatList } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase([textureFormat, viewFormat]);
     const { blockWidth, blockHeight } = kTextureFormatInfo[textureFormat];
 
     const compatible = viewFormat === undefined || viewCompatible(textureFormat, viewFormat);
@@ -108,9 +111,12 @@ g.test('aspect')
       .combine('format', kTextureFormats)
       .combine('aspect', kTextureAspects)
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
+  })
   .fn(async t => {
     const { format, aspect } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
     const info = kTextureFormatInfo[format];
 
     const texture = t.device.createTexture({

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -9,7 +9,9 @@ import {
   kTextureFormatInfo,
   kTextureFormats,
   kTextureViewDimensions,
+  kFeaturesForFormats,
   viewCompatible,
+  filterFormatsByFeature,
 } from '../../capability_info.js';
 import { kResourceStates } from '../../gpu_test.js';
 import {
@@ -31,14 +33,20 @@ g.test('format')
   )
   .params(u =>
     u
-      .combine('textureFormat', kTextureFormats)
-      .combine('viewFormat', [undefined, ...kTextureFormats])
+      .combine('textureFormatFeature', kFeaturesForFormats)
+      .combine('viewFormatFeature', kFeaturesForFormats)
       .beginSubcases()
+      .expand('textureFormat', ({ textureFormatFeature }) =>
+        filterFormatsByFeature(textureFormatFeature, kTextureFormats)
+      )
+      .expand('viewFormat', ({ viewFormatFeature }) =>
+        filterFormatsByFeature(viewFormatFeature, [undefined, ...kTextureFormats])
+      )
       .combine('useViewFormatList', [false, true])
   )
   .before(async t => {
-    const { textureFormat, viewFormat } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase([textureFormat, viewFormat]);
+    const { textureFormatFeature, viewFormatFeature } = t.params;
+    await t.selectDeviceOrSkipTestCase([textureFormatFeature, viewFormatFeature]);
   })
   .fn(async t => {
     const { textureFormat, viewFormat, useViewFormatList } = t.params;

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -34,7 +34,7 @@ g.test('color_attachments,device_mismatch')
     - created from same device in ColorAttachment0, but from different device in ColorAttachment1
     `
   )
-  .paramsSubcasesOnly([
+  .paramsSimple([
     {
       view0Mismatched: false,
       target0Mismatched: false,
@@ -60,7 +60,7 @@ g.test('color_attachments,device_mismatch')
       target1Mismatched: true,
     },
   ])
-  .fn(async t => {
+  .before(async t => {
     const { view0Mismatched, target0Mismatched, view1Mismatched, target1Mismatched } = t.params;
 
     const mismatched = view0Mismatched || target0Mismatched || view1Mismatched || target1Mismatched;
@@ -68,6 +68,10 @@ g.test('color_attachments,device_mismatch')
     if (mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { view0Mismatched, target0Mismatched, view1Mismatched, target1Mismatched } = t.params;
+    const mismatched = view0Mismatched || target0Mismatched || view1Mismatched || target1Mismatched;
 
     const view0Texture = view0Mismatched
       ? t.getDeviceMismatchedRenderTexture(4)
@@ -110,13 +114,14 @@ g.test('depth_stencil_attachment,device_mismatch')
   .desc(
     'Tests beginRenderPass cannot be called with a depth stencil attachment whose texture view is created from another device'
   )
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
 
     const descriptor: GPUTextureDescriptor = {
       size: { width: 4, height: 4, depthOrArrayLayers: 1 },
@@ -150,14 +155,14 @@ g.test('occlusion_query_set,device_mismatch')
   .desc(
     'Tests beginRenderPass cannot be called with an occlusion query set created from another device'
   )
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const occlusionQuerySet = device.createQuerySet({

--- a/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/buffer_texture_copies.spec.ts
@@ -71,9 +71,12 @@ g.test('depth_stencil_format,copy_usage_and_aspect')
       .beginSubcases()
       .combine('aspect', ['all', 'depth-only', 'stencil-only'] as const)
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
+  })
   .fn(async t => {
     const { format, aspect } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const textureSize = { width: 1, height: 1, depthOrArrayLayers: 1 };
     const texture = t.device.createTexture({
@@ -133,9 +136,12 @@ g.test('depth_stencil_format,copy_buffer_size')
         { width: 4, height: 4, depthOrArrayLayers: 3 },
       ])
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
+  })
   .fn(async t => {
     const { format, aspect, copyType, copySize } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const texture = t.device.createTexture({
       size: copySize,
@@ -237,9 +243,12 @@ g.test('depth_stencil_format,copy_buffer_offset')
       .beginSubcases()
       .combine('offset', [1, 2, 4, 6, 8])
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
+  })
   .fn(async t => {
     const { format, aspect, copyType, offset } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const textureSize = { width: 4, height: 4, depthOrArrayLayers: 1 };
 

--- a/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
@@ -56,14 +56,14 @@ g.test('buffer_state')
 
 g.test('buffer,device_mismatch')
   .desc(`Tests clearBuffer cannot be called with buffer created from another device.`)
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
     const size = 8;
 

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -64,14 +64,14 @@ setPipeline should generate an error iff using an 'invalid' pipeline.
 
 g.test('pipeline,device_mismatch')
   .desc('Tests setPipeline cannot be called with a compute pipeline created from another device')
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const pipeline = device.createComputePipeline({
@@ -180,13 +180,14 @@ g.test('indirect_dispatch_buffer,device_mismatch')
   .desc(
     'Tests dispatchIndirect cannot be called with an indirect buffer created from another device'
   )
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
 
     const pipeline = t.createNoOpComputePipeline();
 

--- a/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
@@ -97,18 +97,22 @@ g.test('buffer,device_mismatch')
   .desc(
     'Tests copyBufferToBuffer cannot be called with src buffer or dst buffer created from another device'
   )
-  .paramsSubcasesOnly([
+  .paramsSimple([
     { srcMismatched: false, dstMismatched: false }, // control case
     { srcMismatched: true, dstMismatched: false },
     { srcMismatched: false, dstMismatched: true },
   ] as const)
-  .fn(async t => {
+  .before(async t => {
     const { srcMismatched, dstMismatched } = t.params;
     const mismatched = srcMismatched || dstMismatched;
 
     if (mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { srcMismatched, dstMismatched } = t.params;
+    const mismatched = srcMismatched || dstMismatched;
 
     const device = mismatched ? t.mismatchedDevice : t.device;
 

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -11,6 +11,8 @@ import {
   kTextureUsages,
   textureDimensionAndFormatCompatible,
   kTextureDimensions,
+  kFeaturesForFormats,
+  filterFormatsByFeature,
 } from '../../../../capability_info.js';
 import { kResourceStates } from '../../../../gpu_test.js';
 import { align, lcm } from '../../../../util/math.js';
@@ -350,15 +352,20 @@ Test the formats of textures in copyTextureToTexture must be copy-compatible.
 `
   )
   .params(u =>
-    u //
-      .combine('srcFormat', kTextureFormats)
-      .combine('dstFormat', kTextureFormats)
+    u
+      .combine('srcFormatFeature', kFeaturesForFormats)
+      .combine('dstFormatFeature', kFeaturesForFormats)
+      .beginSubcases()
+      .expand('srcFormat', ({ srcFormatFeature }) =>
+        filterFormatsByFeature(srcFormatFeature, kTextureFormats)
+      )
+      .expand('dstFormat', ({ dstFormatFeature }) =>
+        filterFormatsByFeature(dstFormatFeature, kTextureFormats)
+      )
   )
   .before(async t => {
-    const { srcFormat, dstFormat } = t.params;
-    const srcFormatInfo = kTextureFormatInfo[srcFormat];
-    const dstFormatInfo = kTextureFormatInfo[dstFormat];
-    await t.selectDeviceOrSkipTestCase([srcFormatInfo.feature, dstFormatInfo.feature]);
+    const { srcFormatFeature, dstFormatFeature } = t.params;
+    await t.selectDeviceOrSkipTestCase([srcFormatFeature, dstFormatFeature]);
   })
   .fn(async t => {
     const { srcFormat, dstFormat } = t.params;

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -112,18 +112,22 @@ g.test('texture,device_mismatch')
   .desc(
     'Tests copyTextureToTexture cannot be called with src texture or dst texture created from another device.'
   )
-  .paramsSubcasesOnly([
+  .paramsSimple([
     { srcMismatched: false, dstMismatched: false }, // control case
     { srcMismatched: true, dstMismatched: false },
     { srcMismatched: false, dstMismatched: true },
   ] as const)
-  .fn(async t => {
+  .before(async t => {
     const { srcMismatched, dstMismatched } = t.params;
     const mismatched = srcMismatched || dstMismatched;
 
     if (mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { srcMismatched, dstMismatched } = t.params;
+    const mismatched = srcMismatched || dstMismatched;
 
     const device = mismatched ? t.mismatchedDevice : t.device;
     const size = { width: 4, height: 4, depthOrArrayLayers: 1 };
@@ -345,16 +349,21 @@ Test the formats of textures in copyTextureToTexture must be copy-compatible.
 - for all destination texture formats
 `
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u //
       .combine('srcFormat', kTextureFormats)
       .combine('dstFormat', kTextureFormats)
   )
-  .fn(async t => {
+  .before(async t => {
     const { srcFormat, dstFormat } = t.params;
     const srcFormatInfo = kTextureFormatInfo[srcFormat];
     const dstFormatInfo = kTextureFormatInfo[dstFormat];
     await t.selectDeviceOrSkipTestCase([srcFormatInfo.feature, dstFormatInfo.feature]);
+  })
+  .fn(async t => {
+    const { srcFormat, dstFormat } = t.params;
+    const srcFormatInfo = kTextureFormatInfo[srcFormat];
+    const dstFormatInfo = kTextureFormatInfo[dstFormat];
 
     const textureSize = {
       width: lcm(srcFormatInfo.blockWidth, dstFormatInfo.blockWidth),
@@ -423,6 +432,10 @@ Note: this is only tested for 2D textures as it is the only dimension compatible
       .combine('srcCopyLevel', [1, 2])
       .combine('dstCopyLevel', [0, 1])
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+  })
   .fn(async t => {
     const {
       format,
@@ -432,8 +445,6 @@ Note: this is only tested for 2D textures as it is the only dimension compatible
       srcCopyLevel,
       dstCopyLevel,
     } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
-
     const kMipLevelCount = 3;
 
     const srcTexture = t.device.createTexture({
@@ -683,9 +694,12 @@ Test the validations on the member 'aspect' of GPUImageCopyTexture in CopyTextur
       .combine('sourceAspect', ['all', 'depth-only', 'stencil-only'] as const)
       .combine('destinationAspect', ['all', 'depth-only', 'stencil-only'] as const)
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+  })
   .fn(async t => {
     const { format, sourceAspect, destinationAspect } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const kTextureSize = { width: 16, height: 8, depthOrArrayLayers: 1 };
 
@@ -760,9 +774,12 @@ TODO: Express the offsets in "block size" so as to be able to test non-4x4 compr
       .combine('srcCopyLevel', [0, 1, 2])
       .combine('dstCopyLevel', [0, 1, 2])
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+  })
   .fn(async t => {
     const { format, dimension, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
     const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
     const kTextureSize = {

--- a/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
@@ -54,13 +54,19 @@ g.test('indirect_buffer,device_mismatch')
   .desc(
     'Tests draw(Indexed)Indirect cannot be called with an indirect buffer created from another device'
   )
-  .paramsSubcasesOnly(kIndirectDrawTestParams.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { encoderType, indexed, mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u =>
+    u
+      .combine('mismatched', [true, false])
+      .beginSubcases()
+      .combineWithParams(kIndirectDrawTestParams)
+  )
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { encoderType, indexed, mismatched } = t.params;
 
     const device = mismatched ? t.mismatchedDevice : t.device;
 

--- a/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
@@ -32,14 +32,19 @@ Tests index buffer must be valid.
 
 g.test('index_buffer,device_mismatch')
   .desc('Tests setIndexBuffer cannot be called with an index buffer created from another device')
-  .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { encoderType, mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u =>
+    u
+      .combine('mismatched', [true, false])
+      .beginSubcases()
+      .combineWithParams(kRenderEncodeTypeParams)
+  )
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { encoderType, mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const indexBuffer = device.createBuffer({

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -30,14 +30,14 @@ Tests setPipeline should generate an error iff using an 'invalid' pipeline.
 
 g.test('pipeline,device_mismatch')
   .desc('Tests setPipeline cannot be called with a render pipeline created from another device')
-  .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { encoderType, mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]).combineWithParams(kRenderEncodeTypeParams))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { encoderType, mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const pipeline = device.createRenderPipeline({

--- a/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
@@ -58,14 +58,14 @@ Tests vertex buffer must be valid.
 
 g.test('vertex_buffer,device_mismatch')
   .desc('Tests setVertexBuffer cannot be called with a vertex buffer created from another device')
-  .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { encoderType, mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]).combineWithParams(kRenderEncodeTypeParams))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { encoderType, mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const vertexBuffer = device.createBuffer({

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -136,17 +136,17 @@ g.test('bind_group,device_mismatch')
   .params(u =>
     u
       .combine('encoderType', kProgrammableEncoderTypes)
+      .combine('mismatched', [true, false])
       .beginSubcases()
       .combine('useU32Array', [true, false])
-      .combine('mismatched', [true, false])
   )
-  .fn(async t => {
-    const { encoderType, useU32Array, mismatched } = t.params;
-
-    if (mismatched) {
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { encoderType, useU32Array, mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const buffer = device.createBuffer({

--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -68,9 +68,12 @@ g.test('valid_texture_formats')
       .beginSubcases()
       .combine('attachment', ['color', 'depthStencil'])
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
+  })
   .fn(async t => {
     const { format, attachment } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     const colorRenderable =
       kTextureFormatInfo[format].renderable && kTextureFormatInfo[format].color;
@@ -116,9 +119,12 @@ g.test('depth_stencil_readonly')
       .combine('depthReadOnly', [false, true])
       .combine('stencilReadOnly', [false, true])
   )
+  .before(async t => {
+    const { depthStencilFormat } = t.params;
+    await t.selectDeviceForTextureFormatOrSkipTestCase(depthStencilFormat);
+  })
   .fn(async t => {
     const { depthStencilFormat, depthReadOnly, stencilReadOnly } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(depthStencilFormat);
 
     let shouldError = false;
     if (

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -23,14 +23,15 @@ Tests that set occlusion query set with all types in render pass descriptor:
 - {undefined} for occlusion query set in render pass descriptor
   `
   )
-  .paramsSubcasesOnly(u => u.combine('type', [undefined, ...kQueryTypes]))
-  .fn(async t => {
-    const type = t.params.type;
-
+  .params(u => u.combine('type', [undefined, ...kQueryTypes]))
+  .before(async t => {
+    const { type } = t.params;
     if (type) {
       await t.selectDeviceForQueryTypeOrSkipTestCase(type);
     }
-
+  })
+  .fn(async t => {
+    const type = t.params.type;
     const querySet = type === undefined ? undefined : createQuerySetWithType(t, type, 1);
 
     const encoder = t.createEncoder('render pass', { occlusionQuerySet: querySet });
@@ -87,10 +88,14 @@ Tests that write timestamp to all types of query set on all possible encoders:
       .beginSubcases()
       .expand('queryIndex', p => (p.type === 'timestamp' ? [0, 2] : [0]))
   )
+  .before(async t => {
+    const { type } = t.params;
+    if (type) {
+      await t.selectDeviceForQueryTypeOrSkipTestCase(type);
+    }
+  })
   .fn(async t => {
     const { type, queryIndex } = t.params;
-
-    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
 
     const count = 2;
     const querySet = createQuerySetWithType(t, type, count);
@@ -108,9 +113,11 @@ Tests that write timestamp to a invalid query set that failed during creation:
   `
   )
   .paramsSubcasesOnly(u => u.combine('querySetState', ['valid', 'invalid'] as const))
+  .before(async t => {
+    await t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
+  })
   .fn(async t => {
     const { querySetState } = t.params;
-    await t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
 
     const querySet = t.createQuerySetWithState(querySetState, {
       type: 'timestamp',
@@ -124,16 +131,16 @@ Tests that write timestamp to a invalid query set that failed during creation:
 
 g.test('timestamp_query,device_mismatch')
   .desc('Tests writeTimestamp cannot be called with a query set created from another device')
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { mismatched } = t.params;
-
+  .params(u => u.combine('mismatched', [true, false]))
+  .before(async t => {
     await t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
 
-    if (mismatched) {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase('timestamp-query');
     }
-
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const querySet = device.createQuerySet({

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -148,18 +148,22 @@ g.test('query_set_buffer,device_mismatch')
   .desc(
     'Tests resolveQuerySet cannot be called with a query set or destination buffer created from another device'
   )
-  .paramsSubcasesOnly([
+  .paramsSimple([
     { querySetMismatched: false, bufferMismatched: false }, // control case
     { querySetMismatched: true, bufferMismatched: false },
     { querySetMismatched: false, bufferMismatched: true },
   ] as const)
-  .fn(async t => {
+  .before(async t => {
     const { querySetMismatched, bufferMismatched } = t.params;
     const mismatched = querySetMismatched || bufferMismatched;
 
     if (mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { querySetMismatched, bufferMismatched } = t.params;
+    const mismatched = querySetMismatched || bufferMismatched;
 
     const device = mismatched ? t.mismatchedDevice : t.device;
     const queryCout = 1;

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -29,18 +29,22 @@ g.test('device_mismatch')
     - bundle0 and bundle1 from different device
     `
   )
-  .paramsSubcasesOnly([
+  .paramsSimple([
     { bundle0Mismatched: false, bundle1Mismatched: false }, // control case
     { bundle0Mismatched: true, bundle1Mismatched: false },
     { bundle0Mismatched: false, bundle1Mismatched: true },
   ])
-  .fn(async t => {
+  .before(async t => {
     const { bundle0Mismatched, bundle1Mismatched } = t.params;
     const mismatched = bundle0Mismatched || bundle1Mismatched;
 
     if (mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { bundle0Mismatched, bundle1Mismatched } = t.params;
+    const mismatched = bundle0Mismatched || bundle1Mismatched;
 
     const device = mismatched ? t.mismatchedDevice : t.device;
 
@@ -132,10 +136,12 @@ g.test('depth_stencil_formats_mismatch')
       { bundleFormat: 'stencil8', passFormat: 'depth24plus-stencil8' },
     ] as const)
   )
-  .fn(async t => {
+  .before(async t => {
     const { bundleFormat, passFormat } = t.params;
     await t.selectDeviceForTextureFormatOrSkipTestCase([bundleFormat, passFormat]);
-
+  })
+  .fn(async t => {
+    const { bundleFormat, passFormat } = t.params;
     const compatible = bundleFormat === passFormat;
 
     const bundleEncoder = t.device.createRenderBundleEncoder({
@@ -183,6 +189,9 @@ g.test('depth_stencil_readonly_mismatch')
         return true;
       })
   )
+  .before(async t => {
+    await t.selectDeviceForTextureFormatOrSkipTestCase(t.params.depthStencilFormat);
+  })
   .fn(async t => {
     const {
       depthStencilFormat,
@@ -191,7 +200,6 @@ g.test('depth_stencil_readonly_mismatch')
       passDepthReadOnly,
       passStencilReadOnly,
     } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(depthStencilFormat);
 
     const compatible =
       (!passDepthReadOnly || bundleDepthReadOnly === passDepthReadOnly) &&

--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -177,6 +177,10 @@ Test the computation of requiredBytesInCopy by computing the minimum data size f
         return [p._offsetMultiplier * info.bytesPerBlock];
       })
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       bufferOffset,
@@ -190,7 +194,6 @@ Test the computation of requiredBytesInCopy by computing the minimum data size f
       method,
     } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     // In the CopyB2T and CopyT2B cases we need to have bytesPerRow 256-aligned,
     // to make this happen we align the bytesInACompleteRow value and multiply
@@ -246,10 +249,13 @@ Test that rowsPerImage has no alignment constraints.
       // Copy height is info.blockHeight, so rowsPerImage must be equal or greater than it.
       .filter(({ rowsPerImage, format }) => rowsPerImage >= kTextureFormatInfo[format].blockHeight)
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { rowsPerImage, format, method } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const size = { width: info.blockWidth, height: info.blockHeight, depthOrArrayLayers: 1 };
     const texture = t.device.createTexture({
@@ -285,10 +291,13 @@ Test the alignment requirement on the linear data offset (block size, or 4 for d
       .beginSubcases()
       .expand('offset', texelBlockAlignmentTestExpanderForOffset)
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { format, offset, method } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     const size = { width: info.blockWidth, height: info.blockHeight, depthOrArrayLayers: 1 };
     const texture = t.device.createTexture({
@@ -386,6 +395,10 @@ Test that bytesPerRow, if specified must be big enough for a full copy row.
         ];
       })
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       method,
@@ -398,7 +411,6 @@ Test that bytesPerRow, if specified must be big enough for a full copy row.
       _success,
     } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
 
     // We create an aligned texture using the widthInBlocks which may be different from the
     // copyWidthInBlocks. This allows us to test scenarios where the two may be different.

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -70,13 +70,13 @@ g.test('texture,device_mismatch')
   .paramsSubcasesOnly(u =>
     u.combine('method', kImageCopyTypes).combine('mismatched', [true, false])
   )
-  .fn(async t => {
-    const { method, mismatched } = t.params;
-
-    if (mismatched) {
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { method, mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const texture = device.createTexture({
@@ -257,6 +257,10 @@ Test the copy must be a full subresource if the texture's format is depth/stenci
       // need to examine depth dimension via copyDepthModifier to determine whether it is a full copy for a 3D texture.
       .expand('copyDepthModifier', ({ dimension: d }) => (d === '3d' ? [0, -1] : [0]))
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       method,
@@ -270,8 +274,6 @@ Test the copy must be a full subresource if the texture's format is depth/stenci
     } = t.params;
 
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
-
     const size = { width: 32 * info.blockWidth, height: 32 * info.blockHeight, depthOrArrayLayers };
     if (dimension === '1d') {
       size.height = 1;
@@ -345,6 +347,10 @@ Test that the texture copy origin must be aligned to the format's block size.
       .unless(p => p.dimension === '1d' && p.coordinateToTest !== 'x')
       .expand('valueToCoordinate', texelBlockAlignmentTestExpanderForValueToCoordinate)
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const {
       valueToCoordinate,
@@ -355,8 +361,6 @@ Test that the texture copy origin must be aligned to the format's block size.
       dimension,
     } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
-
     const size = { width: 0, height: 0, depthOrArrayLayers };
     const origin = { x: 0, y: 0, z: 0 };
     let success = true;
@@ -406,11 +410,13 @@ Test that the copy size must be aligned to the texture's format's block size.
       .unless(p => p.dimension === '1d' && p.coordinateToTest !== 'width')
       .expand('valueToCoordinate', texelBlockAlignmentTestExpanderForValueToCoordinate)
   )
+  .before(async t => {
+    const info = kTextureFormatInfo[t.params.format];
+    await t.selectDeviceOrSkipTestCase(info.feature);
+  })
   .fn(async t => {
     const { valueToCoordinate, coordinateToTest, dimension, format, method } = t.params;
     const info = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(info.feature);
-
     const size = { width: 0, height: 0, depthOrArrayLayers: 0 };
     const origin = { x: 0, y: 0, z: 0 };
     let success = true;

--- a/src/webgpu/api/validation/query_set/create.spec.ts
+++ b/src/webgpu/api/validation/query_set/create.spec.ts
@@ -22,10 +22,11 @@ Tests that create query set with the count for all query types:
       .beginSubcases()
       .combine('count', [0, kMaxQueryCount, kMaxQueryCount + 1])
   )
+  .before(async t => {
+    await t.selectDeviceForQueryTypeOrSkipTestCase(t.params.type);
+  })
   .fn(async t => {
     const { type, count } = t.params;
-
-    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
 
     t.expectValidationError(() => {
       t.device.createQuerySet({ type, count });

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -614,14 +614,14 @@ g.test('destination_texture,device_mismatch')
   .desc(
     'Tests copyExternalImageToTexture cannot be called with a destination texture created from another device'
   )
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
     const copySize = { width: 1, height: 1, depthOrArrayLayers: 1 };
 
@@ -752,9 +752,12 @@ g.test('destination_texture,format')
         { width: 1, height: 1, depthOrArrayLayers: 1 },
       ])
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+  })
   .fn(async t => {
     const { format, copySize } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const imageBitmap = await t.createImageBitmap(t.getImageData(1, 1));
 

--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -32,9 +32,8 @@ Tests that use a destroyed query set in writeTimestamp on {non-pass, compute, re
   `
   )
   .params(u => u.beginSubcases().combine('querySetState', ['valid', 'destroyed'] as const))
+  .before(async t => await t.selectDeviceOrSkipTestCase('timestamp-query'))
   .fn(async t => {
-    await t.selectDeviceOrSkipTestCase('timestamp-query');
-
     const querySet = t.createQuerySetWithState(t.params.querySetState, {
       type: 'timestamp',
       count: 2,

--- a/src/webgpu/api/validation/queue/submit.spec.ts
+++ b/src/webgpu/api/validation/queue/submit.spec.ts
@@ -19,18 +19,22 @@ g.test('command_buffer,device_mismatch')
     - cb0 and cb1 from different device
     `
   )
-  .paramsSubcasesOnly([
+  .paramsSimple([
     { cb0Mismatched: false, cb1Mismatched: false }, // control case
     { cb0Mismatched: true, cb1Mismatched: false },
     { cb0Mismatched: false, cb1Mismatched: true },
   ])
-  .fn(async t => {
+  .before(async t => {
     const { cb0Mismatched, cb1Mismatched } = t.params;
     const mismatched = cb0Mismatched || cb1Mismatched;
 
     if (mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
+  })
+  .fn(async t => {
+    const { cb0Mismatched, cb1Mismatched } = t.params;
+    const mismatched = cb0Mismatched || cb1Mismatched;
 
     const encoder0 = cb0Mismatched
       ? t.mismatchedDevice.createCommandEncoder()

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -175,14 +175,14 @@ Tests calling writeBuffer with the buffer missed COPY_DST usage.
 
 g.test('buffer,device_mismatch')
   .desc('Tests writeBuffer cannot be called with a buffer created from another device')
-  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .fn(async t => {
-    const { mismatched } = t.params;
-
-    if (mismatched) {
+  .params(u => u.combine('mismatched', [true, false]))
+  .before(async t => {
+    if (t.params.mismatched) {
       await t.selectMismatchedDeviceOrSkipTestCase(undefined);
     }
-
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const buffer = device.createBuffer({

--- a/src/webgpu/api/validation/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass_descriptor.spec.ts
@@ -598,14 +598,18 @@ g.test('depth_stencil_attachment')
   - stencilLoadOp and stencilStoreOp must be provided iff the format has a stencil aspect and stencilReadOnly is not true.
   `
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u //
       .combine('format', kDepthStencilFormats)
+      .beginSubcases()
       .combine('depthReadOnly', [false, true])
       .combine('stencilReadOnly', [false, true])
       .combine('setDepthLoadStoreOp', [false, true])
       .combine('setStencilLoadStoreOp', [false, true])
   )
+  .before(async t => {
+    await t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+  })
   .fn(async t => {
     const {
       format,
@@ -614,7 +618,6 @@ g.test('depth_stencil_attachment')
       setDepthLoadStoreOp,
       setStencilLoadStoreOp,
     } = t.params;
-    await t.selectDeviceForTextureFormatOrSkipTestCase(format);
 
     let isValid = true;
     const info = kTextureFormatInfo[format];

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -619,6 +619,10 @@ g.test('subresources_and_binding_types_combination_for_aspect')
           p.compute && (p.binding0InBundle || p.binding1InBundle || p.type1 === 'render-target')
       )
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+  })
   .fn(async t => {
     const {
       compute,
@@ -634,7 +638,6 @@ g.test('subresources_and_binding_types_combination_for_aspect')
       _resourceSuccess,
       _usageSuccess,
     } = t.params;
-    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
 
     const texture = t.createTexture({
       arrayLayerCount: TOTAL_LAYERS,

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -194,10 +194,13 @@ Tests creating 2d compressed textures on destroyed device. Tests valid combinati
         );
       })
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+  })
   .fn(async t => {
     const { awaitLost, format, usageType, usageCopy } = t.params;
-    const { blockWidth, blockHeight, feature } = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
     await t.executeAfterDestroy(() => {
       t.device.createTexture({
         size: { width: blockWidth, height: blockHeight },
@@ -266,10 +269,13 @@ Tests creating texture views on 2d compressed textures from destroyed device. Te
         );
       })
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+  })
   .fn(async t => {
     const { awaitLost, format, usageType, usageCopy } = t.params;
-    const { blockWidth, blockHeight, feature } = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(feature);
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
     const texture = t.device.createTexture({
       size: { width: blockWidth, height: blockHeight },
       usage: kTextureUsageTypeInfo[usageType] | kTextureUsageCopyInfo[usageCopy],
@@ -482,9 +488,12 @@ Tests creating query sets on destroyed device.
   `
   )
   .params(u => u.combine('type', kQueryTypes).beginSubcases().combine('awaitLost', [true, false]))
+  .before(async t => {
+    const { type } = t.params;
+    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
+  })
   .fn(async t => {
     const { awaitLost, type } = t.params;
-    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
     await t.executeAfterDestroy(() => {
       t.device.createQuerySet({ type, count: 4 });
     }, awaitLost);
@@ -661,9 +670,12 @@ Tests encoding and finishing a writeTimestamp command on destroyed device.
       .combine('stage', kCommandValidationStages)
       .combine('awaitLost', [true, false])
   )
+  .before(async t => {
+    const { type } = t.params;
+    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
+  })
   .fn(async t => {
     const { type, stage, awaitLost } = t.params;
-    await t.selectDeviceForQueryTypeOrSkipTestCase(type);
     const querySet = t.device.createQuerySet({ type, count: 2 });
     await t.executeCommandsAfterDestroy(stage, awaitLost, 'non-pass', maker => {
       maker.encoder.writeTimestamp(querySet, 0);
@@ -844,10 +856,13 @@ Tests writeTexture on queue on destroyed device with compressed formats.
       .beginSubcases()
       .combine('awaitLost', [true, false])
   )
+  .before(async t => {
+    const { format } = t.params;
+    await t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+  })
   .fn(async t => {
     const { format, awaitLost } = t.params;
-    const { blockWidth, blockHeight, bytesPerBlock, feature } = kTextureFormatInfo[format];
-    await t.selectDeviceOrSkipTestCase(feature);
+    const { blockWidth, blockHeight, bytesPerBlock } = kTextureFormatInfo[format];
     const data = new Uint8Array(bytesPerBlock);
     const texture = t.device.createTexture({
       size: { width: blockWidth, height: blockHeight },

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -1039,3 +1039,18 @@ export const kLimits = keysOf(kLimitInfo);
 export function viewCompatible(a: GPUTextureFormat, b: GPUTextureFormat): boolean {
   return a === b || a + '-srgb' === b || b + '-srgb' === a;
 }
+
+export function getFeaturesForFormats<T>(
+  formats: readonly (T & (GPUTextureFormat | undefined))[]
+): readonly (GPUFeatureName | undefined)[] {
+  return Array.from(new Set(formats.map(f => (f ? kTextureFormatInfo[f].feature : undefined))));
+}
+
+export function filterFormatsByFeature<T>(
+  feature: GPUFeatureName | undefined,
+  formats: readonly (T & (GPUTextureFormat | undefined))[]
+): readonly (T & (GPUTextureFormat | undefined))[] {
+  return formats.filter(f => f === undefined || kTextureFormatInfo[f].feature === feature);
+}
+
+export const kFeaturesForFormats = getFeaturesForFormats(kTextureFormats);

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -228,13 +228,15 @@ g.test('gpu,with_texture_compression,bc')
 Tests that a BC format passes validation iff the feature is enabled.`
   )
   .params(u => u.combine('textureCompressionBC', [false, true]))
-  .fn(async t => {
+  .before(async t => {
     const { textureCompressionBC } = t.params;
 
     if (textureCompressionBC) {
       await t.selectDeviceOrSkipTestCase('texture-compression-bc');
     }
-
+  })
+  .fn(async t => {
+    const { textureCompressionBC } = t.params;
     const shouldError = !textureCompressionBC;
     t.expectGPUError(
       'validation',
@@ -255,12 +257,15 @@ g.test('gpu,with_texture_compression,etc2')
 Tests that an ETC2 format passes validation iff the feature is enabled.`
   )
   .params(u => u.combine('textureCompressionETC2', [false, true]))
-  .fn(async t => {
+  .before(async t => {
     const { textureCompressionETC2 } = t.params;
 
     if (textureCompressionETC2) {
       await t.selectDeviceOrSkipTestCase('texture-compression-etc2' as GPUFeatureName);
     }
+  })
+  .fn(async t => {
+    const { textureCompressionETC2 } = t.params;
 
     const shouldError = !textureCompressionETC2;
     t.expectGPUError(

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -625,6 +625,12 @@ g.test('copy_contents_from_gpu_context_canvas')
       .combine('width', [1, 2, 4, 15, 255, 256])
       .combine('height', [1, 2, 4, 15, 255, 256])
   )
+  .before(async t => {
+    const { srcAndDstInSameGPUDevice } = t.params;
+    if (!srcAndDstInSameGPUDevice) {
+      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    }
+  })
   .fn(async t => {
     const {
       width,
@@ -637,14 +643,7 @@ g.test('copy_contents_from_gpu_context_canvas')
       srcDoFlipYDuringCopy,
     } = t.params;
 
-    let device: GPUDevice;
-
-    if (!srcAndDstInSameGPUDevice) {
-      await t.selectMismatchedDeviceOrSkipTestCase(undefined);
-      device = t.mismatchedDevice;
-    } else {
-      device = t.device;
-    }
+    const device = srcAndDstInSameGPUDevice ? t.device : t.mismatchedDevice;
 
     const { canvas } = t.initGPUCanvasContent({
       device,


### PR DESCRIPTION
Pipeline gathering subcase results
    
Makes some tests run 10x faster. On average, a 10-35% total
runtime reduction.

Running a test group is changed so that a FixtureSharedState is
shared between subcases. Creation of the state can be overriden
by the test fixture.

Subcase finalization is non-blocking until the end of the
test group run. This means that resolution of eventual async
expectations don't block subsequent subcases from starting.
All eventually expectations are finally waited on at the end of
the testcase.

This results in a bit worse device lost granularity as it
may not be possible to tell exactly where a device lost error
occured. Also, unexpected validation and OOM errors are caught
at the whole testcase level instead of the subcase level. This is
probably fine since subcases are intended to be like a "for-loop"
so exact reporting is probably not crucial.

Test finalization and releasing the device back to the
device pool occurs in the same step. This is necessary since we
shouldn't start reusing the device until eventual expectations
which operate on the same device are complete. This means a single
testcase shouldn't have complex interactions with the device pool.
To maintain this invariant, we require move methods for selecting
a device with optional formats/features to occur in the `before`
stage before any of the subcases run using the fixture shared state.
Then, all subcases run using the same device.

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
