### PR TITLE
Add api,validation,resource_usages,buffer,in_pass_encoder:* - Part III

### DIFF
--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -531,3 +531,76 @@ dispatch calls refer to different usage scopes.`
       encoder.finish();
     }, false);
   });
+
+g.test('subresources,buffer_usage_in_one_render_pass_with_no_draw')
+  .desc(
+    `
+Test that when one buffer is used in one render pass encoder, its list of internal usages within one
+usage scope (all the commands in the whole render pass) can only be a compatible usage list even if
+there is no draw call in the render pass.
+    `
+  )
+  .params(u =>
+    u
+      .combine('usage0', ['uniform', 'storage', 'read-only-storage', 'vertex', 'index'] as const)
+      .combine('usage1', ['uniform', 'storage', 'read-only-storage', 'vertex', 'index'] as const)
+      .beginSubcases()
+      .combine('hasOverlap', [true, false])
+      .combine('visibility0', ['compute', 'fragment'] as const)
+      .unless(t => t.visibility0 === 'compute' && !IsBufferUsageInBindGroup(t.usage0))
+      .combine('visibility1', ['compute', 'fragment'] as const)
+      .unless(t => t.visibility1 === 'compute' && !IsBufferUsageInBindGroup(t.usage1))
+  )
+  .fn(async t => {
+    const { usage0, usage1, hasOverlap, visibility0, visibility1 } = t.params;
+
+    const UseBufferOnRenderPassEncoder = (
+      buffer: GPUBuffer,
+      offset: number,
+      type: 'uniform' | 'storage' | 'read-only-storage' | 'vertex' | 'index',
+      bindGroupVisibility: 'compute' | 'fragment',
+      renderPassEncoder: GPURenderPassEncoder
+    ) => {
+      switch (type) {
+        case 'uniform':
+        case 'storage':
+        case 'read-only-storage': {
+          const bindGroup = t.createBindGroupForTest(buffer, offset, type, bindGroupVisibility);
+          renderPassEncoder.setBindGroup(0, bindGroup);
+          break;
+        }
+        case 'vertex': {
+          renderPassEncoder.setVertexBuffer(0, buffer, offset, kBoundBufferSize);
+          break;
+        }
+        case 'index': {
+          renderPassEncoder.setIndexBuffer(buffer, 'uint16', offset, kBoundBufferSize);
+          break;
+        }
+      }
+    };
+
+    const buffer = t.device.createBuffer({
+      size: kBoundBufferSize * 2,
+      usage:
+        GPUBufferUsage.UNIFORM |
+        GPUBufferUsage.STORAGE |
+        GPUBufferUsage.VERTEX |
+        GPUBufferUsage.INDEX,
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const renderPassEncoder = t.beginSimpleRenderPass(encoder);
+    const offset0 = 0;
+    UseBufferOnRenderPassEncoder(buffer, offset0, usage0, visibility0, renderPassEncoder);
+    const offset1 = hasOverlap ? offset0 : kBoundBufferSize;
+    UseBufferOnRenderPassEncoder(buffer, offset1, usage1, visibility1, renderPassEncoder);
+    renderPassEncoder.end();
+
+    const fail =
+      (usage0 === 'storage' && usage1 !== 'storage') ||
+      (usage0 !== 'storage' && usage1 === 'storage');
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, fail);
+  });

--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -184,7 +184,7 @@ rules are not related to the buffer offset or the bind group layout visibilities
       }
     };
 
-    const buffer = t.device.createBuffer({
+    const buffer = t.createBufferWithState('valid', {
       size: kBoundBufferSize * 2,
       usage:
         GPUBufferUsage.UNIFORM |
@@ -246,7 +246,7 @@ bindGroup, dynamicOffsets), do not contribute directly to a usage scope.`
   .fn(async t => {
     const { usage0, usage1, visibility0, visibility1, hasOverlap } = t.params;
 
-    const buffer = t.device.createBuffer({
+    const buffer = t.createBufferWithState('valid', {
       size: kBoundBufferSize * 2,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.STORAGE,
     });
@@ -334,7 +334,7 @@ referenced by that bind group is "used" in the usage scope. `
       hasOverlap,
     } = t.params;
 
-    const buffer = t.device.createBuffer({
+    const buffer = t.createBufferWithState('valid', {
       size: kBoundBufferSize * 2,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.STORAGE | GPUBufferUsage.INDIRECT,
     });
@@ -505,7 +505,7 @@ dispatch calls refer to different usage scopes.`
       }
     };
 
-    const buffer = t.device.createBuffer({
+    const buffer = t.createBufferWithState('valid', {
       size: kBoundBufferSize * 2,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.STORAGE | GPUBufferUsage.INDIRECT,
     });
@@ -580,7 +580,7 @@ there is no draw call in the render pass.
       }
     };
 
-    const buffer = t.device.createBuffer({
+    const buffer = t.createBufferWithState('valid', {
       size: kBoundBufferSize * 2,
       usage:
         GPUBufferUsage.UNIFORM |
@@ -597,9 +597,7 @@ there is no draw call in the render pass.
     UseBufferOnRenderPassEncoder(buffer, offset1, usage1, visibility1, renderPassEncoder);
     renderPassEncoder.end();
 
-    const fail =
-      (usage0 === 'storage' && usage1 !== 'storage') ||
-      (usage0 !== 'storage' && usage1 === 'storage');
+    const fail = (usage0 === 'storage') !== (usage1 === 'storage');
     t.expectValidationError(() => {
       encoder.finish();
     }, fail);

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -364,7 +364,7 @@ g.test('subresources,texture_usages_in_copy_and_render_pass')
     ) => {
       switch (usage) {
         case 'copy-src': {
-          const buffer = t.device.createBuffer({
+          const buffer = t.createBufferWithState('valid', {
             size: 4,
             usage: GPUBufferUsage.COPY_DST,
           });
@@ -372,7 +372,7 @@ g.test('subresources,texture_usages_in_copy_and_render_pass')
           break;
         }
         case 'copy-dst': {
-          const buffer = t.device.createBuffer({
+          const buffer = t.createBufferWithState('valid', {
             size: 4,
             usage: GPUBufferUsage.COPY_SRC,
           });


### PR DESCRIPTION
This patch adds the third part of
api,validation,resource_usages,buffer,in_pass_encoder:*:
-subresources,buffer_usage_in_one_render_pass_with_no_draw

Note that the exising test "buffer_usage_in_render_pass" will finally
be replaced by the below tests when these tests are all implemented to
make the whole test framework much cleaner and simpler:
-subresources,buffer_usage_in_one_render_pass_with_no_draw
-subresources,buffer_usage_in_one_render_pass_with_one_draw
-subresources,buffer_usage_in_one_render_pass_with_two_draws




Issue: #905

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
