### PR TITLE
Convert `exp` tests to use new interval framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -12,6 +12,7 @@ import {
   ceilInterval,
   correctlyRoundedInterval,
   cosInterval,
+  expInterval,
   F32Interval,
   ulpInterval,
 } from '../webgpu/util/f32_interval.js';
@@ -727,5 +728,37 @@ g.test('cosInterval')
     t.expect(
       objectEquals(expected, got),
       `cosInterval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('expInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: 0, expected: [1,1] },
+      { input: 1, expected: [kValue.f32.positive.e, plusOneULP(kValue.f32.positive.e)] },
+      { input: 89, expected: arrayToInterval([kValue.f32.positive.max, Number.POSITIVE_INFINITY]) },
+    ]
+  )
+  .fn(t => {
+    const error = (input: number, result: number): number => {
+      const n = 3 + 2 * Math.abs(input);
+      return n * oneULP(result);
+    };
+
+    const input = t.params.input;
+    let expected: F32Interval;
+    if (t.params.expected instanceof Array) {
+      const [begin, end] = t.params.expected;
+      expected = arrayToInterval([begin - error(input, begin), end + error(input, end)]);
+    } else {
+      expected = t.params.expected;
+    }
+
+    const got = expInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `expInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -1199,6 +1199,7 @@ g.test('f32LimitsEquivalency')
     { bits: kBit.f32.positive.pi.third, value: kValue.f32.positive.pi.third },
     { bits: kBit.f32.positive.pi.quarter, value: kValue.f32.positive.pi.quarter },
     { bits: kBit.f32.positive.pi.sixth, value: kValue.f32.positive.pi.sixth },
+    { bits: kBit.f32.positive.e, value: kValue.f32.positive.e },
     { bits: kBit.f32.negative.max, value: kValue.f32.negative.max },
     { bits: kBit.f32.negative.min, value: kValue.f32.negative.min },
     { bits: kBit.f32.negative.nearest_min, value: kValue.f32.negative.nearest_min },

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -9,11 +9,11 @@ Returns the natural exponentiation of e1 (e.g. e^e1). Component-wise when T is a
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ulpComparator } from '../../../../../util/compare.js';
-import { kBit, kValue } from '../../../../../util/constants.js';
-import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
-import { biasedRange } from '../../../../../util/math.js';
-import { allInputSources, Case, run } from '../../expression.js';
+import { kValue } from '../../../../../util/constants.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { expInterval } from '../../../../../util/f32_interval.js';
+import { biasedRange, linearRange } from '../../../../../util/math.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,24 +34,20 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const n = (x: number): number => {
-      return 3 + 2 * Math.abs(x);
-    };
-
     const makeCase = (x: number): Case => {
-      const expected = f32(Math.exp(x));
-      return { input: f32(x), expected: ulpComparator(x, expected, n) };
+      return makeUnaryF32IntervalCase(x, expInterval);
     };
 
     // floor(ln(max f32 value)) = 88, so exp(88) will be within range of a f32, but exp(89) will not
+    // floor(ln(max f64 value)) = 709, so exp(709) can be handled by the testing framework, but exp(710) will misbehave
     const cases: Array<Case> = [
-      makeCase(0), // Returns 1 by definition
-      makeCase(-89), // Returns subnormal value
-      makeCase(kValue.f32.negative.min), // Closest to returning 0 as possible
-      { input: f32(89), expected: f32Bits(kBit.f32.infinity.positive) }, // Overflows
-      ...biasedRange(kValue.f32.negative.max, -88, 100).map(x => makeCase(x)),
-      ...biasedRange(kValue.f32.positive.min, 88, 100).map(x => makeCase(x)),
-    ];
+      0, // Returns 1 by definition
+      -89, // Returns subnormal value
+      kValue.f32.negative.min, // Closest to returning 0 as possible
+      ...biasedRange(kValue.f32.negative.max, -88, 100),
+      ...biasedRange(kValue.f32.positive.min, 88, 100),
+      ...linearRange(89, 709, 10), // Overflows f32, but not f64
+    ].map(x => makeCase(x));
 
     run(t, builtin('exp'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -36,6 +36,7 @@ export const kBit = {
         quarter: 0x3f49_0fdb,
         sixth: 0x3f06_0a92,
       },
+      e: 0x402d_f854,
     },
     negative: {
       max: 0x8080_0000,
@@ -259,6 +260,7 @@ export const kValue = {
         quarter: hexToF32(kBit.f32.positive.pi.quarter),
         sixth: hexToF32(kBit.f32.positive.pi.sixth),
       },
+      e: hexToF32(kBit.f32.positive.e),
     },
     negative: {
       max: hexToF32(kBit.f32.negative.max),

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -443,3 +443,14 @@ export function cosInterval(n: number): F32Interval {
 
   return runPointOp(toInterval(n), op);
 }
+
+/** Calculate an acceptance interval for exp(x) */
+export function expInterval(x: number | F32Interval): F32Interval {
+  const op: PointToIntervalOp = {
+    impl: (impl_x: number): F32Interval => {
+      return ulpInterval(Math.exp(impl_x), 3 + 2 * Math.abs(impl_x));
+    },
+  };
+
+  return runPointOp(toInterval(x), op);
+}


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
