### PR TITLE
ShaderValidationTest: remove string overload

### DIFF
--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -12,10 +12,7 @@ export class ShaderValidationTest extends GPUTest {
    * ```ts
    * t.expectCompileResult(true, `wgsl code`); // Expect success
    * t.expectCompileResult(false, `wgsl code`); // Expect validation error with any error string
-   * t.expectCompileResult('substr', `wgsl code`); // Expect validation error containing 'substr'
    * ```
-   *
-   * MAINTENANCE_TODO(gpuweb/gpuweb#1813): Remove the "string" overload if there are no standard error codes.
    */
   expectCompileResult(expectedResult: boolean | string, code: string) {
     let shaderModule: GPUShaderModule;
@@ -36,23 +33,6 @@ export class ShaderValidationTest extends GPUTest {
         .map(m => `${m.lineNum}:${m.linePos}: ${m.type}: ${m.message}`)
         .join('\n');
       error.extra.compilationInfo = compilationInfo;
-
-      if (typeof expectedResult === 'string') {
-        for (const msg of compilationInfo.messages) {
-          if (msg.type === 'error' && msg.message.indexOf(expectedResult) !== -1) {
-            error.message =
-              `Found expected compilationInfo message substring «${expectedResult}».\n` +
-              messagesLog;
-            this.rec.debug(error);
-            return;
-          }
-        }
-
-        // Here, no error message was found, but one was expected.
-        error.message = `Missing expected substring «${expectedResult}».\n` + messagesLog;
-        this.rec.validationFailed(error);
-        return;
-      }
 
       if (compilationInfo.messages.some(m => m.type === 'error')) {
         if (expectedResult) {

--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -14,7 +14,7 @@ export class ShaderValidationTest extends GPUTest {
    * t.expectCompileResult(false, `wgsl code`); // Expect validation error with any error string
    * ```
    */
-  expectCompileResult(expectedResult: boolean | string, code: string) {
+  expectCompileResult(expectedResult: boolean, code: string) {
     let shaderModule: GPUShaderModule;
     this.expectGPUError(
       'validation',


### PR DESCRIPTION
There are no standard error codes in the WGSL spec.
So remove support for checking them.
See https://github.com/gpuweb/gpuweb/issues/1813

This is https://github.com/gpuweb/cts/pull/751 with merge conflicts resolved.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
