### PR TITLE
Handle backends flushing inputs in `atan2` tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -5,9 +5,9 @@ Execution tests for the 'atan2' builtin function
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { assert } from '../../../../../../common/util/util.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ulpThreshold } from '../../../../../util/compare.js';
+import { anyOf, ulpThreshold } from '../../../../../util/compare.js';
 import { f32, TypeF32 } from '../../../../../util/conversion.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { flushSubnormalNumber, fullF32Range } from '../../../../../util/math.js';
 import { Case, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -54,7 +54,9 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (y: number, x: number): Case => {
       assert(x !== 0, 'atan2 is undefined for x = 0');
-      return { input: [f32(y), f32(x)], expected: f32(Math.atan2(y, x)) };
+      // Subnormals are already excluded from the x values, so do not need to test x being flushed.
+      const expected = [f32(Math.atan2(y, x)), f32(Math.atan2(flushSubnormalNumber(y), x))];
+      return { input: [f32(y), f32(x)], expected: anyOf(...expected) };
     };
 
     const numeric_range = fullF32Range({
@@ -62,15 +64,15 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       neg_sub: 10,
       pos_sub: 10,
       pos_norm: 100,
-    }).filter(x => {
-      return x !== 0;
     });
 
-    const cases: Array<Case> = numeric_range.map(x => makeCase(0.0, x));
+    const cases: Array<Case> = [];
     numeric_range.forEach((y, y_idx) => {
       numeric_range.forEach((x, x_idx) => {
-        if (x_idx >= y_idx) {
-          cases.push(makeCase(y, x));
+        if (flushSubnormalNumber(x) !== 0) {
+          if (x_idx >= y_idx) {
+            cases.push(makeCase(y, x));
+          }
         }
       });
     });

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -33,10 +33,8 @@ export function clamp(n: number, { min, max }: { min: number; max: number }): nu
   return Math.min(Math.max(n, min), max);
 }
 
-/**
- * @returns 0 if |val| is a subnormal f32 number, otherwise returns |val|
- */
-function flushSubnormalNumber(val: number): number {
+/** @returns 0 if |val| is a subnormal f32 number, otherwise returns |val| */
+export function flushSubnormalNumber(val: number): number {
   const u32_val = new Uint32Array(new Float32Array([val]).buffer)[0];
   return (u32_val & 0x7f800000) === 0 ? 0 : val;
 }
@@ -50,9 +48,7 @@ function flushSubnormalBits(val: number): number {
   return (val & 0x7f800000) === 0 ? 0 : val;
 }
 
-/**
- * @returns 0 if |val| is a subnormal f32 number, otherwise returns |val|
- */
+/** @returns 0 if |val| is a subnormal f32 number, otherwise returns |val| */
 export function flushSubnormalScalar(val: Scalar): Scalar {
   return isSubnormalScalar(val) ? f32(0) : val;
 }


### PR DESCRIPTION
Fixes #1339

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
