### PR TITLE
Fix texture_descriptor_view_formats capability check tests

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -98,9 +98,16 @@ g.test('texture_view_descriptor')
   .fn(async t => {
     const { format, enable_required_feature } = t.params;
 
+    // If the required feature isn't enabled then the texture will fail to create and we won't be
+    // able to test createView, so pick and alternate guaranteed format instead. This will almost
+    // certainly not be view-compatible with the format being tested, but that doesn't matter since
+    // createView should throw an exception due to the format feature not being enabled before it
+    // has a chance to validate that the view and texture formats aren't compatible.
+    const textureFormat = enable_required_feature ? format : 'rgba8unorm';
+
     const formatInfo = kTextureFormatInfo[format];
     const testTexture = t.device.createTexture({
-      format,
+      format: textureFormat,
       size: [formatInfo.blockWidth, formatInfo.blockHeight, 1] as const,
       usage: GPUTextureUsage.TEXTURE_BINDING,
     });


### PR DESCRIPTION
These tests couldn't pass because the texture creation would fail prior to the view creation due to using a format without the required feature enabled. Updated test forces use of an incompatible format, but it doesn't impact the correctness of the test because the thrown error being checked for is specced to happen prior to any other validation.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
