### PR TITLE
Add api,validation,resource_usages,buffer,in_pass_encoder:* - Part IV

### DIFF
--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -8,6 +8,25 @@ import { ValidationTest } from '../../validation_test.js';
 
 const kBoundBufferSize = 256;
 
+type BufferUsage =
+  | 'uniform'
+  | 'storage'
+  | 'read-only-storage'
+  | 'vertex'
+  | 'index'
+  | 'indirect'
+  | 'indexedIndirect';
+
+const kAllBufferUsages: BufferUsage[] = [
+  'uniform',
+  'storage',
+  'read-only-storage',
+  'vertex',
+  'index',
+  'indirect',
+  'indexedIndirect',
+];
+
 class F extends ValidationTest {
   createBindGroupLayoutForTest(
     type: 'uniform' | 'storage' | 'read-only-storage',
@@ -59,18 +78,51 @@ class F extends ValidationTest {
       ],
     });
   }
+
+  createRenderPipelineForTest(
+    pipelineLayout: GPUPipelineLayout | undefined,
+    vertexBufferCount: number
+  ): GPURenderPipeline {
+    const vertexBuffers: GPUVertexBufferLayout[] = [];
+    for (let i = 0; i < vertexBufferCount; ++i) {
+      vertexBuffers.push({
+        arrayStride: 4,
+        attributes: [
+          {
+            format: 'float32',
+            shaderLocation: i,
+            offset: 0,
+          },
+        ],
+      });
+    }
+
+    return this.device.createRenderPipeline({
+      layout: pipelineLayout,
+      vertex: {
+        module: this.device.createShaderModule({
+          code: this.getNoOpShaderCode('VERTEX'),
+        }),
+        entryPoint: 'main',
+        buffers: vertexBuffers,
+      },
+      fragment: {
+        module: this.device.createShaderModule({
+          code: `
+              @stage(fragment) fn main()
+                -> @location(0) vec4<f32> {
+                  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+              }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+      primitive: { topology: 'point-list' },
+    });
+  }
 }
 
-function IsBufferUsageInBindGroup(
-  bufferUsage:
-    | 'uniform'
-    | 'storage'
-    | 'read-only-storage'
-    | 'vertex'
-    | 'index'
-    | 'indirect'
-    | 'indexedIndirect'
-): boolean {
+function IsBufferUsageInBindGroup(bufferUsage: BufferUsage): boolean {
   switch (bufferUsage) {
     case 'uniform':
     case 'storage':
@@ -101,26 +153,10 @@ rules are not related to the buffer offset or the bind group layout visibilities
       .combine('inSamePass', [true, false])
       .combine('hasOverlap', [true, false])
       .beginSubcases()
-      .combine('usage0', [
-        'uniform',
-        'storage',
-        'read-only-storage',
-        'vertex',
-        'index',
-        'indirect',
-        'indexedIndirect',
-      ] as const)
+      .combine('usage0', kAllBufferUsages)
       .combine('visibility0', ['compute', 'fragment'] as const)
       .unless(t => t.visibility0 === 'compute' && !IsBufferUsageInBindGroup(t.usage0))
-      .combine('usage1', [
-        'uniform',
-        'storage',
-        'read-only-storage',
-        'vertex',
-        'index',
-        'indirect',
-        'indexedIndirect',
-      ] as const)
+      .combine('usage1', kAllBufferUsages)
       .combine('visibility1', ['compute', 'fragment'] as const)
       // The situation that the index buffer is reset by another setIndexBuffer call will be tested
       // in another test case.
@@ -137,14 +173,7 @@ rules are not related to the buffer offset or the bind group layout visibilities
       buffer: GPUBuffer,
       index: number,
       offset: number,
-      type:
-        | 'uniform'
-        | 'storage'
-        | 'read-only-storage'
-        | 'vertex'
-        | 'index'
-        | 'indirect'
-        | 'indexedIndirect',
+      type: BufferUsage,
       bindGroupVisibility: 'compute' | 'fragment',
       renderPassEncoder: GPURenderPassEncoder
     ) => {
@@ -173,7 +202,7 @@ rules are not related to the buffer offset or the bind group layout visibilities
         case 'indexedIndirect': {
           const renderPipeline = t.createNoOpRenderPipeline();
           renderPassEncoder.setPipeline(renderPipeline);
-          const indexBuffer = t.device.createBuffer({
+          const indexBuffer = t.createBufferWithState('valid', {
             size: 4,
             usage: GPUBufferUsage.INDEX,
           });
@@ -557,7 +586,7 @@ there is no draw call in the render pass.
     const UseBufferOnRenderPassEncoder = (
       buffer: GPUBuffer,
       offset: number,
-      type: 'uniform' | 'storage' | 'read-only-storage' | 'vertex' | 'index',
+      type: BufferUsage,
       bindGroupVisibility: 'compute' | 'fragment',
       renderPassEncoder: GPURenderPassEncoder
     ) => {
@@ -577,6 +606,10 @@ there is no draw call in the render pass.
           renderPassEncoder.setIndexBuffer(buffer, 'uint16', offset, kBoundBufferSize);
           break;
         }
+        case 'indirect':
+        case 'indexedIndirect':
+          unreachable();
+          break;
       }
     };
 
@@ -595,6 +628,272 @@ there is no draw call in the render pass.
     UseBufferOnRenderPassEncoder(buffer, offset0, usage0, visibility0, renderPassEncoder);
     const offset1 = hasOverlap ? offset0 : kBoundBufferSize;
     UseBufferOnRenderPassEncoder(buffer, offset1, usage1, visibility1, renderPassEncoder);
+    renderPassEncoder.end();
+
+    const fail = (usage0 === 'storage') !== (usage1 === 'storage');
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, fail);
+  });
+
+g.test('subresources,buffer_usage_in_one_render_pass_with_one_draw')
+  .desc(
+    `
+Test that when one buffer is used in one render pass encoder where there is one draw call, its list
+of internal usages within one usage scope (all the commands in the whole render pass) can only be a
+compatible usage list. The usage scope rules are not related to the buffer offset or the bind group
+layout visibilities.`
+  )
+  .params(u =>
+    u
+      .combine('usage0', kAllBufferUsages)
+      .combine('usage1', kAllBufferUsages)
+      .beginSubcases()
+      .combine('usage0AccessibleInDraw', [true, false])
+      .combine('usage1AccessibleInDraw', [true, false])
+      .combine('drawBeforeUsage1', [true, false])
+      .combine('visibility0', ['compute', 'fragment'] as const)
+      .filter(t => {
+        // The buffer with `indirect` or `indexedIndirect` usage is always accessible in the draw
+        // call.
+        if (
+          (t.usage0 === 'indirect' || t.usage0 === 'indexedIndirect') &&
+          (!t.usage0AccessibleInDraw || t.visibility0 !== 'fragment' || !t.drawBeforeUsage1)
+        ) {
+          return false;
+        }
+        // The bufer usages `vertex` and `index` do nothing with shader visibilities.
+        if ((t.usage0 === 'vertex' || t.usage0 === 'index') && t.visibility0 !== 'fragment') {
+          return false;
+        }
+
+        if (t.usage0AccessibleInDraw && t.visibility0 !== 'fragment') {
+          return false;
+        }
+        if (t.drawBeforeUsage1 && t.usage1AccessibleInDraw) {
+          return false;
+        }
+        return true;
+      })
+      .combine('visibility1', ['compute', 'fragment'] as const)
+      .filter(t => {
+        if (
+          (t.usage1 === 'indirect' || t.usage1 === 'indexedIndirect') &&
+          (!t.usage1AccessibleInDraw || t.visibility1 !== 'fragment' || t.drawBeforeUsage1)
+        ) {
+          return false;
+        }
+        if ((t.usage1 === 'vertex' || t.usage1 === 'index') && t.visibility1 !== 'fragment') {
+          return false;
+        }
+        // When the first buffer usage is `indirect` or `indexedIndirect`, there has already been
+        // one draw call, so in this test we always make the second usage inaccessible in the draw
+        // call.
+        if (
+          t.usage1AccessibleInDraw &&
+          (t.visibility1 !== 'fragment' ||
+            t.usage0 === 'indirect' ||
+            t.usage0 === 'indexedIndirect')
+        ) {
+          return false;
+        }
+        // When the first buffer usage is `index` and is accessible in the draw call, the second
+        // usage cannot be `indirect` (it should be `indexedIndirect` for the tests on indirect draw
+        // calls)
+        if (t.usage0 === 'index' && t.usage0AccessibleInDraw && t.usage1 === 'indirect') {
+          return false;
+        }
+        return true;
+      })
+      .combine('hasOverlap', [true, false])
+  )
+  .fn(async t => {
+    const {
+      usage0AccessibleInDraw,
+      usage1AccessibleInDraw,
+      drawBeforeUsage1,
+      usage0,
+      visibility0,
+      usage1,
+      visibility1,
+      hasOverlap,
+    } = t.params;
+    const buffer = t.createBufferWithState('valid', {
+      size: kBoundBufferSize * 2,
+      usage:
+        GPUBufferUsage.UNIFORM |
+        GPUBufferUsage.STORAGE |
+        GPUBufferUsage.VERTEX |
+        GPUBufferUsage.INDEX |
+        GPUBufferUsage.INDIRECT,
+    });
+
+    const UseBufferOnRenderPassEncoder = (
+      bufferAccessibleInDraw: boolean,
+      bufferIndex: number,
+      offset: number,
+      usage: BufferUsage,
+      bindGroupVisibility: 'compute' | 'fragment',
+      renderPassEncoder: GPURenderPassEncoder,
+      usedBindGroupLayouts: GPUBindGroupLayout[]
+    ) => {
+      switch (usage) {
+        case 'uniform':
+        case 'storage':
+        case 'read-only-storage': {
+          const bindGroup = t.createBindGroupForTest(buffer, offset, usage, bindGroupVisibility);
+          renderPassEncoder.setBindGroup(bufferIndex, bindGroup);
+          if (bufferAccessibleInDraw && bindGroupVisibility === 'fragment') {
+            usedBindGroupLayouts.push(t.createBindGroupLayoutForTest(usage, bindGroupVisibility));
+          }
+          break;
+        }
+        case 'vertex': {
+          renderPassEncoder.setVertexBuffer(bufferIndex, buffer, offset);
+          break;
+        }
+        case 'index': {
+          renderPassEncoder.setIndexBuffer(buffer, 'uint16', offset);
+          break;
+        }
+        case 'indirect':
+        case 'indexedIndirect': {
+          break;
+        }
+      }
+    };
+
+    const MakeDrawCallWithOneUsage = (
+      usage: BufferUsage,
+      offset: number,
+      renderPassEncoder: GPURenderPassEncoder
+    ) => {
+      switch (usage) {
+        case 'uniform':
+        case 'read-only-storage':
+        case 'storage':
+        case 'vertex':
+          renderPassEncoder.draw(1);
+          break;
+        case 'index':
+          renderPassEncoder.drawIndexed(1);
+          break;
+        case 'indirect':
+          renderPassEncoder.drawIndirect(buffer, offset);
+          break;
+        case 'indexedIndirect': {
+          const indexBuffer = t.device.createBuffer({
+            size: 4,
+            usage: GPUBufferUsage.INDEX,
+          });
+          renderPassEncoder.setIndexBuffer(indexBuffer, 'uint16');
+          renderPassEncoder.drawIndexedIndirect(buffer, offset);
+          break;
+        }
+      }
+    };
+
+    const encoder = t.device.createCommandEncoder();
+    const renderPassEncoder = t.beginSimpleRenderPass(encoder);
+
+    // Set buffer with usage0
+    const offset0 = 0;
+    // Invisible bind groups or vertex buffers are all bound to the slot 1.
+    const bufferIndex0 = visibility0 === 'fragment' ? 0 : 1;
+    let vertexBufferCount = 0;
+    const usedBindGroupLayouts: GPUBindGroupLayout[] = [];
+
+    UseBufferOnRenderPassEncoder(
+      usage0AccessibleInDraw,
+      bufferIndex0,
+      offset0,
+      usage0,
+      visibility0,
+      renderPassEncoder,
+      usedBindGroupLayouts
+    );
+
+    // Set pipeline and do draw call if drawBeforeUsage1 === true
+    if (drawBeforeUsage1) {
+      const pipelineLayout = t.device.createPipelineLayout({
+        bindGroupLayouts: usedBindGroupLayouts,
+      });
+      if (usage0 === 'vertex' && usage0AccessibleInDraw) {
+        ++vertexBufferCount;
+      }
+      const pipeline = t.createRenderPipelineForTest(pipelineLayout, vertexBufferCount);
+      renderPassEncoder.setPipeline(pipeline);
+      if (!usage0AccessibleInDraw) {
+        renderPassEncoder.draw(1);
+      } else {
+        MakeDrawCallWithOneUsage(usage0, offset0, renderPassEncoder);
+      }
+    }
+
+    // Set buffer with usage1.
+    const offset1 = hasOverlap ? offset0 : kBoundBufferSize;
+    let bufferIndex1 = 0;
+    if (visibility1 !== 'fragment') {
+      // Invisible bind groups or vertex buffers are all bound to the slot 1.
+      bufferIndex1 = 1;
+    } else if (visibility0 === 'fragment' && usage0AccessibleInDraw) {
+      // When buffer is bound to different bind groups or bound as vertex buffers in one render pass
+      // encoder, the second buffer binding should consume the slot 1.
+      if (IsBufferUsageInBindGroup(usage0) && IsBufferUsageInBindGroup(usage1)) {
+        bufferIndex1 = 1;
+      } else if (usage0 === 'vertex' && usage1 === 'vertex') {
+        bufferIndex1 = 1;
+      }
+    }
+
+    UseBufferOnRenderPassEncoder(
+      usage1AccessibleInDraw,
+      bufferIndex1,
+      offset1,
+      usage1,
+      visibility1,
+      renderPassEncoder,
+      usedBindGroupLayouts
+    );
+
+    // Set pipeline and do draw call if drawBeforeUsage1 === false
+    if (!drawBeforeUsage1) {
+      const pipelineLayout = t.device.createPipelineLayout({
+        bindGroupLayouts: usedBindGroupLayouts,
+      });
+      if (usage1 === 'vertex' && usage1AccessibleInDraw) {
+        ++vertexBufferCount;
+      }
+      const pipeline = t.createRenderPipelineForTest(pipelineLayout, vertexBufferCount);
+      renderPassEncoder.setPipeline(pipeline);
+
+      assert(usage0 !== 'indirect');
+      if (!usage0AccessibleInDraw && !usage1AccessibleInDraw) {
+        renderPassEncoder.draw(1);
+      } else if (usage0AccessibleInDraw && !usage1AccessibleInDraw) {
+        MakeDrawCallWithOneUsage(usage0, offset0, renderPassEncoder);
+      } else if (!usage0AccessibleInDraw && usage1AccessibleInDraw) {
+        MakeDrawCallWithOneUsage(usage1, offset1, renderPassEncoder);
+      } else {
+        if (usage1 === 'indexedIndirect') {
+          if (usage0 !== 'index') {
+            const indexBuffer = t.createBufferWithState('valid', {
+              size: 4,
+              usage: GPUBufferUsage.INDEX,
+            });
+            renderPassEncoder.setIndexBuffer(indexBuffer, 'uint16');
+          }
+          renderPassEncoder.drawIndexedIndirect(buffer, offset1);
+        } else if (usage1 === 'indirect') {
+          assert(usage0 !== 'index');
+          renderPassEncoder.drawIndirect(buffer, offset1);
+        } else if (usage0 === 'index' || usage1 === 'index') {
+          renderPassEncoder.drawIndexed(1);
+        } else {
+          renderPassEncoder.draw(1);
+        }
+      }
+    }
     renderPassEncoder.end();
 
     const fail = (usage0 === 'storage') !== (usage1 === 'storage');


### PR DESCRIPTION
This patch adds the 4th part of
api,validation,resource_usages,buffer,in_pass_encoder:*:
-subresources,buffer_usage_in_one_render_pass_with_one_draw




Issue: #905

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
