### PR TITLE
Explicitly specify 2d texture views in some cases

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -96,12 +96,14 @@ g.test('subresources,color_attachments')
     });
 
     const colorAttachment1 = t.getColorAttachment(texture, {
+      dimension: '2d',
       baseArrayLayer: layer0,
       arrayLayerCount: 1,
       baseMipLevel: level0,
       mipLevelCount: 1,
     });
     const colorAttachment2 = t.getColorAttachment(texture, {
+      dimension: '2d',
       baseArrayLayer: layer1,
       baseMipLevel: level1,
       mipLevelCount: 1,
@@ -185,6 +187,7 @@ g.test('subresources,color_attachment_and_bind_group')
     const bindGroup = t.createBindGroupForTest(bindGroupView, bgUsage, 'float');
 
     const colorAttachment = t.getColorAttachment(texture, {
+      dimension: '2d',
       baseArrayLayer: colorAttachmentLayer,
       arrayLayerCount: 1,
       baseMipLevel: colorAttachmentLevel,
@@ -292,6 +295,7 @@ g.test('subresources,depth_stencil_attachment_and_bind_group')
     const bindGroup = t.createBindGroupForTest(bindGroupView, 'texture', sampleType);
 
     const attachmentView = texture.createView({
+      dimension: '2d',
       baseArrayLayer: dsLayer,
       arrayLayerCount: 1,
       baseMipLevel: dsLevel,


### PR DESCRIPTION
This allows these tests to pass once the texture view creation
defaults are updated. Also backwards compatible with the old view
creation logic.

Algorithm changed in https://github.com/gpuweb/gpuweb/pull/2755

I *think* this is the last update needed in order for https://dawn-review.googlesource.com/c/dawn/+/87306 to land.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
