### PR TITLE
Fix unary tests with subnormal inputs

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -7,6 +7,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { correctlyRoundedMatch, anyOf } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
+import { isSubnormalNumber } from '../../../../../util/math.js';
 import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -51,7 +52,7 @@ Component-wise when T is a vector.
 
     const makeCase = (x: number): Case => {
       const result = x - Math.floor(x);
-      if (result < 1.0) {
+      if (result < 1.0 || isSubnormalNumber(x)) {
         return makeUnaryF32Case(x, x => x - Math.floor(x));
       }
       // Very small negative numbers can lead to catastrophic cancellation, thus calculating a fract of 1.0, which is

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -391,7 +391,13 @@ function calculateFlushedResults(value: number): Set<Scalar> {
  */
 export function makeUnaryF32Case(param: number, op: (p: number) => number): Case {
   const f32_param = quantizeToF32(param);
+  const is_param_subnormal = isSubnormalNumber(f32_param);
   const expected = calculateFlushedResults(op(f32_param));
+  if (is_param_subnormal) {
+    calculateFlushedResults(op(0)).forEach(value => {
+      expected.add(value);
+    });
+  }
   return { input: [f32(param)], expected: anyOf(...expected) };
 }
 


### PR DESCRIPTION
Fixes:
webgpu:shader,execution,expression,call,builtin,ceil:*
webgpu:shader,execution,expression,call,builtin,floor:*
webgpu:shader,execution,expression,call,builtin,fract:*

Bug: tint:1546

Issue: crbug.com/tint/1546
