### PR TITLE
Replace `;` with `,` in WGSL structs.

### DIFF
--- a/src/stress/adapter/device_allocation.spec.ts
+++ b/src/stress/adapter/device_allocation.spec.ts
@@ -49,7 +49,7 @@ async function createDeviceAndComputeCommands(adapter: GPUAdapter) {
       compute: {
         module: device.createShaderModule({
           code: `
-              struct Buffer { data: array<u32>; };
+              struct Buffer { data: array<u32>, };
 
               @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
               @compute @workgroup_size(1) fn main(
@@ -110,7 +110,7 @@ async function createDeviceAndRenderCommands(adapter: GPUAdapter) {
   for (let pipelineIndex = 0; pipelineIndex < kNumPipelines; ++pipelineIndex) {
     const module = device.createShaderModule({
       code: `
-          struct Buffer { data: array<vec4<u32>, ${(kSize * kSize) / 4}>; };
+          struct Buffer { data: array<vec4<u32>, ${(kSize * kSize) / 4}>, };
 
           @group(0) @binding(0) var<uniform> buffer: Buffer;
           @vertex fn vmain(

--- a/src/stress/compute/compute_pass.spec.ts
+++ b/src/stress/compute/compute_pass.spec.ts
@@ -22,7 +22,7 @@ GPUComputePipeline.`
       compute: {
         module: t.device.createShaderModule({
           code: `
-            struct Buffer { data: array<u32>; };
+            struct Buffer { data: array<u32>, };
             @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
             @compute @workgroup_size(1) fn main(
                 @builtin(global_invocation_id) id: vec3<u32>) {
@@ -67,7 +67,7 @@ GPUComputePipeline.`
     const stages = iterRange(kNumIterations, i => ({
       module: t.device.createShaderModule({
         code: `
-        struct Buffer { data: u32; };
+        struct Buffer { data: u32, };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
         @compute @workgroup_size(1) fn main${i}() {
           buffer.data = buffer.data + 1u;
@@ -111,7 +111,7 @@ groups.`
     );
     const module = t.device.createShaderModule({
       code: `
-        struct Buffer { data: array<u32>; };
+        struct Buffer { data: array<u32>, };
         @group(0) @binding(0) var<storage, read_write> buffer1: Buffer;
         @group(0) @binding(1) var<storage, read_write> buffer2: Buffer;
         @compute @workgroup_size(1) fn main(
@@ -163,7 +163,7 @@ g.test('many_dispatches')
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const module = t.device.createShaderModule({
       code: `
-        struct Buffer { data: array<u32>; };
+        struct Buffer { data: array<u32>, };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
         @compute @workgroup_size(1) fn main(
             @builtin(global_invocation_id) id: vec3<u32>) {
@@ -208,7 +208,7 @@ g.test('huge_dispatches')
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const module = t.device.createShaderModule({
       code: `
-        struct Buffer { data: array<u32>; };
+        struct Buffer { data: array<u32>, };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
         @compute @workgroup_size(1) fn main(
             @builtin(global_invocation_id) id: vec3<u32>) {

--- a/src/stress/queue/submit.spec.ts
+++ b/src/stress/queue/submit.spec.ts
@@ -23,7 +23,7 @@ results verified at the end of the test.`
       compute: {
         module: t.device.createShaderModule({
           code: `
-            struct Buffer { data: array<u32>; };
+            struct Buffer { data: array<u32>, };
             @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
             @compute @workgroup_size(1) fn main(
                 @builtin(global_invocation_id) id: vec3<u32>) {
@@ -68,7 +68,7 @@ submit() call.`
       compute: {
         module: t.device.createShaderModule({
           code: `
-            struct Buffer { data: array<u32>; };
+            struct Buffer { data: array<u32>, };
             @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
             @compute @workgroup_size(1) fn main(
                 @builtin(global_invocation_id) id: vec3<u32>) {

--- a/src/stress/render/render_pass.spec.ts
+++ b/src/stress/render/render_pass.spec.ts
@@ -159,7 +159,7 @@ buffer.`
     const kSize = 128;
     const module = t.device.createShaderModule({
       code: `
-    struct Uniforms { index: u32; };
+    struct Uniforms { index: u32, };
     @group(0) @binding(0) var<uniform> uniforms: Uniforms;
     @vertex fn vmain() -> @builtin(position) vec4<f32> {
       let index = uniforms.index;

--- a/src/stress/render/vertex_buffers.spec.ts
+++ b/src/stress/render/vertex_buffers.spec.ts
@@ -18,7 +18,7 @@ function createHugeVertexBuffer(t: GPUTest, size: number) {
     compute: {
       module: t.device.createShaderModule({
         code: `
-        struct Buffer { data: array<vec2<u32>>; };
+        struct Buffer { data: array<vec2<u32>>, };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
         @compute @workgroup_size(1) fn main(
             @builtin(global_invocation_id) id: vec3<u32>) {

--- a/src/stress/shaders/entry_points.spec.ts
+++ b/src/stress/shaders/entry_points.spec.ts
@@ -10,7 +10,7 @@ export const g = makeTestGroup(GPUTest);
 
 const makeCode = (numEntryPoints: number) => {
   const kBaseCode = `
-      struct Buffer { data: u32; };
+      struct Buffer { data: u32, };
       @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
       fn main() { buffer.data = buffer.data + 1u;  }
       `;

--- a/src/stress/shaders/non_halting.spec.ts
+++ b/src/stress/shaders/non_halting.spec.ts
@@ -19,7 +19,7 @@ device loss.`
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const module = t.device.createShaderModule({
       code: `
-        struct Buffer { data: u32; };
+        struct Buffer { data: u32, };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
         @compute @workgroup_size(1) fn main() {
           loop {
@@ -59,7 +59,7 @@ device loss.`
   .fn(async t => {
     const module = t.device.createShaderModule({
       code: `
-        struct Data { counter: u32; increment: u32; };
+        struct Data { counter: u32, increment: u32, };
         @group(0) @binding(0) var<uniform> data: Data;
         @vertex fn vmain() -> @builtin(position) vec4<f32> {
           var counter: u32 = data.counter;
@@ -131,7 +131,7 @@ device loss.`
   .fn(async t => {
     const module = t.device.createShaderModule({
       code: `
-        struct Data { counter: u32; increment: u32; };
+        struct Data { counter: u32, increment: u32, };
         @group(0) @binding(0) var<uniform> data: Data;
         @vertex fn vmain() -> @builtin(position) vec4<f32> {
           return vec4<f32>(0.0, 0.0, 0.0, 1.0);

--- a/src/stress/shaders/slow.spec.ts
+++ b/src/stress/shaders/slow.spec.ts
@@ -15,7 +15,7 @@ g.test('compute')
     const buffer = t.makeBufferWithContents(data, GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC);
     const module = t.device.createShaderModule({
       code: `
-        struct Buffer { data: array<u32>; };
+        struct Buffer { data: array<u32>, };
         @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
         @compute @workgroup_size(1) fn main(
             @builtin(global_invocation_id) id: vec3<u32>) {
@@ -51,7 +51,7 @@ g.test('vertex')
   .fn(async t => {
     const module = t.device.createShaderModule({
       code: `
-        struct Data { counter: u32; increment: u32; };
+        struct Data { counter: u32, increment: u32, };
         @group(0) @binding(0) var<uniform> data: Data;
         @vertex fn vmain() -> @builtin(position) vec4<f32> {
           var counter: u32 = data.counter;
@@ -125,7 +125,7 @@ g.test('fragment')
   .fn(async t => {
     const module = t.device.createShaderModule({
       code: `
-        struct Data { counter: u32; increment: u32; };
+        struct Data { counter: u32, increment: u32, };
         @group(0) @binding(0) var<uniform> data: Data;
         @vertex fn vmain() -> @builtin(position) vec4<f32> {
           return vec4<f32>(0.0, 0.0, 0.0, 1.0);

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -443,7 +443,7 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
 
     const readsPerRow = Math.ceil(minBytesPerRow / expectedDataSize);
     const reducer = `
-    struct Buffer { data: array<u32>; };
+    struct Buffer { data: array<u32>, };
     @group(0) @binding(0) var<storage, read> expected: Buffer;
     @group(0) @binding(1) var<storage, read> in: Buffer;
     @group(0) @binding(2) var<storage, read_write> out: Buffer;

--- a/src/webgpu/util/shader.ts
+++ b/src/webgpu/util/shader.ts
@@ -65,8 +65,8 @@ export function getPlainTypeInfo(sampleType: GPUTextureSampleType): keyof typeof
  *
  * return:
  * struct Outputs {
- *     @location(0) o1 : vec4<f32>;
- *     @location(2) o3 : vec2<u32>;
+ *     @location(0) o1 : vec4<f32>,
+ *     @location(2) o3 : vec2<u32>,
  * }
  * @fragment fn main() -> Outputs {
  *     return Outputs(vec4<f32>(1.0, 0.0, 1.0, 1.0), vec4<u32>(1, 2));

--- a/src/webgpu/web_platform/worker/worker.ts
+++ b/src/webgpu/web_platform/worker/worker.ts
@@ -14,7 +14,7 @@ async function basicTest() {
     compute: {
       module: device.createShaderModule({
         code: `
-          struct Buffer { data: array<u32>; };
+          struct Buffer { data: array<u32>, };
 
           @group(0) @binding(0) var<storage, read_write> buffer: Buffer;
           @compute @workgroup_size(1u) fn main(


### PR DESCRIPTION
This CL updates a few more structs which are using the deprecated
`;` instead of `,` to end each member.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
