### PR TITLE
Use subcases in subresources,buffer_usage_in_render_pass

### DIFF
--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -93,6 +93,9 @@ bind group layout visibility.`
   )
   .params(u =>
     u
+      .combine('inSamePass', [true, false])
+      .combine('hasOverlap', [true, false])
+      .beginSubcases()
       .combine('usage0', [
         'uniform',
         'storage',
@@ -121,8 +124,6 @@ bind group layout visibility.`
           (t.visibility1 === 'compute' && !IsBufferUsageInBindGroup(t.usage1)) ||
           (t.usage0 === 'index' && t.usage1 === 'index')
       )
-      .combine('inSamePass', [true, false])
-      .combine('hasOverlap', [true, false])
   )
   .fn(async t => {
     const { usage0, visibility0, usage1, visibility1, inSamePass, hasOverlap } = t.params;


### PR DESCRIPTION
This patch uses subcases and shortens several test parameters to ensure
the name of the test won't be too long to handle on the bots.

This patch also improves the test to ensure all the commands won't
reset a buffer in the render pass encoder. The situations that a buffer is
reset by another call in one render pass will be tested in another test.





Issue: #905

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
