### PR TITLE
Add skipLibCheck to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "allowUnreachableCode": true,
     /* Module Options */
     "moduleResolution": "node",
-    "esModuleInterop": false
+    "esModuleInterop": false,
+    "skipLibCheck": true,
   },
   "include": ["src/**/*.ts"],
   "typedocOptions": {


### PR DESCRIPTION
This PR adds the `skipLibCheck` option into the `tsconfig.json` file and
turns it on. Adding the flag takes a local full rebuild of the CTS
using the dawn CTS runner from 14-16s down to 8-9s.
