### PR TITLE
Convert `ceil` tests to using new interval framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -9,6 +9,7 @@ import {
   absInterval,
   absoluteErrorInterval,
   atanInterval,
+  ceilInterval,
   correctlyRoundedInterval,
   F32Interval,
   ulpInterval,
@@ -624,5 +625,50 @@ g.test('atanInterval')
     t.expect(
       objectEquals(expected, got),
       `atanInterval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('ceilInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: [0, 0] },
+      { input: 0.1, expected: [1, 1] },
+      { input: 0.9, expected: [1, 1] },
+      { input: 1.0, expected: [1, 1] },
+      { input: 1.1, expected: [2, 2] },
+      { input: 1.9, expected: [2, 2] },
+      { input: -0.1, expected: [0, 0] },
+      { input: -0.9, expected: [0, 0] },
+      { input: -1.0, expected: [-1, -1] },
+      { input: -1.1, expected: [-1, -1] },
+      { input: -1.9, expected: [-1, -1] },
+
+      // Edge cases
+      { input: Number.POSITIVE_INFINITY, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
+      { input: kValue.f32.positive.min, expected: [1, 1] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+      { input: kValue.f32.negative.max, expected: [0, 0] },
+      { input: kValue.powTwo.to30, expected: [kValue.powTwo.to30, kValue.powTwo.to30] },
+      { input: -kValue.powTwo.to30, expected: [-kValue.powTwo.to30, -kValue.powTwo.to30] },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: [0, 1] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0, 1] },
+      { input: kValue.f32.subnormal.negative.min, expected: [0, 0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [0, 0] },
+
+    ]
+  )
+  .fn(t => {
+    const input = t.params.input;
+    const expected = arrayToInterval(t.params.expected);
+
+    const got = ceilInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `ceilInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -10,11 +10,10 @@ Returns the ceiling of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedMatch } from '../../../../../util/compare.js';
-import { kBit } from '../../../../../util/constants.js';
-import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { ceilInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,39 +34,27 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
     const makeCase = (x: number): Case => {
-      return makeUnaryF32Case(x, Math.ceil);
+      return makeUnaryF32IntervalCase(x, ceilInterval);
     };
 
     const cases: Array<Case> = [
       // Small positive numbers
-      { input: f32(0.1), expected: f32(1.0) },
-      { input: f32(0.9), expected: f32(1.0) },
-      { input: f32(1.1), expected: f32(2.0) },
-      { input: f32(1.9), expected: f32(2.0) },
-
+      0.1,
+      0.9,
+      1.0,
+      1.1,
+      1.9,
       // Small negative numbers
-      { input: f32(-0.1), expected: f32(0.0) },
-      { input: f32(-0.9), expected: f32(0.0) },
-      { input: f32(-1.1), expected: f32(-1.0) },
-      { input: f32(-1.9), expected: f32(-1.0) },
+      -0.1,
+      -0.9,
+      -1.0,
+      -1.1,
+      -1.9,
+      ...fullF32Range(),
+    ].map(x => makeCase(x));
 
-      // Min and Max f32
-      { input: f32Bits(kBit.f32.negative.max), expected: f32(0.0) },
-      { input: f32Bits(kBit.f32.negative.min), expected: f32Bits(kBit.f32.negative.min) },
-      { input: f32Bits(kBit.f32.positive.min), expected: f32(1.0) },
-      { input: f32Bits(kBit.f32.positive.max), expected: f32Bits(kBit.f32.positive.max) },
-
-      // Infinity f32
-      { input: f32Bits(kBit.f32.infinity.negative), expected: f32Bits(kBit.f32.infinity.negative) },
-      { input: f32Bits(kBit.f32.infinity.positive), expected: f32Bits(kBit.f32.infinity.positive) },
-      ...fullF32Range().map(x => makeCase(x)),
-    ];
-
-    run(t, builtin('ceil'), [TypeF32], TypeF32, cfg, cases);
+    run(t, builtin('ceil'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -419,3 +419,14 @@ export function atanInterval(n: number): F32Interval {
 
   return runPointOp(toInterval(n), op);
 }
+
+/** Calculate an acceptance interval of ceil(x) */
+export function ceilInterval(n: number): F32Interval {
+  const op: PointToIntervalOp = {
+    impl: (impl_n: number): F32Interval => {
+      return correctlyRoundedInterval(Math.ceil(impl_n));
+    },
+  };
+
+  return runPointOp(toInterval(n), op);
+}


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
