### PR TITLE
wgsl: Add stubs for the read-write-modify atomic operations.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atomicAdd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicAdd.spec.ts
@@ -1,0 +1,39 @@
+export const description = `
+Atomically read, add and store value.
+
+ * Load the original value pointed to by atomic_ptr.
+ * Obtains a new value by adding with the value v.
+ * Store the new value using atomic_ptr.
+
+Returns the original value stored in the atomic object.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('add')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicAdd(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicAnd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicAnd.spec.ts
@@ -1,0 +1,39 @@
+export const description = `
+Atomically read, and and store value.
+
+ * Load the original value pointed to by atomic_ptr.
+ * Obtains a new value by anding with the value v.
+ * Store the new value using atomic_ptr.
+
+Returns the original value stored in the atomic object.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('and')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicAnd(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicCompareExchangeWeak.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicCompareExchangeWeak.spec.ts
@@ -1,0 +1,49 @@
+export const description = `
+Performs the following steps atomically:
+ * Load the original value pointed to by atomic_ptr.
+ * Compare the original value to the value v using an equality operation.
+ * Store the value v only if the result of the equality comparison was true.
+
+Returns a two member structure, where the first member, old_value, is the original
+value of the atomic object and the second member, exchanged, is whether or not
+the comparison succeeded.
+
+Note: the equality comparison may spuriously fail on some implementations.
+That is, the second component of the result vector may be false even if the first
+component of the result vector equals cmp.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('exchange')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+
+struct __atomic_compare_exchange_result<T> {
+  old_value : T;    // old value stored in the atomic
+  exchanged : bool; // true if the exchange was done
+}
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicExchange.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicExchange.spec.ts
@@ -1,0 +1,33 @@
+export const description = `
+Atomically stores the value v in the atomic object pointed to atomic_ptr and returns the original value stored in the atomic object.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('exchange')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicExchange(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicMax.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicMax.spec.ts
@@ -1,0 +1,39 @@
+export const description = `
+Atomically read, max and store value.
+
+ * Load the original value pointed to by atomic_ptr.
+ * Obtains a new value by taking the max with the value v.
+ * Store the new value using atomic_ptr.
+
+Returns the original value stored in the atomic object.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('max')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicMax(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicMin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicMin.spec.ts
@@ -1,0 +1,39 @@
+export const description = `
+Atomically read, min and store value.
+
+ * Load the original value pointed to by atomic_ptr.
+ * Obtains a new value by take the min with the value v.
+ * Store the new value using atomic_ptr.
+
+Returns the original value stored in the atomic object.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('min')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicMin(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicOr.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicOr.spec.ts
@@ -1,0 +1,39 @@
+export const description = `
+Atomically read, or and store value.
+
+ * Load the original value pointed to by atomic_ptr.
+ * Obtains a new value by or'ing with the value v.
+ * Store the new value using atomic_ptr.
+
+Returns the original value stored in the atomic object.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('or')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicOr(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicSub.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicSub.spec.ts
@@ -1,0 +1,39 @@
+export const description = `
+Atomically read, subtract and store value.
+
+ * Load the original value pointed to by atomic_ptr.
+ * Obtains a new value by subtracting with the value v.
+ * Store the new value using atomic_ptr.
+
+Returns the original value stored in the atomic object.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('sub')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicSub(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicXor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicXor.spec.ts
@@ -1,0 +1,39 @@
+export const description = `
+Atomically read, xor and store value.
+
+ * Load the original value pointed to by atomic_ptr.
+ * Obtains a new value by xor'ing with the value v.
+ * Store the new value using atomic_ptr.
+
+Returns the original value stored in the atomic object.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('xor')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+SC is storage or workgroup
+T is i32 or u32
+
+fn atomicXor(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+  )
+  .unimplemented();


### PR DESCRIPTION
This PR adds unimplmented stubs for the read-write-modify atomic operations.

 * `atomicAdd`
 * `atomicAnd`
 * `atomicCompareExchangeWeak`
 * `atomicExchange`
 * `atomicMax`
 * `atomicMin`
 * `atomicOr`
 * `atomicSub`
 * `atomicXor`

Issue #1275, #1276, #1277, #1278, #1279, #1280, #1281, #1282, #1283

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
