### PR TITLE
Add --colors flag for enabling color output

### DIFF
--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -6,6 +6,7 @@ import { Logger } from '../internal/logging/logger.js';
 import { LiveTestCaseResult } from '../internal/logging/result.js';
 import { parseQuery } from '../internal/query/parseQuery.js';
 import { parseExpectationsForTestQuery } from '../internal/query/query.js';
+import { Colors } from '../util/colors.js';
 import { setGPUProvider } from '../util/navigator_gpu.js';
 import { assert, unreachable } from '../util/util.js';
 
@@ -16,6 +17,7 @@ function usage(rc: number): never {
   console.log(`  tools/run_${sys.type} [OPTIONS...] QUERIES...`);
   console.log(`  tools/run_${sys.type} 'unittests:*' 'webgpu:buffers,*'`);
   console.log('Options:');
+  console.log('  --colors             Enable ANSI colors in output.');
   console.log('  --verbose            Print result/log of every test as it runs.');
   console.log(
     '  --list               Print all testcase names that match the given query and exit.'
@@ -35,6 +37,8 @@ interface GPUProviderModule {
 
 type listModes = 'none' | 'cases' | 'unimplemented';
 
+Colors.enabled = false;
+
 let verbose = false;
 let listMode: listModes = 'none';
 let debug = false;
@@ -48,7 +52,9 @@ const gpuProviderFlags: string[] = [];
 for (let i = 0; i < sys.args.length; ++i) {
   const a = sys.args[i];
   if (a.startsWith('-')) {
-    if (a === '--verbose') {
+    if (a === '--colors') {
+      Colors.enabled = true;
+    } else if (a === '--verbose') {
       verbose = true;
     } else if (a === '--list') {
       listMode = 'cases';

--- a/src/common/runtime/server.ts
+++ b/src/common/runtime/server.ts
@@ -10,6 +10,7 @@ import { LiveTestCaseResult } from '../internal/logging/result.js';
 import { parseQuery } from '../internal/query/parseQuery.js';
 import { TestQueryWithExpectation } from '../internal/query/query.js';
 import { TestTreeLeaf } from '../internal/tree.js';
+import { Colors } from '../util/colors.js';
 import { setGPUProvider } from '../util/navigator_gpu.js';
 
 import sys from './helper/sys.js';
@@ -18,6 +19,7 @@ function usage(rc: number): never {
   console.log('Usage:');
   console.log(`  tools/run_${sys.type} [OPTIONS...]`);
   console.log('Options:');
+  console.log('  --colors             Enable ANSI colors in output.');
   console.log('  --verbose            Print result/log of every test as it runs.');
   console.log('  --gpu-provider       Path to node module that provides the GPU implementation.');
   console.log('  --gpu-provider-flag  Flag to set on the gpu-provider as <flag>=<value>');
@@ -44,6 +46,8 @@ if (!sys.existsSync('src/common/runtime/cmdline.ts')) {
   usage(1);
 }
 
+Colors.enabled = false;
+
 let debug = false;
 let gpuProviderModule: GPUProviderModule | undefined = undefined;
 
@@ -51,7 +55,9 @@ const gpuProviderFlags: string[] = [];
 for (let i = 0; i < sys.args.length; ++i) {
   const a = sys.args[i];
   if (a.startsWith('-')) {
-    if (a === '--gpu-provider') {
+    if (a === '--colors') {
+      Colors.enabled = true;
+    } else if (a === '--gpu-provider') {
       const modulePath = sys.args[++i];
       gpuProviderModule = require(modulePath);
     } else if (a === '--gpu-provider-flag') {

--- a/src/common/util/colors.ts
+++ b/src/common/util/colors.ts
@@ -6,6 +6,9 @@
  * style.
  */
 export interface Colors {
+  // Are colors enabled?
+  enabled: boolean;
+
   // Returns the string formatted to contain the specified color or style.
   (s: string): string;
 
@@ -77,6 +80,7 @@ try {
   Colors = require('ansi-colors') as Colors;
 } catch {
   const passthrough = ((s: string) => s) as Colors;
+  passthrough.enabled = false;
   passthrough.reset = passthrough;
   passthrough.bold = passthrough;
   passthrough.dim = passthrough;


### PR DESCRIPTION
Default to no-colors.

Allows users to write to logs without the ANSI escape codes.