### PR TITLE
Partially revert #1532

### DIFF
--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -46,12 +46,12 @@ g.test('attachment_state')
       shouldError = true;
     }
 
-    t.shouldThrow(shouldError ? 'TypeError' : false, () => {
+    t.expectValidationError(() => {
       t.device.createRenderBundleEncoder({
         colorFormats: Array(colorFormatCount).fill(colorFormat),
         depthStencilFormat,
       });
-    });
+    }, shouldError);
   });
 
 g.test('valid_texture_formats')
@@ -82,21 +82,21 @@ g.test('valid_texture_formats')
 
     switch (attachment) {
       case 'color': {
-        t.shouldThrow(colorRenderable ? false : 'TypeError', () => {
+        t.expectValidationError(() => {
           t.device.createRenderBundleEncoder({
             colorFormats: [format],
           });
-        });
+        }, !colorRenderable);
 
         break;
       }
       case 'depthStencil': {
-        t.shouldThrow(depthStencil ? false : 'TypeError', () => {
+        t.expectValidationError(() => {
           t.device.createRenderBundleEncoder({
             colorFormats: [],
             depthStencilFormat: format,
           });
-        });
+        }, !depthStencil);
 
         break;
       }
@@ -135,14 +135,14 @@ g.test('depth_stencil_readonly')
       shouldError = true;
     }
 
-    t.shouldThrow(shouldError ? 'TypeError' : false, () => {
+    t.expectValidationError(() => {
       t.device.createRenderBundleEncoder({
         colorFormats: [],
         depthStencilFormat,
         depthReadOnly,
         stencilReadOnly,
       });
-    });
+    }, shouldError);
   });
 
 g.test('depth_stencil_readonly_with_undefined_depth')


### PR DESCRIPTION
The changes to check for exceptions being thrown in #1532 should
only apply to cases where we are testing for an required feature
being enabled. The updates to createRenderBundleEncoder.spec.ts
were unnecessary and have started causing failures. I should have
noticed that when I reviewed and landed it. Sorry!

FYI @Gyuyoung 

Issue: #919

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
