### PR TITLE
wgsl: Stub textureSampleBias tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -1,0 +1,119 @@
+export const description = `
+Execution tests for the 'textureSampleBias' builtin function
+
+Samples a texture with a bias to the mip level.
+Must only be used in a fragment shader stage.
+Must only be invoked in uniform control flow.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplebias')
+  .desc(
+    `
+Tests that 'textureSampleBias' can only be called in 'fragment' shaders.
+`
+  )
+  .params(u =>  u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('control_flow')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplebias')
+  .desc(
+    `
+Tests that 'textureSampleBias' can only be called in uniform control flow.
+`
+  )
+  .params(u =>  u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('sampled')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplebias')
+  .desc(
+    `
+fn textureSampleBias(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, bias: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f32, offset: vec3<i32>) -> vec4<f32>
+fn textureSampleBias(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, bias: f32) -> vec4<f32>
+
+Parameters:
+ * t: The sampled texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * bias: The bias to apply to the mip level before sampling. bias must be between -16.0 and 15.99.
+ * offset:
+    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+      This offset is applied before applying any texture wrapping modes.
+    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    - Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', [
+        'texture_2d',
+        'texture_3d',
+        'texture_cube',
+      ] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', [
+        'left-wrap',
+        'right-wrap',
+        'bottom-wrap',
+        'top-wrap',
+        'in-bounds'] as const)
+      .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
+      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+    )
+  .unimplemented();
+
+g.test('arrayed')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplebias')
+  .desc(
+    `
+C: i32, u32
+
+fn textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: C, bias: f32) -> vec4<f32>
+fn textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: C, bias: f32, offset: vec2<i32>) -> vec4<f32>
+fn textureSampleBias(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: C, bias: f32) -> vec4<f32>
+
+Parameters:
+ * t: The sampled texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * array_index: The 0-based texture array index to sample.
+ * bias: The bias to apply to the mip level before sampling. bias must be between -16.0 and 15.99.
+ * offset:
+    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+      This offset is applied before applying any texture wrapping modes.
+    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    - Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', [
+        'texture_2d_array',
+        'texture_cube_array',
+      ] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', [
+        'left-wrap',
+        'right-wrap',
+        'bottom-wrap',
+        'top-wrap',
+        'in-bounds'] as const)
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+       /* array_index not param'd as out-of-bounds is implementation specific */
+      .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
+      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -18,7 +18,7 @@ g.test('stage')
 Tests that 'textureSampleBias' can only be called in 'fragment' shaders.
 `
   )
-  .params(u =>  u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
   .unimplemented();
 
 g.test('control_flow')
@@ -28,7 +28,7 @@ g.test('control_flow')
 Tests that 'textureSampleBias' can only be called in uniform control flow.
 `
   )
-  .params(u =>  u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
   .unimplemented();
 
 g.test('sampled')
@@ -56,21 +56,18 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', [
-        'texture_2d',
-        'texture_3d',
-        'texture_cube',
-      ] as const)
+      .combine('texture_type', ['texture_2d', 'texture_3d', 'texture_cube'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', [
         'left-wrap',
         'right-wrap',
         'bottom-wrap',
         'top-wrap',
-        'in-bounds'] as const)
+        'in-bounds',
+      ] as const)
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
-    )
+  )
   .unimplemented();
 
 g.test('arrayed')
@@ -99,20 +96,18 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', [
-        'texture_2d_array',
-        'texture_cube_array',
-      ] as const)
+      .combine('texture_type', ['texture_2d_array', 'texture_cube_array'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', [
         'left-wrap',
         'right-wrap',
         'bottom-wrap',
         'top-wrap',
-        'in-bounds'] as const)
+        'in-bounds',
+      ] as const)
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-       /* array_index not param'd as out-of-bounds is implementation specific */
+      /* array_index not param'd as out-of-bounds is implementation specific */
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )


### PR DESCRIPTION
This PR adds unimplemented stubs for the `textureSampleBias` tests

Issue: #1267

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
