### PR TITLE
wgsl: Implement f32 `exp` test

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -47,13 +47,12 @@ Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a
         const cmp = compare(got, target, ulpMatch);
         if (cmp.matched) {
           return cmp;
-        } else {
-          return {
-            matched: false,
-            got: got.toString(),
-            expected: `within 3 + 2 * |${x}| ULP of ${target}`,
-          };
         }
+        return {
+          matched: false,
+          got: got.toString(),
+          expected: `within 3 + 2 * |${x}| ULP of ${target}`,
+        };
       };
     };
 

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -4,6 +4,13 @@ Execution tests for the 'exp' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { Comparator, compare, ulpThreshold } from '../../../../../util/compare.js';
+import { kBit, kValue } from '../../../../../util/constants.js';
+import { f32, f32Bits, Scalar, TypeF32 } from '../../../../../util/conversion.js';
+import { biasedRange } from '../../../../../util/math.js';
+import { Case, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -27,7 +34,46 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a vector.
 `
   )
-  .unimplemented();
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cmp = (x: number, target: Scalar): Comparator => {
+      return (got, _) => {
+        const c = 3 + 2 * Math.abs(x);
+        const ulpMatch = ulpThreshold(c);
+        const cmp = compare(got, target, ulpMatch);
+        if (cmp.matched) {
+          return cmp;
+        } else {
+          return {
+            matched: false,
+            got: got.toString(),
+            expected: `within 3 + 2 * |${x}| ULP of ${target}`,
+          };
+        }
+      };
+    };
+
+    const makeCase = (x: number): Case => {
+      const expected = f32(Math.exp(x));
+      return { input: f32(x), expected: cmp(x, expected) };
+    };
+
+    // ln(max f32 value) ~ 88, so exp(88) will be within range of a f32, but exp(89) will not
+    const cases: Array<Case> = [
+      makeCase(0), // Returns 1 by definition
+      makeCase(-89), // Returns subnormal value
+      makeCase(kValue.f32.negative.min), // Closest to returning 0 as possible
+      { input: f32(89), expected: f32Bits(kBit.f32.infinity.positive) }, // Overflows
+      ...biasedRange(kValue.f32.negative.max, -88, 100).map(x => makeCase(x)),
+      ...biasedRange(kValue.f32.positive.min, 88, 100).map(x => makeCase(x)),
+    ];
+
+    run(t, builtin('exp'), [TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')


### PR DESCRIPTION
Issue: #1204

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
