### PR TITLE
Implement new F32Interval class for floating point tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -86,7 +86,7 @@ g.test('contains_number')
     { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.infinity.negative, expected: true },
     { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: Number.NaN, expected: true },
 
-    // Upper edge
+    // Maximum f32 boundary
     { bounds: [0, kValue.f32.positive.max], value: kValue.f32.positive.min, expected: true },
     { bounds: [0, kValue.f32.positive.max], value: kValue.f32.positive.max, expected: true },
     { bounds: [0, kValue.f32.positive.max], value: kValue.f32.infinity.positive, expected: true },
@@ -94,7 +94,7 @@ g.test('contains_number')
     { bounds: [0, kValue.f32.positive.max], value: kValue.f32.negative.max, expected: false },
     { bounds: [0, kValue.f32.positive.max], value: kValue.f32.infinity.negative, expected: false },
 
-    // Lower edge
+    // Minimum f32 boundary
     { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.positive.min, expected: false },
     { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.positive.max, expected: false },
     { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.infinity.positive, expected: false },
@@ -154,6 +154,7 @@ g.test('contains_interval')
       { lhs: [0, kValue.f32.infinity.positive], rhs: [0, 0], expected: true},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [-1, 0], expected: false},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [0, 1], expected: true},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [0, kValue.f32.positive.max], expected: true},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [0, kValue.f32.infinity.positive], expected: true},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [100, kValue.f32.infinity.positive], expected: true},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
@@ -161,12 +162,13 @@ g.test('contains_interval')
       // Lower infinity
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [0, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [-1, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.negative.min, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [0, 1], expected: false},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, -100 ], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
 
