### PR TITLE
shader/execution: Reduce `atan2` cases

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -38,10 +38,10 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     };
 
     const numeric_range = fullF32Range({
-      neg_norm: 1000,
-      neg_sub: 100,
-      pos_sub: 100,
-      pos_norm: 1000,
+      neg_norm: 100,
+      neg_sub: 10,
+      pos_sub: 10,
+      pos_norm: 100,
     }).filter(x => {
       return x !== 0;
     });


### PR DESCRIPTION
We were testing over 2 million cases. This was, unsurprisingly, slow.

Reduce down to 24,000 cases.


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
