### PR TITLE
wgsl: Stub tests for textureNumLayers builtin

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
@@ -1,0 +1,98 @@
+export const description = `
+Execution tests for the 'textureNumLayers' builtin function
+
+Returns the number of layers (elements) of an array texture.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('sampled')
+  .specURL('https://www.w3.org/TR/WGSL/#texturenumlayers')
+  .desc(
+    `
+T, a sampled type.
+
+fn textureNumLayers(t: texture_2d_array<T>) -> u32
+fn textureNumLayers(t: texture_cube_array<T>) -> u32
+
+Parameters
+ * t The sampled array texture.
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', ['texture_2d_array', 'texture_cube_array'] as const)
+      .combine('sampled_type', ['f32', 'i32', 'u32'] as const)
+  )
+  .unimplemented();
+
+g.test('arrayed')
+  .specURL('https://www.w3.org/TR/WGSL/#texturenumlayers')
+  .desc(
+    `
+fn textureNumLayers(t: texture_depth_2d_array) -> u32
+fn textureNumLayers(t: texture_depth_cube_array) -> u32
+
+Parameters
+ * t The depth array texture.
+`
+  )
+  .params(u =>
+    u.combine('texture_type', ['texture_depth_2d_array', 'texture_depth_cube_array'] as const)
+  )
+  .unimplemented();
+
+g.test('storage')
+  .specURL('https://www.w3.org/TR/WGSL/#texturenumlayers')
+  .desc(
+    `
+F: rgba8unorm
+   rgba8snorm
+   rgba8uint
+   rgba8sint
+   rgba16uint
+   rgba16sint
+   rgba16float
+   r32uint
+   r32sint
+   r32float
+   rg32uint
+   rg32sint
+   rg32float
+   rgba32uint
+   rgba32sint
+   rgba32float
+A: read, write, read_write
+
+fn textureNumLayers(t: texture_storage_2d_array<F,A>) -> u32
+
+Parameters
+ * t The sampled storage array texture.
+`
+  )
+  .params(u =>
+    u
+      .combine('texel_format', [
+        'rgba8unorm',
+        'rgba8snorm',
+        'rgba8uint',
+        'rgba8sint',
+        'rgba16uint',
+        'rgba16sint',
+        'rgba16float',
+        'r32uint',
+        'r32sint',
+        'r32float',
+        'rg32uint',
+        'rg32sint',
+        'rg32float',
+        'rgba32uint',
+        'rgba32sint',
+        'rgba32float',
+      ] as const)
+      .combine('access_mode', ['read', 'write', 'read_write'] as const)
+  )
+  .unimplemented();


### PR DESCRIPTION
This CL adds unimplemented stubs for the `textureNumLayers` builtin.

Issue #1263

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
