### PR TITLE
Roll @webgpu/types to 0.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/offscreencanvas": "^2019.6.4",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "0.1.15",
+        "@webgpu/types": "0.1.18",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1227,9 +1227,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.15.tgz",
-      "integrity": "sha512-ZmVadVywHYarPkXi6ieoiHRotkrfLVKo6WIkmh2QuJ76prDFnILYoOoym9PMY/sdEI4Jf9ICwJEGBoPvbXJNSQ==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.18.tgz",
+      "integrity": "sha512-HFHT3rriksKciYqdjHEOe2cQt14XnyLuieKyJN8bA23SG2NrTYZaoFOSuVA3EgPIyHGfelpXM+8QqNJ/3rCRCg==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10483,9 +10483,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.15.tgz",
-      "integrity": "sha512-ZmVadVywHYarPkXi6ieoiHRotkrfLVKo6WIkmh2QuJ76prDFnILYoOoym9PMY/sdEI4Jf9ICwJEGBoPvbXJNSQ==",
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.18.tgz",
+      "integrity": "sha512-HFHT3rriksKciYqdjHEOe2cQt14XnyLuieKyJN8bA23SG2NrTYZaoFOSuVA3EgPIyHGfelpXM+8QqNJ/3rCRCg==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/offscreencanvas": "^2019.6.4",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "0.1.15",
+    "@webgpu/types": "0.1.18",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/stress/adapter/device_allocation.spec.ts
+++ b/src/stress/adapter/device_allocation.spec.ts
@@ -45,6 +45,7 @@ async function createDeviceAndComputeCommands(adapter: GPUAdapter) {
 
   for (let pipelineIndex = 0; pipelineIndex < kNumPipelines; ++pipelineIndex) {
     const pipeline = device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: device.createShaderModule({
           code: `

--- a/src/stress/compute/compute_pass.spec.ts
+++ b/src/stress/compute/compute_pass.spec.ts
@@ -18,6 +18,7 @@ GPUComputePipeline.`
     const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: t.device.createShaderModule({
           code: `
@@ -77,7 +78,7 @@ GPUComputePipeline.`
     }));
     for (const compute of stages) {
       const encoder = t.device.createCommandEncoder();
-      const pipeline = t.device.createComputePipeline({ compute });
+      const pipeline = t.device.createComputePipeline({ layout: 'auto', compute });
       const bindGroup = t.device.createBindGroup({
         layout: pipeline.getBindGroupLayout(0),
         entries: [{ binding: 0, resource: { buffer } }],
@@ -121,7 +122,10 @@ groups.`
       `,
     });
     const kNumIterations = 250_000;
-    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: { module, entryPoint: 'main' },
+    });
     const encoder = t.device.createCommandEncoder();
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
@@ -168,7 +172,10 @@ g.test('many_dispatches')
       `,
     });
     const kNumIterations = 1_000_000;
-    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: { module, entryPoint: 'main' },
+    });
     const encoder = t.device.createCommandEncoder();
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
@@ -211,7 +218,10 @@ g.test('huge_dispatches')
       `,
     });
     const kNumIterations = 16;
