### PR TITLE
wgsl: Add stubs for the pack and unpack methods.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
@@ -1,0 +1,19 @@
+export const description = `
+Converts two floating point values to half-precision floating point numbers, and then combines them into one u32 value.
+Component e[i] of the input is converted to a IEEE-754 binary16 value,
+which is then placed in bits 16 × i through 16 × i + 15 of the result.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('pack')
+  .specURL('https://www.w3.org/TR/WGSL/#pack-builtin-functions')
+  .desc(
+    `
+@const fn pack2x16float(e: vec2<f32>) -> u32
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
@@ -1,0 +1,20 @@
+export const description = `
+Converts two normalized floating point values to 16-bit signed integers, and then combines them into one u32 value.
+Component e[i] of the input is converted to a 16-bit twos complement integer value
+⌊ 0.5 + 32767 × min(1, max(-1, e[i])) ⌋ which is then placed in
+bits 16 × i through 16 × i + 15 of the result.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('pack')
+  .specURL('https://www.w3.org/TR/WGSL/#pack-builtin-functions')
+  .desc(
+    `
+@const fn pack2x16snorm(e: vec2<f32>) -> u32
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
@@ -1,0 +1,20 @@
+export const description = `
+Converts two normalized floating point values to 16-bit unsigned integers, and then combines them into one u32 value.
+Component e[i] of the input is converted to a 16-bit unsigned integer value
+⌊ 0.5 + 65535 × min(1, max(0, e[i])) ⌋ which is then placed in
+bits 16 × i through 16 × i + 15 of the result.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('pack')
+  .specURL('https://www.w3.org/TR/WGSL/#pack-builtin-functions')
+  .desc(
+    `
+@const fn pack2x16unorm(e: vec2<f32>) -> u32
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
@@ -1,0 +1,20 @@
+export const description = `
+Converts four normalized floating point values to 8-bit signed integers, and then combines them into one u32 value.
+Component e[i] of the input is converted to an 8-bit twos complement integer value
+⌊ 0.5 + 127 × min(1, max(-1, e[i])) ⌋ which is then placed in
+bits 8 × i through 8 × i + 7 of the result.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('pack')
+  .specURL('https://www.w3.org/TR/WGSL/#pack-builtin-functions')
+  .desc(
+    `
+@const fn pack4x8snorm(e: vec4<f32>) -> u32
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8unorm.spec.ts
@@ -1,0 +1,20 @@
+export const description = `
+Converts four normalized floating point values to 8-bit unsigned integers, and then combines them into one u32 value.
+Component e[i] of the input is converted to an 8-bit unsigned integer value
+⌊ 0.5 + 255 × min(1, max(0, e[i])) ⌋ which is then placed in
+bits 8 × i through 8 × i + 7 of the result.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('pack')
+  .specURL('https://www.w3.org/TR/WGSL/#pack-builtin-functions')
+  .desc(
+    `
+@const fn pack4x8unorm(e: vec4<f32>) -> u32
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
@@ -1,0 +1,20 @@
+export const description = `
+Decomposes a 32-bit value into two 16-bit chunks, and reinterpets each chunk as
+a floating point value.
+Component i of the result is the f32 representation of v, where v is the
+interpretation of bits 16×i through 16×i+15 of e as an IEEE-754 binary16 value.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('unpack')
+  .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
+  .desc(
+    `
+@const fn unpack2x16float(e: u32) -> vec2<f32>
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
@@ -1,0 +1,20 @@
+export const description = `
+Decomposes a 32-bit value into two 16-bit chunks, then reinterprets each chunk
+as a signed normalized floating point value.
+Component i of the result is max(v ÷ 32767, -1), where v is the interpretation
+of bits 16×i through 16×i+15 of e as a twos-complement signed integer.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('unpack')
+  .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
+  .desc(
+    `
+@const fn unpack2x16snorm(e: u32) -> vec2<f32>
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -1,0 +1,20 @@
+export const description = `
+Decomposes a 32-bit value into two 16-bit chunks, then reinterprets each chunk
+as an unsigned normalized floating point value.
+Component i of the result is v ÷ 65535, where v is the interpretation of bits
+16×i through 16×i+15 of e as an unsigned integer.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('unpack')
+  .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
+  .desc(
+    `
+@const fn unpack2x16unorm(e: u32) -> vec2<f32>
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
@@ -1,0 +1,20 @@
+export const description = `
+Decomposes a 32-bit value into four 8-bit chunks, then reinterprets each chunk
+as a signed normalized floating point value.
+Component i of the result is max(v ÷ 127, -1), where v is the interpretation of
+bits 8×i through 8×i+7 of e as a twos-complement signed integer.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('unpack')
+  .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
+  .desc(
+    `
+@const fn unpack4x8snorm(e: u32) -> vec4<f32>
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
@@ -1,0 +1,20 @@
+export const description = `
+Decomposes a 32-bit value into four 8-bit chunks, then reinterprets each chunk
+as an unsigned normalized floating point value.
+Component i of the result is v ÷ 255, where v is the interpretation of bits 8×i
+through 8×i+7 of e as an unsigned integer.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('unpack')
+  .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
+  .desc(
+    `
+@const fn unpack4x8unorm(e: u32) -> vec4<f32>
+`
+  )
+  .unimplemented();


### PR DESCRIPTION
This PR adds unimplemented stubs for the pack and unpack methods.

 * `pack4x8snorm`
 * `pack4x8unorm`
 * `pack2x16snorm`
 * `pack2x16unorm`
 * `pack2x16float`
 * `unpack4x8snorm`
 * `unpack4x8unorm`
 * `unpack2x16snorm`
 * `unpack2x16unorm`
 * `unpack2x16float`

Issue #1284, #1285, #1286, #1287, #1288, #1289, #1290, #1291, #1292, #1293

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
