### PR TITLE
Minor comment fixes

### DIFF
--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -85,7 +85,7 @@ export class TestGroup<F extends Fixture> implements TestGroupBuilder<F> {
 
   private checkName(name: string): void {
     assert(
-      // Shouldn't happen due to the rule above. Just makes sure that treated
+      // Shouldn't happen due to the rule above. Just makes sure that treating
       // unencoded strings as encoded strings is OK.
       name === decodeURIComponent(name),
       `Not decodeURIComponent-idempotent: ${name} !== ${decodeURIComponent(name)}`

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -79,7 +79,7 @@ g.test('compute,zero_init')
         }
       })
       .beginSubcases()
-      // Fewer subases: Only 0 and 2. If double-nested containers work, single-nested should too.
+      // Fewer subcases: Only 0 and 2. If double-nested containers work, single-nested should too.
       .combine('_containerDepth', [0, 2])
       .expandWithParams(function* (p) {
         const kElementCounts = [

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -64,7 +64,7 @@ const kTestTypes = [
 
 g.test('stage_inout')
   .desc(
-    `Test that each @builtin]] attribute is validated against the required stage and in/out usage for that built-in variable.`
+    `Test that each @builtin attribute is validated against the required stage and in/out usage for that built-in variable.`
   )
   .params(u =>
     u
@@ -96,7 +96,7 @@ g.test('stage_inout')
 
 g.test('type')
   .desc(
-    `Test that each @builtin]] attribute is validated against the required type of that built-in variable.`
+    `Test that each @builtin attribute is validated against the required type of that built-in variable.`
   )
   .params(u =>
     u

--- a/src/webgpu/shader/validation/shader_io/util.ts
+++ b/src/webgpu/shader/validation/shader_io/util.ts
@@ -54,7 +54,7 @@ export function generateShader({
       param = `${attribute} value : ${type}`;
     }
 
-    // Vertex shaders must always return `builtin(position)`.
+    // Vertex shaders must always return `@builtin(position)`.
     if (stage === 'vertex') {
       retType = `-> @builtin(position) vec4<f32>`;
       retVal = `return vec4<f32>();`;


### PR DESCRIPTION
This PR fixes a few minor spelling issues and some syntax issues
in comments.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
