### PR TITLE
Add more interpolate tests.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -59,6 +59,47 @@ g.test('type_and_sampling')
     t.expectCompileResult(kValidInterpolationAttributes.has(interpolate), code);
   });
 
+g.test('reversed_type_and_sampling')
+  .desc(`Test that type must come before sampling.`)
+  .params(u =>
+    u
+      .combine('stage', ['vertex', 'fragment'] as const)
+      .combine('io', ['in', 'out'] as const)
+      .combine('use_struct', [true, false] as const)
+      .combine('type', ['', 'flat', 'perspective', 'linear'] as const)
+      .combine('sampling', ['', 'center', 'centroid', 'sample'] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    if (t.params.stage === 'vertex' && t.params.use_struct === false) {
+      t.skip('vertex output must include a position builtin, so must use a struct');
+    }
+    if (t.params.type === '' && t.params.sampling === '') {
+      t.skip('both blank is valid');
+    }
+
+    let interpolate = '';
+    if (t.params.type !== '' || t.params.sampling !== '') {
+      interpolate = '@interpolate(';
+      if (t.params.sampling !== '') {
+        interpolate += `${t.params.sampling}`;
+      }
+      if (t.params.type !== '') {
+        interpolate += `, ${t.params.type}`;
+      }
+      interpolate += `)`;
+    }
+    const code = generateShader({
+      attribute: '@location(0)' + interpolate,
+      type: 'f32',
+      stage: t.params.stage,
+      io: t.params.io,
+      use_struct: t.params.use_struct,
+    });
+
+    t.expectCompileResult(false, code);
+  });
+
 g.test('require_location')
   .desc(`Test that the interpolate attribute is only accepted with user-defined IO.`)
   .params(u =>
@@ -111,4 +152,17 @@ g.test('integral_types')
     });
 
     t.expectCompileResult(t.params.attribute === '@interpolate(flat)', code);
+  });
+
+g.test('duplicate')
+  .desc(`Test that the interpolate attribute can only be applied once.`)
+  .fn(t => {
+    const code = generateShader({
+      attribute: `@location(0) @interpolate(flat) @interpolate(flat)`,
+      type: 'vec4<f32>',
+      stage: 'fragment',
+      io: 'in',
+      use_struct: false,
+    });
+    t.expectCompileResult(false, code);
   });


### PR DESCRIPTION
This PR validates that the interpolate sampling parameter can not come
before the type parameter. It also tests that the `interpolate` attribute can
only be applied once.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
