### PR TITLE
wgsl: Stub synchronization builtin functions.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/storageBarrier.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/storageBarrier.spec.ts
@@ -1,0 +1,38 @@
+export const description = `
+'storageBarrier' affects memory and atomic operations in the storage address space.
+
+All synchronization functions execute a control barrier with Acquire/Release memory ordering.
+That is, all synchronization functions, and affected memory and atomic operations are ordered
+in program order relative to the synchronization function. Additionally, the affected memory
+and atomic operations program-ordered before the synchronization function must be visible to
+all other threads in the workgroup before any affected memory or atomic operation program-ordered
+after the synchronization function is executed by a member of the workgroup. All synchronization
+functions use the Workgroup memory scope. All synchronization functions have a Workgroup
+execution scope.
+
+All synchronization functions must only be used in the compute shader stage.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#sync-builtin-functions')
+  .desc(
+    `
+All synchronization functions must only be used in the compute shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['vertex', 'fragment', 'compute'] as const))
+  .unimplemented();
+
+g.test('barrier')
+  .specURL('https://www.w3.org/TR/WGSL/#sync-builtin-functions')
+  .desc(
+    `
+fn storageBarrier()
+`
+  )
+  .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/workgroupBarrier.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/workgroupBarrier.spec.ts
@@ -1,0 +1,38 @@
+export const description = `
+'workgroupBarrier' affects memory and atomic operations in the workgroup address space.
+
+All synchronization functions execute a control barrier with Acquire/Release memory ordering.
+That is, all synchronization functions, and affected memory and atomic operations are ordered
+in program order relative to the synchronization function. Additionally, the affected memory
+and atomic operations program-ordered before the synchronization function must be visible to
+all other threads in the workgroup before any affected memory or atomic operation program-ordered
+after the synchronization function is executed by a member of the workgroup. All synchronization
+functions use the Workgroup memory scope. All synchronization functions have a Workgroup
+execution scope.
+
+All synchronization functions must only be used in the compute shader stage.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#sync-builtin-functions')
+  .desc(
+    `
+All synchronization functions must only be used in the compute shader stage.
+`
+  )
+  .params(u => u.combine('stage', ['vertex', 'fragment', 'compute'] as const))
+  .unimplemented();
+
+g.test('barrier')
+  .specURL('https://www.w3.org/TR/WGSL/#sync-builtin-functions')
+  .desc(
+    `
+fn workgroupBarrier()
+`
+  )
+  .unimplemented();


### PR DESCRIPTION
This PR adds unimplemented stubs for the synchronization builtin functions.

 * `storageBarrier`
 * `workgroupBarrier`

Issue #1249, #1295

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
