### PR TITLE
Fix crash in GPUTest.init awaiting provider

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -2,7 +2,6 @@ import { Fixture, SubcaseBatchState, TestParams } from '../common/framework/fixt
 import {
   assert,
   range,
-  rejectWithoutUncaught,
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
   unreachable,
@@ -68,9 +67,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
   /** Provider for default device. */
   private provider: Promise<DeviceProvider> | undefined;
   /** Provider for mismatched device. */
-  private mismatchedProvider: Promise<DeviceProvider> = rejectWithoutUncaught(
-    new Error('selectMismatchedDeviceOrSkipTestCase was not called in beforeAllSubcases')
-  );
+  private mismatchedProvider: Promise<DeviceProvider> | undefined;
 
   async postInit(): Promise<void> {
     // Skip all subcases if there's no device.
@@ -83,7 +80,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     // Ensure devicePool.release is called for both providers even if one rejects.
     await Promise.all([
       this.provider?.then(x => ('device' in x ? devicePool.release(x) : undefined)),
-      this.mismatchedProvider.then(x => ('device' in x ? devicePool.release(x) : undefined)),
+      this.mismatchedProvider?.then(x => ('device' in x ? devicePool.release(x) : undefined)),
     ]);
   }
 
@@ -145,7 +142,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
   }
 
   /** @internal MAINTENANCE_TODO: Make this not visible to test code? */
-  acquireMismatchedProvider(): Promise<DeviceProvider> {
+  acquireMismatchedProvider(): Promise<DeviceProvider> | undefined {
     return this.mismatchedProvider;
   }
 
@@ -180,7 +177,7 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
 
   // Should never be undefined in a test. If it is, init() must not have run/finished.
   private provider: DeviceProvider = undefined!;
-  private mismatchedProvider: DeviceProvider = undefined!;
+  private mismatchedProvider: DeviceProvider | undefined = undefined;
 
   async init() {
     await super.init();
@@ -201,6 +198,10 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
    * e.g. for creating objects for by device_mismatch validation tests.
    */
   get mismatchedDevice(): GPUDevice {
+    assert(
+      this.mismatchedProvider !== undefined,
+      'selectMismatchedDeviceOrSkipTestCase was not called in beforeAllSubcases'
+    );
     return this.mismatchedProvider.device;
   }
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -176,8 +176,8 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
   }
 
   // Should never be undefined in a test. If it is, init() must not have run/finished.
-  private provider: DeviceProvider = undefined!;
-  private mismatchedProvider: DeviceProvider | undefined = undefined;
+  private provider: DeviceProvider | undefined;
+  private mismatchedProvider: DeviceProvider | undefined;
 
   async init() {
     await super.init();
@@ -190,6 +190,7 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
    * GPUDevice for the test to use.
    */
   get device(): GPUDevice {
+    assert(this.provider !== undefined, 'internal error: GPUDevice missing?');
     return this.provider.device;
   }
 
@@ -770,7 +771,7 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
    * Expects that the device should be lost for a particular reason at the teardown of the test.
    */
   expectDeviceLost(reason: GPUDeviceLostReason): void {
-    assert('device' in this.provider);
+    assert(this.provider !== undefined, 'internal error: GPUDevice missing?');
     this.provider.expectDeviceLost(reason);
   }
 


### PR DESCRIPTION


Issue: https://dawn-review.googlesource.com/c/dawn/+/89482

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
