### PR TITLE
Duplicate params: catch in ParamsBuilder, improve error in loadTreeForQuery

### DIFF
--- a/src/common/framework/params_builder.ts
+++ b/src/common/framework/params_builder.ts
@@ -1,4 +1,6 @@
 import { Merged, mergeParams } from '../internal/params_utils.js';
+import { stringifyPublicParams } from '../internal/query/stringify_params.js';
+import { assert, mapLazy } from '../util/util.js';
 
 // ================================================================
 // "Public" ParamsBuilder API / Documentation
@@ -159,8 +161,7 @@ export class CaseParamsBuilder<CaseP extends {}>
   ): CaseParamsBuilder<Merged<CaseP, { [name in NewPKey]: NewPValue }>> {
     return this.expandWithParams(function* (p) {
       for (const value of expander(p)) {
-        // TypeScript doesn't know here that NewPKey is always a single literal string type.
-        yield { [key]: value } as { [name in NewPKey]: NewPValue };
+        yield { [key]: value } as { readonly [name in NewPKey]: NewPValue };
       }
     });
   }
@@ -169,6 +170,13 @@ export class CaseParamsBuilder<CaseP extends {}>
   combineWithParams<NewP extends {}>(
     newParams: Iterable<NewP>
   ): CaseParamsBuilder<Merged<CaseP, NewP>> {
+    const seenValues = new Set<string>();
+    for (const params of newParams) {
+      const paramsStr = stringifyPublicParams(params);
+      assert(!seenValues.has(paramsStr), `Duplicate entry in combine[WithParams]: ${paramsStr}`);
+      seenValues.add(paramsStr);
+    }
+
     return this.expandWithParams(() => newParams);
   }
 
@@ -177,7 +185,8 @@ export class CaseParamsBuilder<CaseP extends {}>
     key: NewPKey,
     values: Iterable<NewPValue>
   ): CaseParamsBuilder<Merged<CaseP, { [name in NewPKey]: NewPValue }>> {
-    return this.expand(key, () => values);
+    const mapped = mapLazy(values, v => ({ [key]: v } as { [name in NewPKey]: NewPValue }));
+    return this.combineWithParams(mapped);
   }
 
   /** @inheritdoc */

--- a/src/common/framework/params_builder.ts
+++ b/src/common/framework/params_builder.ts
@@ -170,6 +170,7 @@ export class CaseParamsBuilder<CaseP extends {}>
   combineWithParams<NewP extends {}>(
     newParams: Iterable<NewP>
   ): CaseParamsBuilder<Merged<CaseP, NewP>> {
+    assertNotGenerator(newParams);
     const seenValues = new Set<string>();
     for (const params of newParams) {
       const paramsStr = stringifyPublicParams(params);
@@ -185,6 +186,7 @@ export class CaseParamsBuilder<CaseP extends {}>
     key: NewPKey,
     values: Iterable<NewPValue>
   ): CaseParamsBuilder<Merged<CaseP, { [name in NewPKey]: NewPValue }>> {
+    assertNotGenerator(values);
     const mapped = mapLazy(values, v => ({ [key]: v } as { [name in NewPKey]: NewPValue }));
     return this.combineWithParams(mapped);
   }
@@ -274,6 +276,7 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
   combineWithParams<NewP extends {}>(
     newParams: Iterable<NewP>
   ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, NewP>> {
+    assertNotGenerator(newParams);
     return this.expandWithParams(() => newParams);
   }
 
@@ -282,6 +285,7 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
     key: NewPKey,
     values: Iterable<NewPValue>
   ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, { [name in NewPKey]: NewPValue }>> {
+    assertNotGenerator(values);
     return this.expand(key, () => values);
   }
 
@@ -320,4 +324,14 @@ function filterGenerator<Base, A>(
       }
     }
   };
+}
+
+/** Assert an object is not a Generator (a thing returned from a generator function). */
+function assertNotGenerator(x: object) {
+  if ('constructor' in x) {
+    assert(
+      x.constructor !== (function* () {})().constructor,
+      'Argument must not be a generator, as generators are not reusable'
+    );
+  }
 }

--- a/src/common/internal/tree.ts
+++ b/src/common/internal/tree.ts
@@ -527,14 +527,16 @@ function getOrInsertSubtree<T extends TestQuery>(
 }
 
 function insertLeaf(parent: TestSubtree, query: TestQuerySingleCase, t: RunCase) {
-  const key = '';
   const leaf: TestTreeLeaf = {
     readableRelativeName: readableNameForCase(query),
     query,
     run: (rec, expectations) => t.run(rec, query, expectations || []),
     isUnimplemented: t.isUnimplemented,
   };
-  assert(!parent.children.has(key));
+
+  // This is a leaf (e.g. s:f:t:x=1;* -> s:f:t:x=1). The key is always ''.
+  const key = '';
+  assert(!parent.children.has(key), `Duplicate testcase: ${query}`);
   parent.children.set(key, leaf);
 }
 

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -176,6 +176,17 @@ export function* iterRange<T>(n: number, fn: (i: number) => T): Iterable<T> {
   }
 }
 
