### PR TITLE
Add handling of non-unique results in `atan2` tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -53,9 +53,16 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     const cfg: Config = t.params;
     cfg.cmpFloats = ulpMatch(4096);
 
+    const extra_cases = (result: number): Array<number> => {
+      if (result === 0 || result === Math.PI || result === -Math.PI) {
+        return [0, Math.PI, -Math.PI];
+      }
+      return [];
+    };
+
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (y: number, x: number): Case => {
-      return makeBinaryF32Case(y, x, Math.atan2, true);
+      return makeBinaryF32Case(y, x, Math.atan2, true, extra_cases);
     };
 
     const numeric_range = fullF32Range({

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -404,12 +404,15 @@ export function makeUnaryF32Case(param: number, op: (p: number) => number): Case
  * @param skip_param1_zero_flush should the builder skip cases where the param1 would be flushed to 0,
  *                               this is to avoid performing division by 0, other invalid operations.
  *                               The caller is responsible for making sure the initial param1 isn't 0.
+ * @param extra_cases callback that generates additional cases that should be expected for special
+ *                    results. This is specifically used to handle periodic cases in trig functions.
  */
 export function makeBinaryF32Case(
   param0: number,
   param1: number,
   op: (p0: number, p1: number) => number,
-  skip_param1_zero_flush: boolean = false
+  skip_param1_zero_flush: boolean = false,
+  extra_cases?: (result: number) => Array<number>
 ): Case {
   const f32_param0 = quantizeToF32(param0);
   const f32_param1 = quantizeToF32(param1);
@@ -430,6 +433,17 @@ export function makeBinaryF32Case(
     calculateFlushedResults(op(0, 0)).forEach(value => {
       expected.add(value);
     });
+  }
+
+  if (extra_cases !== undefined) {
+    // Need to store new cases to a separate container to avoid modifying |expected| while iterating it
+    const new_cases = new Set<Scalar>();
+    expected.forEach(e => {
+      extra_cases(e.value as number)
+        .map(f64)
+        .forEach(x => new_cases.add(x));
+    });
+    new_cases.forEach(x => expected.add(x));
   }
 
   return { input: [f32(param0), f32(param1)], expected: anyOf(...expected) };

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -435,7 +435,7 @@ export function makeBinaryF32Case(
     });
   }
 
-  if (extra_cases !== undefined) {
+  if (typeof extra_cases !== 'undefined') {
     // Need to store new cases to a separate container to avoid modifying |expected| while iterating it
     const new_cases = new Set<Scalar>();
     expected.forEach(e => {


### PR DESCRIPTION
Issue #

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
