### PR TITLE
Update pipeline output targets validation with different writeMask

### DIFF
--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -59,6 +59,7 @@ Whenever a new generally-useful helper is added, it should be indexed here.
     CSS Color Module Level 4.
 - {@link webgpu/util/create_elements}:
     Helpers for creating web elements like HTMLCanvasElement, OffscrrenCanvas, etc.
+- {@link webgpu/util/shader}: Helpers for creating fragment shader based on intended output values, plainType, and componentCount.
 - {@link webgpu/util/texture/base}: General texture-related helpers.
 - {@link webgpu/util/texture/layout}: Helpers for working with linear image data
     (like in copyBufferToTexture, copyTextureToBuffer, writeTexture).

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
 import { kRenderableColorTextureFormats, kTextureFormatInfo } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { getFragmentShaderCodeWithOutput } from '../../../util/shader.js';
+import { getFragmentShaderCodeWithOutput, getPlainTypeInfo } from '../../../util/shader.js';
 import { kTexelRepresentationInfo } from '../../../util/texture/texel_data.js';
 import { TexelView } from '../../../util/texture/texel_view.js';
 import { textureContentIsOKByT2B } from '../../../util/texture/texture_ok.js';
@@ -91,7 +91,7 @@ g.test('color,attachments')
                       writeValues[i].B,
                       writeValues[i].A,
                     ],
-                    sampleType: info.sampleType,
+                    plainType: getPlainTypeInfo(info.sampleType),
                     componentCount,
                   }
             )
@@ -183,7 +183,7 @@ g.test('color,component_count')
           code: getFragmentShaderCodeWithOutput([
             {
               values,
-              sampleType: info.sampleType,
+              plainType: getPlainTypeInfo(info.sampleType),
               componentCount,
             },
           ]),