-      // Lower infinity
+      // Full infinity
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [-1, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, 1], expected: true},
@@ -175,6 +177,24 @@ g.test('contains_interval')
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, -100 ], expected: true},
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: true},
+
+      // Maximum f32 boundary
+      { lhs: [0, kValue.f32.positive.max], rhs: [0, 0], expected: true},
+      { lhs: [0, kValue.f32.positive.max], rhs: [-1, 0], expected: false},
+      { lhs: [0, kValue.f32.positive.max], rhs: [0, 1], expected: true},
+      { lhs: [0, kValue.f32.positive.max], rhs: [0, kValue.f32.positive.max], expected: true},
+      { lhs: [0, kValue.f32.positive.max], rhs: [0, kValue.f32.infinity.positive], expected: true},
+      { lhs: [0, kValue.f32.positive.max], rhs: [100, kValue.f32.infinity.positive], expected: true},
+      { lhs: [0, kValue.f32.positive.max], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
+
+      // Minimum f32 boundary
+      { lhs: [kValue.f32.negative.min, 0], rhs: [0, 0], expected: true},
+      { lhs: [kValue.f32.negative.min, 0], rhs: [-1, 0], expected: true},
+      { lhs: [kValue.f32.negative.min, 0], rhs: [kValue.f32.negative.min, 0], expected: true},
+      { lhs: [kValue.f32.negative.min, 0], rhs: [0, 1], expected: false},
+      { lhs: [kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, 0], expected: true},
+      { lhs: [kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, -100 ], expected: true},
+      { lhs: [kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
     ]
   )
   .fn(t => {
@@ -383,14 +403,14 @@ g.test('ulpInterval')
       { value: kValue.f32.positive.max, num_ulp: 1, expected: [kValue.f32.positive.nearest_max, Number.POSITIVE_INFINITY] },
       { value: kValue.f32.positive.max, num_ulp: 4096, expected: [hexToF32(0x7f7fefff), Number.POSITIVE_INFINITY] },
       { value: kValue.f32.positive.min, num_ulp: 0, expected: [ kValue.f32.positive.min,  kValue.f32.positive.min] },
-      { value: kValue.f32.positive.min, num_ulp: 1, expected: [0, hexToF32(0x01000000)] },
-      { value: kValue.f32.positive.min, num_ulp: 4096, expected: [hexToF32(0x867ff000), hexToF32(0x06800800)] },
+      { value: kValue.f32.positive.min, num_ulp: 1, expected: [0, hexToF32(0x00800001)] },
+      { value: kValue.f32.positive.min, num_ulp: 4096, expected: [0, hexToF32(0x00801000)] },
       { value: kValue.f32.negative.min, num_ulp: 0, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
       { value: kValue.f32.negative.min, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.nearest_min] },
       { value: kValue.f32.negative.min, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, hexToF32(0xff7fefff)] },
       { value: kValue.f32.negative.max, num_ulp: 0, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
-      { value: kValue.f32.negative.max, num_ulp: 1, expected: [hexToF32(0x81000000), 0] },
-      { value: kValue.f32.negative.max, num_ulp: 4096, expected: [hexToF32(0x86800800), hexToF32(0x067ff000)] },
+      { value: kValue.f32.negative.max, num_ulp: 1, expected: [hexToF32(0x80800001), 0] },
+      { value: kValue.f32.negative.max, num_ulp: 4096, expected: [hexToF32(0x80801000), 0] },
 
       // 32-bit subnormals
       { value: kValue.f32.subnormal.positive.max, num_ulp: 0, expected: [0, kValue.f32.subnormal.positive.max] },

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1,0 +1,439 @@
+export const description = `
+F32Interval unit tests.
+`;
+
+import { makeTestGroup } from '../common/framework/test_group.js';
+import { objectEquals } from '../common/util/util.js';
+import { kValue } from '../webgpu/util/constants.js';
+import {
+  absoluteErrorInterval,
+  correctlyRoundedInterval,
+  F32Interval,
+  ulpInterval,
+} from '../webgpu/util/f32_interval.js';
+import { hexToF32, hexToF64 } from '../webgpu/util/math.js';
+
+import { UnitTest } from './unit_test.js';
+
+export const g = makeTestGroup(UnitTest);
+
+/** Convert a pair of numbers in an array to a F32Interval
+ *
+ * Used for fluently specifying test params as `[a, b]` instead of
+ * `new F32Interval(a, b)`
+ */
+function arrayToInterval(bounds: [number, number]): F32Interval {
+  const [begin, end] = bounds;
+  return new F32Interval(begin, end);
+}
+
+interface ContainsNumberCase {
+  bounds: [number, number];
+  value: number;
+  expected: boolean;
+}
+
+g.test('contains_number')
+  .paramsSubcasesOnly<ContainsNumberCase>(
+    // prettier-ignore
+    [
+    // Common usage
+    { bounds: [0, 10], value: 0, expected: true },
+    { bounds: [0, 10], value: 10, expected: true },
+    { bounds: [0, 10], value: 5, expected: true },
+    { bounds: [0, 10], value: -5, expected: false },
+    { bounds: [0, 10], value: 50, expected: false },
+    { bounds: [0, 10], value: Number.NaN, expected: false },
+    { bounds: [-5, 10], value: 0, expected: true },
+    { bounds: [-5, 10], value: 10, expected: true },
+    { bounds: [-5, 10], value: 5, expected: true },
+    { bounds: [-5, 10], value: -5, expected: true },
+    { bounds: [-5, 10], value: -6, expected: false },
+    { bounds: [-5, 10], value: 50, expected: false },
+    { bounds: [-5, 10], value: -10, expected: false },
+
+    // Point
+    { bounds: [0, 0], value: 0, expected: true },
+    { bounds: [0, 0], value: 10, expected: false },
+    { bounds: [0, 0], value: -1000, expected: false },
+    { bounds: [10, 10], value: 10, expected: true },
+    { bounds: [10, 10], value: 0, expected: false },
+    { bounds: [10, 10], value: -10, expected: false },
+    { bounds: [10, 10], value: 11, expected: false },
+
+    // Upper infinity
+    { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.positive.min, expected: true },
+    { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.positive.max, expected: true },
+    { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.infinity.positive, expected: true },
+    { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.negative.min, expected: false },
+    { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.negative.max, expected: false },
+    { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.infinity.negative, expected: false },
+
+    // Lower infinity
+    { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.positive.min, expected: false },
+    { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.positive.max, expected: false },
+    { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.infinity.positive, expected: false },
+    { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.negative.min, expected: true },
+    { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.negative.max, expected: true },
+    { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.infinity.negative, expected: true },
+
+    // Full infinity
+    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.positive.min, expected: true },
+    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.positive.max, expected: true },
+    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.infinity.positive, expected: true },
+    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.negative.min, expected: true },
+    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.negative.max, expected: true },
+    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.infinity.negative, expected: true },
+    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: Number.NaN, expected: true },
+
+    // Upper edge
+    { bounds: [0, kValue.f32.positive.max], value: kValue.f32.positive.min, expected: true },
+    { bounds: [0, kValue.f32.positive.max], value: kValue.f32.positive.max, expected: true },
+    { bounds: [0, kValue.f32.positive.max], value: kValue.f32.infinity.positive, expected: true },
+    { bounds: [0, kValue.f32.positive.max], value: kValue.f32.negative.min, expected: false },
+    { bounds: [0, kValue.f32.positive.max], value: kValue.f32.negative.max, expected: false },
+    { bounds: [0, kValue.f32.positive.max], value: kValue.f32.infinity.negative, expected: false },
+
+    // Lower edge
+    { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.positive.min, expected: false },
+    { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.positive.max, expected: false },
+    { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.infinity.positive, expected: false },
+    { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.negative.min, expected: true },
+    { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.negative.max, expected: true },
+    { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.infinity.negative, expected: true },
+
+    // Subnormals
+    { bounds: [0, kValue.f32.positive.min], value: kValue.f32.subnormal.positive.min, expected: true },
+    { bounds: [0, kValue.f32.positive.min], value: kValue.f32.subnormal.positive.max, expected: true },
+    { bounds: [0, kValue.f32.positive.min], value: kValue.f32.subnormal.negative.min, expected: false },
+    { bounds: [0, kValue.f32.positive.min], value: kValue.f32.subnormal.negative.max, expected: false },
+    { bounds: [kValue.f32.negative.max, 0], value: kValue.f32.subnormal.positive.min, expected: false },
+    { bounds: [kValue.f32.negative.max, 0], value: kValue.f32.subnormal.positive.max, expected: false },
+    { bounds: [kValue.f32.negative.max, 0], value: kValue.f32.subnormal.negative.min, expected: true },
+    { bounds: [kValue.f32.negative.max, 0], value: kValue.f32.subnormal.negative.max, expected: true },
+    { bounds: [0, kValue.f32.subnormal.positive.min], value: kValue.f32.subnormal.positive.min, expected: true },
+    { bounds: [0, kValue.f32.subnormal.positive.min], value: kValue.f32.subnormal.positive.max, expected: false },
+    { bounds: [0, kValue.f32.subnormal.positive.min], value: kValue.f32.subnormal.negative.min, expected: false },
+    { bounds: [0, kValue.f32.subnormal.positive.min], value: kValue.f32.subnormal.negative.max, expected: false },
+    { bounds: [kValue.f32.subnormal.negative.max, 0], value: kValue.f32.subnormal.positive.min, expected: false },
+    { bounds: [kValue.f32.subnormal.negative.max, 0], value: kValue.f32.subnormal.positive.max, expected: false },
+    { bounds: [kValue.f32.subnormal.negative.max, 0], value: kValue.f32.subnormal.negative.min, expected: false },
+    { bounds: [kValue.f32.subnormal.negative.max, 0], value: kValue.f32.subnormal.negative.max, expected: true },
+    ]
+  )
+  .fn(t => {
+    const i = arrayToInterval(t.params.bounds);
+    const value = t.params.value;
+    const expected = t.params.expected;
+
+    const got = i.contains(value);
+    t.expect(expected === got, `${i}.contains(${value}) returned ${got}. Expected ${expected}`);
+  });
+
+interface ContainsIntervalCase {
+  lhs: [number, number];
+  rhs: [number, number];
+  expected: boolean;
+}
+
+g.test('contains_interval')
+  .paramsSubcasesOnly<ContainsIntervalCase>(
+    // prettier-ignore
+    [
+      // Common usage
+      { lhs: [-10, 10], rhs: [0, 0], expected: true},
+      { lhs: [-10, 10], rhs: [-1, 0], expected: true},
+      { lhs: [-10, 10], rhs: [0, 2], expected: true},
+      { lhs: [-10, 10], rhs: [-1, 2], expected: true},
+      { lhs: [-10, 10], rhs: [0, 10], expected: true},
+      { lhs: [-10, 10], rhs: [-10, 2], expected: true},
+      { lhs: [-10, 10], rhs: [-10, 10], expected: true},
+      { lhs: [-10, 10], rhs: [-100, 10], expected: false},
+
+      // Upper infinity
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [0, 0], expected: true},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [-1, 0], expected: false},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [0, 1], expected: true},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [0, kValue.f32.infinity.positive], expected: true},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [100, kValue.f32.infinity.positive], expected: true},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
+
+      // Lower infinity
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [0, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [-1, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [0, 1], expected: false},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, -100 ], expected: true},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
+
+      // Lower infinity
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [-1, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, 1], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, kValue.f32.infinity.positive], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [100, kValue.f32.infinity.positive], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, -100 ], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: true},
+    ]
+  )
+  .fn(t => {
+    const lhs = arrayToInterval(t.params.lhs);
+    const rhs = arrayToInterval(t.params.rhs);
+    const expected = t.params.expected;
+
+    const got = lhs.contains(rhs);
+    t.expect(expected === got, `${lhs}.contains(${rhs}) returned ${got}. Expected ${expected}`);
+  });
+
+interface SpanCase {
+  intervals: Array<[number, number]>;
+  expected: [number, number];
+}
+
+g.test('span')
+  .paramsSubcasesOnly<SpanCase>(
+    // prettier-ignore
+    [
+      // Single Intervals
+      { intervals: [[0, 10]], expected: [0, 10]},
+      { intervals: [[0, kValue.f32.positive.max]], expected: [0, kValue.f32.infinity.positive]},
+      { intervals: [[0, kValue.f32.positive.nearest_max]], expected: [0, kValue.f32.positive.nearest_max]},
+      { intervals: [[0, kValue.f32.infinity.positive]], expected: [0, kValue.f32.infinity.positive]},
+      { intervals: [[kValue.f32.negative.min, 0]], expected: [kValue.f32.negative.min, 0]},
+      { intervals: [[kValue.f32.negative.nearest_min, 0]], expected: [kValue.f32.negative.nearest_min, 0]},
+      { intervals: [[kValue.f32.infinity.negative, 0]], expected: [kValue.f32.infinity.negative, 0]},
+
+      // Double Intervals
+      { intervals: [[0, 1], [2, 5]], expected: [0, 5]},
+      { intervals: [[2, 5], [0, 1]], expected: [0, 5]},
+      { intervals: [[0, 2], [1, 5]], expected: [0, 5]},
+      { intervals: [[0, 5], [1, 2]], expected: [0, 5]},
+      { intervals: [[kValue.f32.infinity.negative, 0], [0, kValue.f32.infinity.positive]], expected: [kValue.f32.infinity.negative, kValue.f32.infinity.positive]},
+
+      // Multiple Intervals
+      { intervals: [[0, 1], [2, 3], [4, 5]], expected: [0, 5]},
+      { intervals: [[0, 1], [4, 5], [2, 3]], expected: [0, 5]},
+      { intervals: [[0, 1], [0, 1], [0, 1]], expected: [0, 1]},
+    ]
+  )
+  .fn(t => {
+    const intervals = t.params.intervals.map(arrayToInterval);
+    const expected = arrayToInterval(t.params.expected);
+
+    const got = F32Interval.span(...intervals);
+    t.expect(
+      objectEquals(got, expected),
+      `span({${intervals}}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+interface CorrectlyRoundedCase {
+  value: number;
+  expected: [number, number];
+}
+
+g.test('correctlyRoundedInterval')
+  .paramsSubcasesOnly<CorrectlyRoundedCase>(
+    // prettier-ignore
+    [
+      // Edge Cases
+      { value: kValue.f32.infinity.positive, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
+      { value: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+      { value: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
+      { value: kValue.f32.negative.max, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
+
+      // 32-bit subnormals
+      { value: kValue.f32.subnormal.positive.min, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: kValue.f32.subnormal.positive.max, expected: [0, kValue.f32.subnormal.positive.max] },
+      { value: kValue.f32.subnormal.negative.min, expected: [kValue.f32.subnormal.negative.min, 0] },
+      { value: kValue.f32.subnormal.negative.max, expected: [kValue.f32.subnormal.negative.max, 0] },
+
+      // 64-bit subnormals
+      { value: hexToF64(0x00000000, 0x00000001), expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x00000000, 0x00000002), expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x800fffff, 0xffffffff), expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800fffff, 0xfffffffe), expected: [kValue.f32.subnormal.negative.max, 0] },
+
+      // 32-bit normals
+      { value: 0, expected: [0, 0] },
+      { value: hexToF32(0x03800000), expected: [hexToF32(0x03800000), hexToF32(0x03800000)] },
+      { value: hexToF32(0x03800001), expected: [hexToF32(0x03800001), hexToF32(0x03800001)] },
+      { value: hexToF32(0x83800000), expected: [hexToF32(0x83800000), hexToF32(0x83800000)] },
+      { value: hexToF32(0x83800001), expected: [hexToF32(0x83800001), hexToF32(0x83800001)] },
+
+      // 64-bit normals
+      { value: hexToF64(0x3ff00000, 0x00000001), expected: [hexToF32(0x3f800000), hexToF32(0x3f800001)] },
+      { value: hexToF64(0x3ff00000, 0x00000002), expected: [hexToF32(0x3f800000), hexToF32(0x3f800001)] },
+      { value: hexToF64(0x3ff00010, 0x00000010), expected: [hexToF32(0x3f800080), hexToF32(0x3f800081)] },
+      { value: hexToF64(0x3ff00020, 0x00000020), expected: [hexToF32(0x3f800100), hexToF32(0x3f800101)] },
+      { value: hexToF64(0xbff00000, 0x00000001), expected: [hexToF32(0xbf800001), hexToF32(0xbf800000)] },
+      { value: hexToF64(0xbff00000, 0x00000002), expected: [hexToF32(0xbf800001), hexToF32(0xbf800000)] },
+      { value: hexToF64(0xbff00010, 0x00000010), expected: [hexToF32(0xbf800081), hexToF32(0xbf800080)] },
+      { value: hexToF64(0xbff00020, 0x00000020), expected: [hexToF32(0xbf800101), hexToF32(0xbf800100)] },
+    ]
+  )
+  .fn(t => {
+    const value = t.params.value;
+    const expected = arrayToInterval(t.params.expected);
+
+    const got = correctlyRoundedInterval(value);
+    t.expect(
+      objectEquals(expected, got),
+      `correctlyRoundedInterval(${value}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+interface AbsoluteErrorCase {
+  value: number;
+  error: number;
+  expected: [number, number];
+}
+
+g.test('absoluteErrorInterval')
+  .paramsSubcasesOnly<AbsoluteErrorCase>(
+    // prettier-ignore
+    [
+      // Edge Cases
+      { value: kValue.f32.infinity.positive, error: 0, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, error: 2 ** -11, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, error: 1, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, error: 0, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.infinity.negative, error: 1, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.positive.max, error: 0, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.max, error: 2 ** -11, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.max, error: 1, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.min, error: 0, expected: [kValue.f32.positive.min,  kValue.f32.positive.min] },
+      { value: kValue.f32.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.positive.min, error: 1, expected: [-1, 1] },
+      { value: kValue.f32.negative.min, error: 0, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.negative.min, error: 2 ** -11, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.negative.min, error: 1, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.negative.max, error: 0, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
+      { value: kValue.f32.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.negative.max, error: 1, expected: [-1, 1] },
+
+      // 32-bit subnormals
+      { value: kValue.f32.subnormal.positive.max, error: 0, expected: [0, kValue.f32.subnormal.positive.max] },
+      { value: kValue.f32.subnormal.positive.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.subnormal.positive.max, error: 1, expected: [-1, 1] },
+      { value: kValue.f32.subnormal.positive.min, error: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: kValue.f32.subnormal.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.subnormal.positive.min, error: 1, expected: [-1, 1] },
+      { value: kValue.f32.subnormal.negative.min, error: 0, expected: [kValue.f32.subnormal.negative.min, 0] },
+      { value: kValue.f32.subnormal.negative.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.subnormal.negative.min, error: 1, expected: [-1, 1] },
+      { value: kValue.f32.subnormal.negative.max, error: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: kValue.f32.subnormal.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.subnormal.negative.max, error: 1, expected: [-1, 1] },
+
+      // 64-bit subnormals
+      { value: hexToF64(0x00000000, 0x00000001), error: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x00000000, 0x00000001), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: hexToF64(0x00000000, 0x00000001), error: 1, expected: [-1, 1] },
+      { value: hexToF64(0x00000000, 0x00000002), error: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x00000000, 0x00000002), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: hexToF64(0x00000000, 0x00000002), error: 1, expected: [-1, 1] },
+      { value: hexToF64(0x800fffff, 0xffffffff), error: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800fffff, 0xffffffff), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: hexToF64(0x800fffff, 0xffffffff), error: 1, expected: [-1, 1] },
+      { value: hexToF64(0x800fffff, 0xfffffffe), error: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800fffff, 0xfffffffe), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: hexToF64(0x800fffff, 0xfffffffe), error: 1, expected: [-1, 1] },
+
+      // Zero
+      { value: 0, error: 0, expected: [0, 0] },
+      { value: 0, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: 0, error: 1, expected: [-1, 1] },
+    ]
+  )
+  .fn(t => {
+    const value = t.params.value;
+    const error = t.params.error;
+    const expected = arrayToInterval(t.params.expected);
+
+    const got = absoluteErrorInterval(value, error);
+    t.expect(
+      objectEquals(expected, got),
+      `absoluteErrorInterval(${value}, ${error}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+interface ULPCase {
+  value: number;
+  num_ulp: number;
+  expected: [number, number];
+}
+
+g.test('ulpInterval')
+  .paramsSubcasesOnly<ULPCase>(
+    // prettier-ignore
+    [
+      // Edge Cases
+      { value: kValue.f32.infinity.positive, num_ulp: 0, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, num_ulp: 1, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, num_ulp: 4096, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, num_ulp: 0, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.infinity.negative, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.infinity.negative, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.positive.max, num_ulp: 0, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.max, num_ulp: 1, expected: [kValue.f32.positive.nearest_max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.max, num_ulp: 4096, expected: [hexToF32(0x7f7fefff), Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.min, num_ulp: 0, expected: [ kValue.f32.positive.min,  kValue.f32.positive.min] },
+      { value: kValue.f32.positive.min, num_ulp: 1, expected: [0, hexToF32(0x01000000)] },
+      { value: kValue.f32.positive.min, num_ulp: 4096, expected: [hexToF32(0x867ff000), hexToF32(0x06800800)] },
+      { value: kValue.f32.negative.min, num_ulp: 0, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+      { value: kValue.f32.negative.min, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.nearest_min] },
+      { value: kValue.f32.negative.min, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, hexToF32(0xff7fefff)] },
+      { value: kValue.f32.negative.max, num_ulp: 0, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
+      { value: kValue.f32.negative.max, num_ulp: 1, expected: [hexToF32(0x81000000), 0] },
+      { value: kValue.f32.negative.max, num_ulp: 4096, expected: [hexToF32(0x86800800), hexToF32(0x067ff000)] },
+
+      // 32-bit subnormals
+      { value: kValue.f32.subnormal.positive.max, num_ulp: 0, expected: [0, kValue.f32.subnormal.positive.max] },
+      { value: kValue.f32.subnormal.positive.max, num_ulp: 1, expected: [kValue.f32.negative.max, hexToF32(0x00ffffff)] },
+      { value: kValue.f32.subnormal.positive.max, num_ulp: 4096, expected: [hexToF32(0x86800000), hexToF64(0x38d000ff, 0xfffe0000)] },
+      { value: kValue.f32.subnormal.positive.min, num_ulp: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: kValue.f32.subnormal.positive.min, num_ulp: 1, expected: [kValue.f32.negative.max, hexToF32(0x00800001)] },
+      { value: kValue.f32.subnormal.positive.min, num_ulp: 4096, expected: [hexToF32(0x86800000), hexToF64(0x38d00000, 0x00020000)] },
+      { value: kValue.f32.subnormal.negative.min, num_ulp: 0, expected: [kValue.f32.subnormal.negative.min, 0] },
+      { value: kValue.f32.subnormal.negative.min, num_ulp: 1, expected: [hexToF32(0x80ffffff), kValue.f32.positive.min] },
+      { value: kValue.f32.subnormal.negative.min, num_ulp: 4096, expected: [hexToF64(0xb8d000ff, 0xfffe0000), hexToF32(0x06800000)] },
+      { value: kValue.f32.subnormal.negative.max, num_ulp: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: kValue.f32.subnormal.negative.max, num_ulp: 1, expected: [hexToF32(0x80800001), kValue.f32.positive.min] },
+      { value: kValue.f32.subnormal.negative.max, num_ulp: 4096, expected: [hexToF64(0xb8d00000, 0x00020000), hexToF32(0x06800000)] },
+
+      // 64-bit subnormals
+      { value: hexToF64(0x00000000, 0x00000001), num_ulp: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x00000000, 0x00000001), num_ulp: 1, expected: [kValue.f32.negative.max, hexToF32(0x00800001)] },
+      { value: hexToF64(0x00000000, 0x00000001), num_ulp: 4096, expected: [hexToF32(0x86800000), hexToF64(0x38d00000, 0x00020000)] },
+      { value: hexToF64(0x00000000, 0x00000002), num_ulp: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x00000000, 0x00000002), num_ulp: 1, expected: [kValue.f32.negative.max, hexToF32(0x00800001)] },
+      { value: hexToF64(0x00000000, 0x00000002), num_ulp: 4096, expected: [hexToF32(0x86800000), hexToF64(0x38d00000, 0x00020000)] },
+      { value: hexToF64(0x800fffff, 0xffffffff), num_ulp: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800fffff, 0xffffffff), num_ulp: 1, expected: [hexToF32(0x80800001), kValue.f32.positive.min] },
+      { value: hexToF64(0x800fffff, 0xffffffff), num_ulp: 4096, expected: [hexToF64(0xb8d00000, 0x00020000), hexToF32(0x06800000)] },
+      { value: hexToF64(0x800fffff, 0xfffffffe), num_ulp: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800fffff, 0xfffffffe), num_ulp: 1, expected: [hexToF32(0x80800001), kValue.f32.positive.min] },
+      { value: hexToF64(0x800fffff, 0xfffffffe), num_ulp: 4096, expected: [hexToF64(0xb8d00000, 0x00020000), hexToF32(0x06800000)] },
+
+      // Zero
+      { value: 0, num_ulp: 0, expected: [0, 0] },
+      { value: 0, num_ulp: 1, expected: [kValue.f32.negative.max, kValue.f32.positive.min] },
+      { value: 0, num_ulp: 4096, expected: [hexToF32(0x86800000), hexToF32(0x06800000)] },
+    ]
+  )
+  .fn(t => {
+    const value = t.params.value;
+    const num_ulp = t.params.num_ulp;
+    const expected = arrayToInterval(t.params.expected);
+
+    const got = ulpInterval(value, num_ulp);
+    t.expect(
+      objectEquals(expected, got),
+      `ulpInterval(${value}, ${num_ulp}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -201,8 +201,8 @@ g.test('oneULPFlushToZero')
 
     // Normals
     { target: hexToF32(kBit.f32.positive.max), expect: hexToF32(0x73800000) },
-    { target: hexToF32(kBit.f32.positive.min), expect: hexToF32(0x00800000) },
-    { target: hexToF32(kBit.f32.negative.max), expect: hexToF32(0x00800000) },
+    { target: hexToF32(kBit.f32.positive.min), expect: hexToF32(0x00000001) },
+    { target: hexToF32(kBit.f32.negative.max), expect: hexToF32(0x00000001) },
     { target: hexToF32(kBit.f32.negative.min), expect: hexToF32(0x73800000) },
     { target: 1, expect: hexToF32(0x33800000) },
     { target: 2, expect: hexToF32(0x34000000) },

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -3,12 +3,16 @@ Util math unit tests.
 `;
 
 import { makeTestGroup } from '../common/framework/test_group.js';
+import { objectEquals } from '../common/util/util.js';
 import { kBit, kValue } from '../webgpu/util/constants.js';
 import { f32, f32Bits, float32ToUint32, Scalar } from '../webgpu/util/conversion.js';
 import {
   biasedRange,
   correctlyRounded,
+  correctlyRoundedF32,
   fullF32Range,
+  hexToF32,
+  hexToF64,
   lerp,
   linearRange,
   nextAfter,
@@ -19,20 +23,6 @@ import {
 import { UnitTest } from './unit_test.js';
 
 export const g = makeTestGroup(UnitTest);
-
-/** Converts a 32-bit hex values to a 32-bit float value */
-function hexToF32(hex: number): number {
-  return new Float32Array(new Uint32Array([hex]).buffer)[0];
-}
-
-/** Converts two 32-bit hex values to a 64-bit float value */
-function hexToFloat64(h32: number, l32: number): number {
-  const u32Arr = new Uint32Array(2);
-  u32Arr[0] = l32;
-  u32Arr[1] = h32;
-  const f64Arr = new Float64Array(u32Arr.buffer);
-  return f64Arr[0];
-}
 
 /**
  * @returns true if arrays are equal within 1ULP, doing element-wise comparison as needed, and considering NaNs to be equal.
@@ -433,21 +423,21 @@ g.test('correctlyRounded')
     { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: kValue.f32.subnormal.negative.min, is_correct: true },
 
     // 64-bit subnormals
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToF64(0x00000000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x00000000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x00000000, 0x00000001), is_correct: true },
 
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToF64(0x00000000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x00000000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x00000000, 0x00000002), is_correct: true },
 
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToF64(0x800fffff, 0xffffffff), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x800fffff, 0xffffffff), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x800fffff, 0xffffffff), is_correct: true },
 
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToF64(0x800fffff, 0xfffffffe), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x800fffff, 0xfffffffe), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x800fffff, 0xfffffffe), is_correct: true },
 
     // 32-bit normals
     { test_val: f32Bits(kBit.f32.positive.max), target: hexToF32(kBit.f32.positive.max), is_correct: true },
@@ -464,22 +454,22 @@ g.test('correctlyRounded')
     { test_val: f32Bits(0x83800001), target: hexToF32(0x83800010), is_correct: false },
 
     // 64-bit normals
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00010, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00020, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00030, 0x00000002), is_correct: false },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00040, 0x00000002), is_correct: false },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00050, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00060, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00070, 0x00000002), is_correct: false },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00080, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00010, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00020, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00030, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00040, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00050, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00060, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00070, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00080, 0x00000002), is_correct: false },
   ]
   )
   .fn(t => {
@@ -574,21 +564,21 @@ g.test('correctlyRoundedNoFlushOnly')
     { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: kValue.f32.subnormal.negative.min, is_correct: true },
 
     // 64-bit subnormals
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToF64(0x00000000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x00000000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x00000000, 0x00000001), is_correct: true },
 
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToF64(0x00000000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x00000000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x00000000, 0x00000002), is_correct: true },
 
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToF64(0x800fffff, 0xffffffff), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x800fffff, 0xffffffff), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x800fffff, 0xffffffff), is_correct: true },
 
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToF64(0x800fffff, 0xfffffffe), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x800fffff, 0xfffffffe), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x800fffff, 0xfffffffe), is_correct: true },
 
     // 32-bit normals
     { test_val: f32Bits(kBit.f32.positive.max), target: hexToF32(kBit.f32.positive.max), is_correct: true },
@@ -605,22 +595,22 @@ g.test('correctlyRoundedNoFlushOnly')
     { test_val: f32Bits(0x83800001), target: hexToF32(0x83800010), is_correct: false },
 
     // 64-bit normals
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00010, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00020, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00030, 0x00000002), is_correct: false },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00040, 0x00000002), is_correct: false },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00050, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00060, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00070, 0x00000002), is_correct: false },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00080, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00010, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00020, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00030, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00040, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00050, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00060, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00070, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00080, 0x00000002), is_correct: false },
   ]
   )
   .fn(t => {
@@ -715,21 +705,21 @@ g.test('correctlyRoundedFlushToZeroOnly')
     { test_val: f32Bits(kBit.f32.subnormal.negative.min), target: kValue.f32.subnormal.negative.min, is_correct: true },
 
     // 64-bit subnormals
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToF64(0x00000000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x00000000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x00000000, 0x00000001), is_correct: true },
 
-    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x00000000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.positive.min), target: hexToF64(0x00000000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x00000000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x00000000, 0x00000002), is_correct: true },
 
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xffffffff), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToF64(0x800fffff, 0xffffffff), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x800fffff, 0xffffffff), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x800fffff, 0xffffffff), is_correct: true },
 
-    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
-    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
-    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToFloat64(0x800fffff, 0xfffffffe), is_correct: true },
+    { test_val: f32Bits(kBit.f32.subnormal.negative.max), target: hexToF64(0x800fffff, 0xfffffffe), is_correct: true },
+    { test_val: f32Bits(kBit.f32.positive.zero), target: hexToF64(0x800fffff, 0xfffffffe), is_correct: true },
+    { test_val: f32Bits(kBit.f32.negative.zero), target: hexToF64(0x800fffff, 0xfffffffe), is_correct: true },
 
     // 32-bit normals
     { test_val: f32Bits(kBit.f32.positive.max), target: hexToF32(kBit.f32.positive.max), is_correct: true },
@@ -746,22 +736,22 @@ g.test('correctlyRoundedFlushToZeroOnly')
     { test_val: f32Bits(0x83800001), target: hexToF32(0x83800010), is_correct: false },
 
     // 64-bit normals
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00010, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00020, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0x3f800000), target: hexToFloat64(0x3ff00030, 0x00000002), is_correct: false },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0x3f800001), target: hexToFloat64(0x3ff00040, 0x00000002), is_correct: false },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00050, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000001), is_correct: true },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00060, 0x00000001), is_correct: false },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0xbf800000), target: hexToFloat64(0xbff00070, 0x00000002), is_correct: false },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00000, 0x00000002), is_correct: true },
-    { test_val: f32Bits(0xbf800001), target: hexToFloat64(0xbff00080, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00010, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00020, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0x3f800000), target: hexToF64(0x3ff00030, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0x3f800001), target: hexToF64(0x3ff00040, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00050, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00000, 0x00000001), is_correct: true },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00060, 0x00000001), is_correct: false },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0xbf800000), target: hexToF64(0xbff00070, 0x00000002), is_correct: false },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00000, 0x00000002), is_correct: true },
+    { test_val: f32Bits(0xbf800001), target: hexToF64(0xbff00080, 0x00000002), is_correct: false },
   ]
   )
   .fn(t => {
@@ -773,6 +763,64 @@ g.test('correctlyRoundedFlushToZeroOnly')
     t.expect(
       got === is_correct,
       `correctlyRounded(${test_val}, ${target}) returned ${got}. Expected ${is_correct}`
+    );
+  });
+
+interface correctlyRoundedF32Case {
+  value: number;
+  expected: Array<number>;
+}
+
+g.test('correctlyRoundedF32')
+  .paramsSubcasesOnly<correctlyRoundedF32Case>(
+    // prettier-ignore
+    [
+      // Edge Cases
+      { value: kValue.f32.infinity.positive, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.positive.max, expected: [kValue.f32.positive.max] },
+      { value: kValue.f32.negative.min, expected: [kValue.f32.negative.min] },
+
+      // 32-bit subnormals
+      { value: kValue.f32.subnormal.positive.min, expected: [kValue.f32.subnormal.positive.min] },
+      { value: kValue.f32.subnormal.positive.max, expected: [kValue.f32.subnormal.positive.max] },
+      { value: kValue.f32.subnormal.negative.min, expected: [kValue.f32.subnormal.negative.min] },
+      { value: kValue.f32.subnormal.negative.max, expected: [kValue.f32.subnormal.negative.max] },
+
+      // 64-bit subnormals
+      { value: hexToF64(0x00000000, 0x00000001), expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x00000000, 0x00000002), expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x800fffff, 0xffffffff), expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800fffff, 0xfffffffe), expected: [kValue.f32.subnormal.negative.max, 0] },
+
+      // 32-bit normals
+      { value: 0, expected: [0] },
+      { value: kValue.f32.positive.min, expected: [kValue.f32.positive.min] },
+      { value: kValue.f32.negative.max, expected: [kValue.f32.negative.max] },
+      { value: hexToF32(0x03800000), expected: [hexToF32(0x03800000)] },
+      { value: hexToF32(0x03800001), expected: [hexToF32(0x03800001)] },
+      { value: hexToF32(0x83800000), expected: [hexToF32(0x83800000)] },
+      { value: hexToF32(0x83800001), expected: [hexToF32(0x83800001)] },
+
+      // 64-bit normals
+      { value: hexToF64(0x3ff00000, 0x00000001), expected: [hexToF32(0x3f800000), hexToF32(0x3f800001)] },
+      { value: hexToF64(0x3ff00000, 0x00000002), expected: [hexToF32(0x3f800000), hexToF32(0x3f800001)] },
+      { value: hexToF64(0x3ff00010, 0x00000010), expected: [hexToF32(0x3f800080), hexToF32(0x3f800081)] },
+      { value: hexToF64(0x3ff00020, 0x00000020), expected: [hexToF32(0x3f800100), hexToF32(0x3f800101)] },
+      { value: hexToF64(0xbff00000, 0x00000001), expected: [hexToF32(0xbf800001), hexToF32(0xbf800000)] },
+      { value: hexToF64(0xbff00000, 0x00000002), expected: [hexToF32(0xbf800001), hexToF32(0xbf800000)] },
+      { value: hexToF64(0xbff00010, 0x00000010), expected: [hexToF32(0xbf800081), hexToF32(0xbf800080)] },
+      { value: hexToF64(0xbff00020, 0x00000020), expected: [hexToF32(0xbf800101), hexToF32(0xbf800100)] },
+    ]
+  )
+  .fn(t => {
+    const value = t.params.value;
+    const expected = t.params.expected;
+
+    const got = correctlyRoundedF32(value);
+    t.expect(
+      objectEquals(expected, got),
+      `correctlyRoundedF32(${value}) returned [${got}]. Expected [${expected}]`
     );
   });
 
@@ -1100,6 +1148,8 @@ g.test('f32LimitsEquivalency')
     { bits: kBit.f32.subnormal.positive.min, value: kValue.f32.subnormal.positive.min },
     { bits: kBit.f32.subnormal.negative.max, value: kValue.f32.subnormal.negative.max },
     { bits: kBit.f32.subnormal.negative.min, value: kValue.f32.subnormal.negative.min },
+    { bits: kBit.f32.infinity.positive, value: kValue.f32.infinity.positive },
+    { bits: kBit.f32.infinity.negative, value: kValue.f32.infinity.negative },
   ])
   .fn(test => {
     const bits = test.params.bits;

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -67,8 +67,6 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       { input: f32Bits(kBit.f32.negative.zero), expected: f32(0) },
       { input: f32Bits(kBit.f32.positive.min), expected: f32Bits(kBit.f32.positive.min) },
       { input: f32Bits(kBit.f32.negative.max), expected: f32Bits(kBit.f32.negative.max) },
-      { input: f32Bits(kBit.f32.positive.min), expected: f32Bits(kBit.f32.negative.max) },
-      { input: f32Bits(kBit.f32.negative.max), expected: f32Bits(kBit.f32.positive.min) },
       { input: f32Bits(kBit.f32.positive.zero), expected: f32Bits(kBit.f32.positive.zero) },
       { input: f32Bits(kBit.f32.negative.zero), expected: f32Bits(kBit.f32.negative.zero) },
       { input: f32Bits(kBit.f32.positive.zero), expected: f32Bits(kBit.f32.negative.zero) },

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -454,12 +454,13 @@ export function makeBinaryF32Case(
 
 /**
  * Generates a Case for the param and unary interval generator provided.
- * The Case will use use an IntervalComparator for matching results.
+ * The Case will use use an interval comparator for matching results.
  * @param param the param to pass into the unary operation
  * @param op callback that implements generating an acceptance interval for a unary operation
  */
+// Will be used in test implementations
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function makeUnaryF32IntervalCase(param: number, op: PointToInterval) {
+export function makeUnaryF32IntervalCase(param: number, op: PointToInterval): Case {
   param = quantizeToF32(param);
   const interval = op(param);
   return { input: [f32(param)], expected: intervalComparator(interval) };
@@ -467,13 +468,18 @@ export function makeUnaryF32IntervalCase(param: number, op: PointToInterval) {
 
 /**
  * Generates a Case for the params and binary interval generator provided.
- * The Case will use use an IntervalComparator for matching results.
+ * The Case will use use an interval comparator for matching results.
  * @param param0 the first param or left hand side to pass into the binary operation
  * @param param1 the second param or rhs hand side to pass into the binary operation
  * @param op callback that implements generating an acceptance interval for a binary operation
  */
+// Will be used in test implementations
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function makeBinaryF32IntervalCase(param0: number, param1: number, op: BinaryToInterval) {
+export function makeBinaryF32IntervalCase(
+  param0: number,
+  param1: number,
+  op: BinaryToInterval
+): Case {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
   const interval = op(param0, param1);
@@ -482,19 +488,20 @@ export function makeBinaryF32IntervalCase(param0: number, param1: number, op: Bi
 
 /**
  * Generates a Case for the params and ternary interval generator provided.
- * The Case will use use an IntervalComparator for matching results.
+ * The Case will use use an interval comparator for matching results.
  * @param param0 the first param to pass into the ternary operation
  * @param param1 the second param to pass into the ternary operation
  * @param param2 the third param to pass into the ternary operation
  * @param op callback that implements generating an acceptance interval for a ternary operation
  */
+// Will be used in test implementations
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function makeTernaryF32IntervalCase(
   param0: number,
   param1: number,
   param2: number,
   op: TernaryToInterval
-) {
+): Case {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
   param2 = quantizeToF32(param2);

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -1,5 +1,11 @@
 import { GPUTest } from '../../../gpu_test.js';
-import { compare, Comparator, FloatMatch, anyOf } from '../../../util/compare.js';
+import {
+  compare,
+  Comparator,
+  FloatMatch,
+  anyOf,
+  intervalComparator,
+} from '../../../util/compare.js';
 import {
   ScalarType,
   Scalar,
@@ -12,6 +18,11 @@ import {
   f32,
   f64,
 } from '../../../util/conversion.js';
+import {
+  BinaryToInterval,
+  PointToInterval,
+  TernaryToInterval,
+} from '../../../util/f32_interval.js';
 import { flushSubnormalNumber, isSubnormalNumber, quantizeToF32 } from '../../../util/math.js';
 
 // Helper for converting Values to Comparators.
@@ -439,4 +450,54 @@ export function makeBinaryF32Case(
   }
 
   return { input: [f32(param0), f32(param1)], expected: anyOf(...expected) };
+}
+
+/**
+ * Generates a Case for the param and unary interval generator provided.
+ * The Case will use use an IntervalComparator for matching results.
+ * @param param the param to pass into the unary operation
+ * @param op callback that implements generating an acceptance interval for a unary operation
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function makeUnaryF32IntervalCase(param: number, op: PointToInterval) {
+  param = quantizeToF32(param);
+  const interval = op(param);
+  return { input: [f32(param)], expected: intervalComparator(interval) };
+}
+
+/**
+ * Generates a Case for the params and binary interval generator provided.
+ * The Case will use use an IntervalComparator for matching results.
+ * @param param0 the first param or left hand side to pass into the binary operation
+ * @param param1 the second param or rhs hand side to pass into the binary operation
+ * @param op callback that implements generating an acceptance interval for a binary operation
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function makeBinaryF32IntervalCase(param0: number, param1: number, op: BinaryToInterval) {
+  param0 = quantizeToF32(param0);
+  param1 = quantizeToF32(param1);
+  const interval = op(param0, param1);
+  return { input: [f32(param0), f32(param1)], expected: intervalComparator(interval) };
+}
+
+/**
+ * Generates a Case for the params and ternary interval generator provided.
+ * The Case will use use an IntervalComparator for matching results.
+ * @param param0 the first param to pass into the ternary operation
+ * @param param1 the second param to pass into the ternary operation
+ * @param param2 the third param to pass into the ternary operation
+ * @param op callback that implements generating an acceptance interval for a ternary operation
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function makeTernaryF32IntervalCase(
+  param0: number,
+  param1: number,
+  param2: number,
+  op: TernaryToInterval
+) {
+  param0 = quantizeToF32(param0);
+  param1 = quantizeToF32(param1);
+  param2 = quantizeToF32(param2);
+  const interval = op(param0, param1, param2);
+  return { input: [f32(param0), f32(param1), f32(param2)], expected: intervalComparator(interval) };
 }

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -1,6 +1,7 @@
 import { Colors } from '../../common/util/colors.js';
 
 import { f32, isFloatValue, Scalar, Value, Vector } from './conversion.js';
+import { F32Interval } from './f32_interval.js';
 import { correctlyRounded, oneULP, withinULP } from './math.js';
 
 /** Comparison describes the result of a Comparator function. */
@@ -57,6 +58,21 @@ export function ulpMatch(ulp: number): FloatMatch {
 export function correctlyRoundedMatch(): FloatMatch {
   return (got, expected) => {
     return correctlyRounded(f32(got), expected);
+  };
+}
+
+/**
+ * @returns a FloatMatch that return true iff |got| is contained in the interval |i|.
+ *
+ * The standard |expected| parameter is ignored.
+ *
+ * NB: This will be removed at the end of transition to the new FP testing framework.
+ *
+ * @param i interval to test the |got| value against.
+ */
+export function intervalMatch(i: F32Interval): FloatMatch {
+  return (got, _) => {
+    return i.contains(got);
   };
 }
 
@@ -171,6 +187,26 @@ export function ulpComparator(x: number, target: Scalar, n: (x: number) => numbe
       matched: false,
       got: got.toString(),
       expected: `within ${c} * ULP (${ulp}) of ${target}`,
+    };
+  };
+}
+
+/** @returns a Comparator that checks whether a result is contained within a target interval
+ *
+ * NB: This will be removed at the end of transition to the new FP testing framework.
+ */
+export function intervalComparator(i: F32Interval): Comparator {
+  const match = intervalMatch(i);
+  return (got, _) => {
+    // The second param is ignored by match
+    const cmp = compare(got, f32(0.0), match);
+    if (cmp.matched) {
+      return cmp;
+    }
+    return {
+      matched: false,
+      got: got.toString(),
+      expected: `within ${i}`,
     };
   };
 }

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -254,6 +254,10 @@ export const kValue = {
         min: hexToF32(kBit.f32.subnormal.negative.min),
       },
     },
+    infinity: {
+      positive: hexToF32(kBit.f32.infinity.positive),
+      negative: hexToF32(kBit.f32.infinity.negative),
+    },
   },
 
   powTwo: {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1,0 +1,394 @@
+import { assert } from '../../common/util/util.js';
+
+import { kValue } from './constants.js';
+import { correctlyRoundedF32, flushSubnormalNumber, isF32Finite, oneULP } from './math.js';
+
+/** Represents a closed interval in the f32 range */
+export class F32Interval {
+  public readonly begin: number;
+  public readonly end: number;
+  private static _infinite: F32Interval;
+
+  /** Constructor
+   *
+   * Bounds that are out of range for F32 are converted to appropriate edge or
+   * infinity values, so that all values above/below the f32 range are lumped
+   * together.
+   *
+   * The edge values map out to the infinities due to:
+   *   If an allowable return value for any operation is greater in magnitude
+   *   than the largest representable finite floating-point value, then that
+   *   operation may additionally return either the infinity with the same sign
+   *   or the largest finite value with the same sign.
+   *
+   * @param begin number indicating the lower bound of the interval
+   * @param end number indicating the upper bound of the interval
+   */
+  public constructor(begin: number, end: number) {
+    assert(!Number.isNaN(begin) && !Number.isNaN(end), `bounds need to be non-NaN`);
+    assert(begin <= end, `begin (${begin}) must be equal or before end (${end})`);
+
+    if (begin === Number.NEGATIVE_INFINITY || begin <= kValue.f32.negative.min) {
+      this.begin = Number.NEGATIVE_INFINITY;
+    } else if (begin === Number.POSITIVE_INFINITY || begin >= kValue.f32.positive.max) {
+      this.begin = kValue.f32.positive.max;
+    } else {
+      this.begin = begin;
+    }
+
+    if (end === Number.POSITIVE_INFINITY || end >= kValue.f32.positive.max) {
+      this.end = Number.POSITIVE_INFINITY;
+    } else if (end === Number.NEGATIVE_INFINITY || end <= kValue.f32.negative.min) {
+      this.end = kValue.f32.negative.min;
+    } else {
+      this.end = end;
+    }
+  }
+
+  /** @returns if a point or interval is completely contained by this interval */
+  public contains(n: number | F32Interval): boolean {
+    if (Number.isNaN(n)) {
+      // Being the infinite interval indicates that the accuracy is not defined
+      // for this test, so the test is just checking that this input doesn't
+      // cause the implementation to misbehave, so NaN is acceptable.
+      return this.begin === Number.NEGATIVE_INFINITY && this.end === Number.POSITIVE_INFINITY;
+    }
+    const i = toInterval(n);
+    return this.begin <= i.begin && this.end >= i.end;
+  }
+
+  /** @returns if this interval contains a single point */
+  public isPoint(): boolean {
+    return this.begin === this.end;
+  }
+
+  /** @returns an interval with the tightest bounds that includes all provided intervals */
+  static span(...intervals: F32Interval[]): F32Interval {
+    assert(intervals.length > 0, `span of an empty list of F32Intervals is not allowed`);
+    let begin = Number.POSITIVE_INFINITY;
+    let end = Number.NEGATIVE_INFINITY;
+    intervals.forEach(i => {
+      begin = Math.min(i.begin, begin);
+      end = Math.max(i.end, end);
+    });
+    return new F32Interval(begin, end);
+  }
+
+  /** @returns a string representation for logging purposes */
+  public toString(): string {
+    return `[${this.begin}, ${this.end}]`;
+  }
+
+  /** @returns a singleton for the infinite interval
+   * This interval is used in situations where accuracy is not defined, so any
+   * result is valid.
+   */
+  public static infinite(): F32Interval {
+    if (this._infinite === undefined) {
+      this._infinite = new F32Interval(Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
+    }
+    return this._infinite;
+  }
+}
+
+/** @returns an interval containing the point or the original interval */
+function toInterval(n: number | F32Interval): F32Interval {
+  if (n instanceof F32Interval) {
+    return n;
+  }
+  return new F32Interval(n, n);
+}
+
+/**
+ * A function that converts a point to an interval of valid results.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface PointToInterval {
+  (x: number): F32Interval;
+}
+
+/** Operation used to implement a PointToInterval */
+interface PointToIntervalOp {
+  /** @returns acceptance interval for a function at point x */
+  impl: (x: number) => F32Interval;
+
+  /**
+   * Calculates where in the domain defined by x the min/max extrema of impl
+   * occur and returns a span of those points to be used as the domain instead.
+   *
+   * If not defined the ends of the existing domain are assumed to be the
+   * extrema.
+   *
+   * This is only implemented for functions that meet all of the following
+   * criteria:
+   *   a) non-monotonic
+   *   b) used in inherited accuracy calculations
+   *   c) need to take in an interval for b)
+   *      i.e. fooInterval takes in x: number | F32Interval, not x: number
+   */
+  extrema?: (x: F32Interval) => F32Interval;
+}
+
+/**
+ * A function that converts a pair of points to an interval of valid results.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface BinaryToInterval {
+  (x: number, y: number): F32Interval;
+}
+
+/** Operation used to implement a BinaryToInterval */
+interface BinaryToIntervalOp {
+  /** @returns acceptance interval for a function at point (x, y) */
+  impl: (x: number, y: number) => F32Interval;
+  /**
+   * Calculates where in domain defined by x & y the min/max extrema of impl
+   * occur and returns spans of those points to be used as the domain instead.
+   *
+   * If not defined the ends of the existing domain are assumed to be the
+   * extrema.
+   *
+   * This is only implemented for functions that meet all of the following
+   * criteria:
+   *   a) non-monotonic
+   *   b) used in inherited accuracy calculations
+   *   c) need to take in an interval for b)
+   */
+  extrema?: (x: F32Interval, y: F32Interval) => [F32Interval, F32Interval];
+}
+
+/**
+ * A function that converts a triplet of points to an interval of valid results.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface TernaryToInterval {
+  (x: number, y: number, z: number): F32Interval;
+}
+
+/** Operation used to implement a TernaryToInterval */
+interface TernaryToIntervalOp {
+  /** @returns acceptance interval for a function at point (x, y, z) */
+  impl: (x: number, y: number, z: number) => F32Interval;
+  // All current ternary operations that are used in inheritance (clamp*) are
+  // monotonic, so extrema calculation isn't needed. Re-using the Op interface
+  // pattern for symmetry with the other operations
+}
+
+/** Convert a point to an interval valid results, using a specific function
+ *
+ * This handles correctly rounding and flushing inputs as needed.
+ * Duplicate inputs are pruned before invoking op.impl.
+ * op.extrema is invoked before this point in the call stack.
+ *
+ * @param n value to flush & round then invoke op.impl on
+ * @param op operation defining the function being run
+ * @returns a span over all of the outputs of op.impl
+ */
+function roundAndFlushPointToInterval(n: number, op: PointToIntervalOp) {
+  assert(!Number.isNaN(n), `flush not defined for NaN`);
+  const values = correctlyRoundedF32(n);
+  const inputs = new Set<number>([...values, ...values.map(flushSubnormalNumber)]);
+  const results = new Set<F32Interval>([...inputs].map(op.impl));
+  return F32Interval.span(...results);
+}
+
+/** Convert a pair to an interval valid results, using a specific function
+ *
+ * This handles correctly rounding and flushing inputs as needed.
+ * Duplicate inputs are pruned before invoking op.impl.
+ * All unique combinations of x & y are run.
+ * op.extrema is invoked before this point in the call stack.
+ *
+ * @param x first param to flush & round then invoke op.impl on
+ * @param y second param to flush & round then invoke op.impl on
+ * @param op operation defining the function being run
+ * @returns a span over all of the outputs of op.impl
+ */
+function roundAndFlushBinaryToInterval(x: number, y: number, op: BinaryToIntervalOp): F32Interval {
+  assert(!Number.isNaN(x), `flush not defined for NaN`);
+  assert(!Number.isNaN(y), `flush not defined for NaN`);
+  const x_values = correctlyRoundedF32(x);
+  const y_values = correctlyRoundedF32(y);
+  const x_inputs = new Set<number>([...x_values, ...x_values.map(flushSubnormalNumber)]);
+  const y_inputs = new Set<number>([...y_values, ...y_values.map(flushSubnormalNumber)]);
+  const intervals = new Set<F32Interval>();
+  x_inputs.forEach(inner_x => {
+    y_inputs.forEach(inner_y => {
+      intervals.add(op.impl(inner_x, inner_y));
+    });
+  });
+  return F32Interval.span(...intervals);
+}
+
+/** Convert a triplet to an interval valid results, using a specific function
+ *
+ * This handles correctly rounding and flushing inputs as needed.
+ * Duplicate inputs are pruned before invoking op.impl.
+ * All unique combinations of x, y & z are run.
+ * op.extrema is invoked before this point in the call stack.
+ *
+ * @param x first param to flush & round then invoke op.impl on
+ * @param y second param to flush & round then invoke op.impl on
+ * @param z third param to flush & round then invoke op.impl on
+ * @param op operation defining the function being run
+ * @returns a span over all of the outputs of op.impl
+ */
+function roundAndFlushTernaryToInterval(
+  x: number,
+  y: number,
+  z: number,
+  op: TernaryToIntervalOp
+): F32Interval {
+  assert(!Number.isNaN(x), `flush not defined for NaN`);
+  assert(!Number.isNaN(y), `flush not defined for NaN`);
+  assert(!Number.isNaN(z), `flush not defined for NaN`);
+  const x_values = correctlyRoundedF32(x);
+  const y_values = correctlyRoundedF32(y);
+  const z_values = correctlyRoundedF32(z);
+  const x_inputs = new Set<number>([...x_values, ...x_values.map(flushSubnormalNumber)]);
+  const y_inputs = new Set<number>([...y_values, ...y_values.map(flushSubnormalNumber)]);
+  const z_inputs = new Set<number>([...z_values, ...z_values.map(flushSubnormalNumber)]);
+  const intervals = new Set<F32Interval>();
+  // prettier-ignore
+  x_inputs.forEach(inner_x => {
+    y_inputs.forEach(inner_y => {
+      z_inputs.forEach(inner_z => {
+        intervals.add(op.impl(inner_x, inner_y, inner_z));
+      });
+    });
+  });
+
+  return F32Interval.span(...intervals);
+}
+
+/** Calculate the acceptance interval for a unary function over an interval
+ *
+ * If the interval is actually a point, this just decays to
+ * roundAndFlushPointToInterval.
+ *
+ * The provided domain interval may be adjusted if the operation defines an
+ * extrema function.
+ *
+ * @param x input domain interval
+ * @param op operation defining the function being run
+ * @returns a span over all of the outputs of op.impl
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function runPointOp(x: F32Interval, op: PointToIntervalOp): F32Interval {
+  if (x.isPoint()) {
+    return roundAndFlushPointToInterval(x.begin, op);
+  }
+
+  if (op.extrema !== undefined) {
+    x = op.extrema(x);
+  }
+  return F32Interval.span(
+    roundAndFlushPointToInterval(x.begin, op),
+    roundAndFlushPointToInterval(x.end, op)
+  );
+}
+
+/** Calculate the acceptance interval for a binary function over an interval
+ *
+ * The provided domain intervals may be adjusted if the operation defines an
+ * extrema function.
+ *
+ * @param x first input domain interval
+ * @param y second input domain interval
+ * @param op operation defining the function being run
+ * @returns a span over all of the outputs of op.impl
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function runBinaryOp(x: F32Interval, y: F32Interval, op: BinaryToIntervalOp): F32Interval {
+  if (op.extrema !== undefined) {
+    [x, y] = op.extrema(x, y);
+  }
+  const x_values = new Set<number>([x.begin, x.end]);
+  const y_values = new Set<number>([y.begin, y.end]);
+
+  const results = new Set<F32Interval>();
+  x_values.forEach(inner_x => {
+    y_values.forEach(inner_y => {
+      results.add(roundAndFlushBinaryToInterval(inner_x, inner_y, op));
+    });
+  });
+
+  return F32Interval.span(...results);
+}
+
+/** Calculate the acceptance interval for a ternary function over an interval
+ *
+ * The provided domain intervals may be adjusted if the operation defines an
+ * extrema function.
+ *
+ * @param x first input domain interval
+ * @param y second input domain interval
+ * @param z third input domain interval
+ * @param op operation defining the function being run
+ * @returns a span over all of the outputs of op.impl
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function runTernaryOp(
+  x: F32Interval,
+  y: F32Interval,
+  z: F32Interval,
+  op: TernaryToIntervalOp
+): F32Interval {
+  const x_values = new Set<number>([x.begin, x.end]);
+  const y_values = new Set<number>([y.begin, y.end]);
+  const z_values = new Set<number>([z.begin, z.end]);
+  const results = new Set<F32Interval>();
+  x_values.forEach(inner_x => {
+    y_values.forEach(inner_y => {
+      z_values.forEach(inner_z => {
+        results.add(roundAndFlushTernaryToInterval(inner_x, inner_y, inner_z, op));
+      });
+    });
+  });
+
+  return F32Interval.span(...results);
+}
+
+/** @returns an interval of the correctly rounded values around the point */
+export function correctlyRoundedInterval(n: number): F32Interval {
+  return roundAndFlushPointToInterval(n, {
+    impl: (impl_n: number) => {
+      assert(!Number.isNaN(impl_n), `absolute not defined for NaN`);
+      return toInterval(impl_n);
+    },
+  });
+}
+
+/** @returns an interval of the absolute error around the point */
+export function absoluteErrorInterval(n: number, error_range: number): F32Interval {
+  return roundAndFlushPointToInterval(n, {
+    impl: (impl_n: number) => {
+      assert(!Number.isNaN(n), `absolute not defined for NaN`);
+      if (!isF32Finite(n)) {
+        return toInterval(n);
+      }
+
+      return new F32Interval(impl_n - error_range, impl_n + error_range);
+    },
+  });
+}
+
+/** @returns an interval of N * ULP around the point */
+export function ulpInterval(n: number, numULP: number): F32Interval {
+  numULP = Math.abs(numULP);
+  return roundAndFlushPointToInterval(n, {
+    impl: (impl_n: number) => {
+      if (!isF32Finite(n)) {
+        return toInterval(n);
+      }
+
+      const ulp_flush = oneULP(impl_n, true);
+      const ulp_noflush = oneULP(impl_n, false);
+      const ulp = Math.max(ulp_flush, ulp_noflush);
+      return new F32Interval(impl_n - numULP * ulp, impl_n + numULP * ulp);
+    },
+  });
+}


### PR DESCRIPTION
This implements the F32Interval class and fundamental accuracy
functions described in my prototype for reworking,
https://github.com/gpuweb/cts/pull/1402, how floating point tests are
written.

This also adds in testing that did not appear in my prototype.

There are a couple of functions that are not currently used that I
have included in this patch that have suppressions for unused-vars on
them. I included them in this patch since they are logically grouped
with this code. These supressions will be removed in future patches.

Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
