### PR TITLE
Raise maxComputeWorkgroupStorageSize from 16352 to 16384

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -1020,7 +1020,7 @@ export const kLimitInfo = /* prettier-ignore */ makeTable(
   'maxVertexBufferArrayStride':                [           ,      2048,                          ],
   'maxInterStageShaderComponents':             [           ,        60,                          ],
 
-  'maxComputeWorkgroupStorageSize':            [           ,     16352,                          ],
+  'maxComputeWorkgroupStorageSize':            [           ,     16384,                          ],
   'maxComputeInvocationsPerWorkgroup':         [           ,       256,                          ],
   'maxComputeWorkgroupSizeX':                  [           ,       256,                          ],
   'maxComputeWorkgroupSizeY':                  [           ,       256,                          ],


### PR DESCRIPTION


Issue: https://github.com/gpuweb/gpuweb/pull/2834

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
