### PR TITLE
Describe the number_of_bind_group_layouts_exceeds_the_maximum_value test

### DIFF
--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -78,35 +78,44 @@ g.test('number_of_dynamic_buffers_exceeds_the_maximum_value')
     });
   });
 
-g.test('number_of_bind_group_layouts_exceeds_the_maximum_value').fn(async t => {
-  const bindGroupLayoutDescriptor: GPUBindGroupLayoutDescriptor = {
-    entries: [],
-  };
+g.test('number_of_bind_group_layouts_exceeds_the_maximum_value')
+  .desc(
+    `
+    Test that creating a pipeline layout fails with a validation error if the number of bind group
+    layouts exceeds the maximum value in the pipeline layout.
+    - Test that creation of a pipeline using the maximum number of bind groups added a bind group
+      fails.
+  `
+  )
+  .fn(async t => {
+    const bindGroupLayoutDescriptor: GPUBindGroupLayoutDescriptor = {
+      entries: [],
+    };
 
-  // 4 is the maximum number of bind group layouts.
-  const maxBindGroupLayouts = [1, 2, 3, 4].map(() =>
-    t.device.createBindGroupLayout(bindGroupLayoutDescriptor)
-  );
+    // 4 is the maximum number of bind group layouts.
+    const maxBindGroupLayouts = [1, 2, 3, 4].map(() =>
+      t.device.createBindGroupLayout(bindGroupLayoutDescriptor)
+    );
 
-  const goodPipelineLayoutDescriptor = {
-    bindGroupLayouts: maxBindGroupLayouts,
-  };
+    const goodPipelineLayoutDescriptor = {
+      bindGroupLayouts: maxBindGroupLayouts,
+    };
 
-  // Control case
-  t.device.createPipelineLayout(goodPipelineLayoutDescriptor);
+    // Control case
+    t.device.createPipelineLayout(goodPipelineLayoutDescriptor);
 
-  // Check bind group layouts exceed maximum in pipeline layout.
-  const badPipelineLayoutDescriptor = {
-    bindGroupLayouts: [
-      ...maxBindGroupLayouts,
-      t.device.createBindGroupLayout(bindGroupLayoutDescriptor),
-    ],
-  };
+    // Check bind group layouts exceed maximum in pipeline layout.
+    const badPipelineLayoutDescriptor = {
+      bindGroupLayouts: [
+        ...maxBindGroupLayouts,
+        t.device.createBindGroupLayout(bindGroupLayoutDescriptor),
+      ],
+    };
 
-  t.expectValidationError(() => {
-    t.device.createPipelineLayout(badPipelineLayoutDescriptor);
+    t.expectValidationError(() => {
+      t.device.createPipelineLayout(badPipelineLayoutDescriptor);
+    });
   });
-});
 
 g.test('bind_group_layouts,device_mismatch')
   .desc(


### PR DESCRIPTION
This PR adds a description for the number_of_bind_group_layouts_exceeds_the_maximum_value
test.

Issue: #1563 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
