### PR TITLE
Add api,validation,resource_usages,buffer,in_pass_misc:* - Part I

### DIFF
--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -8,7 +8,7 @@ import { ValidationTest } from '../../validation_test.js';
 
 const kBoundBufferSize = 256;
 
-type BufferUsage =
+export type BufferUsage =
   | 'uniform'
   | 'storage'
   | 'read-only-storage'
@@ -17,7 +17,7 @@ type BufferUsage =
   | 'indirect'
   | 'indexedIndirect';
 
-const kAllBufferUsages: BufferUsage[] = [
+export const kAllBufferUsages: BufferUsage[] = [
   'uniform',
   'storage',
   'read-only-storage',
@@ -27,7 +27,7 @@ const kAllBufferUsages: BufferUsage[] = [
   'indexedIndirect',
 ];
 
-class F extends ValidationTest {
+export class BufferResourceUsageTest extends ValidationTest {
   createBindGroupLayoutForTest(
     type: 'uniform' | 'storage' | 'read-only-storage',
     resourceVisibility: 'compute' | 'fragment'
@@ -138,7 +138,7 @@ function IsBufferUsageInBindGroup(bufferUsage: BufferUsage): boolean {
   }
 }
 
-export const g = makeTestGroup(F);
+export const g = makeTestGroup(BufferResourceUsageTest);
 
 g.test('subresources,buffer_usage_in_one_compute_pass_with_no_dispatch')
   .desc(

--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_misc.spec.ts
@@ -1,0 +1,216 @@
+export const description = `
+Test other buffer usage validation rules that are not tests in ./in_pass_encoder.spec.js.
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+
+import { BufferResourceUsageTest, kAllBufferUsages } from './in_pass_encoder.spec.js';
+
+export const g = makeTestGroup(BufferResourceUsageTest);
+
+const kBufferSize = 256;
+
+g.test('subresources,reset_buffer_usage_before_dispatch')
+  .desc(
+    `
+Test that the buffer usages which are reset by another state-setting commands before a dispatch call
+do not contribute directly to any usage scope in a compute pass.`
+  )
+  .params(u =>
+    u
+      .combine('usage0', ['uniform', 'storage', 'read-only-storage'] as const)
+      .combine('usage1', ['uniform', 'storage', 'read-only-storage', 'indirect'] as const)
+  )
+  .fn(async t => {
+    const { usage0, usage1 } = t.params;
+
+    const kUsages = GPUBufferUsage.UNIFORM | GPUBufferUsage.STORAGE | GPUBufferUsage.INDIRECT;
+    const buffer = t.createBufferWithState('valid', {
+      size: kBufferSize,
+      usage: kUsages,
+    });
+    const anotherBuffer = t.createBufferWithState('valid', {
+      size: kBufferSize,
+      usage: kUsages,
+    });
+
+    const bindGroupLayouts: GPUBindGroupLayout[] = [
+      t.createBindGroupLayoutForTest(usage0, 'compute'),
+    ];
+    if (usage1 !== 'indirect') {
+      bindGroupLayouts.push(t.createBindGroupLayoutForTest(usage1, 'compute'));
+    }
+    const pipelineLayout = t.device.createPipelineLayout({ bindGroupLayouts });
+    const computePipeline = t.createNoOpComputePipeline(pipelineLayout);
+
+    const encoder = t.device.createCommandEncoder();
+    const computePassEncoder = encoder.beginComputePass();
+    computePassEncoder.setPipeline(computePipeline);
+
+    // Set usage0 for buffer at bind group index 0
+    const bindGroup0 = t.createBindGroupForTest(buffer, 0, usage0, 'compute');
+    computePassEncoder.setBindGroup(0, bindGroup0);
+
+    // Reset bind group index 0 with another bind group that uses anotherBuffer
+    const anotherBindGroup = t.createBindGroupForTest(anotherBuffer, 0, usage0, 'compute');
+    computePassEncoder.setBindGroup(0, anotherBindGroup);
+
+    // Set usage1 for buffer
+    switch (usage1) {
+      case 'uniform':
+      case 'storage':
+      case 'read-only-storage': {
+        const bindGroup1 = t.createBindGroupForTest(buffer, 0, usage1, 'compute');
+        computePassEncoder.setBindGroup(1, bindGroup1);
+        computePassEncoder.dispatchWorkgroups(1);
+        break;
+      }
+      case 'indirect': {
+        computePassEncoder.dispatchWorkgroupsIndirect(buffer, 0);
+        break;
+      }
+    }
+    computePassEncoder.end();
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, false);
+  });
+
+g.test('subresources,reset_buffer_usage_before_draw')
+  .desc(
+    `
+Test that the buffer usages which are reset by another state-setting commands before a draw call
+still contribute directly to the usage scope of the draw call.`
+  )
+  .params(u =>
+    u
+      .combine('usage0', ['uniform', 'storage', 'read-only-storage', 'vertex', 'index'] as const)
+      .combine('usage1', kAllBufferUsages)
+      .unless(t => {
+        return t.usage0 === 'index' && t.usage1 === 'indirect';
+      })
+  )
+  .fn(async t => {
+    const { usage0, usage1 } = t.params;
+
+    const kUsages =
+      GPUBufferUsage.UNIFORM |
+      GPUBufferUsage.STORAGE |
+      GPUBufferUsage.INDIRECT |
+      GPUBufferUsage.VERTEX |
+      GPUBufferUsage.INDEX;
+    const buffer = t.createBufferWithState('valid', {
+      size: kBufferSize,
+      usage: kUsages,
+    });
+    const anotherBuffer = t.createBufferWithState('valid', {
+      size: kBufferSize,
+      usage: kUsages,
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const renderPassEncoder = t.beginSimpleRenderPass(encoder);
+
+    const bindGroupLayouts: GPUBindGroupLayout[] = [];
+    let vertexBufferCount = 0;
+
+    // Set buffer as usage0 and reset buffer with anotherBuffer as usage0
+    switch (usage0) {
+      case 'uniform':
+      case 'storage':
+      case 'read-only-storage': {
+        const bindGroup0 = t.createBindGroupForTest(buffer, 0, usage0, 'fragment');
+        renderPassEncoder.setBindGroup(bindGroupLayouts.length, bindGroup0);
+
+        const anotherBindGroup = t.createBindGroupForTest(anotherBuffer, 0, usage0, 'fragment');
+        renderPassEncoder.setBindGroup(bindGroupLayouts.length, anotherBindGroup);
+
+        bindGroupLayouts.push(t.createBindGroupLayoutForTest(usage0, 'fragment'));
+        break;
+      }
+      case 'vertex': {
+        renderPassEncoder.setVertexBuffer(vertexBufferCount, buffer);
+        renderPassEncoder.setVertexBuffer(vertexBufferCount, anotherBuffer);
+
+        ++vertexBufferCount;
+        break;
+      }
+      case 'index': {
+        renderPassEncoder.setIndexBuffer(buffer, 'uint16');
+        renderPassEncoder.setIndexBuffer(anotherBuffer, 'uint16');
+        break;
+      }
+    }
+
+    // Set buffer as usage1
+    switch (usage1) {
+      case 'uniform':
+      case 'storage':
+      case 'read-only-storage': {
+        const bindGroup1 = t.createBindGroupForTest(buffer, 0, usage1, 'fragment');
+        renderPassEncoder.setBindGroup(bindGroupLayouts.length, bindGroup1);
+
+        bindGroupLayouts.push(t.createBindGroupLayoutForTest(usage1, 'fragment'));
+        break;
+      }
+      case 'vertex': {
+        renderPassEncoder.setVertexBuffer(vertexBufferCount, buffer);
+        ++vertexBufferCount;
+        break;
+      }
+      case 'index': {
+        renderPassEncoder.setIndexBuffer(buffer, 'uint16');
+        break;
+      }
+      case 'indirect':
+      case 'indexedIndirect':
+        break;
+    }
+
+    // Add draw call
+    const pipelineLayout = t.device.createPipelineLayout({
+      bindGroupLayouts,
+    });
+    const renderPipeline = t.createRenderPipelineForTest(pipelineLayout, vertexBufferCount);
+    renderPassEncoder.setPipeline(renderPipeline);
+    switch (usage1) {
+      case 'indexedIndirect': {
+        if (usage0 !== 'index') {
+          const indexBuffer = t.createBufferWithState('valid', {
+            size: 4,
+            usage: GPUBufferUsage.INDEX,
+          });
+          renderPassEncoder.setIndexBuffer(indexBuffer, 'uint16');
+        }
+        renderPassEncoder.drawIndexedIndirect(buffer, 0);
+        break;
+      }
+      case 'indirect': {
+        renderPassEncoder.drawIndirect(buffer, 0);
+        break;
+      }
+      case 'index': {
+        renderPassEncoder.drawIndexed(1);
+        break;
+      }
+      case 'vertex':
+      case 'uniform':
+      case 'storage':
+      case 'read-only-storage': {
+        if (usage0 === 'index') {
+          renderPassEncoder.drawIndexed(1);
+        } else {
+          renderPassEncoder.draw(1);
+        }
+        break;
+      }
+    }
+
+    renderPassEncoder.end();
+
+    const fail = (usage0 === 'storage') !== (usage1 === 'storage');
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, fail);
+  });


### PR DESCRIPTION
This patch adds the first part of
api,validation,resource_usages,buffer,in_pass_misc:*:
-subresources,reset_buffer_usage_before_dispatch
-subresources,reset_buffer_usage_before_draw




Issue: #905 

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
