### PR TITLE
src/webgpu/util/texture/texel_data: Use `,` for member delimiters

### DIFF
--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -56,7 +56,7 @@ function doTest(
   @group(0) @binding(0) var tex : texture_2d<${shaderType}>;
 
   struct Output {
-    ${rep.componentOrder.map(C => `result${C} : ${shaderType};`).join('\n')}
+    ${rep.componentOrder.map(C => `result${C} : ${shaderType},`).join('\n')}
   };
   @group(0) @binding(1) var<storage, read_write> output : Output;
 


### PR DESCRIPTION
instead of `;`.
Spec change: https://github.com/gpuweb/gpuweb/pull/2656

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
