### PR TITLE
Use commas for struct member delimeters

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atomicCompareExchangeWeak.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicCompareExchangeWeak.spec.ts
@@ -38,8 +38,8 @@ T is i32 or u32
 fn atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
 
 struct __atomic_compare_exchange_result<T> {
-  old_value : T;    // old value stored in the atomic
-  exchanged : bool; // true if the exchange was done
+  old_value : T,    // old value stored in the atomic
+  exchanged : bool, // true if the exchange was done
 }
 `
   )

--- a/src/webgpu/web_platform/reftests/canvas_complex.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_complex.html.ts
@@ -217,9 +217,9 @@ export function run(
           module: t.device.createShaderModule({
             code: `
 struct VertexOutput {
-  @builtin(position) Position : vec4<f32>;
-  @location(0) fragUV : vec2<f32>;
-};
+  @builtin(position) Position : vec4<f32>,
+  @location(0) fragUV : vec2<f32>,
+}
 
 @vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
@@ -336,9 +336,9 @@ fn linearMain(@location(0) fragUV: vec2<f32>) -> @location(0) vec4<f32> {
           module: t.device.createShaderModule({
             code: `
 struct VertexOutput {
-  @builtin(position) Position : vec4<f32>;
-  @location(0) fragColor : vec4<f32>;
-};
+  @builtin(position) Position : vec4<f32>,
+  @location(0) fragColor : vec4<f32>,
+}
 
 @vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
@@ -417,8 +417,8 @@ fn main(@location(0) fragColor: vec4<f32>) -> @location(0) vec4<f32> {
           module: t.device.createShaderModule({
             code: `
 struct VertexOutput {
-  @builtin(position) Position : vec4<f32>;
-};
+  @builtin(position) Position : vec4<f32>
+}
 
 @vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
@@ -503,8 +503,8 @@ fn main(@builtin(position) fragcoord: vec4<f32>) -> @location(0) vec4<f32> {
           module: t.device.createShaderModule({
             code: `
 struct VertexOutput {
-  @builtin(position) Position : vec4<f32>;
-};
+  @builtin(position) Position : vec4<f32>
+}
 
 @vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -52,9 +52,9 @@ export function run(
         module: t.device.createShaderModule({
           code: `
 struct VertexOutput {
-@builtin(position) Position : vec4<f32>;
-@location(0) fragColor : vec4<f32>;
-};
+@builtin(position) Position : vec4<f32>,
+@location(0) fragColor : vec4<f32>,
+}
 
 @vertex
 fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {


### PR DESCRIPTION
Most of these were already done, but a few were missed or recently
slipped in.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
