### PR TITLE
Update the texture format tests of GPUColorTargetState to expect exceptions

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -51,7 +51,8 @@ g.test('texture_descriptor')
 g.test('texture_view_descriptor')
   .desc(
     `
-  Test creating a texture view with all texture formats will fail if the required optional feature is not enabled.
+  Test creating a texture view with all texture formats will fail if the required optional feature
+  is not enabled.
   `
   )
   .params(u =>
@@ -155,7 +156,7 @@ g.test('color_target_state')
   .fn(async t => {
     const { format, enable_required_feature } = t.params;
 
-    t.expectValidationError(() => {
+    t.shouldThrow(enable_required_feature ? false : 'TypeError', () => {
       t.device.createRenderPipeline({
         layout: 'auto',
         vertex: {
@@ -180,7 +181,7 @@ g.test('color_target_state')
           targets: [{ format }],
         },
       });
-    }, !enable_required_feature);
+    });
   });
 
 g.test('depth_stencil_state')
@@ -211,7 +212,7 @@ g.test('depth_stencil_state')
   .fn(async t => {
     const { format, enable_required_feature } = t.params;
 
-    t.expectValidationError(() => {
+    t.shouldThrow(enable_required_feature ? false : 'TypeError', () => {
       t.device.createRenderPipeline({
         layout: 'auto',
         vertex: {
@@ -239,7 +240,7 @@ g.test('depth_stencil_state')
           targets: [{ format: 'rgba8unorm' }],
         },
       });
-    }, !enable_required_feature);
+    });
   });
 
 g.test('render_bundle_encoder_descriptor_color_format')


### PR DESCRIPTION
This PR updates the existing texture format tests of the color target state and
the depth stencil state to expect exceptions rather than validation errors in those
cases.

Additionally, this PR fixes the long line over 80 columns added by the previous PR.

Issue: #919 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
