### PR TITLE
Change Scalar.toString() to include hex bits

### DIFF
--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -498,19 +498,24 @@ export class Scalar {
       return Colors.bold(this.value.toString());
     }
     switch (this.value) {
-      case 0:
       case Infinity:
       case -Infinity:
         return Colors.bold(this.value.toString());
       default: {
+        // Uint8Array.map returns a Uint8Array, so cannot use .map directly
+        const hex = Array.from(this.bits)
+          .reverse()
+          .map(x => x.toString(16).padStart(2, '0'))
+          .join('');
         const n = this.value as Number;
-        if (n !== null) {
-          return (
-            Colors.bold(this.value.toString()) +
-            `(0x${this.value.toString(16)}, subnormal: ${isSubnormalNumber(n.valueOf())})`
-          );
+        if (n !== null && isFloatValue(this)) {
+          let str = this.value.toString();
+          str = str.indexOf('.') > 0 || str.indexOf('e') > 0 ? str : `${str}.0`;
+          return isSubnormalNumber(n.valueOf())
+            ? `${Colors.bold(str)} (0x${hex} subnormal)`
+            : `${Colors.bold(str)} (0x${hex})`;
         }
-        return Colors.bold(this.value.toString()) + `(0x${this.value.toString(16)})`;
+        return `${Colors.bold(this.value.toString())} (0x${hex})`;
       }
     }
   }
@@ -699,7 +704,7 @@ export type Value = Scalar | Vector;
 export function isFloatValue(v: Value): boolean {
   if (v instanceof Scalar) {
     const s = v;
-    return s.type.kind === s.type.kind || s.type.kind === 'f32' || s.type.kind === 'f16';
+    return s.type.kind === 'f64' || s.type.kind === 'f32' || s.type.kind === 'f16';
   }
   return false;
 }


### PR DESCRIPTION
Currently this is includes the value of the Scalar in base 16, which
isn't that useful. For unsigned integers this maps directly to the
bits, but for pretty much any other numeric type it is just making a
harder to read version of toString().

I am pretty sure the intent here was to include the bits in a readable
format so that one could easily evaluate what is being stored.

This changes the return of toString() from:
```
-1.00048828125(0x-1.002, subnormal: false)
```
to this:
```
-1.00048828125 (hex: 0xbf801000, subnormal: false)
```
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
