### PR TITLE
Test invariant can only be applied once.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/invariant.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/invariant.spec.ts
@@ -61,3 +61,27 @@ g.test('invalid_use_of_parameters')
     `;
     t.expectCompileResult(t.params.suffix === '', code);
   });
+
+g.test('duplicate')
+  .desc(`Test that the invariant attribute can only be applied once.`)
+  .params(u =>
+    u
+      .combineWithParams(kBuiltins)
+      .combine('use_struct', [true, false] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    if (t.params.name !== 'position') {
+      t.skip('only valid with position');
+    }
+
+    const code = generateShader({
+      attribute: `@builtin(${t.params.name}) @invariant @invariant`,
+      type: t.params.type,
+      stage: t.params.stage,
+      io: t.params.io,
+      use_struct: t.params.use_struct,
+    });
+
+    t.expectCompileResult(false, code);
+  });


### PR DESCRIPTION
This PR adds a check that the invariant attribute can only be applied
once.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
