### PR TITLE
Update storage texture format tests to expect exceptions

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -75,7 +75,7 @@ g.test('storage_texture_binding_layout')
   .fn(async t => {
     const { format, enable_required_feature } = t.params;
 
-    t.expectValidationError(() => {
+    t.shouldThrow(enable_required_feature ? false : 'TypeError', () => {
       t.device.createBindGroupLayout({
         entries: [
           {
@@ -87,7 +87,7 @@ g.test('storage_texture_binding_layout')
           },
         ],
       });
-    }, !enable_required_feature);
+    });
   });
 
 g.test('color_target_state')

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -43,11 +43,11 @@ g.test('duplicate_bindings')
       });
     }
 
-    t.expectValidationError(() => {
+    t.shouldThrow(_valid ? false : 'TypeError', () => {
       t.device.createBindGroupLayout({
         entries,
       });
-    }, !_valid);
+    });
   });
 
 g.test('visibility')
@@ -69,11 +69,11 @@ g.test('visibility')
 
     const success = (visibility & ~info.validStages) === 0;
 
-    t.expectValidationError(() => {
+    t.shouldThrow(success ? false : 'TypeError', () => {
       t.device.createBindGroupLayout({
         entries: [{ binding: 0, visibility, ...entry }],
       });
-    }, !success);
+    });
   });
 
 g.test('multisampled_validation')
@@ -87,7 +87,7 @@ g.test('multisampled_validation')
 
     const success = viewDimension === '2d' || viewDimension === undefined;
 
-    t.expectValidationError(() => {
+    t.shouldThrow(success ? false : 'TypeError', () => {
       t.device.createBindGroupLayout({
         entries: [
           {
@@ -97,7 +97,7 @@ g.test('multisampled_validation')
           },
         ],
       });
-    }, !success);
+    });
   });
 
 g.test('max_dynamic_buffers')
@@ -142,9 +142,9 @@ g.test('max_dynamic_buffers')
       entries,
     };
 
-    t.expectValidationError(() => {
+    t.shouldThrow(extraDynamicBuffers > 0 ? 'TypeError' : false, () => {
       t.device.createBindGroupLayout(descriptor);
-    }, extraDynamicBuffers > 0);
+    });
   });
 
 /**
@@ -227,9 +227,9 @@ g.test('max_resources_per_stage,in_bind_group_layout')
       (maxedVisibility & extraVisibility) !== 0 &&
       maxedTypeInfo.perStageLimitClass.class === extraTypeInfo.perStageLimitClass.class;
 
-    t.expectValidationError(() => {
+    t.shouldThrow(newBindingCountsTowardSamePerStageLimit ? 'TypeError' : false, () => {
       t.device.createBindGroupLayout(newDescriptor);
-    }, newBindingCountsTowardSamePerStageLimit);
+    });
   });
 
 // One pipeline layout can have a maximum number of each type of binding *per stage* (which is


### PR DESCRIPTION
This PR updates existing storage texture format tests to
expect exceptions rather than validation errors in those
cases.

Issue: #919 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
