### PR TITLE
Take new createView() dimension default logic into account

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1055,6 +1055,7 @@ class ImageCopyTest extends GPUTest {
     for (let z = 0; z < copySize[2]; ++z) {
       const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
         view: depthTexture.createView({
+          dimension: '2d',
           baseArrayLayer: z,
           arrayLayerCount: 1,
           baseMipLevel: copyMipLevel,
@@ -1082,6 +1083,7 @@ class ImageCopyTest extends GPUTest {
           {
             binding: 0,
             resource: inputTexture.createView({
+              dimension: '2d',
               baseArrayLayer: z,
               arrayLayerCount: 1,
               baseMipLevel: 0,

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -643,6 +643,7 @@ g.test('subresources_and_binding_types_combination_for_aspect')
     });
 
     const view0 = texture.createView({
+      dimension: '2d',
       baseMipLevel: BASE_LEVEL,
       mipLevelCount: 1,
       baseArrayLayer: BASE_LAYER,
@@ -651,6 +652,7 @@ g.test('subresources_and_binding_types_combination_for_aspect')
     });
 
     const view1 = texture.createView({
+      dimension: '2d',
       baseMipLevel: baseLevel,
       mipLevelCount: 1,
       baseArrayLayer: baseLayer,

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -147,13 +147,18 @@ export function viewDimensionsForTextureDimension(textureDimension: GPUTextureDi
 
 /** Returns the default view dimension for a given texture descriptor. */
 export function defaultViewDimensionsForTexture(textureDescriptor: Readonly<GPUTextureDescriptor>) {
-  if (textureDescriptor.dimension == '2d') {
-    const sizeDict = reifyExtent3D(textureDescriptor.size);
-    if (sizeDict.depthOrArrayLayers > 1) {
-      return '2d-array';
+  switch (textureDescriptor.dimension) {
+    case '1d':
+      return '1d';
+    case '2d': {
+      const sizeDict = reifyExtent3D(textureDescriptor.size);
+      return sizeDict.depthOrArrayLayers > 1 ? '2d-array' : '2d';
     }
+    case '3d':
+      return '3d';
+    default:
+      unreachable();
   }
-  return textureDescriptor.dimension;
 }
 
 /** Reifies the optional fields of `GPUTextureDescriptor`.

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -145,6 +145,17 @@ export function viewDimensionsForTextureDimension(textureDimension: GPUTextureDi
   }
 }
 
+/** Returns the default view dimension for a given texture descriptor. */
+export function defaultViewDimensionsForTexture(textureDescriptor: Readonly<GPUTextureDescriptor>) {
+  if (textureDescriptor.dimension == '2d') {
+    const sizeDict = reifyExtent3D(textureDescriptor.size);
+    if (sizeDict.depthOrArrayLayers > 1) {
+      return '2d-array';
+    }
+  }
+  return textureDescriptor.dimension;
+}
+
 /** Reifies the optional fields of `GPUTextureDescriptor`.
  * MAINTENANCE_TODO: viewFormats should not be omitted here, but it seems likely that the
  * @webgpu/types definition will have to change before we can include it again.
@@ -172,7 +183,7 @@ export function reifyTextureViewDescriptor(
 
   const format = view.format ?? texture.format;
   const mipLevelCount = view.mipLevelCount ?? texture.mipLevelCount - baseMipLevel;
-  const dimension = view.dimension ?? texture.dimension;
+  const dimension = view.dimension ?? defaultViewDimensionsForTexture(texture);
 
   let arrayLayerCount = view.arrayLayerCount;
   if (arrayLayerCount === undefined) {


### PR DESCRIPTION
The logic for determining the default `dimension` for `GPUTexture.createView()` calls was recently updated in https://github.com/gpuweb/gpuweb/pull/2755. After updating the implementation in Chrome to match the new logic, these were some tests that were shown to be failing.

I can't guarantee that this represents all changes needed (in fact, it's a surprisingly small number of changes). They were just the ones that our automated tools caught.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
