### PR TITLE
wgsl: update textureGather tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -61,7 +61,13 @@ Parameters:
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
+      .combine('coords', [
+        'left-wrap',
+        'right-wrap',
+        'bottom-wrap',
+        'top-wrap',
+        'in-bounds',
+      ] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
@@ -101,7 +107,13 @@ Parameters:
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
+      .combine('coords', [
+        'left-wrap',
+        'right-wrap',
+        'bottom-wrap',
+        'top-wrap',
+        'in-bounds',
+      ] as const)
       /* array_index not param'd as out-of-bounds is implementation specific */
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
@@ -131,7 +143,13 @@ Parameters:
     u
       .combine('texture_type', ['texture_depth_2d', 'texture_depth_cube'])
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
-      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
+      .combine('coords', [
+        'left-wrap',
+        'right-wrap',
+        'bottom-wrap',
+        'top-wrap',
+        'in-bounds',
+      ] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
@@ -164,7 +182,13 @@ Parameters:
       .combine('texture_type', ['texture_depth_2d_array', 'texture_depth_cube_array'])
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
+      .combine('coords', [
+        'left-wrap',
+        'right-wrap',
+        'bottom-wrap',
+        'top-wrap',
+        'in-bounds',
+      ] as const)
       /* array_index not param'd as out-of-bounds is implementation specific */
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -58,12 +58,10 @@ Parameters:
     u
       .combine('texture_type', ['texture_2d', 'texture_cube'] as const)
       .combine('T', ['f32', 'i32', 'u32'] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
-      .combine('C_value', [-1, 0, 1, 2, 3, 4])
-      .combine('coords', [
-        /* less then min value, */ [0, 0],
-        ['max', 'max'] /* greater then max value */,
-      ] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
@@ -100,17 +98,11 @@ Parameters:
     u
       .combine('texture_type', ['texture_2d_array', 'texture_cube_array'])
       .combine('T', ['f32', 'i32', 'u32'] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
-      .combine('C_value', [-1, 0, 1, 2, 3, 4])
-      .combine('coords', [
-        /* less then min value, */ [0, 0],
-        ['max', 'max'] /* greater then max value */,
-      ] as const)
-      .combine('array_index', [
-        /* one less then min */ -1,
-        0,
-        1 /* max, one more then max */,
-      ] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
+      /* array_index not param'd as out-of-bounds is implementation specific */
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
@@ -138,10 +130,8 @@ Parameters:
   .params(u =>
     u
       .combine('texture_type', ['texture_depth_2d', 'texture_depth_cube'])
-      .combine('coords', [
-        /* less then min value, */ [0, 0],
-        ['max', 'max'] /* greater then max value */,
-      ] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
@@ -172,16 +162,10 @@ Parameters:
   .params(u =>
     u
       .combine('texture_type', ['texture_depth_2d_array', 'texture_depth_cube_array'])
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', [
-        /* less then min value, */ [0, 0],
-        ['max', 'max'] /* greater then max value */,
-      ] as const)
-      .combine('array_index', [
-        /* one less then min, */ -1,
-        0,
-        1 /* max, one more then max */,
-      ] as const)
+      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
+      /* array_index not param'd as out-of-bounds is implementation specific */
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -48,12 +48,10 @@ Parameters:
   .params(u =>
     u
       .combine('texture_type', ['texture_depth_2d_array', 'texture_depth_cube_array'] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4])
-      .combine('coords', [
-        /* less then min value, */ [0, 0],
-        ['max', 'max'] /* greater then max value */,
-      ] as const)
+      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
@@ -83,10 +81,8 @@ Parameters:
   .params(u =>
     u
       .combine('texture_type', ['texture_depth_2d', 'texture_depth_cube'])
-      .combine('coords', [
-        /* less then min value, */ [0, 0],
-        ['max', 'max'] /* greater then max value */,
-      ] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -51,7 +51,13 @@ Parameters:
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4])
-      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
+      .combine('coords', [
+        'left-wrap',
+        'right-wrap',
+        'bottom-wrap',
+        'top-wrap',
+        'in-bounds',
+      ] as const)
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
@@ -82,7 +88,13 @@ Parameters:
     u
       .combine('texture_type', ['texture_depth_2d', 'texture_depth_cube'])
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
-      .combine('coords', ['left-wrap', 'right-wrap', 'bottom-wrap', 'top-wrap', 'in-bounds'] as const)
+      .combine('coords', [
+        'left-wrap',
+        'right-wrap',
+        'bottom-wrap',
+        'top-wrap',
+        'in-bounds',
+      ] as const)
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )


### PR DESCRIPTION
This PR updates the textureGather and textureGatherCompare tests with
more information on the coords and sampler.

Issue: #1337, #1260

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
