### PR TITLE
Describe each test of the validation tests in render|compute pass encoder

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -2,44 +2,6 @@ export const description = `
 Texture Usages Validation Tests in Render Pass and Compute Pass.
 
 TODO: update for new binding structure.
-
-TODO: description per test
-
-Test Coverage:
-  - For each combination of two texture usages:
-    - For various subresource ranges (different mip levels or array layers) that overlap a given
-      subresources or not for color formats:
-      - For various places that resources are used, for example, used in bundle or used in render
-        pass directly.
-        - Check that an error is generated when read-write or write-write usages are binding to the
-          same texture subresource. Otherwise, no error should be generated. One exception is race
-          condition upon two writeonly-storage-texture usages, which is valid.
-
-  - For each combination of two texture usages:
-    - For various aspects (all, depth-only, stencil-only) that overlap a given subresources or not
-      for depth/stencil formats:
-      - Check that an error is generated when read-write or write-write usages are binding to the
-        same aspect. Otherwise, no error should be generated.
-
-  - Test combinations of two shader stages:
-    - Texture usages in bindings with invisible shader stages should be validated. Invisible shader
-      stages include shader stage with visibility none, compute shader stage in render pass, and
-      vertex/fragment shader stage in compute pass.
-
-  - Tests replaced bindings:
-    - Texture usages via bindings replaced by another setBindGroup() upon the same bindGroup index
-      in render pass should be validated. However, replaced bindings should not be validated in
-      compute pass.
-
-  - Test texture usages in bundle:
-    - Texture usages in bundle should be validated if that bundle is executed in the current scope.
-
-  - Test texture usages with unused bindings:
-    - Texture usages should be validated even its bindings is not used in pipeline.
-
-  - Test texture usages validation scope:
-    - Texture usages should be validated per each render pass. And they should be validated per each
-      dispatch call in compute.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
@@ -253,8 +215,14 @@ const BASE_LAYER = 1;
 const TOTAL_LAYERS = 6;
 const SLICE_COUNT = 2;
 
-// For all tests below, we test compute pass if 'compute' is true, and test render pass otherwise.
 g.test('subresources_and_binding_types_combination_for_color')
+  .desc(
+    `
+    Test the resource usage rules by using two views of the same GPUTexture in a usage scope. Tests
+    various combinations of {sampled, storage, render target} usages, mip-level ranges, and
+    array-layer ranges, in {compute pass, render pass, render pass via bundle}.
+  `
+  )
   .params(u =>
     u
       .combine('compute', [false, true])
@@ -316,7 +284,8 @@ g.test('subresources_and_binding_types_combination_for_color')
           _resourceSuccess: true,
         },
 
-        // The second texture usage contains the whole mip chain where the first texture usage is using.
+        // The second texture usage contains the whole mip chain where the first texture usage is
+        // using.
         {
           levelCount0: 1,
           layerCount0: 1,
@@ -338,7 +307,8 @@ g.test('subresources_and_binding_types_combination_for_color')
           _resourceSuccess: false,
         },
 
-        // The second texture usage contains all subresources where the first texture usage is using.
+        // The second texture usage contains all subresources where the first texture usage is
+        // using.
         {
           levelCount0: 1,
           layerCount0: 1,
@@ -371,7 +341,8 @@ g.test('subresources_and_binding_types_combination_for_color')
           _resourceSuccess: false,
         },
 
-        // Both of the two usages access a few array layers on the same level but they don't overlap.
+        // Both of the two usages access a few array layers on the same level but they don't
+        // overlap.
         {
           levelCount0: 1,
           layerCount0: SLICE_COUNT,
@@ -551,6 +522,15 @@ g.test('subresources_and_binding_types_combination_for_color')
   });
 
 g.test('subresources_and_binding_types_combination_for_aspect')
+  .desc(
+    `
+    Test the resource usage rules by using two views of the same GPUTexture in a usage scope. Tests
+    various combinations of {sampled, render target} usages, {all, depth-only, stencil-only} aspects
+    that overlap a given subresources in {compute pass, render pass, render pass via bundle}.
+      - Check that an error is generated when read-write or write-write usages are binding to the
+        same aspect. Otherwise, no error should be generated.
+  `
+  )
   .params(u =>
     u
       .combine('compute', [false, true])
@@ -756,6 +736,15 @@ g.test('subresources_and_binding_types_combination_for_aspect')
   });
 
 g.test('shader_stages_and_visibility')
+  .desc(
+    `
+    Test combinations of two shader stages. Tests the texture usages in bindings with invisible
+    shader stages.
+      - Test the writeonly-storage-texture binding type is not supported in vertex stage.
+      - Test invisible shader stages include shader stage with visibility none, compute shader
+        stage in render pass, and vertex/fragment shader stage in compute pass.
+  `
+  )
   .params(u =>
     u
       .combine('compute', [false, true])
@@ -826,10 +815,15 @@ g.test('shader_stages_and_visibility')
     });
   });
 
-// We should validate the texture usages in bindings which are replaced by another setBindGroup()
-// call site upon the same index in the same render pass. However, replaced bindings in compute
-// should not be validated.
 g.test('replaced_binding')
+  .desc(
+    `
+    Test the texture usages via bindings replaced by another bindGroup.
+      - In render pass, the recording should succeed.
+      - In compute pass, the recording should fail with a validation error because validation only
+        occurs inside dispatchWorkgroups() which only looks at the current resource usages.
+  `
+  )
   .params(u =>
     u
       .combine('compute', [false, true])
@@ -885,8 +879,9 @@ g.test('replaced_binding')
     pass.setBindGroup(0, bindGroup1);
     pass.end();
 
-    // MAINTENANCE_TODO: If the Compatible Usage List (https://gpuweb.github.io/gpuweb/#compatible-usage-list)
-    // gets programmatically defined in capability_info, use it here, instead of this logic, for clarity.
+    // MAINTENANCE_TODO: If the Compatible Usage List
+    // (https://gpuweb.github.io/gpuweb/#compatible-usage-list) gets programmatically defined in
+    // capability_info, use it here, instead of this logic, for clarity.
     let success = entry.storageTexture?.access !== 'write-only';
     // Replaced bindings should not be validated in compute pass, because validation only occurs
     // inside dispatchWorkgroups() which only looks at the current resource usages.
@@ -898,6 +893,12 @@ g.test('replaced_binding')
   });
 
 g.test('bindings_in_bundle')
+  .desc(
+    `
+    Test the texture usages in bundles by using two bindings of the same texture with various
+    combination of {sampled, storage, render target} usages.
+  `
+  )
   .params(u =>
     u
       .combine('type0', ['render-target', ...kTextureBindingTypes] as const)
@@ -939,7 +940,8 @@ g.test('bindings_in_bundle')
           (p._sampleCount !== undefined &&
             p._sampleCount > 1 &&
             (p._usage0 === 'STORAGE_BINDING' || p._usage1 === 'STORAGE_BINDING')) ||
-          // If both are sampled, we create two views of the same texture, so both must be multisampled.
+          // If both are sampled, we create two views of the same texture, so both must be
+          // multisampled.
           (p.type0 === 'multisampled-texture' && p.type1 === 'sampled-texture') ||
           (p.type0 === 'sampled-texture' && p.type1 === 'multisampled-texture')
       )
@@ -1030,6 +1032,14 @@ g.test('bindings_in_bundle')
   });
 
 g.test('unused_bindings_in_pipeline')
+  .desc(
+    `
+    Test the texture usages with unused bindings in the pipeline.
+      - Test the recording succeeds in the compute pass even though it's bindings is not used in the
+        pipeline.
+      - Test the recording fails in the render pass.
+  `
+  )
   .params(u =>
     u
       .combine('compute', [false, true])
@@ -1150,6 +1160,12 @@ g.test('unused_bindings_in_pipeline')
   });
 
 g.test('validation_scope,no_draw_or_dispatch')
+  .desc(
+    `
+    Test the texture usages without the draw or dispatch on the same pass that has two bind groups.
+      - In compute pass, no validation error should be generated.
+  `
+  )
   .params(u => u.combine('compute', [false, true]))
   .fn(async t => {
     const { compute } = t.params;
@@ -1168,6 +1184,12 @@ g.test('validation_scope,no_draw_or_dispatch')
   });
 
 g.test('validation_scope,same_draw_or_dispatch')
+  .desc(
+    `
+    Test the texture usages with the same draw or dispatch on the same pass that has two bind
+    groups. A validation error should be generated.
+  `
+  )
   .params(u => u.combine('compute', [false, true]))
   .fn(async t => {
     const { compute } = t.params;
@@ -1185,6 +1207,13 @@ g.test('validation_scope,same_draw_or_dispatch')
   });
 
 g.test('validation_scope,different_draws_or_dispatches')
+  .desc(
+    `
+    Test the texture usages with the different draw or dispatch on the same pass that has two bind
+    groups. A validation error should be generated even though the pass draws or dispatches per each
+    bindGroup.
+  `
+  )
   .params(u => u.combine('compute', [false, true]))
   .fn(async t => {
     const { compute } = t.params;
@@ -1206,6 +1235,12 @@ g.test('validation_scope,different_draws_or_dispatches')
   });
 
 g.test('validation_scope,different_passes')
+  .desc(
+    `
+    Test the texture usages with different passes that have their own bind group. No validation
+    error should be generated.
+  `
+  )
   .params(u => u.combine('compute', [false, true]))
   .fn(async t => {
     const { compute } = t.params;


### PR DESCRIPTION
This PR adds a description to each test of the validation tests written
in texture/in_pass_encoder.spec.ts file.

Issue: #923 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
