### PR TITLE
Add validation,resource_usages,texture,in_render_misc:* - Part IV

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -1,7 +1,5 @@
 export const description = `
-TODO:
-- 2 views: upon the same subresource, or different subresources of the same texture
-    - texture usages in copies and in render pass
+Texture Usages Validation Tests on All Kinds of WebGPU Subresource Usage Scopes.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
@@ -312,4 +310,111 @@ g.test('subresources,set_unused_bind_group')
     t.expectValidationError(() => {
       encoder.finish();
     }, !success);
+  });
+
+g.test('subresources,texture_usages_in_copy_and_render_pass')
+  .desc(
+    `
+  Test that using one texture subresource in a render pass encoder and a copy command is always
+  allowed as WebGPU SPEC (chapter 3.4.5) defines that out of any pass encoder, each command always
+  belongs to one usage scope.`
+  )
+  .params(u =>
+    u
+      .combine('usage0', [
+        'copy-src',
+        'copy-dst',
+        'texture',
+        'storage',
+        'color-attachment',
+      ] as const)
+      .combine('usage1', [
+        'copy-src',
+        'copy-dst',
+        'texture',
+        'storage',
+        'color-attachment',
+      ] as const)
+      .filter(
+        ({ usage0, usage1 }) =>
+          usage0 === 'copy-src' ||
+          usage0 === 'copy-dst' ||
+          usage1 === 'copy-src' ||
+          usage1 === 'copy-dst'
+      )
+  )
+  .fn(async t => {
+    const { usage0, usage1 } = t.params;
+
+    const texture = t.device.createTexture({
+      format: 'rgba8unorm',
+      usage:
+        GPUTextureUsage.COPY_SRC |
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.STORAGE_BINDING |
+        GPUTextureUsage.RENDER_ATTACHMENT,
+      size: [kTextureSize, kTextureSize, 1],
+    });
+
+    const UseTextureOnCommandEncoder = (
+      texture: GPUTexture,
+      usage: 'copy-src' | 'copy-dst' | 'texture' | 'storage' | 'color-attachment',
+      encoder: GPUCommandEncoder
+    ) => {
+      switch (usage) {
+        case 'copy-src': {
+          const buffer = t.device.createBuffer({
+            size: 4,
+            usage: GPUBufferUsage.COPY_DST,
+          });
+          encoder.copyTextureToBuffer({ texture }, { buffer }, [1, 1, 1]);
+          break;
+        }
+        case 'copy-dst': {
+          const buffer = t.device.createBuffer({
+            size: 4,
+            usage: GPUBufferUsage.COPY_SRC,
+          });
+          encoder.copyBufferToTexture({ buffer }, { texture }, [1, 1, 1]);
+          break;
+        }
+        case 'color-attachment': {
+          const renderPassEncoder = encoder.beginRenderPass({
+            colorAttachments: [{ view: texture.createView(), loadOp: 'load', storeOp: 'store' }],
+          });
+          renderPassEncoder.end();
+          break;
+        }
+        case 'texture':
+        case 'storage': {
+          const colorTexture = t.device.createTexture({
+            format: 'rgba8unorm',
+            usage: GPUTextureUsage.RENDER_ATTACHMENT,
+            size: [kTextureSize, kTextureSize, 1],
+          });
+          const renderPassEncoder = encoder.beginRenderPass({
+            colorAttachments: [
+              { view: colorTexture.createView(), loadOp: 'load', storeOp: 'store' },
+            ],
+          });
+          const bindGroup = t.createBindGroupForTest(
+            texture.createView({
+              dimension: '2d-array',
+            }),
+            usage,
+            'float'
+          );
+          renderPassEncoder.setBindGroup(0, bindGroup);
+          renderPassEncoder.end();
+          break;
+        }
+      }
+    };
+    const encoder = t.device.createCommandEncoder();
+    UseTextureOnCommandEncoder(texture, usage0, encoder);
+    UseTextureOnCommandEncoder(texture, usage1, encoder);
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, false);
   });


### PR DESCRIPTION
This patch adds the last part of the below test:
validation,resource_usages,texture,in_render_misc:*
- subresources,texture_usages_in_copy_and_render_pass




Issue: #905

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
