### PR TITLE
wgsl: Cleanup duplicate description text

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -1,5 +1,18 @@
 export const description = `
 Execution tests for the 'abs' builtin function
+
+S is AbstractInt, i32, or u32
+T is S or vecN<S>
+@const fn abs(e: T ) -> T
+The absolute value of e. Component-wise when T is a vector. If e is a signed
+integral scalar type and evaluates to the largest negative value, then the
+result is e. If e is an unsigned integral type, then the result is e.
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn abs(e: T ) -> T
+Returns the absolute value of e (e.g. e with a positive sign bit).
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -23,16 +36,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn abs(e: T ) -> T
-The absolute value of e. Component-wise when T is a vector. If e is a signed
-integral scalar type and evaluates to the largest negative value, then the
-result is e. If e is an unsigned integral type, then the result is e.
-`
-  )
+  .desc(`abstract int tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -42,16 +46,7 @@ result is e. If e is an unsigned integral type, then the result is e.
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn abs(e: T ) -> T
-The absolute value of e. Component-wise when T is a vector. If e is a signed
-integral scalar type and evaluates to the largest negative value, then the
-result is e. If e is an unsigned integral type, then the result is e.
-`
-  )
+  .desc(`unsigned int tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -100,16 +95,7 @@ result is e. If e is an unsigned integral type, then the result is e.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn abs(e: T ) -> T
-The absolute value of e. Component-wise when T is a vector. If e is a signed
-integral scalar type and evaluates to the largest negative value, then the
-result is e. If e is an unsigned integral type, then the result is e.
-`
-  )
+  .desc(`signed int tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -164,14 +150,7 @@ result is e. If e is an unsigned integral type, then the result is e.
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn abs(e: T ) -> T
-Returns the absolute value of e (e.g. e with a positive sign bit).
-Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -181,14 +160,7 @@ Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn abs(e: T ) -> T
-Returns the absolute value of e (e.g. e with a positive sign bit).
-Component-wise when T is a vector.
-`
-  )
+  .desc(`float 32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -213,14 +185,7 @@ Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn abs(e: T ) -> T
-Returns the absolute value of e (e.g. e with a positive sign bit).
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'acos' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn acos(e: T ) -> T
+Returns the arc cosine of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn acos(e: T ) -> T
-Returns the arc cosine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the arc cosine of e. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn acos(e: T ) -> T
-Returns the arc cosine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the arc cosine of e. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn acos(e: T ) -> T
-Returns the arc cosine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -1,5 +1,14 @@
 export const description = `
 Execution tests for the 'acosh' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn acosh(e: T ) -> T
+Returns the hyperbolic arc cosine of e. The result is 0 when e < 1.
+Computes the non-negative functional inverse of cosh.
+Component-wise when T is a vector.
+Note: The result is not mathematically meaningful when e < 1.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,16 +18,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn acosh(e: T ) -> T
-Returns the hyperbolic arc cosine of e. The result is 0 when e < 1.
-Computes the non-negative functional inverse of cosh.
-Component-wise when T is a vector.
-Note: The result is not mathematically meaningful when e < 1.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -28,16 +28,7 @@ Note: The result is not mathematically meaningful when e < 1.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn acosh(e: T ) -> T
-Returns the hyperbolic arc cosine of e. The result is 0 when e < 1.
-Computes the non-negative functional inverse of cosh.
-Component-wise when T is a vector.
-Note: The result is not mathematically meaningful when e < 1.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -47,16 +38,7 @@ Note: The result is not mathematically meaningful when e < 1.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn acosh(e: T ) -> T
-Returns the hyperbolic arc cosine of e. The result is 0 when e < 1.
-Computes the non-negative functional inverse of cosh.
-Component-wise when T is a vector.
-Note: The result is not mathematically meaningful when e < 1.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/all.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/all.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'all' builtin function
+
+S is a bool
+T is S or vecN<S>
+@const fn all(e: T) -> bool
+Returns e if e is scalar.
+Returns true if each component of e is true if e is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -21,18 +27,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('bool')
   .specURL('https://www.w3.org/TR/WGSL/#logical-builtin-functions')
-  .desc(
-    `
-# scalar
-e: bool
-@const fn all(e) -> bool
-Returns e.
-
-# vector
-@const fn all(e: vecN<bool>) -> bool
-Returns true if each component of e is true.
-`
-  )
+  .desc(`bool tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/any.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/any.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'any' builtin function
+
+S is a bool
+T is S or vecN<S>
+@const fn all(e) -> bool
+Returns e if e is scalar.
+Returns true if any component of e is true if e is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -21,18 +27,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('bool')
   .specURL('https://www.w3.org/TR/WGSL/#logical-builtin-functions')
-  .desc(
-    `
-# scalar
-e: bool
-@const fn all(e) -> bool
-Returns e.
-
-# vector
-@const fn any(e: vecN<bool>) -> bool
-Returns true if any component of e is true.
-`
-  )
+  .desc(`bool tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/arrayLength.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/arrayLength.spec.ts
@@ -1,5 +1,8 @@
 export const description = `
 Execution tests for the 'arrayLength' builtin function
+
+fn arrayLength(e: ptr<storage,array<T>> ) -> u32
+Returns the number of elements in the runtime-sized array.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,10 +12,5 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('array')
   .specURL('https://www.w3.org/TR/WGSL/#array-builtin-functions')
-  .desc(
-    `
-fn arrayLength(e: ptr<storage,array<T>> ) -> u32
-Returns the number of elements in the runtime-sized array.
-`
-  )
+  .desc(`array length tests`)
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'asin' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn asin(e: T ) -> T
+Returns the arc sine of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn asin(e: T ) -> T
-Returns the arc sine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the arc sine of e. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn asin(e: T ) -> T
-Returns the arc sine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the arc sine of e. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn asin(e: T ) -> T
-Returns the arc sine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
@@ -1,5 +1,13 @@
 export const description = `
 Execution tests for the 'sinh' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn asinh(e: T ) -> T
+Returns the hyperbolic arc sine of e.
+Computes the functional inverse of sinh.
+Component-wise when T is a vector.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,15 +17,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn asinh(e: T ) -> T
-Returns the hyperbolic arc sine of e.
-Computes the functional inverse of sinh.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float test`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -27,15 +27,7 @@ Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn asinh(e: T ) -> T
-Returns the hyperbolic arc sine of e.
-Computes the functional inverse of sinh.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -45,15 +37,7 @@ Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn asinh(e: T ) -> T
-Returns the hyperbolic arc sine of e.
-Computes the functional inverse of sinh.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'atan' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn atan(e: T ) -> T
+Returns the arc tangent of e. Component-wise when T is a vector.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -16,13 +22,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn atan(e: T ) -> T
-Returns the arc tangent of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -34,9 +34,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn atan(e: T ) -> T
-Returns the arc tangent of e. Component-wise when T is a vector.
+f32 tests
 
 TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
@@ -87,13 +85,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn atan(e: T ) -> T
-Returns the arc tangent of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'atan2' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn atan2(e1: T ,e2: T ) -> T
+Returns the arc tangent of e1 over e2. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -15,16 +20,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-atan2:
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn atan2(e1: T ,e2: T ) -> T
-Returns the arc tangent of e1 over e2. Component-wise when T is a vector.
-
-TODO(#792): Decide what the ground-truth is for these tests. [1]
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -36,10 +32,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-atan2:
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn atan2(e1: T ,e2: T ) -> T
-Returns the arc tangent of e1 over e2. Component-wise when T is a vector.
+f32 tests
 
 TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
@@ -86,16 +79,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-atan2:
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn atan2(e1: T ,e2: T ) -> T
-Returns the arc tangent of e1 over e2. Component-wise when T is a vector.
-
-TODO(#792): Decide what the ground-truth is for these tests. [1]
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -1,5 +1,13 @@
 export const description = `
 Execution tests for the 'atanh' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn atanh(e: T ) -> T
+Returns the hyperbolic arc tangent of e. The result is 0 when abs(e) ≥ 1.
+Computes the functional inverse of tanh.
+Component-wise when T is a vector.
+Note: The result is not mathematically meaningful when abs(e) >= 1.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,16 +17,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn atanh(e: T ) -> T
-Returns the hyperbolic arc tangent of e. The result is 0 when abs(e) ≥ 1.
-Computes the functional inverse of tanh.
-Component-wise when T is a vector.
-Note: The result is not mathematically meaningful when abs(e) >= 1.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -28,16 +27,7 @@ Note: The result is not mathematically meaningful when abs(e) >= 1.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn atanh(e: T ) -> T
-Returns the hyperbolic arc tangent of e. The result is 0 when abs(e) ≥ 1.
-Computes the functional inverse of tanh.
-Component-wise when T is a vector.
-Note: The result is not mathematically meaningful when abs(e) >= 1.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -47,16 +37,7 @@ Note: The result is not mathematically meaningful when abs(e) >= 1.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn atanh(e: T ) -> T
-Returns the hyperbolic arc tangent of e. The result is 0 when abs(e) ≥ 1.
-Computes the functional inverse of tanh.
-Component-wise when T is a vector.
-Note: The result is not mathematically meaningful when abs(e) >= 1.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'ceil' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn ceil(e: T ) -> T
+Returns the ceiling of e. Component-wise when T is a vector.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -16,13 +22,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn ceil(e: T ) -> T
-Returns the ceiling of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -32,13 +32,7 @@ Returns the ceiling of e. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn ceil(e: T ) -> T
-Returns the ceiling of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -82,13 +76,7 @@ Returns the ceiling of e. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn ceil(e: T ) -> T
-Returns the ceiling of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -1,5 +1,16 @@
 export const description = `
 Execution tests for the 'clamp' builtin function
+
+S is AbstractInt, i32, or u32
+T is S or vecN<S>
+@const fn clamp(e: T , low: T, high: T) -> T
+Returns min(max(e,low),high). Component-wise when T is a vector.
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const clamp(e: T , low: T , high: T) -> T
+Returns either min(max(e,low),high), or the median of the three values e, low, high.
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -108,14 +119,7 @@ function generateFloatTestCases(test_values: Array<Scalar>): Array<Case> {
 
 g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn clamp(e: T , low: T, high: T) -> T
-Returns min(max(e,low),high). Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract int tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -125,14 +129,7 @@ Returns min(max(e,low),high). Component-wise when T is a vector.
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn clamp(e: T , low: T, high: T) -> T
-Returns min(max(e,low),high). Component-wise when T is a vector.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -162,14 +159,7 @@ Returns min(max(e,low),high). Component-wise when T is a vector.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn clamp(e: T , low: T, high: T) -> T
-Returns min(max(e,low),high). Component-wise when T is a vector.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -201,14 +191,7 @@ Returns min(max(e,low),high). Component-wise when T is a vector.
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const clamp(e: T , low: T , high: T) -> T
-Returns either min(max(e,low),high), or the median of the three values e, low, high.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -218,14 +201,7 @@ Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const clamp(e: T , low: T , high: T) -> T
-Returns either min(max(e,low),high), or the median of the three values e, low, high.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -267,14 +243,7 @@ Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const clamp(e: T , low: T , high: T) -> T
-Returns either min(max(e,low),high), or the median of the three values e, low, high.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'cos' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn cos(e: T ) -> T
+Returns the cosine of e. Component-wise when T is a vector.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -15,13 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn cos(e: T ) -> T
-Returns the cosine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -33,9 +33,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn cos(e: T ) -> T
-Returns the cosine of e. Component-wise when T is a vector.
+f32 tests
 
 TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
@@ -61,13 +59,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn cos(e: T ) -> T
-Returns the cosine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'cosh' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn cosh(e: T ) -> T
+Returns the hyperbolic cosine of e. Component-wise when T is a vector
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn cosh(e: T ) -> T
-Returns the hyperbolic cosine of e. Component-wise when T is a vector
-`
-  )
+  .desc(`abstract float`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the hyperbolic cosine of e. Component-wise when T is a vector
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn cosh(e: T ) -> T
-Returns the hyperbolic cosine of e. Component-wise when T is a vector
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the hyperbolic cosine of e. Component-wise when T is a vector
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn cosh(e: T ) -> T
-Returns the hyperbolic cosine of e. Component-wise when T is a vector
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/countLeadingZeros.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countLeadingZeros.spec.ts
@@ -1,5 +1,13 @@
 export const description = `
 Execution tests for the 'countLeadingZeros' builtin function
+
+S is i32 or u32
+T is S or vecN<S>
+@const fn countLeadingZeros(e: T ) -> T
+The number of consecutive 0 bits starting from the most significant bit of e,
+when T is a scalar type.
+Component-wise when T is a vector.
+Also known as "clz" in some languages.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -13,16 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn countLeadingZeros(e: T ) -> T
-The number of consecutive 0 bits starting from the most significant bit of e,
-when T is a scalar type.
-Component-wise when T is a vector.
-Also known as "clz" in some languages.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -139,16 +138,7 @@ Also known as "clz" in some languages.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn countLeadingZeros(e: T ) -> T
-The number of consecutive 0 bits starting from the most significant bit of e,
-when T is a scalar type.
-Component-wise when T is a vector.
-Also known as "clz" in some languages.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/countOneBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countOneBits.spec.ts
@@ -1,5 +1,12 @@
 export const description = `
 Execution tests for the 'countOneBits' builtin function
+
+S is i32 or u32
+T is S or vecN<S>
+@const fn countOneBits(e: T ) -> T
+The number of 1 bits in the representation of e.
+Also known as "population count".
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -13,15 +20,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn countOneBits(e: T ) -> T
-The number of 1 bits in the representation of e.
-Also known as "population count".
-Component-wise when T is a vector.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -138,15 +137,7 @@ Component-wise when T is a vector.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn countOneBits(e: T ) -> T
-The number of 1 bits in the representation of e.
-Also known as "population count".
-Component-wise when T is a vector.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/countTrailingZeros.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countTrailingZeros.spec.ts
@@ -1,5 +1,13 @@
 export const description = `
 Execution tests for the 'countTrailingZeros' builtin function
+
+S is i32 or u32
+T is S or vecN<S>
+@const fn countTrailingZeros(e: T ) -> T
+The number of consecutive 0 bits starting from the least significant bit of e,
+when T is a scalar type.
+Component-wise when T is a vector.
+Also known as "ctz" in some languages.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -13,16 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn countTrailingZeros(e: T ) -> T
-The number of consecutive 0 bits starting from the least significant bit of e,
-when T is a scalar type.
-Component-wise when T is a vector.
-Also known as "ctz" in some languages.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -139,16 +138,7 @@ Also known as "ctz" in some languages.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn countTrailingZeros(e: T ) -> T
-The number of consecutive 0 bits starting from the least significant bit of e,
-when T is a scalar type.
-Component-wise when T is a vector.
-Also known as "ctz" in some languages.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -1,5 +1,9 @@
 export const description = `
 Execution tests for the 'cross' builtin function
+
+T is AbstractFloat, f32, or f16
+@const fn cross(e1: vec3<T> ,e2: vec3<T>) -> vec3<T>
+Returns the cross product of e1 and e2.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,36 +13,18 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const fn cross(e1: vec3<T> ,e2: vec3<T>) -> vec3<T>
-Returns the cross product of e1 and e2.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const fn cross(e1: vec3<T> ,e2: vec3<T>) -> vec3<T>
-Returns the cross product of e1 and e2.
-`
-  )
+  .desc(`f32 tests`)
   .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const fn cross(e1: vec3<T> ,e2: vec3<T>) -> vec3<T>
-Returns the cross product of e1 and e2.
-`
-  )
+  .desc(`f16 tests`)
   .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'degrees' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<T>
+@const fn degrees(e1: T ) -> T
+Converts radians to degrees, approximating e1 × 180 ÷ π. Component-wise when T is a vector
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn degrees(e1: T ) -> T
-Converts radians to degrees, approximating e1 × 180 ÷ π. Component-wise when T is a vector
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Converts radians to degrees, approximating e1 × 180 ÷ π. Component-wise when 
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn degrees(e1: T ) -> T
-Converts radians to degrees, approximating e1 × 180 ÷ π. Component-wise when T is a vector
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Converts radians to degrees, approximating e1 × 180 ÷ π. Component-wise when 
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn degrees(e1: T ) -> T
-Converts radians to degrees, approximating e1 × 180 ÷ π. Component-wise when T is a vector
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'determinant' builtin function
+
+T is AbstractFloat, f32, or f16
+@const determinant(e: matCxC<T> ) -> T
+Returns the determinant of e.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const determinant(e: matCxC<T> ) -> T
-Returns the determinant of e.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the determinant of e.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const determinant(e: matCxC<T> ) -> T
-Returns the determinant of e.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the determinant of e.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const determinant(e: matCxC<T> ) -> T
-Returns the determinant of e.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'distance' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn distance(e1: T ,e2: T ) -> f32
+Returns the distance between e1 and e2 (e.g. length(e1-e2)).
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +15,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn distance(e1: T ,e2: T ) -> f32
-Returns the distance between e1 and e2 (e.g. length(e1-e2)).
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +25,7 @@ Returns the distance between e1 and e2 (e.g. length(e1-e2)).
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn distance(e1: T ,e2: T ) -> f32
-Returns the distance between e1 and e2 (e.g. length(e1-e2)).
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +35,7 @@ Returns the distance between e1 and e2 (e.g. length(e1-e2)).
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn distance(e1: T ,e2: T ) -> f32
-Returns the distance between e1 and e2 (e.g. length(e1-e2)).
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'dot' builtin function
+
+T is AbstractInt, AbstractFloat, i32, u32, f32, or f16
+@const fn dot(e1: vecN<T>,e2: vecN<T>) -> T
+Returns the dot product of e1 and e2.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
-  .desc(
-    `
-T is AbstractInt, AbstractFloat, i32, u32, f32, or f16
-@const fn dot(e1: vecN<T>,e2: vecN<T>) -> T
-Returns the dot product of e1 and e2.
-`
-  )
+  .desc(`abstract int tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the dot product of e1 and e2.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
-  .desc(
-    `
-T is AbstractInt, AbstractFloat, i32, u32, f32, or f16
-@const fn dot(e1: vecN<T>,e2: vecN<T>) -> T
-Returns the dot product of e1 and e2.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the dot product of e1 and e2.
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
-  .desc(
-    `
-T is AbstractInt, AbstractFloat, i32, u32, f32, or f16
-@const fn dot(e1: vecN<T>,e2: vecN<T>) -> T
-Returns the dot product of e1 and e2.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -57,13 +44,7 @@ Returns the dot product of e1 and e2.
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
-  .desc(
-    `
-T is AbstractInt, AbstractFloat, i32, u32, f32, or f16
-@const fn dot(e1: vecN<T>,e2: vecN<T>) -> T
-Returns the dot product of e1 and e2.
-`
-  )
+  .desc(`abstract float test`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -73,13 +54,7 @@ Returns the dot product of e1 and e2.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
-  .desc(
-    `
-T is AbstractInt, AbstractFloat, i32, u32, f32, or f16
-@const fn dot(e1: vecN<T>,e2: vecN<T>) -> T
-Returns the dot product of e1 and e2.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -89,13 +64,7 @@ Returns the dot product of e1 and e2.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
-  .desc(
-    `
-T is AbstractInt, AbstractFloat, i32, u32, f32, or f16
-@const fn dot(e1: vecN<T>,e2: vecN<T>) -> T
-Returns the dot product of e1 and e2.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdx.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdx.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'dpdx' builtin function
+
+T is f32 or vecN<f32>
+fn dpdx(e:T) -> T
+Partial derivative of e with respect to window x coordinates.
+The result is the same as either dpdxFine(e) or dpdxCoarse(e).
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,14 +15,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-fn dpdx(e:T) -> T
-Partial derivative of e with respect to window x coordinates.
-The result is the same as either dpdxFine(e) or dpdxCoarse(e).
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdxCoarse.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdxCoarse.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'dpdxCoarse' builtin function
+
+T is f32 or vecN<f32>
+fn dpdxCoarse(e:T) ->T
+Returns the partial derivative of e with respect to window x coordinates using local differences.
+This may result in fewer unique positions that dpdxFine(e).
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,14 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-fn dpdxCoarse(e:T) ->T
-Returns the partial derivative of e with respect to window x coordinates using local differences.
-This may result in fewer unique positions that dpdxFine(e).
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdxFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdxFine.spec.ts
@@ -1,5 +1,9 @@
 export const description = `
 Execution tests for the 'dpdxFine' builtin function
+
+T is f32 or vecN<f32>
+fn dpdxFine(e:T) ->T
+Returns the partial derivative of e with respect to window x coordinates.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +13,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-fn dpdxFine(e:T) ->T
-Returns the partial derivative of e with respect to window x coordinates.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdy.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdy.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'dpdy' builtin function
+
+T is f32 or vecN<f32>
+fn dpdy(e:T) ->T
+Partial derivative of e with respect to window y coordinates.
+The result is the same as either dpdyFine(e) or dpdyCoarse(e).
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,14 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-fn dpdy(e:T) ->T
-Partial derivative of e with respect to window y coordinates.
-The result is the same as either dpdyFine(e) or dpdyCoarse(e).
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdyCoarse.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdyCoarse.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'dpdyCoarse' builtin function
+
+T is f32 or vecN<f32>
+fn dpdyCoarse(e:T) ->T
+Returns the partial derivative of e with respect to window y coordinates using local differences.
+This may result in fewer unique positions that dpdyFine(e).
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,14 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-fn dpdyCoarse(e:T) ->T
-Returns the partial derivative of e with respect to window y coordinates using local differences.
-This may result in fewer unique positions that dpdyFine(e).
-`
-  )
+  .desc(`f32 test`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdyFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdyFine.spec.ts
@@ -1,5 +1,9 @@
 export const description = `
 Execution tests for the 'dpdyFine' builtin function
+
+T is f32 or vecN<f32>
+fn dpdyFine(e:T) ->T
+Returns the partial derivative of e with respect to window y coordinates.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +13,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-fn dpdyFine(e:T) ->T
-Returns the partial derivative of e with respect to window y coordinates.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'exp' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn exp(e1: T ) -> T
+Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -16,13 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn exp(e1: T ) -> T
-Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -32,13 +31,7 @@ Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn exp(e1: T ) -> T
-Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -69,13 +62,7 @@ Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn exp(e1: T ) -> T
-Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'exp2' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn exp2(e: T ) -> T
+Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -16,13 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn exp2(e: T ) -> T
-Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -32,13 +31,7 @@ Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn exp2(e: T ) -> T
-Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -69,13 +62,7 @@ Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn exp2(e: T ) -> T
-Returns 2 raised to the power e (e.g. 2^e). Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
@@ -1,5 +1,34 @@
 export const description = `
 Execution tests for the 'extractBits' builtin function
+
+T is u32 or vecN<u32>
+@const fn extractBits(e: T, offset: u32, count: u32) -> T
+Reads bits from an integer, without sign extension.
+
+When T is a scalar type, then:
+  w is the bit width of T
+  o = min(offset,w)
+  c = min(count, w - o)
+
+The result is 0 if c is 0.
+Otherwise, bits 0..c-1 of the result are copied from bits o..o+c-1 of e.
+Other bits of the result are 0.
+Component-wise when T is a vector.
+
+
+T is i32 or vecN<i32>
+@const fn extractBits(e: T, offset: u32, count: u32) -> T
+Reads bits from an integer, with sign extension.
+
+When T is a scalar type, then:
+  w is the bit width of T
+  o = min(offset,w)
+  c = min(count, w - o)
+
+The result is 0 if c is 0.
+Otherwise, bits 0..c-1 of the result are copied from bits o..o+c-1 of e.
+Other bits of the result are the same as bit c-1 of the result.
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -23,26 +52,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is u32 or vecN<u32>
-@const fn extractBits(
-  e: T,
-  offset: u32,
-  count: u32) -> T
-Reads bits from an integer, without sign extension.
-
-When T is a scalar type, then:
-  w is the bit width of T
-  o = min(offset,w)
-  c = min(count, w - o)
-
-The result is 0 if c is 0.
-Otherwise, bits 0..c-1 of the result are copied from bits o..o+c-1 of e.
-Other bits of the result are 0.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -184,26 +194,7 @@ Component-wise when T is a vector.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32 or vecN<i32>
-@const fn extractBits(
-  e: T,
-  offset: u32,
-  count: u32) -> T
-Reads bits from an integer, with sign extension.
-
-When T is a scalar type, then:
-  w is the bit width of T
-  o = min(offset,w)
-  c = min(count, w - o)
-
-The result is 0 if c is 0.
-Otherwise, bits 0..c-1 of the result are copied from bits o..o+c-1 of e.
-Other bits of the result are the same as bit c-1 of the result.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
@@ -1,5 +1,9 @@
 export const description = `
 Execution tests for the 'faceForward' builtin function
+
+T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
+@const fn faceForward(e1: T ,e2: T ,e3: T ) -> T
+Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +13,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn faceForward(e1: T ,e2: T ,e3: T ) -> T
-Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +23,7 @@ Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn faceForward(e1: T ,e2: T ,e3: T ) -> T
-Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +33,7 @@ Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn faceForward(e1: T ,e2: T ,e3: T ) -> T
-Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
@@ -1,5 +1,17 @@
 export const description = `
 Execution tests for the 'firstLeadingBit' builtin function
+
+T is u32 or vecN<u32>
+@const fn firstLeadingBit(e: T ) -> T
+For scalar T, the result is: T(-1) if e is zero.
+Otherwise the position of the most significant 1 bit in e.
+Component-wise when T is a vector.
+
+T is i32 or vecN<i32>
+@const fn firstLeadingBit(e: T ) -> T
+For scalar T, the result is: -1 if e is 0 or -1.
+Otherwise the position of the most significant bit in e that is different from e’s sign bit.
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -13,15 +25,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is u32 or vecN<u32>
-@const fn firstLeadingBit(e: T ) -> T
-For scalar T, the result is: T(-1) if e is zero.
-Otherwise the position of the most significant 1 bit in e.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -138,15 +142,7 @@ Component-wise when T is a vector.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32 or vecN<i32>
-@const fn firstLeadingBit(e: T ) -> T
-For scalar T, the result is: -1 if e is 0 or -1.
-Otherwise the position of the most significant bit in e that is different from e’s sign bit.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/firstTrailingBit.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/firstTrailingBit.spec.ts
@@ -1,5 +1,13 @@
 export const description = `
 Execution tests for the 'firstTrailingBit' builtin function
+
+S is i32, u32
+T is S or vecN<S>
+@const fn firstTrailingBit(e: T ) -> T
+For scalar T, the result is: T(-1) if e is zero.
+Otherwise the position of the least significant 1 bit in e.
+Component-wise when T is a vector.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -13,15 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn firstTrailingBit(e: T ) -> T
-For scalar T, the result is: T(-1) if e is zero.
-Otherwise the position of the least significant 1 bit in e.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -138,15 +138,7 @@ Component-wise when T is a vector.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn firstTrailingBit(e: T ) -> T
-For scalar T, the result is: T(-1) if e is zero.
-Otherwise the position of the least significant 1 bit in e.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'floor' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn floor(e: T ) -> T
+Returns the floor of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -16,13 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn floor(e: T ) -> T
-Returns the floor of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -32,13 +31,7 @@ Returns the floor of e. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn floor(e: T ) -> T
-Returns the floor of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -80,13 +73,7 @@ Returns the floor of e. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn floor(e: T ) -> T
-Returns the floor of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'fma' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn fma(e1: T ,e2: T ,e3: T ) -> T
+Returns e1 * e2 + e3. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn fma(e1: T ,e2: T ,e3: T ) -> T
-Returns e1 * e2 + e3. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns e1 * e2 + e3. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn fma(e1: T ,e2: T ,e3: T ) -> T
-Returns e1 * e2 + e3. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns e1 * e2 + e3. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn fma(e1: T ,e2: T ,e3: T ) -> T
-Returns e1 * e2 + e3. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'fract' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn fract(e: T ) -> T
+Returns the fractional part of e, computed as e - floor(e).
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -15,14 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn fract(e: T ) -> T
-Returns the fractional part of e, computed as e - floor(e).
-Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -32,14 +31,7 @@ Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn fract(e: T ) -> T
-Returns the fractional part of e, computed as e - floor(e).
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -103,14 +95,7 @@ Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn fract(e: T ) -> T
-Returns the fractional part of e, computed as e - floor(e).
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
@@ -1,5 +1,16 @@
 export const description = `
 Execution tests for the 'frexp' builtin function
+
+S is f32 or f16
+T is S or vecN<S>
+
+@const fn frexp(e: T) -> result_struct
+
+Splits e into a significand and exponent of the form significand * 2^exponent.
+Returns the result_struct for the appropriate overload.
+
+
+The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -11,19 +22,12 @@ g.test('scalar_f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is f32
-
-@const fn frexp(e:T) -> __frexp_result
-
-Splits e into a significand and exponent of the form significand * 2^exponent.
-Returns the __frexp_result built-in structure, defined as follows:
+f32 tests
 
 struct __frexp_result {
   sig : f32, // significand part
   exp : i32  // exponent part
 }
-
-The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 `
   )
   .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
@@ -33,19 +37,12 @@ g.test('scalar_f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is f16
-
-@const fn frexp(e:T) -> __frexp_result_f16
-
-Splits e into a significand and exponent of the form significand * 2^exponent.
-Returns the __frexp_result_f16 built-in structure, defined as if as follows:
+f16 tests
 
 struct __frexp_result_f16 {
   sig : f16, // significand part
   exp : i32  // exponent part
 }
-
-The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 `
   )
   .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
@@ -55,19 +52,12 @@ g.test('vector_f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is vecN<f32>
-
-@const fn frexp(e:T) -> __frexp_result_vecN
-
-Splits the components of e into a significand and exponent of the form significand * 2^exponent.
-Returns the __frexp_result_vecN built-in structure, defined as follows:
+vecN<f32>
 
 struct __frexp_result_vecN {
   sig : vecN<f32>, // significand part
   exp : vecN<i32>  // exponent part
 }
-
-The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
 `
   )
   .params(u =>
@@ -81,19 +71,12 @@ g.test('vector_f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is vecN< f16 >
-
-@const fn frexp(e:T) -> __frexp_result_vecN_f16
-
-Splits the components of e into a significand and exponent of the form significand * 2^exponent.
-Returns the __frexp_result_vecN built-in structure, defined as if as follows:
+vecN<f16>
 
 struct __frexp_result_vecN_f16 {
   sig : vecN<f16>, // significand part
   exp : vecN<i32>  // exponent part
 }
-
-The magnitude of each component of the significand is in the range of [0.5, 1.0) or 0.
 `
   )
   .params(u =>

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidth.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidth.spec.ts
@@ -13,7 +13,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc( `f32 tests`)
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidth.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidth.spec.ts
@@ -1,5 +1,9 @@
 export const description = `
 Execution tests for the 'fwidth' builtin function
+
+T is f32 or vecN<f32>
+fn fwidth(e:T) ->T
+Returns abs(dpdx(e)) + abs(dpdy(e)).
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +13,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-fn fwidth(e:T) ->T
-Returns abs(dpdx(e)) + abs(dpdy(e)).
-`
-  )
+  .desc( `f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidthCoarse.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidthCoarse.spec.ts
@@ -1,5 +1,9 @@
 export const description = `
 Execution tests for the 'fwidthCoarse' builtin function
+
+T is f32 or vecN<f32>
+fn fwidthCoarse(e:T) ->T
+Returns abs(dpdxCoarse(e)) + abs(dpdyCoarse(e)).
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +13,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-fn fwidthCoarse(e:T) ->T
-Returns abs(dpdxCoarse(e)) + abs(dpdyCoarse(e)).
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidthFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidthFine.spec.ts
@@ -1,5 +1,9 @@
 export const description = `
 Execution tests for the 'fwidthFine' builtin function
+
+T is f32 or vecN<f32>
+fn fwidthFine(e:T) ->T
+Returns abs(dpdxFine(e)) + abs(dpdyFine(e)).
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +13,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-fn fwidthFine(e:T) ->T
-Returns abs(dpdxFine(e)) + abs(dpdyFine(e)).
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
@@ -3,11 +3,7 @@ Execution tests for the 'insertBits' builtin function
 
 S is i32 or u32
 T is S or vecN<S>
-@const fn insertBits(
-  e: T,
-  newbits:T,
-  offset: u32,
-  count: u32) -> T  Sets bits in an integer.
+@const fn insertBits(e: T, newbits:T, offset: u32, count: u32) -> T  Sets bits in an integer.
 
 When T is a scalar type, then:
   w is the bit width of T

--- a/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
@@ -1,5 +1,23 @@
 export const description = `
 Execution tests for the 'insertBits' builtin function
+
+S is i32 or u32
+T is S or vecN<S>
+@const fn insertBits(
+  e: T,
+  newbits:T,
+  offset: u32,
+  count: u32) -> T  Sets bits in an integer.
+
+When T is a scalar type, then:
+  w is the bit width of T
+  o = min(offset,w)
+  c = min(count, w - o)
+
+The result is e if c is 0.
+Otherwise, bits o..o+c-1 of the result are copied from bits 0..c-1 of newbits.
+Other bits of the result are copied from e.
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -23,26 +41,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('integer')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn insertBits(
-  e: T,
-  newbits:T,
-  offset: u32,
-  count: u32) -> T	Sets bits in an integer.
-
-When T is a scalar type, then:
-  w is the bit width of T
-  o = min(offset,w)
-  c = min(count, w - o)
-
-The result is e if c is 0.
-Otherwise, bits o..o+c-1 of the result are copied from bits 0..c-1 of newbits.
-Other bits of the result are copied from e.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`integer tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'inverseSqrt' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn inverseSqrt(e: T ) -> T
+Returns the reciprocal of sqrt(e). Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -16,13 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn inverseSqrt(e: T ) -> T
-Returns the reciprocal of sqrt(e). Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -32,13 +31,7 @@ Returns the reciprocal of sqrt(e). Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn inverseSqrt(e: T ) -> T
-Returns the reciprocal of sqrt(e). Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -67,13 +60,7 @@ Returns the reciprocal of sqrt(e). Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn inverseSqrt(e: T ) -> T
-Returns the reciprocal of sqrt(e). Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -1,5 +1,15 @@
 export const description = `
 Execution tests for the 'ldexp' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+
+K is AbstractInt, i32
+I is K or vecN<K>, where
+  I is a scalar if T is a scalar, or a vector when T is a vector
+
+@const fn ldexp(e1: T ,e2: I ) -> T
+Returns e1 * 2^e2. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -18,11 +28,6 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-I is AbstractInt, i32, vecN<AbstractInt>, or vecN<i32>, where
-  I is a scalar if T is a scalar, or a vector when T is a vector
-@const fn ldexp(e1: T ,e2: I ) -> T
-Returns e1 * 2^e2. Component-wise when T is a vector.
 `
   )
   .params(u =>
@@ -34,15 +39,7 @@ Returns e1 * 2^e2. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-I is AbstractInt, i32, vecN<AbstractInt>, or vecN<i32>, where
-  I is a scalar if T is a scalar, or a vector when T is a vector
-@const fn ldexp(e1: T ,e2: I ) -> T
-Returns e1 * 2^e2. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -97,15 +94,7 @@ Returns e1 * 2^e2. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-I is AbstractInt, i32, vecN<AbstractInt>, or vecN<i32>, where
-  I is a scalar if T is a scalar, or a vector when T is a vector
-@const fn ldexp(e1: T ,e2: I ) -> T
-Returns e1 * 2^e2. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'length' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn length(e: T ) -> f32
+Returns the length of e (e.g. abs(e) if T is a scalar, or sqrt(e[0]^2 + e[1]^2 + ...) if T is a vector).
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn length(e: T ) -> f32
-Returns the length of e (e.g. abs(e) if T is a scalar, or sqrt(e[0]^2 + e[1]^2 + ...) if T is a vector).
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the length of e (e.g. abs(e) if T is a scalar, or sqrt(e[0]^2 + e[1]^2 +
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn length(e: T ) -> f32
-Returns the length of e (e.g. abs(e) if T is a scalar, or sqrt(e[0]^2 + e[1]^2 + ...) if T is a vector).
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the length of e (e.g. abs(e) if T is a scalar, or sqrt(e[0]^2 + e[1]^2 +
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn length(e: T ) -> f32
-Returns the length of e (e.g. abs(e) if T is a scalar, or sqrt(e[0]^2 + e[1]^2 + ...) if T is a vector).
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'log' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn log(e: T ) -> T
+Returns the natural logarithm of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -16,13 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn log(e: T ) -> T
-Returns the natural logarithm of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -35,9 +34,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn log(e: T ) -> T
-Returns the natural logarithm of e. Component-wise when T is a vector.
+f32 tests
 
 TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
@@ -85,13 +82,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn log(e: T ) -> T
-Returns the natural logarithm of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'log2' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn log2(e: T ) -> T
+Returns the base-2 logarithm of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -16,13 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn log2(e: T ) -> T
-Returns the base-2 logarithm of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -35,9 +34,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn log2(e: T ) -> T
-Returns the base-2 logarithm of e. Component-wise when T is a vector.
+f32 tests
 
 TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
@@ -85,13 +82,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn log2(e: T ) -> T
-Returns the base-2 logarithm of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -1,5 +1,19 @@
 export const description = `
 Execution tests for the 'max' builtin function
+
+S is AbstractInt, i32, or u32
+T is S or vecN<S>
+@const fn max(e1: T ,e2: T) -> T
+Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a vector.
+
+S is AbstractFloat, f32, f16
+T is vecN<S>
+@const fn max(e1: T ,e2: T) -> T
+Returns e2 if e1 is less than e2, and e1 otherwise.
+If one operand is a NaN, the other is returned.
+If both operands are NaNs, a NaN is returned.
+Component-wise when T is a vector.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -36,14 +50,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn max(e1: T ,e2: T) -> T
-Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract int tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -53,14 +60,7 @@ Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a v
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn max(e1: T ,e2: T) -> T
-Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a vector.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -82,14 +82,7 @@ Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a v
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn max(e1: T ,e2: T) -> T
-Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a vector.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -111,16 +104,7 @@ Returns e2 if e1 is less than e2, and e1 otherwise. Component-wise when T is a v
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn max(e1: T ,e2: T ) -> T
-Returns e2 if e1 is less than e2, and e1 otherwise.
-If one operand is a NaN, the other is returned.
-If both operands are NaNs, a NaN is returned.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -130,16 +114,7 @@ Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn max(e1: T ,e2: T ) -> T
-Returns e2 if e1 is less than e2, and e1 otherwise.
-If one operand is a NaN, the other is returned.
-If both operands are NaNs, a NaN is returned.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -177,16 +152,7 @@ Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn max(e1: T ,e2: T ) -> T
-Returns e2 if e1 is less than e2, and e1 otherwise.
-If one operand is a NaN, the other is returned.
-If both operands are NaNs, a NaN is returned.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -1,5 +1,18 @@
 export const description = `
 Execution tests for the 'min' builtin function
+
+S is AbstractInt, i32, or u32
+T is S or vecN<S>
+@const fn min(e1: T ,e2: T) -> T
+Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a vector.
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn min(e1: T ,e2: T) -> T
+Returns e2 if e2 is less than e1, and e1 otherwise.
+If one operand is a NaN, the other is returned.
+If both operands are NaNs, a NaN is returned.
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -36,14 +49,7 @@ function generateTestCases(
 
 g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn min(e1: T ,e2: T) -> T
-Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract int tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -53,14 +59,7 @@ Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a v
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn min(e1: T ,e2: T) -> T
-Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a vector.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -82,14 +81,7 @@ Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a v
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-S is AbstractInt, i32, or u32
-T is S or vecN<S>
-@const fn min(e1: T ,e2: T) -> T
-Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a vector.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -111,16 +103,7 @@ Returns e1 if e1 is less than e2, and e2 otherwise. Component-wise when T is a v
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn min(e1: T ,e2: T ) -> T
-Returns e2 if e2 is less than e1, and e1 otherwise.
-If one operand is a NaN, the other is returned.
-If both operands are NaNs, a NaN is returned.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -130,16 +113,7 @@ Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn min(e1: T ,e2: T ) -> T
-Returns e2 if e2 is less than e1, and e1 otherwise.
-If one operand is a NaN, the other is returned.
-If both operands are NaNs, a NaN is returned.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -177,16 +151,7 @@ Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn min(e1: T ,e2: T ) -> T
-Returns e2 if e2 is less than e1, and e1 otherwise.
-If one operand is a NaN, the other is returned.
-If both operands are NaNs, a NaN is returned.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -1,5 +1,17 @@
 export const description = `
 Execution tests for the 'mix' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn mix(e1: T, e2: T, e3: T) -> T
+Returns the linear blend of e1 and e2 (e.g. e1*(1-e3)+e2*e3). Component-wise when T is a vector.
+
+T is AbstractFloat, f32, or f16
+T2 is vecN<T>
+@const fn mix(e1: T2, e2: T2, e3: T) -> T2
+Returns the component-wise linear blend of e1 and e2, using scalar blending factor e3 for each component.
+Same as mix(e1,e2,T2(e3)).
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -7,15 +19,9 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('scalar_abstract_float')
+g.test('matching_abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn mix(e1: T ,e2: T ,e3: T) -> T
-Returns the linear blend of e1 and e2 (e.g. e1*(1-e3)+e2*e3). Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests with matching params`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -23,15 +29,9 @@ Returns the linear blend of e1 and e2 (e.g. e1*(1-e3)+e2*e3). Component-wise whe
   )
   .unimplemented();
 
-g.test('scalar_f32')
+g.test('matching_f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn mix(e1: T ,e2: T ,e3: T) -> T
-Returns the linear blend of e1 and e2 (e.g. e1*(1-e3)+e2*e3). Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 test with matching third param`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +41,7 @@ Returns the linear blend of e1 and e2 (e.g. e1*(1-e3)+e2*e3). Component-wise whe
 
 g.test('scalar_f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn mix(e1: T ,e2: T ,e3: T) -> T
-Returns the linear blend of e1 and e2 (e.g. e1*(1-e3)+e2*e3). Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests with matching third param`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -55,17 +49,9 @@ Returns the linear blend of e1 and e2 (e.g. e1*(1-e3)+e2*e3). Component-wise whe
   )
   .unimplemented();
 
-g.test('vector_abstract_float')
+g.test('nonmatching_abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-T2 is vecN<T>
-@const fn mix(e1: T2 ,e2: T2 ,e3: T) -> T2
-Returns the component-wise linear blend of e1 and e2, using scalar blending factor e3 for each component.
-Same as mix(e1,e2,T2(e3)).
-`
-  )
+  .desc(`abstract float tests with vector params and scalar third param`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -73,17 +59,9 @@ Same as mix(e1,e2,T2(e3)).
   )
   .unimplemented();
 
-g.test('vector_f32')
+g.test('nonmatching_f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-T2 is vecN<T>
-@const fn mix(e1: T2 ,e2: T2 ,e3: T) -> T2
-Returns the component-wise linear blend of e1 and e2, using scalar blending factor e3 for each component.
-Same as mix(e1,e2,T2(e3)).
-`
-  )
+  .desc(`f32 tests with vector params and scalar third param`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -91,17 +69,9 @@ Same as mix(e1,e2,T2(e3)).
   )
   .unimplemented();
 
-g.test('vector_f16')
+g.test('monmatching_f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-T2 is vecN<T>
-@const fn mix(e1: T2 ,e2: T2 ,e3: T) -> T2
-Returns the component-wise linear blend of e1 and e2, using scalar blending factor e3 for each component.
-Same as mix(e1,e2,T2(e3)).
-`
-  )
+  .desc(`f16 tests with vector params and scalar third param`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -1,5 +1,19 @@
 export const description = `
 Execution tests for the 'modf' builtin function
+
+T is f32 or f16
+@const fn modf(e:T) -> result_struct
+Splits |e| into fractional and whole number parts.
+The whole part is (|e| % 1.0), and the fractional part is |e| minus the whole part.
+Returns the result_struct for the given type.
+
+S is f32 or f16
+T is vecN<S>
+@const fn modf(e:T) -> result_struct
+Splits the components of |e| into fractional and whole number parts.
+The |i|'th component of the whole and fractional parts equal the whole and fractional parts of modf(e[i]).
+Returns the result_struct for the given type.
+
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -12,10 +26,7 @@ g.test('scalar_f32')
   .desc(
     `
 T is f32
-@const fn modf(e:T) -> __modf_result
-Splits |e| into fractional and whole number parts.
-The whole part is (|e| % 1.0), and the fractional part is |e| minus the whole part.
-Returns the __modf_result built-in structure, defined as follows:
+
 struct __modf_result {
   fract : f32, // fractional part
   whole : f32  // whole part
@@ -30,10 +41,7 @@ g.test('scalar_f16')
   .desc(
     `
 T is f16
-@const fn modf(e:T) -> __modf_result_f16
-Splits |e| into fractional and whole number parts.
-The whole part is (|e| % 1.0), and the fractional part is |e| minus the whole part.
-Returns the __modf_result_f16 built-in structure, defined as if as follows:
+
 struct __modf_result_f16 {
   fract : f16, // fractional part
   whole : f16  // whole part
@@ -48,10 +56,7 @@ g.test('vector_f32')
   .desc(
     `
 T is vecN<f32>
-@const fn modf(e:T) -> __modf_result_vecN
-Splits the components of |e| into fractional and whole number parts.
-The |i|'th component of the whole and fractional parts equal the whole and fractional parts of modf(e[i]).
-Returns the __modf_result_vecN built-in structure, defined as follows:
+
 struct __modf_result_vecN {
   fract : vecN<f32>, // fractional part
   whole : vecN<f32>  // whole part
@@ -70,10 +75,7 @@ g.test('vector_f16')
   .desc(
     `
 T is vecN<f16>
-@const fn modf(e:T) -> __modf_result_vecN_f16
-Splits the components of |e| into fractional and whole number parts.
-The |i|'th component of the whole and fractional parts equal the whole and fractional parts of modf(e[i]).
-Returns the __modf_result_vecN_f16 built-in structure, defined as if as follows:
+
 struct __modf_result_vecN_f16 {
   fract : vecN<f16>, // fractional part
   whole : vecN<f16>  // whole part

--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -1,5 +1,9 @@
 export const description = `
 Execution tests for the 'normalize' builtin function
+
+T is AbstractFloat, f32, or f16
+@const fn normalize(e: vecN<T> ) -> vecN<T>
+Returns a unit vector in the same direction as e.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +13,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const fn normalize(e: vecN<T> ) -> vecN<T>
-Returns a unit vector in the same direction as e.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +23,7 @@ Returns a unit vector in the same direction as e.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const fn normalize(e: vecN<T> ) -> vecN<T>
-Returns a unit vector in the same direction as e.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +33,7 @@ Returns a unit vector in the same direction as e.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const fn normalize(e: vecN<T> ) -> vecN<T>
-Returns a unit vector in the same direction as e.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'pow' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn pow(e1: T ,e2: T ) -> T
+Returns e1 raised to the power e2. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn pow(e1: T ,e2: T ) -> T
-Returns e1 raised to the power e2. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns e1 raised to the power e2. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn pow(e1: T ,e2: T ) -> T
-Returns e1 raised to the power e2. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns e1 raised to the power e2. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn pow(e1: T ,e2: T ) -> T
-Returns e1 raised to the power e2. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'quantizeToF16' builtin function
+
+T is f32 or vecN<f32>
+@const fn quantizeToF16(e: T ) -> T
+Quantizes a 32-bit floating point value e as if e were converted to a IEEE 754
+binary16 value, and then converted back to a IEEE 754 binary32 value.
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,15 +15,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is f32 or vecN<f32>
-@const fn quantizeToF16(e: T ) -> T
-Quantizes a 32-bit floating point value e as if e were converted to a IEEE 754
-binary16 value, and then converted back to a IEEE 754 binary32 value.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'radians' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn radians(e1: T ) -> T
+Converts degrees to radians, approximating e1 * π / 180.
+Component-wise when T is a vector
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,14 +15,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn radians(e1: T ) -> T
-Converts degrees to radians, approximating e1 * π / 180.
-Component-wise when T is a vector
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -26,14 +25,7 @@ Component-wise when T is a vector
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn radians(e1: T ) -> T
-Converts degrees to radians, approximating e1 * π / 180.
-Component-wise when T is a vector
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -43,14 +35,7 @@ Component-wise when T is a vector
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn radians(e1: T ) -> T
-Converts degrees to radians, approximating e1 * π / 180.
-Component-wise when T is a vector
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'reflect' builtin function
+
+T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
+@const fn reflect(e1: T ,e2: T ) -> T
+For the incident vector e1 and surface orientation e2, returns the reflection
+direction e1-2*dot(e2,e1)*e2.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,14 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn reflect(e1: T ,e2: T ) -> T
-For the incident vector e1 and surface orientation e2, returns the reflection
-direction e1-2*dot(e2,e1)*e2.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -26,14 +24,7 @@ direction e1-2*dot(e2,e1)*e2.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn reflect(e1: T ,e2: T ) -> T
-For the incident vector e1 and surface orientation e2, returns the reflection
-direction e1-2*dot(e2,e1)*e2.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -43,14 +34,7 @@ direction e1-2*dot(e2,e1)*e2.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn reflect(e1: T ,e2: T ) -> T
-For the incident vector e1 and surface orientation e2, returns the reflection
-direction e1-2*dot(e2,e1)*e2.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
@@ -1,5 +1,13 @@
 export const description = `
 Execution tests for the 'refract' builtin function
+
+T is vecN<I>
+I is AbstractFloat, f32, or f16
+@const fn refract(e1: T ,e2: T ,e3: I ) -> T
+For the incident vector e1 and surface normal e2, and the ratio of indices of
+refraction e3, let k = 1.0 -e3*e3* (1.0 - dot(e2,e1) * dot(e2,e1)).
+If k < 0.0, returns the refraction vector 0.0, otherwise return the refraction
+vector e3*e1- (e3* dot(e2,e1) + sqrt(k)) *e2.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,17 +17,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is vecN<I>
-I is AbstractFloat, f32, or f16
-@const fn refract(e1: T ,e2: T ,e3: I ) -> T
-For the incident vector e1 and surface normal e2, and the ratio of indices of
-refraction e3, let k = 1.0 -e3*e3* (1.0 - dot(e2,e1) * dot(e2,e1)).
-If k < 0.0, returns the refraction vector 0.0, otherwise return the refraction
-vector e3*e1- (e3* dot(e2,e1) + sqrt(k)) *e2.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -29,17 +27,7 @@ vector e3*e1- (e3* dot(e2,e1) + sqrt(k)) *e2.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is vecN<I>
-I is AbstractFloat, f32, or f16
-@const fn refract(e1: T ,e2: T ,e3: I ) -> T
-For the incident vector e1 and surface normal e2, and the ratio of indices of
-refraction e3, let k = 1.0 -e3*e3* (1.0 - dot(e2,e1) * dot(e2,e1)).
-If k < 0.0, returns the refraction vector 0.0, otherwise return the refraction
-vector e3*e1- (e3* dot(e2,e1) + sqrt(k)) *e2.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -49,17 +37,7 @@ vector e3*e1- (e3* dot(e2,e1) + sqrt(k)) *e2.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is vecN<I>
-I is AbstractFloat, f32, or f16
-@const fn refract(e1: T ,e2: T ,e3: I ) -> T
-For the incident vector e1 and surface normal e2, and the ratio of indices of
-refraction e3, let k = 1.0 -e3*e3* (1.0 - dot(e2,e1) * dot(e2,e1)).
-If k < 0.0, returns the refraction vector 0.0, otherwise return the refraction
-vector e3*e1- (e3* dot(e2,e1) + sqrt(k)) *e2.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/reverseBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reverseBits.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'reversBits' builtin function
+
+S is i32, u32
+T is S or vecN<S>
+@const fn reverseBits(e: T ) -> T
+Reverses the bits in e: The bit at position k of the result equals the bit at position 31-k of e.
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -13,14 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn reverseBits(e: T ) -> T
-Reverses the bits in e: The bit at position k of the result equals the bit at position 31-k of e.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`u32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -138,14 +137,7 @@ Component-wise when T is a vector.
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions')
-  .desc(
-    `
-T is i32, u32, vecN<i32>, or vecN<u32>
-@const fn reverseBits(e: T ) -> T
-Reverses the bits in e: The bit at position k of the result equals the bit at position 31-k of e.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`i32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -1,5 +1,13 @@
 export const description = `
 Execution tests for the 'round' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn round(e: T) -> T
+Result is the integer k nearest to e, as a floating point value.
+When e lies halfway between integers k and k+1, the result is k when k is even,
+and k+1 when k is odd.
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,16 +17,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn round(e: T ) -> T
-Result is the integer k nearest to e, as a floating point value.
-When e lies halfway between integers k and k+1, the result is k when k is even,
-and k+1 when k is odd.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -28,16 +27,7 @@ Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn round(e: T ) -> T
-Result is the integer k nearest to e, as a floating point value.
-When e lies halfway between integers k and k+1, the result is k when k is even,
-and k+1 when k is odd.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -47,16 +37,7 @@ Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn round(e: T ) -> T
-Result is the integer k nearest to e, as a floating point value.
-When e lies halfway between integers k and k+1, the result is k when k is even,
-and k+1 when k is odd.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
@@ -1,5 +1,13 @@
 export const description = `
 Execution tests for the 'select' builtin function
+
+T is scalar, abstract numeric type, or vector
+@const fn select(f: T, t: T, cond: bool) -> T
+Returns t when cond is true, and f otherwise.
+
+T is scalar or abstract numeric type
+@const fn select(f: vecN<T>, t: vecN<T>, cond: vecN<bool>) -> vecN<T>
+Component-wise selection. Result component i is evaluated as select(f[i],t[i],cond[i]).
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -55,13 +63,7 @@ const dataType = {
 
 g.test('scalar')
   .specURL('https://www.w3.org/TR/WGSL/#logical-builtin-functions')
-  .desc(
-    `
-T is scalar, abstract numeric type, or vector
-@const fn select(f: T, t: T, cond: bool) -> T
-Returns t when cond is true, and f otherwise.
-`
-  )
+  .desc(`scalar tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -131,13 +133,7 @@ Returns t when cond is true, and f otherwise.
 
 g.test('vector')
   .specURL('https://www.w3.org/TR/WGSL/#logical-builtin-functions')
-  .desc(
-    `
-T is scalar or abstract numeric type
-@const fn select(f: vecN<T>, t: vecN<T>, cond: vecN<bool>) -> vecN<T>
-Component-wise selection. Result component i is evaluated as select(f[i],t[i],cond[i]).
-`
-  )
+  .desc(`vector tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'sign' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn sign(e: T ) -> T
+Returns the sign of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sign(e: T ) -> T
-Returns the sign of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the sign of e. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sign(e: T ) -> T
-Returns the sign of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the sign of e. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sign(e: T ) -> T
-Returns the sign of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'sin' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn sin(e: T ) -> T
+Returns the sine of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -15,13 +20,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sin(e: T ) -> T
-Returns the sine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -33,9 +32,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sin(e: T ) -> T
-Returns the sine of e. Component-wise when T is a vector.
+f32 tests
 
 TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
@@ -61,15 +58,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sin(e: T ) -> T
-Returns the sine of e. Component-wise when T is a vector.
-
-TODO(#792): Decide what the ground-truth is for these tests. [1]
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'sinh' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn sinh(e: T ) -> T
+Returns the hyperbolic sine of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sinh(e: T ) -> T
-Returns the hyperbolic sine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the hyperbolic sine of e. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sinh(e: T ) -> T
-Returns the hyperbolic sine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the hyperbolic sine of e. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sinh(e: T ) -> T
-Returns the hyperbolic sine of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -1,5 +1,12 @@
 export const description = `
 Execution tests for the 'smoothstep' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn smoothstep(low: T , high: T , x: T ) -> T
+Returns the smooth Hermite interpolation between 0 and 1.
+Component-wise when T is a vector.
+For scalar T, the result is t * t * (3.0 - 2.0 * t), where t = clamp((x - low) / (high - low), 0.0, 1.0).
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,15 +16,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn smoothstep(low: T , high: T , x: T ) -> T
-Returns the smooth Hermite interpolation between 0 and 1.
-Component-wise when T is a vector.
-For scalar T, the result is t * t * (3.0 - 2.0 * t), where t = clamp((x - low) / (high - low), 0.0, 1.0).
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -27,15 +26,7 @@ For scalar T, the result is t * t * (3.0 - 2.0 * t), where t = clamp((x - low) /
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn smoothstep(low: T , high: T , x: T ) -> T
-Returns the smooth Hermite interpolation between 0 and 1.
-Component-wise when T is a vector.
-For scalar T, the result is t * t * (3.0 - 2.0 * t), where t = clamp((x - low) / (high - low), 0.0, 1.0).
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -45,15 +36,7 @@ For scalar T, the result is t * t * (3.0 - 2.0 * t), where t = clamp((x - low) /
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn smoothstep(low: T , high: T , x: T ) -> T
-Returns the smooth Hermite interpolation between 0 and 1.
-Component-wise when T is a vector.
-For scalar T, the result is t * t * (3.0 - 2.0 * t), where t = clamp((x - low) / (high - low), 0.0, 1.0).
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'sqrt' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn sqrt(e: T ) -> T
+Returns the square root of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sqrt(e: T ) -> T
-Returns the square root of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the square root of e. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sqrt(e: T ) -> T
-Returns the square root of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the square root of e. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn sqrt(e: T ) -> T
-Returns the square root of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'step' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn step(edge: T ,x: T ) -> T
+Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn step(edge: T ,x: T ) -> T
-Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn step(edge: T ,x: T ) -> T
-Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn step(edge: T ,x: T ) -> T
-Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'tan' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn tan(e: T ) -> T
+Returns the tangent of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn tan(e: T ) -> T
-Returns the tangent of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the tangent of e. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn tan(e: T ) -> T
-Returns the tangent of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the tangent of e. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn tan(e: T ) -> T
-Returns the tangent of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
@@ -1,5 +1,10 @@
 export const description = `
 Execution tests for the 'tanh' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn tanh(e: T ) -> T
+Returns the hyperbolic tangent of e. Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +14,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn tanh(e: T ) -> T
-Returns the hyperbolic tangent of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -25,13 +24,7 @@ Returns the hyperbolic tangent of e. Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn tanh(e: T ) -> T
-Returns the hyperbolic tangent of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -41,13 +34,7 @@ Returns the hyperbolic tangent of e. Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn tanh(e: T ) -> T
-Returns the hyperbolic tangent of e. Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
@@ -1,5 +1,9 @@
 export const description = `
 Execution tests for the 'transpose' builtin function
+
+T is AbstractFloat, f32, or f16
+@const transpose(e: matRxC<T> ) -> matCxR<T>
+Returns the transpose of e.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,13 +13,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const transpose(e: matRxC<T> ) -> matCxR<T>
-Returns the transpose of e.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -26,13 +24,7 @@ Returns the transpose of e.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const transpose(e: matRxC<T> ) -> matCxR<T>
-Returns the transpose of e.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -43,13 +35,7 @@ Returns the transpose of e.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, or f16
-@const transpose(e: matRxC<T> ) -> matCxR<T>
-Returns the transpose of e.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -1,5 +1,11 @@
 export const description = `
 Execution tests for the 'trunc' builtin function
+
+S is AbstractFloat, f32, f16
+T is S or vecN<S>
+@const fn trunc(e: T ) -> T
+Returns the nearest whole number whose absolute value is less than or equal to e.
+Component-wise when T is a vector.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -9,14 +15,7 @@ export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn trunc(e: T ) -> T
-Returns the nearest whole number whose absolute value is less than or equal to e.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`abstract float tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -26,14 +25,7 @@ Component-wise when T is a vector.
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn trunc(e: T ) -> T
-Returns the nearest whole number whose absolute value is less than or equal to e.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f32 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
@@ -43,14 +35,7 @@ Component-wise when T is a vector.
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(
-    `
-T is AbstractFloat, f32, f16, vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn trunc(e: T ) -> T
-Returns the nearest whole number whose absolute value is less than or equal to e.
-Component-wise when T is a vector.
-`
-  )
+  .desc(`f16 tests`)
   .params(u =>
     u
       .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)


### PR DESCRIPTION
The description for each builtin was placed in the specific test `desc` field
when it would be better in the testsuite `description`. This PR moves the
descriptions up to the `description` block.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
