### PR TITLE
remove doInit/doFinalize

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -32,18 +32,10 @@ export class SubcaseBatchState {
     return this._params;
   }
 
-  /** @internal */
-  doInit(): Promise<void> {
-    return this.init();
-  }
-
-  /** @internal */
-  doFinalize(): Promise<void> {
-    return this.finalize();
-  }
-
-  protected async init() {}
-  protected async finalize() {}
+  /** @internal MAINTENANCE_TODO: Make this not visible to test code? */
+  async init() {}
+  /** @internal MAINTENANCE_TODO: Make this not visible to test code? */
+  async finalize() {}
 }
 
 /**
@@ -90,19 +82,23 @@ export class Fixture<S extends SubcaseBatchState = SubcaseBatchState> {
     return this._sharedState;
   }
 
-  // This has to be a member function instead of an async `createFixture` function, because
-  // we need to be able to ergonomically override it in subclasses.
   /**
    * Override this to do additional pre-test-function work in a derived fixture.
+   * This has to be a member function instead of an async `createFixture` function, because
+   * we need to be able to ergonomically override it in subclasses.
+   *
+   * @internal MAINTENANCE_TODO: Make this not visible to test code?
    */
-  protected async init(): Promise<void> {}
+  async init(): Promise<void> {}
 
   /**
    * Override this to do additional post-test-function work in a derived fixture.
    *
    * Called even if init was unsuccessful.
+   *
+   * @internal MAINTENANCE_TODO: Make this not visible to test code?
    */
-  protected async finalize(): Promise<void> {
+  async finalize(): Promise<void> {
     assert(
       this.numOutstandingAsyncExpectations === 0,
       'there were outstanding immediateAsyncExpectations (e.g. expectUncapturedError) at the end of the test'
@@ -129,16 +125,6 @@ export class Fixture<S extends SubcaseBatchState = SubcaseBatchState> {
         o.close();
       }
     }
-  }
-
-  /** @internal */
-  doInit(): Promise<void> {
-    return this.init();
-  }
-
-  /** @internal */
-  doFinalize(): Promise<void> {
-    return this.finalize();
   }
 
   /**

--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -433,11 +433,11 @@ class RunCaseSpecific implements RunCase {
 
       const inst = new this.fixture(sharedState, rec, params);
       try {
-        await inst.doInit();
+        await inst.init();
         await this.fn(inst as Fixture & { params: {} });
       } finally {
         // Runs as long as constructor succeeded, even if initialization or the test failed.
-        await inst.doFinalize();
+        await inst.finalize();
       }
     } catch (ex) {
       // There was an exception from constructor, init, test, or finalize.
@@ -493,7 +493,7 @@ class RunCaseSpecific implements RunCase {
       rec.start();
       const sharedState = this.fixture.MakeSharedState(this.params);
       try {
-        await sharedState.doInit();
+        await sharedState.init();
         if (this.beforeFn) {
           await this.beforeFn(sharedState);
         }
@@ -545,7 +545,7 @@ class RunCaseSpecific implements RunCase {
         }
       } finally {
         // Runs as long as the shared state constructor succeeded, even if initialization or a test failed.
-        await sharedState.doFinalize();
+        await sharedState.finalize();
       }
     } catch (ex) {
       // There was an exception from sharedState/fixture constructor, init, beforeFn, or test.

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -129,13 +129,13 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     this.mismatchedAcquiredDevice = this.mismatchedProvider.acquire();
   }
 
-  protected async init(): Promise<void> {
+  async init(): Promise<void> {
     await super.init();
 
     this.provider = await devicePool.reserve();
   }
 
-  protected async finalize(): Promise<void> {
+  async finalize(): Promise<void> {
     await super.finalize();
 
     if (this.provider) {


### PR DESCRIPTION
I think these are here for historical reasons, they're adding unnecessary complexity.

Issue: None

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
