### PR TITLE
Update the color and depth stencil formats of RenderBundleEncoder tests to expect exceptions

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -268,11 +268,11 @@ g.test('render_bundle_encoder_descriptor_color_format')
   .fn(async t => {
     const { format, enable_required_feature } = t.params;
 
-    t.expectValidationError(() => {
+    t.shouldThrow(enable_required_feature ? false : 'TypeError', () => {
       t.device.createRenderBundleEncoder({
         colorFormats: [format],
       });
-    }, !enable_required_feature);
+    });
   });
 
 g.test('render_bundle_encoder_descriptor_depth_stencil_format')
@@ -303,10 +303,10 @@ g.test('render_bundle_encoder_descriptor_depth_stencil_format')
   .fn(async t => {
     const { format, enable_required_feature } = t.params;
 
-    t.expectValidationError(() => {
+    t.shouldThrow(enable_required_feature ? false : 'TypeError', () => {
       t.device.createRenderBundleEncoder({
         colorFormats: ['rgba8unorm'],
         depthStencilFormat: format,
       });
-    }, !enable_required_feature);
+    });
   });

--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -46,12 +46,12 @@ g.test('attachment_state')
       shouldError = true;
     }
 
-    t.expectValidationError(() => {
+    t.shouldThrow(shouldError ? 'TypeError' : false, () => {
       t.device.createRenderBundleEncoder({
         colorFormats: Array(colorFormatCount).fill(colorFormat),
         depthStencilFormat,
       });
-    }, shouldError);
+    });
   });
 
 g.test('valid_texture_formats')
@@ -82,21 +82,21 @@ g.test('valid_texture_formats')
 
     switch (attachment) {
       case 'color': {
-        t.expectValidationError(() => {
+        t.shouldThrow(colorRenderable ? false : 'TypeError', () => {
           t.device.createRenderBundleEncoder({
             colorFormats: [format],
           });
-        }, !colorRenderable);
+        });
 
         break;
       }
       case 'depthStencil': {
-        t.expectValidationError(() => {
+        t.shouldThrow(depthStencil ? false : 'TypeError', () => {
           t.device.createRenderBundleEncoder({
             colorFormats: [],
             depthStencilFormat: format,
           });
-        }, !depthStencil);
+        });
 
         break;
       }
@@ -135,14 +135,14 @@ g.test('depth_stencil_readonly')
       shouldError = true;
     }
 
-    t.expectValidationError(() => {
+    t.shouldThrow(shouldError ? 'TypeError' : false, () => {
       t.device.createRenderBundleEncoder({
         colorFormats: [],
         depthStencilFormat,
         depthReadOnly,
         stencilReadOnly,
       });
-    }, shouldError);
+    });
   });
 
 g.test('depth_stencil_readonly_with_undefined_depth')


### PR DESCRIPTION
This PR updates the existing formats of the RenderbundleEncoder creation
tests to expect exceptions rather than validation errors in those cases.

Issue: #919

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
