### PR TITLE
Roll @webgpu/types to 0.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/offscreencanvas": "^2019.6.4",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "0.1.14",
+        "@webgpu/types": "0.1.15",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1227,9 +1227,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.14.tgz",
-      "integrity": "sha512-+zUQ4FmzZTPHLAm7Fjggtb/qqlDrpdBDuCjaWx82dbZNYRKiGRFWw2bYPHYXSSWHQak48KGQEKWxRWCaZiwemg==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.15.tgz",
+      "integrity": "sha512-ZmVadVywHYarPkXi6ieoiHRotkrfLVKo6WIkmh2QuJ76prDFnILYoOoym9PMY/sdEI4Jf9ICwJEGBoPvbXJNSQ==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10483,9 +10483,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.14.tgz",
-      "integrity": "sha512-+zUQ4FmzZTPHLAm7Fjggtb/qqlDrpdBDuCjaWx82dbZNYRKiGRFWw2bYPHYXSSWHQak48KGQEKWxRWCaZiwemg==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.15.tgz",
+      "integrity": "sha512-ZmVadVywHYarPkXi6ieoiHRotkrfLVKo6WIkmh2QuJ76prDFnILYoOoym9PMY/sdEI4Jf9ICwJEGBoPvbXJNSQ==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/offscreencanvas": "^2019.6.4",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "0.1.14",
+    "@webgpu/types": "0.1.15",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
@@ -45,7 +45,7 @@ export class ProgrammableStateTest extends GPUTest {
   }
 
   setBindGroup(
-    encoder: GPUProgrammablePassEncoder,
+    encoder: GPUBindingCommandsMixin,
     index: number,
     factory: (index: number) => GPUBindGroup
   ) {
@@ -137,7 +137,7 @@ export class ProgrammableStateTest extends GPUTest {
     }
   }
 
