### PR TITLE
Add wrapper around ULP calculation to handle flush vs no flush

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -17,6 +17,7 @@ import {
   linearRange,
   nextAfter,
   oneULP,
+  oneULPImpl,
   withinULP,
 } from '../webgpu/util/math.js';
 
@@ -182,7 +183,7 @@ interface OneULPCase {
   expect: number;
 }
 
-g.test('oneULPFlushToZero')
+g.test('oneULPImplFlushToZero')
   .paramsSimple<OneULPCase>([
     // Edge Cases
     { target: Number.NaN, expect: Number.NaN },
@@ -195,27 +196,27 @@ g.test('oneULPFlushToZero')
 
     // Subnormals
     { target: hexToF32(kBit.f32.subnormal.positive.min), expect: hexToF32(0x00800000) },
+    { target: 2.82e-40, expect: hexToF32(0x00800000) }, // positive subnormal
     { target: hexToF32(kBit.f32.subnormal.positive.max), expect: hexToF32(0x00800000) },
     { target: hexToF32(kBit.f32.subnormal.negative.min), expect: hexToF32(0x00800000) },
+    { target: -2.82e-40, expect: hexToF32(0x00800000) }, // negative subnormal
     { target: hexToF32(kBit.f32.subnormal.negative.max), expect: hexToF32(0x00800000) },
 
     // Normals
-    { target: hexToF32(kBit.f32.positive.max), expect: hexToF32(0x73800000) },
     { target: hexToF32(kBit.f32.positive.min), expect: hexToF32(0x00000001) },
-    { target: hexToF32(kBit.f32.negative.max), expect: hexToF32(0x00000001) },
-    { target: hexToF32(kBit.f32.negative.min), expect: hexToF32(0x73800000) },
     { target: 1, expect: hexToF32(0x33800000) },
     { target: 2, expect: hexToF32(0x34000000) },
     { target: 4, expect: hexToF32(0x34800000) },
     { target: 1000000, expect: hexToF32(0x3d800000) },
+    { target: hexToF32(kBit.f32.positive.max), expect: hexToF32(0x73800000) },
+    { target: hexToF32(kBit.f32.negative.max), expect: hexToF32(0x00000001) },
     { target: -1, expect: hexToF32(0x33800000) },
     { target: -2, expect: hexToF32(0x34000000) },
     { target: -4, expect: hexToF32(0x34800000) },
     { target: -1000000, expect: hexToF32(0x3d800000) },
+    { target: hexToF32(kBit.f32.negative.min), expect: hexToF32(0x73800000) },
 
-    // Not precisely expressible as float32
-    { target: 2.82e-40, expect: hexToF32(0x00800000) }, // positive subnormal
-    { target: -2.82e-40, expect: hexToF32(0x00800000) }, // negative subnormal
+    // No precise f32 value
     { target: 0.001, expect: hexToF32(0x2f000000) }, // positive normal
     { target: -0.001, expect: hexToF32(0x2f000000) }, // negative normal
     { target: 1e40, expect: hexToF32(0x73800000) }, // positive out of range
@@ -223,15 +224,15 @@ g.test('oneULPFlushToZero')
   ])
   .fn(t => {
     const target = t.params.target;
-    const got = oneULP(target, true);
+    const got = oneULPImpl(target, true);
     const expect = t.params.expect;
     t.expect(
       got === expect || (Number.isNaN(got) && Number.isNaN(expect)),
-      `oneULP(${target}, true) returned ${got}. Expected ${expect}`
+      `oneULPImpl(${target}, true) returned ${got}. Expected ${expect}`
     );
   });
 
