### PR TITLE
Fix non-object-type test-parameter values

### DIFF
--- a/src/common/internal/params_utils.ts
+++ b/src/common/internal/params_utils.ts
@@ -111,7 +111,7 @@ function typeAssert<T extends 'pass'>() {}
   }
 }
 
-export type Merged<A, B> = ResolveType<MergedFromFlat<A, FlattenUnionOfInterfaces<B>>>;
+export type Merged<A, B> = MergedFromFlat<A, FlattenUnionOfInterfaces<B>>;
 export type MergedFromFlat<A, B> = {
   [K in keyof A | keyof B]: K extends keyof B ? B[K] : K extends keyof A ? A[K] : never;
 };

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -21,7 +21,7 @@ import { GPUTest } from './gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-// Note: spaces in test names are replaced with underscores: webgpu:examples:test_name=
+// Note: spaces aren't allowed in test names; use underscores.
 g.test('test_name').fn(t => {});
 
 g.test('not_implemented_yet,without_plan').unimplemented();

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -6,6 +6,9 @@ import { clamp } from './math.js';
 /**
  * Encodes a JS `number` into a "normalized" (unorm/snorm) integer representation with `bits` bits.
  * Input must be between -1 and 1 if signed, or 0 and 1 if unsigned.
+ *
+ * MAINTENANCE_TODO: See if performance of texel_data improves if this function is pre-specialized
+ * for a particular `bits`/`signed`.
  */
 export function floatAsNormalizedInteger(float: number, bits: number, signed: boolean): number {
   if (signed) {


### PR DESCRIPTION
The `ResolveType` "magic" type-function only exists to make the inferred types more readable when you read them in an IDE. But it was forcing all test-parameter value types to be objects (`extends {}`) instead of preserving better types, like `instanceof Scalar` (seen [here](https://github.com/gpuweb/cts/pull/1333/commits/d5c99d42e397bc7a637e52678dc89befa2144ccb#r862129274) or `instanceof Function` (seen somewhere else recently).

Also fixup a few unrelated comments.

Issue: None

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
