### PR TITLE
wgsl: Add stub tests for the textureSample builtin.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -25,7 +25,7 @@ A texture gather operation reads from a 2D, 2D array, cube, or cube array textur
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 
-import { generateCoordBoundaries } from './utils.js';
+import { generateCoordBoundaries, generateOffsets } from './utils.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -62,7 +62,7 @@ Parameters:
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
       .combine('coords', generateCoordBoundaries(2))
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+      .combine('offset', generateOffsets(2))
   )
   .unimplemented();
 
@@ -130,7 +130,7 @@ Parameters:
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
       .combine('coords', generateCoordBoundaries(2))
       /* array_index not param'd as out-of-bounds is implementation specific */
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+      .combine('offset', generateOffsets(2))
   )
   .unimplemented();
 
@@ -189,7 +189,7 @@ Parameters:
     u
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+      .combine('offset', generateOffsets(2))
   )
   .unimplemented();
 
@@ -240,7 +240,7 @@ Parameters:
       .combine('C', ['i32', 'u32'] as const)
       .combine('coords', generateCoordBoundaries(2))
       /* array_index not param'd as out-of-bounds is implementation specific */
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+      .combine('offset', generateOffsets(2))
   )
   .unimplemented();
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -19,7 +19,7 @@ A texture gather compare operation performs a depth comparison on four texels in
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 
-import { generateCoordBoundaries } from './utils.js';
+import { generateCoordBoundaries, generateOffsets } from './utils.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -53,7 +53,7 @@ Parameters:
       .combine('C_value', [-1, 0, 1, 2, 3, 4])
       .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+      .combine('offset', generateOffsets(2))
   )
   .unimplemented();
 
