### PR TITLE
Implement api,validation,capability_checks,features,texture_formats:texture_descriptor_view_formats

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -3,8 +3,6 @@ Tests for capability checking for features enabling optional texture formats.
 
 TODO(#902): test GPUCanvasConfiguration.format (it doesn't allow any optional formats today but the
   error might still be different - exception instead of validation.
-
-TODO(#920): test GPUTextureDescriptor.viewFormats (if/when it takes formats)
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
@@ -44,6 +42,38 @@ g.test('texture_descriptor')
         format,
         size: [formatInfo.blockWidth, formatInfo.blockHeight, 1] as const,
         usage: GPUTextureUsage.TEXTURE_BINDING,
+      });
+    });
+  });
+
+g.test('texture_descriptor_view_formats')
+  .desc(
+    `
+  Test creating a texture with view formats that have an optional texture format will fail if the
+  required optional feature is not enabled.
+  `
+  )
+  .params(u =>
+    u.combine('format', kOptionalTextureFormats).combine('enable_required_feature', [true, false])
+  )
+  .beforeAllSubcases(t => {
+    const { format, enable_required_feature } = t.params;
+
+    const formatInfo = kTextureFormatInfo[format];
+    if (enable_required_feature) {
+      t.selectDeviceOrSkipTestCase(formatInfo.feature);
+    }
+  })
+  .fn(async t => {
+    const { format, enable_required_feature } = t.params;
+
+    const formatInfo = kTextureFormatInfo[format];
+    t.shouldThrow(enable_required_feature ? false : 'TypeError', () => {
+      t.device.createTexture({
+        format,
+        size: [formatInfo.blockWidth, formatInfo.blockHeight, 1] as const,
+        usage: GPUTextureUsage.TEXTURE_BINDING,
+        viewFormats: [format],
       });
     });
   });


### PR DESCRIPTION
This PR adds the texture_descriptor_view_formats test in
'api,validation,capability_checks,features,texture_formats:*' in order to
check if creating a new texture with a viewFormats list throws an exception
when the required feature is not enabled.

Issue: #920 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
