### PR TITLE
Update comment ending characters.

### DIFF
--- a/src/webgpu/shader/validation/parse/comments.spec.ts
+++ b/src/webgpu/shader/validation/parse/comments.spec.ts
@@ -27,11 +27,26 @@ parameters
 
 g.test('line_comment_terminators')
   .desc(`Test that line comments are terminated by any blankspace other than space and \t`)
-  .params(u => u.combine('blankspace', [' ', '\t', '\n', '\v', '\f', '\r']).beginSubcases())
+  .params(u =>
+    u
+      .combine('blankspace', [
+        [' ', 'space'],
+        ['\t', 'tab'],
+        ['\u000a', 'line_feed'],
+        ['\u000b', 'vertical_tab'],
+        ['\u000c', 'form_feed'],
+        ['\u000d', 'carriage_return'],
+        ['\u000d\u000a', 'carriage_return_line_feed'],
+        ['\u0085', 'next_line'],
+        ['\u2028', 'line_separator'],
+        ['\u2029', 'paragraph_separator'],
+      ])
+      .beginSubcases()
+  )
   .fn(t => {
-    const code = `// Line comment${t.params.blankspace}let invalid_outside_comment = should_fail`;
+    const code = `// Line comment${t.params.blankspace[0]}let invalid_outside_comment = should_fail`;
 
-    t.expectCompileResult([' ', '\t'].includes(t.params.blankspace), code);
+    t.expectCompileResult([' ', '\t'].includes(t.params.blankspace[0]), code);
   });
 
 g.test('unterminated_block_comment')


### PR DESCRIPTION
This PR updates the list of comment ending characters to match the
current spec. The characters were converted to unicode and text variants
added to make debugging easier.

Issue: #1159

This does not currently pass in Tint as the list of line ending characters has not been integrated.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
