### PR TITLE
attachment_compatibility: Properly set d/sReadOnly when testing it.

### DIFF
--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -535,7 +535,12 @@ Test that the depth stencil read only state in render passes or bundles is compa
     );
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
-      attachmentInfo: { colorFormats: ['rgba8unorm'], depthStencilFormat: format },
+      attachmentInfo: {
+        colorFormats: ['rgba8unorm'],
+        depthStencilFormat: format,
+        depthReadOnly,
+        stencilReadOnly,
+      },
     });
     encoder.setPipeline(pipeline);
 


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
