### PR TITLE
Allow eventualExpectOk to accept Promise.all

### DIFF
--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -240,10 +240,7 @@ g.test('color,attachments')
         }
       );
     });
-    const results = await Promise.all(promises);
-    for (let i = 0; i < results.length; i++) {
-      t.expectOK(results[i]);
-    }
+    t.eventualExpectOK(Promise.all(promises));
   });
 
 g.test('color,component_count')


### PR DESCRIPTION
Followup of #1344

This should avoid awaiting on each expectations when we have multiple parallel ones.