### PR TITLE
Remove references to depth24unorm-stencil8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/offscreencanvas": "^2019.6.4",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "0.1.18",
+        "@webgpu/types": "0.1.19",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1227,9 +1227,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.18.tgz",
-      "integrity": "sha512-HFHT3rriksKciYqdjHEOe2cQt14XnyLuieKyJN8bA23SG2NrTYZaoFOSuVA3EgPIyHGfelpXM+8QqNJ/3rCRCg==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.19.tgz",
+      "integrity": "sha512-FTmG9ZyxXabWqqhMmbyckego9t49EtbSnIjzlnJIJlHx+phCwmtVyVfjjODVce2WYvOmwyWLvZblVQpFxPVjeQ==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10483,9 +10483,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.18.tgz",
-      "integrity": "sha512-HFHT3rriksKciYqdjHEOe2cQt14XnyLuieKyJN8bA23SG2NrTYZaoFOSuVA3EgPIyHGfelpXM+8QqNJ/3rCRCg==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.19.tgz",
+      "integrity": "sha512-FTmG9ZyxXabWqqhMmbyckego9t49EtbSnIjzlnJIJlHx+phCwmtVyVfjjODVce2WYvOmwyWLvZblVQpFxPVjeQ==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/offscreencanvas": "^2019.6.4",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "0.1.18",
+    "@webgpu/types": "0.1.19",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -27,7 +27,7 @@ export const description = `writeTexture + copyBufferToTexture + copyTextureToBu
   - add another initMethod which renders the texture [3]
   - test copyT2B with buffer size not divisible by 4 (not done because expectContents 4-byte alignment)
   - Convert the float32 values in initialData into the ones compatible to the depth aspect of
-    depthFormats when depth16unorm and depth24unorm-stencil8 are supported by the browsers in
+    depthFormats when depth16unorm is supported by the browsers in
     DoCopyTextureToBufferWithDepthAspectTest().
 
 TODO: Expand tests of GPUExtent3D [1]
@@ -1111,9 +1111,7 @@ class ImageCopyTest extends GPUTest {
     mipLevel: number
   ): void {
     // [2]: need to convert the float32 values in initialData into the ones compatible
-    // to the depth aspect of depthFormats when depth16unorm and depth24unorm-stencil8 are supported
-    // by the browsers.
-    assert(format !== 'depth24unorm-stencil8');
+    // to the depth aspect of depthFormats when depth16unorm is supported by the browsers.
 
     // Generate the initial depth data uploaded to the texture as float32.
     const initialData = new Float32Array(copySize[0] * copySize[1] * copySize[2]);

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -723,7 +723,6 @@ Test the validations on the member 'aspect' of GPUImageCopyTexture in CopyTextur
       // kUnsizedDepthStencilFormats
       depth24plus: ['all', 'depth-only'],
       'depth24plus-stencil8': ['all'],
-      'depth24unorm-stencil8': ['all'],
       'depth32float-stencil8': ['all'],
 
       // kSizedDepthStencilFormats

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -131,7 +131,6 @@ const kUnsizedDepthStencilFormatInfo = /* prettier-ignore */ makeTable(kTexFmtIn
   'depth24plus':           [            ,              ,          ,        ,    true,     false,          ,          ,          ,      'depth'],
   'depth24plus-stencil8':  [            ,              ,          ,        ,    true,      true,          ,          ,          ,      'depth'],
   // MAINTENANCE_TODO: These should really be sized formats; see below MAINTENANCE_TODO about multi-aspect formats.
-  'depth24unorm-stencil8': [            ,              ,          ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth24unorm-stencil8'],
   'depth32float-stencil8': [            ,              ,          ,        ,    true,      true,          ,          ,          ,      'depth',                ,             ,              ,  'depth32float-stencil8'],
 } as const);
 
@@ -257,7 +256,7 @@ export const kCanvasTextureFormats = ['bgra8unorm', 'rgba8unorm', 'rgba16float']
 // Exists just for documentation. Otherwise could be inferred by `makeTable`.
 // MAINTENANCE_TODO: Refactor this to separate per-aspect data for multi-aspect formats. In particular:
 // - bytesPerBlock only makes sense on a per-aspect basis. But this table can't express that.
-//   So we put depth24unorm-stencil8 and depth32float-stencil8 to be unsized formats for now.
+//   So we put depth32float-stencil8 to be an unsized format for now.
 export type TextureFormatInfo = {
   /** Whether the format can be used as `RENDER_ATTACHMENT`. */
   renderable: boolean;
@@ -394,11 +393,6 @@ const kDepthStencilFormatCapabilityInBufferTextureCopy = {
     CopyT2B: ['all', 'depth-only'],
     texelAspectSize: { 'depth-only': 4, 'stencil-only': -1 },
   },
-  'depth24unorm-stencil8': {
-    CopyB2T: ['stencil-only'],
-    CopyT2B: ['stencil-only'],
-    texelAspectSize: { 'depth-only': -1, 'stencil-only': 1 },
-  },
   'depth32float-stencil8': {
     CopyB2T: ['stencil-only'],
     CopyT2B: ['depth-only', 'stencil-only'],
@@ -441,11 +435,6 @@ export const kDepthStencilFormatResolvedAspect: {
     all: 'depth32float',
     'depth-only': 'depth32float',
     'stencil-only': undefined,
-  },
-  'depth24unorm-stencil8': {
-    all: 'depth24unorm-stencil8',
-    'depth-only': 'depth24plus', // Should this be depth24unorm? See https://github.com/gpuweb/gpuweb/issues/2732
-    'stencil-only': 'stencil8',
   },
   'depth32float-stencil8': {
     all: 'depth32float-stencil8',

--- a/src/webgpu/util/color_space_conversion.ts
+++ b/src/webgpu/util/color_space_conversion.ts
@@ -216,7 +216,7 @@ export function makeInPlaceColorConversion({
   srcPremultiplied: boolean;
   dstPremultiplied: boolean;
   srcColorSpace?: PredefinedColorSpace;
-  dstColorSpace?: GPUPredefinedColorSpace;
+  dstColorSpace?: PredefinedColorSpace;
 }): InPlaceColorConversion {
   const requireColorSpaceConversion = srcColorSpace !== dstColorSpace;
   const requireUnpremultiplyAlpha =

--- a/src/webgpu/util/copy_to_texture.ts
+++ b/src/webgpu/util/copy_to_texture.ts
@@ -42,7 +42,7 @@ export class CopyToTextureUtils extends GPUTest {
       srcPremultiplied: boolean;
       dstPremultiplied: boolean;
       srcColorSpace?: PredefinedColorSpace;
-      dstColorSpace?: GPUPredefinedColorSpace;
+      dstColorSpace?: PredefinedColorSpace;
     }
   ): TexelView {
     const applyConversion = makeInPlaceColorConversion(conversion);

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -759,41 +759,6 @@ export const kTexelRepresentationInfo: {
       numericRange: { min: 0, max: 1 },
     },
     stencil8: makeIntegerInfo([TexelComponent.Stencil], 8, { signed: false }),
-    'depth24unorm-stencil8': {
-      componentOrder: [TexelComponent.Depth, TexelComponent.Stencil],
-      componentInfo: {
-        Depth: {
-          dataType: 'unorm',
-          bitLength: 24,
-        },
-        Stencil: {
-          dataType: 'uint',
-          bitLength: 8,
-        },
-      },
-      encode: components => {
-        assert(components.Stencil !== undefined);
-        assertInIntegerRange(components.Stencil, 8, false);
-        return {
-          Depth: floatAsNormalizedInteger(components.Depth ?? unreachable(), 24, false),
-          Stencil: components.Stencil,
-        };
-      },
-      decode: components => {
-        assert(components.Stencil !== undefined);
-        assertInIntegerRange(components.Stencil, 8, false);
-        return {
-          Depth: normalizedIntegerAsFloat(components.Depth ?? unreachable(), 24, false),
-          Stencil: components.Stencil,
-        };
-      },
-      pack: () => unreachable('depth24unorm-stencil8 data cannot be packed'),
-      unpackBits: () => unreachable('depth24unorm-stencil8 data cannot be unpacked'),
-      numberToBits: () => unreachable('not implemented'),
-      bitsToNumber: () => unreachable('not implemented'),
-      bitsToULPFromZero: () => unreachable('not implemented'),
-      numericRange: null,
-    },
     'depth32float-stencil8': {
       componentOrder: [TexelComponent.Depth, TexelComponent.Stencil],
       componentInfo: {


### PR DESCRIPTION
Removed from WebGPU because it didn't provide any additional capabilities compared to depth24plus-stencil8.

Issue: https://github.com/gpuweb/gpuweb/pull/2950

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
