### PR TITLE
Remove redundant entry point tests

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/shader_module.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/shader_module.spec.ts
@@ -7,7 +7,6 @@ Note: entry point matching tests are in ../shader_module/entry_point.spec.ts
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import {
   getFragmentShaderCodeWithOutput,
-  getShaderWithEntryPoint,
   kDefaultVertexShaderCode,
   kDefaultFragmentShaderCode,
 } from '../../../util/shader.js';
@@ -110,89 +109,4 @@ g.test('invalid,fragment')
         targets: [{ format: 'rgba8unorm' }],
       },
     });
-  });
-
-const kEntryPointTestCases = [
-  { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main' },
-  { shaderModuleEntryPoint: 'main', stageEntryPoint: '' },
-  { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0' },
-  { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\0a' },
-  { shaderModuleEntryPoint: 'main', stageEntryPoint: 'mian' },
-  { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main ' },
-  { shaderModuleEntryPoint: 'main', stageEntryPoint: 'ma in' },
-  { shaderModuleEntryPoint: 'main', stageEntryPoint: 'main\n' },
-  { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'mian' },
-  { shaderModuleEntryPoint: 'mian', stageEntryPoint: 'main' },
-  { shaderModuleEntryPoint: 'mainmain', stageEntryPoint: 'mainmain' },
-  { shaderModuleEntryPoint: 'mainmain', stageEntryPoint: 'foo' },
-  { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: 'main_t12V3' },
-  { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: 'main_t12V5' },
-  { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: '_main_t12V3' },
-  { shaderModuleEntryPoint: 'séquençage', stageEntryPoint: 'séquençage' },
-  { shaderModuleEntryPoint: 'séquençage', stageEntryPoint: 'sequencage' },
-];
-
-g.test('entry_point,vertex')
-  .desc(
-    `
-Tests calling createRenderPipeline(Async) with valid vertex stage shader and different entryPoints,
-and check that the APIs only accept matching entryPoint.
-
-The entryPoint in shader module include standard "main" and others.
-The entryPoint assigned in descriptor include:
-- Matching case (control case)
-- Empty string
-- Mistyping
-- Containing invalid char, including space and control codes (Null character)
-- Unicode entrypoints and their ASCIIfied version
-
-TODO:
-- Test unicode normalization (gpuweb/gpuweb#1160)
-- Fine-tune test cases to reduce number by removing trivially similiar cases
-`
-  )
-  .params(u => u.combine('isAsync', [true, false]).combineWithParams(kEntryPointTestCases))
-  .fn(async t => {
-    const { isAsync, shaderModuleEntryPoint, stageEntryPoint } = t.params;
-    const descriptor: GPURenderPipelineDescriptor = {
-      layout: 'auto',
-      vertex: {
-        module: t.device.createShaderModule({
-          code: getShaderWithEntryPoint('vertex', shaderModuleEntryPoint),
-        }),
-        entryPoint: stageEntryPoint,
-      },
-    };
-    const _success = shaderModuleEntryPoint === stageEntryPoint;
-    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
-  });
-
-g.test('entry_point,fragment')
-  .desc(
-    `
-Tests calling createRenderPipeline(Async) with valid fragment stage shader and different entryPoints,
-and check that the APIs only accept matching entryPoint.
-`
-  )
-  .params(u => u.combine('isAsync', [true, false]).combineWithParams(kEntryPointTestCases))
-  .fn(async t => {
-    const { isAsync, shaderModuleEntryPoint, stageEntryPoint } = t.params;
-    const descriptor: GPURenderPipelineDescriptor = {
-      layout: 'auto',
-      vertex: {
-        module: t.device.createShaderModule({
-          code: kDefaultVertexShaderCode,
-        }),
-        entryPoint: 'main',
-      },
-      fragment: {
-        module: t.device.createShaderModule({
-          code: getShaderWithEntryPoint('fragment', shaderModuleEntryPoint),
-        }),
-        entryPoint: stageEntryPoint,
-        targets: [{ format: 'rgba8unorm' }],
-      },
-    };
-    const _success = shaderModuleEntryPoint === stageEntryPoint;
-    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
   });


### PR DESCRIPTION
Follow up of #1520
(As these tests are already splited into `validation/shader_module/entry_point.spec.ts`)
