### PR TITLE
Change importExternalTexture,destroy to importExternalTexture,expired

### DIFF
--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -165,11 +165,12 @@ TODO: Multiplanar scenarios
     });
   });
 
-g.test('importExternalTexture,destroy')
+g.test('importExternalTexture,expired')
   .desc(
     `
-Tests that a GPUExternalTexture is destroyed by a microtask and that using it after it has been
-destroyed results in an error.
+Tests that GPUExternalTexture.expired is false when video frame is not updated
+from imported HTMLVideoElement and change to true when video frame is updated.
+Using expired GPUExternalTextures result in an error.
 `
   )
   .fn(async t => {
@@ -206,32 +207,44 @@ destroyed results in an error.
       return commandEncoder.finish();
     };
 
+    let externalTexture: GPUExternalTexture;
     await startPlayingAndWaitForVideo(video, async () => {
       // 1. Enqueue a microtask which uses the GPUExternalTexture. This should happen immediately
-      // after the current microtask - before the GPUExternalTexture is destroyed.
+      // after the current microtask.
       const microtask1 = Promise.resolve().then(() => {
         const commandBuffer = useExternalTexture();
         t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), false);
+        t.expect(!externalTexture.expired);
       });
 
-      // 2. importExternalTexture enqueues a microtask that destroys the GPUExternalTexture.
-      const externalTexture = t.device.importExternalTexture({ source: video });
+      // 2. importExternalTexture which should stay active if video frame is not updated.
+      externalTexture = t.device.importExternalTexture({ source: video });
       // Set `bindGroup` here, which will then be used in microtask1 and microtask3.
       bindGroup = t.device.createBindGroup({
         layout: bindGroupLayout,
         entries: [{ binding: 0, resource: externalTexture }],
       });
 
-      // 3. Enqueue a microtask which uses the GPUExternalTexture. This should happen immediately
-      // after the microtask which destroys the GPUExternalTexture.
+      // 3. Enqueue a microtask which uses the GPUExternalTexture. The GPUExternalTexture
+      // should still keep alive.
       const microtask3 = Promise.resolve().then(() => {
         const commandBuffer = useExternalTexture();
-        t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), true);
+        t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), false);
+        t.expect(!externalTexture.expired);
       });
 
       // Now make sure the test doesn't end before all of those microtasks complete.
       await microtask1;
       await microtask3;
+    });
+
+    // Update new video frame.
+    await startPlayingAndWaitForVideo(video, async () => {
+      // 4. VideoFrame is updated. GPUExternalTexture should be expired. Using the
+      // GPUExternalTexture should result an error.
+      const commandBuffer = useExternalTexture();
+      t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), true);
+      t.expect(externalTexture.expired);
     });
   });
 

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -169,8 +169,8 @@ g.test('importExternalTexture,expired')
   .desc(
     `
 Tests that GPUExternalTexture.expired is false when video frame is not updated
-from imported HTMLVideoElement and change to true when video frame is updated.
-Using expired GPUExternalTextures result in an error.
+from imported HTMLVideoElement and will be changed to true when video frame is
+updated. Using expired GPUExternalTexture results in an error.
 `
   )
   .fn(async t => {
@@ -241,7 +241,7 @@ Using expired GPUExternalTextures result in an error.
     // Update new video frame.
     await startPlayingAndWaitForVideo(video, async () => {
       // 4. VideoFrame is updated. GPUExternalTexture should be expired. Using the
-      // GPUExternalTexture should result an error.
+      // GPUExternalTexture should result in an error.
       const commandBuffer = useExternalTexture();
       t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), true);
       t.expect(externalTexture.expired);


### PR DESCRIPTION
The lifecycle of GPUExternalTexture changes from single js microtask to
align with video frame from imported HTMLVideoElement.
GPUExternalTexture.expired should changes from false to true when latest
video frame from HTMLVideoElement is updated.

fixed:#1473




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
