### PR TITLE
[wgsl] use subcases in texture tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureDimension.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureDimension.spec.ts
@@ -50,6 +50,7 @@ Parameters:
         'texture_cube_array',
         'texture_multisampled_2d',
       ] as const)
+      .beginSubcases()
       .combine('sampled_type', ['f32', 'i32', 'u32'] as const)
       .combine('level', [undefined, 0, 1, 'textureNumLevels', 'textureNumLevels+1'] as const)
   )
@@ -85,6 +86,7 @@ Parameters:
         'texture_depth_cube_array',
         'texture_depth_multisampled_2d',
       ])
+      .beginSubcases()
       .combine('level', [undefined, 0, 1, 'textureNumLevels', 'textureNumLevels+1'] as const)
   )
   .unimplemented();
@@ -140,6 +142,7 @@ Parameters:
         'rgba32sint',
         'rgba32float',
       ] as const)
+      .beginSubcases()
       .combine('access_mode', ['read', 'write', 'read_write'] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -57,6 +57,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('T', ['f32', 'i32', 'u32'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
@@ -87,6 +88,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('T', ['f32', 'i32', 'u32'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
@@ -124,6 +126,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('T', ['f32', 'i32', 'u32'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
@@ -157,6 +160,7 @@ Parameters:
   .params(
     u =>
       u
+        .beginSubcases()
         .combine('T', ['f32', 'i32', 'u32'] as const)
         .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
         .combine('C', ['i32', 'u32'] as const)
@@ -187,6 +191,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -207,6 +212,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
   )
@@ -236,6 +242,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('coords', generateCoordBoundaries(2))
@@ -262,6 +269,7 @@ Parameters:
   .params(
     u =>
       u
+        .beginSubcases()
         .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
         .combine('C', ['i32', 'u32'] as const)
         .combine('coords', generateCoordBoundaries(3))

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -55,9 +55,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('T', ['f32', 'i32', 'u32'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
@@ -86,9 +85,8 @@ Parameters:
  * coords: The texture coordinates
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('T', ['f32', 'i32', 'u32'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
@@ -124,9 +122,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('T', ['f32', 'i32', 'u32'] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
@@ -157,10 +154,9 @@ Parameters:
  * array_index: The 0-based texture array index
 `
   )
-  .params(
+  .paramsSubcasesOnly(
     u =>
       u
-        .beginSubcases()
         .combine('T', ['f32', 'i32', 'u32'] as const)
         .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
         .combine('C', ['i32', 'u32'] as const)
@@ -189,9 +185,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -210,9 +205,8 @@ Parameters:
  * coords: The texture coordinates
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
   )
@@ -240,9 +234,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('coords', generateCoordBoundaries(2))
@@ -266,10 +259,9 @@ Parameters:
  * array_index: The 0-based texture array index
 `
   )
-  .params(
+  .paramsSubcasesOnly(
     u =>
       u
-        .beginSubcases()
         .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
         .combine('C', ['i32', 'u32'] as const)
         .combine('coords', generateCoordBoundaries(3))

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -48,6 +48,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4])
@@ -75,6 +76,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4])
@@ -105,6 +107,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -127,6 +130,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -46,9 +46,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4])
@@ -74,9 +73,8 @@ Parameters:
  * depth_ref: The reference value to compare the sampled depth value against
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4])
@@ -105,9 +103,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -128,9 +125,8 @@ Parameters:
  * depth_ref: The reference value to compare the sampled depth value against
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -131,9 +131,8 @@ Parameters:
  * level: The mip level, with level 0 containing a full size version of the texture
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('coords', generateCoordBoundaries(2))
       .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
@@ -153,11 +152,8 @@ Parameters:
  * coords: The 0-based texel coordinate
 `
   )
-  .params(u =>
-    u
-      .beginSubcases()
-      .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', generateCoordBoundaries(2))
+  .paramsSubcasesOnly(u =>
+    u.combine('C', ['i32', 'u32'] as const).combine('coords', generateCoordBoundaries(2))
   )
   .unimplemented();
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -110,6 +110,7 @@ Parameters:
         'texture_multisampled_2d',
         'texture_depth_multisampled_2d',
       ] as const)
+      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('coords', generateCoordBoundaries(2))
       .combine('sample_index', [-1, 0, `sampleCount-1`, `sampleCount`] as const)
@@ -132,6 +133,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('coords', generateCoordBoundaries(2))
       .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
@@ -152,7 +154,10 @@ Parameters:
 `
   )
   .params(u =>
-    u.combine('C', ['i32', 'u32'] as const).combine('coords', generateCoordBoundaries(2))
+    u
+      .beginSubcases()
+      .combine('C', ['i32', 'u32'] as const)
+      .combine('coords', generateCoordBoundaries(2))
   )
   .unimplemented();
 
@@ -175,6 +180,7 @@ Parameters:
   .params(u =>
     u
       .combine('texture_type', ['texture_2d_array', 'texture_depth_2d_array'] as const)
+      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('coords', generateCoordBoundaries(2))
       .combine('array_index', [-1, 0, `numlayers-1`, `numlayers`] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
@@ -77,7 +77,6 @@ Parameters
   .params(u =>
     u
       .beginSubcases()
-
       .combine('texel_format', [
         'rgba8unorm',
         'rgba8snorm',

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
@@ -25,6 +25,7 @@ Parameters
   .params(u =>
     u
       .combine('texture_type', ['texture_2d_array', 'texture_cube_array'] as const)
+      .beginSubcases()
       .combine('sampled_type', ['f32', 'i32', 'u32'] as const)
   )
   .unimplemented();
@@ -75,6 +76,8 @@ Parameters
   )
   .params(u =>
     u
+      .beginSubcases()
+
       .combine('texel_format', [
         'rgba8unorm',
         'rgba8snorm',

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLevels.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLevels.spec.ts
@@ -36,6 +36,7 @@ Parameters
         'texture_cube',
         'texture_cube_array`',
       ] as const)
+      .beginSubcases()
       .combine('sampled_type', ['f32', 'i32', 'u32'] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumSamples.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumSamples.spec.ts
@@ -21,7 +21,7 @@ Parameters
  * t The multisampled texture.
 `
   )
-  .params(u => u.combine('sampled_type', ['f32', 'i32', 'u32'] as const))
+  .params(u => u.beginSubcases().combine('sampled_type', ['f32', 'i32', 'u32'] as const))
   .unimplemented();
 
 g.test('depth')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -46,6 +46,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('coords', generateCoordBoundaries(1))
   )
@@ -72,6 +73,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -101,6 +103,7 @@ Parameters:
   .params(u =>
     u
       .combine('texture_type', ['texture_3d', 'texture_cube'] as const)
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('coords', generateCoordBoundaries(3))
       .combine('offset', generateOffsets(3))
@@ -128,6 +131,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -158,6 +162,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
@@ -185,6 +190,7 @@ Parameters:
   .params(
     u =>
       u
+        .beginSubcases()
         .combine('C', ['i32', 'u32'] as const)
         .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
         .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
@@ -207,6 +213,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('coords', generateCoordBoundaries(3))
   )
@@ -236,6 +243,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
@@ -263,6 +271,7 @@ Parameters:
   .params(
     u =>
       u
+        .beginSubcases()
         .combine('C', ['i32', 'u32'] as const)
         .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
         .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -44,9 +44,8 @@ Parameters:
  * coords The texture coordinates used for sampling.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('coords', generateCoordBoundaries(1))
   )
@@ -71,9 +70,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -129,9 +127,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -160,9 +157,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
@@ -187,10 +183,9 @@ Parameters:
  * array_index The 0-based texture array index to sample.
 `
   )
-  .params(
+  .paramsSubcasesOnly(
     u =>
       u
-        .beginSubcases()
         .combine('C', ['i32', 'u32'] as const)
         .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
         .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
@@ -211,9 +206,8 @@ Parameters:
  * coords The texture coordinates used for sampling.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('coords', generateCoordBoundaries(3))
   )
@@ -241,9 +235,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
@@ -268,10 +261,9 @@ Parameters:
  * array_index The 0-based texture array index to sample.
 `
   )
-  .params(
+  .paramsSubcasesOnly(
     u =>
       u
-        .beginSubcases()
         .combine('C', ['i32', 'u32'] as const)
         .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
         .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -53,9 +53,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
@@ -118,9 +117,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('C', ['i32', 'u32'] as const)
@@ -153,9 +151,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('C', ['i32', 'u32'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -55,6 +55,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
@@ -86,6 +87,7 @@ Parameters:
   .params(u =>
     u
       .combine('texture_type', ['texture_3d', 'texture_cube'] as const)
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('bias', [-16.1, -16, 0, 1, 15.99, 16] as const)
@@ -118,6 +120,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('C', ['i32', 'u32'] as const)
@@ -152,6 +155,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('C', ['i32', 'u32'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
@@ -54,6 +54,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -76,6 +77,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -107,6 +109,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('C', ['i32', 'u32'] as const)
@@ -135,6 +138,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('C', ['i32', 'u32'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
@@ -52,9 +52,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -75,9 +74,8 @@ Parameters:
  * depth_ref The reference value to compare the sampled depth value against.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -107,9 +105,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('C', ['i32', 'u32'] as const)
@@ -136,9 +133,8 @@ Parameters:
  * depth_ref The reference value to compare the sampled depth value against.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('C', ['i32', 'u32'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
@@ -56,9 +56,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -79,9 +78,8 @@ Parameters:
  * depth_ref The reference value to compare the sampled depth value against.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -111,9 +109,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('C', ['i32', 'u32'] as const)
@@ -140,9 +137,8 @@ Parameters:
  * depth_ref The reference value to compare the sampled depth value against.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('C', ['i32', 'u32'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
@@ -58,6 +58,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -80,6 +81,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('depth_ref', [-1 /* smaller ref */, 0 /* equal ref */, 1 /* larger ref */] as const)
@@ -111,6 +113,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('C', ['i32', 'u32'] as const)
@@ -139,6 +142,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('C', ['i32', 'u32'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -32,6 +32,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -62,6 +63,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('offset', generateOffsets(3))
@@ -94,6 +96,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -128,6 +131,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -30,9 +30,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -61,9 +60,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('offset', generateOffsets(3))
@@ -94,9 +92,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -129,9 +126,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -38,6 +38,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -74,6 +75,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -112,6 +114,7 @@ Parameters:
   .params(u =>
     u
       .combine('texture_type', ['texture_3d', 'texture_cube'] as const)
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(3))
       .combine('offset', generateOffsets(3))
@@ -147,6 +150,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -185,6 +189,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -223,6 +228,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -262,6 +268,7 @@ Parameters:
   .params(u =>
     u
       .combine('texture_type', ['texture_depth_cube', 'texture_depth_cube_array'] as const)
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -285,6 +292,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -36,9 +36,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
       .combine('offset', generateOffsets(2))
@@ -73,9 +72,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -148,9 +146,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -187,9 +184,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -226,9 +222,8 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('C', ['i32', 'u32'] as const)
       .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -290,9 +285,8 @@ Parameters:
  * coords The texture coordinates used for sampling.
 `
   )
-  .params(u =>
+  .paramsSubcasesOnly(u =>
     u
-      .beginSubcases()
       .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
       .combine('coords', generateCoordBoundaries(2))
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -38,6 +38,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('F', TexelFormats)
       .combine('coords', generateCoordBoundaries(1))
       .combine('C', ['i32', 'u32'] as const)
@@ -61,6 +62,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('F', TexelFormats)
       .combine('coords', generateCoordBoundaries(2))
       .combine('C', ['i32', 'u32'] as const)
@@ -86,6 +88,7 @@ Parameters:
   .params(
     u =>
       u
+        .beginSubcases()
         .combine('F', TexelFormats)
         .combine('coords', generateCoordBoundaries(2))
         .combine('C', ['i32', 'u32'] as const)
@@ -111,6 +114,7 @@ Parameters:
   )
   .params(u =>
     u
+      .beginSubcases()
       .combine('F', TexelFormats)
       .combine('coords', generateCoordBoundaries(3))
       .combine('C', ['i32', 'u32'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -38,8 +38,8 @@ Parameters:
   )
   .params(u =>
     u
+      .combineWithParams(TexelFormats)
       .beginSubcases()
-      .combine('F', TexelFormats)
       .combine('coords', generateCoordBoundaries(1))
       .combine('C', ['i32', 'u32'] as const)
   )
@@ -62,8 +62,8 @@ Parameters:
   )
   .params(u =>
     u
+      .combineWithParams(TexelFormats)
       .beginSubcases()
-      .combine('F', TexelFormats)
       .combine('coords', generateCoordBoundaries(2))
       .combine('C', ['i32', 'u32'] as const)
   )
@@ -88,8 +88,8 @@ Parameters:
   .params(
     u =>
       u
+        .combineWithParams(TexelFormats)
         .beginSubcases()
-        .combine('F', TexelFormats)
         .combine('coords', generateCoordBoundaries(2))
         .combine('C', ['i32', 'u32'] as const)
         .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
@@ -114,8 +114,8 @@ Parameters:
   )
   .params(u =>
     u
+      .combineWithParams(TexelFormats)
       .beginSubcases()
-      .combine('F', TexelFormats)
       .combine('coords', generateCoordBoundaries(3))
       .combine('C', ['i32', 'u32'] as const)
   )

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -47,22 +47,22 @@ export type StorageClass = 'storage' | 'uniform' | 'private' | 'function' | 'wor
 
 /** List of texel formats and their shader representation */
 export const TexelFormats = [
-  ['rgba8unorm', 'f32'],
-  ['rgba8snorm', 'f32'],
-  ['rgba8uint', 'u32'],
-  ['rgba8sint', 'i32'],
-  ['rgba16uint', 'u32'],
-  ['rgba16sint', 'i32'],
-  ['rgba16float', 'f32'],
-  ['r32uint', 'u32'],
-  ['r32sint', 'i32'],
-  ['r32float', 'f32'],
-  ['rg32uint', 'u32'],
-  ['rg32sint', 'i32'],
-  ['rg32float', 'f32'],
-  ['rgba32uint', 'i32'],
-  ['rgba32sint', 'i32'],
-  ['rgba32float', 'f32'],
+  { format: 'rgba8unorm', _shaderType: 'f32' },
+  { format: 'rgba8snorm', _shaderType: 'f32' },
+  { format: 'rgba8uint', _shaderType: 'u32' },
+  { format: 'rgba8sint', _shaderType: 'i32' },
+  { format: 'rgba16uint', _shaderType: 'u32' },
+  { format: 'rgba16sint', _shaderType: 'i32' },
+  { format: 'rgba16float', _shaderType: 'f32' },
+  { format: 'r32uint', _shaderType: 'u32' },
+  { format: 'r32sint', _shaderType: 'i32' },
+  { format: 'r32float', _shaderType: 'f32' },
+  { format: 'rg32uint', _shaderType: 'u32' },
+  { format: 'rg32sint', _shaderType: 'i32' },
+  { format: 'rg32float', _shaderType: 'f32' },
+  { format: 'rgba32uint', _shaderType: 'i32' },
+  { format: 'rgba32sint', _shaderType: 'i32' },
+  { format: 'rgba32float', _shaderType: 'f32' },
 ] as const;
 
 /**


### PR DESCRIPTION
This CL uses subcases to break the texture execution tests into logical chunks based on
the type of texture being tested.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
