### PR TITLE
wgsl: Stub tests for modf builtin.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -1,0 +1,80 @@
+export const description = `
+Execution tests for the 'modf' builtin function
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('scalar_f32')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is f32
+@const fn modf(e:T) -> __modf_result
+Splits e into fractional and whole number parts. Returns the __modf_result built-in structure, defined as follows:
+struct __modf_result {
+  fract : f32, // fractional part
+  whole : f32  // whole part
+}
+`
+  )
+  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .unimplemented();
+
+g.test('scalar_f16')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is f16
+@const fn modf(e:T) -> __modf_result_f16
+Splits e into fractional and whole number parts. Returns the __modf_result_f16 built-in structure, defined as if as follows:
+struct __modf_result_f16 {
+  fract : f16, // fractional part
+  whole : f16  // whole part
+}
+`
+  )
+  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .unimplemented();
+
+g.test('vector_f32')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vecN<f32>
+@const fn modf(e:T) -> __modf_result_vecN
+Splits the components of e into fractional and whole number parts. Returns the __modf_result_vecN built-in structure, defined as follows:
+struct __modf_result_vecN {
+  fract : vecN<f32>, // fractional part
+  whole : vecN<f32>  // whole part
+}
+`
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [2, 3, 4] as const)
+  )
+  .unimplemented();
+
+g.test('vector_f16')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vecN<f16>
+@const fn modf(e:T) -> __modf_result_vecN_f16
+Splits the components of e into fractional and whole number parts. Returns the __modf_result_vecN_f16 built-in structure, defined as if as follows:
+struct __modf_result_vecN_f16 {
+  fract : vecN<f16>, // fractional part
+  whole : vecN<f16>  // whole part
+}
+`
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [2, 3, 4] as const)
+  )
+  .unimplemented();


### PR DESCRIPTION
This PR adds unimplemented stubs for the `modf` builtin.

Issue: #1229 #1228 #1227 #1226

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
