### PR TITLE
wgsl: Add support for f64 to Scalar

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -4,7 +4,7 @@ Execution Tests for the f32 arithmetic binary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { correctlyRoundedThreshold, ulpThreshold } from '../../../../util/compare.js';
+import { correctlyRoundedMatch, ulpMatch } from '../../../../util/compare.js';
 import { TypeF32 } from '../../../../util/conversion.js';
 import { biasedRange, fullF32Range } from '../../../../util/math.js';
 import { Case, Config, makeBinaryF32Case, run } from '../expression.js';
@@ -28,7 +28,7 @@ Accuracy: Correctly rounded
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (lhs: number, rhs: number): Case => {
       return makeBinaryF32Case(lhs, rhs, (l: number, r: number): number => {
@@ -62,7 +62,7 @@ Accuracy: Correctly rounded
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (lhs: number, rhs: number): Case => {
       return makeBinaryF32Case(lhs, rhs, (l: number, r: number): number => {
@@ -96,7 +96,7 @@ Accuracy: Correctly rounded
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (lhs: number, rhs: number): Case => {
       return makeBinaryF32Case(lhs, rhs, (l: number, r: number): number => {
@@ -130,7 +130,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = ulpThreshold(2.5);
+    cfg.cmpFloats = ulpMatch(2.5);
 
     const makeCase = (lhs: number, rhs: number): Case => {
       return makeBinaryF32Case(

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'abs' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import {
   f32Bits,
@@ -117,7 +117,7 @@ result is e. If e is an unsigned integral type, then the result is e.
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     run(t, builtin('abs'), [TypeI32], TypeI32, cfg, [
       // Min and max i32
@@ -196,7 +196,7 @@ Component-wise when T is a vector.
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number): Case => {
       return makeUnaryF32Case(x, Math.abs);

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'atan' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ulpThreshold } from '../../../../../util/compare.js';
+import { ulpMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { fullF32Range } from '../../../../../util/math.js';
@@ -81,7 +81,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     ];
 
     const cfg: Config = t.params;
-    cfg.cmpFloats = ulpThreshold(4096);
+    cfg.cmpFloats = ulpMatch(4096);
     run(t, builtin('atan'), [TypeF32], TypeF32, cfg, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'atan2' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ulpThreshold } from '../../../../../util/compare.js';
+import { ulpMatch } from '../../../../../util/compare.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { flushSubnormalNumber, fullF32Range } from '../../../../../util/math.js';
 import { Case, Config, makeBinaryF32Case, run } from '../../expression.js';
@@ -51,7 +51,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = ulpThreshold(4096);
+    cfg.cmpFloats = ulpMatch(4096);
 
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (y: number, x: number): Case => {

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'ceil' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { fullF32Range } from '../../../../../util/math.js';
@@ -46,7 +46,7 @@ Returns the ceiling of e. Component-wise when T is a vector.
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number): Case => {
       return makeUnaryF32Case(x, Math.ceil);

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'clamp' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { anyOf, correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { anyOf, correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import {
   f32,
@@ -233,7 +233,7 @@ Component-wise when T is a vector.
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     // This array must be strictly increasing, since that ordering determines
     // the expected values.

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'cos' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { absThreshold } from '../../../../../util/compare.js';
+import { absMatch } from '../../../../../util/compare.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { linearRange } from '../../../../../util/math.js';
 import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
@@ -55,7 +55,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     const cases = linearRange(-Math.PI, Math.PI, 1000).map(x => makeCase(x));
 
     const cfg: Config = t.params;
-    cfg.cmpFloats = absThreshold(2 ** -11);
+    cfg.cmpFloats = absMatch(2 ** -11);
     run(t, builtin('cos'), [TypeF32], TypeF32, cfg, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'exp' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ulpCmp } from '../../../../../util/compare.js';
+import { ulpComparator } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange } from '../../../../../util/math.js';
@@ -51,7 +51,7 @@ Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a
 
     const makeCase = (x: number): Case => {
       const expected = f32(Math.exp(x));
-      return { input: f32(x), expected: ulpCmp(x, expected, n) };
+      return { input: f32(x), expected: ulpComparator(x, expected, n) };
     };
 
     // floor(ln(max f32 value)) = 88, so exp(88) will be within range of a f32, but exp(89) will not

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'exp2' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ulpCmp } from '../../../../../util/compare.js';
+import { ulpComparator } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange } from '../../../../../util/math.js';
@@ -51,7 +51,7 @@ Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
 
     const makeCase = (x: number): Case => {
       const expected = f32(Math.pow(2, x));
-      return { input: f32(x), expected: ulpCmp(x, expected, n) };
+      return { input: f32(x), expected: ulpComparator(x, expected, n) };
     };
 
     // floor(log2(max f32 value)) = 127, so exp2(127) will be within range of a f32, but exp2(128) will not

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'floor' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { fullF32Range } from '../../../../../util/math.js';
@@ -46,7 +46,7 @@ Returns the floor of e. Component-wise when T is a vector.
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number): Case => {
       return makeUnaryF32Case(x, Math.floor);

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'fract' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedThreshold, anyOf } from '../../../../../util/compare.js';
+import { correctlyRoundedMatch, anyOf } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
@@ -47,7 +47,7 @@ Component-wise when T is a vector.
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number): Case => {
       const result = x - Math.floor(x);

--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'inverseSqrt' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ulpThreshold } from '../../../../../util/compare.js';
+import { ulpMatch } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
@@ -61,7 +61,7 @@ Returns the reciprocal of sqrt(e). Component-wise when T is a vector.
     ];
 
     const cfg: Config = t.params;
-    cfg.cmpFloats = ulpThreshold(2);
+    cfg.cmpFloats = ulpMatch(2);
     run(t, builtin('inverseSqrt'), [TypeF32], TypeF32, cfg, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'ldexp' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kValue } from '../../../../../util/constants.js';
 import { f32, i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
 import { biasedRange, linearRange, quantizeToI32 } from '../../../../../util/math.js';
@@ -91,7 +91,7 @@ Returns e1 * 2^e2. Component-wise when T is a vector.
       });
     });
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
     run(t, builtin('ldexp'), [TypeF32, TypeI32], TypeF32, cfg, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'log' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { absThreshold, FloatMatch, ulpThreshold } from '../../../../../util/compare.js';
+import { absMatch, FloatMatch, ulpMatch } from '../../../../../util/compare.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
@@ -64,19 +64,19 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     switch (t.params.range) {
       case 'low': // [0, 0.5)
         runRange(
-          ulpThreshold(3),
+          ulpMatch(3),
           linearRange(kValue.f32.positive.min, 0.5, 20).map(x => makeCase(x))
         );
         break;
       case 'mid': // [0.5, 2.0]
         runRange(
-          absThreshold(2 ** -21),
+          absMatch(2 ** -21),
           linearRange(0.5, 2.0, 20).map(x => makeCase(x))
         );
         break;
       case 'high': // (2.0, +∞]
         runRange(
-          ulpThreshold(3),
+          ulpMatch(3),
           biasedRange(2.0, 2 ** 32, 1000).map(x => makeCase(x))
         );
         break;

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'log2' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { absThreshold, FloatMatch, ulpThreshold } from '../../../../../util/compare.js';
+import { absMatch, FloatMatch, ulpMatch } from '../../../../../util/compare.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
@@ -64,19 +64,19 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     switch (t.params.range) {
       case 'low': // [0, 0.5)
         runRange(
-          ulpThreshold(3),
+          ulpMatch(3),
           linearRange(kValue.f32.positive.min, 0.5, 20).map(x => makeCase(x))
         );
         break;
       case 'mid': // [0.5, 2.0]
         runRange(
-          absThreshold(2 ** -21),
+          absMatch(2 ** -21),
           linearRange(0.5, 2.0, 20).map(x => makeCase(x))
         );
         break;
       case 'high': // (2.0, +∞]
         runRange(
-          ulpThreshold(3),
+          ulpMatch(3),
           biasedRange(2.0, 2 ** 32, 1000).map(x => makeCase(x))
         );
         break;

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'max' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import {
   i32,
@@ -68,7 +68,7 @@ Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a v
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number, y: number): Case => {
       return { input: [u32(x), u32(y)], expected: u32(Math.max(x, y)) };
@@ -97,7 +97,7 @@ Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a v
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number, y: number): Case => {
       return { input: [i32(x), i32(y)], expected: i32(Math.max(x, y)) };
@@ -147,7 +147,7 @@ Component-wise when T is a vector.
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number, y: number): Case => {
       return makeBinaryF32Case(x, y, Math.max);

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'min' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedThreshold } from '../../../../../util/compare.js';
+import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import {
   i32,
@@ -68,7 +68,7 @@ Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a v
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number, y: number): Case => {
       return { input: [u32(x), u32(y)], expected: u32(Math.min(x, y)) };
@@ -97,7 +97,7 @@ Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a v
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number, y: number): Case => {
       return { input: [i32(x), i32(y)], expected: i32(Math.min(x, y)) };
@@ -147,7 +147,7 @@ Component-wise when T is a vector.
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number, y: number): Case => {
       return makeBinaryF32Case(x, y, Math.min);

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -4,7 +4,7 @@ Execution tests for the 'sin' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { absThreshold } from '../../../../../util/compare.js';
+import { absMatch } from '../../../../../util/compare.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { linearRange } from '../../../../../util/math.js';
 import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
@@ -55,7 +55,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     const cases = linearRange(-Math.PI, Math.PI, 1000).map(x => makeCase(x));
 
     const cfg: Config = t.params;
-    cfg.cmpFloats = absThreshold(2 ** -11);
+    cfg.cmpFloats = absMatch(2 ** -11);
     run(t, builtin('sin'), [TypeF32], TypeF32, cfg, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -10,6 +10,7 @@ import {
   Vector,
   VectorType,
   f32,
+  f64,
 } from '../../../util/conversion.js';
 import { flushSubnormalNumber, isSubnormalNumber, quantizeToF32 } from '../../../util/math.js';
 
@@ -377,9 +378,9 @@ function packScalarsToVector(
   };
 }
 
-/** @returns a set of flushed and non-flushed f32 results for a given number. */
+/** @returns a set of flushed and non-flushed floating point results for a given number. */
 function calculateFlushedResults(value: number): Set<Scalar> {
-  return new Set([f32(value), f32(flushSubnormalNumber(value))]);
+  return new Set([f64(value), f64(flushSubnormalNumber(value))]);
 }
 
 /**

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -4,7 +4,7 @@ Execution Tests for the f32 arithmetic unary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { correctlyRoundedThreshold } from '../../../../util/compare.js';
+import { correctlyRoundedMatch } from '../../../../util/compare.js';
 import { TypeF32 } from '../../../../util/conversion.js';
 import { fullF32Range } from '../../../../util/math.js';
 import { Case, Config, makeUnaryF32Case, run } from '../expression.js';
@@ -28,7 +28,7 @@ Accuracy: Correctly rounded
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedThreshold();
+    cfg.cmpFloats = correctlyRoundedMatch();
 
     const makeCase = (x: number): Case => {
       return makeUnaryF32Case(x, (p: number): number => {

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -72,14 +72,13 @@ export function compare(got: Value, expected: Value, cmpFloats: FloatMatch): Com
     // Check types
     const gTy = got.type;
     const eTy = expected.type;
-    if (gTy !== eTy) {
-      if (!isFloatValue(got) || !isFloatValue(expected)) {
-        return {
-          matched: false,
-          got: `${Colors.red(gTy.toString())}(${got})`,
-          expected: `${Colors.red(eTy.toString())}(${expected})`,
-        };
-      }
+    const bothFloatTypes = isFloatValue(got) && isFloatValue(expected);
+    if (gTy !== eTy && !bothFloatTypes) {
+      return {
+        matched: false,
+        got: `${Colors.red(gTy.toString())}(${got})`,
+        expected: `${Colors.red(eTy.toString())}(${expected})`,
+      };
     }
   }
 

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -1,6 +1,6 @@
 import { Colors } from '../../common/util/colors.js';
 
-import { f32, Scalar, Value, Vector } from './conversion.js';
+import { f32, isFloatValue, Scalar, Value, Vector } from './conversion.js';
 import { correctlyRounded, oneULP, withinULP } from './math.js';
 
 /** Comparison describes the result of a Comparator function. */
@@ -24,7 +24,7 @@ export interface Comparator {
  * @returns a FloatMatch that returns true iff the two numbers are equal to, or
  * less than the specified absolute error threshold.
  */
-export function absThreshold(diff: number): FloatMatch {
+export function absMatch(diff: number): FloatMatch {
   return (got, expected) => {
     if (got === expected) {
       return true;
@@ -40,7 +40,7 @@ export function absThreshold(diff: number): FloatMatch {
  * @returns a FloatMatch that returns true iff the two numbers are within or
  * equal to the specified ULP threshold value.
  */
-export function ulpThreshold(ulp: number): FloatMatch {
+export function ulpMatch(ulp: number): FloatMatch {
   return (got, expected) => {
     if (got === expected) {
       return true;
@@ -54,7 +54,7 @@ export function ulpThreshold(ulp: number): FloatMatch {
  * to |got|.
  * |got| must be expressible as a float32.
  */
-export function correctlyRoundedThreshold(): FloatMatch {
+export function correctlyRoundedMatch(): FloatMatch {
   return (got, expected) => {
     return correctlyRounded(f32(got), expected);
   };
@@ -73,18 +73,20 @@ export function compare(got: Value, expected: Value, cmpFloats: FloatMatch): Com
     const gTy = got.type;
     const eTy = expected.type;
     if (gTy !== eTy) {
-      return {
-        matched: false,
-        got: `${Colors.red(gTy.toString())}(${got})`,
-        expected: `${Colors.red(eTy.toString())}(${expected})`,
-      };
+      if (!isFloatValue(got) || !isFloatValue(expected)) {
+        return {
+          matched: false,
+          got: `${Colors.red(gTy.toString())}(${got})`,
+          expected: `${Colors.red(eTy.toString())}(${expected})`,
+        };
+      }
     }
   }
 
   if (got instanceof Scalar) {
     const g = got;
     const e = expected as Scalar;
-    const isFloat = g.type.kind === 'f32';
+    const isFloat = g.type.kind === 'f64' || g.type.kind === 'f32' || g.type.kind === 'f16';
     const matched =
       (isFloat && cmpFloats(g.value as number, e.value as number)) ||
       (!isFloat && g.value === e.value);
@@ -147,11 +149,11 @@ export function anyOf(...values: Value[]): Comparator {
  * N is n(x), where x is the input into the function under test, not the result of the function.
  * For a function f(x) = X that is being tested, the acceptance interval is defined as within X +/- n(x) * ulp(X).
  */
-export function ulpCmp(x: number, target: Scalar, n: (x: number) => number): Comparator {
+export function ulpComparator(x: number, target: Scalar, n: (x: number) => number): Comparator {
   const c = n(x);
-  const ulpMatch = ulpThreshold(c);
+  const match = ulpMatch(c);
   return (got, _) => {
-    const cmp = compare(got, target, ulpMatch);
+    const cmp = compare(got, target, match);
     if (cmp.matched) {
       return cmp;
     }

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -314,7 +314,17 @@ export function uint32ToInt32(u32: number): number {
 }
 
 /** A type of number representable by Scalar. */
-export type ScalarKind = 'f32' | 'f16' | 'u32' | 'u16' | 'u8' | 'i32' | 'i16' | 'i8' | 'bool';
+export type ScalarKind =
+  | 'f64'
+  | 'f32'
+  | 'f16'
+  | 'u32'
+  | 'u16'
+  | 'u8'
+  | 'i32'
+  | 'i16'
+  | 'i8'
+  | 'bool';
 
 /** ScalarType describes the type of WGSL Scalar. */
 export class ScalarType {
@@ -384,6 +394,9 @@ export const TypeI32 = new ScalarType('i32', 4, (buf: Uint8Array, offset: number
 export const TypeU32 = new ScalarType('u32', 4, (buf: Uint8Array, offset: number) =>
   u32(new Uint32Array(buf.buffer, offset)[0])
 );
+export const TypeF64 = new ScalarType('f64', 8, (buf: Uint8Array, offset: number) =>
+  f32(new Float64Array(buf.buffer, offset)[0])
+);
 export const TypeF32 = new ScalarType('f32', 4, (buf: Uint8Array, offset: number) =>
   f32(new Float32Array(buf.buffer, offset)[0])
 );
@@ -409,6 +422,8 @@ export const TypeBool = new ScalarType('bool', 4, (buf: Uint8Array, offset: numb
 /** @returns the ScalarType from the ScalarKind */
 export function scalarType(kind: ScalarKind): ScalarType {
   switch (kind) {
+    case 'f64':
+      return TypeF64;
     case 'f32':
       return TypeF32;
     case 'f16':
@@ -493,6 +508,11 @@ export class Scalar {
   }
 }
 
+/** Create an f64 from a numeric value, a JS `number`. */
+export function f64(value: number): Scalar {
+  const arr = new Float32Array([value]);
+  return new Scalar(TypeF64, arr[0], arr);
+}
 /** Create an f32 from a numeric value, a JS `number`. */
 export function f32(value: number): Scalar {
   const arr = new Float32Array([value]);
@@ -666,3 +686,12 @@ export function vec4(x: Scalar, y: Scalar, z: Scalar, w: Scalar) {
 
 /** Value is a Scalar or Vector value. */
 export type Value = Scalar | Vector;
+
+/** @returns if the Value is a float scalar type */
+export function isFloatValue(v: Value): boolean {
+  if (v instanceof Scalar) {
+    const s = v as Scalar;
+    return s.type.kind === s.type.kind || s.type.kind === 'f32' || s.type.kind === 'f16';
+  }
+  return false;
+}


### PR DESCRIPTION
This is needed so that test expectation can be specified in a higher
precision than what WGSL is operating on (64-bits for 32-bits). This
allows for fluent specification of test conditions like correctly
rounded, instead of having to implement a per case Comparator.

This PR also renames some of the related helpers with similar names so
it is clearer what they return.

Fixes #1332

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
