### PR TITLE
Add tests for container type reflection attributes

### DIFF
--- a/src/webgpu/api/operation/reflection.spec.ts
+++ b/src/webgpu/api/operation/reflection.spec.ts
@@ -1,0 +1,124 @@
+export const description = `
+Tests that object attributes which reflect the object's creation properties are properly set.
+`;
+
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { GPUTest } from '../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('buffer_reflection_attributes')
+  .desc(`For every buffer attribute, the corresponding descriptor value is carried over.`)
+  .params(u =>
+    u.beginSubcases().combine('descriptor', [
+      { size: 4, usage: GPUBufferUsage.VERTEX },
+      {
+        size: 16,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+      },
+      { size: 32, usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST },
+      { size: 32, usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.MAP_WRITE, invalid: true },
+    ] as const)
+  )
+  .fn(async t => {
+    const { descriptor } = t.params;
+
+    t.expectValidationError(() => {
+      const buffer = t.device.createBuffer(descriptor);
+
+      t.expect(buffer.size === descriptor.size);
+      t.expect(buffer.usage === descriptor.usage);
+    }, descriptor.invalid === true);
+  });
+
+g.test('texture_reflection_attributes')
+  .desc(`For every texture attribute, the corresponding descriptor value is carried over.`)
+  .params(u =>
+    u.beginSubcases().combine('descriptor', [
+      {
+        size: { width: 4, height: 4 },
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+      },
+      {
+        size: { width: 8, height: 8, depthOrArrayLayers: 8 },
+        format: 'bgra8unorm',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      },
+      {
+        size: [4, 4],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+        mipLevelCount: 2,
+      },
+      {
+        size: [16, 16, 16],
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+        dimension: '3d',
+      },
+      { size: [32], format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, dimension: '1d' },
+      {
+        size: { width: 4, height: 4 },
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        sampleCount: 4,
+      },
+      {
+        size: { width: 4, height: 4 },
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+        sampleCount: 4,
+        invalid: true,
+      },
+    ] as const)
+  )
+  .fn(async t => {
+    const { descriptor } = t.params;
+
+    let width: number;
+    let height: number;
+    let depthOrArrayLayers: number;
+    if (Array.isArray(descriptor.size)) {
+      width = descriptor.size[0];
+      height = descriptor.size[1] || 1;
+      depthOrArrayLayers = descriptor.size[2] || 1;
+    } else {
+      width = (descriptor.size as GPUExtent3DDict).width;
+      height = (descriptor.size as GPUExtent3DDict).height || 1;
+      depthOrArrayLayers = (descriptor.size as GPUExtent3DDict).depthOrArrayLayers || 1;
+    }
+
+    t.expectValidationError(() => {
+      const texture = t.device.createTexture(descriptor);
+
+      t.expect(texture.width === width);
+      t.expect(texture.height === height);
+      t.expect(texture.depthOrArrayLayers === depthOrArrayLayers);
+      t.expect(texture.format === descriptor.format);
+      t.expect(texture.usage === descriptor.usage);
+      t.expect(texture.dimension === (descriptor.dimension || '2d'));
+      t.expect(texture.mipLevelCount === (descriptor.mipLevelCount || 1));
+      t.expect(texture.sampleCount === (descriptor.sampleCount || 1));
+    }, descriptor.invalid === true);
+  });
+
+g.test('query_set_reflection_attributes')
+  .desc(`For every queue attribute, the corresponding descriptor value is carried over.`)
+  .params(u =>
+    u.beginSubcases().combine('descriptor', [
+      { type: 'occlusion', count: 4 },
+      { type: 'occlusion', count: 16 },
+      { type: 'occlusion', count: 8193, invalid: true },
+    ] as const)
+  )
+  .fn(async t => {
+    const { descriptor } = t.params;
+
+    t.expectValidationError(() => {
+      const querySet = t.device.createQuerySet(descriptor);
+
+      t.expect(querySet.type === descriptor.type);
+      t.expect(querySet.count === descriptor.count);
+    }, descriptor.invalid === true);
+  });

