### PR TITLE
wgsl: Add stubs for the atomicStore builtin.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atomicStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicStore.spec.ts
@@ -1,0 +1,33 @@
+export const description = `
+Atomically stores the value v in the atomic object pointed to by atomic_ptr.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-store')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('store')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-store')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicStore(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T)
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();


### PR DESCRIPTION
This PR adds unimplemented stub tests for the `atomicStore` builtin.

Issue #1274

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
