### PR TITLE
wgsl: Extend `anyOf` to accept `Comparator`s

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -4,8 +4,8 @@ Execution tests for the 'atan2' builtin function
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ulpMatch } from '../../../../../util/compare.js';
-import { TypeF32 } from '../../../../../util/conversion.js';
+import { anyOf, ulpMatch } from '../../../../../util/compare.js';
+import { f64, TypeF32 } from '../../../../../util/conversion.js';
 import { flushSubnormalNumber, fullF32Range } from '../../../../../util/math.js';
 import { Case, Config, makeBinaryF32Case, run } from '../../expression.js';
 
@@ -55,12 +55,12 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (y: number, x: number): Case => {
-      // If y is subnormal, expect possible results of atan2(0, x)
-      let extra_cases: Array<number> = [];
+      const c = makeBinaryF32Case(y, x, Math.atan2, true);
       if (flushSubnormalNumber(y) === 0.0) {
-        extra_cases = [0.0, Math.PI, -Math.PI];
+        // If y is subnormal, also expect possible results of atan2(0, x)
+        c.expected = anyOf(c.expected, f64(0), f64(Math.PI), f64(-Math.PI));
       }
-      return makeBinaryF32Case(y, x, Math.atan2, true, extra_cases);
+      return c;
     };
 
     const numeric_range = fullF32Range({

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -409,8 +409,7 @@ export function makeBinaryF32Case(
   param0: number,
   param1: number,
   op: (p0: number, p1: number) => number,
-  skip_param1_zero_flush: boolean = false,
-  extra_cases?: Array<number>
+  skip_param1_zero_flush: boolean = false
 ): Case {
   const f32_param0 = quantizeToF32(param0);
   const f32_param1 = quantizeToF32(param1);
@@ -431,9 +430,6 @@ export function makeBinaryF32Case(
     calculateFlushedResults(op(0, 0)).forEach(value => {
       expected.add(value);
     });
-  }
-  if (typeof extra_cases !== 'undefined') {
-    extra_cases.forEach(x => calculateFlushedResults(x).forEach(xx => expected.add(xx)));
   }
 
   return { input: [f32(param0), f32(param1)], expected: anyOf(...expected) };

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -128,12 +128,19 @@ export function compare(got: Value, expected: Value, cmpFloats: FloatMatch): Com
   throw new Error(`unhandled type '${typeof got}`);
 }
 
-/** @returns a Comparator that checks whether a test value matches any of the provided values */
-export function anyOf(...values: Value[]): Comparator {
+/** @returns a Comparator that checks whether a test value matches any of the provided options */
+export function anyOf(...expectations: (Value | Comparator)[]): Comparator {
   return (got, cmpFloats) => {
     const failed: Array<string> = [];
-    for (const e of values) {
-      const cmp = compare(got, e, cmpFloats);
+    for (const e of expectations) {
+      let cmp: Comparison;
+      if ((e as Value).type !== undefined) {
+        const v = e as Value;
+        cmp = compare(got, v, cmpFloats);
+      } else {
+        const c = e as Comparator;
+        cmp = c(got, cmpFloats);
+      }
       if (cmp.matched) {
         return cmp;
       }


### PR DESCRIPTION
Also removes need for passing additional information into
`makeBinaryF32Case`

Fixes #1391

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
