### PR TITLE
Convert `cos` tests to using new interval framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -10,6 +10,7 @@ import {
   absoluteErrorInterval,
   atanInterval,
   correctlyRoundedInterval,
+  cosInterval,
   F32Interval,
   ulpInterval,
 } from '../webgpu/util/f32_interval.js';
@@ -624,5 +625,36 @@ g.test('atanInterval')
     t.expect(
       objectEquals(expected, got),
       `atanInterval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('cosInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      // This test does not include some common cases. i.e. f(x = π/2) = 0, because the difference between true x
+      // and x as a f32 is sufficiently large, such that the high slope of f @ x causes the results to be substantially
+      // different, so instead of getting 0 you get a value on the order of 10^-8 away from 0, thus difficult to express
+      // in a human readable manner.
+      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.negative.min, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.negative.pi.whole, expected: [-1, plusOneULP(-1)] },
+      { input: kValue.f32.negative.pi.third, expected: [minusOneULP(1/2), 1/2] },
+      { input: 0, expected: [1, 1] },
+      { input: kValue.f32.positive.pi.third, expected: [minusOneULP(1/2), 1/2] },
+      { input: kValue.f32.positive.pi.whole, expected: [-1, plusOneULP(-1)] },
+      { input: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: Number.POSITIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+    ]
+  )
+  .fn(t => {
+    const error = 2 ** -11;
+    const input = t.params.input;
+    const [begin, end] = t.params.expected;
+    const expected = arrayToInterval([begin - error, end + error]);
+    const got = cosInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `cosInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -10,10 +10,10 @@ Returns the cosine of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { absMatch } from '../../../../../util/compare.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { cosInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -40,17 +40,17 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    // [1]: Need to decide what the ground-truth is.
-    const makeCase = (x: number): Case => {
-      return makeUnaryF32Case(x, Math.cos);
+    const makeCase = (n: number): Case => {
+      return makeUnaryF32IntervalCase(n, cosInterval);
     };
 
-    // Spec defines accuracy on [-π, π]
-    const cases = linearRange(-Math.PI, Math.PI, 1000).map(x => makeCase(x));
+    const cases: Array<Case> = [
+      // Well defined accuracy range
+      ...linearRange(-Math.PI, Math.PI, 1000),
 
-    const cfg: Config = t.params;
-    cfg.cmpFloats = absMatch(2 ** -11);
-    run(t, builtin('cos'), [TypeF32], TypeF32, cfg, cases);
+      ...fullF32Range(),
+    ].map(makeCase);
+    run(t, builtin('cos'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -419,3 +419,16 @@ export function atanInterval(n: number): F32Interval {
 
   return runPointOp(toInterval(n), op);
 }
+
+/** Calculate an acceptance interval of cos(x) */
+export function cosInterval(n: number): F32Interval {
+  const op: PointToIntervalOp = {
+    impl: (impl_n: number): F32Interval => {
+      return kValue.f32.negative.pi.whole <= impl_n && impl_n <= kValue.f32.positive.pi.whole
+        ? absoluteErrorInterval(Math.cos(impl_n), 2 ** -11)
+        : F32Interval.infinite();
+    },
+  };
+
+  return runPointOp(toInterval(n), op);
+}


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
