### PR TITLE
Update texture format tests to expect exceptions

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -8,6 +8,7 @@ TODO(#902): test GPUCanvasConfiguration.format (it doesn't allow any optional fo
 TODO(#920): test GPUTextureDescriptor.viewFormats (if/when it takes formats)
 `;
 
+import { assert } from '../../../../../common/util/util.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kAllTextureFormats, kTextureFormatInfo } from '../../../../capability_info.js';
 import { ValidationTest } from '../../validation_test.js';
@@ -23,8 +24,6 @@ g.test('texture_descriptor')
     `
   Test creating a texture with an optional texture format will fail if the required optional feature
   is not enabled.
-
-  TODO(#919): Actually it should throw an exception, not fail with a validation error.
   `
   )
   .params(u =>
@@ -42,13 +41,13 @@ g.test('texture_descriptor')
     const { format, enable_required_feature } = t.params;
 
     const formatInfo = kTextureFormatInfo[format];
-    t.expectValidationError(() => {
+    t.shouldThrow(enable_required_feature ? false : 'TypeError', () => {
       t.device.createTexture({
         format,
         size: [formatInfo.blockWidth, formatInfo.blockHeight, 1] as const,
         usage: GPUTextureUsage.TEXTURE_BINDING,
       });
-    }, !enable_required_feature);
+    });
   });
 
 g.test('storage_texture_binding_layout')

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -8,7 +8,6 @@ TODO(#902): test GPUCanvasConfiguration.format (it doesn't allow any optional fo
 TODO(#920): test GPUTextureDescriptor.viewFormats (if/when it takes formats)
 `;
 
-import { assert } from '../../../../../common/util/util.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kAllTextureFormats, kTextureFormatInfo } from '../../../../capability_info.js';
 import { ValidationTest } from '../../validation_test.js';

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -5,7 +5,6 @@ Start here when looking for examples of basic framework usage.
 `;
 
 import { makeTestGroup } from '../common/framework/test_group.js';
-import { assert } from '../common/util/util.js';
 
 import { GPUTest } from './gpu_test.js';
 

--- a/src/webgpu/examples.spec.ts
+++ b/src/webgpu/examples.spec.ts
@@ -5,6 +5,7 @@ Start here when looking for examples of basic framework usage.
 `;
 
 import { makeTestGroup } from '../common/framework/test_group.js';
+import { assert } from '../common/util/util.js';
 
 import { GPUTest } from './gpu_test.js';
 
@@ -238,17 +239,13 @@ Tests that a BC format passes validation iff the feature is enabled.`
   .fn(async t => {
     const { textureCompressionBC } = t.params;
     const shouldError = !textureCompressionBC;
-    t.expectGPUError(
-      'validation',
-      () => {
-        t.device.createTexture({
-          format: 'bc1-rgba-unorm',
-          size: [4, 4, 1],
-          usage: GPUTextureUsage.TEXTURE_BINDING,
-        });
-      },
-      shouldError
-    );
+    t.shouldThrow(shouldError ? 'TypeError' : false, () => {
+      t.device.createTexture({
+        format: 'bc1-rgba-unorm',
+        size: [4, 4, 1],
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+      });
+    });
   });
 
 g.test('gpu,with_texture_compression,etc2')
@@ -268,15 +265,11 @@ Tests that an ETC2 format passes validation iff the feature is enabled.`
     const { textureCompressionETC2 } = t.params;
 
     const shouldError = !textureCompressionETC2;
-    t.expectGPUError(
-      'validation',
-      () => {
-        t.device.createTexture({
-          format: 'etc2-rgb8unorm',
-          size: [4, 4, 1],
-          usage: GPUTextureUsage.TEXTURE_BINDING,
-        });
-      },
-      shouldError
-    );
+    t.shouldThrow(shouldError ? 'TypeError' : false, () => {
+      t.device.createTexture({
+        format: 'etc2-rgb8unorm',
+        size: [4, 4, 1],
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+      });
+    });
   });


### PR DESCRIPTION
https://github.com/gpuweb/gpuweb/pull/2887 updated the spec to specify that usage of texture formats without the appropriate feature enabled should throw a `TypeError` exception in order to normalize behavior with missing enums on browsers that don't implement the feature yet. This PR updates existing texture format tests to expect exceptions rather than validation errors in those cases.

Chrome implementation is incoming: https://chromium-review.googlesource.com/c/chromium/src/+/3674219

Some new tests should be added to verify the same behavior for other scenarios that require the same logic, such as view creation and context configuration. My preference is to add those in a follow up.

Issue: https://github.com/gpuweb/gpuweb/pull/2887

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
