### PR TITLE
Explicitly destroy devices created by requestDevice_limits

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice_limits.spec.ts
@@ -60,6 +60,10 @@ g.test('supported_limits')
       device.limits[limit] === value,
       'Devices reported limit should match the required limit'
     );
+    // Explicitly destroy the device so that the tests don't have to wait for garbage collection to
+    // clean it up. Otherwise native resource limits may be hit due to so many devices being created
+    // in a short timeframe.
+    device.destroy();
   });
 
 g.test('better_than_supported')
@@ -162,6 +166,10 @@ g.test('worse_than_default')
         device.limits[limit] === kLimitInfo[limit].default,
         'Devices reported limit should match the default limit'
       );
+      // Explicitly destroy the device so that the tests don't have to wait for garbage collection
+      // to clean it up. Otherwise native resource limits may be hit due to so many devices being
+      // created in a short timeframe.
+      device.destroy();
     } else {
       t.shouldReject('OperationError', adapter.requestDevice({ requiredLimits }));
     }


### PR DESCRIPTION
These tests are consistently failing after N iterations with
device creation failures (for example, with D3D12 it starts
reporting that createCommandQueue() failed with E_OUTOFMEMORY).
Local testing shows that if a garbage collect is forced the tests
start passing again, indicating that the issue is that the devices
are not being cleaned up fast enough.

Explicitly destroying the new device after each test iteration
appears to resolve the problem.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
