### PR TITLE
Test creating multisampled textures with RENDER_ATTACHMENT usage

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -301,9 +301,14 @@ g.test('sampleCount,various_sampleCount_with_all_formats')
 
 g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
   .desc(
-    `Test texture creation with valid sample count when dimensions, arrayLayerCount, mipLevelCount, format, and usage varies.
-     Texture can be single sample (sampleCount is 1) or multi-sample (sampleCount is 4).
-     Multisample texture requires that 1) its dimension is 2d or undefined, 2) its format supports multisample, 3) its mipLevelCount and arrayLayerCount are 1, 4) its usage doesn't include STORAGE_BINDING.`
+    `Test texture creation with valid sample count when dimensions, arrayLayerCount, mipLevelCount,
+     format, and usage varies. Texture can be single sample (sampleCount is 1) or multi-sample
+     (sampleCount is 4). Multisample texture requires that
+     1) its dimension is 2d or undefined,
+     2) its format supports multisample,
+     3) its mipLevelCount and arrayLayerCount are 1,
+     4) its usage doesn't include STORAGE_BINDING,
+     5) its usage includes RENDER_ATTACHMENT.`
   )
   .params(u =>
     u
@@ -317,24 +322,24 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
           arrayLayerCount === 2 && dimension !== '2d' && dimension !== undefined
       )
       .combine('mipLevelCount', [1, 2])
-      .combine('usage', kTextureUsages)
+      .expand('usage', p => {
+        const usageSet = new Set<number>();
+        for (const usage0 of kTextureUsages) {
+          for (const usage1 of kTextureUsages) {
+            usageSet.add(usage0 | usage1);
+          }
+        }
+        return usageSet;
+      })
       // Filter out incompatible dimension type and format combinations.
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
-      .unless(({ sampleCount, usage, format, mipLevelCount, dimension }) => {
+      .unless(({ usage, format, mipLevelCount, dimension }) => {
         const info = kTextureFormatInfo[format];
         return (
           ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 &&
             (!info.renderable || dimension !== '2d')) ||
           ((usage & GPUConst.TextureUsage.STORAGE_BINDING) !== 0 && !info.storage) ||
-          (mipLevelCount !== 1 && dimension === '1d') ||
-          // MAINTENANCE_TODO: test that it is not allowed to create a multisampled texture without
-          // RENDER_ATTACHMENT usage.
-          (sampleCount > 1 &&
-            (!info.multisample ||
-              (usage &
-                (GPUConst.TextureUsage.STORAGE_BINDING |
-                  GPUConst.TextureUsage.RENDER_ATTACHMENT)) ===
-                0))
+          (mipLevelCount !== 1 && dimension === '1d')
         );
       })
   )
@@ -369,6 +374,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
         kTextureFormatInfo[format].multisample &&
         mipLevelCount === 1 &&
         arrayLayerCount === 1 &&
+        (usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 &&
         (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0);
 
     t.expectValidationError(() => {


### PR DESCRIPTION
fixes: #1521

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
