### PR TITLE
[wgs] sync modf text with spec update.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -13,7 +13,9 @@ g.test('scalar_f32')
     `
 T is f32
 @const fn modf(e:T) -> __modf_result
-Splits e into fractional and whole number parts. Returns the __modf_result built-in structure, defined as follows:
+Splits |e| into fractional and whole number parts.
+The whole part is (|e| % 1.0), and the fractional part is |e| minus the whole part.
+Returns the __modf_result built-in structure, defined as follows:
 struct __modf_result {
   fract : f32, // fractional part
   whole : f32  // whole part
@@ -29,7 +31,9 @@ g.test('scalar_f16')
     `
 T is f16
 @const fn modf(e:T) -> __modf_result_f16
-Splits e into fractional and whole number parts. Returns the __modf_result_f16 built-in structure, defined as if as follows:
+Splits |e| into fractional and whole number parts.
+The whole part is (|e| % 1.0), and the fractional part is |e| minus the whole part.
+Returns the __modf_result_f16 built-in structure, defined as if as follows:
 struct __modf_result_f16 {
   fract : f16, // fractional part
   whole : f16  // whole part
@@ -45,7 +49,9 @@ g.test('vector_f32')
     `
 T is vecN<f32>
 @const fn modf(e:T) -> __modf_result_vecN
-Splits the components of e into fractional and whole number parts. Returns the __modf_result_vecN built-in structure, defined as follows:
+Splits the components of |e| into fractional and whole number parts.
+The |i|'th component of the whole and fractional parts equal the whole and fractional parts of modf(e[i]).
+Returns the __modf_result_vecN built-in structure, defined as follows:
 struct __modf_result_vecN {
   fract : vecN<f32>, // fractional part
   whole : vecN<f32>  // whole part
@@ -65,7 +71,9 @@ g.test('vector_f16')
     `
 T is vecN<f16>
 @const fn modf(e:T) -> __modf_result_vecN_f16
-Splits the components of e into fractional and whole number parts. Returns the __modf_result_vecN_f16 built-in structure, defined as if as follows:
+Splits the components of |e| into fractional and whole number parts.
+The |i|'th component of the whole and fractional parts equal the whole and fractional parts of modf(e[i]).
+Returns the __modf_result_vecN_f16 built-in structure, defined as if as follows:
 struct __modf_result_vecN_f16 {
   fract : vecN<f16>, // fractional part
   whole : vecN<f16>  // whole part


### PR DESCRIPTION
This PR syncs the text of the `modf` spec with the spec text.

Issue: https://github.com/gpuweb/gpuweb/issues/2468




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
