### PR TITLE
wgsl: Stub frexp test

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
@@ -1,0 +1,92 @@
+export const description = `
+Execution tests for the 'frexp' builtin function
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('scalar_f32')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is f32
+
+@const fn frexp(e:T) -> __frexp_result
+
+Splits e into a significand and exponent of the form significand * 2^exponent.
+Returns the __frexp_result built-in structure, defined as follows:
+
+struct __frexp_result {
+  sig : f32, // significand part
+  exp : i32  // exponent part
+}
+
+The magnitude of the significand is in the range of [0.5, 1.0) or 0.
+`
+  )
+  .unimplemented();
+
+g.test('scalar_f16')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is f16
+
+@const fn frexp(e:T) -> __frexp_result_f16
+
+Splits e into a significand and exponent of the form significand * 2^exponent.
+Returns the __frexp_result_f16 built-in structure, defined as if as follows:
+
+struct __frexp_result_f16 {
+  sig : f16, // significand part
+  exp : i32  // exponent part
+}
+
+The magnitude of the significand is in the range of [0.5, 1.0) or 0.
+`
+  )
+  .unimplemented();
+
+g.test('vector_f32')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vecN<f32>
+
+@const fn frexp(e:T) -> __frexp_result_vecN
+
+Splits the components of e into a significand and exponent of the form significand * 2^exponent.
+Returns the __frexp_result_vecN built-in structure, defined as follows:
+
+struct __frexp_result_vecN {
+  sig : vecN<f32>, // significand part
+  exp : vecN<i32>  // exponent part
+}
+
+The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
+`
+  )
+  .unimplemented();
+
+g.test('vector_f16')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vecN< f16 >
+
+@const fn frexp(e:T) -> __frexp_result_vecN_f16
+
+Splits the components of e into a significand and exponent of the form significand * 2^exponent.
+Returns the __frexp_result_vecN built-in structure, defined as if as follows:
+
+struct __frexp_result_vecN_f16 {
+  sig : vecN<f16>, // significand part
+  exp : vecN<i32>  // exponent part
+}
+
+The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
+`
+  )
+  .unimplemented();


### PR DESCRIPTION
This PR adds unimplemented stubs for the various frexp builtin cases.

Issue: #1208 #1209 #1210 #1211

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
