### PR TITLE
Fix tests using DS attachments not encompassing all aspects.

### DIFF
--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -1,5 +1,5 @@
 import { assert } from '../../../../../common/util/util.js';
-import { resolvePerAspectFormat } from '../../../../capability_info.js';
+import { kTextureFormatInfo } from '../../../../capability_info.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { virtualMipSize } from '../../../../util/texture/base.js';
 import { CheckContents } from '../texture_zero.spec.js';
@@ -100,9 +100,11 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
   state,
   subresourceRange
 ) => {
+  const formatInfo = kTextureFormatInfo[params.format];
+
   assert(params.dimension === '2d');
   for (const viewDescriptor of t.generateTextureViewDescriptorsForRendering(
-    params.aspect,
+    'all',
     subresourceRange
   )) {
     assert(viewDescriptor.baseMipLevel !== undefined);
@@ -145,21 +147,20 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
       ],
       depthStencilAttachment: {
         view: texture.createView(viewDescriptor),
-        depthStoreOp: type === 'depth' ? 'store' : undefined,
-        depthLoadOp: type === 'depth' ? 'load' : undefined,
-        stencilStoreOp: type === 'stencil' ? 'store' : undefined,
-        stencilLoadOp: type === 'stencil' ? 'load' : undefined,
+        depthStoreOp: formatInfo.depth ? 'store' : undefined,
+        depthLoadOp: formatInfo.depth ? 'load' : undefined,
+        stencilStoreOp: formatInfo.stencil ? 'store' : undefined,
+        stencilLoadOp: formatInfo.stencil ? 'load' : undefined,
       },
     });
 
-    const pipelineDSFormat = resolvePerAspectFormat(params.format, params.aspect);
     switch (type) {
       case 'depth': {
         const expectedDepth = t.stateToTexelComponents[state].Depth;
         assert(expectedDepth !== undefined);
 
         pass.setPipeline(
-          getDepthTestEqualPipeline(t, pipelineDSFormat, params.sampleCount, expectedDepth)
+          getDepthTestEqualPipeline(t, params.format, params.sampleCount, expectedDepth)
         );
         break;
       }
@@ -168,7 +169,7 @@ const checkContents: (type: 'depth' | 'stencil', ...args: Parameters<CheckConten
         const expectedStencil = t.stateToTexelComponents[state].Stencil;
         assert(expectedStencil !== undefined);
 
-        pass.setPipeline(getStencilTestEqualPipeline(t, pipelineDSFormat, params.sampleCount));
+        pass.setPipeline(getStencilTestEqualPipeline(t, params.format, params.sampleCount));
         pass.setStencilReference(expectedStencil);
         break;
       }

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -301,7 +301,7 @@ export class TextureZeroInitTest extends GPUTest {
     commandEncoder.pushDebugGroup('initializeWithStoreOp');
 
     for (const viewDescriptor of this.generateTextureViewDescriptorsForRendering(
-      this.p.aspect,
+      'all',
       subresourceRange
     )) {
       if (kTextureFormatInfo[this.p.format].color) {
@@ -321,12 +321,12 @@ export class TextureZeroInitTest extends GPUTest {
         const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
           view: texture.createView(viewDescriptor),
         };
-        if (kTextureFormatInfo[this.p.format].depth && this.p.aspect !== 'stencil-only') {
+        if (kTextureFormatInfo[this.p.format].depth) {
           depthStencilAttachment.depthClearValue = initializedStateAsDepth[state];
           depthStencilAttachment.depthLoadOp = 'clear';
           depthStencilAttachment.depthStoreOp = 'store';
         }
-        if (kTextureFormatInfo[this.p.format].stencil && this.p.aspect !== 'depth-only') {
+        if (kTextureFormatInfo[this.p.format].stencil) {
           depthStencilAttachment.stencilClearValue = initializedStateAsStencil[state];
           depthStencilAttachment.stencilLoadOp = 'clear';
           depthStencilAttachment.stencilStoreOp = 'store';
@@ -413,10 +413,7 @@ export class TextureZeroInitTest extends GPUTest {
     const commandEncoder = this.device.createCommandEncoder();
     commandEncoder.pushDebugGroup('discardTexture');
 
-    for (const desc of this.generateTextureViewDescriptorsForRendering(
-      this.p.aspect,
-      subresourceRange
-    )) {
+    for (const desc of this.generateTextureViewDescriptorsForRendering('all', subresourceRange)) {
       if (kTextureFormatInfo[this.p.format].color) {
         commandEncoder
           .beginRenderPass({
@@ -433,11 +430,11 @@ export class TextureZeroInitTest extends GPUTest {
         const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
           view: texture.createView(desc),
         };
-        if (kTextureFormatInfo[this.p.format].depth && this.p.aspect !== 'stencil-only') {
+        if (kTextureFormatInfo[this.p.format].depth) {
           depthStencilAttachment.depthLoadOp = 'load';
           depthStencilAttachment.depthStoreOp = 'discard';
         }
-        if (kTextureFormatInfo[this.p.format].stencil && this.p.aspect !== 'depth-only') {
+        if (kTextureFormatInfo[this.p.format].stencil) {
           depthStencilAttachment.stencilLoadOp = 'load';
           depthStencilAttachment.stencilStoreOp = 'discard';
         }

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -1,6 +1,8 @@
 export const description = `
 Note: render pass 'occlusionQuerySet' validation is tested in queries/general.spec.ts
 
+TODO: Check that depth-stencil attachment views must encompass all aspects.
+
 TODO: check for duplication (render_pass/, etc.), plan, and implement.
 Note possibly a lot of this should be operation tests instead.
 Notes:

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -618,6 +618,15 @@ g.test('subresources_and_binding_types_combination_for_aspect')
           // 'render-target'
           p.compute && (p.binding0InBundle || p.binding1InBundle || p.type1 === 'render-target')
       )
+      .unless(
+        p =>
+          // Depth-stencil attachment views must encompass all aspects of the texture. Invalid
+          // cases are for depth-stencil textures when the aspect is not 'all'.
+          p.type1 === 'render-target' &&
+          kTextureFormatInfo[p.format].depth &&
+          kTextureFormatInfo[p.format].stencil &&
+          p.aspect1 !== 'all'
+      )
   )
   .beforeAllSubcases(t => {
     const { format } = t.params;


### PR DESCRIPTION
Also adds a TODO that this validation must be tested.

See https://bugs.chromium.org/p/dawn/issues/detail?id=1394

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
   - Tested against dawn.node on Metal.

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
