### PR TITLE
wgsl: Fixup coord parameters in texture tests.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -24,10 +24,11 @@ A texture gather operation reads from a 2D, 2D array, cube, or cube array textur
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { generateCoordBoundaries } from './utils';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('sampled')
+g.test('sampled_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturegather')
   .desc(
     `
@@ -36,7 +37,6 @@ T: i32, u32, f32
 
 fn textureGather(component: C, t: texture_2d<T>, s: sampler, coords: vec2<f32>) -> vec4<T>
 fn textureGather(component: C, t: texture_2d<T>, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<T>
-fn textureGather(component: C, t: texture_cube<T>, s: sampler, coords: vec3<f32>) -> vec4<T>
 
 Parameters:
  * component:
@@ -56,23 +56,46 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', ['texture_2d', 'texture_cube'] as const)
       .combine('T', ['f32', 'i32', 'u32'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-      .combine('coords', [
-        'left-wrap',
-        'right-wrap',
-        'bottom-wrap',
-        'top-wrap',
-        'in-bounds',
-      ] as const)
+      .combine('coords', generateCoordBoundaries(2))
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
 
-g.test('sampled_array')
+
+g.test('sampled_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegather')
+  .desc(
+    `
+C: i32, u32
+T: i32, u32, f32
+
+fn textureGather(component: C, t: texture_cube<T>, s: sampler, coords: vec3<f32>) -> vec4<T>
+
+Parameters:
+ * component:
+    - The index of the channel to read from the selected texels.
+    - When provided, the component expression must a creation-time expression (e.g. 1).
+    - Its value must be at least 0 and at most 3. Values outside of this range will result in a shader-creation error.
+ * t: The sampled texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+`
+  )
+  .params(u =>
+    u
+      .combine('T', ['f32', 'i32', 'u32'] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      .combine('coords', generateCoordBoundaries(3))
+  )
+  .unimplemented();
+
+g.test('sampled_array_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturegather')
   .desc(
     `
@@ -81,6 +104,43 @@ T: i32, u32, f32
 
 fn textureGather(component: C, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: C) -> vec4<T>
 fn textureGather(component: C, t: texture_2d_array<T>, s: sampler, coords: vec2<f32>, array_index: C, offset: vec2<i32>) -> vec4<T>
+
+Parameters:
+ * component:
+    - The index of the channel to read from the selected texels.
+    - When provided, the component expression must a creation-time expression (e.g. 1).
+    - Its value must be at least 0 and at most 3. Values outside of this range will result in a shader-creation error.
+ * t: The sampled texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * array_index: The 0-based texture array index
+ * offset:
+    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+      This offset is applied before applying any texture wrapping modes.
+    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    - Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('T', ['f32', 'i32', 'u32'] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      .combine('coords', generateCoordBoundaries(2))
+      /* array_index not param'd as out-of-bounds is implementation specific */
+      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+  )
+  .unimplemented();
+
+g.test('sampled_array_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegather')
+  .desc(
+    `
+C: i32, u32
+T: i32, u32, f32
+
 fn textureGather(component: C, t: texture_cube_array<T>, s: sampler, coords: vec3<f32>, array_index: C) -> vec4<T>
 
 Parameters:
@@ -92,40 +152,25 @@ Parameters:
  * s: The sampler type
  * coords: The texture coordinates
  * array_index: The 0-based texture array index
- * offset:
-    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
-      This offset is applied before applying any texture wrapping modes.
-    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
-    - Each offset component must be at least -8 and at most 7.
-      Values outside of this range will result in a shader-creation error.
 `
   )
   .params(u =>
     u
-      .combine('texture_type', ['texture_2d_array', 'texture_cube_array'])
       .combine('T', ['f32', 'i32', 'u32'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-      .combine('coords', [
-        'left-wrap',
-        'right-wrap',
-        'bottom-wrap',
-        'top-wrap',
-        'in-bounds',
-      ] as const)
+      .combine('coords', generateCoordBoundaries(3))
       /* array_index not param'd as out-of-bounds is implementation specific */
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
 
-g.test('depth')
+g.test('depth_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturegather')
   .desc(
     `
 fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> vec4<f32>
 fn textureGather(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
-fn textureGather(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> vec4<f32>
 
 Parameters:
  * t: The depth texture to read from
@@ -141,20 +186,32 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', ['texture_depth_2d', 'texture_depth_cube'])
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
-      .combine('coords', [
-        'left-wrap',
-        'right-wrap',
-        'bottom-wrap',
-        'top-wrap',
-        'in-bounds',
-      ] as const)
+      .combine('coords', generateCoordBoundaries(2))
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
 
-g.test('depth_array')
+g.test('depth_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegather')
+  .desc(
+    `
+fn textureGather(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> vec4<f32>
+
+Parameters:
+ * t: The depth texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', generateCoordBoundaries(3))
+  )
+  .unimplemented();
+
+g.test('depth_array_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturegather')
   .desc(
     `
@@ -162,7 +219,6 @@ C: i32, u32
 
 fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: C) -> vec4<f32>
 fn textureGather(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: C, offset: vec2<i32>) -> vec4<f32>
-fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: C) -> vec4<f32>
 
 Parameters:
  * t: The depth texture to read from
@@ -179,17 +235,34 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', ['texture_depth_2d_array', 'texture_depth_cube_array'])
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', [
-        'left-wrap',
-        'right-wrap',
-        'bottom-wrap',
-        'top-wrap',
-        'in-bounds',
-      ] as const)
+      .combine('coords', generateCoordBoundaries(2))
       /* array_index not param'd as out-of-bounds is implementation specific */
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+  )
+  .unimplemented();
+
+g.test('depth_array_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegather')
+  .desc(
+    `
+C: i32, u32
+
+fn textureGather(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: C) -> vec4<f32>
+
+Parameters:
+ * t: The depth texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * array_index: The 0-based texture array index
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords', generateCoordBoundaries(3))
+      /* array_index not param'd as out-of-bounds is implementation specific */
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -25,7 +25,7 @@ A texture gather operation reads from a 2D, 2D array, cube, or cube array textur
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 
-import { generateCoordBoundaries } from './utils';
+import { generateCoordBoundaries } from './utils.js';
 
 export const g = makeTestGroup(GPUTest);
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -24,6 +24,7 @@ A texture gather operation reads from a 2D, 2D array, cube, or cube array textur
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+
 import { generateCoordBoundaries } from './utils';
 
 export const g = makeTestGroup(GPUTest);
@@ -64,7 +65,6 @@ Parameters:
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
-
 
 g.test('sampled_3d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturegather')
@@ -154,14 +154,15 @@ Parameters:
  * array_index: The 0-based texture array index
 `
   )
-  .params(u =>
-    u
-      .combine('T', ['f32', 'i32', 'u32'] as const)
-      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
-      .combine('C', ['i32', 'u32'] as const)
-      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-      .combine('coords', generateCoordBoundaries(3))
-      /* array_index not param'd as out-of-bounds is implementation specific */
+  .params(
+    u =>
+      u
+        .combine('T', ['f32', 'i32', 'u32'] as const)
+        .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+        .combine('C', ['i32', 'u32'] as const)
+        .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+        .combine('coords', generateCoordBoundaries(3))
+    /* array_index not param'd as out-of-bounds is implementation specific */
   )
   .unimplemented();
 
@@ -258,11 +259,12 @@ Parameters:
  * array_index: The 0-based texture array index
 `
   )
-  .params(u =>
-    u
-      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
-      .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', generateCoordBoundaries(3))
-      /* array_index not param'd as out-of-bounds is implementation specific */
+  .params(
+    u =>
+      u
+        .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+        .combine('C', ['i32', 'u32'] as const)
+        .combine('coords', generateCoordBoundaries(3))
+    /* array_index not param'd as out-of-bounds is implementation specific */
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -18,10 +18,11 @@ A texture gather compare operation performs a depth comparison on four texels in
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { generateCoordBoundaries } from './utils';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('array')
+g.test('array_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturegathercompare')
   .desc(
     `
@@ -29,7 +30,6 @@ C: i32, u32
 
 fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: C, depth_ref: f32) -> vec4<f32>
 fn textureGatherCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: C, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
-fn textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: C, depth_ref: f32) -> vec4<f32>
 
 Parameters:
  * t: The depth texture to read from
@@ -47,29 +47,47 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', ['texture_depth_2d_array', 'texture_depth_cube_array'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4])
-      .combine('coords', [
-        'left-wrap',
-        'right-wrap',
-        'bottom-wrap',
-        'top-wrap',
-        'in-bounds',
-      ] as const)
+      .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
 
-g.test('sampled_array')
+g.test('array_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegathercompare')
+  .desc(
+    `
+C: i32, u32
+
+fn textureGatherCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: C, depth_ref: f32) -> vec4<f32>
+
+Parameters:
+ * t: The depth texture to read from
+ * s: The sampler_comparison
+ * coords: The texture coordinates
+ * array_index: The 0-based array index.
+ * depth_ref: The reference value to compare the sampled depth value against
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4])
+      .combine('coords', generateCoordBoundaries(3))
+      .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
+  )
+  .unimplemented();
+
+g.test('sampled_array_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturegathercompare')
   .desc(
     `
 fn textureGatherCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> vec4<f32>
 fn textureGatherCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> vec4<f32>
-fn textureGatherCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> vec4<f32>
 
 Parameters:
  * t: The depth texture to read from
@@ -86,16 +104,30 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', ['texture_depth_2d', 'texture_depth_cube'])
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
-      .combine('coords', [
-        'left-wrap',
-        'right-wrap',
-        'bottom-wrap',
-        'top-wrap',
-        'in-bounds',
-      ] as const)
+      .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+  )
+  .unimplemented();
+
+g.test('sampled_array_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturegathercompare')
+  .desc(
+    `
+fn textureGatherCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> vec4<f32>
+
+Parameters:
+ * t: The depth texture to read from
+ * s: The sampler_comparison
+ * coords: The texture coordinates
+ * depth_ref: The reference value to compare the sampled depth value against
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', generateCoordBoundaries(3))
+      .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -19,7 +19,7 @@ A texture gather compare operation performs a depth comparison on four texels in
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 
-import { generateCoordBoundaries } from './utils';
+import { generateCoordBoundaries } from './utils.js';
 
 export const g = makeTestGroup(GPUTest);
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -18,6 +18,7 @@ A texture gather compare operation performs a depth comparison on four texels in
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+
 import { generateCoordBoundaries } from './utils';
 
 export const g = makeTestGroup(GPUTest);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -18,6 +18,7 @@ If an out of bounds access occurs, the built-in function returns one of:
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { generateCoordBoundaries } from './utils';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -38,7 +39,7 @@ Parameters:
   .params(u =>
     u
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', [-1, 0, `dimension-1`, `dimension`] as const)
+      .combine('coords', generateCoordBoundaries(1))
       .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
   )
   .unimplemented();
@@ -60,8 +61,7 @@ Parameters:
   .params(u =>
     u
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
-      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords', generateCoordBoundaries(2))
       .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
   )
   .unimplemented();
@@ -83,9 +83,7 @@ Parameters:
   .params(u =>
     u
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
-      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
-      .combine('coords_2', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords', generateCoordBoundaries(3))
       .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
   )
   .unimplemented();
@@ -112,8 +110,7 @@ Parameters:
         'texture_depth_multisampled_2d',
       ] as const)
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
-      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords', generateCoordBoundaries(2))
       .combine('sample_index', [-1, 0, `sampleCount-1`, `sampleCount`] as const)
   )
   .unimplemented();
@@ -135,8 +132,7 @@ Parameters:
   .params(u =>
     u
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
-      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords', generateCoordBoundaries(2))
       .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
   )
   .unimplemented();
@@ -157,8 +153,7 @@ Parameters:
   .params(u =>
     u
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
-      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords', generateCoordBoundaries(2))
   )
   .unimplemented();
 
@@ -182,8 +177,7 @@ Parameters:
     u
       .combine('texture_type', ['texture_2d_array', 'texture_depth_2d_array'] as const)
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords_0', [-1, 0, `dimensions-1`, `dimension`] as const)
-      .combine('coords_1', [-1, 0, `dimensions-1`, `dimension`] as const)
+      .combine('coords', generateCoordBoundaries(2))
       .combine('array_index', [-1, 0, `numlayers-1`, `numlayers`] as const)
       .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -18,6 +18,7 @@ If an out of bounds access occurs, the built-in function returns one of:
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+
 import { generateCoordBoundaries } from './utils';
 
 export const g = makeTestGroup(GPUTest);
@@ -151,9 +152,7 @@ Parameters:
 `
   )
   .params(u =>
-    u
-      .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', generateCoordBoundaries(2))
+    u.combine('C', ['i32', 'u32'] as const).combine('coords', generateCoordBoundaries(2))
   )
   .unimplemented();
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -19,7 +19,7 @@ If an out of bounds access occurs, the built-in function returns one of:
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 
-import { generateCoordBoundaries } from './utils';
+import { generateCoordBoundaries } from './utils.js';
 
 export const g = makeTestGroup(GPUTest);
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -8,6 +8,7 @@ Must only be invoked in uniform control flow.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+
 import { generateCoordBoundaries } from './utils';
 
 export const g = makeTestGroup(GPUTest);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -9,7 +9,7 @@ Must only be invoked in uniform control flow.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 
-import { generateCoordBoundaries } from './utils';
+import { generateCoordBoundaries } from './utils.js';
 
 export const g = makeTestGroup(GPUTest);
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -8,6 +8,7 @@ Must only be invoked in uniform control flow.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { generateCoordBoundaries } from './utils';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -31,12 +32,39 @@ Tests that 'textureSampleBias' can only be called in uniform control flow.
   .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
   .unimplemented();
 
-g.test('sampled')
+g.test('sampled_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesamplebias')
   .desc(
     `
 fn textureSampleBias(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, bias: f32) -> vec4<f32>
 fn textureSampleBias(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, bias: f32, offset: vec2<i32>) -> vec4<f32>
+
+Parameters:
+ * t: The sampled texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * bias: The bias to apply to the mip level before sampling. bias must be between -16.0 and 15.99.
+ * offset:
+    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+      This offset is applied before applying any texture wrapping modes.
+    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    - Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', generateCoordBoundaries(2))
+      .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
+      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+  )
+  .unimplemented();
+
+g.test('sampled_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplebias')
+  .desc(
+    `
 fn textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f32) -> vec4<f32>
 fn textureSampleBias(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, bias: f32, offset: vec3<i32>) -> vec4<f32>
 fn textureSampleBias(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, bias: f32) -> vec4<f32>
@@ -56,21 +84,15 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', ['texture_2d', 'texture_3d', 'texture_cube'] as const)
+      .combine('texture_type', ['texture_3d', 'texture_cube'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
-      .combine('coords', [
-        'left-wrap',
-        'right-wrap',
-        'bottom-wrap',
-        'top-wrap',
-        'in-bounds',
-      ] as const)
+      .combine('coords', generateCoordBoundaries(3))
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
       .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();
 
-g.test('arrayed')
+g.test('arrayed_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesamplebias')
   .desc(
     `
@@ -78,6 +100,39 @@ C: i32, u32
 
 fn textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: C, bias: f32) -> vec4<f32>
 fn textureSampleBias(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: C, bias: f32, offset: vec2<i32>) -> vec4<f32>
+
+Parameters:
+ * t: The sampled texture to read from
+ * s: The sampler type
+ * coords: The texture coordinates
+ * array_index: The 0-based texture array index to sample.
+ * bias: The bias to apply to the mip level before sampling. bias must be between -16.0 and 15.99.
+ * offset:
+    - The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+      This offset is applied before applying any texture wrapping modes.
+    - The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    - Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', generateCoordBoundaries(2))
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      /* array_index not param'd as out-of-bounds is implementation specific */
+      .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
+      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+  )
+  .unimplemented();
+
+g.test('arrayed_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplebias')
+  .desc(
+    `
+C: i32, u32
+
 fn textureSampleBias(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: C, bias: f32) -> vec4<f32>
 
 Parameters:
@@ -96,19 +151,11 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('texture_type', ['texture_2d_array', 'texture_cube_array'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
-      .combine('coords', [
-        'left-wrap',
-        'right-wrap',
-        'bottom-wrap',
-        'top-wrap',
-        'in-bounds',
-      ] as const)
+      .combine('coords', generateCoordBoundaries(3))
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
       /* array_index not param'd as out-of-bounds is implementation specific */
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Generates the boundary entries for the given number of dimensions
+ *
+ * @param numDimensions: The number of dimensions to generate for
+ * @returns an array of generated coord boundarys
+ */
+export function generateCoordBoundaries(numDimensions: number) {
+  let ret = ['in-bounds'];
+
+  if (numDimensions < 1 || numDimensions > 3) {
+    throw new Error(`invalid numDimensions: ${numDimensions}`);
+  }
+
+  let name = 'xyz';
+  for (let i = 0; i < numDimensions; ++i) {
+    for (let j of ['min', 'max']) {
+      for (let k of ['wrap', 'boundary']) {
+        ret.push(`${name[i]}-${j}-${k}`);
+      }
+    }
+  }
+
+  return ret;
+}

--- a/src/webgpu/shader/execution/expression/call/builtin/utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/utils.ts
@@ -5,16 +5,16 @@
  * @returns an array of generated coord boundarys
  */
 export function generateCoordBoundaries(numDimensions: number) {
-  let ret = ['in-bounds'];
+  const ret = ['in-bounds'];
 
   if (numDimensions < 1 || numDimensions > 3) {
     throw new Error(`invalid numDimensions: ${numDimensions}`);
   }
 
-  let name = 'xyz';
+  const name = 'xyz';
   for (let i = 0; i < numDimensions; ++i) {
-    for (let j of ['min', 'max']) {
-      for (let k of ['wrap', 'boundary']) {
+    for (const j of ['min', 'max']) {
+      for (const k of ['wrap', 'boundary']) {
         ret.push(`${name[i]}-${j}-${k}`);
       }
     }


### PR DESCRIPTION
The current texture stubs didn't take into account the dimensionality of the coord param.
The 3 dimension coords have been pulled out into their own tests. A helper added to generate
the various coordinates for a given dimension size.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
