### PR TITLE
wgsl: Add unimplemented quantizeToF16 spec

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -1,0 +1,21 @@
+export const description = `
+Execution tests for the 'quantizeToF16' builtin function
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('f32')
+  .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
+  .desc(
+    `
+T is f32 or vecN<f32>
+@const fn quantizeToF16(e: T ) -> T
+Quantizes a 32-bit floating point value e as if e were converted to a IEEE 754
+binary16 value, and then converted back to a IEEE 754 binary32 value.
+Component-wise when T is a vector.
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -8,7 +8,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
-  .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
 T is f32 or vecN<f32>


### PR DESCRIPTION
This CL stubs out the `quantizeToF16` as an unimplemented test.

Issue: #1200

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