@@ -393,7 +393,7 @@ The attachment has a load value of [1, 0, 0, 1]
           code: getFragmentShaderCodeWithOutput([
             {
               values: output,
-              sampleType: info.sampleType,
+              plainType: getPlainTypeInfo(info.sampleType),
               componentCount,
             },
           ]),

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -3,9 +3,10 @@ export const description = `
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { range, unreachable } from '../../../../common/util/util.js';
+import { range } from '../../../../common/util/util.js';
 import { kRenderableColorTextureFormats, kTextureFormatInfo } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
+import { getFragmentShaderCodeWithOutput } from '../../../util/shader.js';
 import { kTexelRepresentationInfo } from '../../../util/texture/texel_data.js';
 import { TexelView } from '../../../util/texture/texel_view.js';
 import { textureContentIsOKByT2B } from '../../../util/texture/texture_ok.js';
@@ -22,109 +23,7 @@ const kVertexShader = `
 }
 `;
 
-class F extends GPUTest {
-  // Build fragment shader based on output value and types
-  // e.g. write to color target 0 a vec4<f32>(1.0, 0.0, 1.0, 1.0) and color target 2 a vec2<u32>(1, 2)
-  // outputs: [
-  //   {
-  //     values: [1, 0, 1, 1],,
-  //     sampleType: 'float',
-  //     componentCount: 4,
-  //   },
-  //   null,
-  //   {
-  //     values: [1, 2],
-  //     sampleType: 'uint',
-  //     componentCount: 2,
-  //   },
-  // ]
-  //
-  // return:
-  // struct Outputs {
-  //     @location(0) o1 : vec4<f32>;
-  //     @location(2) o3 : vec2<u32>;
-  // }
-  // @stage(fragment) fn main() -> Outputs {
-  //     return Outputs(vec4<f32>(1.0, 0.0, 1.0, 1.0), vec4<u32>(1, 2));
-  // }
-  getFragmentShaderCode(
-    outputs: ({
-      values: readonly number[];
-      sampleType: GPUTextureSampleType;
-      componentCount: number;
-    } | null)[]
-  ): string {
-    const resultStrings = [] as string[];
-    let outputStructString = '';
-
-    for (let i = 0; i < outputs.length; i++) {
-      const o = outputs[i];
-      if (o === null) {
-        continue;
-      }
-
-      let fragColorType;
-      let suffix;
-      let fractionDigits = 0;
-      switch (o.sampleType) {
-        case 'sint':
-          fragColorType = 'i32';
-          suffix = '';
-          break;
-        case 'uint':
-          fragColorType = 'u32';
-          suffix = 'u';
-          break;
-        case 'float':
-        case 'unfilterable-float':
-          fragColorType = 'f32';
-          suffix = '';
-          fractionDigits = 4;
-          break;
-        default:
-          unreachable();
-      }
-
-      let outputType;
-      const v = o.values.map(n => n.toFixed(fractionDigits));
-      switch (o.componentCount) {
-        case 1:
-          outputType = fragColorType;
-          resultStrings.push(`${v[0]}${suffix}`);
-          break;
-        case 2:
-          outputType = `vec2<${fragColorType}>`;
-          resultStrings.push(`${outputType}(${v[0]}${suffix}, ${v[1]}${suffix})`);
-          break;
-        case 3:
-          outputType = `vec3<${fragColorType}>`;
-          resultStrings.push(`${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix})`);
-          break;
-        case 4:
-          outputType = `vec4<${fragColorType}>`;
-          resultStrings.push(
-            `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix}, ${v[3]}${suffix})`
-          );
-          break;
-        default:
-          unreachable();
-      }
-
-      outputStructString += `@location(${i}) o${i} : ${outputType},\n`;
-    }
-
-    return `
-    struct Outputs {
-      ${outputStructString}
-    }
-
-    @stage(fragment) fn main() -> Outputs {
-        return Outputs(${resultStrings.join(',')});
-    }`;
-  }
-}
-
-export const g = makeTestGroup(F);
+export const g = makeTestGroup(GPUTest);
 
 // Values to write into each attachment
 // We make values different for each attachment index and each channel
@@ -181,7 +80,7 @@ g.test('color,attachments')
       },
       fragment: {
         module: t.device.createShaderModule({
-          code: t.getFragmentShaderCode(
+          code: getFragmentShaderCodeWithOutput(
             range(attachmentCount, i =>
               i === emptyAttachmentId
                 ? null
@@ -281,7 +180,7 @@ g.test('color,component_count')
       },
       fragment: {
         module: t.device.createShaderModule({
-          code: t.getFragmentShaderCode([
+          code: getFragmentShaderCodeWithOutput([
             {
               values,
               sampleType: info.sampleType,
@@ -491,7 +390,7 @@ The attachment has a load value of [1, 0, 0, 1]
       },
       fragment: {
         module: t.device.createShaderModule({
-          code: t.getFragmentShaderCode([
+          code: getFragmentShaderCodeWithOutput([
             {
               values: output,
               sampleType: info.sampleType,

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -441,21 +441,16 @@ g.test('pipeline_output_targets')
     });
 
     let _success = true;
-    if (hasShaderOutput) {
-      if (info) {
-        // there is a target correspond to the pipeline output
-        assert(format !== undefined);
-        const sampleTypeSuccess =
-          info.sampleType === 'float' || info.sampleType === 'unfilterable-float'
-            ? sampleType === 'float'
-            : info.sampleType === sampleType;
-        _success =
-          sampleTypeSuccess &&
-          componentCount >= kTexelRepresentationInfo[format].componentOrder.length;
-      } else {
-        // there is no target correspond to the pipeline output
-        _success = writeMask === 0;
-      }
+    if (hasShaderOutput && info) {
+      // there is a target correspond to the pipeline output
+      assert(format !== undefined);
+      const sampleTypeSuccess =
+        info.sampleType === 'float' || info.sampleType === 'unfilterable-float'
+          ? sampleType === 'float'
+          : info.sampleType === sampleType;
+      _success =
+        sampleTypeSuccess &&
+        componentCount >= kTexelRepresentationInfo[format].componentOrder.length;
     }
 
     t.doCreateRenderPipelineTest(isAsync, _success, descriptor);

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -454,7 +454,7 @@ g.test('pipeline_output_targets')
   .params(u =>
     u
       .combine('isAsync', [false, true])
-      .combine('writeMask', [0, 0xf])
+      .combine('writeMask', [0, 0x1, 0x2, 0x4, 0x8, 0xf])
       .combine('format', kRenderableColorTextureFormats)
       .beginSubcases()
       .combine('sampleType', ['float', 'uint', 'sint'] as const)

--- a/src/webgpu/util/shader.ts
+++ b/src/webgpu/util/shader.ts
@@ -1,18 +1,53 @@
 import { unreachable } from '../../common/util/util.js';
 
+const kPlainTypeInfo = {
+  i32: {
+    suffix: '',
+    fractionDigits: 0,
+  },
+  u32: {
+    suffix: 'u',
+    fractionDigits: 0,
+  },
+  f32: {
+    suffix: '',
+    fractionDigits: 4,
+  },
+};
+
+/**
+ *
+ * @param sampleType sampleType of texture format
+ * @returns plain type compatible of the sampleType
+ */
+export function getPlainTypeInfo(sampleType: GPUTextureSampleType): keyof typeof kPlainTypeInfo {
+  switch (sampleType) {
+    case 'sint':
+      return 'i32';
+    case 'uint':
+      return 'u32';
+    case 'float':
+    case 'unfilterable-float':
+    case 'depth':
+      return 'f32';
+    default:
+      unreachable();
+  }
+}
+
 /**
  * Build a fragment shader based on output value and types
  * e.g. write to color target 0 a vec4<f32>(1.0, 0.0, 1.0, 1.0) and color target 2 a vec2<u32>(1, 2)
  * outputs: [
  *   {
  *     values: [1, 0, 1, 1],,
- *     sampleType: 'float',
+ *     plainType: 'f32',
  *     componentCount: 4,
  *   },
  *   null,
  *   {
  *     values: [1, 2],
- *     sampleType: 'uint',
+ *     plainType: 'u32',
  *     componentCount: 2,
  *   },
  * ]
@@ -31,7 +66,7 @@ import { unreachable } from '../../common/util/util.js';
 export function getFragmentShaderCodeWithOutput(
   outputs: ({
     values: readonly number[];
-    sampleType: GPUTextureSampleType;
+    plainType: 'i32' | 'u32' | 'f32';
     componentCount: number;
   } | null)[]
 ): string {
@@ -50,46 +85,26 @@ export function getFragmentShaderCodeWithOutput(
       continue;
     }
 
-    let fragColorType;
-    let suffix;
-    let fractionDigits = 0;
-    switch (o.sampleType) {
-      case 'sint':
-        fragColorType = 'i32';
-        suffix = '';
-        break;
-      case 'uint':
-        fragColorType = 'u32';
-        suffix = 'u';
-        break;
-      case 'float':
-      case 'unfilterable-float':
-      case 'depth':
-        fragColorType = 'f32';
-        suffix = '';
-        fractionDigits = 4;
-        break;
-      default:
-        unreachable();
-    }
+    const plainType = o.plainType;
+    const { suffix, fractionDigits } = kPlainTypeInfo[plainType];
 
     let outputType;
     const v = o.values.map(n => n.toFixed(fractionDigits));
     switch (o.componentCount) {
       case 1:
-        outputType = fragColorType;
+        outputType = plainType;
         resultStrings.push(`${v[0]}${suffix}`);
         break;
       case 2:
-        outputType = `vec2<${fragColorType}>`;
+        outputType = `vec2<${plainType}>`;
         resultStrings.push(`${outputType}(${v[0]}${suffix}, ${v[1]}${suffix})`);
         break;
       case 3:
-        outputType = `vec3<${fragColorType}>`;
+        outputType = `vec3<${plainType}>`;
         resultStrings.push(`${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix})`);
         break;
       case 4:
-        outputType = `vec4<${fragColorType}>`;
+        outputType = `vec4<${plainType}>`;
         resultStrings.push(
           `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix}, ${v[3]}${suffix})`
         );

--- a/src/webgpu/util/shader.ts
+++ b/src/webgpu/util/shader.ts
@@ -1,0 +1,112 @@
+import { unreachable } from '../../common/util/util.js';
+
+/**
+ * Build a fragment shader based on output value and types
+ * e.g. write to color target 0 a vec4<f32>(1.0, 0.0, 1.0, 1.0) and color target 2 a vec2<u32>(1, 2)
+ * outputs: [
+ *   {
+ *     values: [1, 0, 1, 1],,
+ *     sampleType: 'float',
+ *     componentCount: 4,
+ *   },
+ *   null,
+ *   {
+ *     values: [1, 2],
+ *     sampleType: 'uint',
+ *     componentCount: 2,
+ *   },
+ * ]
+ *
+ * return:
+ * struct Outputs {
+ *     @location(0) o1 : vec4<f32>;
+ *     @location(2) o3 : vec2<u32>;
+ * }
+ * @stage(fragment) fn main() -> Outputs {
+ *     return Outputs(vec4<f32>(1.0, 0.0, 1.0, 1.0), vec4<u32>(1, 2));
+ * }
+ * @param outputs the shader outputs for each location attribute
+ * @returns the fragment shader string
+ */
+export function getFragmentShaderCodeWithOutput(
+  outputs: ({
+    values: readonly number[];
+    sampleType: GPUTextureSampleType;
+    componentCount: number;
+  } | null)[]
+): string {
+  if (outputs.length === 0) {
+    return `
+        @stage(fragment) fn main() {
+        }`;
+  }
+
+  const resultStrings = [] as string[];
+  let outputStructString = '';
+
+  for (let i = 0; i < outputs.length; i++) {
+    const o = outputs[i];
+    if (o === null) {
+      continue;
+    }
+
+    let fragColorType;
+    let suffix;
+    let fractionDigits = 0;
+    switch (o.sampleType) {
+      case 'sint':
+        fragColorType = 'i32';
+        suffix = '';
+        break;
+      case 'uint':
+        fragColorType = 'u32';
+        suffix = 'u';
+        break;
+      case 'float':
+      case 'unfilterable-float':
+      case 'depth':
+        fragColorType = 'f32';
+        suffix = '';
+        fractionDigits = 4;
+        break;
+      default:
+        unreachable();
+    }
+
+    let outputType;
+    const v = o.values.map(n => n.toFixed(fractionDigits));
+    switch (o.componentCount) {
+      case 1:
+        outputType = fragColorType;
+        resultStrings.push(`${v[0]}${suffix}`);
+        break;
+      case 2:
+        outputType = `vec2<${fragColorType}>`;
+        resultStrings.push(`${outputType}(${v[0]}${suffix}, ${v[1]}${suffix})`);
+        break;
+      case 3:
+        outputType = `vec3<${fragColorType}>`;
+        resultStrings.push(`${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix})`);
+        break;
+      case 4:
+        outputType = `vec4<${fragColorType}>`;
+        resultStrings.push(
+          `${outputType}(${v[0]}${suffix}, ${v[1]}${suffix}, ${v[2]}${suffix}, ${v[3]}${suffix})`
+        );
+        break;
+      default:
+        unreachable();
+    }
+
+    outputStructString += `@location(${i}) o${i} : ${outputType},\n`;
+  }
+
+  return `
+    struct Outputs {
+      ${outputStructString}
+    }
+
+    @stage(fragment) fn main() -> Outputs {
+        return Outputs(${resultStrings.join(',')});
+    }`;
+}


### PR DESCRIPTION
Issue: #928

I believe the `attachment_compatibility.spec.ts` updates are already done in https://github.com/gpuweb/cts/pull/655
The missing part is validation at createRenderPipeline

Spec update: https://github.com/gpuweb/gpuweb/pull/1918
https://www.w3.org/TR/webgpu/#fragment-state

Failing current Chrome Canary, a fix is at https://dawn-review.googlesource.com/c/dawn/+/86980

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