+/** Creates a (reusable) iterable object that maps `f` over `xs`, lazily. */
+export function mapLazy<T, R>(xs: Iterable<T>, f: (x: T) => R): Iterable<R> {
+  return {
+    *[Symbol.iterator]() {
+      for (const x of xs) {
+        yield f(x);
+      }
+    },
+  };
+}
+
 const TypedArrayBufferViewInstances = [
   new Uint8Array(),
   new Uint8ClampedArray(),

--- a/src/unittests/params_builder_toplevel.spec.ts
+++ b/src/unittests/params_builder_toplevel.spec.ts
@@ -87,15 +87,15 @@ g.test('generator').fn(t0 => {
 
   g.test('generator')
     .params(u =>
-      u.combineWithParams(
-        (function* () {
+      u.combineWithParams({
+        *[Symbol.iterator]() {
           for (let x = 0; x < 3; ++x) {
             for (let y = 0; y < 2; ++y) {
               yield { x, y };
             }
           }
-        })()
-      )
+        },
+      })
     )
     .fn(t => {
       ran.push(t.params);

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -130,11 +130,24 @@ g.test('duplicate_test_params,none').fn(() => {
 g.test('duplicate_test_params,basic').fn(t => {
   {
     const g = makeTestGroupForUnitTesting(UnitTest);
-    g.test('abc')
-      .paramsSimple([
+    const builder = g.test('abc');
+    t.shouldThrow('Error', () => {
+      builder.paramsSimple([
         { a: 1 }, //
         { a: 1 },
-      ])
+      ]);
+      g.validate();
+    });
+  }
+  {
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('abc')
+      .params(u =>
+        u.expandWithParams(() => [
+          { a: 1 }, //
+          { a: 1 },
+        ])
+      )
       .fn(() => {});
     t.shouldThrow('Error', () => {
       g.validate();
@@ -155,16 +168,30 @@ g.test('duplicate_test_params,basic').fn(t => {
 });
 
 g.test('duplicate_test_params,with_different_private_params').fn(t => {
-  const g = makeTestGroupForUnitTesting(UnitTest);
-  g.test('abc')
-    .paramsSimple([
-      { a: 1, _b: 1 }, //
-      { a: 1, _b: 2 },
-    ])
-    .fn(() => {});
-  t.shouldThrow('Error', () => {
-    g.validate();
-  });
+  {
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    const builder = g.test('abc');
+    t.shouldThrow('Error', () => {
+      builder.paramsSimple([
+        { a: 1, _b: 1 }, //
+        { a: 1, _b: 2 },
+      ]);
+    });
+  }
+  {
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('abc')
+      .params(u =>
+        u.expandWithParams(() => [
+          { a: 1, _b: 1 }, //
+          { a: 1, _b: 2 },
+        ])
+      )
+      .fn(() => {});
+    t.shouldThrow('Error', () => {
+      g.validate();
+    });
+  }
 });
 
 g.test('invalid_test_name').fn(t => {
@@ -191,9 +218,9 @@ g.test('param_value,valid').fn(() => {
 g.test('param_value,invalid').fn(t => {
   for (const badChar of ';=*') {
     const g = makeTestGroupForUnitTesting(UnitTest);
-    g.test('a').paramsSimple([{ badChar }]);
+    const builder = g.test('a');
     t.shouldThrow('Error', () => {
-      g.validate();
+      builder.paramsSimple([{ badChar }]);
     });
   }
 });

--- a/src/unittests/test_group_test.ts
+++ b/src/unittests/test_group_test.ts
@@ -23,6 +23,12 @@ export class TestGroupTest extends UnitTest {
     for (const t of g.iterate()) {
       gcases.push(...Array.from(t.iterate(), c => c.id));
     }
-    this.expect(objectEquals(gcases, cases));
+    this.expect(
+      objectEquals(gcases, cases),
+      `expected
+  ${JSON.stringify(cases)}
+got
+  ${JSON.stringify(gcases)}`
+    );
   }
 }


### PR DESCRIPTION
The check in ParamsBuilder is a bit more local than the one in
loadTreeForQuery, so hopefully easier to debug.

Only combine()/combineWithParams() can catch duplicate params
efficiently (just once, instead of once per parent parameterization), so
other methods don't check for them.
In those cases, the assertion in loadTreeForQuery will be hit, so
improve the error for that assertion, too.

Issue: fixes #1409

<hr>

**Requirements for PR author:**

- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Helpers and types promote readability and maintainability.