### PR TITLE
Convert `abs` tests to use interval framework

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -17,18 +17,11 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
-import {
-  f32Bits,
-  i32Bits,
-  TypeF32,
-  TypeI32,
-  TypeU32,
-  u32Bits,
-} from '../../../../../util/conversion.js';
+import { i32Bits, TypeF32, TypeI32, TypeU32, u32Bits } from '../../../../../util/conversion.js';
+import { absInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -96,10 +89,7 @@ g.test('i32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
-    run(t, builtin('abs'), [TypeI32], TypeI32, cfg, [
+    run(t, builtin('abs'), [TypeI32], TypeI32, t.params, [
       // Min and max i32
       // If e evaluates to the largest negative value, then the result is e.
       { input: i32Bits(kBit.i32.negative.min), expected: i32Bits(kBit.i32.negative.min) },
@@ -157,20 +147,17 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
     const makeCase = (x: number): Case => {
-      return makeUnaryF32Case(x, Math.abs);
+      return makeUnaryF32IntervalCase(x, absInterval);
     };
 
     const cases: Array<Case> = [
-      { input: f32Bits(kBit.f32.infinity.negative), expected: f32Bits(kBit.f32.infinity.positive) },
-      { input: f32Bits(kBit.f32.infinity.positive), expected: f32Bits(kBit.f32.infinity.positive) },
-      ...fullF32Range().map(x => makeCase(x)),
-    ];
+      Number.NEGATIVE_INFINITY,
+      ...fullF32Range(),
+      Number.POSITIVE_INFINITY,
+    ].map(x => makeCase(x));
 
-    run(t, builtin('abs'), [TypeF32], TypeF32, cfg, cases);
+    run(t, builtin('abs'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -590,8 +590,6 @@ export function makeBinaryF32Case(
  * @param param the param to pass into the unary operation
  * @param op callback that implements generating an acceptance interval for a unary operation
  */
-// Will be used in test implementations
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function makeUnaryF32IntervalCase(param: number, op: PointToInterval): Case {
   param = quantizeToF32(param);
   const interval = op(param);

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -44,8 +44,8 @@ export class F32Interval {
    * Due to values that are above/below the f32 range being indistinguishable
    * from other values out of range in the same way, there some unintuitive
    * behaviours here, for example:
-   *   [0, max f32 +1].contains(+∞) will return true.
-   * */
+   *   [0, greater than max f32].contains(+∞) will return true.
+   */
   public contains(n: number | F32Interval): boolean {
     if (Number.isNaN(n)) {
       // Being the infinite interval indicates that the accuracy is not defined

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -35,8 +35,7 @@ export function clamp(n: number, { min, max }: { min: number; max: number }): nu
 
 /** @returns 0 if |val| is a subnormal f32 number, otherwise returns |val| */
 export function flushSubnormalNumber(val: number): number {
-  const u32_val = new Uint32Array(new Float32Array([val]).buffer)[0];
-  return (u32_val & 0x7f800000) === 0 ? 0 : val;
+  return val > kValue.f32.negative.max && val < kValue.f32.positive.min ? 0 : val;
 }
 
 /** @returns 0 if |val| is a subnormal f32 number, otherwise returns |val| */
@@ -67,7 +66,6 @@ export function isSubnormalNumber(val: number): boolean {
 }
 
 /** @returns if number is in the finite range of f32 */
-// eslint-disable-next-line no-unused-vars
 export function isF32Finite(n: number) {
   return n >= kValue.f32.negative.min && n <= kValue.f32.positive.max;
 }


### PR DESCRIPTION
Issue: #792

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
