### PR TITLE
wgsl: Implement `exp2` f32 tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -4,6 +4,13 @@ Execution tests for the 'exp2' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { ulpCmp } from '../../../../../util/compare.js';
+import { kBit, kValue } from '../../../../../util/constants.js';
+import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
+import { biasedRange } from '../../../../../util/math.js';
+import { Case, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -27,7 +34,33 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
 `
   )
-  .unimplemented();
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const n = (x: number): number => {
+      return 3 + 2 * Math.abs(x);
+    };
+
+    const makeCase = (x: number): Case => {
+      const expected = f32(Math.pow(2, x));
+      return { input: f32(x), expected: ulpCmp(x, expected, n) };
+    };
+
+    // floor(log2(max f32 value)) = 127, so exp2(127) will be within range of a f32, but exp2(128) will not
+    const cases: Array<Case> = [
+      makeCase(0), // Returns 1 by definition
+      makeCase(-127), // Returns subnormal value
+      makeCase(kValue.f32.negative.min), // Closest to returning 0 as possible
+      { input: f32(128), expected: f32Bits(kBit.f32.infinity.positive) }, // Overflows
+      ...biasedRange(kValue.f32.negative.max, -127, 100).map(x => makeCase(x)),
+      ...biasedRange(kValue.f32.positive.min, 127, 100).map(x => makeCase(x)),
+    ];
+
+    run(t, builtin('exp2'), [TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -1,7 +1,7 @@
 import { Colors } from '../../common/util/colors.js';
 
 import { f32, Scalar, Value, Vector } from './conversion.js';
-import { correctlyRounded, withinULP } from './math.js';
+import { correctlyRounded, oneULP, withinULP } from './math.js';
 
 /** Comparison describes the result of a Comparator function. */
 export interface Comparison {
@@ -139,5 +139,30 @@ export function anyOf(...values: Value[]): Comparator {
       failed.push(cmp.expected);
     }
     return { matched: false, got: got.toString(), expected: failed.join(' or ') };
+  };
+}
+
+/** @returns a Comparator that checks whether a result is within N * ULP of a target value, where N is a defined by a function
+ *
+ * N is n(x), where x is the input into the function under test, not the result of the function.
+ * For a function f(x) = X that is being tested, the acceptable interval is defined as within X +/- n(x) * ulp(X).
+ */
+export function ulpCmp(x: number, target: Scalar, n: (x: number) => number): Comparator {
+  const c = n(x);
+  const ulpMatch = ulpThreshold(c);
+  return (got, _) => {
+    const cmp = compare(got, target, ulpMatch);
+    if (cmp.matched) {
+      return cmp;
+    }
+    const ulp = Math.max(
+      oneULP(target.value as number, true),
+      oneULP(target.value as number, false)
+    );
+    return {
+      matched: false,
+      got: got.toString(),
+      expected: `within ${c} * ULP (${ulp}) of ${target}`,
+    };
   };
 }

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -142,10 +142,10 @@ export function anyOf(...values: Value[]): Comparator {
   };
 }
 
-/** @returns a Comparator that checks whether a result is within N * ULP of a target value, where N is a defined by a function
+/** @returns a Comparator that checks whether a result is within N * ULP of a target value, where N is defined by a function
  *
  * N is n(x), where x is the input into the function under test, not the result of the function.
- * For a function f(x) = X that is being tested, the acceptable interval is defined as within X +/- n(x) * ulp(X).
+ * For a function f(x) = X that is being tested, the acceptance interval is defined as within X +/- n(x) * ulp(X).
  */
 export function ulpCmp(x: number, target: Scalar, n: (x: number) => number): Comparator {
   const c = n(x);


### PR DESCRIPTION
Also factors out generating Comparators that take in a function to a
common utility

Issue: #1205

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
