### PR TITLE
Update @stage attributes.

### DIFF
--- a/src/stress/adapter/device_allocation.spec.ts
+++ b/src/stress/adapter/device_allocation.spec.ts
@@ -52,7 +52,7 @@ async function createDeviceAndComputeCommands(adapter: GPUAdapter) {
               struct Buffer { data: array<u32>; };
 
               @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-              @stage(compute) @workgroup_size(1) fn main(
+              @compute @workgroup_size(1) fn main(
                   @builtin(global_invocation_id) id: vec3<u32>) {
                 buffer.data[id.x * ${kLimitInfo.maxComputeWorkgroupSizeX.default}u + id.y] =
                   buffer.data[id.x * ${kLimitInfo.maxComputeWorkgroupSizeX.default}u + id.y] +
@@ -113,7 +113,7 @@ async function createDeviceAndRenderCommands(adapter: GPUAdapter) {
           struct Buffer { data: array<vec4<u32>, ${(kSize * kSize) / 4}>; };
 
           @group(0) @binding(0) var<uniform> buffer: Buffer;
-          @stage(vertex) fn vmain(
+          @vertex fn vmain(
             @builtin(vertex_index) vertexIndex: u32
           ) -> @builtin(position) vec4<f32> {
             let index = buffer.data[vertexIndex / 4u][vertexIndex % 4u];
@@ -124,7 +124,7 @@ async function createDeviceAndRenderCommands(adapter: GPUAdapter) {
             return vec4<f32>(fma(position, a, b), 0.0, 1.0);
           }
 
-          @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+          @fragment fn fmain() -> @location(0) vec4<f32> {
             return vec4<f32>(${pipelineIndex}.0 / ${kNumPipelines}.0, 0.0, 0.0, 1.0);
           }
         `,

--- a/src/stress/compute/compute_pass.spec.ts
+++ b/src/stress/compute/compute_pass.spec.ts
@@ -24,7 +24,7 @@ GPUComputePipeline.`
           code: `
             struct Buffer { data: array<u32>; };
             @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-            @stage(compute) @workgroup_size(1) fn main(
+            @compute @workgroup_size(1) fn main(
                 @builtin(global_invocation_id) id: vec3<u32>) {
               buffer.data[id.x] = buffer.data[id.x] + 1u;
             }
@@ -69,7 +69,7 @@ GPUComputePipeline.`
         code: `
         struct Buffer { data: u32; };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-        @stage(compute) @workgroup_size(1) fn main${i}() {
+        @compute @workgroup_size(1) fn main${i}() {
           buffer.data = buffer.data + 1u;
         }
         `,
@@ -114,7 +114,7 @@ groups.`
         struct Buffer { data: array<u32>; };
         @group(0) @binding(0) var<storage, read_write> buffer1: Buffer;
         @group(0) @binding(1) var<storage, read_write> buffer2: Buffer;
-        @stage(compute) @workgroup_size(1) fn main(
+        @compute @workgroup_size(1) fn main(
             @builtin(global_invocation_id) id: vec3<u32>) {
           buffer1.data[id.x] = buffer1.data[id.x] + 1u;
           buffer2.data[id.x] = buffer2.data[id.x] + 2u;
@@ -165,7 +165,7 @@ g.test('many_dispatches')
       code: `
         struct Buffer { data: array<u32>; };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-        @stage(compute) @workgroup_size(1) fn main(
+        @compute @workgroup_size(1) fn main(
             @builtin(global_invocation_id) id: vec3<u32>) {
           buffer.data[id.x] = buffer.data[id.x] + 1u;
         }
@@ -210,7 +210,7 @@ g.test('huge_dispatches')
       code: `
         struct Buffer { data: array<u32>; };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-        @stage(compute) @workgroup_size(1) fn main(
+        @compute @workgroup_size(1) fn main(
             @builtin(global_invocation_id) id: vec3<u32>) {
           let index = (id.z * 512u + id.y) * 512u + id.x;
           buffer.data[index] = buffer.data[index] + 1u;

--- a/src/stress/queue/submit.spec.ts
+++ b/src/stress/queue/submit.spec.ts
@@ -25,7 +25,7 @@ results verified at the end of the test.`
           code: `
             struct Buffer { data: array<u32>; };
             @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-            @stage(compute) @workgroup_size(1) fn main(
+            @compute @workgroup_size(1) fn main(
                 @builtin(global_invocation_id) id: vec3<u32>) {
               buffer.data[id.x] = buffer.data[id.x] + 1u;
             }
@@ -70,7 +70,7 @@ submit() call.`
           code: `
             struct Buffer { data: array<u32>; };
             @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-            @stage(compute) @workgroup_size(1) fn main(
+            @compute @workgroup_size(1) fn main(
                 @builtin(global_invocation_id) id: vec3<u32>) {
               buffer.data[id.x] = buffer.data[id.x] + 1u;
             }

--- a/src/stress/render/render_pass.spec.ts
+++ b/src/stress/render/render_pass.spec.ts
@@ -17,7 +17,7 @@ a single render pass for every output fragment, with each pass executing a one-v
     const kSize = 1024;
     const module = t.device.createShaderModule({
       code: `
-    @stage(vertex) fn vmain(@builtin(vertex_index) index: u32)
+    @vertex fn vmain(@builtin(vertex_index) index: u32)
         -> @builtin(position) vec4<f32> {
       let position = vec2<f32>(f32(index % ${kSize}u), f32(index / ${kSize}u));
       let r = vec2<f32>(1.0 / f32(${kSize}));
@@ -25,7 +25,7 @@ a single render pass for every output fragment, with each pass executing a one-v
       let b = r - vec2<f32>(1.0);
       return vec4<f32>(fma(position, a, b), 0.0, 1.0);
     }
-    @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+    @fragment fn fmain() -> @location(0) vec4<f32> {
       return vec4<f32>(1.0, 0.0, 1.0, 1.0);
     }
     `,
@@ -78,7 +78,7 @@ pass does a single draw call, with one pass per output fragment.`
     const kHeight = 8;
     const module = t.device.createShaderModule({
       code: `
-    @stage(vertex) fn vmain(@builtin(vertex_index) index: u32)
+    @vertex fn vmain(@builtin(vertex_index) index: u32)
         -> @builtin(position) vec4<f32> {
       let position = vec2<f32>(f32(index % ${kWidth}u), f32(index / ${kWidth}u));
       let size = vec2<f32>(f32(${kWidth}), f32(${kHeight}));
@@ -87,7 +87,7 @@ pass does a single draw call, with one pass per output fragment.`
       let b = r - vec2<f32>(1.0);
       return vec4<f32>(fma(position, a, b), 0.0, 1.0);
     }
-    @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+    @fragment fn fmain() -> @location(0) vec4<f32> {
       return vec4<f32>(1.0, 0.0, 1.0, 1.0);
     }
     `,
@@ -161,7 +161,7 @@ buffer.`
       code: `
     struct Uniforms { index: u32; };
     @group(0) @binding(0) var<uniform> uniforms: Uniforms;
-    @stage(vertex) fn vmain() -> @builtin(position) vec4<f32> {
+    @vertex fn vmain() -> @builtin(position) vec4<f32> {
       let index = uniforms.index;
       let position = vec2<f32>(f32(index % ${kSize}u), f32(index / ${kSize}u));
       let r = vec2<f32>(1.0 / f32(${kSize}));
@@ -169,7 +169,7 @@ buffer.`
       let b = r - vec2<f32>(1.0);
       return vec4<f32>(fma(position, a, b), 0.0, 1.0);
     }
-    @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+    @fragment fn fmain() -> @location(0) vec4<f32> {
       return vec4<f32>(1.0, 0.0, 1.0, 1.0);
     }
     `,
@@ -241,7 +241,7 @@ render pass with a single pipeline, and one draw call per fragment of the output
     const kSize = 4096;
     const module = t.device.createShaderModule({
       code: `
-    @stage(vertex) fn vmain(@builtin(vertex_index) index: u32)
+    @vertex fn vmain(@builtin(vertex_index) index: u32)
         -> @builtin(position) vec4<f32> {
       let position = vec2<f32>(f32(index % ${kSize}u), f32(index / ${kSize}u));
       let r = vec2<f32>(1.0 / f32(${kSize}));
@@ -249,7 +249,7 @@ render pass with a single pipeline, and one draw call per fragment of the output
       let b = r - vec2<f32>(1.0);
       return vec4<f32>(fma(position, a, b), 0.0, 1.0);
     }
-    @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+    @fragment fn fmain() -> @location(0) vec4<f32> {
       return vec4<f32>(1.0, 0.0, 1.0, 1.0);
     }
     `,
@@ -301,7 +301,7 @@ call which draws multiple vertices for each fragment of a large output texture.`
     const kVertsPerFragment = (kSize * kSize) / (kTextureSize * kTextureSize);
     const module = t.device.createShaderModule({
       code: `
-    @stage(vertex) fn vmain(@builtin(vertex_index) vert_index: u32)
+    @vertex fn vmain(@builtin(vertex_index) vert_index: u32)
         -> @builtin(position) vec4<f32> {
       let index = vert_index / ${kVertsPerFragment}u;
       let position = vec2<f32>(f32(index % ${kTextureSize}u), f32(index / ${kTextureSize}u));
@@ -310,7 +310,7 @@ call which draws multiple vertices for each fragment of a large output texture.`
       let b = r - vec2<f32>(1.0);
       return vec4<f32>(fma(position, a, b), 0.0, 1.0);
     }
-    @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+    @fragment fn fmain() -> @location(0) vec4<f32> {
       return vec4<f32>(1.0, 0.0, 1.0, 1.0);
     }
     `,

--- a/src/stress/render/vertex_buffers.spec.ts
+++ b/src/stress/render/vertex_buffers.spec.ts
@@ -20,7 +20,7 @@ function createHugeVertexBuffer(t: GPUTest, size: number) {
         code: `
         struct Buffer { data: array<vec2<u32>>; };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-        @stage(compute) @workgroup_size(1) fn main(
+        @compute @workgroup_size(1) fn main(
             @builtin(global_invocation_id) id: vec3<u32>) {
           let base = id.x * ${size}u;
           for (var x: u32 = 0u; x < ${size}u; x = x + 1u) {
@@ -64,14 +64,14 @@ g.test('many')
     const buffer = createHugeVertexBuffer(t, kSize);
     const module = t.device.createShaderModule({
       code: `
-    @stage(vertex) fn vmain(@location(0) position: vec2<u32>)
+    @vertex fn vmain(@location(0) position: vec2<u32>)
         -> @builtin(position) vec4<f32> {
       let r = vec2<f32>(1.0 / f32(${kSize}));
       let a = 2.0 * r;
       let b = r - vec2<f32>(1.0);
       return vec4<f32>(fma(vec2<f32>(position), a, b), 0.0, 1.0);
     }
-    @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+    @fragment fn fmain() -> @location(0) vec4<f32> {
       return vec4<f32>(1.0, 0.0, 1.0, 1.0);
     }
     `,

--- a/src/stress/shaders/entry_points.spec.ts
+++ b/src/stress/shaders/entry_points.spec.ts
@@ -15,7 +15,7 @@ const makeCode = (numEntryPoints: number) => {
       fn main() { buffer.data = buffer.data + 1u;  }
       `;
   const makeEntryPoint = (i: number) => `
-      @stage(compute) @workgroup_size(1) fn computeMain${i}() { main(); }
+      @compute @workgroup_size(1) fn computeMain${i}() { main(); }
       `;
   return kBaseCode + range(numEntryPoints, makeEntryPoint).join('');
 };

--- a/src/stress/shaders/non_halting.spec.ts
+++ b/src/stress/shaders/non_halting.spec.ts
@@ -21,7 +21,7 @@ device loss.`
       code: `
         struct Buffer { data: u32; };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-        @stage(compute) @workgroup_size(1) fn main() {
+        @compute @workgroup_size(1) fn main() {
           loop {
             if (buffer.data == 1u) {
               break;
@@ -61,7 +61,7 @@ device loss.`
       code: `
         struct Data { counter: u32; increment: u32; };
         @group(0) @binding(0) var<uniform> data: Data;
-        @stage(vertex) fn vmain() -> @builtin(position) vec4<f32> {
+        @vertex fn vmain() -> @builtin(position) vec4<f32> {
           var counter: u32 = data.counter;
           loop {
             if (counter % 2u == 1u) {
@@ -71,7 +71,7 @@ device loss.`
           }
           return vec4<f32>(1.0, 1.0, 0.0, f32(counter));
         }
-        @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+        @fragment fn fmain() -> @location(0) vec4<f32> {
           return vec4<f32>(1.0);
         }
       `,
@@ -133,10 +133,10 @@ device loss.`
       code: `
         struct Data { counter: u32; increment: u32; };
         @group(0) @binding(0) var<uniform> data: Data;
-        @stage(vertex) fn vmain() -> @builtin(position) vec4<f32> {
+        @vertex fn vmain() -> @builtin(position) vec4<f32> {
           return vec4<f32>(0.0, 0.0, 0.0, 1.0);
         }
-        @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+        @fragment fn fmain() -> @location(0) vec4<f32> {
           var counter: u32 = data.counter;
           loop {
             if (counter % 2u == 1u) {

--- a/src/stress/shaders/slow.spec.ts
+++ b/src/stress/shaders/slow.spec.ts
@@ -17,7 +17,7 @@ g.test('compute')
       code: `
         struct Buffer { data: array<u32>; };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-        @stage(compute) @workgroup_size(1) fn main(
+        @compute @workgroup_size(1) fn main(
             @builtin(global_invocation_id) id: vec3<u32>) {
           loop {
             if (buffer.data[id.x] == 1000000u) {
@@ -53,7 +53,7 @@ g.test('vertex')
       code: `
         struct Data { counter: u32; increment: u32; };
         @group(0) @binding(0) var<uniform> data: Data;
-        @stage(vertex) fn vmain() -> @builtin(position) vec4<f32> {
+        @vertex fn vmain() -> @builtin(position) vec4<f32> {
           var counter: u32 = data.counter;
           loop {
             counter = counter + data.increment;
@@ -63,7 +63,7 @@ g.test('vertex')
           }
           return vec4<f32>(1.0, 1.0, 0.0, f32(counter));
         }
-        @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+        @fragment fn fmain() -> @location(0) vec4<f32> {
           return vec4<f32>(1.0, 1.0, 0.0, 1.0);
         }
       `,
@@ -127,10 +127,10 @@ g.test('fragment')
       code: `
         struct Data { counter: u32; increment: u32; };
         @group(0) @binding(0) var<uniform> data: Data;
-        @stage(vertex) fn vmain() -> @builtin(position) vec4<f32> {
+        @vertex fn vmain() -> @builtin(position) vec4<f32> {
           return vec4<f32>(0.0, 0.0, 0.0, 1.0);
         }
-        @stage(fragment) fn fmain() -> @location(0) vec4<f32> {
+        @fragment fn fmain() -> @location(0) vec4<f32> {
           var counter: u32 = data.counter;
           loop {
             counter = counter + data.increment;

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -337,7 +337,7 @@ class F extends GPUTest {
               copyLayer: f32
             };
             @group(0) @binding(0) var<uniform> param: Params;
-            @stage(vertex)
+            @vertex
             fn main(@builtin(vertex_index) VertexIndex : u32)-> @builtin(position) vec4<f32> {
               var depthValue = 0.5 + 0.2 * sin(param.copyLayer);
               var pos : array<vec3<f32>, 6> = array<vec3<f32>, 6>(
@@ -358,7 +358,7 @@ class F extends GPUTest {
       renderPipelineDescriptor.fragment = {
         module: this.device.createShaderModule({
           code: `
-            @stage(fragment)
+            @fragment
             fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(0.0, 1.0, 0.0, 1.0);
             }`,
@@ -1250,7 +1250,7 @@ g.test('copy_multisampled_color')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-            @stage(vertex)
+            @vertex
             fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
               var pos = array<vec2<f32>, 3>(
                   vec2<f32>(-1.0,  1.0),
@@ -1265,7 +1265,7 @@ g.test('copy_multisampled_color')
       fragment: {
         module: t.device.createShaderModule({
           code: `
-            @stage(fragment)
+            @fragment
             fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(0.3, 0.5, 0.8, 1.0);
             }`,
@@ -1313,7 +1313,7 @@ g.test('copy_multisampled_color')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-          @stage(vertex)
+          @vertex
           fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
             var pos = array<vec2<f32>, 6>(
               vec2<f32>(-1.0,  1.0),
@@ -1332,7 +1332,7 @@ g.test('copy_multisampled_color')
           code: `
           @group(0) @binding(0) var sourceTexture : texture_multisampled_2d<f32>;
           @group(0) @binding(1) var destinationTexture : texture_multisampled_2d<f32>;
-          @stage(fragment)
+          @fragment
           fn main(@builtin(position) coord_in: vec4<f32>) -> @location(0) vec4<f32> {
             var coord_in_vec2 = vec2<i32>(i32(coord_in.x), i32(coord_in.y));
             for (var sampleIndex = 0; sampleIndex < ${kSampleCount};
@@ -1426,7 +1426,7 @@ g.test('copy_multisampled_depth')
     const vertexState: GPUVertexState = {
       module: t.device.createShaderModule({
         code: `
-          @stage(vertex)
+          @vertex
           fn main(@builtin(vertex_index) VertexIndex : u32)-> @builtin(position) vec4<f32> {
             var pos : array<vec3<f32>, 6> = array<vec3<f32>, 6>(
                 vec3<f32>(-1.0,  1.0, 0.5),
@@ -1492,7 +1492,7 @@ g.test('copy_multisampled_depth')
       fragment: {
         module: t.device.createShaderModule({
           code: `
-          @stage(fragment)
+          @fragment
           fn main() -> @location(0) vec4<f32> {
             return vec4<f32>(0.0, 1.0, 0.0, 1.0);
           }`,

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -807,7 +807,7 @@ class ImageCopyTest extends GPUTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-            @stage(vertex)
+            @vertex
             fn main(@builtin(vertex_index) VertexIndex : u32)-> @builtin(position) vec4<f32> {
               var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
                   vec2<f32>(-1.0,  1.0),
@@ -829,7 +829,7 @@ class ImageCopyTest extends GPUTest {
               stencilBitIndex: u32
             };
             @group(0) @binding(0) var<uniform> param: Params;
-            @stage(fragment)
+            @fragment
             fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(f32(1u << param.stencilBitIndex) / 255.0, 0.0, 0.0, 0.0);
             }`,
@@ -1015,7 +1015,7 @@ class ImageCopyTest extends GPUTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-          @stage(vertex)
+          @vertex
           fn main(@builtin(vertex_index) VertexIndex : u32)-> @builtin(position) vec4<f32> {
             var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
                 vec2<f32>(-1.0,  1.0),
@@ -1033,7 +1033,7 @@ class ImageCopyTest extends GPUTest {
         module: this.device.createShaderModule({
           code: `
             @group(0) @binding(0) var inputTexture: texture_2d<f32>;
-            @stage(fragment) fn main(@builtin(position) fragcoord : vec4<f32>) ->
+            @fragment fn main(@builtin(position) fragcoord : vec4<f32>) ->
               @builtin(frag_depth) f32 {
               var depthValue : vec4<f32> = textureLoad(inputTexture, vec2<i32>(fragcoord.xy), 0);
               return depthValue.x;

--- a/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
@@ -69,7 +69,7 @@ export class ProgrammableStateTest extends GPUTest {
           @group(${groups.b}) @binding(0) var<storage> b : Data;
           @group(${groups.out}) @binding(0) var<storage, read_write> out : Data;
 
-          @stage(compute) @workgroup_size(1) fn main() {
+          @compute @workgroup_size(1) fn main() {
             out.value = ${algorithm};
             return;
           }
@@ -91,7 +91,7 @@ export class ProgrammableStateTest extends GPUTest {
       case 'render bundle': {
         const wgslShaders = {
           vertex: `
-            @stage(vertex) fn vert_main() -> @builtin(position) vec4<f32> {
+            @vertex fn vert_main() -> @builtin(position) vec4<f32> {
               return vec4<f32>(0.5, 0.5, 0.0, 1.0);
             }
           `,
@@ -105,7 +105,7 @@ export class ProgrammableStateTest extends GPUTest {
             @group(${groups.b}) @binding(0) var<storage> b : Data;
             @group(${groups.out}) @binding(0) var<storage, read_write> out : Data;
 
-            @stage(fragment) fn frag_main() -> @location(0) vec4<f32> {
+            @fragment fn frag_main() -> @location(0) vec4<f32> {
               out.value = ${algorithm};
               return vec4<f32>(1.0, 0.0, 0.0, 1.0);
             }

--- a/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
@@ -23,7 +23,7 @@ class VertexAndIndexStateTrackingTest extends GPUTest {
           @builtin(position) position : vec4<f32>,
           @location(0) color : vec4<f32>,
         };
-        @stage(vertex)
+        @vertex
         fn main(input : Inputs)-> Outputs {
           var outputs : Outputs;
           outputs.position =
@@ -57,7 +57,7 @@ class VertexAndIndexStateTrackingTest extends GPUTest {
         struct Input {
           @location(0) color : vec4<f32>
         };
-        @stage(fragment)
+        @fragment
         fn main(input : Input) -> @location(0) vec4<f32> {
           return input.color;
         }`,
@@ -398,7 +398,7 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
       struct Input {
         @location(0) color : vec4<f32>
       };
-      @stage(fragment)
+      @fragment
       fn main(input : Input) -> @location(0) vec4<f32> {
         return input.color;
       }`,
@@ -421,7 +421,7 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
           @builtin(position) position : vec4<f32>,
           @location(0) color : vec4<f32>,
         };
-        @stage(vertex)
+        @vertex
         fn main(input : Inputs)-> Outputs {
           var outputs : Outputs;
           outputs.position =
@@ -473,7 +473,7 @@ g.test('set_vertex_buffer_but_not_used_in_draw')
           @builtin(position) position : vec4<f32>,
           @location(0) color : vec4<f32>,
         };
-        @stage(vertex)
+        @vertex
         fn main(input : Inputs)-> Outputs {
           var kPositions = array<f32, 2> (0.25, 0.75);
           var outputs : Outputs;

--- a/src/webgpu/api/operation/compute/basic.spec.ts
+++ b/src/webgpu/api/operation/compute/basic.spec.ts
@@ -37,7 +37,7 @@ g.test('memcpy').fn(async t => {
           @group(0) @binding(0) var<storage, read> src : Data;
           @group(0) @binding(1) var<storage, read_write> dst : Data;
 
-          @stage(compute) @workgroup_size(1) fn main() {
+          @compute @workgroup_size(1) fn main() {
             dst.value = src.value;
             return;
           }
@@ -115,7 +115,7 @@ g.test('large_dispatch')
 
             @group(0) @binding(0) var<storage, read_write> dst : OutputBuffer;
 
-            @stage(compute) @workgroup_size(${wgSizes[0]}, ${wgSizes[1]}, ${wgSizes[2]})
+            @compute @workgroup_size(${wgSizes[0]}, ${wgSizes[1]}, ${wgSizes[2]})
             fn main(
               @builtin(global_invocation_id) GlobalInvocationID : vec3<u32>
             ) {

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -128,7 +128,7 @@ export function checkOpsValidForContext(
 }
 
 const kDummyVertexShader = `
-@stage(vertex) fn vert_main() -> @builtin(position) vec4<f32> {
+@vertex fn vert_main() -> @builtin(position) vec4<f32> {
   return vec4<f32>(0.5, 0.5, 0.0, 1.0);
 }
 `;
@@ -321,7 +321,7 @@ export class BufferSyncTest extends GPUTest {
       };
 
       @group(0) @binding(0) var<storage, read_write> data : Data;
-      @stage(compute) @workgroup_size(1) fn main() {
+      @compute @workgroup_size(1) fn main() {
         data.a = ${value}u;
       }
     `;
@@ -367,7 +367,7 @@ export class BufferSyncTest extends GPUTest {
       };
 
       @group(0) @binding(0) var<storage, read_write> data : Data;
-      @stage(fragment) fn frag_main() -> @location(0) vec4<f32> {
+      @fragment fn frag_main() -> @location(0) vec4<f32> {
         data.a = ${value}u;
         return vec4<f32>();  // result does't matter
       }
@@ -506,7 +506,7 @@ export class BufferSyncTest extends GPUTest {
       @group(0) @binding(0) var<storage, read> srcData : Data;
       @group(0) @binding(1) var<storage, read_write> dstData : Data;
 
-      @stage(compute) @workgroup_size(1) fn main() {
+      @compute @workgroup_size(1) fn main() {
         dstData.a = srcData.a;
       }
     `;
@@ -545,7 +545,7 @@ export class BufferSyncTest extends GPUTest {
         @location(0) @interpolate(flat) data : u32,
       };
 
-      @stage(vertex) fn vert_main(@location(0) input: u32) -> VertexOutput {
+      @vertex fn vert_main(@location(0) input: u32) -> VertexOutput {
         var output : VertexOutput;
         output.position = vec4<f32>(0.5, 0.5, 0.0, 1.0);
         output.data = input;
@@ -559,7 +559,7 @@ export class BufferSyncTest extends GPUTest {
 
       @group(0) @binding(0) var<storage, read_write> data : Data;
 
-      @stage(fragment) fn frag_main(@location(0) @interpolate(flat) input : u32) -> @location(0) vec4<f32> {
+      @fragment fn frag_main(@location(0) @interpolate(flat) input : u32) -> @location(0) vec4<f32> {
         data.a = input;
         return vec4<f32>();  // result does't matter
       }
@@ -609,7 +609,7 @@ export class BufferSyncTest extends GPUTest {
       @group(0) @binding(0) var<uniform> constant: Data;
       @group(0) @binding(1) var<storage, read_write> data : Data;
 
-      @stage(fragment) fn frag_main() -> @location(0) vec4<f32> {
+      @fragment fn frag_main() -> @location(0) vec4<f32> {
         data.a = constant.a;
         return vec4<f32>();  // result does't matter
       }
@@ -631,7 +631,7 @@ export class BufferSyncTest extends GPUTest {
         @group(0) @binding(0) var<storage, read> srcData : Data;
         @group(0) @binding(1) var<storage, read_write> dstData : Data;
 
-        @stage(fragment) fn frag_main() -> @location(0) vec4<f32> {
+        @fragment fn frag_main() -> @location(0) vec4<f32> {
           dstData.a = srcData.a;
           return vec4<f32>();  // result does't matter
         }

--- a/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
@@ -38,7 +38,7 @@ const fullscreenQuadWGSL = `
     @builtin(position) Position : vec4<f32>
   };
 
-  @stage(vertex) fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
+  @vertex fn vert_main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
     var pos = array<vec2<f32>, 6>(
         vec2<f32>( 1.0,  1.0),
         vec2<f32>( 1.0, -1.0),
@@ -188,7 +188,7 @@ class TextureSyncTestHelper extends OperationContextHelper {
                 @group(0) @binding(0) var inputTex: texture_2d<f32>;
                 @group(0) @binding(1) var outputTex: texture_storage_2d<rgba8unorm, write>;
 
-                @stage(fragment) fn frag_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
+                @fragment fn frag_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
                   let coord = vec2<i32>(fragCoord.xy);
                   textureStore(outputTex, coord, textureLoad(inputTex, coord, 0));
                   return vec4<f32>();
@@ -240,7 +240,7 @@ class TextureSyncTestHelper extends OperationContextHelper {
                 @group(0) @binding(0) var inputTex: texture_2d<f32>;
                 @group(0) @binding(1) var outputTex: texture_storage_2d<rgba8unorm, write>;
 
-                @stage(compute) @workgroup_size(8, 8)
+                @compute @workgroup_size(8, 8)
                 fn main(@builtin(global_invocation_id) gid : vec3<u32>) {
                   if (any(gid.xy >= vec2<u32>(textureDimensions(inputTex)))) {
                     return;
@@ -455,7 +455,7 @@ class TextureSyncTestHelper extends OperationContextHelper {
 
                 @group(0) @binding(0) var outputTex: texture_storage_2d<rgba8unorm, write>;
 
-                @stage(fragment) fn frag_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
+                @fragment fn frag_main(@builtin(position) fragCoord: vec4<f32>) -> @location(0) vec4<f32> {
                   textureStore(outputTex, vec2<i32>(fragCoord.xy), ${storedValue});
                   return vec4<f32>();
                 }
@@ -505,7 +505,7 @@ class TextureSyncTestHelper extends OperationContextHelper {
               code: `
                 @group(0) @binding(0) var outputTex: texture_storage_2d<rgba8unorm, write>;
 
-                @stage(compute) @workgroup_size(8, 8)
+                @compute @workgroup_size(8, 8)
                 fn main(@builtin(global_invocation_id) gid : vec3<u32>) {
                   if (any(gid.xy >= vec2<u32>(textureDimensions(outputTex)))) {
                     return;

--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -53,7 +53,7 @@ g.test('render_pass_resolve')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-            @stage(vertex) fn main(
+            @vertex fn main(
               @builtin(vertex_index) VertexIndex : u32
               ) -> @builtin(position) vec4<f32> {
               var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
@@ -75,7 +75,7 @@ g.test('render_pass_resolve')
               @location(3) fragColor3 : vec4<f32>,
             };
 
-            @stage(fragment) fn main() -> Output {
+            @fragment fn main() -> Output {
               return Output(
                 vec4<f32>(1.0, 1.0, 1.0, 1.0),
                 vec4<f32>(1.0, 1.0, 1.0, 1.0),

--- a/src/webgpu/api/operation/render_pass/storeop2.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeop2.spec.ts
@@ -31,7 +31,7 @@ TODO: needs review and rename
       vertex: {
         module: t.device.createShaderModule({
           code: `
-            @stage(vertex) fn main(
+            @vertex fn main(
               @builtin(vertex_index) VertexIndex : u32
               ) -> @builtin(position) vec4<f32> {
               var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
@@ -47,7 +47,7 @@ TODO: needs review and rename
       fragment: {
         module: t.device.createShaderModule({
           code: `
-            @stage(fragment) fn main() -> @location(0) vec4<f32> {
+            @fragment fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(1.0, 0.0, 0.0, 1.0);
             }
             `,

--- a/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/culling_tests.spec.ts
@@ -116,7 +116,7 @@ TODO: check the contents of the depth and stencil outputs [2]
         vertex: {
           module: t.device.createShaderModule({
             code: `
-              @stage(vertex) fn main(
+              @vertex fn main(
                 @builtin(vertex_index) VertexIndex : u32
                 ) -> @builtin(position) vec4<f32> {
                 var pos : array<vec2<f32>, 6> = array<vec2<f32>, 6>(
@@ -134,7 +134,7 @@ TODO: check the contents of the depth and stencil outputs [2]
         fragment: {
           module: t.device.createShaderModule({
             code: `
-              @stage(fragment) fn main(
+              @fragment fn main(
                 @builtin(front_facing) FrontFacing : bool
                 ) -> @location(0) vec4<f32> {
                 var color : vec4<f32>;

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -12,7 +12,7 @@ import { TexelView } from '../../../util/texture/texel_view.js';
 import { textureContentIsOKByT2B } from '../../../util/texture/texture_ok.js';
 
 const kVertexShader = `
-@stage(vertex) fn main(
+@vertex fn main(
 @builtin(vertex_index) VertexIndex : u32
 ) -> @builtin(position) vec4<f32> {
   var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(

--- a/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/primitive_topology.spec.ts
@@ -334,7 +334,7 @@ class PrimitiveTopologyTest extends GPUTest {
         vertex: {
           module: this.device.createShaderModule({
             code: `
-              @stage(vertex) fn main(
+              @vertex fn main(
                 @location(0) pos : vec4<f32>
                 ) -> @builtin(position) vec4<f32> {
                 return pos;
@@ -357,7 +357,7 @@ class PrimitiveTopologyTest extends GPUTest {
         fragment: {
           module: this.device.createShaderModule({
             code: `
-              @stage(fragment) fn main() -> @location(0) vec4<f32> {
+              @fragment fn main() -> @location(0) vec4<f32> {
                 return vec4<f32>(0.0, 1.0, 0.0, 1.0);
               }`,
           }),

--- a/src/webgpu/api/operation/rendering/basic.spec.ts
+++ b/src/webgpu/api/operation/rendering/basic.spec.ts
@@ -62,7 +62,7 @@ g.test('fullscreen_quad').fn(async t => {
     vertex: {
       module: t.device.createShaderModule({
         code: `
-        @stage(vertex) fn main(
+        @vertex fn main(
           @builtin(vertex_index) VertexIndex : u32
           ) -> @builtin(position) vec4<f32> {
             var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
@@ -78,7 +78,7 @@ g.test('fullscreen_quad').fn(async t => {
     fragment: {
       module: t.device.createShaderModule({
         code: `
-          @stage(fragment) fn main() -> @location(0) vec4<f32> {
+          @fragment fn main() -> @location(0) vec4<f32> {
             return vec4<f32>(0.0, 1.0, 0.0, 1.0);
           }
           `,
@@ -231,7 +231,7 @@ g.test('large_draw')
 
           @group(0) @binding(0) var<uniform> params: Params;
 
-          @stage(vertex) fn main(
+          @vertex fn main(
               @builtin(vertex_index) v: u32,
               @builtin(instance_index) i: u32)
               -> @builtin(position) vec4<f32> {
@@ -246,7 +246,7 @@ g.test('large_draw')
       fragment: {
         module: t.device.createShaderModule({
           code: `
-            @stage(fragment) fn main() -> @location(0) vec4<f32> {
+            @fragment fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(1.0, 1.0, 0.0, 1.0);
             }
             `,

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -185,7 +185,7 @@ struct Uniform {
 };
 @group(0) @binding(0) var<uniform> u : Uniform;
 
-@stage(fragment) fn main() -> @location(0) vec4<f32> {
+@fragment fn main() -> @location(0) vec4<f32> {
   return u.color;
 }
           `,
@@ -195,7 +195,7 @@ struct Uniform {
       vertex: {
         module: t.device.createShaderModule({
           code: `
-@stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+@vertex fn main() -> @builtin(position) vec4<f32> {
     return vec4<f32>(0.0, 0.0, 0.0, 1.0);
 }
           `,

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -102,7 +102,7 @@ g.test('depth_compare_func')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-            @stage(vertex) fn main(
+            @vertex fn main(
               @builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
               return vec4<f32>(0.5, 0.5, ${kMiddleDepthValue}, 1.0);
             }
@@ -113,7 +113,7 @@ g.test('depth_compare_func')
       fragment: {
         module: t.device.createShaderModule({
           code: `
-            @stage(fragment) fn main() -> @location(0) vec4<f32> {
+            @fragment fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(1.0, 1.0, 1.0, 1.0);
             }
             `,
@@ -200,7 +200,7 @@ g.test('reverse_depth')
               @location(0) color : vec4<f32>,
             };
 
-            @stage(vertex) fn main(
+            @vertex fn main(
               @builtin(vertex_index) VertexIndex : u32,
               @builtin(instance_index) InstanceIndex : u32) -> Output {
               // TODO: remove workaround for Tint unary array access broke
@@ -229,7 +229,7 @@ g.test('reverse_depth')
       fragment: {
         module: t.device.createShaderModule({
           code: `
-            @stage(fragment) fn main(
+            @fragment fn main(
               @location(0) color : vec4<f32>
               ) -> @location(0) vec4<f32> {
               return color;

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -93,7 +93,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
         @location(0) @interpolate(flat) vertexIndex: u32,
       };
 
-      @stage(vertex)
+      @vertex
       fn vtest(@builtin(vertex_index) idx: u32) -> VFTest {
         var vf: VFTest;
         vf.pos = vec4<f32>(vertexX(idx), 0.0, vertexZ(idx), 1.0);
@@ -112,13 +112,13 @@ have unexpected values then get drawn to the color buffer, which is later checke
         output.fragInputZDiff[vf.vertexIndex] = vf.pos.z - expectedFragPosZ(vf.vertexIndex);
       }
 
-      @stage(fragment)
+      @fragment
       fn ftest_WriteDepth(vf: VFTest) -> @builtin(frag_depth) f32 {
         checkZ(vf);
         return kDepths[vf.vertexIndex % ${kNumDepthValues}u];
       }
 
-      @stage(fragment)
+      @fragment
       fn ftest_NoWriteDepth(vf: VFTest) {
         checkZ(vf);
       }
@@ -130,7 +130,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
         @location(0) @interpolate(flat) vertexIndex: u32,
       };
 
-      @stage(vertex)
+      @vertex
       fn vcheck(@builtin(vertex_index) idx: u32) -> VFCheck {
         var vf: VFCheck;
         // Depth=0.5 because we want to render every point, not get clipped.
@@ -144,7 +144,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
         @location(0) color: f32,
       };
 
-      @stage(fragment)
+      @fragment
       fn fcheck(vf: VFCheck) -> FCheck {
         let vertZ = vertexZ(vf.vertexIndex);
         let outOfRange = vertZ < 0.0 || vertZ > 1.0;
@@ -390,7 +390,7 @@ to be empty.`
         @location(0) @interpolate(flat) vertexIndex: u32,
       };
 
-      @stage(vertex)
+      @vertex
       fn vmain(@builtin(vertex_index) idx: u32) -> VF {
         var vf: VF;
         // Depth=0.5 because we want to render every point, not get clipped.
@@ -399,7 +399,7 @@ to be empty.`
         return vf;
       }
 
-      @stage(fragment)
+      @fragment
       fn finit(vf: VF) -> @builtin(frag_depth) f32 {
         // Expected values of the ftest pipeline.
         return clamp(kDepths[vf.vertexIndex], vpMin, vpMax);
@@ -410,7 +410,7 @@ to be empty.`
         @location(0) color: f32,
       };
 
-      @stage(fragment)
+      @fragment
       fn ftest(vf: VF) -> FTest {
         var f: FTest;
         f.depth = kDepths[vf.vertexIndex]; // Should get clamped to the viewport.

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -91,7 +91,7 @@ struct Inputs {
   @location(0) vertexPosition : vec2<f32>,
 };
 
-@stage(vertex) fn vert_main(input : Inputs
+@vertex fn vert_main(input : Inputs
   ) -> @builtin(position) vec4<f32> {
   // 3u is the number of points in a triangle to convert from index
   // to id.
@@ -116,7 +116,7 @@ struct Output {
 
 @group(0) @binding(0) var<storage, read_write> output : Output;
 
-@stage(fragment) fn frag_main() -> @location(0) vec4<f32> {
+@fragment fn frag_main() -> @location(0) vec4<f32> {
   output.value = 1u;
   return vec4<f32>(0.0, 1.0, 0.0, 1.0);
 }
@@ -537,7 +537,7 @@ ${interStageScalarShaderLocations
 ${accumulateVariableDeclarationsInVertexShader}
 };
 
-@stage(vertex) fn main(input : Inputs) -> Outputs {
+@vertex fn main(input : Inputs) -> Outputs {
   var output : Outputs;
 ${interStageScalarShaderLocations.map(i => `  output.outAttrib${i} = input.attrib${i};`).join('\n')}
 ${accumulateVariableAssignmentsInVertexShader}
@@ -570,7 +570,7 @@ struct OutBuffer {
 };
 @group(0) @binding(0) var<storage, read_write> outBuffer : OutBuffer;
 
-@stage(fragment) fn main(input : Inputs) {
+@fragment fn main(input : Inputs) {
 ${interStageScalarShaderLocations
   .map(i => `  outBuffer.primitives[input.primitiveId].attrib${i} = input.attrib${i};`)
   .join('\n')}

--- a/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
@@ -172,7 +172,7 @@ Params:
       layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
-          code: `@stage(vertex) fn main(@location(0) pos : vec2<f32>) -> @builtin(position) vec4<f32> {
+          code: `@vertex fn main(@location(0) pos : vec2<f32>) -> @builtin(position) vec4<f32> {
               return vec4<f32>(pos, 0.0, 1.0);
           }`,
         }),
@@ -192,7 +192,7 @@ Params:
       },
       fragment: {
         module: t.device.createShaderModule({
-          code: `@stage(fragment) fn main() -> @location(0) vec4<f32> {
+          code: `@fragment fn main() -> @location(0) vec4<f32> {
             return vec4<f32>(0.0, 1.0, 0.0, 1.0);
         }`,
         }),

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -103,7 +103,7 @@ class F extends GPUTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-        @stage(fragment)
+        @fragment
         fn main(@location(0) i_color : vec4<f32>) -> @location(0) vec4<f32> {
             return i_color;
         }`,
@@ -514,7 +514,7 @@ g.test('uniform_buffer')
   @group(0) @binding(0) var<uniform> ubo : UBO;
   @group(0) @binding(1) var outImage : texture_storage_2d<rgba8unorm, write>;
 
-  @stage(compute) @workgroup_size(1) fn main() {
+  @compute @workgroup_size(1) fn main() {
       if (all(ubo.value == vec4<u32>(0u, 0u, 0u, 0u))) {
           textureStore(outImage, vec2<i32>(0, 0), vec4<f32>(0.0, 1.0, 0.0, 1.0));
       } else {
@@ -549,7 +549,7 @@ g.test('readonly_storage_buffer')
     @group(0) @binding(0) var<storage, read> ssbo : SSBO;
     @group(0) @binding(1) var outImage : texture_storage_2d<rgba8unorm, write>;
 
-    @stage(compute) @workgroup_size(1) fn main() {
+    @compute @workgroup_size(1) fn main() {
         if (all(ssbo.value == vec4<u32>(0u, 0u, 0u, 0u))) {
             textureStore(outImage, vec2<i32>(0, 0), vec4<f32>(0.0, 1.0, 0.0, 1.0));
         } else {
@@ -584,7 +584,7 @@ g.test('storage_buffer')
     @group(0) @binding(0) var<storage, read_write> ssbo : SSBO;
     @group(0) @binding(1) var outImage : texture_storage_2d<rgba8unorm, write>;
 
-    @stage(compute) @workgroup_size(1) fn main() {
+    @compute @workgroup_size(1) fn main() {
         if (all(ssbo.value == vec4<u32>(0u, 0u, 0u, 0u))) {
             textureStore(outImage, vec2<i32>(0, 0), vec4<f32>(0.0, 1.0, 0.0, 1.0));
         } else {
@@ -614,7 +614,7 @@ g.test('vertex_buffer')
         @builtin(position) position : vec4<f32>,
       };
 
-      @stage(vertex) fn main(@location(0) pos : vec4<f32>) -> VertexOut {
+      @vertex fn main(@location(0) pos : vec4<f32>) -> VertexOut {
         var output : VertexOut;
         if (all(pos == vec4<f32>(0.0, 0.0, 0.0, 0.0))) {
           output.color = vec4<f32>(0.0, 1.0, 0.0, 1.0);
@@ -677,7 +677,7 @@ GPUBuffer, all the contents in that GPUBuffer have been initialized to 0.`
       @builtin(position) position : vec4<f32>,
     };
 
-    @stage(vertex)
+    @vertex
     fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOut {
       var output : VertexOut;
       if (VertexIndex == 0u) {
@@ -745,7 +745,7 @@ have been initialized to 0.`
       @builtin(position) position : vec4<f32>,
     };
 
-    @stage(vertex) fn main() -> VertexOut {
+    @vertex fn main() -> VertexOut {
       var output : VertexOut;
       output.color = vec4<f32>(1.0, 0.0, 0.0, 1.0);
       output.position = vec4<f32>(0.0, 0.0, 0.0, 1.0);
@@ -822,7 +822,7 @@ g.test('indirect_buffer_for_dispatch_indirect')
           code: `
         @group(0) @binding(0) var outImage : texture_storage_2d<rgba8unorm, write>;
 
-        @stage(compute) @workgroup_size(1) fn main() {
+        @compute @workgroup_size(1) fn main() {
           textureStore(outImage, vec2<i32>(0, 0), vec4<f32>(1.0, 0.0, 0.0, 1.0));
         }`,
         }),

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -7,7 +7,7 @@ import { CheckContents } from '../texture_zero.spec.js';
 function makeFullscreenVertexModule(device: GPUDevice) {
   return device.createShaderModule({
     code: `
-    @stage(vertex)
+    @vertex
     fn main(@builtin(vertex_index) VertexIndex : u32)
          -> @builtin(position) vec4<f32> {
       var pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
@@ -41,7 +41,7 @@ function getDepthTestEqualPipeline(
           @location(0) outSuccess : f32,
         };
 
-        @stage(fragment)
+        @fragment
         fn main() -> Outputs {
           var output : Outputs;
           output.FragDepth = f32(${expected});
@@ -76,7 +76,7 @@ function getStencilTestEqualPipeline(
       entryPoint: 'main',
       module: t.device.createShaderModule({
         code: `
-        @stage(fragment)
+        @fragment
         fn main() -> @location(0) f32 {
           return 1.0;
         }

--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -69,7 +69,7 @@ export const checkContentsBySampling: CheckContents = (
             };
             @group(0) @binding(3) var<storage, read_write> result : Result;
 
-            @stage(compute) @workgroup_size(1)
+            @compute @workgroup_size(1)
             fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
               let flatIndex : u32 = ${componentCount}u * (
                 ${width}u * ${height}u * GlobalInvocationID.z +

--- a/src/webgpu/api/operation/sampling/anisotropy.spec.ts
+++ b/src/webgpu/api/operation/sampling/anisotropy.spec.ts
@@ -64,7 +64,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
               @location(0) fragUV : vec2<f32>,
             };
 
-            @stage(vertex) fn main(
+            @vertex fn main(
               @builtin(vertex_index) VertexIndex : u32) -> Outputs {
               var position : array<vec3<f32>, 6> = array<vec3<f32>, 6>(
                 vec3<f32>(-0.5, 0.5, -0.5),
@@ -103,7 +103,7 @@ class SamplerAnisotropicFilteringSlantedPlaneTest extends GPUTest {
             @group(0) @binding(0) var sampler0 : sampler;
             @group(0) @binding(1) var texture0 : texture_2d<f32>;
 
-            @stage(fragment) fn main(
+            @fragment fn main(
               @builtin(position) FragCoord : vec4<f32>,
               @location(0) fragUV: vec2<f32>)
               -> @location(0) vec4<f32> {

--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -13,7 +13,7 @@ const kValidShaderSources = [
     valid: true,
     unicode: false,
     _code: `
-      @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+      @vertex fn main() -> @builtin(position) vec4<f32> {
         return vec4<f32>(0.0, 0.0, 0.0, 1.0);
       }`,
   },
@@ -22,7 +22,7 @@ const kValidShaderSources = [
     unicode: true,
     _code: `
       // 頂点シェーダー 👩‍💻
-      @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+      @vertex fn main() -> @builtin(position) vec4<f32> {
         return vec4<f32>(0.0, 0.0, 0.0, 1.0);
       }`,
   },
@@ -34,7 +34,7 @@ const kInvalidShaderSources = [
     unicode: false,
     _errorLine: 4,
     _code: `
-      @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+      @vertex fn main() -> @builtin(position) vec4<f32> {
         // Expected Error: unknown function 'unknown'
         return unknown(0.0, 0.0, 0.0, 1.0);
       }`,
@@ -45,7 +45,7 @@ const kInvalidShaderSources = [
     _errorLine: 5,
     _code: `
       // 頂点シェーダー 👩‍💻
-      @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+      @vertex fn main() -> @builtin(position) vec4<f32> {
         // Expected Error: unknown function 'unknown'
         return unknown(0.0, 0.0, 0.0, 1.0);
       }`,

--- a/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
+++ b/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
@@ -51,7 +51,7 @@ function makeBlitPipeline(
     vertex: {
       module: device.createShaderModule({
         code: `
-          @stage(vertex) fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
+          @vertex fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
             var pos = array<vec2<f32>, 6>(
                                         vec2<f32>(-1.0, -1.0),
                                         vec2<f32>(-1.0,  1.0),
@@ -70,7 +70,7 @@ function makeBlitPipeline(
           ? device.createShaderModule({
               code: `
             @group(0) @binding(0) var src: texture_multisampled_2d<f32>;
-            @stage(fragment) fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+            @fragment fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
               var result : vec4<f32>;
               for (var i = 0; i < ${multisample.sample}; i = i + 1) {
                 result = result + textureLoad(src, vec2<i32>(coord.xy), i);
@@ -81,7 +81,7 @@ function makeBlitPipeline(
           : device.createShaderModule({
               code: `
             @group(0) @binding(0) var src: texture_2d<f32>;
-            @stage(fragment) fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
+            @fragment fn main(@builtin(position) coord: vec4<f32>) -> @location(0) vec4<f32> {
               return textureLoad(src, vec2<i32>(coord.xy), 0);
             }`,
             }),
@@ -130,7 +130,7 @@ g.test('texture_binding')
           code: `
           @group(0) @binding(0) var src: texture_2d<f32>;
           @group(0) @binding(1) var dst: texture_storage_2d<rgba8unorm, write>;
-          @stage(compute) @workgroup_size(1, 1) fn main(
+          @compute @workgroup_size(1, 1) fn main(
             @builtin(global_invocation_id) global_id: vec3<u32>,
           ) {
             var coord = vec2<i32>(global_id.xy);

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -186,7 +186,7 @@ struct VSOutputs {
   @builtin(position) position : vec4<f32>,
 };
 
-@stage(vertex) fn vsMain(input : Inputs) -> VSOutputs {
+@vertex fn vsMain(input : Inputs) -> VSOutputs {
   doTest(input);
 
   // Place that point at pixel (vertexIndex, instanceIndex) in a framebuffer of size
@@ -201,7 +201,7 @@ struct VSOutputs {
   return output;
 }
 
-@stage(fragment) fn fsMain(@location(0) @interpolate(flat) result : i32)
+@fragment fn fsMain(@location(0) @interpolate(flat) result : i32)
   -> @location(0) i32 {
   return result;
 }

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -57,7 +57,7 @@ class IndexFormatTest extends GPUTest {
       // NOTE: These positions will create triangles that cut right through pixel centers. If this
       // results in different rasterization results on different hardware, tweak to avoid this.
       code: `
-        @stage(vertex)
+        @vertex
         fn main(@builtin(vertex_index) VertexIndex : u32)
              -> @builtin(position) vec4<f32> {
           var pos = array<vec2<f32>, 4>(
@@ -76,7 +76,7 @@ class IndexFormatTest extends GPUTest {
 
     const fragmentModule = this.device.createShaderModule({
       code: `
-        @stage(fragment)
+        @fragment
         fn main() -> @location(0) u32 {
           return 1u;
         }

--- a/src/webgpu/api/validation/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/attachment_compatibility.spec.ts
@@ -143,7 +143,7 @@ class F extends ValidationTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-            @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+            @vertex fn main() -> @builtin(position) vec4<f32> {
               return vec4<f32>(0.0, 0.0, 0.0, 0.0);
             }`,
         }),
@@ -151,7 +151,7 @@ class F extends ValidationTest {
       },
       fragment: {
         module: this.device.createShaderModule({
-          code: '@stage(fragment) fn main() {}',
+          code: '@fragment fn main() {}',
         }),
         entryPoint: 'main',
         targets,

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -122,7 +122,7 @@ g.test('color_target_state')
         vertex: {
           module: t.device.createShaderModule({
             code: `
-              @stage(vertex)
+              @vertex
               fn main()-> @builtin(position) vec4<f32> {
                 return vec4<f32>(0.0, 0.0, 0.0, 1.0);
               }`,
@@ -132,7 +132,7 @@ g.test('color_target_state')
         fragment: {
           module: t.device.createShaderModule({
             code: `
-              @stage(fragment)
+              @fragment
               fn main() -> @location(0) vec4<f32> {
                 return vec4<f32>(0.0, 1.0, 0.0, 1.0);
               }`,
@@ -178,7 +178,7 @@ g.test('depth_stencil_state')
         vertex: {
           module: t.device.createShaderModule({
             code: `
-              @stage(vertex)
+              @vertex
               fn main()-> @builtin(position) vec4<f32> {
                 return vec4<f32>(0.0, 0.0, 0.0, 1.0);
               }`,
@@ -191,7 +191,7 @@ g.test('depth_stencil_state')
         fragment: {
           module: t.device.createShaderModule({
             code: `
-              @stage(fragment)
+              @fragment
               fn main() -> @location(0) vec4<f32> {
                 return vec4<f32>(0.0, 1.0, 0.0, 1.0);
               }`,

--- a/src/webgpu/api/validation/createComputePipeline.spec.ts
+++ b/src/webgpu/api/validation/createComputePipeline.spec.ts
@@ -16,19 +16,19 @@ class F extends ValidationTest {
     let code;
     switch (shaderStage) {
       case 'compute': {
-        code = `@stage(compute) @workgroup_size(1) fn ${entryPoint}() {}`;
+        code = `@compute @workgroup_size(1) fn ${entryPoint}() {}`;
         break;
       }
       case 'vertex': {
         code = `
-        @stage(vertex) fn ${entryPoint}() -> @builtin(position) vec4<f32> {
+        @vertex fn ${entryPoint}() -> @builtin(position) vec4<f32> {
           return vec4<f32>(0.0, 0.0, 0.0, 1.0);
         }`;
         break;
       }
       case 'fragment': {
         code = `
-        @stage(fragment) fn ${entryPoint}() -> @location(0) vec4<i32> {
+        @fragment fn ${entryPoint}() -> @location(0) vec4<i32> {
           return vec4<i32>(0, 1, 0, 1);
         }`;
         break;
@@ -217,7 +217,7 @@ g.test('shader_module,device_mismatch')
     const device = mismatched ? t.mismatchedDevice : t.device;
 
     const module = device.createShaderModule({
-      code: '@stage(compute) @workgroup_size(1) fn main() {}',
+      code: '@compute @workgroup_size(1) fn main() {}',
     });
 
     const descriptor = {

--- a/src/webgpu/api/validation/createRenderPipeline.spec.ts
+++ b/src/webgpu/api/validation/createRenderPipeline.spec.ts
@@ -74,7 +74,7 @@ class F extends ValidationTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-            @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+            @vertex fn main() -> @builtin(position) vec4<f32> {
               return vec4<f32>(0.0, 0.0, 0.0, 1.0);
             }`,
         }),
@@ -694,7 +694,7 @@ g.test('pipeline_layout,device_mismatch')
       vertex: {
         module: t.device.createShaderModule({
           code: `
-        @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+        @vertex fn main() -> @builtin(position) vec4<f32> {
           return vec4<f32>(0.0, 0.0, 0.0, 1.0);
         }
       `,
@@ -731,7 +731,7 @@ g.test('shader_module,device_mismatch')
     const { isAsync, vertex_mismatched, fragment_mismatched, _success } = t.params;
 
     const code = `
-      @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+      @vertex fn main() -> @builtin(position) vec4<f32> {
         return vec4<f32>(0.0, 0.0, 0.0, 1.0);
       }
     `;

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -76,7 +76,7 @@ g.test('pipeline,device_mismatch')
       layout: 'auto',
       compute: {
         module: device.createShaderModule({
-          code: '@stage(compute) @workgroup_size(1) fn main() {}',
+          code: '@compute @workgroup_size(1) fn main() {}',
         }),
         entryPoint: 'main',
       },

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -16,7 +16,7 @@ class F extends ValidationTest {
       vertex: {
         module: this.device.createShaderModule({
           code: `
-            @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+            @vertex fn main() -> @builtin(position) vec4<f32> {
               return vec4<f32>(0.0, 0.0, 0.0, 1.0);
             }`,
         }),
@@ -25,7 +25,7 @@ class F extends ValidationTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            @stage(fragment) fn main() -> @location(0) vec4<f32> {
+            @fragment fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(0.0, 1.0, 0.0, 1.0);
             }`,
         }),

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -42,13 +42,13 @@ g.test('pipeline,device_mismatch')
       layout: 'auto',
       vertex: {
         module: device.createShaderModule({
-          code: `@stage(vertex) fn main() -> @builtin(position) vec4<f32> { return vec4<f32>(); }`,
+          code: `@vertex fn main() -> @builtin(position) vec4<f32> { return vec4<f32>(); }`,
         }),
         entryPoint: 'main',
       },
       fragment: {
         module: device.createShaderModule({
-          code: '@stage(fragment) fn main() {}',
+          code: '@fragment fn main() {}',
         }),
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm', writeMask: 0 }],

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -23,7 +23,7 @@ class F extends ValidationTest {
             struct Inputs {
             ${range(bufferCount, i => `\n@location(${i}) a_position${i} : vec3<f32>,`).join('')}
             };
-            @stage(vertex) fn main(input : Inputs
+            @vertex fn main(input : Inputs
               ) -> @builtin(position) vec4<f32> {
               return vec4<f32>(0.0, 0.0, 0.0, 1.0);
             }`,
@@ -43,7 +43,7 @@ class F extends ValidationTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            @stage(fragment) fn main() -> @location(0) vec4<f32> {
+            @fragment fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(0.0, 1.0, 0.0, 1.0);
             }`,
         }),

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -83,11 +83,11 @@ class F extends ValidationTest {
     bindGroups: Array<Array<GPUBindGroupLayoutEntry>>
   ): GPURenderPipeline {
     const shader = `
-      @stage(vertex) fn vs_main() -> @builtin(position) vec4<f32> {
+      @vertex fn vs_main() -> @builtin(position) vec4<f32> {
         return vec4<f32>(1.0, 1.0, 0.0, 1.0);
       }
 
-      @stage(fragment) fn fs_main() -> @location(0) vec4<f32> {
+      @fragment fn fs_main() -> @location(0) vec4<f32> {
         return vec4<f32>(0.0, 1.0, 0.0, 1.0);
       }
     `;
@@ -114,7 +114,7 @@ class F extends ValidationTest {
     bindGroups: Array<Array<GPUBindGroupLayoutEntry>>
   ): GPUComputePipeline {
     const shader = `
-      @stage(compute) @workgroup_size(1)
+      @compute @workgroup_size(1)
         fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
       }
     `;

--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -109,7 +109,7 @@ export class BufferResourceUsageTest extends ValidationTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-              @stage(fragment) fn main()
+              @fragment fn main()
                 -> @location(0) vec4<f32> {
                   return vec4<f32>(0.0, 0.0, 0.0, 1.0);
               }`,

--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -1058,7 +1058,7 @@ g.test('unused_bindings_in_pipeline')
       format: 'rgba8unorm',
     });
 
-    const wgslVertex = `@stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+    const wgslVertex = `@vertex fn main() -> @builtin(position) vec4<f32> {
   return vec4<f32>();
 }`;
     const wgslFragment = pp`
@@ -1068,7 +1068,7 @@ g.test('unused_bindings_in_pipeline')
       ${pp._if(useBindGroup1)}
       @group(1) @binding(0) var image1 : texture_storage_2d<rgba8unorm, write>;
       ${pp._endif}
-      @stage(fragment) fn main() {}
+      @fragment fn main() {}
     `;
 
     const wgslCompute = pp`
@@ -1078,7 +1078,7 @@ g.test('unused_bindings_in_pipeline')
       ${pp._if(useBindGroup1)}
       @group(1) @binding(0) var image1 : texture_storage_2d<rgba8unorm, write>;
       ${pp._endif}
-      @stage(compute) @workgroup_size(1) fn main() {}
+      @compute @workgroup_size(1) fn main() {}
     `;
 
     const pipeline = compute

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -248,7 +248,7 @@ g.test('subresources,set_unused_bind_group')
           module: t.device.createShaderModule({
             code: `
               @group(0) @binding(0) var texture0 : texture_2d_array<f32>;
-              @stage(fragment) fn main()
+              @fragment fn main()
                 -> @location(0) vec4<f32> {
                   return textureLoad(texture0, vec2<i32>(), 0, 0);
               }`,
@@ -279,7 +279,7 @@ g.test('subresources,set_unused_bind_group')
           module: t.device.createShaderModule({
             code: `
             @group(0) @binding(0) var texture0 : texture_storage_2d_array<rgba8unorm, write>;
-            @stage(compute) @workgroup_size(1)
+            @compute @workgroup_size(1)
             fn main() {
               textureStore(texture0, vec2<i32>(), 0, vec4<f32>());
             }`,

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -299,14 +299,14 @@ export class ValidationTest extends GPUTest {
     switch (stage) {
       case 'VERTEX':
         return `
-          @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+          @vertex fn main() -> @builtin(position) vec4<f32> {
             return vec4<f32>();
           }
         `;
       case 'FRAGMENT':
-        return `@stage(fragment) fn main() {}`;
+        return `@fragment fn main() {}`;
       case 'COMPUTE':
-        return `@stage(compute) @workgroup_size(1) fn main() {}`;
+        return `@compute @workgroup_size(1) fn main() {}`;
     }
   }
 

--- a/src/webgpu/api/validation/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/vertex_state.spec.ts
@@ -12,7 +12,7 @@ import {
 import { ValidationTest } from './validation_test.js';
 
 const VERTEX_SHADER_CODE_WITH_NO_INPUT = `
-  @stage(vertex) fn main() -> @builtin(position) vec4<f32> {
+  @vertex fn main() -> @builtin(position) vec4<f32> {
     return vec4<f32>(0.0, 0.0, 0.0, 0.0);
   }
 `;
@@ -71,7 +71,7 @@ class F extends ValidationTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            @stage(fragment) fn main() -> @location(0) vec4<f32> {
+            @fragment fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(0.0, 1.0, 0.0, 1.0);
             }`,
         }),
@@ -91,7 +91,7 @@ class F extends ValidationTest {
     const vsModule = this.device.createShaderModule({ code: vertexShader });
     const fsModule = this.device.createShaderModule({
       code: `
-        @stage(fragment) fn main() -> @location(0) vec4<f32> {
+        @fragment fn main() -> @location(0) vec4<f32> {
           return vec4<f32>(0.0, 1.0, 0.0, 1.0);
         }`,
     });
@@ -129,7 +129,7 @@ class F extends ValidationTest {
       struct Inputs {
         ${interfaces}
       };
-      @stage(vertex) fn main(input : Inputs) -> @builtin(position) vec4<f32> {
+      @vertex fn main(input : Inputs) -> @builtin(position) vec4<f32> {
         ${body}
         return vec4<f32>(0.0, 0.0, 0.0, 0.0);
       }

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -447,7 +447,7 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
     @group(0) @binding(0) var<storage, read> expected: Buffer;
     @group(0) @binding(1) var<storage, read> in: Buffer;
     @group(0) @binding(2) var<storage, read_write> out: Buffer;
-    @stage(compute) @workgroup_size(1) fn reduce(
+    @compute @workgroup_size(1) fn reduce(
         @builtin(global_invocation_id) id: vec3<u32>) {
       let rowBaseIndex = id.x * ${bytesPerRow / 4}u;
       let readSize = ${expectedDataSize / 4}u;

--- a/src/webgpu/shader/execution/evaluation_order.spec.ts
+++ b/src/webgpu/shader/execution/evaluation_order.spec.ts
@@ -418,7 +418,7 @@ fn test_body() -> i32 {
 
 @group(0) @binding(0) var<storage, write> output : i32;
 
-@stage(compute) @workgroup_size(1)
+@compute @workgroup_size(1)
 fn main() {
   output = test_body();
 }

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -203,7 +203,7 @@ ${
 }
 @group(0) @binding(1) var<storage, write> outputs : array<Output, ${cases.length}>;
 
-@stage(compute) @workgroup_size(1)
+@compute @workgroup_size(1)
 fn main() {
   for(var i = 0; i < ${cases.length}; i = i + 1) {
     outputs[i].value = ${expr};

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -764,7 +764,7 @@ const testShaderFunctions = `
 const shaderEntryPoint = `
   // Change to pipeline overridable constant when possible.
   let workgroupXSize = 256u;
-  @stage(compute) @workgroup_size(workgroupXSize) fn main(
+  @compute @workgroup_size(workgroupXSize) fn main(
     @builtin(local_invocation_id) local_invocation_id : vec3<u32>,
     @builtin(workgroup_id) workgroup_id : vec3<u32>) {
 `;

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -53,7 +53,7 @@ function runShaderTest(
 
     ${testSource}
 
-    @stage(compute) @workgroup_size(1)
+    @compute @workgroup_size(1)
     fn main() {
       _ = constants.zero; // Ensure constants buffer is statically-accessed
       result.value = runTest();

--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -370,7 +370,7 @@ class F extends GPUTest {
         ${typeInfo.validationFunc}
       }
 
-      @stage(vertex) fn main(
+      @vertex fn main(
         @builtin(vertex_index) VertexIndex : u32,
         attributes : Attributes
         ) -> @builtin(position) vec4<f32> {
@@ -435,7 +435,7 @@ class F extends GPUTest {
       fragment: {
         module: this.device.createShaderModule({
           code: `
-            @stage(fragment) fn main() -> @location(0) vec4<f32> {
+            @fragment fn main() -> @location(0) vec4<f32> {
               return vec4<f32>(1.0, 0.0, 0.0, 1.0);
             }`,
         }),

--- a/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
+++ b/src/webgpu/shader/execution/sampling/gradients_in_varying_loop.spec.ts
@@ -47,7 +47,7 @@ class DerivativesTest extends GPUTest {
               @location(0) fragUV : vec2<f32>,
             };
 
-            @stage(vertex) fn main(
+            @vertex fn main(
               @builtin(vertex_index) VertexIndex : u32) -> Outputs {
               // Full screen quad
               var position : array<vec3<f32>, 6> = array<vec3<f32>, 6>(
@@ -87,7 +87,7 @@ class DerivativesTest extends GPUTest {
             };
             @binding(0) @group(0) var<uniform> uniforms : Uniforms;
 
-            @stage(fragment) fn main(
+            @fragment fn main(
               @builtin(position) FragCoord : vec4<f32>,
               @location(0) fragUV: vec2<f32>) -> @location(0) vec4<f32> {
 

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -116,7 +116,7 @@ g.test('inputs')
       let group_height = ${t.params.groupSize.y}u;
       let group_depth = ${t.params.groupSize.z}u;
 
-      @stage(compute) @workgroup_size(group_width, group_height, group_depth)
+      @compute @workgroup_size(group_width, group_height, group_depth)
       fn main(
         ${params}
         ) {

--- a/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/shared_structs.spec.ts
@@ -37,7 +37,7 @@ g.test('shared_with_buffer')
       @group(0) @binding(0)
       var<storage, read_write> outputs : S;
 
-      @stage(compute) @workgroup_size(${wgsize[0]}, ${wgsize[1]}, ${wgsize[2]})
+      @compute @workgroup_size(${wgsize[0]}, ${wgsize[1]}, ${wgsize[2]})
       fn main(inputs : S) {
         if (inputs.group_id.x == ${targetGroup[0]}u &&
             inputs.group_id.y == ${targetGroup[1]}u &&
@@ -129,12 +129,12 @@ g.test('shared_between_stages')
         vec2<f32>( 0.7, -0.7),
       );
 
-      @stage(vertex)
+      @vertex
       fn vert_main(@builtin(vertex_index) index : u32) -> Interface {
         return Interface(vec4<f32>(vertices[index], 0.0, 1.0), 1.0);
       }
 
-      @stage(fragment)
+      @fragment
       fn frag_main(inputs : Interface) -> @location(0) vec4<f32> {
         // Toggle red vs green based on the x position.
         var color = vec4<f32>(0.0, 0.0, 0.0, 1.0);
@@ -257,12 +257,12 @@ g.test('shared_with_non_entry_point_function')
         return out;
       }
 
-      @stage(vertex)
+      @vertex
       fn vert_main(inputs : Inputs) -> Outputs {
         return process(inputs);
       }
 
-      @stage(fragment)
+      @fragment
       fn frag_main(@location(0) color : vec4<f32>) -> @location(0) vec4<f32> {
         return color;
       }

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -389,7 +389,7 @@ g.test('compute,zero_init')
 
     const wgsl = `
       ${moduleScope}
-      @stage(compute) @workgroup_size(${t.params.workgroupSize})
+      @compute @workgroup_size(${t.params.workgroupSize})
       fn main() {
         ${functionScope}
         ${checkZeroCode}

--- a/src/webgpu/shader/validation/parse/comments.spec.ts
+++ b/src/webgpu/shader/validation/parse/comments.spec.ts
@@ -15,7 +15,7 @@ g.test('comments')
  * /* I can nest /**/ comments. */
  * // I can nest line comments too.
  **/
-@stage(fragment) // This is the stage
+@fragment // This is the stage
 fn main(/*
 no
 parameters

--- a/src/webgpu/shader/validation/parse/source.spec.ts
+++ b/src/webgpu/shader/validation/parse/source.spec.ts
@@ -9,7 +9,7 @@ g.test('valid_source')
   .desc(`Tests that a valid source is consumed successfully.`)
   .fn(t => {
     const code = `
-    @stage(fragment)
+    @fragment
     fn main() -> @location(0) vec4<f32> {
       return vec4<f32>(.4, .2, .3, .1);
     }`;

--- a/src/webgpu/shader/validation/parse/var_and_let.spec.ts
+++ b/src/webgpu/shader/validation/parse/var_and_let.spec.ts
@@ -61,7 +61,7 @@ g.test('initializer_type')
     const { variableOrConstant, lhsType, rhsType } = t.params;
 
     const code = `
-      @stage(fragment)
+      @fragment
       fn main() {
         ${variableOrConstant} a : ${lhsType} = ${rhsType}();
       }

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -209,7 +209,7 @@ g.test('duplicates')
       ${ra} a : u32,
       ${rb} b : u32,
     };
-    @stage(fragment)
+    @fragment
     fn main(${p1} p1 : u32,
             ${p2} p2 : u32,
             s1 : S1,
@@ -241,7 +241,7 @@ g.test('missing_vertex_position')
       ${t.params.attribute} value : vec4<f32>
     };
 
-    @stage(vertex)
+    @vertex
     fn main() -> ${t.params.use_struct ? 'S' : `${t.params.attribute} vec4<f32>`} {
       return ${t.params.use_struct ? 'S' : 'vec4<f32>'}();
     }

--- a/src/webgpu/shader/validation/shader_io/entry_point.ts
+++ b/src/webgpu/shader/validation/shader_io/entry_point.ts
@@ -15,20 +15,20 @@ g.test('missing_attribute_on_param')
     const fragment_attr = t.params.target_stage === 'fragment' ? '' : '@location(1)';
     const compute_attr = t.params.target_stage === 'compute' ? '' : '@builtin(workgroup_id)';
     const code = `
-@stage(vertex)
+@vertex
 fn vert_main(@location(0) a : f32,
              ${vertex_attr}  b : f32,
 @             location(2) c : f32) -> @builtin(position) vec4<f32> {
   return vec4<f32>();
 }
 
-@stage(fragment)
+@fragment
 fn frag_main(@location(0)  a : f32,
              ${fragment_attr} b : f32,
 @             location(2)  c : f32) {
 }
 
-@stage(compute) @workgroup_size(1)
+@compute @workgroup_size(1)
 fn comp_main(@builtin(global_invocation_id) a : vec3<u32>,
              ${compute_attr}                   b : vec3<u32>,
              @builtin(local_invocation_id)  c : vec3<u32>) {
@@ -65,16 +65,16 @@ struct ComputeInputs {
   @builtin(local_invocation_id)  c : vec3<u32>,
 };
 
-@stage(vertex)
+@vertex
 fn vert_main(inputs : VertexInputs) -> @builtin(position) vec4<f32> {
   return vec4<f32>();
 }
 
-@stage(fragment)
+@fragment
 fn frag_main(inputs : FragmentInputs) {
 }
 
-@stage(compute) @workgroup_size(1)
+@compute @workgroup_size(1)
 fn comp_main(inputs : ComputeInputs) {
 }
 `;
@@ -88,12 +88,12 @@ g.test('missing_attribute_on_return_type')
     const vertex_attr = t.params.target_stage === 'vertex' ? '' : '@builtin(position)';
     const fragment_attr = t.params.target_stage === 'fragment' ? '' : '@location(0)';
     const code = `
-@stage(vertex)
+@vertex
 fn vert_main() -> ${vertex_attr} vec4<f32> {
   return vec4<f32>();
 }
 
-@stage(fragment)
+@fragment
 fn frag_main() -> ${fragment_attr} vec4<f32> {
   return vec4<f32>();
 }
@@ -121,12 +121,12 @@ struct FragmentOutputs {
 @  location(2)  c : f32,
 };
 
-@stage(vertex)
+@vertex
 fn vert_main() -> VertexOutputs {
   return VertexOutputs();
 }
 
-@stage(fragment)
+@fragment
 fn frag_main() -> FragmentOutputs {
   return FragmentOutputs();
 }

--- a/src/webgpu/shader/validation/shader_io/invariant.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/invariant.spec.ts
@@ -38,7 +38,7 @@ g.test('not_valid_on_user_defined_io')
       @location(0) ${invariant} loc0 : vec4<f32>,
       @builtin(position) position : vec4<f32>,
     };
-    @stage(vertex)
+    @vertex
     fn main() -> VertexOut {
       return VertexOut();
     }
@@ -54,7 +54,7 @@ g.test('invalid_use_of_parameters')
     struct VertexOut {
       @builtin(position) @invariant${t.params.suffix} position : vec4<f32>
     };
-    @stage(vertex)
+    @vertex
     fn main() -> VertexOut {
       return VertexOut();
     }

--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -166,7 +166,7 @@ g.test('duplicates')
       @location(${ra}) a : f32,
       @location(${rb}) b : f32,
     };
-    @stage(fragment)
+    @fragment
     fn main(@location(${p1}) p1 : f32,
             @location(${p2}) p2 : f32,
             s1 : S1,

--- a/src/webgpu/shader/validation/shader_io/shareable_types.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/shareable_types.spec.ts
@@ -78,7 +78,7 @@ g.test('io_shareable_type')
           @location(0) @interpolate(flat) a : ${type}
         };
 
-        @stage(fragment)
+        @fragment
         fn main(inputs : MyInputs) {
         }
       `;
@@ -88,7 +88,7 @@ g.test('io_shareable_type')
           @location(0) a : ${type}
         };
 
-        @stage(fragment)
+        @fragment
         fn main() -> MyOutputs {
           return MyOutputs();
         }
@@ -97,7 +97,7 @@ g.test('io_shareable_type')
       code = `
       var<${storageClass}> a : ${type} = ${type}();
 
-      @stage(fragment)
+      @fragment
       fn main() {
       }
       `;

--- a/src/webgpu/shader/validation/shader_io/util.ts
+++ b/src/webgpu/shader/validation/shader_io/util.ts
@@ -37,7 +37,7 @@ export function generateShader({
 
   if (stage !== '') {
     // Generate the entry point attributes.
-    code += `@stage(${stage})`;
+    code += `@${stage}`;
     if (stage === 'compute') {
       code += ' @workgroup_size(1)';
     }

--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -64,7 +64,7 @@ export class ShaderValidationTest extends GPUTest {
    */
   wrapInEntryPoint(code: string) {
     return `
-      @stage(compute) @workgroup_size(1)
+      @compute @workgroup_size(1)
       fn main() {
         ${code}
       }`;

--- a/src/webgpu/util/shader.ts
+++ b/src/webgpu/util/shader.ts
@@ -57,7 +57,7 @@ export function getPlainTypeInfo(sampleType: GPUTextureSampleType): keyof typeof
  *     @location(0) o1 : vec4<f32>;
  *     @location(2) o3 : vec2<u32>;
  * }
- * @stage(fragment) fn main() -> Outputs {
+ * @fragment fn main() -> Outputs {
  *     return Outputs(vec4<f32>(1.0, 0.0, 1.0, 1.0), vec4<u32>(1, 2));
  * }
  * @param outputs the shader outputs for each location attribute
@@ -72,7 +72,7 @@ export function getFragmentShaderCodeWithOutput(
 ): string {
   if (outputs.length === 0) {
     return `
-        @stage(fragment) fn main() {
+        @fragment fn main() {
         }`;
   }
 
@@ -121,7 +121,7 @@ export function getFragmentShaderCodeWithOutput(
       ${outputStructString}
     }
 
-    @stage(fragment) fn main() -> Outputs {
+    @fragment fn main() -> Outputs {
         return Outputs(${resultStrings.join(',')});
     }`;
 }

--- a/src/webgpu/util/texture/texel_data.spec.ts
+++ b/src/webgpu/util/texture/texel_data.spec.ts
@@ -60,7 +60,7 @@ function doTest(
   };
   @group(0) @binding(1) var<storage, read_write> output : Output;
 
-  @stage(compute) @workgroup_size(1)
+  @compute @workgroup_size(1)
   fn main() {
       var texel : vec4<${shaderType}> = textureLoad(tex, vec2<i32>(0, 0), 0);
       ${rep.componentOrder.map(C => `output.result${C} = texel.${C.toLowerCase()};`).join('\n')}

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -56,7 +56,7 @@ function createExternalTextureSamplingTestPipeline(t: GPUTest): GPURenderPipelin
     vertex: {
       module: t.device.createShaderModule({
         code: `
-        @stage(vertex) fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
+        @vertex fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4<f32> {
             var pos = array<vec4<f32>, 6>(
               vec4<f32>( 1.0,  1.0, 0.0, 1.0),
               vec4<f32>( 1.0, -1.0, 0.0, 1.0),
@@ -77,7 +77,7 @@ function createExternalTextureSamplingTestPipeline(t: GPUTest): GPURenderPipelin
         @group(0) @binding(0) var s : sampler;
         @group(0) @binding(1) var t : texture_external;
 
-        @stage(fragment) fn main(@builtin(position) FragCoord : vec4<f32>)
+        @fragment fn main(@builtin(position) FragCoord : vec4<f32>)
                                  -> @location(0) vec4<f32> {
             return textureSampleLevel(t, s, FragCoord.xy / vec2<f32>(16.0, 16.0));
         }
@@ -309,7 +309,7 @@ Tests that we can import an HTMLVideoElement into a GPUExternalTexture and use i
               @group(0) @binding(0) var t : texture_external;
               @group(0) @binding(1) var outImage : texture_storage_2d<rgba8unorm, write>;
 
-              @stage(compute) @workgroup_size(1) fn main() {
+              @compute @workgroup_size(1) fn main() {
                 var red : vec4<f32> = textureLoad(t, vec2<i32>(10,10));
                 textureStore(outImage, vec2<i32>(0, 0), red);
                 var green : vec4<f32> = textureLoad(t, vec2<i32>(70,118));

--- a/src/webgpu/web_platform/reftests/canvas_complex.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_complex.html.ts
@@ -221,7 +221,7 @@ struct VertexOutput {
   @location(0) fragUV : vec2<f32>;
 };
 
-@stage(vertex)
+@vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
   var pos = array<vec2<f32>, 6>(
       vec2<f32>( 1.0,  1.0),
@@ -266,7 +266,7 @@ fn gammaDecompress(n: f32) -> f32 {
   return r;
 }
 
-@stage(fragment)
+@fragment
 fn srgbMain(@location(0) fragUV: vec2<f32>) -> @location(0) vec4<f32> {
   var result = textureSample(myTexture, mySampler, fragUV);
   result.r = gammaDecompress(result.r);
@@ -275,7 +275,7 @@ fn srgbMain(@location(0) fragUV: vec2<f32>) -> @location(0) vec4<f32> {
   return result;
 }
 
-@stage(fragment)
+@fragment
 fn linearMain(@location(0) fragUV: vec2<f32>) -> @location(0) vec4<f32> {
   return textureSample(myTexture, mySampler, fragUV);
 }
@@ -340,7 +340,7 @@ struct VertexOutput {
   @location(0) fragColor : vec4<f32>;
 };
 
-@stage(vertex)
+@vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
   var pos = array<vec2<f32>, 6>(
       vec2<f32>( 0.5,  0.5),
@@ -374,7 +374,7 @@ fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
         fragment: {
           module: t.device.createShaderModule({
             code: `
-@stage(fragment)
+@fragment
 fn main(@location(0) fragColor: vec4<f32>) -> @location(0) vec4<f32> {
   return fragColor;
 }
@@ -420,7 +420,7 @@ struct VertexOutput {
   @builtin(position) Position : vec4<f32>;
 };
 
-@stage(vertex)
+@vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
   var pos = array<vec2<f32>, 6>(
       vec2<f32>( 1.0,  1.0),
@@ -444,7 +444,7 @@ fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
 @group(0) @binding(0) var mySampler: sampler;
 @group(0) @binding(1) var myTexture: texture_2d<f32>;
 
-@stage(fragment)
+@fragment
 fn main(@builtin(position) fragcoord: vec4<f32>) -> @location(0) vec4<f32> {
   var coord = vec2<u32>(floor(fragcoord.xy));
   var color = vec4<f32>(0.0, 0.0, 0.0, 1.0);
@@ -506,7 +506,7 @@ struct VertexOutput {
   @builtin(position) Position : vec4<f32>;
 };
 
-@stage(vertex)
+@vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
   var pos = array<vec2<f32>, 6>(
       vec2<f32>( 1.0,  1.0),
@@ -529,7 +529,7 @@ fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
             code: `
 @group(0) @binding(0) var outImage : texture_storage_2d<${format}, write>;
 
-@stage(fragment)
+@fragment
 fn main(@builtin(position) fragcoord: vec4<f32>) -> @location(0) vec4<f32> {
   var coord = vec2<u32>(floor(fragcoord.xy));
   var color = vec4<f32>(0.0, 0.0, 0.0, 1.0);
@@ -602,7 +602,7 @@ fn main(@builtin(position) fragcoord: vec4<f32>) -> @location(0) vec4<f32> {
             code: `
 @group(0) @binding(0) var outImage : texture_storage_2d<${format}, write>;
 
-@stage(compute) @workgroup_size(1, 1, 1)
+@compute @workgroup_size(1, 1, 1)
 fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
   var color = vec4<f32>(0.0, 0.0, 0.0, 1.0);
   if (GlobalInvocationID.x < ${halfCanvasWidthStr}u) {
@@ -654,7 +654,7 @@ fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
             code: `
 @group(0) @binding(0) var outImage : texture_storage_2d<${format}, write>;
 
-@stage(compute) @workgroup_size(16, 16, 1)
+@compute @workgroup_size(16, 16, 1)
 fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
   if (GlobalInvocationID.x >= ${canvasWidthStr}u ||
       GlobalInvocationID.y >= ${canvasHeightStr}u) {

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -56,7 +56,7 @@ struct VertexOutput {
 @location(0) fragColor : vec4<f32>;
 };
 
-@stage(vertex)
+@vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
 var pos = array<vec2<f32>, 6>(
     vec2<f32>( 0.75,  0.75),
@@ -90,7 +90,7 @@ return output;
       fragment: {
         module: t.device.createShaderModule({
           code: `
-@stage(fragment)
+@fragment
 fn main(@location(0) fragColor: vec4<f32>) -> @location(0) vec4<f32> {
 return fragColor;
 }

--- a/src/webgpu/web_platform/worker/worker.ts
+++ b/src/webgpu/web_platform/worker/worker.ts
@@ -17,7 +17,7 @@ async function basicTest() {
           struct Buffer { data: array<u32>; };
 
           @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
-          @stage(compute) @workgroup_size(1u) fn main(
+          @compute @workgroup_size(1u) fn main(
               @builtin(global_invocation_id) id: vec3<u32>) {
             buffer.data[id.x] = id.x + ${kOffset}u;
           }


### PR DESCRIPTION
This PR updates the `@stage` attributes to the shorter `@vertex`, `@fragment` and `@compute`
formats.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
