### PR TITLE
Add api,validation,resource_usages,buffer,in_pass_misc:* - Part II

### DIFF
--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_misc.spec.ts
@@ -3,8 +3,9 @@ Test other buffer usage validation rules that are not tests in ./in_pass_encoder
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { unreachable } from '../../../../../common/util/util.js';
 
-import { BufferResourceUsageTest, kAllBufferUsages } from './in_pass_encoder.spec.js';
+import { BufferUsage, BufferResourceUsageTest, kAllBufferUsages } from './in_pass_encoder.spec.js';
 
 export const g = makeTestGroup(BufferResourceUsageTest);
 
@@ -213,4 +214,196 @@ still contribute directly to the usage scope of the draw call.`
     t.expectValidationError(() => {
       encoder.finish();
     }, fail);
+  });
+
+g.test('subresources,buffer_usages_in_copy_and_pass')
+  .desc(
+    `
+  Test that using one buffer in a copy command, a render or compute pass encoder is always allowed
+  as WebGPU SPEC (chapter 3.4.5) defines that out of any pass encoder, each command belongs to one
+  separated usage scope.`
+  )
+  .params(u =>
+    u
+      .combine('usage0', [
+        'copy-src',
+        'copy-dst',
+        'uniform',
+        'storage',
+        'read-only-storage',
+        'vertex',
+        'index',
+        'indirect',
+        'indexedIndirect',
+      ] as const)
+      .combine('usage1', [
+        'copy-src',
+        'copy-dst',
+        'uniform',
+        'storage',
+        'read-only-storage',
+        'vertex',
+        'index',
+        'indirect',
+        'indexedIndirect',
+      ] as const)
+      .combine('pass', ['render', 'compute'])
+      .unless(({ usage0, usage1, pass }) => {
+        const IsCopy = (usage: BufferUsage | 'copy-src' | 'copy-dst') => {
+          return usage === 'copy-src' || usage === 'copy-dst';
+        };
+        // We intend to test copy usages in this test.
+        if (!IsCopy(usage0) && !IsCopy(usage1)) {
+          return true;
+        }
+        // When both usage0 and usage1 are copy usages, 'pass' is meaningless so in such situation
+        // we just need to reserve one value as 'pass'.
+        if (IsCopy(usage0) && IsCopy(usage1)) {
+          return pass === 'compute';
+        }
+
+        const IsValidComputeUsage = (usage: BufferUsage | 'copy-src' | 'copy-dst') => {
+          switch (usage) {
+            case 'vertex':
+            case 'index':
+            case 'indexedIndirect':
+              return false;
+            default:
+              return true;
+          }
+        };
+        if (pass === 'compute') {
+          return !IsValidComputeUsage(usage0) || !IsValidComputeUsage(usage1);
+        }
+
+        return false;
+      })
+  )
+  .fn(async t => {
+    const { usage0, usage1, pass } = t.params;
+
+    const kUsages =
+      GPUBufferUsage.COPY_SRC |
+      GPUBufferUsage.COPY_DST |
+      GPUBufferUsage.UNIFORM |
+      GPUBufferUsage.STORAGE |
+      GPUBufferUsage.INDIRECT |
+      GPUBufferUsage.VERTEX |
+      GPUBufferUsage.INDEX;
+    const buffer = t.createBufferWithState('valid', {
+      size: kBufferSize,
+      usage: kUsages,
+    });
+
+    const UseBufferOnCommandEncoder = (
+      usage:
+        | 'copy-src'
+        | 'copy-dst'
+        | 'uniform'
+        | 'storage'
+        | 'read-only-storage'
+        | 'vertex'
+        | 'index'
+        | 'indirect'
+        | 'indexedIndirect',
+      encoder: GPUCommandEncoder
+    ) => {
+      switch (usage) {
+        case 'copy-src': {
+          const destinationBuffer = t.createBufferWithState('valid', {
+            size: 4,
+            usage: GPUBufferUsage.COPY_DST,
+          });
+          encoder.copyBufferToBuffer(buffer, 0, destinationBuffer, 0, 4);
+          break;
+        }
+        case 'copy-dst': {
+          const sourceBuffer = t.createBufferWithState('valid', {
+            size: 4,
+            usage: GPUBufferUsage.COPY_SRC,
+          });
+          encoder.copyBufferToBuffer(sourceBuffer, 0, buffer, 0, 4);
+          break;
+        }
+        case 'uniform':
+        case 'storage':
+        case 'read-only-storage': {
+          const bindGroup = t.createBindGroupForTest(buffer, 0, usage, 'fragment');
+          switch (pass) {
+            case 'render': {
+              const renderPassEncoder = t.beginSimpleRenderPass(encoder);
+              renderPassEncoder.setBindGroup(0, bindGroup);
+              renderPassEncoder.end();
+              break;
+            }
+            case 'compute': {
+              const computePassEncoder = encoder.beginComputePass();
+              computePassEncoder.setBindGroup(0, bindGroup);
+              computePassEncoder.end();
+              break;
+            }
+            default:
+              unreachable();
+          }
+          break;
+        }
+        case 'vertex': {
+          const renderPassEncoder = t.beginSimpleRenderPass(encoder);
+          renderPassEncoder.setVertexBuffer(0, buffer);
+          renderPassEncoder.end();
+          break;
+        }
+        case 'index': {
+          const renderPassEncoder = t.beginSimpleRenderPass(encoder);
+          renderPassEncoder.setIndexBuffer(buffer, 'uint16');
+          renderPassEncoder.end();
+          break;
+        }
+        case 'indirect': {
+          switch (pass) {
+            case 'render': {
+              const renderPassEncoder = t.beginSimpleRenderPass(encoder);
+              const renderPipeline = t.createNoOpRenderPipeline();
+              renderPassEncoder.setPipeline(renderPipeline);
+              renderPassEncoder.drawIndirect(buffer, 0);
+              renderPassEncoder.end();
+              break;
+            }
+            case 'compute': {
+              const computePassEncoder = encoder.beginComputePass();
+              const computePipeline = t.createNoOpComputePipeline();
+              computePassEncoder.setPipeline(computePipeline);
+              computePassEncoder.dispatchWorkgroupsIndirect(buffer, 0);
+              computePassEncoder.end();
+              break;
+            }
+            default:
+              unreachable();
+          }
+          break;
+        }
+        case 'indexedIndirect': {
+          const renderPassEncoder = t.beginSimpleRenderPass(encoder);
+          const renderPipeline = t.createNoOpRenderPipeline();
+          renderPassEncoder.setPipeline(renderPipeline);
+          const indexBuffer = t.createBufferWithState('valid', {
+            size: 4,
+            usage: GPUBufferUsage.INDEX,
+          });
+          renderPassEncoder.setIndexBuffer(indexBuffer, 'uint16');
+          renderPassEncoder.drawIndexedIndirect(buffer, 0);
+          renderPassEncoder.end();
+          break;
+        }
+        default:
+          unreachable();
+      }
+    };
+
+    const encoder = t.device.createCommandEncoder();
+    UseBufferOnCommandEncoder(usage0, encoder);
+    UseBufferOnCommandEncoder(usage1, encoder);
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, false);
   });


### PR DESCRIPTION
This patch adds the last part of
api,validation,resource_usages,buffer,in_pass_misc:*:
-subresources,buffer_usages_in_copy_and_pass




Fixed: #905

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
