### PR TITLE
wgsl: Stub tests for the transpose builtin.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
@@ -1,0 +1,59 @@
+export const description = `
+Execution tests for the 'transpose' builtin function
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('abstract_float')
+  .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
+  .desc(
+    `
+T is AbstractFloat, f32, or f16
+transpose(e: matRxC<T> ) -> matCxR<T>
+Returns the transpose of e.
+`
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('rows', [2, 3, 4] as const)
+      .combine('cols', [2, 3, 4] as const)
+  )
+  .unimplemented();
+
+g.test('f32')
+  .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
+  .desc(
+    `
+T is AbstractFloat, f32, or f16
+transpose(e: matRxC<T> ) -> matCxR<T>
+Returns the transpose of e.
+`
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('rows', [2, 3, 4] as const)
+      .combine('cols', [2, 3, 4] as const)
+  )
+  .unimplemented();
+
+g.test('f16')
+  .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
+  .desc(
+    `
+T is AbstractFloat, f32, or f16
+transpose(e: matRxC<T> ) -> matCxR<T>
+Returns the transpose of e.
+`
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('rows', [2, 3, 4] as const)
+      .combine('cols', [2, 3, 4] as const)
+  )
+  .unimplemented();


### PR DESCRIPTION
This CL adds unimplemented stub tests for the `transpose` builtin.

Issue: #1246

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
