### PR TITLE
Const tests

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -2,13 +2,24 @@ export const description = `Unit tests for conversion`;
 
 import { makeTestGroup } from '../common/internal/test_group.js';
 import {
+  bool,
+  f16Bits,
+  f32,
+  f32Bits,
   float16BitsToFloat32,
   float32ToFloat16Bits,
   float32ToFloatBits,
   floatBitsToNormalULPFromZero,
   floatBitsToNumber,
+  i32,
   kFloat16Format,
   kFloat32Format,
+  Scalar,
+  u32,
+  vec2,
+  vec3,
+  vec4,
+  Vector,
 } from '../webgpu/util/conversion.js';
 
 import { UnitTest } from './unit_test.js';
@@ -155,4 +166,69 @@ g.test('floatBitsToULPFromZero,32').fn(t => {
   testThrows(0b0_11111111_00000000000000000000001);
   testThrows(0b1_11111111_11111111111111111111111);
   testThrows(0b1_11111111_00000000000000000000001);
+});
+
+g.test('scalarWGSL').fn(t => {
+  const cases: Array<[Scalar, string]> = [
+    [f32(0.0), '0.0f'],
+    [f32(1.0), '1.0f'],
+    [f32(-1.0), '-1.0f'],
+    [f32Bits(0x70000000), '1.5845632502852868e+29f'],
+    [f32Bits(0xf0000000), '-1.5845632502852868e+29f'],
+    [f16Bits(0), '0.0h'],
+    [f16Bits(0x3c00), '1.0h'],
+    [f16Bits(0xbc00), '-1.0h'],
+    [u32(0), '0u'],
+    [u32(1), '1u'],
+    [u32(2000000000), '2000000000u'],
+    [u32(-1), '4294967295u'],
+    [i32(0), '0i'],
+    [i32(1), '1i'],
+    [i32(-1), '-1i'],
+    [bool(true), 'true'],
+    [bool(false), 'false'],
+  ];
+  for (const [value, expect] of cases) {
+    const got = value.wgsl();
+    t.expect(
+      got === expect,
+      `[value: ${value.value}, type: ${value.type}]
+got:    ${got}
+expect: ${expect}`
+    );
+  }
+});
+
+g.test('vectorWGSL').fn(t => {
+  const cases: Array<[Vector, string]> = [
+    [vec2(f32(42.0), f32(24.0)), 'vec2(42.0f, 24.0f)'],
+    [vec2(f16Bits(0x5140), f16Bits(0x4e00)), 'vec2(42.0h, 24.0h)'],
+    [vec2(u32(42), u32(24)), 'vec2(42u, 24u)'],
+    [vec2(i32(42), i32(24)), 'vec2(42i, 24i)'],
+    [vec2(bool(false), bool(true)), 'vec2(false, true)'],
+
+    [vec3(f32(0.0), f32(1.0), f32(-1.0)), 'vec3(0.0f, 1.0f, -1.0f)'],
+    [vec3(f16Bits(0), f16Bits(0x3c00), f16Bits(0xbc00)), 'vec3(0.0h, 1.0h, -1.0h)'],
+    [vec3(u32(0), u32(1), u32(-1)), 'vec3(0u, 1u, 4294967295u)'],
+    [vec3(i32(0), i32(1), i32(-1)), 'vec3(0i, 1i, -1i)'],
+    [vec3(bool(true), bool(false), bool(true)), 'vec3(true, false, true)'],
+
+    [vec4(f32(1.0), f32(-2.0), f32(4.0), f32(-8.0)), 'vec4(1.0f, -2.0f, 4.0f, -8.0f)'],
+    [
+      vec4(f16Bits(0xbc00), f16Bits(0x4000), f16Bits(0xc400), f16Bits(0x4800)),
+      'vec4(-1.0h, 2.0h, -4.0h, 8.0h)',
+    ],
+    [vec4(u32(1), u32(-2), u32(4), u32(-8)), 'vec4(1u, 4294967294u, 4u, 4294967288u)'],
+    [vec4(i32(1), i32(-2), i32(4), i32(-8)), 'vec4(1i, -2i, 4i, -8i)'],
+    [vec4(bool(false), bool(true), bool(true), bool(false)), 'vec4(false, true, true, false)'],
+  ];
+  for (const [value, expect] of cases) {
+    const got = value.wgsl();
+    t.expect(
+      got === expect,
+      `[values: ${value.elements}, type: ${value.type}]
+got:    ${got}
+expect: ${expect}`
+    );
+  }
 });

