### PR TITLE
Do not use `write` access mode for storage buffers

### DIFF
--- a/src/webgpu/shader/execution/evaluation_order.spec.ts
+++ b/src/webgpu/shader/execution/evaluation_order.spec.ts
@@ -416,7 +416,7 @@ fn test_body() -> i32 {
   ${body}
 }
 
-@group(0) @binding(0) var<storage, write> output : i32;
+@group(0) @binding(0) var<storage, read_write> output : i32;
 
 @compute @workgroup_size(1)
 fn main() {

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -300,7 +300,7 @@ function buildPipeline(
 struct Output {
   @size(${kValueStride}) value : ${storageType(returnType)}
 };
-@group(0) @binding(0) var<storage, write> outputs : array<Output, ${cases.length}>;
+@group(0) @binding(0) var<storage, read_write> outputs : array<Output, ${cases.length}>;
 `;
 
   switch (inputSource) {

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -49,7 +49,7 @@ function runShaderTest(
     struct Result {
       value: u32
     };
-    @group(1) @binding(1) var<storage, write> result: Result;
+    @group(1) @binding(1) var<storage, read_write> result: Result;
 
     ${testSource}
 

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -104,11 +104,11 @@ g.test('inputs')
       struct V {
         data : array<vec3<u32>>
       };
-      @group(0) @binding(0) var<storage, write> local_id_out : V;
-      @group(0) @binding(1) var<storage, write> local_index_out : S;
-      @group(0) @binding(2) var<storage, write> global_id_out : V;
-      @group(0) @binding(3) var<storage, write> group_id_out : V;
-      @group(0) @binding(4) var<storage, write> num_groups_out : V;
+      @group(0) @binding(0) var<storage, read_write> local_id_out : V;
+      @group(0) @binding(1) var<storage, read_write> local_index_out : S;
+      @group(0) @binding(2) var<storage, read_write> global_id_out : V;
+      @group(0) @binding(3) var<storage, read_write> group_id_out : V;
+      @group(0) @binding(4) var<storage, read_write> num_groups_out : V;
 
       ${structures}
 


### PR DESCRIPTION
WGSL does not support write-only storage buffers. Use `read_write`
instead.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