-g.test('oneULPNoFlush')
+g.test('oneULPImplNoFlush')
   .paramsSimple<OneULPCase>([
     // Edge Cases
     { target: Number.NaN, expect: Number.NaN },
@@ -244,23 +245,27 @@ g.test('oneULPNoFlush')
 
     // Subnormals
     { target: hexToF32(kBit.f32.subnormal.positive.min), expect: hexToF32(0x00000001) },
+    { target: -2.82e-40, expect: hexToF32(0x00000001) }, // negative subnormal
     { target: hexToF32(kBit.f32.subnormal.positive.max), expect: hexToF32(0x00000001) },
     { target: hexToF32(kBit.f32.subnormal.negative.min), expect: hexToF32(0x00000001) },
+    { target: 2.82e-40, expect: hexToF32(0x00000001) }, // positive subnormal
     { target: hexToF32(kBit.f32.subnormal.negative.max), expect: hexToF32(0x00000001) },
 
     // Normals
+    { target: hexToF32(kBit.f32.positive.min), expect: hexToF32(0x00000001) },
     { target: 1, expect: hexToF32(0x33800000) },
     { target: 2, expect: hexToF32(0x34000000) },
     { target: 4, expect: hexToF32(0x34800000) },
     { target: 1000000, expect: hexToF32(0x3d800000) },
+    { target: hexToF32(kBit.f32.positive.max), expect: hexToF32(0x73800000) },
+    { target: hexToF32(kBit.f32.negative.max), expect: hexToF32(0x00000001) },
     { target: -1, expect: hexToF32(0x33800000) },
     { target: -2, expect: hexToF32(0x34000000) },
     { target: -4, expect: hexToF32(0x34800000) },
     { target: -1000000, expect: hexToF32(0x3d800000) },
+    { target: hexToF32(kBit.f32.negative.min), expect: hexToF32(0x73800000) },
 
-    // Non-f32 expressible
-    { target: 2.82e-40, expect: hexToF32(0x00000001) }, // positive subnormal
-    { target: -2.82e-40, expect: hexToF32(0x00000001) }, // negative subnormal
+    // No precise f32 value
     { target: 0.001, expect: hexToF32(0x2f000000) }, // positive normal
     { target: -0.001, expect: hexToF32(0x2f000000) }, // negative normal
     { target: 1e40, expect: hexToF32(0x73800000) }, // positive out of range
@@ -268,11 +273,60 @@ g.test('oneULPNoFlush')
   ])
   .fn(t => {
     const target = t.params.target;
-    const got = oneULP(target, false);
+    const got = oneULPImpl(target, false);
     const expect = t.params.expect;
     t.expect(
       got === expect || (Number.isNaN(got) && Number.isNaN(expect)),
-      `oneULP(${target}, true) returned ${got}. Expected ${expect}`
+      `oneULPImpl(${target}, true) returned ${got}. Expected ${expect}`
+    );
+  });
+
+g.test('oneULP')
+  .paramsSimple<OneULPCase>([
+    // Edge Cases
+    { target: Number.NaN, expect: Number.NaN },
+    { target: Number.NEGATIVE_INFINITY, expect: hexToF32(0x73800000) },
+    { target: Number.POSITIVE_INFINITY, expect: hexToF32(0x73800000) },
+
+    // Zeroes
+    { target: +0, expect: hexToF32(0x00800000) },
+    { target: -0, expect: hexToF32(0x00800000) },
+
+    // Subnormals
+    { target: hexToF32(kBit.f32.subnormal.negative.max), expect: hexToF32(0x00800000) },
+    { target: -2.82e-40, expect: hexToF32(0x00800000) },
+    { target: hexToF32(kBit.f32.subnormal.negative.min), expect: hexToF32(0x00800000) },
+    { target: hexToF32(kBit.f32.subnormal.positive.max), expect: hexToF32(0x00800000) },
+    { target: 2.82e-40, expect: hexToF32(0x00800000) },
+    { target: hexToF32(kBit.f32.subnormal.positive.min), expect: hexToF32(0x00800000) },
+
+    // Normals
+    { target: hexToF32(kBit.f32.positive.min), expect: hexToF32(0x00000001) },
+    { target: 1, expect: hexToF32(0x33800000) },
+    { target: 2, expect: hexToF32(0x34000000) },
+    { target: 4, expect: hexToF32(0x34800000) },
+    { target: 1000000, expect: hexToF32(0x3d800000) },
+    { target: hexToF32(kBit.f32.positive.max), expect: hexToF32(0x73800000) },
+    { target: hexToF32(kBit.f32.negative.max), expect: hexToF32(0x000000001) },
+    { target: -1, expect: hexToF32(0x33800000) },
+    { target: -2, expect: hexToF32(0x34000000) },
+    { target: -4, expect: hexToF32(0x34800000) },
+    { target: -1000000, expect: hexToF32(0x3d800000) },
+    { target: hexToF32(kBit.f32.negative.min), expect: hexToF32(0x73800000) },
+
+    // No precise f32 value
+    { target: -0.001, expect: hexToF32(0x2f000000) }, // negative normal
+    { target: -1e40, expect: hexToF32(0x73800000) }, // negative out of range
+    { target: 0.001, expect: hexToF32(0x2f000000) }, // positive normal
+    { target: 1e40, expect: hexToF32(0x73800000) }, // positive out of range
+  ])
+  .fn(t => {
+    const target = t.params.target;
+    const got = oneULP(target);
+    const expect = t.params.expect;
+    t.expect(
+      got === expect || (Number.isNaN(got) && Number.isNaN(expect)),
+      `oneULP(${target}) returned ${got}. Expected ${expect}`
     );
   });
 

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -17,7 +17,6 @@ import {
   linearRange,
   nextAfter,
   oneULP,
-  oneULPImpl,
   withinULP,
 } from '../webgpu/util/math.js';
 