-    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: { module, entryPoint: 'main' },
+    });
     const bindGroup = t.device.createBindGroup({
       layout: pipeline.getBindGroupLayout(0),
       entries: [{ binding: 0, resource: { buffer } }],

--- a/src/stress/queue/submit.spec.ts
+++ b/src/stress/queue/submit.spec.ts
@@ -19,6 +19,7 @@ results verified at the end of the test.`
     const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: t.device.createShaderModule({
           code: `
@@ -63,6 +64,7 @@ submit() call.`
     const data = new Uint32Array([...iterRange(kNumElements, x => x)]);
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: t.device.createShaderModule({
           code: `

--- a/src/stress/render/render_pass.spec.ts
+++ b/src/stress/render/render_pass.spec.ts
@@ -31,6 +31,7 @@ a single render pass for every output fragment, with each pass executing a one-v
     `,
     });
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vmain', buffers: [] },
       primitive: { topology: 'point-list' },
       fragment: {
@@ -120,6 +121,7 @@ pass does a single draw call, with one pass per output fragment.`
     const encoder = t.device.createCommandEncoder();
     range(kWidth * kHeight, i => {
       const pipeline = t.device.createRenderPipeline({
+        layout: 'auto',
         vertex: { module, entryPoint: 'vmain', buffers: [] },
         primitive: { topology: 'point-list' },
         depthStencil: {
@@ -253,6 +255,7 @@ render pass with a single pipeline, and one draw call per fragment of the output
     `,
     });
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vmain', buffers: [] },
       primitive: { topology: 'point-list' },
       fragment: {
@@ -313,6 +316,7 @@ call which draws multiple vertices for each fragment of a large output texture.`
     `,
     });
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vmain', buffers: [] },
       primitive: { topology: 'point-list' },
       fragment: {

--- a/src/stress/render/vertex_buffers.spec.ts
+++ b/src/stress/render/vertex_buffers.spec.ts
@@ -14,6 +14,7 @@ function createHugeVertexBuffer(t: GPUTest, size: number) {
     usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
   });
   const pipeline = t.device.createComputePipeline({
+    layout: 'auto',
     compute: {
       module: t.device.createShaderModule({
         code: `
@@ -76,6 +77,7 @@ g.test('many')
     `,
     });
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module,
         entryPoint: 'vmain',

--- a/src/stress/shaders/non_halting.spec.ts
+++ b/src/stress/shaders/non_halting.spec.ts
@@ -31,7 +31,10 @@ device loss.`
         }
       `,
     });
-    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: { module, entryPoint: 'main' },
+    });
     const encoder = t.device.createCommandEncoder();
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
@@ -75,6 +78,7 @@ device loss.`
     });
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vmain', buffers: [] },
       primitive: { topology: 'point-list' },
       fragment: {
@@ -146,6 +150,7 @@ device loss.`
     });
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vmain', buffers: [] },
       primitive: { topology: 'point-list' },
       fragment: {

--- a/src/stress/shaders/slow.spec.ts
+++ b/src/stress/shaders/slow.spec.ts
@@ -28,7 +28,10 @@ g.test('compute')
         }
       `,
     });
-    const pipeline = t.device.createComputePipeline({ compute: { module, entryPoint: 'main' } });
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: { module, entryPoint: 'main' },
+    });
     const encoder = t.device.createCommandEncoder();
     const pass = encoder.beginComputePass();
     pass.setPipeline(pipeline);
@@ -67,6 +70,7 @@ g.test('vertex')
     });
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vmain', buffers: [] },
       primitive: { topology: 'point-list' },
       fragment: {
@@ -140,6 +144,7 @@ g.test('fragment')
     });
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vmain', buffers: [] },
       primitive: { topology: 'point-list' },
       fragment: {

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -1243,6 +1243,7 @@ g.test('copy_multisampled_color')
 
     // Initialize sourceTexture with a draw call.
     const renderPipelineForInit = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `
@@ -1305,6 +1306,7 @@ g.test('copy_multisampled_color')
     // Verify if all the sub-pixel values at the same location of sourceTexture and
     // destinationTexture are equal.
     const renderPipelineForValidation = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `
@@ -1438,6 +1440,7 @@ g.test('copy_multisampled_depth')
 
     // Initialize the depth aspect of source texture with a draw call
     const renderPipelineForInit = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: vertexState,
       depthStencil: {
         format: kDepthFormat,
@@ -1481,6 +1484,7 @@ g.test('copy_multisampled_depth')
     // depthCompareFunction == 'equal' and depthWriteEnabled == false in the render pipeline
     const kColorFormat = 'rgba8unorm';
     const renderPipelineForVerify = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: vertexState,
       fragment: {
         module: t.device.createShaderModule({

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1011,6 +1011,7 @@ class ImageCopyTest extends GPUTest {
     );
 
     const renderPipeline = this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
@@ -11,6 +11,7 @@ import { GPUTest } from '../../../../gpu_test.js';
 class VertexAndIndexStateTrackingTest extends GPUTest {
   GetRenderPipelineForTest(arrayStride: number): GPURenderPipeline {
     return this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: `
@@ -408,6 +409,7 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
 
     // Create renderPipeline1 that uses both positionBuffer and colorBuffer.
     const renderPipeline1 = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `
@@ -459,6 +461,7 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
     });
 
     const renderPipeline2 = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -26,6 +26,7 @@ g.test('memcpy').fn(async t => {
   });
 
   const pipeline = t.device.createComputePipeline({
+    layout: 'auto',
     compute: {
       module: t.device.createShaderModule({
         code: `
@@ -104,6 +105,7 @@ g.test('large_dispatch')
     const wgSizes = [1, 1, 1];
     wgSizes[t.params.largeDimension] = t.params.workgroupSize;
     const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -327,6 +327,7 @@ export class BufferSyncTest extends GPUTest {
     `;
 
     return this.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: this.device.createShaderModule({
           code: wgslCompute,
@@ -338,6 +339,7 @@ export class BufferSyncTest extends GPUTest {
 
   createTrivialRenderPipeline(wgslShaders: { vertex: string; fragment: string }) {
     return this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: wgslShaders.vertex,
@@ -510,6 +512,7 @@ export class BufferSyncTest extends GPUTest {
     `;
 
     return this.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: this.device.createShaderModule({
           code: wgslCompute,
@@ -564,6 +567,7 @@ export class BufferSyncTest extends GPUTest {
     };
 
     return this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: wgslShaders.vertex,
@@ -635,6 +639,7 @@ export class BufferSyncTest extends GPUTest {
     };
 
     return this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: wgslShaders.vertex,

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -49,6 +49,7 @@ g.test('render_pass_resolve')
     // well as a line between the portions that contain the midpoint color due to the multisample
     // resolve.
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -27,6 +27,7 @@ TODO: needs review and rename
 
     // create render pipeline
     const renderPipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -112,6 +112,7 @@ TODO: check the contents of the depth and stencil outputs [2]
     // 2. The bottom-right one is clockwise (CW)
     pass.setPipeline(
       t.device.createRenderPipeline({
+        layout: 'auto',
         vertex: {
           module: t.device.createShaderModule({
             code: `

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -72,6 +72,7 @@ g.test('color,attachments')
       })
     );
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: kVertexShader,
@@ -172,6 +173,7 @@ g.test('color,component_count')
     });
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: kVertexShader,
@@ -382,6 +384,7 @@ The attachment has a load value of [1, 0, 0, 1]
     });
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: kVertexShader,

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -330,6 +330,7 @@ class PrimitiveTopologyTest extends GPUTest {
     // Output color is solid green.
     renderPass.setPipeline(
       this.device.createRenderPipeline({
+        layout: 'auto',
         vertex: {
           module: this.device.createShaderModule({
             code: `

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -58,6 +58,7 @@ g.test('fullscreen_quad').fn(async t => {
   const colorAttachmentView = colorAttachment.createView();
 
   const pipeline = t.device.createRenderPipeline({
+    layout: 'auto',
     vertex: {
       module: t.device.createShaderModule({
         code: `

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -160,6 +160,7 @@ g.test('GPUBlendComponent')
     }
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       fragment: {
         targets: [
           {

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -98,6 +98,7 @@ g.test('depth_compare_func')
     const depthTextureView = depthTexture.createView();
 
     const pipelineDescriptor: GPURenderPipelineDescriptor = {
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `
@@ -190,6 +191,7 @@ g.test('reverse_depth')
     const depthTextureView = depthTexture.createView();
 
     const pipelineDescriptor: GPURenderPipelineDescriptor = {
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -171,6 +171,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
     // Draw points at different vertex depths and fragment depths into the depth attachment,
     // with a viewport of [0.25,0.75].
     const testPipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vtest' },
       primitive: {
         topology: 'point-list',
@@ -187,6 +188,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
 
     // Use depth comparison to check that the depth attachment now has the expected values.
     const checkPipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vcheck' },
       primitive: { topology: 'point-list' },
       depthStencil: {
@@ -421,6 +423,7 @@ to be empty.`
 
     // Initialize depth attachment with expected values, in [0.25,0.75].
     const initPipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vmain' },
       primitive: { topology: 'point-list' },
       depthStencil: { format, depthWriteEnabled: true },
@@ -431,6 +434,7 @@ to be empty.`
     // With a viewport set to [0.25,0.75], output values in [0.0,1.0] and check they're clamped
     // before the depth test, regardless of whether unclippedDepth is enabled.
     const testPipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module, entryPoint: 'vmain' },
       primitive: {
         topology: 'point-list',

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -124,6 +124,7 @@ struct Output {
     });
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: vertexModule,
         entryPoint: 'vert_main',
@@ -517,6 +518,7 @@ g.test('vertex_attributes,basic')
     }
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
@@ -169,6 +169,7 @@ Params:
     const indirectBuffer = t.MakeIndirectBuffer(isIndexed, indirectOffset);
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `@stage(vertex) fn main(@location(0) pos : vec2<f32>) -> @builtin(position) vec4<f32> {

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -50,6 +50,7 @@ class F extends GPUTest {
     boundBufferSize: number
   ): void {
     const computePipeline = this.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: computeShaderModule,
         entryPoint: 'main',
@@ -94,6 +95,7 @@ class F extends GPUTest {
     testVertexBuffer: boolean
   ): GPURenderPipeline {
     const renderPipelineDescriptor: GPURenderPipelineDescriptor = {
+      layout: 'auto',
       vertex: {
         module: vertexShaderModule,
         entryPoint: 'main',
@@ -814,6 +816,7 @@ g.test('indirect_buffer_for_dispatch_indirect')
     const { bufferOffset } = t.params;
 
     const computePipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -27,6 +27,7 @@ function getDepthTestEqualPipeline(
   expected: number
 ): GPURenderPipeline {
   return t.device.createRenderPipeline({
+    layout: 'auto',
     vertex: {
       entryPoint: 'main',
       module: makeFullscreenVertexModule(t.device),
@@ -66,6 +67,7 @@ function getStencilTestEqualPipeline(
   sampleCount: number
 ): GPURenderPipeline {
   return t.device.createRenderPipeline({
+    layout: 'auto',
     vertex: {
       entryPoint: 'main',
       module: makeFullscreenVertexModule(t.device),

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -52,6 +52,7 @@ export const checkContentsBySampling: CheckContents = (
         ? 'i32(GlobalInvocationID.x)'
         : unreachable();
     const computePipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         entryPoint: 'main',
         module: t.device.createShaderModule({

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -55,6 +55,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
     await super.init();
 
     this.pipeline = this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
+++ b/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
@@ -116,7 +116,7 @@ g.test('texture_binding')
       viewFormats: [viewFormat],
     });
 
-    // Reinterepret the texture as the view format.
+    // Reinterpret the texture as the view format.
     // Make a texel view of the format that also reinterprets the data.
     const reinterpretedView = texture.createView({ format: viewFormat });
     const reinterpretedTexelView = TexelView.fromTexelsAsBytes(viewFormat, inputTexelView.bytes);

--- a/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
+++ b/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
@@ -47,6 +47,7 @@ function makeBlitPipeline(
   multisample: { sample: number; render: number }
 ) {
   return device.createRenderPipeline({
+    layout: 'auto',
     vertex: {
       module: device.createShaderModule({
         code: `
@@ -123,6 +124,7 @@ g.test('texture_binding')
 
     // Create a pipeline to write data out to rgba8unorm.
     const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -232,6 +232,7 @@ struct VSOutputs {
     }
 
     return this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module,
         entryPoint: 'vsMain',

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -139,6 +139,7 @@ class F extends ValidationTest {
     cullMode?: GPUCullMode
   ) {
     return this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: `

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -118,6 +118,7 @@ g.test('color_target_state')
 
     t.expectValidationError(() => {
       t.device.createRenderPipeline({
+        layout: 'auto',
         vertex: {
           module: t.device.createShaderModule({
             code: `
@@ -173,6 +174,7 @@ g.test('depth_stencil_state')
 
     t.expectValidationError(() => {
       t.device.createRenderPipeline({
+        layout: 'auto',
         vertex: {
           module: t.device.createShaderModule({
             code: `

--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -82,6 +82,7 @@ Call the API with valid compute shader and matching valid entryPoint, making sur
   .fn(async t => {
     const { isAsync } = t.params;
     t.doCreateComputePipelineTest(isAsync, true, {
+      layout: 'auto',
       compute: { module: t.getShaderModule('compute', 'main'), entryPoint: 'main' },
     });
   });
@@ -96,6 +97,7 @@ Tests calling createComputePipeline(Async) with a invalid compute shader, and ch
   .fn(async t => {
     const { isAsync } = t.params;
     t.doCreateComputePipelineTest(isAsync, false, {
+      layout: 'auto',
       compute: {
         module: t.getInvalidShaderModule(),
         entryPoint: 'main',
@@ -118,6 +120,7 @@ and check that the APIs only accept compute shader.
   .fn(async t => {
     const { isAsync, shaderModuleStage } = t.params;
     const descriptor = {
+      layout: 'auto' as const,
       compute: {
         module: t.getShaderModule(shaderModuleStage, 'main'),
         entryPoint: 'main',
@@ -165,6 +168,7 @@ The entryPoint assigned in descriptor include:
   .fn(async t => {
     const { isAsync, shaderModuleEntryPoint, stageEntryPoint } = t.params;
     const descriptor = {
+      layout: 'auto' as const,
       compute: {
         module: t.getShaderModule('compute', shaderModuleEntryPoint),
         entryPoint: stageEntryPoint,
@@ -217,6 +221,7 @@ g.test('shader_module,device_mismatch')
     });
 
     const descriptor = {
+      layout: 'auto' as const,
       compute: {
         module,
         entryPoint: 'main',

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -73,6 +73,7 @@ g.test('pipeline,device_mismatch')
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const pipeline = device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: device.createShaderModule({
           code: '@stage(compute) @workgroup_size(1) fn main() {}',

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -12,6 +12,7 @@ class F extends ValidationTest {
 
   createRenderPipeline(): GPURenderPipeline {
     return this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: `

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -113,6 +113,7 @@ function makeTestPipeline(
   }
 
   return test.device.createRenderPipeline({
+    layout: 'auto',
     vertex: {
       module: test.device.createShaderModule({
         code: test.getNoOpShaderCode('VERTEX'),

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -39,6 +39,7 @@ g.test('pipeline,device_mismatch')
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const pipeline = device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: device.createShaderModule({
           code: `@stage(vertex) fn main() -> @builtin(position) vec4<f32> { return vec4<f32>(); }`,

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -16,6 +16,7 @@ class F extends ValidationTest {
 
   createRenderPipeline(bufferCount: number): GPURenderPipeline {
     return this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: `

--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -80,7 +80,7 @@ class F extends ValidationTest {
   }
 
   createRenderPipelineForTest(
-    pipelineLayout: GPUPipelineLayout | undefined,
+    pipelineLayout: GPUPipelineLayout | GPUAutoLayoutMode,
     vertexBufferCount: number
   ): GPURenderPipeline {
     const vertexBuffers: GPUVertexBufferLayout[] = [];
@@ -853,27 +853,27 @@ different render pass encoders belong to different usage scopes.`
         }
         case 'vertex': {
           const kVertexBufferCount = 1;
-          const pipeline = t.createRenderPipelineForTest(undefined, kVertexBufferCount);
+          const pipeline = t.createRenderPipelineForTest('auto', kVertexBufferCount);
           renderPassEncoder.setPipeline(pipeline);
           renderPassEncoder.setVertexBuffer(0, buffer, offset);
           renderPassEncoder.draw(1);
           break;
         }
         case 'index': {
-          const pipeline = t.createRenderPipelineForTest(undefined, 0);
+          const pipeline = t.createRenderPipelineForTest('auto', 0);
           renderPassEncoder.setPipeline(pipeline);
           renderPassEncoder.setIndexBuffer(buffer, 'uint16', offset);
           renderPassEncoder.drawIndexed(1);
           break;
         }
         case 'indirect': {
-          const pipeline = t.createRenderPipelineForTest(undefined, 0);
+          const pipeline = t.createRenderPipelineForTest('auto', 0);
           renderPassEncoder.setPipeline(pipeline);
           renderPassEncoder.drawIndirect(buffer, offset);
           break;
         }
         case 'indexedIndirect': {
-          const pipeline = t.createRenderPipelineForTest(undefined, 0);
+          const pipeline = t.createRenderPipelineForTest('auto', 0);
           renderPassEncoder.setPipeline(pipeline);
           const indexBuffer = t.createBufferWithState('valid', {
             size: 4,

--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -546,7 +546,7 @@ layout visibilities.`
         ) {
           return false;
         }
-        // The bufer usages `vertex` and `index` do nothing with shader visibilities.
+        // The buffer usages `vertex` and `index` do nothing with shader visibilities.
         if ((t.usage0 === 'vertex' || t.usage0 === 'index') && t.visibility0 !== 'fragment') {
           return false;
         }
@@ -555,7 +555,7 @@ layout visibilities.`
         if (t.usage0AccessibleInDraw && t.visibility0 !== 'fragment') {
           return false;
         }
-        // As usage1 is accssible in the draw call, the draw call cannot be before usage1.
+        // As usage1 is accessible in the draw call, the draw call cannot be before usage1.
         if (t.drawBeforeUsage1 && t.usage1AccessibleInDraw) {
           return false;
         }

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -1079,6 +1079,7 @@ g.test('unused_bindings_in_pipeline')
 
     const pipeline = compute
       ? t.device.createComputePipeline({
+          layout: 'auto',
           compute: {
             module: t.device.createShaderModule({
               code: wgslCompute,
@@ -1087,6 +1088,7 @@ g.test('unused_bindings_in_pipeline')
           },
         })
       : t.device.createRenderPipeline({
+          layout: 'auto',
           vertex: {
             module: t.device.createShaderModule({
               code: wgslVertex,

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -417,6 +417,7 @@ Tests creating compute pipeline on destroyed device.
     const cShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('COMPUTE') });
     await t.executeAfterDestroy(() => {
       t.device.createComputePipeline({
+        layout: 'auto',
         compute: { module: cShader, entryPoint: 'main' },
       });
     }, awaitLost);
@@ -436,6 +437,7 @@ Tests creating render pipeline on destroyed device.
     const fShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('FRAGMENT') });
     await t.executeAfterDestroy(() => {
       t.device.createRenderPipeline({
+        layout: 'auto',
         vertex: { module: vShader, entryPoint: 'main' },
         fragment: {
           module: fShader,
@@ -724,6 +726,7 @@ Tests encoding and dispatching a simple valid compute pass on destroyed device.
     const { stage, awaitLost } = t.params;
     const cShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('COMPUTE') });
     const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: { module: cShader, entryPoint: 'main' },
     });
     await t.executeCommandsAfterDestroy(stage, awaitLost, 'compute pass', maker => {
@@ -750,6 +753,7 @@ Tests encoding and finishing a simple valid render pass on destroyed device.
     const vShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('VERTEX') });
     const fShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('FRAGMENT') });
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module: vShader, entryPoint: 'main' },
       fragment: {
         module: fShader,
@@ -781,6 +785,7 @@ Tests encoding and drawing a render pass including a render bundle on destroyed 
     const vShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('VERTEX') });
     const fShader = t.device.createShaderModule({ code: t.getNoOpShaderCode('FRAGMENT') });
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: { module: vShader, entryPoint: 'main' },
       fragment: {
         module: fShader,

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -312,6 +312,7 @@ export class ValidationTest extends GPUTest {
   /** Return a GPURenderPipeline with default options and no-op vertex and fragment shaders. */
   createNoOpRenderPipeline(): GPURenderPipeline {
     return this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: this.getNoOpShaderCode('VERTEX'),
@@ -333,6 +334,7 @@ export class ValidationTest extends GPUTest {
   createErrorRenderPipeline(): GPURenderPipeline {
     this.device.pushErrorScope('validation');
     const pipeline = this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: '',
@@ -345,7 +347,9 @@ export class ValidationTest extends GPUTest {
   }
 
   /** Return a GPUComputePipeline with a no-op shader. */
-  createNoOpComputePipeline(layout?: GPUPipelineLayout): GPUComputePipeline {
+  createNoOpComputePipeline(
+    layout: GPUPipelineLayout | GPUAutoLayoutMode = 'auto'
+  ): GPUComputePipeline {
     return this.device.createComputePipeline({
       layout,
       compute: {
@@ -361,6 +365,7 @@ export class ValidationTest extends GPUTest {
   createErrorComputePipeline(): GPUComputePipeline {
     this.device.pushErrorScope('validation');
     const pipeline = this.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: this.device.createShaderModule({
           code: '',

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -62,6 +62,7 @@ class F extends ValidationTest {
     vertexShaderCode: string
   ): GPURenderPipelineDescriptor {
     const descriptor: GPURenderPipelineDescriptor = {
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({ code: vertexShaderCode }),
         entryPoint: 'main',
@@ -97,6 +98,7 @@ class F extends ValidationTest {
 
     this.expectValidationError(() => {
       this.device.createRenderPipeline({
+        layout: 'auto',
         vertex: {
           module: vsModule,
           entryPoint: 'main',

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -465,6 +465,7 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
     `;
 
     const pipeline = this.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: this.device.createShaderModule({ code: reducer }),
         entryPoint: 'reduce',

--- a/src/webgpu/shader/execution/evaluation_order.spec.ts
+++ b/src/webgpu/shader/execution/evaluation_order.spec.ts
@@ -433,6 +433,7 @@ fn main() {
 
   const module = t.device.createShaderModule({ code: source });
   const pipeline = t.device.createComputePipeline({
+    layout: 'auto',
     compute: { module, entryPoint: 'main' },
   });
 

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -246,6 +246,7 @@ fn main() {
 
   const module = t.device.createShaderModule({ code: source });
   const pipeline = t.device.createComputePipeline({
+    layout: 'auto',
     compute: { module, entryPoint: 'main' },
   });
 

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -416,6 +416,7 @@ class F extends GPUTest {
     buffers: GPUVertexBufferLayout[];
   }): GPURenderPipeline {
     const pipeline = this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: this.generateVertexShaderCode({

--- a/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
+++ b/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
@@ -38,6 +38,7 @@ class DerivativesTest extends GPUTest {
     await super.init();
 
     this.pipeline = this.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: this.device.createShaderModule({
           code: `

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -131,6 +131,7 @@ g.test('inputs')
     `;
 
     const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: t.device.createShaderModule({
           code: wgsl,

--- a/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
@@ -49,6 +49,7 @@ g.test('shared_with_buffer')
     `;
 
     const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: t.device.createShaderModule({ code: wgsl }),
         entryPoint: 'main',
@@ -149,6 +150,7 @@ g.test('shared_between_stages')
     // Set up the render pipeline.
     const module = t.device.createShaderModule({ code: wgsl });
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module,
         entryPoint: 'vert_main',
@@ -269,6 +271,7 @@ g.test('shared_with_non_entry_point_function')
     // Set up the render pipeline.
     const module = t.device.createShaderModule({ code: wgsl });
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module,
         entryPoint: 'vert_main',

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -398,6 +398,7 @@ g.test('compute,zero_init')
     `;
 
     const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
       compute: {
         module: t.device.createShaderModule({
           code: wgsl,

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -340,8 +340,8 @@ class DeviceHolder implements DeviceProvider {
   }
 
   private async attemptEndTestScope(): Promise<void> {
-    let gpuValidationError: GPUValidationError | GPUOutOfMemoryError | null;
-    let gpuOutOfMemoryError: GPUValidationError | GPUOutOfMemoryError | null;
+    let gpuValidationError: GPUError | null;
+    let gpuOutOfMemoryError: GPUError | null;
 
     // Submit to the queue to attempt to force a GPU flush.
     this.device.queue.submit([]);

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -68,6 +68,7 @@ function doTest(
   }`;
 
   const pipeline = t.device.createComputePipeline({
+    layout: 'auto',
     compute: {
       module: t.device.createShaderModule({
         code: shader,

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -52,6 +52,7 @@ export const g = makeTestGroup(GPUTest);
 
 function createExternalTextureSamplingTestPipeline(t: GPUTest): GPURenderPipeline {
   const pipeline = t.device.createRenderPipeline({
+    layout: 'auto',
     vertex: {
       module: t.device.createShaderModule({
         code: `
@@ -299,6 +300,7 @@ Tests that we can import an HTMLVideoElement into a GPUExternalTexture and use i
       });
 
       const pipeline = t.device.createComputePipeline({
+        layout: 'auto',
         compute: {
           // Shader will load a pixel near the upper left and lower right corners, which are then
           // stored in storage texture.

--- a/src/webgpu/web_platform/reftests/canvas_complex.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_complex.html.ts
@@ -212,6 +212,7 @@ export function run(
       const srcTexture = setupSrcTexture(imageBitmap);
 
       const pipeline = t.device.createRenderPipeline({
+        layout: 'auto',
         vertex: {
           module: t.device.createShaderModule({
             code: `
@@ -330,6 +331,7 @@ fn linearMain(@location(0) fragUV: vec2<f32>) -> @location(0) vec4<f32> {
 
     function DrawVertexColor(ctx: GPUCanvasContext) {
       const pipeline = t.device.createRenderPipeline({
+        layout: 'auto',
         vertex: {
           module: t.device.createShaderModule({
             code: `
@@ -410,6 +412,7 @@ fn main(@location(0) fragColor: vec4<f32>) -> @location(0) vec4<f32> {
       const halfCanvasWidthStr = (ctx.canvas.width / 2).toFixed();
       const halfCanvasHeightStr = (ctx.canvas.height / 2).toFixed();
       const pipeline = t.device.createRenderPipeline({
+        layout: 'auto',
         vertex: {
           module: t.device.createShaderModule({
             code: `
@@ -495,6 +498,7 @@ fn main(@builtin(position) fragcoord: vec4<f32>) -> @location(0) vec4<f32> {
       const halfCanvasWidthStr = (ctx.canvas.width / 2).toFixed();
       const halfCanvasHeightStr = (ctx.canvas.height / 2).toFixed();
       const pipeline = t.device.createRenderPipeline({
+        layout: 'auto',
         vertex: {
           module: t.device.createShaderModule({
             code: `
@@ -592,6 +596,7 @@ fn main(@builtin(position) fragcoord: vec4<f32>) -> @location(0) vec4<f32> {
       const halfCanvasWidthStr = (ctx.canvas.width / 2).toFixed();
       const halfCanvasHeightStr = (ctx.canvas.height / 2).toFixed();
       const pipeline = t.device.createComputePipeline({
+        layout: 'auto',
         compute: {
           module: t.device.createShaderModule({
             code: `
@@ -643,6 +648,7 @@ fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
       const halfCanvasWidthStr = (ctx.canvas.width / 2).toFixed();
       const halfCanvasHeightStr = (ctx.canvas.height / 2).toFixed();
       const pipeline = t.device.createComputePipeline({
+        layout: 'auto',
         compute: {
           module: t.device.createShaderModule({
             code: `

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -47,6 +47,7 @@ export function run(
     });
 
     const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
           code: `

--- a/src/webgpu/web_platform/worker/worker.ts
+++ b/src/webgpu/web_platform/worker/worker.ts
@@ -10,6 +10,7 @@ async function basicTest() {
 
   const kOffset = 1230000;
   const pipeline = device.createComputePipeline({
+    layout: 'auto',
     compute: {
       module: device.createShaderModule({
         code: `


### PR DESCRIPTION
I just rolled the spec into the types (to get the alphaMode update) and it turns out we haven't rolled the types here in a while. The changes aren't too substantial, but each different change is separated into a different commit.

Issue: None

<hr>

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Helpers and types promote readability and maintainability.