### PR TITLE
[wgsl] Add missing @const decorations.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -204,7 +204,7 @@ g.test('abstract_float')
   .desc(
     `
 T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-clamp(e: T , low: T , high: T) -> T
+@const clamp(e: T , low: T , high: T) -> T
 Returns either min(max(e,low),high), or the median of the three values e, low, high.
 Component-wise when T is a vector.
 `
@@ -221,7 +221,7 @@ g.test('f32')
   .desc(
     `
 T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-clamp(e: T , low: T , high: T) -> T
+@const clamp(e: T , low: T , high: T) -> T
 Returns either min(max(e,low),high), or the median of the three values e, low, high.
 Component-wise when T is a vector.
 `
@@ -270,7 +270,7 @@ g.test('f16')
   .desc(
     `
 T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-clamp(e: T , low: T , high: T) -> T
+@const clamp(e: T , low: T , high: T) -> T
 Returns either min(max(e,low),high), or the median of the three values e, low, high.
 Component-wise when T is a vector.
 `

--- a/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
@@ -12,7 +12,7 @@ g.test('abstract_float')
   .desc(
     `
 T is AbstractFloat, f32, or f16
-determinant(e: matCxC<T> ) -> T
+@const determinant(e: matCxC<T> ) -> T
 Returns the determinant of e.
 `
   )
@@ -28,7 +28,7 @@ g.test('f32')
   .desc(
     `
 T is AbstractFloat, f32, or f16
-determinant(e: matCxC<T> ) -> T
+@const determinant(e: matCxC<T> ) -> T
 Returns the determinant of e.
 `
   )
@@ -44,7 +44,7 @@ g.test('f16')
   .desc(
     `
 T is AbstractFloat, f32, or f16
-determinant(e: matCxC<T> ) -> T
+@const determinant(e: matCxC<T> ) -> T
 Returns the determinant of e.
 `
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
@@ -12,7 +12,7 @@ g.test('abstract_float')
   .desc(
     `
 T is AbstractFloat, f32, or f16
-transpose(e: matRxC<T> ) -> matCxR<T>
+@const transpose(e: matRxC<T> ) -> matCxR<T>
 Returns the transpose of e.
 `
   )
@@ -29,7 +29,7 @@ g.test('f32')
   .desc(
     `
 T is AbstractFloat, f32, or f16
-transpose(e: matRxC<T> ) -> matCxR<T>
+@const transpose(e: matRxC<T> ) -> matCxR<T>
 Returns the transpose of e.
 `
   )
@@ -46,7 +46,7 @@ g.test('f16')
   .desc(
     `
 T is AbstractFloat, f32, or f16
-transpose(e: matRxC<T> ) -> matCxR<T>
+@const transpose(e: matRxC<T> ) -> matCxR<T>
 Returns the transpose of e.
 `
   )


### PR DESCRIPTION
This PR syncs the CTS text to the spec text for the new @const decorations.

Issue: https://github.com/gpuweb/gpuweb/issues/2787

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