@@ -183,7 +182,7 @@ interface OneULPCase {
   expect: number;
 }
 
-g.test('oneULPImplFlushToZero')
+g.test('oneULPFlushToZero')
   .paramsSimple<OneULPCase>([
     // Edge Cases
     { target: Number.NaN, expect: Number.NaN },
@@ -224,15 +223,15 @@ g.test('oneULPImplFlushToZero')
   ])
   .fn(t => {
     const target = t.params.target;
-    const got = oneULPImpl(target, true);
+    const got = oneULP(target, true);
     const expect = t.params.expect;
     t.expect(
       got === expect || (Number.isNaN(got) && Number.isNaN(expect)),
-      `oneULPImpl(${target}, true) returned ${got}. Expected ${expect}`
+      `oneULP(${target}, true) returned ${got}. Expected ${expect}`
     );
   });
 
-g.test('oneULPImplNoFlush')
+g.test('oneULPNoFlush')
   .paramsSimple<OneULPCase>([
     // Edge Cases
     { target: Number.NaN, expect: Number.NaN },
@@ -273,11 +272,11 @@ g.test('oneULPImplNoFlush')
   ])
   .fn(t => {
     const target = t.params.target;
-    const got = oneULPImpl(target, false);
+    const got = oneULP(target, false);
     const expect = t.params.expect;
     t.expect(
       got === expect || (Number.isNaN(got) && Number.isNaN(expect)),
-      `oneULPImpl(${target}, true) returned ${got}. Expected ${expect}`
+      `oneULPImpl(${target}, false) returned ${got}. Expected ${expect}`
     );
   });
 

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -179,10 +179,8 @@ export function ulpComparator(x: number, target: Scalar, n: (x: number) => numbe
     if (cmp.matched) {
       return cmp;
     }
-    const ulp = Math.max(
-      oneULP(target.value as number, true),
-      oneULP(target.value as number, false)
-    );
+
+    const ulp = oneULP(target.value as number);
     return {
       matched: false,
       got: got.toString(),

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -386,9 +386,7 @@ export function ulpInterval(n: number, numULP: number): F32Interval {
         return toInterval(n);
       }
 
-      const ulp_flush = oneULP(impl_n, true);
-      const ulp_noflush = oneULP(impl_n, false);
-      const ulp = Math.max(ulp_flush, ulp_noflush);
+      const ulp = oneULP(impl_n);
       const begin = impl_n - numULP * ulp;
       const end = impl_n + numULP * ulp;
       return new F32Interval(

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1,7 +1,7 @@
 import { assert } from '../../common/util/util.js';
 
 import { kBit, kValue } from './constants.js';
-import { f32, f32Bits, f64, i32, Scalar } from './conversion.js';
+import { f32, f32Bits, i32, Scalar } from './conversion.js';
 
 /**
  * A multiple of 8 guaranteed to be way too large to allocate (just under 8 pebibytes).

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -156,7 +156,7 @@ export function nextAfter(val: number, dir: boolean = true, flush: boolean): Sca
  * @param target number to calculate ULP for
  * @param flush should subnormals be flushed to zero
  */
-export function oneULPImpl(target: number, flush: boolean): number {
+function oneULPImpl(target: number, flush: boolean): number {
   if (Number.isNaN(target)) {
     return Number.NaN;
   }
@@ -193,10 +193,15 @@ export function oneULPImpl(target: number, flush: boolean): number {
  * for a more detailed/nuanced discussion of the definition of ulp(x).
  *
  * @param target number to calculate ULP for
- *
+ * @param flush should subnormals be flushed to zero, if not set both flushed
+ *              and non-flush values are considered.
  */
-export function oneULP(target: number): number {
-  return Math.max(oneULPImpl(target, false), oneULPImpl(target, true));
+export function oneULP(target: number, flush?: boolean): number {
+  if (flush === undefined) {
+    return Math.max(oneULPImpl(target, false), oneULPImpl(target, true));
+  }
+
+  return oneULPImpl(target, flush);
 }
 
 /**


### PR DESCRIPTION
Fixes #1516

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
