### PR TITLE
wgsl: Stub tests for textureLoad builtin.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -1,0 +1,190 @@
+export const description = `
+Execution tests for the 'textureLoad' builtin function
+
+Reads a single texel from a texture without sampling or filtering.
+
+Returns the unfiltered texel data.
+
+An out of bounds access occurs if:
+ * any element of coords is outside the range [0, textureDimensions(t, level)) for the corresponding element, or
+ * array_index is outside the range [0, textureNumLayers(t)), or
+ * level is outside the range [0, textureNumLevels(t))
+
+If an out of bounds access occurs, the built-in function returns one of:
+ * The data for some texel within bounds of the texture
+ * A vector (0,0,0,0) or (0,0,0,1) of the appropriate type for non-depth textures
+ * 0.0 for depth textures
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('sampled_1d')
+  .specURL('https://www.w3.org/TR/WGSL/#textureload')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureLoad(t: texture_1d<T>, coords: C, level: C) -> vec4<T>
+
+Parameters:
+ * t: The sampled texture to read from
+ * coords: The 0-based texel coordinate
+ * level: The mip level, with level 0 containing a full size version of the texture
+`
+  )
+  .params(u =>
+    u
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords', [-1, 0, `dimension-1`, `dimension`] as const)
+      .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
+  )
+  .unimplemented();
+
+g.test('sampled_2d')
+  .specURL('https://www.w3.org/TR/WGSL/#textureload')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureLoad(t: texture_2d<T>, coords: vec2<C>, level: C) -> vec4<T>
+
+Parameters:
+ * t: The sampled texture to read from
+ * coords: The 0-based texel coordinate
+ * level: The mip level, with level 0 containing a full size version of the texture
+`
+  )
+  .params(u =>
+    u
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
+  )
+  .unimplemented();
+
+g.test('sampled_3d')
+  .specURL('https://www.w3.org/TR/WGSL/#textureload')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureLoad(t: texture_3d<T>, coords: vec3<C>, level: C) -> vec4<T>
+
+Parameters:
+ * t: The sampled texture to read from
+ * coords: The 0-based texel coordinate
+ * level: The mip level, with level 0 containing a full size version of the texture
+`
+  )
+  .params(u =>
+    u
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords_2', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
+  )
+  .unimplemented();
+
+g.test('multisampled')
+  .specURL('https://www.w3.org/TR/WGSL/#textureload')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureLoad(t: texture_multisampled_2d<T>, coords: vec2<C>, sample_index: C)-> vec4<T>
+fn textureLoad(t: texture_depth_multisampled_2d, coords: vec2<C>, sample_index: C)-> f32
+
+Parameters:
+ * t: The sampled texture to read from
+ * coords: The 0-based texel coordinate
+ * sample_index: The 0-based sample index of the multisampled texture
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', [
+        'texture_multisampled_2d',
+        'texture_depth_multisampled_2d',
+      ] as const)
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('sample_index', [-1, 0, `sampleCount-1`, `sampleCount`] as const)
+  )
+  .unimplemented();
+
+g.test('depth')
+  .specURL('https://www.w3.org/TR/WGSL/#textureload')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureLoad(t: texture_depth_2d, coords: vec2<C>, level: C) -> f32
+
+Parameters:
+ * t: The sampled texture to read from
+ * coords: The 0-based texel coordinate
+ * level: The mip level, with level 0 containing a full size version of the texture
+`
+  )
+  .params(u =>
+    u
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
+  )
+  .unimplemented();
+
+g.test('external')
+  .specURL('https://www.w3.org/TR/WGSL/#textureload')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureLoad(t: texture_external, coords: vec2<C>) -> vec4<f32>
+
+Parameters:
+ * t: The sampled texture to read from
+ * coords: The 0-based texel coordinate
+`
+  )
+  .params(u =>
+    u
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+  )
+  .unimplemented();
+
+g.test('arrayed')
+  .specURL('https://www.w3.org/TR/WGSL/#textureload')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureLoad(t: texture_2d_array<T>, coords: vec2<C>, array_index: C, level: C) -> vec4<T>
+fn textureLoad(t: texture_depth_2d_array, coords: vec2<C>, array_index: C, level: C) -> f32
+
+Parameters:
+ * t: The sampled texture to read from
+ * coords: The 0-based texel coordinate
+ * array_index: The 0-based texture array index
+ * level: The mip level, with level 0 containing a full size version of the texture
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', ['texture_2d_array', 'texture_depth_2d_array'] as const)
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('array_index', [-1, 0, `numlayers-1`, `numlayers`] as const)
+      .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
+  )
+  .unimplemented();


### PR DESCRIPTION
This PR adds unimplemented stubs for the `textureLoad` builtin.

Issue #1262

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
