### PR TITLE
Draw vertex buffer access test for vertex step mode buffer

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -235,12 +235,12 @@ Other cases are handled by robust access and no validation error occurs.
     - Otherwise no validation error in drawIndexed, draIndirect and drawIndexedIndirect
 
 In this test, we use a a render pipeline requiring one vertex step mode with different vertex buffer
-layout (attribute offset, array stride, vertex format). Then for a given drawing parameter set (e.g.,
+layouts (attribute offset, array stride, vertex format). Then for a given drawing parameter set (e.g.,
 vertexCount, instanceCount, firstVertex, indexCount), we calculate the exactly required size for
 vertex step mode vertex buffer. Then, we generate buffer parameters (i.e. GPU buffer size,
 binding offset and binding size) for all buffers, covering both (bound size == required size),
 (bound size == required size - 1), and (bound size == 0), and test that draw and drawIndexed will
-success/error asexpected. Such set of buffer parameters should include cases like weird offset values.
+success/error as expected. Such set of buffer parameters should include cases like weird offset values.
 `
   )
   .params(u =>
@@ -417,7 +417,7 @@ Other cases are handled by robust access and no validation error occurs.
     - No validation error in drawIndirect and drawIndexedIndirect
 
 In this test, we use a a render pipeline requiring one instance step mode with different vertex buffer
-layout (attribute offset, array stride, vertex format). Then for a given drawing parameter set (e.g.,
+layouts (attribute offset, array stride, vertex format). Then for a given drawing parameter set (e.g.,
 vertexCount, instanceCount, firstVertex, indexCount), we calculate the exactly required size for
 vertex step mode vertex buffer. Then, we generate buffer parameters (i.e. GPU buffer size,
 binding offset and binding size) for all buffers, covering both (bound size == required size),


### PR DESCRIPTION
In this PR the vertex step mode vertex buffer OOB validation in draw calls is tested. It test that encoder.draw will validate vertex step mode vertex buffer satisfing `bound size >= (strideCount - 1) * arrayStride + lastStride` iif strideCount  > 0, and other draw call types do not validate vertex step mode vertex buffer OOB.

Issue: #906

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
