### PR TITLE
Sparse color attachment fix

### DIFF
--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -221,25 +221,6 @@ g.test('color,attachments')
     pass.end();
     t.device.queue.submit([encoder.finish()]);
 
-    // for (let i = 0; i < attachmentCount; i++) {
-    //   if (i === emptyAttachmentId) {
-    //     continue;
-    //   }
-    //   const result = await textureContentIsOKByT2B(
-    //     t,
-    //     { texture: renderTargets[i] },
-    //     [1, 1, 1],
-    //     {
-    //       expTexelView: TexelView.fromTexelsAsColors(format, coords => writeValues[i]),
-    //     },
-    //     {
-    //     maxIntDiff: 0,
-    //     maxDiffULPsForNormFormat: 1,
-    //     maxDiffULPsForFloatFormat: 1,
-    //   });
-    //   t.expectOK(result);
-    // }
-
     const promises = range(attachmentCount, i => {
       if (i === emptyAttachmentId) {
         return undefined;

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -2,8 +2,6 @@ export const description = `
 - Test pipeline outputs with different color attachment number, formats, component counts, etc.
 `;
 
-import { assert } from 'console';
-
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range, unreachable } from '../../../../common/util/util.js';
 import { kRenderableColorTextureFormats, kTextureFormatInfo } from '../../../capability_info.js';


### PR DESCRIPTION

Issue: #1121

Addressing https://github.com/gpuweb/cts/pull/1160#discussion_r863308712 to make output value different for each attachment and component. Utilizing the new `texture_ok` helpers

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
