### PR TITLE
Update the createQuerySet test of query_types.spec.ts to expect an exception

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
@@ -10,38 +10,35 @@ export const g = makeTestGroup(ValidationTest);
 g.test('createQuerySet')
   .desc(
     `
-Tests that creating query set shouldn't be valid without the required feature enabled.
-- createQuerySet
-  - type {occlusion, timestamp}
-  - x= {pipeline statistics, timestamp} query {enable, disable}
-
-TODO: This test should expect *synchronous* exceptions, not validation errors, per
-<https://github.com/gpuweb/gpuweb/blob/main/design/ErrorConventions.md>.
-As of this writing, the spec needs to be fixed as well.
+  Tests that creating a query set throws a type error exception if the features don't contain
+  'timestamp-query'.
+    - createQuerySet
+      - type {occlusion, timestamp}
+      - x= {pipeline statistics, timestamp} query {enable, disable}
   `
   )
   .params(u =>
     u
       .combine('type', ['occlusion', 'timestamp'] as const)
-      .combine('timestampQueryEnable', [false, true])
+      .combine('featureContainsTimestampQuery', [false, true])
   )
   .beforeAllSubcases(t => {
-    const { timestampQueryEnable } = t.params;
+    const { featureContainsTimestampQuery } = t.params;
 
     const requiredFeatures: GPUFeatureName[] = [];
-    if (timestampQueryEnable) {
+    if (featureContainsTimestampQuery) {
       requiredFeatures.push('timestamp-query');
     }
 
     t.selectDeviceOrSkipTestCase({ requiredFeatures });
   })
   .fn(async t => {
-    const { type, timestampQueryEnable } = t.params;
+    const { type, featureContainsTimestampQuery } = t.params;
 
     const count = 1;
-    const shouldError = type === 'timestamp' && !timestampQueryEnable;
+    const shouldException = type === 'timestamp' && !featureContainsTimestampQuery;
 
-    t.expectValidationError(() => {
+    t.shouldThrow(shouldException ? 'TypeError' : false, () => {
       t.device.createQuerySet({ type, count });
-    }, shouldError);
+    });
   });


### PR DESCRIPTION
This PR updates the existing createQuerySet test of query_types.spec.ts
in order to expect exceptions rather than validation errors when the device
features don't contain 'timestamp-query'.

Issue: #919 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
