### PR TITLE
Fix val:render_pipeline,multisample_state,alpha_to_coverage,sample_mask

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/multisample_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/multisample_state.spec.ts
@@ -48,7 +48,7 @@ g.test('alpha_to_coverage,count')
 
 g.test('alpha_to_coverage,sample_mask')
   .desc(
-    `If sample_mask builtin is a pipeline output of fragment or if multisample.mask is not 0xFFFFFFFF, multisample.alphaToCoverageEnabled should be false.`
+    `If sample_mask builtin is a pipeline output of fragment, multisample.alphaToCoverageEnabled should be false.`
   )
   .params(u =>
     u
@@ -56,13 +56,12 @@ g.test('alpha_to_coverage,sample_mask')
       .combine('alphaToCoverageEnabled', [false, true])
       .beginSubcases()
       .combine('hasSampleMaskOutput', [false, true])
-      .combine('mask', [0, 0x1, 0x2, 0xffffffff])
   )
   .fn(async t => {
-    const { isAsync, alphaToCoverageEnabled, mask, hasSampleMaskOutput } = t.params;
+    const { isAsync, alphaToCoverageEnabled, hasSampleMaskOutput } = t.params;
 
     const descriptor = t.getDescriptor({
-      multisample: { mask, alphaToCoverageEnabled, count: 4 },
+      multisample: { alphaToCoverageEnabled, count: 4 },
       fragmentShaderCode: hasSampleMaskOutput
         ? `
       struct Output {
@@ -79,7 +78,6 @@ g.test('alpha_to_coverage,sample_mask')
         : kDefaultFragmentShaderCode,
     });
 
-    const _success =
-      !(hasSampleMaskOutput || mask !== 0xffffffff) || alphaToCoverageEnabled === false;
+    const _success = !hasSampleMaskOutput || !alphaToCoverageEnabled;
     t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
   });


### PR DESCRIPTION
Fixing an issue in #1520

Spec language:
- https://www.w3.org/TR/webgpu/#abstract-opdef-validating-gpurenderpipelinedescriptor
- https://www.w3.org/TR/webgpu/#sample-masking

> The shader-output mask takes the output value of "sample_mask" builtin in the fragment shader. If the builtin is not output from the fragment shader, and alphaToCoverageEnabled is enabled, the shader-output mask becomes the alpha-to-coverage mask. Otherwise, it defaults to 0xFFFFFFFF.

`multisample.mask !== 0xFFFFFFFF` and `multisample.alphaToCoverageEnabled === true` isn't a validation error.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
