### PR TITLE
Fix skipping tests when device isn't available

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -32,9 +32,20 @@ export class SubcaseBatchState {
     return this._params;
   }
 
-  /** @internal MAINTENANCE_TODO: Make this not visible to test code? */
+  /**
+   * Runs before the `.before()` function.
+   * @internal MAINTENANCE_TODO: Make this not visible to test code?
+   */
   async init() {}
-  /** @internal MAINTENANCE_TODO: Make this not visible to test code? */
+  /**
+   * Runs between the `.before()` function and the subcases.
+   * @internal MAINTENANCE_TODO: Make this not visible to test code?
+   */
+  async postInit() {}
+  /**
+   * Runs after all subcases finish.
+   * @internal MAINTENANCE_TODO: Make this not visible to test code?
+   */
   async finalize() {}
 }
 

--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -497,6 +497,7 @@ class RunCaseSpecific implements RunCase {
         if (this.beforeFn) {
           await this.beforeFn(sharedState);
         }
+        await sharedState.postInit();
 
         let allPreviousSubcasesFinalizedPromise: Promise<void> = Promise.resolve();
         if (this.subcases) {

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -118,6 +118,17 @@ export function raceWithRejectOnTimeout<T>(p: Promise<T>, ms: number, msg: strin
 }
 
 /**
+ * Returns a `Promise.reject()`, but also registers a dummy `.catch()` handler so it doesn't count
+ * as an uncaught promise rejection in the runtime.
+ */
+export function rejectWithoutUncaught<T>(err: unknown): Promise<T> {
+  const p = Promise.reject(err);
+  // Suppress uncaught promise rejection.
+  p.catch(() => {});
+  return p;
+}
+
+/**
  * Makes a copy of a JS `object`, with the keys reordered into sorted order.
  */
 export function sortObjectByKey(v: { [k: string]: unknown }): { [k: string]: unknown } {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -72,6 +72,11 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     new Error('selectMismatchedDeviceOrSkipTestCase was not called in beforeAllSubcases')
   );
 
+  async postInit(): Promise<void> {
+    // Skip all subcases if there's no device.
+    await this.acquireProvider();
+  }
+
   async finalize(): Promise<void> {
     await super.finalize();
 


### PR DESCRIPTION
Issue: https://dawn-review.googlesource.com/c/dawn/+/89029

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
