### PR TITLE
wgsl: Stub tests for the textureGather builtin.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -64,10 +64,7 @@ Parameters:
         /* less then min value, */ [0, 0],
         ['max', 'max'] /* greater then max value */,
       ] as const)
-      .combine('offset', [
-        undefined,
-        /* less then min, min, */ [0, 0] /* max, greater than max */,
-      ] as const)
+      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
 
@@ -109,15 +106,12 @@ Parameters:
         /* less then min value, */ [0, 0],
         ['max', 'max'] /* greater then max value */,
       ] as const)
-      .combine('offset', [
-        undefined,
-        /* less then min, min, */ [0, 0] /* max, greater than max */,
-      ] as const)
       .combine('array_index', [
         /* one less then min */ -1,
         0,
         1 /* max, one more then max */,
       ] as const)
+      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
 
@@ -148,10 +142,7 @@ Parameters:
         /* less then min value, */ [0, 0],
         ['max', 'max'] /* greater then max value */,
       ] as const)
-      .combine('offset', [
-        undefined,
-        /* less then min, min, */ [0, 0] /* max, greater than max */,
-      ] as const)
+      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
 
@@ -192,14 +183,11 @@ Parameters:
         /* less then min value, */ [0, 0],
         ['max', 'max'] /* greater then max value */,
       ] as const)
-      .combine('offset', [
-        undefined,
-        /* less then min, min, */ [0, 0] /* max, greater than max */,
-      ] as const)
       .combine('array_index', [
         /* one less then min, */ -1,
         0,
         1 /* max, one more then max */,
       ] as const)
