### PR TITLE
wgsl: Generalize unary and binary f32 arithmetic case generation

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -4,74 +4,14 @@ Execution Tests for the f32 arithmetic binary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { anyOf, correctlyRoundedThreshold, ulpThreshold } from '../../../../util/compare.js';
-import { f32, Scalar, TypeF32 } from '../../../../util/conversion.js';
-import {
-  biasedRange,
-  fullF32Range,
-  isSubnormalNumber,
-  quantizeToF32,
-} from '../../../../util/math.js';
-import { Case, Config, run } from '../expression.js';
+import { correctlyRoundedThreshold, ulpThreshold } from '../../../../util/compare.js';
+import { TypeF32 } from '../../../../util/conversion.js';
+import { biasedRange, fullF32Range } from '../../../../util/math.js';
+import { Case, Config, makeBinaryF32Case, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
-
-/**
- * Produces all of the results for a binary op and a specific pair of params, accounting for if subnormal results can be
- * flushed to zero.
- * Does not account for the inputs being flushed.
- * @param lhs the left hand side to pass into the binary operation
- * @param rhs the rhs hand side to pass into the binary operation
- * @param op callback that implements the truth function for the binary operation
- */
-function calculateResults(
-  lhs: number,
-  rhs: number,
-  op: (l: number, r: number) => number
-): Array<Scalar> {
-  const results: Array<Scalar> = [];
-  const value = op(lhs, rhs);
-  results.push(f32(value));
-  if (isSubnormalNumber(value)) {
-    results.push(f32(0.0));
-  }
-  return results;
-}
-
-/**
- * Generates a Case for the params and binary op provide.
- * @param lhs the left hand side to pass into the binary operation
- * @param rhs the rhs hand side to pass into the binary operation
- * @param op callback that implements the truth function for the binary operation
- * @param skip_rhs_zero_flush should the builder skip cases where the rhs would be flushed to 0, this is primarily for
- *                            avoid doing division by 0. The caller is responsible for making sure the initial rhs isn't
- *                            0.
- */
-function makeCaseImpl(
-  lhs: number,
-  rhs: number,
-  op: (l: number, r: number) => number,
-  skip_rhs_zero_flush: boolean = false
-): Case {
-  const f32_lhs = quantizeToF32(lhs);
-  const f32_rhs = quantizeToF32(rhs);
-  const is_lhs_subnormal = isSubnormalNumber(f32_lhs);
-  const is_rhs_subnormal = isSubnormalNumber(f32_rhs);
-  const expected = calculateResults(f32_lhs, f32_rhs, op);
-  if (is_lhs_subnormal) {
-    expected.push(...calculateResults(0.0, f32_rhs, op));
-  }
-  if (!skip_rhs_zero_flush && is_rhs_subnormal) {
-    expected.push(...calculateResults(f32_lhs, 0.0, op));
-  }
-  if (!skip_rhs_zero_flush && is_lhs_subnormal && is_rhs_subnormal) {
-    expected.push(...calculateResults(0.0, 0.0, op));
-  }
-
-  return { input: [f32(lhs), f32(rhs)], expected: anyOf(...expected) };
-}
 
 g.test('addition')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
@@ -91,7 +31,7 @@ Accuracy: Correctly rounded
     cfg.cmpFloats = correctlyRoundedThreshold();
 
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeCaseImpl(lhs, rhs, (l: number, r: number): number => {
+      return makeBinaryF32Case(lhs, rhs, (l: number, r: number): number => {
         return l + r;
       });
     };
@@ -125,7 +65,7 @@ Accuracy: Correctly rounded
     cfg.cmpFloats = correctlyRoundedThreshold();
 
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeCaseImpl(lhs, rhs, (l: number, r: number): number => {
+      return makeBinaryF32Case(lhs, rhs, (l: number, r: number): number => {
         return l - r;
       });
     };
@@ -159,7 +99,7 @@ Accuracy: Correctly rounded
     cfg.cmpFloats = correctlyRoundedThreshold();
 
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeCaseImpl(lhs, rhs, (l: number, r: number): number => {
+      return makeBinaryF32Case(lhs, rhs, (l: number, r: number): number => {
         return l * r;
       });
     };
@@ -193,7 +133,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
     cfg.cmpFloats = ulpThreshold(2.5);
 
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeCaseImpl(
+      return makeBinaryF32Case(
         lhs,
         rhs,
         (l: number, r: number): number => {

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -4,10 +4,9 @@ Execution tests for the 'abs' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { anyOf, correctlyRoundedThreshold } from '../../../../../util/compare.js';
-import { kBit, kValue } from '../../../../../util/constants.js';
+import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { kBit } from '../../../../../util/constants.js';
 import {
-  f32,
   f32Bits,
   i32Bits,
   TypeF32,
@@ -15,7 +14,8 @@ import {
   TypeU32,
   u32Bits,
 } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { fullF32Range } from '../../../../../util/math.js';
+import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -198,93 +198,17 @@ Component-wise when T is a vector.
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
 
-    run(t, builtin('abs'), [TypeF32], TypeF32, cfg, [
-      // Min and Max f32
-      { input: f32Bits(kBit.f32.negative.max), expected: f32Bits(0x0080_0000) },
-      { input: f32Bits(kBit.f32.negative.min), expected: f32Bits(0x7f7f_ffff) },
-      { input: f32Bits(kBit.f32.positive.min), expected: f32Bits(kBit.f32.positive.min) },
-      { input: f32Bits(kBit.f32.positive.max), expected: f32Bits(kBit.f32.positive.max) },
+    const makeCase = (x: number): Case => {
+      return makeUnaryF32Case(x, Math.abs);
+    };
 
-      // Subnormal f32
-      {
-        input: f32Bits(kBit.f32.subnormal.positive.max),
-        expected: anyOf(f32Bits(kBit.f32.subnormal.positive.max), f32(0)),
-      },
-      {
-        input: f32Bits(kBit.f32.subnormal.positive.min),
-        expected: anyOf(f32Bits(kBit.f32.subnormal.positive.min), f32(0)),
-      },
-
-      // Infinity f32
+    const cases: Array<Case> = [
       { input: f32Bits(kBit.f32.infinity.negative), expected: f32Bits(kBit.f32.infinity.positive) },
       { input: f32Bits(kBit.f32.infinity.positive), expected: f32Bits(kBit.f32.infinity.positive) },
+      ...fullF32Range().map(x => makeCase(x)),
+    ];
 
-      // Powers of 2.0: -2.0^i: -1 >= i >= -31
-      { input: f32(kValue.negPowTwo.toMinus1), expected: f32(kValue.powTwo.toMinus1) },
-      { input: f32(kValue.negPowTwo.toMinus2), expected: f32(kValue.powTwo.toMinus2) },
-      { input: f32(kValue.negPowTwo.toMinus3), expected: f32(kValue.powTwo.toMinus3) },
-      { input: f32(kValue.negPowTwo.toMinus4), expected: f32(kValue.powTwo.toMinus4) },
-      { input: f32(kValue.negPowTwo.toMinus5), expected: f32(kValue.powTwo.toMinus5) },
-      { input: f32(kValue.negPowTwo.toMinus6), expected: f32(kValue.powTwo.toMinus6) },
-      { input: f32(kValue.negPowTwo.toMinus7), expected: f32(kValue.powTwo.toMinus7) },
-      { input: f32(kValue.negPowTwo.toMinus8), expected: f32(kValue.powTwo.toMinus8) },
-      { input: f32(kValue.negPowTwo.toMinus9), expected: f32(kValue.powTwo.toMinus9) },
-      { input: f32(kValue.negPowTwo.toMinus10), expected: f32(kValue.powTwo.toMinus10) },
-      { input: f32(kValue.negPowTwo.toMinus11), expected: f32(kValue.powTwo.toMinus11) },
-      { input: f32(kValue.negPowTwo.toMinus12), expected: f32(kValue.powTwo.toMinus12) },
-      { input: f32(kValue.negPowTwo.toMinus13), expected: f32(kValue.powTwo.toMinus13) },
-      { input: f32(kValue.negPowTwo.toMinus14), expected: f32(kValue.powTwo.toMinus14) },
-      { input: f32(kValue.negPowTwo.toMinus15), expected: f32(kValue.powTwo.toMinus15) },
-      { input: f32(kValue.negPowTwo.toMinus16), expected: f32(kValue.powTwo.toMinus16) },
-      { input: f32(kValue.negPowTwo.toMinus17), expected: f32(kValue.powTwo.toMinus17) },
-      { input: f32(kValue.negPowTwo.toMinus18), expected: f32(kValue.powTwo.toMinus18) },
-      { input: f32(kValue.negPowTwo.toMinus19), expected: f32(kValue.powTwo.toMinus19) },
-      { input: f32(kValue.negPowTwo.toMinus20), expected: f32(kValue.powTwo.toMinus20) },
-      { input: f32(kValue.negPowTwo.toMinus21), expected: f32(kValue.powTwo.toMinus21) },
-      { input: f32(kValue.negPowTwo.toMinus22), expected: f32(kValue.powTwo.toMinus22) },
-      { input: f32(kValue.negPowTwo.toMinus23), expected: f32(kValue.powTwo.toMinus23) },
-      { input: f32(kValue.negPowTwo.toMinus24), expected: f32(kValue.powTwo.toMinus24) },
-      { input: f32(kValue.negPowTwo.toMinus25), expected: f32(kValue.powTwo.toMinus25) },
-      { input: f32(kValue.negPowTwo.toMinus26), expected: f32(kValue.powTwo.toMinus26) },
-      { input: f32(kValue.negPowTwo.toMinus27), expected: f32(kValue.powTwo.toMinus27) },
-      { input: f32(kValue.negPowTwo.toMinus28), expected: f32(kValue.powTwo.toMinus28) },
-      { input: f32(kValue.negPowTwo.toMinus29), expected: f32(kValue.powTwo.toMinus29) },
-      { input: f32(kValue.negPowTwo.toMinus30), expected: f32(kValue.powTwo.toMinus30) },
-      { input: f32(kValue.negPowTwo.toMinus31), expected: f32(kValue.powTwo.toMinus31) },
-
-      // Powers of 2.0: -2.0^i: 1 <= i <= 31
-      { input: f32(kValue.negPowTwo.to1), expected: f32(kValue.powTwo.to1) },
-      { input: f32(kValue.negPowTwo.to2), expected: f32(kValue.powTwo.to2) },
-      { input: f32(kValue.negPowTwo.to3), expected: f32(kValue.powTwo.to3) },
-      { input: f32(kValue.negPowTwo.to4), expected: f32(kValue.powTwo.to4) },
-      { input: f32(kValue.negPowTwo.to5), expected: f32(kValue.powTwo.to5) },
-      { input: f32(kValue.negPowTwo.to6), expected: f32(kValue.powTwo.to6) },
-      { input: f32(kValue.negPowTwo.to7), expected: f32(kValue.powTwo.to7) },
-      { input: f32(kValue.negPowTwo.to8), expected: f32(kValue.powTwo.to8) },
-      { input: f32(kValue.negPowTwo.to9), expected: f32(kValue.powTwo.to9) },
-      { input: f32(kValue.negPowTwo.to10), expected: f32(kValue.powTwo.to10) },
-      { input: f32(kValue.negPowTwo.to11), expected: f32(kValue.powTwo.to11) },
-      { input: f32(kValue.negPowTwo.to12), expected: f32(kValue.powTwo.to12) },
-      { input: f32(kValue.negPowTwo.to13), expected: f32(kValue.powTwo.to13) },
-      { input: f32(kValue.negPowTwo.to14), expected: f32(kValue.powTwo.to14) },
-      { input: f32(kValue.negPowTwo.to15), expected: f32(kValue.powTwo.to15) },
-      { input: f32(kValue.negPowTwo.to16), expected: f32(kValue.powTwo.to16) },
-      { input: f32(kValue.negPowTwo.to17), expected: f32(kValue.powTwo.to17) },
-      { input: f32(kValue.negPowTwo.to18), expected: f32(kValue.powTwo.to18) },
-      { input: f32(kValue.negPowTwo.to19), expected: f32(kValue.powTwo.to19) },
-      { input: f32(kValue.negPowTwo.to20), expected: f32(kValue.powTwo.to20) },
-      { input: f32(kValue.negPowTwo.to21), expected: f32(kValue.powTwo.to21) },
-      { input: f32(kValue.negPowTwo.to22), expected: f32(kValue.powTwo.to22) },
-      { input: f32(kValue.negPowTwo.to23), expected: f32(kValue.powTwo.to23) },
-      { input: f32(kValue.negPowTwo.to24), expected: f32(kValue.powTwo.to24) },
-      { input: f32(kValue.negPowTwo.to25), expected: f32(kValue.powTwo.to25) },
-      { input: f32(kValue.negPowTwo.to26), expected: f32(kValue.powTwo.to26) },
-      { input: f32(kValue.negPowTwo.to27), expected: f32(kValue.powTwo.to27) },
-      { input: f32(kValue.negPowTwo.to28), expected: f32(kValue.powTwo.to28) },
-      { input: f32(kValue.negPowTwo.to29), expected: f32(kValue.powTwo.to29) },
-      { input: f32(kValue.negPowTwo.to30), expected: f32(kValue.powTwo.to30) },
-      { input: f32(kValue.negPowTwo.to31), expected: f32(kValue.powTwo.to31) },
-    ]);
+    run(t, builtin('abs'), [TypeF32], TypeF32, cfg, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -8,7 +8,7 @@ import { ulpThreshold } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { Case, Config, run } from '../../expression.js';
+import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -49,10 +49,8 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (x: number): Case => {
-      return { input: f32(x), expected: f32(Math.atan(x)) };
+      return makeUnaryF32Case(x, Math.atan);
     };
-
-    // Well defined/border cases
     const cases: Array<Case> = [
       { input: f32Bits(kBit.f32.infinity.negative), expected: f32(-Math.PI / 2) },
       { input: f32(-Math.sqrt(3)), expected: f32(-Math.PI / 3) },

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -3,12 +3,11 @@ Execution tests for the 'atan2' builtin function
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { assert } from '../../../../../../common/util/util.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { anyOf, ulpThreshold } from '../../../../../util/compare.js';
-import { f32, TypeF32 } from '../../../../../util/conversion.js';
+import { ulpThreshold } from '../../../../../util/compare.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
 import { flushSubnormalNumber, fullF32Range } from '../../../../../util/math.js';
-import { Case, Config, run } from '../../expression.js';
+import { Case, Config, makeBinaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -51,12 +50,12 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
+    const cfg: Config = t.params;
+    cfg.cmpFloats = ulpThreshold(4096);
+
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (y: number, x: number): Case => {
-      assert(x !== 0, 'atan2 is undefined for x = 0');
-      // Subnormals are already excluded from the x values, so do not need to test x being flushed.
-      const expected = [f32(Math.atan2(y, x)), f32(Math.atan2(flushSubnormalNumber(y), x))];
-      return { input: [f32(y), f32(x)], expected: anyOf(...expected) };
+      return makeBinaryF32Case(y, x, Math.atan2, true);
     };
 
     const numeric_range = fullF32Range({
@@ -69,6 +68,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     const cases: Array<Case> = [];
     numeric_range.forEach((y, y_idx) => {
       numeric_range.forEach((x, x_idx) => {
+        // atan2(y, 0) is not well defined, so skipping those cases
         if (flushSubnormalNumber(x) !== 0) {
           if (x_idx >= y_idx) {
             cases.push(makeCase(y, x));
@@ -76,8 +76,6 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
         }
       });
     });
-    const cfg: Config = t.params;
-    cfg.cmpFloats = ulpThreshold(4096);
     run(t, builtin('atan2'), [TypeF32, TypeF32], TypeF32, cfg, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -4,10 +4,11 @@ Execution tests for the 'ceil' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedThreshold, anyOf } from '../../../../../util/compare.js';
-import { kBit, kValue } from '../../../../../util/constants.js';
+import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { fullF32Range } from '../../../../../util/math.js';
+import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -47,7 +48,11 @@ Returns the ceiling of e. Component-wise when T is a vector.
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
 
-    run(t, builtin('ceil'), [TypeF32], TypeF32, cfg, [
+    const makeCase = (x: number): Case => {
+      return makeUnaryF32Case(x, Math.ceil);
+    };
+
+    const cases: Array<Case> = [
       // Small positive numbers
       { input: f32(0.1), expected: f32(1.0) },
       { input: f32(0.9), expected: f32(1.0) },
@@ -66,80 +71,13 @@ Returns the ceiling of e. Component-wise when T is a vector.
       { input: f32Bits(kBit.f32.positive.min), expected: f32(1.0) },
       { input: f32Bits(kBit.f32.positive.max), expected: f32Bits(kBit.f32.positive.max) },
 
-      // Subnormal f32
-      { input: f32Bits(kBit.f32.subnormal.positive.max), expected: anyOf(f32(1.0), f32(0.0)) },
-      { input: f32Bits(kBit.f32.subnormal.positive.min), expected: anyOf(f32(1.0), f32(0.0)) },
-
       // Infinity f32
       { input: f32Bits(kBit.f32.infinity.negative), expected: f32Bits(kBit.f32.infinity.negative) },
       { input: f32Bits(kBit.f32.infinity.positive), expected: f32Bits(kBit.f32.infinity.positive) },
+      ...fullF32Range().map(x => makeCase(x)),
+    ];
 
-      // Powers of +2.0: 2.0^i: 1 <= i <= 31
-      { input: f32(kValue.powTwo.to1), expected: f32(kValue.powTwo.to1) },
-      { input: f32(kValue.powTwo.to2), expected: f32(kValue.powTwo.to2) },
-      { input: f32(kValue.powTwo.to3), expected: f32(kValue.powTwo.to3) },
-      { input: f32(kValue.powTwo.to4), expected: f32(kValue.powTwo.to4) },
-      { input: f32(kValue.powTwo.to5), expected: f32(kValue.powTwo.to5) },
-      { input: f32(kValue.powTwo.to6), expected: f32(kValue.powTwo.to6) },
-      { input: f32(kValue.powTwo.to7), expected: f32(kValue.powTwo.to7) },
-      { input: f32(kValue.powTwo.to8), expected: f32(kValue.powTwo.to8) },
-      { input: f32(kValue.powTwo.to9), expected: f32(kValue.powTwo.to9) },
-      { input: f32(kValue.powTwo.to10), expected: f32(kValue.powTwo.to10) },
-      { input: f32(kValue.powTwo.to11), expected: f32(kValue.powTwo.to11) },
-      { input: f32(kValue.powTwo.to12), expected: f32(kValue.powTwo.to12) },
-      { input: f32(kValue.powTwo.to13), expected: f32(kValue.powTwo.to13) },
-      { input: f32(kValue.powTwo.to14), expected: f32(kValue.powTwo.to14) },
-      { input: f32(kValue.powTwo.to15), expected: f32(kValue.powTwo.to15) },
-      { input: f32(kValue.powTwo.to16), expected: f32(kValue.powTwo.to16) },
-      { input: f32(kValue.powTwo.to17), expected: f32(kValue.powTwo.to17) },
-      { input: f32(kValue.powTwo.to18), expected: f32(kValue.powTwo.to18) },
-      { input: f32(kValue.powTwo.to19), expected: f32(kValue.powTwo.to19) },
-      { input: f32(kValue.powTwo.to20), expected: f32(kValue.powTwo.to20) },
-      { input: f32(kValue.powTwo.to21), expected: f32(kValue.powTwo.to21) },
-      { input: f32(kValue.powTwo.to22), expected: f32(kValue.powTwo.to22) },
-      { input: f32(kValue.powTwo.to23), expected: f32(kValue.powTwo.to23) },
-      { input: f32(kValue.powTwo.to24), expected: f32(kValue.powTwo.to24) },
-      { input: f32(kValue.powTwo.to25), expected: f32(kValue.powTwo.to25) },
-      { input: f32(kValue.powTwo.to26), expected: f32(kValue.powTwo.to26) },
-      { input: f32(kValue.powTwo.to27), expected: f32(kValue.powTwo.to27) },
-      { input: f32(kValue.powTwo.to28), expected: f32(kValue.powTwo.to28) },
-      { input: f32(kValue.powTwo.to29), expected: f32(kValue.powTwo.to29) },
-      { input: f32(kValue.powTwo.to30), expected: f32(kValue.powTwo.to30) },
-      { input: f32(kValue.powTwo.to31), expected: f32(kValue.powTwo.to31) },
-
-      // Powers of -2.0: -2.0^i: 1 <= i <= 31
-      { input: f32(kValue.negPowTwo.to1), expected: f32(kValue.negPowTwo.to1) },
-      { input: f32(kValue.negPowTwo.to2), expected: f32(kValue.negPowTwo.to2) },
-      { input: f32(kValue.negPowTwo.to3), expected: f32(kValue.negPowTwo.to3) },
-      { input: f32(kValue.negPowTwo.to4), expected: f32(kValue.negPowTwo.to4) },
-      { input: f32(kValue.negPowTwo.to5), expected: f32(kValue.negPowTwo.to5) },
-      { input: f32(kValue.negPowTwo.to6), expected: f32(kValue.negPowTwo.to6) },
-      { input: f32(kValue.negPowTwo.to7), expected: f32(kValue.negPowTwo.to7) },
-      { input: f32(kValue.negPowTwo.to8), expected: f32(kValue.negPowTwo.to8) },
-      { input: f32(kValue.negPowTwo.to9), expected: f32(kValue.negPowTwo.to9) },
-      { input: f32(kValue.negPowTwo.to10), expected: f32(kValue.negPowTwo.to10) },
-      { input: f32(kValue.negPowTwo.to11), expected: f32(kValue.negPowTwo.to11) },
-      { input: f32(kValue.negPowTwo.to12), expected: f32(kValue.negPowTwo.to12) },
-      { input: f32(kValue.negPowTwo.to13), expected: f32(kValue.negPowTwo.to13) },
-      { input: f32(kValue.negPowTwo.to14), expected: f32(kValue.negPowTwo.to14) },
-      { input: f32(kValue.negPowTwo.to15), expected: f32(kValue.negPowTwo.to15) },
-      { input: f32(kValue.negPowTwo.to16), expected: f32(kValue.negPowTwo.to16) },
-      { input: f32(kValue.negPowTwo.to17), expected: f32(kValue.negPowTwo.to17) },
-      { input: f32(kValue.negPowTwo.to18), expected: f32(kValue.negPowTwo.to18) },
-      { input: f32(kValue.negPowTwo.to19), expected: f32(kValue.negPowTwo.to19) },
-      { input: f32(kValue.negPowTwo.to20), expected: f32(kValue.negPowTwo.to20) },
-      { input: f32(kValue.negPowTwo.to21), expected: f32(kValue.negPowTwo.to21) },
-      { input: f32(kValue.negPowTwo.to22), expected: f32(kValue.negPowTwo.to22) },
-      { input: f32(kValue.negPowTwo.to23), expected: f32(kValue.negPowTwo.to23) },
-      { input: f32(kValue.negPowTwo.to24), expected: f32(kValue.negPowTwo.to24) },
-      { input: f32(kValue.negPowTwo.to25), expected: f32(kValue.negPowTwo.to25) },
-      { input: f32(kValue.negPowTwo.to26), expected: f32(kValue.negPowTwo.to26) },
-      { input: f32(kValue.negPowTwo.to27), expected: f32(kValue.negPowTwo.to27) },
-      { input: f32(kValue.negPowTwo.to28), expected: f32(kValue.negPowTwo.to28) },
-      { input: f32(kValue.negPowTwo.to29), expected: f32(kValue.negPowTwo.to29) },
-      { input: f32(kValue.negPowTwo.to30), expected: f32(kValue.negPowTwo.to30) },
-      { input: f32(kValue.negPowTwo.to31), expected: f32(kValue.negPowTwo.to31) },
-    ]);
+    run(t, builtin('ceil'), [TypeF32], TypeF32, cfg, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -5,9 +5,9 @@ Execution tests for the 'cos' builtin function
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { absThreshold } from '../../../../../util/compare.js';
-import { f32, TypeF32 } from '../../../../../util/conversion.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
 import { linearRange } from '../../../../../util/math.js';
-import { Case, Config, run } from '../../expression.js';
+import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -48,7 +48,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (x: number): Case => {
-      return { input: f32(x), expected: f32(Math.cos(x)) };
+      return makeUnaryF32Case(x, Math.cos);
     };
 
     // Spec defines accuracy on [-π, π]

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -7,7 +7,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
-import { fullF32Range } from '../../../../../util/math';
+import { fullF32Range } from '../../../../../util/math.js';
 import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -4,10 +4,11 @@ Execution tests for the 'floor' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedThreshold, anyOf } from '../../../../../util/compare.js';
-import { kBit, kValue } from '../../../../../util/constants.js';
+import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { fullF32Range } from '../../../../../util/math';
+import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -47,7 +48,11 @@ Returns the floor of e. Component-wise when T is a vector.
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
 
-    run(t, builtin('floor'), [TypeF32], TypeF32, cfg, [
+    const makeCase = (x: number): Case => {
+      return makeUnaryF32Case(x, Math.floor);
+    };
+
+    const cases: Array<Case> = [
       // Small positive numbers
       { input: f32(0.1), expected: f32(0.0) },
       { input: f32(0.9), expected: f32(0.0) },
@@ -67,77 +72,10 @@ Returns the floor of e. Component-wise when T is a vector.
       { input: f32Bits(kBit.f32.negative.min), expected: f32Bits(kBit.f32.negative.min) },
       { input: f32Bits(kBit.f32.positive.min), expected: f32(0.0) },
       { input: f32Bits(kBit.f32.positive.max), expected: f32Bits(kBit.f32.positive.max) },
+      ...fullF32Range().map(x => makeCase(x)),
+    ];
 
-      // Subnormal f32
-      { input: f32Bits(kBit.f32.subnormal.positive.max), expected: anyOf(f32(1.0), f32(0.0)) },
-      { input: f32Bits(kBit.f32.subnormal.positive.min), expected: anyOf(f32(1.0), f32(0.0)) },
-
-      // Powers of +2.0: 2.0^i: 1 <= i <= 31
-      { input: f32(kValue.powTwo.to1), expected: f32(kValue.powTwo.to1) },
-      { input: f32(kValue.powTwo.to2), expected: f32(kValue.powTwo.to2) },
-      { input: f32(kValue.powTwo.to3), expected: f32(kValue.powTwo.to3) },
-      { input: f32(kValue.powTwo.to4), expected: f32(kValue.powTwo.to4) },
-      { input: f32(kValue.powTwo.to5), expected: f32(kValue.powTwo.to5) },
-      { input: f32(kValue.powTwo.to6), expected: f32(kValue.powTwo.to6) },
-      { input: f32(kValue.powTwo.to7), expected: f32(kValue.powTwo.to7) },
-      { input: f32(kValue.powTwo.to8), expected: f32(kValue.powTwo.to8) },
-      { input: f32(kValue.powTwo.to9), expected: f32(kValue.powTwo.to9) },
-      { input: f32(kValue.powTwo.to10), expected: f32(kValue.powTwo.to10) },
-      { input: f32(kValue.powTwo.to11), expected: f32(kValue.powTwo.to11) },
-      { input: f32(kValue.powTwo.to12), expected: f32(kValue.powTwo.to12) },
-      { input: f32(kValue.powTwo.to13), expected: f32(kValue.powTwo.to13) },
-      { input: f32(kValue.powTwo.to14), expected: f32(kValue.powTwo.to14) },
-      { input: f32(kValue.powTwo.to15), expected: f32(kValue.powTwo.to15) },
-      { input: f32(kValue.powTwo.to16), expected: f32(kValue.powTwo.to16) },
-      { input: f32(kValue.powTwo.to17), expected: f32(kValue.powTwo.to17) },
-      { input: f32(kValue.powTwo.to18), expected: f32(kValue.powTwo.to18) },
-      { input: f32(kValue.powTwo.to19), expected: f32(kValue.powTwo.to19) },
-      { input: f32(kValue.powTwo.to20), expected: f32(kValue.powTwo.to20) },
-      { input: f32(kValue.powTwo.to21), expected: f32(kValue.powTwo.to21) },
-      { input: f32(kValue.powTwo.to22), expected: f32(kValue.powTwo.to22) },
-      { input: f32(kValue.powTwo.to23), expected: f32(kValue.powTwo.to23) },
-      { input: f32(kValue.powTwo.to24), expected: f32(kValue.powTwo.to24) },
-      { input: f32(kValue.powTwo.to25), expected: f32(kValue.powTwo.to25) },
-      { input: f32(kValue.powTwo.to26), expected: f32(kValue.powTwo.to26) },
-      { input: f32(kValue.powTwo.to27), expected: f32(kValue.powTwo.to27) },
-      { input: f32(kValue.powTwo.to28), expected: f32(kValue.powTwo.to28) },
-      { input: f32(kValue.powTwo.to29), expected: f32(kValue.powTwo.to29) },
-      { input: f32(kValue.powTwo.to30), expected: f32(kValue.powTwo.to30) },
-      { input: f32(kValue.powTwo.to31), expected: f32(kValue.powTwo.to31) },
-
-      // Powers of -2.0: -2.0^i: 1 <= i <= 31
-      { input: f32(kValue.negPowTwo.to1), expected: f32(kValue.negPowTwo.to1) },
-      { input: f32(kValue.negPowTwo.to2), expected: f32(kValue.negPowTwo.to2) },
-      { input: f32(kValue.negPowTwo.to3), expected: f32(kValue.negPowTwo.to3) },
-      { input: f32(kValue.negPowTwo.to4), expected: f32(kValue.negPowTwo.to4) },
-      { input: f32(kValue.negPowTwo.to5), expected: f32(kValue.negPowTwo.to5) },
-      { input: f32(kValue.negPowTwo.to6), expected: f32(kValue.negPowTwo.to6) },
-      { input: f32(kValue.negPowTwo.to7), expected: f32(kValue.negPowTwo.to7) },
-      { input: f32(kValue.negPowTwo.to8), expected: f32(kValue.negPowTwo.to8) },
-      { input: f32(kValue.negPowTwo.to9), expected: f32(kValue.negPowTwo.to9) },
-      { input: f32(kValue.negPowTwo.to10), expected: f32(kValue.negPowTwo.to10) },
-      { input: f32(kValue.negPowTwo.to11), expected: f32(kValue.negPowTwo.to11) },
-      { input: f32(kValue.negPowTwo.to12), expected: f32(kValue.negPowTwo.to12) },
-      { input: f32(kValue.negPowTwo.to13), expected: f32(kValue.negPowTwo.to13) },
-      { input: f32(kValue.negPowTwo.to14), expected: f32(kValue.negPowTwo.to14) },
-      { input: f32(kValue.negPowTwo.to15), expected: f32(kValue.negPowTwo.to15) },
-      { input: f32(kValue.negPowTwo.to16), expected: f32(kValue.negPowTwo.to16) },
-      { input: f32(kValue.negPowTwo.to17), expected: f32(kValue.negPowTwo.to17) },
-      { input: f32(kValue.negPowTwo.to18), expected: f32(kValue.negPowTwo.to18) },
-      { input: f32(kValue.negPowTwo.to19), expected: f32(kValue.negPowTwo.to19) },
-      { input: f32(kValue.negPowTwo.to20), expected: f32(kValue.negPowTwo.to20) },
-      { input: f32(kValue.negPowTwo.to21), expected: f32(kValue.negPowTwo.to21) },
-      { input: f32(kValue.negPowTwo.to22), expected: f32(kValue.negPowTwo.to22) },
-      { input: f32(kValue.negPowTwo.to23), expected: f32(kValue.negPowTwo.to23) },
-      { input: f32(kValue.negPowTwo.to24), expected: f32(kValue.negPowTwo.to24) },
-      { input: f32(kValue.negPowTwo.to25), expected: f32(kValue.negPowTwo.to25) },
-      { input: f32(kValue.negPowTwo.to26), expected: f32(kValue.negPowTwo.to26) },
-      { input: f32(kValue.negPowTwo.to27), expected: f32(kValue.negPowTwo.to27) },
-      { input: f32(kValue.negPowTwo.to28), expected: f32(kValue.negPowTwo.to28) },
-      { input: f32(kValue.negPowTwo.to29), expected: f32(kValue.negPowTwo.to29) },
-      { input: f32(kValue.negPowTwo.to30), expected: f32(kValue.negPowTwo.to30) },
-      { input: f32(kValue.negPowTwo.to31), expected: f32(kValue.negPowTwo.to31) },
-    ]);
+    run(t, builtin('floor'), [TypeF32], TypeF32, cfg, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -5,9 +5,9 @@ Execution tests for the 'fract' builtin function
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { correctlyRoundedThreshold, anyOf } from '../../../../../util/compare.js';
-import { kBit } from '../../../../../util/constants.js';
+import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -48,48 +48,57 @@ Component-wise when T is a vector.
   .fn(async t => {
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
-    // prettier-ignore
-    run(t, builtin('fract'), [TypeF32], TypeF32, cfg, [
+
+    const makeCase = (x: number): Case => {
+      const result = x - Math.floor(x);
+      if (result < 1.0) {
+        return makeUnaryF32Case(x, x => x - Math.floor(x));
+      }
+      // Very small negative numbers can lead to catastrophic cancellation, thus calculating a fract of 1.0, which is
+      // technically not a fractional part.
+      // Some platforms return the nearest number less than 1, and others 1.0.
+      // https://github.com/gpuweb/gpuweb/issues/2822 has been filed to clarify.
+      return { input: f32(x), expected: anyOf(f32(1.0), f32Bits(0x3f7f_ffff)) };
+    };
+
+    const cases: Array<Case> = [
       // Zeroes
       { input: f32Bits(kBit.f32.positive.zero), expected: f32(0) },
       { input: f32Bits(kBit.f32.negative.zero), expected: f32(0) },
 
       // Positive numbers
-      { input: f32Bits(0x3dcccccd), expected: f32Bits(0x3dcccccd) }, // ~0.1 -> ~0.1
-      { input: f32(0.5), expected: f32(0.5) }, // 0.5 -> 0.5
-      { input: f32Bits(0x3f666666), expected: f32Bits(0x3f666666) }, // ~0.9 -> ~0.9
-      { input: f32Bits(0x3f800000), expected: f32(0) }, // 1 -> 0
-      { input: f32Bits(0x40000000), expected: f32(0) }, // 2 -> 0
-      { input: f32Bits(0x3f8e147b), expected: f32Bits(0x3de147b0) }, // ~1.11 -> ~0.11
-      { input: f32Bits(0x41200069), expected: f32Bits(0x38d20000) }, // ~10.0001 -> ~0.0001
+      makeCase(0.1), // ~0.1 -> ~0.1
+      makeCase(0.5), // 0.5 -> 0.5
+      makeCase(0.9), // ~0.9 -> ~0.9
+      makeCase(1), // 1 -> 0
+      makeCase(2), // 2 -> 0
+      makeCase(1.11), // ~1.11 -> ~0.11
+      makeCase(10.0001), // ~10.0001 -> ~0.0001
 
       // Negative numbers
-      { input: f32Bits(0xbdcccccd), expected: f32Bits(0x3f666666) }, // ~-0.1 -> ~0.9
-      { input: f32(-0.5), expected: f32(0.5) }, // -0.5 -> 0.5
-      { input: f32Bits(0xbf666666), expected: f32Bits(0x3dccccd0) }, // ~-0.9 -> ~0.1
-      { input: f32Bits(0xbf800000), expected: f32(0) }, // -1 -> 0
-      { input: f32Bits(0xc0000000), expected: f32(0) }, // -2 -> 0
-      { input: f32Bits(0xbf8e147b), expected: f32Bits(0x3f63d70a) }, // ~-1.11 -> ~0.89
-      { input: f32Bits(0xc1200419), expected: f32Bits(0x3f7fbe70) }, // ~-10.0001 -> ~0.999
+      makeCase(-0.1), // ~-0.1 -> ~0.9
+      makeCase(-0.5), // -0.5 -> 0.5
+      makeCase(-0.9), // ~-0.9 -> ~0.1
+      makeCase(-1), // -1 -> 0
+      makeCase(-2), // -2 -> 0
+      makeCase(-1.11), // ~-1.11 -> ~0.89
+      makeCase(-10.0001), // -10.0001 -> ~0.9999
 
       // Min and Max f32
-      { input: f32Bits(kBit.f32.positive.min), expected: f32Bits(kBit.f32.positive.min) },
-      { input: f32Bits(kBit.f32.positive.max), expected: f32(0) },
-      // For negative numbers on the extremes, here and below, different backends disagree on if this should be 1
-      // exactly vs very close to 1. I think what is occurring is that if the calculation is internally done in f32,
-      // i.e. rounding/flushing each step, you end up with one value, but if all of the math is done in a higher
-      // precision, and then converted at the end, you end up with a different value.
-      { input: f32Bits(kBit.f32.negative.max), expected: anyOf(f32Bits(0x3f7fffff), f32(1)) },
-      { input: f32Bits(kBit.f32.negative.min), expected: f32(0) },
+      makeCase(kValue.f32.positive.min),
+      makeCase(kValue.f32.positive.max),
+      makeCase(kValue.f32.negative.max),
+      makeCase(kValue.f32.negative.min),
 
       // Subnormal f32
-      { input: f32Bits(kBit.f32.subnormal.positive.max), expected: anyOf(f32(0), f32Bits(kBit.f32.subnormal.positive.max)) },
-      { input: f32Bits(kBit.f32.subnormal.positive.min), expected: anyOf(f32(0), f32Bits(kBit.f32.subnormal.positive.min)) },
-      // Similar to above when these values are not immediately flushed to zero, how the back end internally calculates
-      // the value will dictate if the end value is 1 or very close to 1.
-      { input: f32Bits(kBit.f32.subnormal.negative.max), expected: anyOf(f32(0), f32Bits(0x3f7fffff), f32(1)) },
-      { input: f32Bits(kBit.f32.subnormal.negative.min), expected: anyOf(f32(0), f32Bits(0x3f7fffff), f32(1)) },
-    ]);
+      makeCase(kValue.f32.subnormal.positive.min),
+      makeCase(kValue.f32.subnormal.positive.max),
+      makeCase(kValue.f32.subnormal.negative.max),
+      makeCase(kValue.f32.subnormal.negative.min),
+    ];
+
+    // prettier-ignore
+    run(t, builtin('fract'), [TypeF32], TypeF32, cfg, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -6,9 +6,9 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { absThreshold, FloatMatch, ulpThreshold } from '../../../../../util/compare.js';
 import { kValue } from '../../../../../util/constants.js';
-import { f32, TypeF32 } from '../../../../../util/conversion.js';
-import { biasedRange, linearRange, quantizeToF32 } from '../../../../../util/math.js';
-import { Case, CaseList, Config, run } from '../../expression.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { biasedRange, linearRange } from '../../../../../util/math.js';
+import { Case, CaseList, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -51,8 +51,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (x: number): Case => {
-      const f32_x = quantizeToF32(x);
-      return { input: f32(x), expected: f32(Math.log(f32_x)) };
+      return makeUnaryF32Case(x, Math.log);
     };
 
     const runRange = (match: FloatMatch, cases: CaseList) => {

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -6,9 +6,9 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { absThreshold, FloatMatch, ulpThreshold } from '../../../../../util/compare.js';
 import { kValue } from '../../../../../util/constants.js';
-import { f32, TypeF32 } from '../../../../../util/conversion.js';
-import { biasedRange, linearRange, quantizeToF32 } from '../../../../../util/math.js';
-import { Case, CaseList, Config, run } from '../../expression.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { biasedRange, linearRange } from '../../../../../util/math.js';
+import { Case, CaseList, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -51,8 +51,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (x: number): Case => {
-      const f32_x = quantizeToF32(x);
-      return { input: f32(x), expected: f32(Math.log2(f32_x)) };
+      return makeUnaryF32Case(x, Math.log2);
     };
 
     const runRange = (match: FloatMatch, cases: CaseList) => {

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -4,40 +4,35 @@ Execution tests for the 'max' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { anyOf, correctlyRoundedThreshold } from '../../../../../util/compare.js';
-import { kBit } from '../../../../../util/constants.js';
+import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { kBit, kValue } from '../../../../../util/constants.js';
 import {
-  f32,
-  f32Bits,
   i32,
-  i32Bits,
-  Scalar,
   TypeF32,
   TypeI32,
   TypeU32,
   u32,
+  uint32ToFloat32,
 } from '../../../../../util/conversion.js';
-import { isSubnormalScalar } from '../../../../../util/math.js';
-import { Case, Config, run } from '../../expression.js';
+import { Case, Config, makeBinaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
-export const g = makeTestGroup(GPUTest);
-
-/** Generate set of max test cases from an ascending list of values */
-function generateTestCases(test_values: Array<Scalar>) {
+/** Generate set of max test cases from list of interesting values */
+function generateTestCases(
+  values: Array<number>,
+  makeCase: (x: number, y: number) => Case
+): Array<Case> {
   const cases = new Array<Case>();
-  test_values.forEach((e, ei) => {
-    test_values.forEach((f, fi) => {
-      const precise_expected = ei >= fi ? e : f;
-      const expected = isSubnormalScalar(precise_expected)
-        ? anyOf(precise_expected, f32(0.0))
-        : precise_expected;
-      cases.push({ input: [e, f], expected });
+  values.forEach(e => {
+    values.forEach(f => {
+      cases.push(makeCase(e, f));
     });
   });
   return cases;
 }
+
+export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
@@ -75,18 +70,14 @@ Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a v
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
 
-    // This array must be strictly increasing, since that ordering determines
-    // the expected values.
-    const test_values: Array<Scalar> = [
-      u32(0),
-      u32(1),
-      u32(2),
-      u32(0x70000000),
-      u32(0x80000000),
-      u32(0xffffffff),
-    ];
+    const makeCase = (x: number, y: number): Case => {
+      return { input: [u32(x), u32(y)], expected: u32(Math.max(x, y)) };
+    };
 
-    run(t, builtin('max'), [TypeU32, TypeU32], TypeU32, cfg, generateTestCases(test_values));
+    const test_values: Array<number> = [0, 1, 2, 0x70000000, 0x80000000, 0xffffffff];
+    const cases = generateTestCases(test_values, makeCase);
+
+    run(t, builtin('max'), [TypeU32, TypeU32], TypeU32, cfg, cases);
   });
 
 g.test('i32')
@@ -108,19 +99,14 @@ Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a v
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
 
-    // This array must be strictly increasing, since that ordering determines
-    // the expected values.
-    const test_values: Array<Scalar> = [
-      i32Bits(0x80000000),
-      i32(-2),
-      i32(-1),
-      i32(0),
-      i32(1),
-      i32(2),
-      i32Bits(0x70000000),
-    ];
+    const makeCase = (x: number, y: number): Case => {
+      return { input: [i32(x), i32(y)], expected: i32(Math.max(x, y)) };
+    };
 
-    run(t, builtin('max'), [TypeI32, TypeI32], TypeI32, cfg, generateTestCases(test_values));
+    const test_values: Array<number> = [-0x70000000, -2, -1, 0, 1, 2, 0x70000000];
+    const cases = generateTestCases(test_values, makeCase);
+
+    run(t, builtin('max'), [TypeI32, TypeI32], TypeI32, cfg, cases);
   });
 
 g.test('abstract_float')
@@ -163,27 +149,30 @@ Component-wise when T is a vector.
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
 
-    // This array must be strictly increasing, since that ordering determines
-    // the expected values.
-    const test_values: Array<Scalar> = [
-      f32Bits(kBit.f32.infinity.negative),
-      f32Bits(kBit.f32.negative.min),
-      f32(-10.0),
-      f32(-1.0),
-      f32Bits(kBit.f32.negative.max),
-      f32Bits(kBit.f32.subnormal.negative.min),
-      f32Bits(kBit.f32.subnormal.negative.max),
-      f32(0.0),
-      f32Bits(kBit.f32.subnormal.positive.min),
-      f32Bits(kBit.f32.subnormal.positive.max),
-      f32Bits(kBit.f32.positive.min),
-      f32(1.0),
-      f32(10.0),
-      f32Bits(kBit.f32.positive.max),
-      f32Bits(kBit.f32.infinity.positive),
-    ];
+    const makeCase = (x: number, y: number): Case => {
+      return makeBinaryF32Case(x, y, Math.max);
+    };
 
-    run(t, builtin('max'), [TypeF32, TypeF32], TypeF32, cfg, generateTestCases(test_values));
+    const test_values: Array<number> = [
+      uint32ToFloat32(kBit.f32.infinity.negative),
+      kValue.f32.negative.min,
+      -10.0,
+      -1.0,
+      kValue.f32.negative.max,
+      kValue.f32.subnormal.negative.min,
+      kValue.f32.subnormal.negative.max,
+      0.0,
+      kValue.f32.subnormal.positive.min,
+      kValue.f32.subnormal.positive.max,
+      kValue.f32.positive.min,
+      1.0,
+      10.0,
+      kValue.f32.positive.max,
+      uint32ToFloat32(kBit.f32.infinity.positive),
+    ];
+    const cases = generateTestCases(test_values, makeCase);
+
+    run(t, builtin('max'), [TypeF32, TypeF32], TypeF32, cfg, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -4,36 +4,31 @@ Execution tests for the 'min' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { anyOf, correctlyRoundedThreshold } from '../../../../../util/compare.js';
-import { kBit } from '../../../../../util/constants.js';
+import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { kBit, kValue } from '../../../../../util/constants.js';
 import {
-  f32,
-  f32Bits,
   i32,
-  i32Bits,
-  Scalar,
   TypeF32,
   TypeI32,
   TypeU32,
   u32,
+  uint32ToFloat32,
 } from '../../../../../util/conversion.js';
-import { isSubnormalScalar } from '../../../../../util/math.js';
-import { Case, Config, run } from '../../expression.js';
+import { Case, Config, makeBinaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
-/** Generate set of min test cases from an ascending list of values */
-function generateTestCases(test_values: Array<Scalar>): Array<Case> {
+/** Generate set of min test cases from list of interesting values */
+function generateTestCases(
+  values: Array<number>,
+  makeCase: (x: number, y: number) => Case
+): Array<Case> {
   const cases = new Array<Case>();
-  test_values.forEach((e, ei) => {
-    test_values.forEach((f, fi) => {
-      const precise_expected = ei <= fi ? e : f;
-      const expected = isSubnormalScalar(precise_expected)
-        ? anyOf(precise_expected, f32(0.0))
-        : precise_expected;
-      cases.push({ input: [e, f], expected });
+  values.forEach(e => {
+    values.forEach(f => {
+      cases.push(makeCase(e, f));
     });
   });
   return cases;
@@ -75,18 +70,14 @@ Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a v
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
 
-    // This array must be strictly increasing, since that ordering determines
-    // the expected values.
-    const test_values: Array<Scalar> = [
-      u32(0),
-      u32(1),
-      u32(2),
-      u32(0x70000000),
-      u32(0x80000000),
-      u32(0xffffffff),
-    ];
+    const makeCase = (x: number, y: number): Case => {
+      return { input: [u32(x), u32(y)], expected: u32(Math.min(x, y)) };
+    };
 
-    run(t, builtin('min'), [TypeU32, TypeU32], TypeU32, cfg, generateTestCases(test_values));
+    const test_values: Array<number> = [0, 1, 2, 0x70000000, 0x80000000, 0xffffffff];
+    const cases = generateTestCases(test_values, makeCase);
+
+    run(t, builtin('min'), [TypeU32, TypeU32], TypeU32, cfg, cases);
   });
 
 g.test('i32')
@@ -108,19 +99,14 @@ Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a v
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
 
-    // This array must be strictly increasing, since that ordering determines
-    // the expected values.
-    const test_values: Array<Scalar> = [
-      i32Bits(0x80000000),
-      i32(-2),
-      i32(-1),
-      i32(0),
-      i32(1),
-      i32(2),
-      i32Bits(0x70000000),
-    ];
+    const makeCase = (x: number, y: number): Case => {
+      return { input: [i32(x), i32(y)], expected: i32(Math.min(x, y)) };
+    };
 
-    run(t, builtin('min'), [TypeI32, TypeI32], TypeI32, cfg, generateTestCases(test_values));
+    const test_values: Array<number> = [-0x70000000, -2, -1, 0, 1, 2, 0x70000000];
+    const cases = generateTestCases(test_values, makeCase);
+
+    run(t, builtin('min'), [TypeI32, TypeI32], TypeI32, cfg, cases);
   });
 
 g.test('abstract_float')
@@ -163,27 +149,30 @@ Component-wise when T is a vector.
     const cfg: Config = t.params;
     cfg.cmpFloats = correctlyRoundedThreshold();
 
-    // This array must be strictly increasing, since that ordering determines
-    // the expected values.
-    const test_values: Array<Scalar> = [
-      f32Bits(kBit.f32.infinity.negative),
-      f32Bits(kBit.f32.negative.min),
-      f32(-10.0),
-      f32(-1.0),
-      f32Bits(kBit.f32.negative.max),
-      f32Bits(kBit.f32.subnormal.negative.min),
-      f32Bits(kBit.f32.subnormal.negative.max),
-      f32(0.0),
-      f32Bits(kBit.f32.subnormal.positive.min),
-      f32Bits(kBit.f32.subnormal.positive.max),
-      f32Bits(kBit.f32.positive.min),
-      f32(1.0),
-      f32(10.0),
-      f32Bits(kBit.f32.positive.max),
-      f32Bits(kBit.f32.infinity.positive),
-    ];
+    const makeCase = (x: number, y: number): Case => {
+      return makeBinaryF32Case(x, y, Math.min);
+    };
 
-    run(t, builtin('min'), [TypeF32, TypeF32], TypeF32, cfg, generateTestCases(test_values));
+    const test_values: Array<number> = [
+      uint32ToFloat32(kBit.f32.infinity.negative),
+      kValue.f32.negative.min,
+      -10.0,
+      -1.0,
+      kValue.f32.negative.max,
+      kValue.f32.subnormal.negative.min,
+      kValue.f32.subnormal.negative.max,
+      0.0,
+      kValue.f32.subnormal.positive.min,
+      kValue.f32.subnormal.positive.max,
+      kValue.f32.positive.min,
+      1.0,
+      10.0,
+      kValue.f32.positive.max,
+      uint32ToFloat32(kBit.f32.infinity.positive),
+    ];
+    const cases = generateTestCases(test_values, makeCase);
+
+    run(t, builtin('min'), [TypeF32, TypeF32], TypeF32, cfg, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -5,9 +5,9 @@ Execution tests for the 'sin' builtin function
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { absThreshold } from '../../../../../util/compare.js';
-import { f32, TypeF32 } from '../../../../../util/conversion.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
 import { linearRange } from '../../../../../util/math.js';
-import { Case, Config, run } from '../../expression.js';
+import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -48,7 +48,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (x: number): Case => {
-      return { input: f32(x), expected: f32(Math.sin(x)) };
+      return makeUnaryF32Case(x, Math.sin);
     };
 
     // Spec defines accuracy on [-π, π]

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -1,5 +1,5 @@
 import { GPUTest } from '../../../gpu_test.js';
-import { compare, Comparator, FloatMatch } from '../../../util/compare.js';
+import { compare, Comparator, FloatMatch, anyOf } from '../../../util/compare.js';
 import {
   ScalarType,
   Scalar,
@@ -9,7 +9,9 @@ import {
   Value,
   Vector,
   VectorType,
+  f32,
 } from '../../../util/conversion.js';
+import { flushSubnormalNumber, isSubnormalNumber, quantizeToF32 } from '../../../util/math.js';
 
 // Helper for converting Values to Comparators.
 function toComparator(input: Value | Comparator): Comparator {
@@ -373,4 +375,61 @@ function packScalarsToVector(
     parameterTypes: packedParameterTypes,
     returnType: packedReturnType,
   };
+}
+
+/** @returns a set of flushed and non-flushed f32 results for a given number. */
+function calculateFlushedResults(value: number): Set<Scalar> {
+  return new Set([f32(value), f32(flushSubnormalNumber(value))]);
+}
+
+/**
+ * Generates a Case for the param and unary op provide.
+ * The Case will use either exact matching or the test level Comparator.
+ * @param param the parameter to pass into the operation
+ * @param op callback that implements the truth function for the unary operation
+ */
+export function makeUnaryF32Case(param: number, op: (p: number) => number): Case {
+  const f32_param = quantizeToF32(param);
+  const expected = calculateFlushedResults(op(f32_param));
+  return { input: [f32(param)], expected: anyOf(...expected) };
+}
+
+/**
+ * Generates a Case for the params and binary op provide.
+ * The Case will use either exact matching or the test level Comparator.
+ * @param param0 the first param or left hand side to pass into the binary operation
+ * @param param1 the second param or rhs hand side to pass into the binary operation
+ * @param op callback that implements the truth function for the binary operation
+ * @param skip_param1_zero_flush should the builder skip cases where the param1 would be flushed to 0,
+ *                               this is to avoid performing division by 0, other invalid operations.
+ *                               The caller is responsible for making sure the initial param1 isn't 0.
+ */
+export function makeBinaryF32Case(
+  param0: number,
+  param1: number,
+  op: (p0: number, p1: number) => number,
+  skip_param1_zero_flush: boolean = false
+): Case {
+  const f32_param0 = quantizeToF32(param0);
+  const f32_param1 = quantizeToF32(param1);
+  const is_param0_subnormal = isSubnormalNumber(f32_param0);
+  const is_param1_subnormal = isSubnormalNumber(f32_param1);
+  const expected = calculateFlushedResults(op(f32_param0, f32_param1));
+  if (is_param0_subnormal) {
+    calculateFlushedResults(op(0, f32_param1)).forEach(value => {
+      expected.add(value);
+    });
+  }
+  if (!skip_param1_zero_flush && is_param1_subnormal) {
+    calculateFlushedResults(op(f32_param0, 0)).forEach(value => {
+      expected.add(value);
+    });
+  }
+  if (!skip_param1_zero_flush && is_param0_subnormal && is_param1_subnormal) {
+    calculateFlushedResults(op(0, 0)).forEach(value => {
+      expected.add(value);
+    });
+  }
+
+  return { input: [f32(param0), f32(param1)], expected: anyOf(...expected) };
 }

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -4,10 +4,10 @@ Execution Tests for the f32 arithmetic unary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { anyOf, correctlyRoundedThreshold } from '../../../../util/compare.js';
-import { f32, TypeF32 } from '../../../../util/conversion.js';
-import { fullF32Range, isSubnormalNumber, quantizeToF32 } from '../../../../util/math.js';
-import { Case, Config, run } from '../expression.js';
+import { correctlyRoundedThreshold } from '../../../../util/compare.js';
+import { TypeF32 } from '../../../../util/conversion.js';
+import { fullF32Range } from '../../../../util/math.js';
+import { Case, Config, makeUnaryF32Case, run } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -31,12 +31,9 @@ Accuracy: Correctly rounded
     cfg.cmpFloats = correctlyRoundedThreshold();
 
     const makeCase = (x: number): Case => {
-      const f32_x = quantizeToF32(x);
-      if (isSubnormalNumber(f32_x)) {
-        return { input: [f32(x)], expected: anyOf(f32(-f32_x), f32(0.0)) };
-      } else {
-        return { input: [f32(x)], expected: f32(-f32_x) };
-      }
+      return makeUnaryF32Case(x, (p: number): number => {
+        return -p;
+      });
     };
 
     const cases = fullF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }).map(x =>


### PR DESCRIPTION
Refactors the case generation code for f32 arithmetic test cases into
a common area and rewrites existing tests to use this new
functionality.

This adds consistent handling of things like flushed
inputs for all tests, instead of playing whack-a-mole as bugs are
discovered.

Fixes #1341

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
