### PR TITLE
[dawn-node]: Move TSC config to file.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,10 +62,6 @@ module.exports = function (grunt) {
           'node_modules/typescript/lib/tsc.js',
           '--project', 'node.tsconfig.json',
           '--outDir', 'out-node/',
-          '--incremental', 'true',
-          '--tsBuildInfoFile', 'out-node/build.tsbuildinfo',
-          '--noEmit', 'false',
-          '--declaration', 'false'
         ],
       },
       'copy-assets': {

--- a/node.tsconfig.json
+++ b/node.tsconfig.json
@@ -5,7 +5,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs"
+    "module": "commonjs",
+    "incremental": false,
+    "noEmit": false,
+    "declaration": false,
   },
 
   "exclude": [


### PR DESCRIPTION
This PR pulls the typescript config out of the grunt file and adds
the options into the `node.tsconfig.json` file. This also disables
the `incremental` flag in order to work around incorrectly
regenerating the test suite.

The removal of `incremental` takes the Building CTS step to
~14s locally.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
