### PR TITLE
Fix memory leak in vertex_buffer_OOB,vertex_step_mode

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -184,7 +184,7 @@ drawIndexedIndirect as it is GPU-validated.
       size: bufferSize,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     };
-    const indexBuffer = t.device.createBuffer(desc);
+    const indexBuffer = t.createBufferWithState('valid', desc);
 
     const drawCallParam: DrawIndexedParameter = {
       indexCount: drawIndexCount,
@@ -330,7 +330,7 @@ success/error as expected. Such set of buffer parameters should include cases li
     );
     const vertexBufferSize = setBufferOffset + setVertexBufferSize;
 
-    const vertexBuffer = t.device.createBuffer({
+    const vertexBuffer = t.createBufferWithState('valid', {
       size: vertexBufferSize,
       usage: GPUBufferUsage.VERTEX,
     });
@@ -382,7 +382,7 @@ success/error as expected. Such set of buffer parameters should include cases li
         size: indexBufferSize,
         usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
       };
-      const indexBuffer = t.device.createBuffer(desc);
+      const indexBuffer = t.createBufferWithState('valid', desc);
 
       const drawParam: DrawIndexedParameter = {
         indexCount,


### PR DESCRIPTION
This PR fix the memory leaking problem in previous PR #1450

Issue: #906

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