-  setPipeline(pass: GPUProgrammablePassEncoder, pipeline: GPUComputePipeline | GPURenderPipeline) {
+  setPipeline(pass: GPUBindingCommandsMixin, pipeline: GPUComputePipeline | GPURenderPipeline) {
     if (pass instanceof GPUComputePassEncoder) {
       pass.setPipeline(pipeline as GPUComputePipeline);
     } else if (pass instanceof GPURenderPassEncoder || pass instanceof GPURenderBundleEncoder) {
@@ -145,9 +145,9 @@ export class ProgrammableStateTest extends GPUTest {
     }
   }
 
-  dispatchOrDraw(pass: GPUProgrammablePassEncoder) {
+  dispatchOrDraw(pass: GPUBindingCommandsMixin) {
     if (pass instanceof GPUComputePassEncoder) {
-      pass.dispatch(1);
+      pass.dispatchWorkgroups(1);
     } else if (pass instanceof GPURenderPassEncoder) {
       pass.draw(1);
     } else if (pass instanceof GPURenderBundleEncoder) {

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -58,7 +58,7 @@ g.test('memcpy').fn(async t => {
   const pass = encoder.beginComputePass();
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, bg);
-  pass.dispatch(1);
+  pass.dispatchWorkgroups(1);
   pass.end();
   t.device.queue.submit([encoder.finish()]);
 
@@ -148,7 +148,7 @@ g.test('large_dispatch')
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bg);
-    pass.dispatch(dims[0], dims[1], dims[2]);
+    pass.dispatchWorkgroups(dims[0], dims[1], dims[2]);
     pass.end();
     t.device.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -419,7 +419,7 @@ export class BufferSyncTest extends GPUTest {
     const bindGroup = this.createBindGroup(pipeline, buffer);
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
-    pass.dispatch(1);
+    pass.dispatchWorkgroups(1);
   }
 
   // Write buffer via BufferToBuffer copy.
@@ -541,7 +541,7 @@ export class BufferSyncTest extends GPUTest {
         @builtin(position) position : vec4<f32>,
         @location(0) @interpolate(flat) data : u32,
       };
-      
+
       @stage(vertex) fn vert_main(@location(0) input: u32) -> VertexOutput {
         var output : VertexOutput;
         output.position = vec4<f32>(0.5, 0.5, 0.0, 1.0);
@@ -553,9 +553,9 @@ export class BufferSyncTest extends GPUTest {
       struct Data {
         a : u32
       };
-      
+
       @group(0) @binding(0) var<storage, read_write> data : Data;
-      
+
       @stage(fragment) fn frag_main(@location(0) @interpolate(flat) input : u32) -> @location(0) vec4<f32> {
         data.a = input;
         return vec4<f32>();  // result does't matter
@@ -601,10 +601,10 @@ export class BufferSyncTest extends GPUTest {
       struct Data {
         a : u32
       };
-      
+
       @group(0) @binding(0) var<uniform> constant: Data;
       @group(0) @binding(1) var<storage, read_write> data : Data;
-      
+
       @stage(fragment) fn frag_main() -> @location(0) vec4<f32> {
         data.a = constant.a;
         return vec4<f32>();  // result does't matter
@@ -662,10 +662,10 @@ export class BufferSyncTest extends GPUTest {
     const bindGroup = this.createBindGroupSrcDstBuffer(pipeline, srcBuffer, dstBuffer);
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
-    pass.dispatch(1);
+    pass.dispatchWorkgroups(1);
   }
 
-  // Write buffer via dispatchIndirect call in compute pass.
+  // Write buffer via dispatchWorkgroupsIndirect call in compute pass.
   encodeReadAsIndirectBufferInComputePass(
     pass: GPUComputePassEncoder,
     srcBuffer: GPUBuffer,
@@ -676,7 +676,7 @@ export class BufferSyncTest extends GPUTest {
     const bindGroup = this.createBindGroup(pipeline, dstBuffer);
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
-    pass.dispatchIndirect(srcBuffer, 0);
+    pass.dispatchWorkgroupsIndirect(srcBuffer, 0);
   }
 
   // Read as vertex input and write buffer via draw call in render pass. Use bundle if needed.

--- a/src/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.ts
@@ -248,7 +248,7 @@ g.test('two_dispatches_in_the_same_compute_pass')
       const bindGroup = t.createBindGroup(pipeline, buffer);
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
-      pass.dispatch(1);
+      pass.dispatchWorkgroups(1);
     }
 
     pass.end();

--- a/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
@@ -263,7 +263,7 @@ class TextureSyncTestHelper extends OperationContextHelper {
             assert(this.computePassEncoder !== undefined);
             this.computePassEncoder.setPipeline(computePipeline);
             this.computePassEncoder.setBindGroup(0, bindGroup);
-            this.computePassEncoder.dispatch(
+            this.computePassEncoder.dispatchWorkgroups(
               Math.ceil(this.kTextureSize[0] / 8),
               Math.ceil(this.kTextureSize[1] / 8)
             );
@@ -528,7 +528,7 @@ class TextureSyncTestHelper extends OperationContextHelper {
             assert(this.computePassEncoder !== undefined);
             this.computePassEncoder.setPipeline(computePipeline);
             this.computePassEncoder.setBindGroup(0, bindGroup);
-            this.computePassEncoder.dispatch(
+            this.computePassEncoder.dispatchWorkgroups(
               Math.ceil(this.kTextureSize[0] / 8),
               Math.ceil(this.kTextureSize[1] / 8)
             );

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -82,7 +82,7 @@ class F extends GPUTest {
     const computePass = encoder.beginComputePass();
     computePass.setBindGroup(0, bindGroup);
     computePass.setPipeline(computePipeline);
-    computePass.dispatch(1);
+    computePass.dispatchWorkgroups(1);
     computePass.end();
     this.queue.submit([encoder.finish()]);
 
@@ -805,8 +805,9 @@ have been initialized to 0.`
 
 g.test('indirect_buffer_for_dispatch_indirect')
   .desc(
-    `Verify when we use a GPUBuffer as an indirect buffer for dispatchIndirect() just after the
-creation of that GPUBuffer, all the contents in that GPUBuffer have been initialized to 0.`
+    `Verify when we use a GPUBuffer as an indirect buffer for dispatchWorkgroupsIndirect() just
+    after the creation of that GPUBuffer, all the contents in that GPUBuffer have been initialized
+    to 0.`
   )
   .paramsSubcasesOnly(u => u.combine('bufferOffset', [0, 16]))
   .fn(async t => {
@@ -861,7 +862,7 @@ creation of that GPUBuffer, all the contents in that GPUBuffer have been initial
     const computePass = encoder.beginComputePass();
     computePass.setBindGroup(0, bindGroup);
     computePass.setPipeline(computePipeline);
-    computePass.dispatchIndirect(indirectBuffer, bufferOffset);
+    computePass.dispatchWorkgroupsIndirect(indirectBuffer, bufferOffset);
     computePass.end();
     t.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -130,7 +130,7 @@ export const checkContentsBySampling: CheckContents = (
       const pass = commandEncoder.beginComputePass();
       pass.setPipeline(computePipeline);
       pass.setBindGroup(0, bindGroup);
-      pass.dispatch(width, height, depth);
+      pass.dispatchWorkgroups(width, height, depth);
       pass.end();
       t.queue.submit([commandEncoder.finish()]);
       ubo.destroy();

--- a/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
+++ b/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
@@ -169,7 +169,7 @@ g.test('texture_binding')
         ],
       })
     );
-    pass.dispatch(kTextureSize, kTextureSize);
+    pass.dispatchWorkgroups(kTextureSize, kTextureSize);
     pass.end();
     t.device.queue.submit([commandEncoder.finish()]);
 

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -121,9 +121,12 @@ g.test('dispatch_sizes')
     encoder.setPipeline(pipeline);
     if (dispatchType === 'direct') {
       const [x, y, z] = workSizes;
-      encoder.dispatch(x, y, z);
+      encoder.dispatchWorkgroups(x, y, z);
     } else if (dispatchType === 'indirect') {
-      encoder.dispatchIndirect(t.createIndirectBuffer('valid', new Uint32Array(workSizes)), 0);
+      encoder.dispatchWorkgroupsIndirect(
+        t.createIndirectBuffer('valid', new Uint32Array(workSizes)),
+        0
+      );
     }
 
     const shouldError =
@@ -137,8 +140,8 @@ const kBufferData = new Uint32Array(6).fill(1);
 g.test('indirect_dispatch_buffer_state')
   .desc(
     `
-Test dispatchIndirect validation by submitting various dispatches with a no-op pipeline and an
-indirectBuffer with 6 elements.
+Test dispatchWorkgroupsIndirect validation by submitting various dispatches with a no-op pipeline
+and an indirectBuffer with 6 elements.
 - indirectBuffer: {'valid', 'invalid', 'destroyed'}
 - indirectOffset:
   - valid, within the buffer: {beginning, middle, end} of the buffer
@@ -167,7 +170,7 @@ indirectBuffer with 6 elements.
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder('compute pass');
     encoder.setPipeline(pipeline);
-    encoder.dispatchIndirect(buffer, offset);
+    encoder.dispatchWorkgroupsIndirect(buffer, offset);
 
     const finishShouldError =
       state === 'invalid' ||
@@ -178,7 +181,7 @@ indirectBuffer with 6 elements.
 
 g.test('indirect_dispatch_buffer,device_mismatch')
   .desc(
-    'Tests dispatchIndirect cannot be called with an indirect buffer created from another device'
+    `Tests dispatchWorkgroupsIndirect cannot be called with an indirect buffer created from another device`
   )
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
   .fn(async t => {
@@ -200,6 +203,6 @@ g.test('indirect_dispatch_buffer,device_mismatch')
 
     const { encoder, validateFinish } = t.createEncoder('compute pass');
     encoder.setPipeline(pipeline);
-    encoder.dispatchIndirect(buffer, 0);
+    encoder.dispatchWorkgroupsIndirect(buffer, 0);
     validateFinish(!mismatched);
   });

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -18,7 +18,7 @@ interface DrawIndexedParameter {
 
 function callDrawIndexed(
   test: GPUTest,
-  encoder: GPURenderEncoderBase,
+  encoder: GPURenderCommandsMixin,
   drawType: 'drawIndexed' | 'drawIndexedIndirect',
   param: DrawIndexedParameter
 ) {

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -152,10 +152,10 @@ class F extends ValidationTest {
     const x = callWithZero ? 0 : 1;
     switch (call) {
       case 'dispatch':
-        pass.dispatch(x, 1, 1);
+        pass.dispatchWorkgroups(x, 1, 1);
         break;
       case 'dispatchIndirect':
-        pass.dispatchIndirect(this.getIndirectBuffer([x, 1, 1]), 0);
+        pass.dispatchWorkgroupsIndirect(this.getIndirectBuffer([x, 1, 1]), 0);
         break;
       default:
         break;

--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -352,7 +352,7 @@ referenced by that bind group is "used" in the usage scope. `
 
         /*
          * setBindGroup(bindGroup0);
-         * dispatch();
+         * dispatchWorkgroups();
          * setBindGroup(bindGroup1);
          */
         if (dispatchBeforeUsage1) {
@@ -365,19 +365,19 @@ referenced by that bind group is "used" in the usage scope. `
           }
           const computePipeline = t.createNoOpComputePipeline(pipelineLayout);
           computePassEncoder.setPipeline(computePipeline);
-          computePassEncoder.dispatch(1);
+          computePassEncoder.dispatchWorkgroups(1);
         }
         break;
       }
       case 'indirect': {
         /*
-         * dispatchIndirect(buffer);
+         * dispatchWorkgroupsIndirect(buffer);
          * setBindGroup(bindGroup1);
          */
         assert(dispatchBeforeUsage1);
         const computePipeline = t.createNoOpComputePipeline();
         computePassEncoder.setPipeline(computePipeline);
-        computePassEncoder.dispatchIndirect(buffer, offset0);
+        computePassEncoder.dispatchWorkgroupsIndirect(buffer, offset0);
         break;
       }
     }
@@ -394,7 +394,7 @@ referenced by that bind group is "used" in the usage scope. `
         /*
          * setBindGroup(bindGroup0);
          * setBindGroup(bindGroup1);
-         * dispatch();
+         * dispatchWorkgroups();
          */
         if (!dispatchBeforeUsage1) {
           const bindGroupLayouts: GPUBindGroupLayout[] = [];
@@ -413,14 +413,14 @@ referenced by that bind group is "used" in the usage scope. `
             : undefined;
           const computePipeline = t.createNoOpComputePipeline(pipelineLayout);
           computePassEncoder.setPipeline(computePipeline);
-          computePassEncoder.dispatch(1);
+          computePassEncoder.dispatchWorkgroups(1);
         }
         break;
       }
       case 'indirect': {
         /*
          * setBindGroup(bindGroup0);
-         * dispatchIndirect(buffer);
+         * dispatchWorkgroupsIndirect(buffer);
          */
         assert(!dispatchBeforeUsage1);
         let pipelineLayout: GPUPipelineLayout | undefined = undefined;
@@ -432,7 +432,7 @@ referenced by that bind group is "used" in the usage scope. `
         }
         const computePipeline = t.createNoOpComputePipeline(pipelineLayout);
         computePassEncoder.setPipeline(computePipeline);
-        computePassEncoder.dispatchIndirect(buffer, offset1);
+        computePassEncoder.dispatchWorkgroupsIndirect(buffer, offset1);
         break;
       }
     }
@@ -490,13 +490,13 @@ dispatch calls refer to different usage scopes.`
           });
           const computePipeline = t.createNoOpComputePipeline(pipelineLayout);
           computePassEncoder.setPipeline(computePipeline);
-          computePassEncoder.dispatch(1);
+          computePassEncoder.dispatchWorkgroups(1);
           break;
         }
         case 'indirect': {
           const computePipeline = t.createNoOpComputePipeline();
           computePassEncoder.setPipeline(computePipeline);
-          computePassEncoder.dispatchIndirect(buffer, offset);
+          computePassEncoder.dispatchWorkgroupsIndirect(buffer, offset);
           break;
         }
         default:

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -232,7 +232,7 @@ class TextureUsageTracking extends ValidationTest {
 
   issueDrawOrDispatch(pass: GPURenderPassEncoder | GPUComputePassEncoder, compute: boolean) {
     if (compute) {
-      (pass as GPUComputePassEncoder).dispatch(1);
+      (pass as GPUComputePassEncoder).dispatchWorkgroups(1);
     } else {
       (pass as GPURenderPassEncoder).draw(3, 1, 0, 0);
     }
@@ -241,7 +241,7 @@ class TextureUsageTracking extends ValidationTest {
   setComputePipelineAndCallDispatch(pass: GPUComputePassEncoder, layout?: GPUPipelineLayout) {
     const pipeline = this.createNoOpComputePipeline(layout);
     pass.setPipeline(pipeline);
-    pass.dispatch(1);
+    pass.dispatchWorkgroups(1);
   }
 }
 
@@ -877,7 +877,7 @@ g.test('replaced_binding')
     // gets programmatically defined in capability_info, use it here, instead of this logic, for clarity.
     let success = entry.storageTexture?.access !== 'write-only';
     // Replaced bindings should not be validated in compute pass, because validation only occurs
-    // inside dispatch() which only looks at the current resource usages.
+    // inside dispatchWorkgroups() which only looks at the current resource usages.
     success ||= compute;
 
     t.expectValidationError(() => {

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -291,7 +291,7 @@ g.test('subresources,set_unused_bind_group')
       computePassEncoder.setBindGroup(0, bindGroup0);
       computePassEncoder.setBindGroup(1, bindGroup1);
       computePassEncoder.setPipeline(computePipeline);
-      computePassEncoder.dispatch(1);
+      computePassEncoder.dispatchWorkgroups(1);
       computePassEncoder.end();
     }
 

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -716,7 +716,7 @@ Tests encoding and dispatching a simple valid compute pass on destroyed device.
     });
     await t.executeCommandsAfterDestroy(stage, awaitLost, 'compute pass', maker => {
       maker.encoder.setPipeline(pipeline);
-      maker.encoder.dispatch(1);
+      maker.encoder.dispatchWorkgroups(1);
       return maker;
     });
   });

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -532,7 +532,7 @@ export class GPUTest extends Fixture {
     const pass = commandEncoder.beginComputePass();
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
-    pass.dispatch(numRows);
+    pass.dispatchWorkgroups(numRows);
     pass.end();
     this.device.queue.submit([commandEncoder.finish()]);
 

--- a/src/webgpu/shader/execution/evaluation_order.spec.ts
+++ b/src/webgpu/shader/execution/evaluation_order.spec.ts
@@ -445,7 +445,7 @@ fn main() {
   const pass = encoder.beginComputePass();
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, group);
-  pass.dispatch(1);
+  pass.dispatchWorkgroups(1);
   pass.end();
 
   t.queue.submit([encoder.finish()]);

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -258,7 +258,7 @@ fn main() {
   const pass = encoder.beginComputePass();
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, group);
-  pass.dispatch(1);
+  pass.dispatchWorkgroups(1);
   pass.end();
 
   t.queue.submit([encoder.finish()]);

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -342,13 +342,13 @@ export class MemoryModelTester {
       const testPass = encoder.beginComputePass();
       testPass.setPipeline(this.testPipeline);
       testPass.setBindGroup(0, this.testBindGroup);
-      testPass.dispatch(numWorkgroups);
+      testPass.dispatchWorkgroups(numWorkgroups);
       testPass.end();
 
       const resultPass = encoder.beginComputePass();
       resultPass.setPipeline(this.resultPipeline);
       resultPass.setBindGroup(0, this.resultBindGroup);
-      resultPass.dispatch(this.params.testingWorkgroups);
+      resultPass.dispatchWorkgroups(this.params.testingWorkgroups);
       resultPass.end();
 
       this.test.device.queue.submit([encoder.finish()]);

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -84,7 +84,7 @@ function runShaderTest(
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, testGroup, dynamicOffsets);
   pass.setBindGroup(1, group);
-  pass.dispatch(1);
+  pass.dispatchWorkgroups(1);
   pass.end();
 
   t.queue.submit([encoder.finish()]);

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -177,7 +177,7 @@ g.test('inputs')
     pass.setBindGroup(0, bindGroup);
     switch (t.params.dispatch) {
       case 'direct':
-        pass.dispatch(t.params.numGroups.x, t.params.numGroups.y, t.params.numGroups.z);
+        pass.dispatchWorkgroups(t.params.numGroups.x, t.params.numGroups.y, t.params.numGroups.z);
         break;
       case 'indirect': {
         const dispatchBuffer = t.device.createBuffer({
@@ -191,7 +191,7 @@ g.test('inputs')
         dispatchData[1] = t.params.numGroups.y;
         dispatchData[2] = t.params.numGroups.z;
         dispatchBuffer.unmap();
-        pass.dispatchIndirect(dispatchBuffer, 0);
+        pass.dispatchWorkgroupsIndirect(dispatchBuffer, 0);
         break;
       }
     }

--- a/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
@@ -71,7 +71,7 @@ g.test('shared_with_buffer')
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
-    pass.dispatch(numGroups[0], numGroups[1], numGroups[2]);
+    pass.dispatchWorkgroups(numGroups[0], numGroups[1], numGroups[2]);
     pass.end();
     t.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -440,7 +440,7 @@ g.test('compute,zero_init')
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup);
-    pass.dispatch(1);
+    pass.dispatchWorkgroups(1);
     pass.end();
     t.queue.submit([encoder.finish()]);
     t.expectGPUBufferValuesEqual(resultBuffer, new Uint32Array([0]));

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -101,7 +101,7 @@ function doTest(
   const pass = encoder.beginComputePass();
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, bindGroup);
-  pass.dispatch(1);
+  pass.dispatchWorkgroups(1);
   pass.end();
   t.device.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -290,7 +290,7 @@ Tests that we can import an HTMLVideoElement into a GPUExternalTexture and use i
       const pass = encoder.beginComputePass();
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bg);
-      pass.dispatch(1);
+      pass.dispatchWorkgroups(1);
       pass.end();
       t.device.queue.submit([encoder.finish()]);
 

--- a/src/webgpu/web_platform/reftests/canvas_complex.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_complex.html.ts
@@ -572,7 +572,7 @@ fn main(@builtin(position) fragcoord: vec4<f32>) -> @location(0) vec4<f32> {
           {
             view: outputTexture.createView(),
 
-            loadValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
+            clearValue: { r: 0.5, g: 0.5, b: 0.5, a: 1.0 },
             loadOp: 'clear',
             storeOp: 'store',
           },
@@ -632,7 +632,7 @@ fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
       const pass = encoder.beginComputePass();
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bg);
-      pass.dispatch(ctx.canvas.width, ctx.canvas.height, 1);
+      pass.dispatchWorkgroups(ctx.canvas.width, ctx.canvas.height, 1);
       pass.end();
       t.device.queue.submit([encoder.finish()]);
     }
@@ -687,7 +687,11 @@ fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
       const pass = encoder.beginComputePass();
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bg);
-      pass.dispatch(align(ctx.canvas.width, 16) / 16, align(ctx.canvas.height, 16) / 16, 1);
+      pass.dispatchWorkgroups(
+        align(ctx.canvas.width, 16) / 16,
+        align(ctx.canvas.height, 16) / 16,
+        1
+      );
       pass.end();
       t.device.queue.submit([encoder.finish()]);
     }

--- a/src/webgpu/web_platform/worker/worker.ts
+++ b/src/webgpu/web_platform/worker/worker.ts
@@ -48,7 +48,7 @@ async function basicTest() {
   const pass = encoder.beginComputePass();
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, bindGroup);
-  pass.dispatch(kNumElements);
+  pass.dispatchWorkgroups(kNumElements);
   pass.end();
 
   encoder.copyBufferToBuffer(buffer, 0, resultBuffer, 0, kBufferSize);


### PR DESCRIPTION
Primary changes are removing deprecated load/store op syntax,
reorganizing of some mixins, and renaming dispatch* to
dispatchWorkgroups*.