### PR TITLE
wgsl: Stub tests for textureSampleCompare

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
@@ -143,4 +143,3 @@ Parameters:
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
   )
   .unimplemented();
-

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
@@ -1,0 +1,146 @@
+export const description = `
+Samples a depth texture and compares the sampled depth values against a reference value.
+
+Must only be used in a fragment shader stage.
+Must only be invoked in uniform control flow.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+import { generateCoordBoundaries, generateOffsets } from './utils.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplecompare')
+  .desc(
+    `
+Tests that 'textureSampleCompare' can only be called in 'fragment' shaders.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('control_flow')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplecompare')
+  .desc(
+    `
+Tests that 'textureSampleCompare' can only be called in uniform control flow.
+`
+  )
+  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
+  .unimplemented();
+
+g.test('2d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplecompare')
+  .desc(
+    `
+fn textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32) -> f32
+fn textureSampleCompare(t: texture_depth_2d, s: sampler_comparison, coords: vec2<f32>, depth_ref: f32, offset: vec2<i32>) -> f32
+
+Parameters:
+ * t  The depth texture to sample.
+ * s  The sampler_comparision type.
+ * coords The texture coordinates used for sampling.
+ * depth_ref The reference value to compare the sampled depth value against.
+ * offset
+    * The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+    * This offset is applied before applying any texture wrapping modes.
+    * The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    * Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', generateCoordBoundaries(2))
+      .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
+      .combine('offset', generateOffsets(2))
+  )
+  .unimplemented();
+
+g.test('3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplecompare')
+  .desc(
+    `
+fn textureSampleCompare(t: texture_depth_cube, s: sampler_comparison, coords: vec3<f32>, depth_ref: f32) -> f32
+
+Parameters:
+ * t  The depth texture to sample.
+ * s  The sampler_comparision type.
+ * coords The texture coordinates used for sampling.
+ * depth_ref The reference value to compare the sampled depth value against.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', generateCoordBoundaries(3))
+      .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
+  )
+  .unimplemented();
+
+g.test('arrayed_2d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplecompare')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: C, depth_ref: f32) -> f32
+fn textureSampleCompare(t: texture_depth_2d_array, s: sampler_comparison, coords: vec2<f32>, array_index: C, depth_ref: f32, offset: vec2<i32>) -> f32
+
+Parameters:
+ * t  The depth texture to sample.
+ * s  The sampler_comparision type.
+ * coords The texture coordinates used for sampling.
+ * array_index: The 0-based texture array index to sample.
+ * depth_ref The reference value to compare the sampled depth value against.
+ * offset
+    * The optional texel offset applied to the unnormalized texture coordinate before sampling the texture.
+    * This offset is applied before applying any texture wrapping modes.
+    * The offset expression must be a creation-time expression (e.g. vec2<i32>(1, 2)).
+    * Each offset component must be at least -8 and at most 7.
+      Values outside of this range will result in a shader-creation error.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', generateCoordBoundaries(2))
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      /* array_index not param'd as out-of-bounds is implementation specific */
+      .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
+      .combine('offset', generateOffsets(2))
+  )
+  .unimplemented();
+
+g.test('arrayed_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesamplecompare')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureSampleCompare(t: texture_depth_cube_array, s: sampler_comparison, coords: vec3<f32>, array_index: C, depth_ref: f32) -> f32
+
+Parameters:
+ * t  The depth texture to sample.
+ * s  The sampler_comparision type.
+ * coords The texture coordinates used for sampling.
+ * array_index: The 0-based texture array index to sample.
+ * depth_ref The reference value to compare the sampled depth value against.
+`
+  )
+  .params(u =>
+    u
+      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
+      .combine('coords', generateCoordBoundaries(3))
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      /* array_index not param'd as out-of-bounds is implementation specific */
+      .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
+  )
+  .unimplemented();
+


### PR DESCRIPTION
This PR adds unimplemented stub tests for the `textureSampleCompare` builtin.

Issue #1268

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
