### PR TITLE
Extend WGSL interpolate tests.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -15,10 +15,16 @@ const kValidInterpolationAttributes = new Set([
   '@interpolate(perspective, center)',
   '@interpolate(perspective, centroid)',
   '@interpolate(perspective, sample)',
+  '@interpolate(perspective,center)',
+  '@interpolate(perspective,centroid)',
+  '@interpolate(perspective,sample)',
   '@interpolate(linear)',
   '@interpolate(linear, center)',
   '@interpolate(linear, centroid)',
   '@interpolate(linear, sample)',
+  '@interpolate(linear,center)',
+  '@interpolate(linear,centroid)',
+  '@interpolate(linear,sample)',
 ]);
 
 g.test('type_and_sampling')
@@ -30,20 +36,31 @@ g.test('type_and_sampling')
       .combine('use_struct', [true, false] as const)
       .combine('type', ['', 'flat', 'perspective', 'linear'] as const)
       .combine('sampling', ['', 'center', 'centroid', 'sample'] as const)
+      .combine('space', [true, false])
       .beginSubcases()
   )
   .fn(t => {
     if (t.params.stage === 'vertex' && t.params.use_struct === false) {
       t.skip('vertex output must include a position builtin, so must use a struct');
     }
+    if (t.params.space && t.params.sampling === '') {
+      t.skip('space only valid with sampling');
+    }
 
     let interpolate = '';
     if (t.params.type !== '' || t.params.sampling !== '') {
       interpolate = '@interpolate(';
       if (t.params.type !== '') {
-        interpolate += `${t.params.type}, `;
+        interpolate += `${t.params.type}`;
       }
-      interpolate += `${t.params.sampling})`;
+      if (t.params.sampling !== '') {
+        interpolate += `,`;
+        if (t.params.space) {
+          interpolate += ' ';
+        }
+        interpolate += `${t.params.sampling}`;
+      }
+      interpolate += `)`;
     }
     const code = generateShader({
       attribute: '@location(0)' + interpolate,

--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -15,16 +15,10 @@ const kValidInterpolationAttributes = new Set([
   '@interpolate(perspective, center)',
   '@interpolate(perspective, centroid)',
   '@interpolate(perspective, sample)',
-  '@interpolate(perspective,center)',
-  '@interpolate(perspective,centroid)',
-  '@interpolate(perspective,sample)',
   '@interpolate(linear)',
   '@interpolate(linear, center)',
   '@interpolate(linear, centroid)',
   '@interpolate(linear, sample)',
-  '@interpolate(linear,center)',
-  '@interpolate(linear,centroid)',
-  '@interpolate(linear,sample)',
 ]);
 
 g.test('type_and_sampling')
@@ -36,15 +30,11 @@ g.test('type_and_sampling')
       .combine('use_struct', [true, false] as const)
       .combine('type', ['', 'flat', 'perspective', 'linear'] as const)
       .combine('sampling', ['', 'center', 'centroid', 'sample'] as const)
-      .combine('space', [true, false])
       .beginSubcases()
   )
   .fn(t => {
     if (t.params.stage === 'vertex' && t.params.use_struct === false) {
       t.skip('vertex output must include a position builtin, so must use a struct');
-    }
-    if (t.params.space && t.params.sampling === '') {
-      t.skip('space only valid with sampling');
     }
 
     let interpolate = '';
@@ -54,11 +44,7 @@ g.test('type_and_sampling')
         interpolate += `${t.params.type}`;
       }
       if (t.params.sampling !== '') {
-        interpolate += `,`;
-        if (t.params.space) {
-          interpolate += ' ';
-        }
-        interpolate += `${t.params.sampling}`;
+        interpolate += `, ${t.params.sampling}`;
       }
       interpolate += `)`;
     }


### PR DESCRIPTION
The current interpolation tests will not attempt to validate an
interpolation with just the type (e.g. `@interpolate(flat)`). This is
due to the `,` always being appended so `@interpolate(flat, )` is
generated which is not a valid value.

This PR updates the generation to only add the `,` if there is a
sampling value to be appended. 

Issue: #1135

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
