### PR TITLE
wgsl: Stub tests for textureNumLevels builtin.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLevels.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLevels.spec.ts
@@ -1,0 +1,64 @@
+export const description = `
+Execution tests for the 'textureNumLevels' builtin function
+
+Returns the number of mip levels of a texture.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('sampled')
+  .specURL('https://www.w3.org/TR/WGSL/#texturenumlevels')
+  .desc(
+    `
+T, a sampled type.
+
+fn textureNumLevels(t: texture_1d<T>) -> u32
+fn textureNumLevels(t: texture_2d<T>) -> u32
+fn textureNumLevels(t: texture_2d_array<T>) -> u32
+fn textureNumLevels(t: texture_3d<T>) -> u32
+fn textureNumLevels(t: texture_cube<T>) -> u32
+fn textureNumLevels(t: texture_cube_array<T>) -> u32
+
+Parameters
+ * t The sampled array texture.
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', [
+        'texture_1d',
+        'texture_2d',
+        'texture_2d_array',
+        'texture_3d',
+        'texture_cube',
+        'texture_cube_array`',
+      ] as const)
+      .combine('sampled_type', ['f32', 'i32', 'u32'] as const)
+  )
+  .unimplemented();
+
+g.test('depth')
+  .specURL('https://www.w3.org/TR/WGSL/#texturenumlevels')
+  .desc(
+    `
+fn textureNumLevels(t: texture_depth_2d) -> u32
+fn textureNumLevels(t: texture_depth_2d_array) -> u32
+fn textureNumLevels(t: texture_depth_cube) -> u32
+fn textureNumLevels(t: texture_depth_cube_array) -> u32
+
+Parameters
+ * t The depth array texture.
+`
+  )
+  .params(u =>
+    u.combine('texture_type', [
+      'texture_depth_2d',
+      'texture_depth_2d_array',
+      'texture_depth_cube',
+      'texture_depth_cube_array',
+    ] as const)
+  )
+  .unimplemented();


### PR DESCRIPTION
This CL adds unimplemented stub tests for the `textureNumLevels` builtin.

Issue #1264

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