--- a/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
@@ -5,7 +5,7 @@ Execution Tests for the bitwise binary expression operations
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { i32, scalarType, u32 } from '../../../../util/conversion.js';
-import { run } from '../expression.js';
+import { allInputSources, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
@@ -24,7 +24,7 @@ Bitwise-or. Component-wise when T is a vector.
   .params(u =>
     u
       .combine('type', ['i32', 'u32'] as const)
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -88,7 +88,7 @@ Bitwise-and. Component-wise when T is a vector.
   .params(u =>
     u
       .combine('type', ['i32', 'u32'] as const)
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -160,7 +160,7 @@ Bitwise-exclusive-or. Component-wise when T is a vector.
   .params(u =>
     u
       .combine('type', ['i32', 'u32'] as const)
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
@@ -24,7 +24,7 @@ Bitwise-or. Component-wise when T is a vector.
   .params(u =>
     u
       .combine('type', ['i32', 'u32'] as const)
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -88,7 +88,7 @@ Bitwise-and. Component-wise when T is a vector.
   .params(u =>
     u
       .combine('type', ['i32', 'u32'] as const)
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -160,7 +160,7 @@ Bitwise-exclusive-or. Component-wise when T is a vector.
   .params(u =>
     u
       .combine('type', ['i32', 'u32'] as const)
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -7,7 +7,7 @@ import { GPUTest } from '../../../../gpu_test.js';
 import { correctlyRoundedMatch, ulpMatch } from '../../../../util/compare.js';
 import { TypeF32 } from '../../../../util/conversion.js';
 import { biasedRange, fullF32Range } from '../../../../util/math.js';
-import { Case, Config, makeBinaryF32Case, run } from '../expression.js';
+import { allInputSources, Case, Config, makeBinaryF32Case, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
@@ -22,9 +22,7 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -56,9 +54,7 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -90,9 +86,7 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -124,9 +118,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -23,7 +23,7 @@ Accuracy: Correctly rounded
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -57,7 +57,7 @@ Accuracy: Correctly rounded
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -91,7 +91,7 @@ Accuracy: Correctly rounded
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -125,7 +125,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
@@ -49,7 +49,7 @@ Accuracy: Correct result
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -78,7 +78,7 @@ Accuracy: Correct result
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -107,7 +107,7 @@ Accuracy: Correct result
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -136,7 +136,7 @@ Accuracy: Correct result
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -165,7 +165,7 @@ Accuracy: Correct result
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -194,7 +194,7 @@ Accuracy: Correct result
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
@@ -7,7 +7,7 @@ import { GPUTest } from '../../../../gpu_test.js';
 import { anyOf } from '../../../../util/compare.js';
 import { bool, f32, Scalar, TypeBool, TypeF32 } from '../../../../util/conversion.js';
 import { flushSubnormalScalar, fullF32Range } from '../../../../util/math.js';
-import { Case, run } from '../expression.js';
+import { allInputSources, Case, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
@@ -48,9 +48,7 @@ Accuracy: Correct result
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
@@ -77,9 +75,7 @@ Accuracy: Correct result
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
@@ -106,9 +102,7 @@ Accuracy: Correct result
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
@@ -135,9 +129,7 @@ Accuracy: Correct result
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
@@ -164,9 +156,7 @@ Accuracy: Correct result
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
@@ -193,9 +183,7 @@ Accuracy: Correct result
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -39,7 +39,7 @@ g.test('abstract_int')
   .desc(`abstract int tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -49,7 +49,7 @@ g.test('u32')
   .desc(`unsigned int tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -98,7 +98,7 @@ g.test('i32')
   .desc(`signed int tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -153,7 +153,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -163,7 +163,7 @@ g.test('f32')
   .desc(`float 32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -188,7 +188,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -28,7 +28,7 @@ import {
   u32Bits,
 } from '../../../../../util/conversion.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -38,9 +38,7 @@ g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`abstract int tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -48,9 +46,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`unsigned int tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     run(t, builtin('abs'), [TypeU32], TypeU32, t.params, [
@@ -97,9 +93,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`signed int tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -152,9 +146,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -162,9 +154,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`float 32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -187,8 +177,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -9,6 +9,7 @@ Returns the arc cosine of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -13,6 +13,7 @@ Note: The result is not mathematically meaningful when e < 1.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -20,9 +21,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -30,9 +29,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -40,8 +37,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -21,7 +21,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -31,7 +31,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -41,7 +41,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/all.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/all.spec.ts
@@ -30,7 +30,7 @@ g.test('bool')
   .desc(`bool tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/all.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/all.spec.ts
@@ -19,7 +19,7 @@ import {
   vec3,
   vec4,
 } from '../../../../../util/conversion.js';
-import { run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -30,7 +30,7 @@ g.test('bool')
   .desc(`bool tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/any.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/any.spec.ts
@@ -30,7 +30,7 @@ g.test('bool')
   .desc(`bool tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/any.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/any.spec.ts
@@ -19,7 +19,7 @@ import {
   vec3,
   vec4,
 } from '../../../../../util/conversion.js';
-import { run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -30,7 +30,7 @@ g.test('bool')
   .desc(`bool tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
@@ -9,6 +9,7 @@ Returns the arc sine of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
@@ -12,6 +12,7 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -19,9 +20,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float test`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -29,9 +28,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -39,8 +36,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
@@ -20,7 +20,7 @@ g.test('abstract_float')
   .desc(`abstract float test`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -30,7 +30,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -40,7 +40,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -14,7 +14,7 @@ import { ulpMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -24,9 +24,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -40,9 +38,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
@@ -85,8 +81,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -25,7 +25,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -41,7 +41,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -86,7 +86,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf, ulpMatch } from '../../../../../util/compare.js';
 import { f64, TypeF32 } from '../../../../../util/conversion.js';
 import { fullF32Range, isSubnormalNumber } from '../../../../../util/math.js';
-import { Case, Config, makeBinaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeBinaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,9 +22,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -38,9 +36,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -81,8 +77,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -23,7 +23,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -39,7 +39,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -82,7 +82,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -12,6 +12,7 @@ Note: The result is not mathematically meaningful when abs(e) >= 1.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -19,9 +20,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -29,9 +28,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -39,8 +36,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -20,7 +20,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -30,7 +30,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -40,7 +40,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -14,7 +14,7 @@ import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -24,9 +24,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -34,9 +32,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -78,8 +74,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -25,7 +25,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -35,7 +35,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -79,7 +79,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -122,7 +122,7 @@ g.test('abstract_int')
   .desc(`abstract int tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -132,7 +132,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -162,7 +162,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -194,7 +194,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -204,7 +204,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -246,7 +246,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -30,7 +30,7 @@ import {
   u32Bits,
 } from '../../../../../util/conversion.js';
 import { isSubnormalScalar } from '../../../../../util/math.js';
-import { Case, Config, run } from '../../expression.js';
+import { allInputSources, Case, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -121,9 +121,7 @@ g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`abstract int tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -131,9 +129,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     // This array must be strictly increasing, since that ordering determines
@@ -161,9 +157,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`i32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     // This array must be strictly increasing, since that ordering determines
@@ -193,9 +187,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -203,9 +195,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -245,8 +235,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -24,7 +24,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -40,7 +40,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -62,7 +62,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -13,7 +13,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { absMatch } from '../../../../../util/compare.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { linearRange } from '../../../../../util/math.js';
-import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,9 +23,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -39,9 +37,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
@@ -61,8 +57,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -9,6 +9,7 @@ Returns the hyperbolic cosine of e. Component-wise when T is a vector
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/countLeadingZeros.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countLeadingZeros.spec.ts
@@ -13,7 +13,7 @@ Also known as "clz" in some languages.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeU32, u32Bits, u32, TypeI32, i32Bits, i32 } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { allInputSources, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,9 +23,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -140,9 +138,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`i32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/countLeadingZeros.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countLeadingZeros.spec.ts
@@ -24,7 +24,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -141,7 +141,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/countOneBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countOneBits.spec.ts
@@ -12,7 +12,7 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeU32, u32Bits, u32, TypeI32, i32Bits, i32 } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { allInputSources, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,9 +22,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -139,9 +137,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`i32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/countOneBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countOneBits.spec.ts
@@ -23,7 +23,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -140,7 +140,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/countTrailingZeros.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countTrailingZeros.spec.ts
@@ -13,7 +13,7 @@ Also known as "ctz" in some languages.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { i32, i32Bits, TypeI32, u32, TypeU32, u32Bits } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { allInputSources, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,9 +23,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -140,9 +138,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`i32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/countTrailingZeros.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countTrailingZeros.spec.ts
@@ -24,7 +24,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -141,7 +141,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -8,23 +8,24 @@ Returns the cross product of e1 and e2.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
-  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
-  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
-  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -14,17 +14,17 @@ export const g = makeTestGroup(GPUTest);
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
-  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
-  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
-  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -9,6 +9,7 @@ Converts radians to degrees, approximating e1 × 180 ÷ π. Component-wise when 
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
@@ -9,35 +9,24 @@ Returns the determinant of e.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
   .desc(`abstract float tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('dimension', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dimension', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
   .desc(`f32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('dimension', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dimension', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
   .desc(`f16 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('dimension', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dimension', [2, 3, 4] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('dimension', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('dimension', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('dimension', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
@@ -18,7 +18,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -28,7 +28,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -38,7 +38,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
@@ -10,6 +10,7 @@ Returns the distance between e1 and e2 (e.g. length(e1-e2)).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,9 +18,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -27,9 +26,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -37,8 +34,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_int')
   .desc(`abstract int tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -47,7 +47,7 @@ g.test('abstract_float')
   .desc(`abstract float test`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -57,7 +57,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -67,7 +67,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -9,65 +9,42 @@ Returns the dot product of e1 and e2.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
   .desc(`abstract int tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
   .desc(`i32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
   .desc(`u32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
   .desc(`abstract float test`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
   .desc(`f32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
   .desc(`f16 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdx.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdx.spec.ts
@@ -10,6 +10,7 @@ The result is the same as either dpdxFine(e) or dpdxCoarse(e).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,8 +18,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdx.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdx.spec.ts
@@ -18,7 +18,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdxCoarse.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdxCoarse.spec.ts
@@ -17,7 +17,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdxCoarse.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdxCoarse.spec.ts
@@ -9,6 +9,7 @@ This may result in fewer unique positions that dpdxFine(e).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,8 +17,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdxFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdxFine.spec.ts
@@ -16,7 +16,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdxFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdxFine.spec.ts
@@ -8,6 +8,7 @@ Returns the partial derivative of e with respect to window x coordinates.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -15,8 +16,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdy.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdy.spec.ts
@@ -9,6 +9,7 @@ The result is the same as either dpdyFine(e) or dpdyCoarse(e).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,8 +17,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdy.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdy.spec.ts
@@ -17,7 +17,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdyCoarse.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdyCoarse.spec.ts
@@ -17,7 +17,7 @@ g.test('f32')
   .desc(`f32 test`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdyCoarse.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdyCoarse.spec.ts
@@ -9,6 +9,7 @@ This may result in fewer unique positions that dpdyFine(e).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,8 +17,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
   .desc(`f32 test`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdyFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdyFine.spec.ts
@@ -16,7 +16,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdyFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdyFine.spec.ts
@@ -8,6 +8,7 @@ Returns the partial derivative of e with respect to window y coordinates.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -15,8 +16,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -24,7 +24,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -34,7 +34,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -65,7 +65,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -13,7 +13,7 @@ import { ulpComparator } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange } from '../../../../../util/math.js';
-import { Case, run } from '../../expression.js';
+import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,9 +23,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -33,9 +31,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const n = (x: number): number => {
@@ -64,8 +60,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -24,7 +24,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -34,7 +34,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -65,7 +65,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -13,7 +13,7 @@ import { ulpComparator } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange } from '../../../../../util/math.js';
-import { Case, run } from '../../expression.js';
+import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,9 +23,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -33,9 +31,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const n = (x: number): number => {
@@ -64,8 +60,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
@@ -44,7 +44,7 @@ import {
   vec4,
   TypeVec,
 } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { allInputSources, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -53,11 +53,7 @@ export const g = makeTestGroup(GPUTest);
 g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('width', [1, 2, 3, 4])
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('width', [1, 2, 3, 4]))
   .fn(async t => {
     const cfg: Config = t.params;
 
@@ -195,11 +191,7 @@ g.test('u32')
 g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`i32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('width', [1, 2, 3, 4])
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('width', [1, 2, 3, 4]))
   .fn(async t => {
     const cfg: Config = t.params;
 

--- a/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
@@ -55,7 +55,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('width', [1, 2, 3, 4])
   )
   .fn(async t => {
@@ -197,7 +197,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('width', [1, 2, 3, 4])
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
@@ -16,7 +16,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -26,7 +26,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -36,7 +36,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
@@ -8,35 +8,24 @@ Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
@@ -28,7 +28,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -145,7 +145,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
@@ -17,7 +17,7 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { i32, i32Bits, TypeI32, u32, TypeU32, u32Bits } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { allInputSources, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -27,9 +27,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -144,9 +142,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`i32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/firstTrailingBit.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/firstTrailingBit.spec.ts
@@ -13,7 +13,7 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { i32, i32Bits, TypeI32, u32, TypeU32, u32Bits } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { allInputSources, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,9 +23,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -140,9 +138,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`i32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/firstTrailingBit.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/firstTrailingBit.spec.ts
@@ -24,7 +24,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -141,7 +141,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -13,7 +13,7 @@ import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kBit } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,9 +23,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -33,9 +31,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -75,8 +71,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -24,7 +24,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -34,7 +34,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -76,7 +76,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
@@ -9,6 +9,7 @@ Returns e1 * e2 + e3. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -14,7 +14,7 @@ import { correctlyRoundedMatch, anyOf } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { isSubnormalNumber } from '../../../../../util/math.js';
-import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -24,9 +24,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -34,9 +32,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -98,8 +94,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -25,7 +25,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -35,7 +35,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -99,7 +99,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
@@ -15,6 +15,7 @@ The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -30,7 +31,7 @@ struct __frexp_result {
 }
 `
   )
-  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
 g.test('scalar_f16')
@@ -45,7 +46,7 @@ struct __frexp_result_f16 {
 }
 `
   )
-  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
 g.test('vector_f32')
@@ -60,11 +61,7 @@ struct __frexp_result_vecN {
 }
 `
   )
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('vector_f16')
@@ -79,9 +76,5 @@ struct __frexp_result_vecN_f16 {
 }
 `
   )
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
@@ -30,7 +30,7 @@ struct __frexp_result {
 }
 `
   )
-  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('scalar_f16')
@@ -45,7 +45,7 @@ struct __frexp_result_f16 {
 }
 `
   )
-  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('vector_f32')
@@ -62,7 +62,7 @@ struct __frexp_result_vecN {
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -81,7 +81,7 @@ struct __frexp_result_vecN_f16 {
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidth.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidth.spec.ts
@@ -16,7 +16,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidth.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidth.spec.ts
@@ -8,6 +8,7 @@ Returns abs(dpdx(e)) + abs(dpdy(e)).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -15,8 +16,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidthCoarse.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidthCoarse.spec.ts
@@ -16,7 +16,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidthCoarse.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidthCoarse.spec.ts
@@ -8,6 +8,7 @@ Returns abs(dpdxCoarse(e)) + abs(dpdyCoarse(e)).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -15,8 +16,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidthFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidthFine.spec.ts
@@ -16,7 +16,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidthFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidthFine.spec.ts
@@ -8,6 +8,7 @@ Returns abs(dpdxFine(e)) + abs(dpdyFine(e)).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -15,8 +16,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#derivative-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
@@ -29,7 +29,7 @@ import {
   vec4,
   TypeVec,
 } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { allInputSources, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -40,7 +40,7 @@ g.test('integer')
   .desc(`integer tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('signed', [false, true])
       .combine('width', [1, 2, 3, 4])
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
@@ -40,7 +40,7 @@ g.test('integer')
   .desc(`integer tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('signed', [false, true])
       .combine('width', [1, 2, 3, 4])
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -24,7 +24,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -34,7 +34,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -63,7 +63,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -13,7 +13,7 @@ import { ulpMatch } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
-import { Case, Config, run } from '../../expression.js';
+import { allInputSources, Case, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,9 +23,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -33,9 +31,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
@@ -62,8 +58,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -18,7 +18,7 @@ import { correctlyRoundedMatch } from '../../../../../util/compare.js';
 import { kValue } from '../../../../../util/constants.js';
 import { f32, i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
 import { biasedRange, linearRange, quantizeToI32 } from '../../../../../util/math.js';
-import { Case, Config, run } from '../../expression.js';
+import { allInputSources, Case, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -31,9 +31,7 @@ g.test('abstract_float')
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -41,9 +39,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const truthFunc = (e1: number, e2: number): Case | undefined => {
@@ -96,8 +92,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -32,7 +32,7 @@ g.test('abstract_float')
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -42,7 +42,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -97,7 +97,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -9,6 +9,7 @@ Returns the length of e (e.g. abs(e) if T is a scalar, or sqrt(e[0]^2 + e[1]^2 +
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -13,7 +13,14 @@ import { absMatch, FloatMatch, ulpMatch } from '../../../../../util/compare.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
-import { Case, CaseList, Config, makeUnaryF32Case, run } from '../../expression.js';
+import {
+  allInputSources,
+  Case,
+  CaseList,
+  Config,
+  makeUnaryF32Case,
+  run,
+} from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -24,7 +31,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )
@@ -41,7 +48,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )
@@ -85,7 +92,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -24,7 +24,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )
@@ -41,7 +41,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )
@@ -85,7 +85,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -13,7 +13,14 @@ import { absMatch, FloatMatch, ulpMatch } from '../../../../../util/compare.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
-import { Case, CaseList, Config, makeUnaryF32Case, run } from '../../expression.js';
+import {
+  allInputSources,
+  Case,
+  CaseList,
+  Config,
+  makeUnaryF32Case,
+  run,
+} from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -24,7 +31,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )
@@ -41,7 +48,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )
@@ -85,7 +92,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -24,7 +24,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )
@@ -41,7 +41,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )
@@ -85,7 +85,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('range', ['low', 'mid', 'high'] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -28,7 +28,7 @@ import {
   u32,
   uint32ToFloat32,
 } from '../../../../../util/conversion.js';
-import { Case, Config, makeBinaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeBinaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -52,9 +52,7 @@ g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`abstract int tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -62,9 +60,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -84,9 +80,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`i32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -106,9 +100,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -116,9 +108,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -154,8 +144,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -53,7 +53,7 @@ g.test('abstract_int')
   .desc(`abstract int tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -63,7 +63,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -85,7 +85,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -107,7 +107,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -117,7 +117,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -155,7 +155,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -52,7 +52,7 @@ g.test('abstract_int')
   .desc(`abstract int tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -62,7 +62,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -84,7 +84,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -106,7 +106,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -116,7 +116,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -154,7 +154,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -27,7 +27,7 @@ import {
   u32,
   uint32ToFloat32,
 } from '../../../../../util/conversion.js';
-import { Case, Config, makeBinaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeBinaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -51,9 +51,7 @@ g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`abstract int tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -61,9 +59,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -83,9 +79,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`i32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -105,9 +99,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -115,9 +107,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -153,8 +143,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -16,6 +16,7 @@ Same as mix(e1,e2,T2(e3)).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -23,9 +24,7 @@ g.test('matching_abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests with matching params`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -33,9 +32,7 @@ g.test('matching_f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 test with matching third param`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -43,38 +40,24 @@ g.test('scalar_f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests with matching third param`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
 g.test('nonmatching_abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests with vector params and scalar third param`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('nonmatching_f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests with vector params and scalar third param`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('monmatching_f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests with vector params and scalar third param`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -24,7 +24,7 @@ g.test('matching_abstract_float')
   .desc(`abstract float tests with matching params`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -34,7 +34,7 @@ g.test('matching_f32')
   .desc(`f32 test with matching third param`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -44,7 +44,7 @@ g.test('scalar_f16')
   .desc(`f16 tests with matching third param`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -54,7 +54,7 @@ g.test('nonmatching_abstract_float')
   .desc(`abstract float tests with vector params and scalar third param`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -64,7 +64,7 @@ g.test('nonmatching_f32')
   .desc(`f32 tests with vector params and scalar third param`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -74,7 +74,7 @@ g.test('monmatching_f16')
   .desc(`f16 tests with vector params and scalar third param`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -18,6 +18,7 @@ Returns the result_struct for the given type.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -33,7 +34,7 @@ struct __modf_result {
 }
 `
   )
-  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
 g.test('scalar_f16')
@@ -48,7 +49,7 @@ struct __modf_result_f16 {
 }
 `
   )
-  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
 g.test('vector_f32')
@@ -63,11 +64,7 @@ struct __modf_result_vecN {
 }
 `
   )
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('vector_f16')
@@ -82,9 +79,5 @@ struct __modf_result_vecN_f16 {
 }
 `
   )
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -33,7 +33,7 @@ struct __modf_result {
 }
 `
   )
-  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('scalar_f16')
@@ -48,7 +48,7 @@ struct __modf_result_f16 {
 }
 `
   )
-  .params(u => u.combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const))
+  .params(u => u.combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const))
   .unimplemented();
 
 g.test('vector_f32')
@@ -65,7 +65,7 @@ struct __modf_result_vecN {
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -84,7 +84,7 @@ struct __modf_result_vecN_f16 {
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -16,7 +16,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -26,7 +26,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -36,7 +36,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -8,6 +8,7 @@ Returns a unit vector in the same direction as e.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -15,9 +16,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -25,9 +24,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -35,8 +32,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -9,6 +9,7 @@ Returns e1 raised to the power e2. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -10,6 +10,7 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,8 +18,6 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -18,7 +18,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
@@ -10,6 +10,7 @@ Component-wise when T is a vector
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,9 +18,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -27,9 +26,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -37,8 +34,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
@@ -18,7 +18,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -28,7 +28,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -38,7 +38,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
@@ -9,35 +9,24 @@ direction e1-2*dot(e2,e1)*e2.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
@@ -20,7 +20,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -30,7 +30,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();
@@ -40,7 +40,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
@@ -12,35 +12,24 @@ vector e3*e1- (e3* dot(e2,e1) + sqrt(k)) *e2.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [2, 3, 4] as const)
-  )
+  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/reverseBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reverseBits.spec.ts
@@ -11,7 +11,7 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeU32, u32Bits, TypeI32, i32Bits } from '../../../../../util/conversion.js';
-import { Config, run } from '../../expression.js';
+import { allInputSources, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,9 +21,7 @@ g.test('u32')
   .specURL('https://www.w3.org/TR/WGSL/#integer-builtin-functions')
   .desc(`u32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;
@@ -139,9 +137,7 @@ g.test('i32')
   .specURL('https://www.w3.org/TR/2021/WD-WGSL-20210929/#integer-builtin-functions')
   .desc(`i32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/reverseBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reverseBits.spec.ts
@@ -22,7 +22,7 @@ g.test('u32')
   .desc(`u32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -140,7 +140,7 @@ g.test('i32')
   .desc(`i32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -12,6 +12,7 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -19,9 +20,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -29,9 +28,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -39,8 +36,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -20,7 +20,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -30,7 +30,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -40,7 +40,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
@@ -65,7 +65,7 @@ g.test('scalar')
   .desc(`scalar tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('component', ['b', 'f', 'i', 'u'] as const)
       .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
   )
@@ -135,7 +135,7 @@ g.test('vector')
   .desc(`vector tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('component', ['b', 'f', 'i', 'u'] as const)
       .combine('overload', ['vec2', 'vec3', 'vec4'] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
@@ -29,7 +29,7 @@ import {
   vec3,
   vec4,
 } from '../../../../../util/conversion.js';
-import { run, CaseList } from '../../expression.js';
+import { run, CaseList, allInputSources } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -65,7 +65,7 @@ g.test('scalar')
   .desc(`scalar tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('component', ['b', 'f', 'i', 'u'] as const)
       .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
   )
@@ -135,7 +135,7 @@ g.test('vector')
   .desc(`vector tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('component', ['b', 'f', 'i', 'u'] as const)
       .combine('overload', ['vec2', 'vec3', 'vec4'] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -9,6 +9,7 @@ Returns the sign of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { absMatch } from '../../../../../util/compare.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { linearRange } from '../../../../../util/math.js';
-import { Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,9 +22,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -38,9 +36,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
@@ -60,8 +56,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -23,7 +23,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -39,7 +39,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
@@ -61,7 +61,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -9,6 +9,7 @@ Returns the hyperbolic sine of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -19,7 +19,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -29,7 +29,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -39,7 +39,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -11,6 +11,7 @@ For scalar T, the result is t * t * (3.0 - 2.0 * t), where t = clamp((x - low) /
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -18,9 +19,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -28,9 +27,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -38,8 +35,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -9,6 +9,7 @@ Returns the square root of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -9,6 +9,7 @@ Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
@@ -9,6 +9,7 @@ Returns the tangent of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
@@ -9,6 +9,7 @@ Returns the hyperbolic tangent of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,9 +17,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -26,9 +25,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -36,8 +33,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
@@ -17,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -37,7 +37,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
@@ -8,6 +8,7 @@ Returns the transpose of e.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -16,7 +17,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('rows', [2, 3, 4] as const)
       .combine('cols', [2, 3, 4] as const)
   )
@@ -27,7 +28,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('rows', [2, 3, 4] as const)
       .combine('cols', [2, 3, 4] as const)
   )
@@ -38,7 +39,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', allInputSources)
       .combine('rows', [2, 3, 4] as const)
       .combine('cols', [2, 3, 4] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
@@ -16,7 +16,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('rows', [2, 3, 4] as const)
       .combine('cols', [2, 3, 4] as const)
   )
@@ -27,7 +27,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('rows', [2, 3, 4] as const)
       .combine('cols', [2, 3, 4] as const)
   )
@@ -38,7 +38,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('rows', [2, 3, 4] as const)
       .combine('cols', [2, 3, 4] as const)
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -10,6 +10,7 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { allInputSources } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,9 +18,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -27,9 +26,7 @@ g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -37,8 +34,6 @@ g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -18,7 +18,7 @@ g.test('abstract_float')
   .desc(`abstract float tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -28,7 +28,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
@@ -38,7 +38,7 @@ g.test('f16')
   .desc(`f16 tests`)
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -50,6 +50,9 @@ export type InputSource =
   | 'storage_r' // Read-only storage buffer
   | 'storage_rw'; // Read-write storage buffer
 
+/** All possible input sources */
+export const allInputSources: InputSource[] = ['uniform', 'storage_r', 'storage_rw'];
+
 /** Configuration for running a expression test */
 export type Config = {
   // Where the input values are read from

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -44,13 +44,16 @@ export type Case = {
 /** CaseList is a list of Cases */
 export type CaseList = Array<Case>;
 
-/** The storage class to use on test input buffers */
-export type StorageClass = 'uniform' | 'storage_r' | 'storage_rw';
+/** The input value source */
+export type InputSource =
+  | 'uniform' // Uniform buffer
+  | 'storage_r' // Read-only storage buffer
+  | 'storage_rw'; // Read-write storage buffer
 
 /** Configuration for running a expression test */
 export type Config = {
   // Where the input values are read from
-  storageClass: StorageClass;
+  inputSource: InputSource;
   // If defined, scalar test cases will be packed into vectors of the given
   // width, which must be 2, 3 or 4.
   // Requires that all parameters of the expression overload are of a scalar
@@ -131,7 +134,7 @@ export function run(
   expressionBuilder: ExpressionBuilder,
   parameterTypes: Array<Type>,
   returnType: Type,
-  cfg: Config = { storageClass: 'storage_r' },
+  cfg: Config = { inputSource: 'storage_r' },
   cases: CaseList
 ) {
   const cmpFloats =
@@ -148,7 +151,7 @@ export function run(
   // The size of the input buffer max exceed the maximum buffer binding size,
   // so chunk the tests up into batches that fit into the limits.
   const maxInputSize =
-    cfg.storageClass === 'uniform'
+    cfg.inputSource === 'uniform'
       ? t.device.limits.maxUniformBufferBindingSize
       : t.device.limits.maxStorageBufferBindingSize;
   const casesPerBatch = Math.floor(maxInputSize / (parameterTypes.length * kValueStride));
@@ -160,7 +163,7 @@ export function run(
       parameterTypes,
       returnType,
       batchCases,
-      cfg.storageClass,
+      cfg.inputSource,
       cmpFloats
     );
   }
@@ -168,13 +171,13 @@ export function run(
 
 /**
  * Runs the list of expression tests. The input data must fit within the buffer
- * binding limits of the given storageClass.
+ * binding limits of the given inputSource.
  * @param t the GPUTest
  * @param expressionBuilder the expression builder function
  * @param parameterTypes the list of expression parameter types
  * @param returnType the return type for the expression overload
  * @param cases list of test cases that fit within the binding limits of the device
- * @param storageClass the storage class to use for the input buffer
+ * @param inputSource the source of the input values
  * @param cmpFloats the method to compare floating point numbers
  */
 function runBatch(
@@ -183,71 +186,9 @@ function runBatch(
   parameterTypes: Array<Type>,
   returnType: Type,
   cases: CaseList,
-  storageClass: StorageClass,
+  inputSource: InputSource,
   cmpFloats: FloatMatch
 ) {
-  // returns the WGSL expression to load the ith parameter of the given type from the input buffer
-  const paramExpr = (ty: Type, i: number) => fromStorage(ty, `inputs[i].param${i}`);
-
-  // resolves to the expression that calls the builtin
-  const expr = toStorage(returnType, expressionBuilder(parameterTypes.map(paramExpr)));
-
-  const storage = storageClass === 'storage_r' ? 'read' : 'read_write';
-
-  // the full WGSL shader source
-  const source = `
-struct Input {
-${parameterTypes
-  .map((ty, i) => `  @size(${kValueStride}) param${i} : ${storageType(ty)},`)
-  .join('\n')}
-};
-
-struct Output {
-  @size(${kValueStride}) value : ${storageType(returnType)}
-};
-
-@group(0) @binding(0)
-${
-  storageClass === 'uniform'
-    ? `var<uniform> inputs : array<Input, ${cases.length}>;`
-    : `var<storage, ${storage}> inputs : array<Input, ${cases.length}>;`
-}
-@group(0) @binding(1) var<storage, write> outputs : array<Output, ${cases.length}>;
-
-@compute @workgroup_size(1)
-fn main() {
-  for(var i = 0; i < ${cases.length}; i = i + 1) {
-    outputs[i].value = ${expr};
-  }
-}
-`;
-  const inputSize = cases.length * parameterTypes.length * kValueStride;
-
-  // Holds all the parameter values for all cases
-  const inputData = new Uint8Array(inputSize);
-
-  // Pack all the input parameter values into the inputData buffer
-  {
-    const caseStride = kValueStride * parameterTypes.length;
-    for (let caseIdx = 0; caseIdx < cases.length; caseIdx++) {
-      const caseBase = caseIdx * caseStride;
-      for (let paramIdx = 0; paramIdx < parameterTypes.length; paramIdx++) {
-        const offset = caseBase + paramIdx * kValueStride;
-        const params = cases[caseIdx].input;
-        if (params instanceof Array) {
-          params[paramIdx].copyTo(inputData, offset);
-        } else {
-          params.copyTo(inputData, offset);
-        }
-      }
-    }
-  }
-  const inputBuffer = t.makeBufferWithContents(
-    inputData,
-    GPUBufferUsage.COPY_SRC |
-      (storageClass === 'uniform' ? GPUBufferUsage.UNIFORM : GPUBufferUsage.STORAGE)
-  );
-
   // Construct a buffer to hold the results of the expression tests
   const outputBufferSize = cases.length * kValueStride;
   const outputBuffer = t.device.createBuffer({
@@ -255,20 +196,15 @@ fn main() {
     usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
   });
 
-  const module = t.device.createShaderModule({ code: source });
-  const pipeline = t.device.createComputePipeline({
-    layout: 'auto',
-    compute: { module, entryPoint: 'main' },
-  });
-
-  const group = t.device.createBindGroup({
-    layout: pipeline.getBindGroupLayout(0),
-    entries: [
-      { binding: 0, resource: { buffer: inputBuffer } },
-      { binding: 1, resource: { buffer: outputBuffer } },
-    ],
-  });
-
+  const [pipeline, group] = buildPipeline(
+    t,
+    expressionBuilder,
+    parameterTypes,
+    returnType,
+    cases,
+    inputSource,
+    outputBuffer
+  );
   const encoder = t.device.createCommandEncoder();
   const pass = encoder.beginComputePass();
   pass.setPipeline(pipeline);
@@ -307,6 +243,131 @@ fn main() {
     type: Uint8Array,
     typedLength: outputBufferSize,
   });
+}
+
+/**
+ * Constructs and returns a GPUComputePipeline and GPUBindGroup for running a
+ * batch of test cases.
+ * @param t the GPUTest
+ * @param expressionBuilder the expression builder function
+ * @param parameterTypes the list of expression parameter types
+ * @param returnType the return type for the expression overload
+ * @param cases list of test cases that fit within the binding limits of the device
+ * @param inputSource the source of the input values
+ * @param outputBuffer the buffer that will hold the output values of the tests
+ */
+function buildPipeline(
+  t: GPUTest,
+  expressionBuilder: ExpressionBuilder,
+  parameterTypes: Array<Type>,
+  returnType: Type,
+  cases: CaseList,
+  inputSource: InputSource,
+  outputBuffer: GPUBuffer
+): [GPUComputePipeline, GPUBindGroup] {
+  // wgsl declaration of output buffer and binding
+  const wgslOutputs = `
+struct Output {
+  @size(${kValueStride}) value : ${storageType(returnType)}
+};
+@group(0) @binding(0) var<storage, write> outputs : array<Output, ${cases.length}>;
+`;
+
+  switch (inputSource) {
+    // Input values come from a buffer.
+    case 'uniform':
+    case 'storage_r':
+    case 'storage_rw': {
+      // returns the WGSL expression to load the ith parameter of the given type from the input buffer
+      const paramExpr = (ty: Type, i: number) => fromStorage(ty, `inputs[i].param${i}`);
+
+      // resolves to the expression that calls the builtin
+      const expr = toStorage(returnType, expressionBuilder(parameterTypes.map(paramExpr)));
+
+      // input binding var<...> declaration
+      const wgslInputVar = (function () {
+        switch (inputSource) {
+          case 'storage_r':
+            return 'var<storage, read>';
+          case 'storage_rw':
+            return 'var<storage, read_write>';
+          case 'uniform':
+            return 'var<uniform>';
+        }
+      })();
+
+      // the full WGSL shader source
+      const source = `
+struct Input {
+${parameterTypes
+  .map((ty, i) => `  @size(${kValueStride}) param${i} : ${storageType(ty)},`)
+  .join('\n')}
+};
+
+${wgslOutputs}
+
+@group(0) @binding(1)
+${wgslInputVar} inputs : array<Input, ${cases.length}>;
+
+@compute @workgroup_size(1)
+fn main() {
+  for(var i = 0; i < ${cases.length}; i++) {
+    outputs[i].value = ${expr};
+  }
+}
+`;
+
+      // size in bytes of the input buffer
+      const inputSize = cases.length * parameterTypes.length * kValueStride;
+
+      // Holds all the parameter values for all cases
+      const inputData = new Uint8Array(inputSize);
+
+      // Pack all the input parameter values into the inputData buffer
+      {
+        const caseStride = kValueStride * parameterTypes.length;
+        for (let caseIdx = 0; caseIdx < cases.length; caseIdx++) {
+          const caseBase = caseIdx * caseStride;
+          for (let paramIdx = 0; paramIdx < parameterTypes.length; paramIdx++) {
+            const offset = caseBase + paramIdx * kValueStride;
+            const params = cases[caseIdx].input;
+            if (params instanceof Array) {
+              params[paramIdx].copyTo(inputData, offset);
+            } else {
+              params.copyTo(inputData, offset);
+            }
+          }
+        }
+      }
+
+      // build the input buffer
+      const inputBuffer = t.makeBufferWithContents(
+        inputData,
+        GPUBufferUsage.COPY_SRC |
+          (inputSource === 'uniform' ? GPUBufferUsage.UNIFORM : GPUBufferUsage.STORAGE)
+      );
+
+      // build the shader module
+      const module = t.device.createShaderModule({ code: source });
+
+      // build the pipeline
+      const pipeline = t.device.createComputePipeline({
+        layout: 'auto',
+        compute: { module, entryPoint: 'main' },
+      });
+
+      // build the bind group
+      const group = t.device.createBindGroup({
+        layout: pipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: { buffer: outputBuffer } },
+          { binding: 1, resource: { buffer: inputBuffer } },
+        ],
+      });
+
+      return [pipeline, group];
+    }
+  }
 }
 
 /**

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -23,7 +23,7 @@ Accuracy: Correctly rounded
   )
   .params(u =>
     u
-      .combine('storageClass', ['uniform', 'storage_r', 'storage_rw'] as const)
+      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -7,7 +7,7 @@ import { GPUTest } from '../../../../gpu_test.js';
 import { correctlyRoundedMatch } from '../../../../util/compare.js';
 import { TypeF32 } from '../../../../util/conversion.js';
 import { fullF32Range } from '../../../../util/math.js';
-import { Case, Config, makeUnaryF32Case, run } from '../expression.js';
+import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -22,9 +22,7 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', ['uniform', 'storage_r', 'storage_rw'] as const)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cfg: Config = t.params;


### PR DESCRIPTION
This stack of changes add another input variant where expression values are shader-creation-time constants, instead of coming from uniform or storage buffers.

This is required to test shader-creation-time expression evaluation.

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
