### PR TITLE
Update 'zero_size' test to check 'usage' field

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -24,10 +24,12 @@ import { ValidationTest } from './validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
 
-g.test('zero_size')
+g.test('zero_size_and_usage')
   .desc(
     `Test texture creation with zero or nonzero size of
-    width, height, depthOrArrayLayers and mipLevelCount for every dimension, and representative formats.`
+    width, height, depthOrArrayLayers and mipLevelCount, usage for every dimension, and
+    representative formats.
+  `
   )
   .params(u =>
     u
@@ -45,6 +47,7 @@ g.test('zero_size')
         'height',
         'depthOrArrayLayers',
         'mipLevelCount',
+        'usage',
       ] as const)
       // Filter out incompatible dimension type and format combinations.
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
@@ -60,6 +63,7 @@ g.test('zero_size')
 
     const size = [info.blockWidth, info.blockHeight, 1];
     let mipLevelCount = 1;
+    let usage = GPUTextureUsage.TEXTURE_BINDING;
 
     switch (zeroArgument) {
       case 'width':
@@ -74,6 +78,9 @@ g.test('zero_size')
       case 'mipLevelCount':
         mipLevelCount = 0;
         break;
+      case 'usage':
+        usage = 0;
+        break;
       default:
         break;
     }
@@ -83,7 +90,7 @@ g.test('zero_size')
       mipLevelCount,
       dimension,
       format,
-      usage: GPUTextureUsage.TEXTURE_BINDING,
+      usage,
     };
 
     const success = zeroArgument === 'none';


### PR DESCRIPTION
This PR makes that 'webgpu,api,validation,createTexture:zero_size'
also tests if a validation is generated when 'usage' value is 0 like
other arguments.

Issue: #1576

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
