### PR TITLE
wgsl: Add missing parameterizations

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -22,6 +22,11 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns the cosine of e. Component-wise when T is a vector.
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('f32')
@@ -62,5 +67,10 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 @const fn cos(e: T ) -> T
 Returns the cosine of e. Component-wise when T is a vector.
 `
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -16,6 +16,11 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns the hyperbolic cosine of e. Component-wise when T is a vector
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('f32')
@@ -27,6 +32,11 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns the hyperbolic cosine of e. Component-wise when T is a vector
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('f16')
@@ -37,5 +47,10 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 @const fn cosh(e: T ) -> T
 Returns the hyperbolic cosine of e. Component-wise when T is a vector
 `
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -16,6 +16,7 @@ T is AbstractFloat, f32, or f16
 Returns the cross product of e1 and e2.
 `
   )
+  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('f32')
@@ -27,6 +28,7 @@ T is AbstractFloat, f32, or f16
 Returns the cross product of e1 and e2.
 `
   )
+  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('f16')
@@ -38,4 +40,5 @@ T is AbstractFloat, f32, or f16
 Returns the cross product of e1 and e2.
 `
   )
+  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -23,6 +23,11 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a vector.
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('f32')
@@ -70,5 +75,10 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 @const fn exp(e1: T ) -> T
 Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a vector.
 `
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -23,6 +23,11 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('f32')
@@ -70,5 +75,10 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 @const fn exp2(e: T ) -> T
 Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
 `
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
@@ -16,6 +16,11 @@ T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('f32')
@@ -27,6 +32,11 @@ T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('f16')
@@ -37,5 +47,10 @@ T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 @const fn faceForward(e1: T ,e2: T ,e3: T ) -> T
 Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
 `
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
@@ -16,6 +16,11 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns e1 * e2 + e3. Component-wise when T is a vector.
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('f32')
@@ -27,6 +32,11 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 Returns e1 * e2 + e3. Component-wise when T is a vector.
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('f16')
@@ -37,5 +47,10 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 @const fn fma(e1: T ,e2: T ,e3: T ) -> T
 Returns e1 * e2 + e3. Component-wise when T is a vector.
 `
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
@@ -26,6 +26,7 @@ struct __frexp_result {
 The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 `
   )
+  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('scalar_f16')
@@ -47,6 +48,7 @@ struct __frexp_result_f16 {
 The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 `
   )
+  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('vector_f32')
@@ -68,6 +70,11 @@ struct __frexp_result_vecN {
 The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [2, 3, 4] as const)
+  )
   .unimplemented();
 
 g.test('vector_f16')
@@ -88,5 +95,10 @@ struct __frexp_result_vecN_f16 {
 
 The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
 `
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -22,6 +22,12 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 @const fn log2(e: T ) -> T
 Returns the base-2 logarithm of e. Component-wise when T is a vector.
 `
+)
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('range', ['low', 'mid', 'high'] as const)
   )
   .unimplemented();
 
@@ -86,5 +92,11 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 @const fn log2(e: T ) -> T
 Returns the base-2 logarithm of e. Component-wise when T is a vector.
 `
+  )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('range', ['low', 'mid', 'high'] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -22,7 +22,7 @@ T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
 @const fn log2(e: T ) -> T
 Returns the base-2 logarithm of e. Component-wise when T is a vector.
 `
-)
+  )
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -18,4 +18,9 @@ binary16 value, and then converted back to a IEEE 754 binary32 value.
 Component-wise when T is a vector.
 `
   )
+  .params(u =>
+    u
+      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
   .unimplemented();


### PR DESCRIPTION
Some of the stubs were updated to have more test cases but the parameterizations
were missing on the stubs. This CL goes back and adds missing parameterizations
where needed.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