--- a/src/webgpu/api/operation/reflection.spec.ts
+++ b/src/webgpu/api/operation/reflection.spec.ts
@@ -3,21 +3,29 @@ Tests that object attributes which reflect the object's creation properties are 
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { GPUConst } from '../../constants.js';
 import { GPUTest } from '../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
 g.test('buffer_reflection_attributes')
   .desc(`For every buffer attribute, the corresponding descriptor value is carried over.`)
-  .params(u =>
-    u.beginSubcases().combine('descriptor', [
-      { size: 4, usage: GPUBufferUsage.VERTEX },
+  .paramsSubcasesOnly(u =>
+    u.combine('descriptor', [
+      { size: 4, usage: GPUConst.BufferUsage.VERTEX },
       {
         size: 16,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
+        usage:
+          GPUConst.BufferUsage.STORAGE |
+          GPUConst.BufferUsage.COPY_SRC |
+          GPUConst.BufferUsage.UNIFORM,
       },
-      { size: 32, usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST },
-      { size: 32, usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.MAP_WRITE, invalid: true },
+      { size: 32, usage: GPUConst.BufferUsage.MAP_READ | GPUConst.BufferUsage.COPY_DST },
+      {
+        size: 32,
+        usage: GPUConst.BufferUsage.MAP_READ | GPUConst.BufferUsage.MAP_WRITE,
+        invalid: true,
+      },
     ] as const)
   )
   .fn(async t => {
@@ -33,41 +41,46 @@ g.test('buffer_reflection_attributes')
 
 g.test('texture_reflection_attributes')
   .desc(`For every texture attribute, the corresponding descriptor value is carried over.`)
-  .params(u =>
-    u.beginSubcases().combine('descriptor', [
+  .paramsSubcasesOnly(u =>
+    u.combine('descriptor', [
       {
         size: { width: 4, height: 4 },
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING,
+        usage: GPUConst.TextureUsage.TEXTURE_BINDING,
       },
       {
         size: { width: 8, height: 8, depthOrArrayLayers: 8 },
         format: 'bgra8unorm',
-        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+        usage: GPUConst.TextureUsage.RENDER_ATTACHMENT | GPUConst.TextureUsage.COPY_SRC,
       },
       {
         size: [4, 4],
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING,
+        usage: GPUConst.TextureUsage.TEXTURE_BINDING,
         mipLevelCount: 2,
       },
       {
         size: [16, 16, 16],
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING,
+        usage: GPUConst.TextureUsage.TEXTURE_BINDING,
         dimension: '3d',
       },
-      { size: [32], format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, dimension: '1d' },
+      {
+        size: [32],
+        format: 'rgba8unorm',
+        usage: GPUConst.TextureUsage.TEXTURE_BINDING,
+        dimension: '1d',
+      },
       {
         size: { width: 4, height: 4 },
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        usage: GPUConst.TextureUsage.RENDER_ATTACHMENT,
         sampleCount: 4,
       },
       {
         size: { width: 4, height: 4 },
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING,
+        usage: GPUConst.TextureUsage.TEXTURE_BINDING,
         sampleCount: 4,
         invalid: true,
       },
@@ -105,8 +118,8 @@ g.test('texture_reflection_attributes')
 
 g.test('query_set_reflection_attributes')
   .desc(`For every queue attribute, the corresponding descriptor value is carried over.`)
-  .params(u =>
-    u.beginSubcases().combine('descriptor', [
+  .paramsSubcasesOnly(u =>
+    u.combine('descriptor', [
       { type: 'occlusion', count: 4 },
       { type: 'occlusion', count: 16 },
       { type: 'occlusion', count: 8193, invalid: true },


### PR DESCRIPTION
Adds tests for Texture, Buffer, and QuerySet to ensure that their
reflection attributes are set properly upon construction.

These properties aren't currently implemented in Chrome, but either I or another team member are likely to get to that shortly. It's fine by me to hold off on landing this until then.
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
