### PR TITLE
Remove CopyExternalImageToTexture:destination_texture,dimension:*

### DIFF
--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -636,36 +636,6 @@ g.test('destination_texture,device_mismatch')
     t.runTest({ source: imageBitmap }, { texture }, copySize, !mismatched);
   });
 
-g.test('destination_texture,dimension')
-  .desc(
-    `
-  Test dst texture dimension is [1d, 2d, 3d].
-
-  Check that an error is generated when texture is not '2d' dimension.
-  `
-  )
-  .params(u =>
-    u //
-      .combine('dimension', ['1d', '2d', '3d'] as const)
-      .beginSubcases()
-      .combine('copySize', [
-        { width: 0, height: 0, depthOrArrayLayers: 0 },
-        { width: 1, height: 1, depthOrArrayLayers: 1 },
-      ])
-  )
-  .fn(async t => {
-    const { dimension, copySize } = t.params;
-    const imageBitmap = await t.createImageBitmap(t.getImageData(1, 1));
-    const dstTexture = t.device.createTexture({
-      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
-      format: 'rgba8unorm',
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-      dimension,
-    });
-
-    t.runTest({ source: imageBitmap }, { texture: dstTexture }, copySize, dimension === '2d');
-  });
-
 g.test('destination_texture,usage')
   .desc(
     `


### PR DESCRIPTION
This patch removes the validation test validation,queue,copyToTexture,CopyExternalImageToTexture:destination_texture,
dimension:* because current WebGPU SPEC doesn't allow creating a texture with
RENDER_ATTACHMENT usage and 1D or 3D dimension, so when using a 1D or 3D texture
as the destination texture of CopyExternalImageToTexture(), we will always meet
an error that the usage of the textures doesn't contain RENDER_ATTACHMENT, then
we don't need to add validation test on the texture dimension.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
