### PR TITLE
wgsl: Stub tests for the textureStore builtin.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -15,8 +15,8 @@ If an out-of-bounds access occurs, the built-in function may do any of the follo
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-
 import { TexelFormats } from '../../../../types.js';
+
 import { generateCoordBoundaries } from './utils.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -83,13 +83,14 @@ Parameters:
  * value The new texel value
 `
   )
-  .params(u =>
-    u
-      .combine('F', TexelFormats)
-      .combine('coords', generateCoordBoundaries(2))
-      .combine('C', ['i32', 'u32'] as const)
-      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-      /* array_index not param'd as out-of-bounds is implementation specific */
+  .params(
+    u =>
+      u
+        .combine('F', TexelFormats)
+        .combine('coords', generateCoordBoundaries(2))
+        .combine('C', ['i32', 'u32'] as const)
+        .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+    /* array_index not param'd as out-of-bounds is implementation specific */
   )
   .unimplemented();
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -1,0 +1,117 @@
+export const description = `
+Writes a single texel to a texture.
+
+The channel format T depends on the storage texel format F.
+See the texel format table for the mapping of texel format to channel format.
+
+Note: An out-of-bounds access occurs if:
+ * any element of coords is outside the range [0, textureDimensions(t)) for the corresponding element, or
+ * array_index is outside the range of [0, textureNumLayers(t))
+
+If an out-of-bounds access occurs, the built-in function may do any of the following:
+ * not be executed
+ * store value to some in bounds texel
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+import { TexelFormats } from '../../../../types.js';
+import { generateCoordBoundaries } from './utils.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('store_1d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturestore')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureStore(t: texture_storage_1d<F,write>, coords: C, value: vec4<T>)
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * value The new texel value
+`
+  )
+  .params(u =>
+    u
+      .combine('F', TexelFormats)
+      .combine('coords', generateCoordBoundaries(1))
+      .combine('C', ['i32', 'u32'] as const)
+  )
+  .unimplemented();
+
+g.test('store_2d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturestore')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureStore(t: texture_storage_2d<F,write>, coords: vec2<C>, value: vec4<T>)
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * value The new texel value
+`
+  )
+  .params(u =>
+    u
+      .combine('F', TexelFormats)
+      .combine('coords', generateCoordBoundaries(2))
+      .combine('C', ['i32', 'u32'] as const)
+  )
+  .unimplemented();
+
+g.test('store_array_2d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturestore')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureStore(t: texture_storage_2d_array<F,write>, coords: vec2<C>, array_index: C, value: vec4<T>)
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * array_index The 0-based texture array index
+ * coords The texture coordinates used for sampling.
+ * value The new texel value
+`
+  )
+  .params(u =>
+    u
+      .combine('F', TexelFormats)
+      .combine('coords', generateCoordBoundaries(2))
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
+      /* array_index not param'd as out-of-bounds is implementation specific */
+  )
+  .unimplemented();
+
+g.test('store_3d_coords')
+  .specURL('https://www.w3.org/TR/WGSL/#texturestore')
+  .desc(
+    `
+C is i32 or u32
+
+fn textureStore(t: texture_storage_3d<F,write>, coords: vec3<C>, value: vec4<T>)
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * value The new texel value
+`
+  )
+  .params(u =>
+    u
+      .combine('F', TexelFormats)
+      .combine('coords', generateCoordBoundaries(3))
+      .combine('C', ['i32', 'u32'] as const)
+  )
+  .unimplemented();

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -45,6 +45,26 @@ export const kMatrixContainerTypes = keysOf(kMatrixContainerTypeInfo);
 
 export type StorageClass = 'storage' | 'uniform' | 'private' | 'function' | 'workgroup';
 
+/** List of texel formats and their shader representation */
+export const TexelFormats = [
+  ['rgba8unorm', 'f32'],
+  ['rgba8snorm', 'f32'],
+  ['rgba8uint', 'u32'],
+  ['rgba8sint', 'i32'],
+  ['rgba16uint', 'u32'],
+  ['rgba16sint', 'i32'],
+  ['rgba16float', 'f32'],
+  ['r32uint', 'u32'],
+  ['r32sint', 'i32'],
+  ['r32float', 'f32'],
+  ['rg32uint', 'u32'],
+  ['rg32sint', 'i32'],
+  ['rg32float', 'f32'],
+  ['rgba32uint', 'i32'],
+  ['rgba32sint', 'i32'],
+  ['rgba32float', 'f32'],
+] as const;
+
 /**
  * Generate a bunch types (vec, mat, sized/unsized array) for testing.
  */


### PR DESCRIPTION
This PR adds unimplemented stubs for the `textureStore` builtin.

Issue #1272

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
