### PR TITLE
Add a test with a Unicode character which would normalize

### DIFF
--- a/src/webgpu/shader/validation/parse/identifiers.spec.ts
+++ b/src/webgpu/shader/validation/parse/identifiers.spec.ts
@@ -473,3 +473,11 @@ g.test('identifiers')
     const code = `var<private> ${t.params.ident} : i32;`;
     t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
   });
+
+g.test('non_normalized')
+  .desc(`Test that identifiers are not unicode normalized`)
+  .fn(t => {
+    const code = `var<private> \u212b : i32;
+var<private> \u00c5 : i32;`;
+    t.expectCompileResult(true, code);
+  });

--- a/src/webgpu/shader/validation/parse/identifiers.spec.ts
+++ b/src/webgpu/shader/validation/parse/identifiers.spec.ts
@@ -477,7 +477,7 @@ g.test('identifiers')
 g.test('non_normalized')
   .desc(`Test that identifiers are not unicode normalized`)
   .fn(t => {
-    const code = `var<private> \u212b : i32;
+    const code = `var<private> \u212b : i32;  // \u212b normalizes with NFC to \u00c5
 var<private> \u00c5 : i32;`;
     t.expectCompileResult(true, code);
   });


### PR DESCRIPTION
This PR adds a test with an identifier named by a character with two
different unicode representations. The test passes if the shader
compiles as the characters are identified as separate identifiers.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
