### PR TITLE
Convert `floor` tests to use new interval framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -15,6 +15,7 @@ import {
   expInterval,
   exp2Interval,
   F32Interval,
+  floorInterval,
   ulpInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
@@ -793,5 +794,50 @@ g.test('exp2Interval')
     t.expect(
       objectEquals(expected, got),
       `exp2Interval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('floorInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: [0, 0] },
+      { input: 0.1, expected: [0, 0] },
+      { input: 0.9, expected: [0, 0] },
+      { input: 1.0, expected: [1, 1] },
+      { input: 1.1, expected: [1, 1] },
+      { input: 1.9, expected: [1, 1] },
+      { input: -0.1, expected: [-1, -1] },
+      { input: -0.9, expected: [-1, -1] },
+      { input: -1.0, expected: [-1, -1] },
+      { input: -1.1, expected: [-2, -2] },
+      { input: -1.9, expected: [-2, -2] },
+
+      // Edge cases
+      { input: Number.POSITIVE_INFINITY, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
+      { input: kValue.f32.positive.min, expected: [0, 0] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+      { input: kValue.f32.negative.max, expected: [-1, -1] },
+      { input: kValue.powTwo.to30, expected: [kValue.powTwo.to30, kValue.powTwo.to30] },
+      { input: -kValue.powTwo.to30, expected: [-kValue.powTwo.to30, -kValue.powTwo.to30] },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: [0, 0] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0, 0] },
+      { input: kValue.f32.subnormal.negative.min, expected: [-1, 0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [-1, 0] },
+    ]
+  )
+  .fn(t => {
+    const input = t.params.input;
+    const expected =
+      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+
+    const got = floorInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `floorInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -9,11 +9,10 @@ Returns the floor of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedMatch } from '../../../../../util/compare.js';
-import { kBit } from '../../../../../util/constants.js';
-import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { floorInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,37 +33,27 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
     const makeCase = (x: number): Case => {
-      return makeUnaryF32Case(x, Math.floor);
+      return makeUnaryF32IntervalCase(x, floorInterval);
     };
 
     const cases: Array<Case> = [
       // Small positive numbers
-      { input: f32(0.1), expected: f32(0.0) },
-      { input: f32(0.9), expected: f32(0.0) },
-      { input: f32(1.0), expected: f32(1.0) },
-      { input: f32(1.1), expected: f32(1.0) },
-      { input: f32(1.9), expected: f32(1.0) },
-
+      0.1,
+      0.9,
+      1.0,
+      1.1,
+      1.9,
       // Small negative numbers
-      { input: f32(-0.1), expected: f32(-1.0) },
-      { input: f32(-0.9), expected: f32(-1.0) },
-      { input: f32(-1.0), expected: f32(-1.0) },
-      { input: f32(-1.1), expected: f32(-2.0) },
-      { input: f32(-1.9), expected: f32(-2.0) },
+      -0.1,
+      -0.9,
+      -1.0,
+      -1.1,
+      -1.9,
+      ...fullF32Range(),
+    ].map(x => makeCase(x));
 
-      // Min and Max f32
-      { input: f32Bits(kBit.f32.negative.max), expected: f32(-1.0) },
-      { input: f32Bits(kBit.f32.negative.min), expected: f32Bits(kBit.f32.negative.min) },
-      { input: f32Bits(kBit.f32.positive.min), expected: f32(0.0) },
-      { input: f32Bits(kBit.f32.positive.max), expected: f32Bits(kBit.f32.positive.max) },
-      ...fullF32Range().map(x => makeCase(x)),
-    ];
-
-    run(t, builtin('floor'), [TypeF32], TypeF32, cfg, cases);
+    run(t, builtin('floor'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -465,3 +465,14 @@ export function exp2Interval(x: number | F32Interval): F32Interval {
 
   return runPointOp(toInterval(x), op);
 }
+
+/** Calculate an acceptance interval of floor(x) */
+export function floorInterval(n: number): F32Interval {
+  const op: PointToIntervalOp = {
+    impl: (impl_n: number): F32Interval => {
+      return correctlyRoundedInterval(Math.floor(impl_n));
+    },
+  };
+
+  return runPointOp(toInterval(n), op);
+}


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