+      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -1,0 +1,205 @@
+export const description = `
+Execution tests for the 'textureGather' builtin function
+
+A texture gather operation reads from a 2D, 2D array, cube, or cube array texture, computing a four-component vector as follows:
+ * Find the four texels that would be used in a sampling operation with linear filtering, from mip level 0:
+   - Use the specified coordinate, array index (when present), and offset (when present).
+   - The texels are adjacent, forming a square, when considering their texture space coordinates (u,v).
+   - Selected texels at the texture edge, cube face edge, or cube corners are handled as in ordinary texture sampling.
+ * For each texel, read one channel and convert it into a scalar value.
+   - For non-depth textures, a zero-based component parameter specifies the channel to use.
+     * If the texture format supports the specified channel, i.e. has more than component channels:
+       - Yield scalar value v[component] when the texel value is v.
+     * Otherwise:
+       - Yield 0.0 when component is 1 or 2.
+       - Yield 1.0 when component is 3 (the alpha channel).
+   - For depth textures, yield the texel value. (Depth textures only have one channel.)
+ * Yield the four-component vector, arranging scalars produced by the previous step into components according to the relative coordinates of the texels, as follows:
+   - Result component  Relative texel coordinate
+      x (umin,vmax)
+      y (umax,vmax)
+      z (umax,vmin)
+      w (umin,vmin)
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('sampled')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegather')
+  .desc(
+    `
+C: i32, u32
+T: i32, u32, f32
+
+fn textureGather(component: C, t: texture_2d<T>, s: sampler, coords: vec2<f32>) -> vec4<T>
+fn textureGather(component: C, t: texture_2d<T>, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<T>
+fn textureGather(component: C, t: texture_cube<T>, s: sampler, coords: vec3<f32>) -> vec4<T>
+
+Parameters:
+ * component:
+    - The index of the channel to read from the selected texels.
+    - When provided, the component expression must a creation-time expression (e.g. 1).
+    - Its value must be at least 0 and at most 3. Values outside of this range will result in a shader-creation error.
+ * t: The sampled texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * offset:
+    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+      This offset is applied before applying any texture wrapping modes.
+    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    - Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', ['texture_2d', 'texture_cube'] as const)
+      .combine('T', ['f32', 'i32', 'u32'] as const)
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4])
+      .combine('coords', [
+        /* less then min value, */ [0, 0],
+        ['max', 'max'] /* greater then max value */,
+      ] as const)
+      .combine('offset', [
+        undefined,
+        /* less then min, min, */ [0, 0] /* max, greater than max */,
+      ] as const)
+  )
+  .unimplemented();
+
+g.test('sampled_array')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegather')
+  .desc(
+    `
+C: i32, u32
+T: i32, u32, f32
+
+fn textureGather(component: C, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: C) -> vec4<T>
+fn textureGather(component: C, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: C, offset: vec2<i32>) -> vec4<T>
+fn textureGather(component: C, t: texture_cube_array<T>, s: sampler, coords: vec3<f32>, array_index: C) -> vec4<T>
+
+Parameters:
+ * component:
+    - The index of the channel to read from the selected texels.
+    - When provided, the component expression must a creation-time expression (e.g. 1).
+    - Its value must be at least 0 and at most 3. Values outside of this range will result in a shader-creation error.
+ * t: The sampled texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * array_index: The 0-based texture array index
+ * offset:
+    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+      This offset is applied before applying any texture wrapping modes.
+    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    - Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', ['texture_2d_array', 'texture_cube_array'])
+      .combine('T', ['f32', 'i32', 'u32'] as const)
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4])
+      .combine('coords', [
+        /* less then min value, */ [0, 0],
+        ['max', 'max'] /* greater then max value */,
+      ] as const)
+      .combine('offset', [
+        undefined,
+        /* less then min, min, */ [0, 0] /* max, greater than max */,
+      ] as const)
+      .combine('array_index', [
+        /* one less then min */ -1,
+        0,
+        1 /* max, one more then max */,
+      ] as const)
+  )
+  .unimplemented();
+
+g.test('depth')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegather')
+  .desc(
+    `
+fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> vec4<f32>
+fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
+fn textureGather(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> vec4<f32>
+
+Parameters:
+ * t: The depth texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * offset:
+    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+      This offset is applied before applying any texture wrapping modes.
+    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    - Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', ['texture_depth_2d', 'texture_depth_cube'])
+      .combine('coords', [
+        /* less then min value, */ [0, 0],
+        ['max', 'max'] /* greater then max value */,
+      ] as const)
+      .combine('offset', [
+        undefined,
+        /* less then min, min, */ [0, 0] /* max, greater than max */,
+      ] as const)
+  )
+  .unimplemented();
+
+g.test('depth_array')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegather')
+  .desc(
+    `
+C: i32, u32
+
+fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: C) -> vec4<f32>
+fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: C, offset: vec2<i32>) -> vec4<f32>
+fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: C) -> vec4<f32>
+
+Parameters:
+ * t: The depth texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * array_index: The 0-based texture array index
+ * offset:
+    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+      This offset is applied before applying any texture wrapping modes.
+    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    - Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', [
+        'texture_depth_2d',
+        'texture_depth_2d_array',
+        'texture_depth_cube',
+        'texture_depth_cube_array',
+        '',
+      ])
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords', [
+        /* less then min value, */ [0, 0],
+        ['max', 'max'] /* greater then max value */,
+      ] as const)
+      .combine('offset', [
+        undefined,
+        /* less then min, min, */ [0, 0] /* max, greater than max */,
+      ] as const)
+      .combine('array_index', [
+        /* one less then min, */ -1,
+        0,
+        1 /* max, one more then max */,
+      ] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -171,13 +171,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', [
-        'texture_depth_2d',
-        'texture_depth_2d_array',
-        'texture_depth_cube',
-        'texture_depth_cube_array',
-        '',
-      ])
+      .combine('texture_type', ['texture_depth_2d_array', 'texture_depth_cube_array'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('coords', [
         /* less then min value, */ [0, 0],


### PR DESCRIPTION
This PR adds unimplmented stub tests for the `textureGather` builtin. There are a few
commented out parameterizations as we don't currently list the valid value ranges for a few
of the params. Those will get filled in when the spec gets clarified.

Issues: #1377

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
