### PR TITLE
Move buffer_texture_copies.spec.ts from encoding/cmds to image_copy path

### DIFF
--- a/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
@@ -1,21 +1,18 @@
 export const description = `
 copyTextureToBuffer and copyBufferToTexture validation tests not covered by
 the general image_copy tests, or by destroyed,*.
-
-TODO:
-- Move all the tests here to image_copy/.
 `;
 
-import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { assert, unreachable } from '../../../../../common/util/util.js';
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { assert, unreachable } from '../../../../common/util/util.js';
 import {
   kDepthStencilFormats,
   depthStencilBufferTextureCopySupported,
   depthStencilFormatAspectSize,
-} from '../../../../capability_info.js';
-import { align } from '../../../../util/math.js';
-import { kBufferCopyAlignment, kBytesPerRowAlignment } from '../../../../util/texture/layout.js';
-import { ValidationTest } from '../../validation_test.js';
+} from '../../../capability_info.js';
+import { align } from '../../../util/math.js';
+import { kBufferCopyAlignment, kBytesPerRowAlignment } from '../../../util/texture/layout.js';
+import { ValidationTest } from '../validation_test.js';
 
 class ImageCopyTest extends ValidationTest {
   testCopyBufferToTexture(
@@ -63,7 +60,7 @@ g.test('depth_stencil_format,copy_usage_and_aspect')
   Validate the combination of usage and aspect of each depth stencil format in copyBufferToTexture,
   copyTextureToBuffer and writeTexture. See https://gpuweb.github.io/gpuweb/#depth-formats for more
   details.
-`
+  `
   )
   .params(u =>
     u //
@@ -119,7 +116,7 @@ g.test('depth_stencil_format,copy_buffer_size')
   - if the copy can be successfully executed with the minimum required buffer size.
   - if the copy fails with a validation error when the buffer size is less than the minimum
   required buffer size.
-`
+  `
   )
   .params(u =>
     u


### PR DESCRIPTION
This PR moves buffer_texture_copies.spec.ts file to webgpu/api/validation/image_copy.

Issue: #1009

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
