### PR TITLE
Update blankspace tests to match spec.

### DIFF
--- a/src/webgpu/shader/validation/parse/blankspace.spec.ts
+++ b/src/webgpu/shader/validation/parse/blankspace.spec.ts
@@ -1,4 +1,4 @@
-export const description = `Validation tests for whitespace handling`;
+export const description = `Validation tests for blankspace handling`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
@@ -25,16 +25,26 @@ g.test('null_characters')
     t.expectCompileResult(!t.params.contains_null, code);
   });
 
-g.test('whitespace')
-  .desc(`Test that all whitespace characters act as delimiters.`)
+g.test('blankspace')
+  .desc(`Test that all blankspace characters act as delimiters.`)
+  .params(u =>
+    u
+      .combine('blankspace', [
+        ['\u0020', 'space'],
+        ['\u0009', 'horizontal_tab'],
+        ['\u000a', 'line_feed'],
+        ['\u000b', 'vertical_tab'],
+        ['\u000c', 'form_feed'],
+        ['\u000d', 'carriage_return'],
+        ['\u0085', 'next_line'],
+        ['\u200e', 'left_to_right_mark'],
+        ['\u200f', 'right_to_left_mark'],
+        ['\u2028', 'line_separator'],
+        ['\u2029', 'paragraph_separator'],
+      ])
+      .beginSubcases()
+  )
   .fn(t => {
-    const code = `
-let space:i32=0;
-let\thorizontal_tab:i32=0;
-let\nlinefeed:i32=0;
-let\vvertical_tab:i32=0;
-let\fformfeed:i32=0;
-let\rcarriage_return:i32=0;
-`;
+    const code = `let${t.params.blankspace[0]}ident : i32 = 0;`;
     t.expectCompileResult(true, code);
   });


### PR DESCRIPTION
This PR renames the test file to blankspace and updates to checked
values to match the list of blankspace characters in the WGSL spec.

Issue: #1159

Note, this does not fully pass on any implementation. The new blankspace characters are
not fully supported yet.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