@@ -108,7 +108,7 @@ Parameters:
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+      .combine('offset', generateOffsets(2))
   )
   .unimplemented();
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -1,0 +1,272 @@
+export const description = `
+Samples a texture.
+
+Must only be used in a fragment shader stage.
+Must only be invoked in uniform control flow.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+import { generateCoordBoundaries, generateOffsets } from './utils.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+Tests that 'textureSample' can only be called in 'fragment' shaders.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('control_flow')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+Tests that 'textureSample' can only be called in uniform control flow.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('sampled_1d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+fn textureSample(t: texture_1d<f32>, s: sampler, coords: f32) -> vec4<f32>
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('coords', generateCoordBoundaries(1))
+  )
+  .unimplemented();
+
+g.test('sampled_2d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+fn textureSample(t: texture_2d<f32>, s: sampler, coords: vec2<f32>) -> vec4<f32>
+fn textureSample(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> vec4<f32>
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * offset
+    * The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+    * This offset is applied before applying any texture wrapping modes.
+    * The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    * Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('coords', generateCoordBoundaries(2))
+      .combine('offset', generateOffsets(2))
+  )
+  .unimplemented();
+
+g.test('sampled_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+fn textureSample(t: texture_3d<f32>, s: sampler, coords: vec3<f32>) -> vec4<f32>
+fn textureSample(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, offset: vec3<i32>) -> vec4<f32>
+fn textureSample(t: texture_cube<f32>, s: sampler, coords: vec3<f32>) -> vec4<f32>
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * offset
+    * The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+    * This offset is applied before applying any texture wrapping modes.
+    * The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    * Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('texture_type', ['texture_3d', 'texture_cube'] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('coords', generateCoordBoundaries(3))
+      .combine('offset', generateOffsets(3))
+  )
+  .unimplemented();
+
+g.test('depth_2d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> f32
+fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> f32
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * offset
+    * The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+    * This offset is applied before applying any texture wrapping modes.
+    * The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    * Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('coords', generateCoordBoundaries(2))
+      .combine('offset', generateOffsets(2))
+  )
+  .unimplemented();
+
+g.test('sampled_array_2d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: C) -> vec4<f32>
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: C, offset: vec2<i32>) -> vec4<f32>
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * array_index The 0-based texture array index to sample.
+ * offset
+    * The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+    * This offset is applied before applying any texture wrapping modes.
+    * The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    * Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('coords', generateCoordBoundaries(2))
+      /* array_index not param'd as out-of-bounds is implementation specific */
+      .combine('offset', generateOffsets(2))
+  )
+  .unimplemented();
+
+g.test('sampled_array_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureSample(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: C) -> vec4<f32>
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * array_index The 0-based texture array index to sample.
+`
+  )
+  .params(
+    u =>
+      u
+        .combine('C', ['i32', 'u32'] as const)
+        .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+        .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+        .combine('coords', generateCoordBoundaries(3))
+    /* array_index not param'd as out-of-bounds is implementation specific */
+  )
+  .unimplemented();
+
+g.test('depth_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+fn textureSample(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> f32
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('coords', generateCoordBoundaries(3))
+  )
+  .unimplemented();
+
+g.test('depth_array_2d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: C) -> f32
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: C, offset: vec2<i32>) -> f32
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * array_index The 0-based texture array index to sample.
+ * offset
+    * The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+    * This offset is applied before applying any texture wrapping modes.
+    * The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    * Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('coords', generateCoordBoundaries(2))
+      /* array_index not param'd as out-of-bounds is implementation specific */
+      .combine('offset', generateOffsets(2))
+  )
+  .unimplemented();
+
+g.test('depth_array_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: C) -> f32
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * array_index The 0-based texture array index to sample.
+`
+  )
+  .params(
+    u =>
+      u
+        .combine('C', ['i32', 'u32'] as const)
+        .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+        .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+        .combine('coords', generateCoordBoundaries(3))
+    /* array_index not param'd as out-of-bounds is implementation specific */
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -9,7 +9,7 @@ Must only be invoked in uniform control flow.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 
-import { generateCoordBoundaries } from './utils.js';
+import { generateCoordBoundaries, generateOffsets } from './utils.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -58,7 +58,7 @@ Parameters:
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+      .combine('offset', generateOffsets(2))
   )
   .unimplemented();
 
@@ -89,7 +89,7 @@ Parameters:
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+      .combine('offset', generateOffsets(3))
   )
   .unimplemented();
 
@@ -124,7 +124,7 @@ Parameters:
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
       /* array_index not param'd as out-of-bounds is implementation specific */
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
-      .combine('offset', [undefined, [-9, -9], [-8, -8], [0, 0], [1, 2], [7, 7], [8, 8]] as const)
+      .combine('offset', generateOffsets(2))
   )
   .unimplemented();
 

--- a/src/webgpu/shader/execution/expression/call/builtin/utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/utils.ts
@@ -2,7 +2,7 @@
  * Generates the boundary entries for the given number of dimensions
  *
  * @param numDimensions: The number of dimensions to generate for
- * @returns an array of generated coord boundarys
+ * @returns an array of generated coord boundaries
  */
 export function generateCoordBoundaries(numDimensions: number) {
   const ret = ['in-bounds'];
@@ -20,5 +20,26 @@ export function generateCoordBoundaries(numDimensions: number) {
     }
   }
 
+  return ret;
+}
+
+/**
+ * Generates a set of offset values to attempt in the range [-9, 8].
+ *
+ * @param numDimensions: The number of dimensions to generate for
+ * @return an array of generated offset values
+ */
+export function generateOffsets(numDimensions: number) {
+  if (numDimensions < 2 || numDimensions > 3) {
+    throw new Error(`generateOffsets: invalid numDimensions: ${numDimensions}`);
+  }
+  const ret: Array<undefined | Array<number>> = [undefined];
+  for (const val of [-9, -8, 0, 1, 7, 8]) {
+    const v = [];
+    for (let i = 0; i < numDimensions; ++i) {
+      v.push(val);
+    }
+    ret.push(v);
+  }
   return ret;
 }


### PR DESCRIPTION
This PR adds unimplmented stubs for the `textureSample` builtin.

Issue #1266

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
