### PR TITLE
Add positive case into invariant duplicate test.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/invariant.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/invariant.spec.ts
@@ -68,6 +68,7 @@ g.test('duplicate')
     u
       .combineWithParams(kBuiltins)
       .combine('use_struct', [true, false] as const)
+      .combine('attr', ['', '@invariant'] as const)
       .beginSubcases()
   )
   .fn(t => {
@@ -76,12 +77,12 @@ g.test('duplicate')
     }
 
     const code = generateShader({
-      attribute: `@builtin(${t.params.name}) @invariant @invariant`,
+      attribute: `@builtin(${t.params.name}) @invariant ${t.params.attr}`,
       type: t.params.type,
       stage: t.params.stage,
       io: t.params.io,
       use_struct: t.params.use_struct,
     });
 
-    t.expectCompileResult(false, code);
+    t.expectCompileResult(t.params.attr === '', code);
   });


### PR DESCRIPTION
This updates the invariant duplicate test to have both positive and
negative cases so we have a control that other syntax changes don't
hide issues with this test.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
