### PR TITLE
Convert `log` tests to using new interval framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -16,6 +16,7 @@ import {
   exp2Interval,
   F32Interval,
   floorInterval,
+  logInterval,
   ulpInterval,
   negationInterval,
   sinInterval,
@@ -841,6 +842,40 @@ g.test('floorInterval')
     t.expect(
       objectEquals(expected, got),
       `floorInterval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('logInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: arrayToInterval([Number.NEGATIVE_INFINITY, kValue.f32.negative.min]) },
+      { input: 1, expected: [0, 0] },
+      { input: kValue.f32.positive.e, expected: [minusOneULP(1), 1] },
+      { input: kValue.f32.positive.max, expected: [minusOneULP(hexToF32(0x42b17218)), hexToF32(0x42b17218)] },  // ~88.72...
+    ]
+  )
+  .fn(t => {
+    const error = (input: number, result: number): number => {
+      if (input >= 0.5 && input <= 2.0) {
+        return 2 ** -21;
+      }
+      return 3 * oneULP(result);
+    };
+
+    const input = t.params.input;
+    let expected: F32Interval;
+    if (t.params.expected instanceof Array) {
+      const [begin, end] = t.params.expected;
+      expected = arrayToInterval([begin - error(input, begin), end + error(input, end)]);
+    } else {
+      expected = t.params.expected;
+    }
+
+    const got = logInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `logInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -9,18 +9,11 @@ Returns the natural logarithm of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { absMatch, FloatMatch, ulpMatch } from '../../../../../util/compare.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
+import { logInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
-import {
-  allInputSources,
-  Case,
-  CaseList,
-  Config,
-  makeUnaryF32Case,
-  run,
-} from '../../expression.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -30,10 +23,7 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('range', ['low', 'mid', 'high'] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
@@ -47,53 +37,28 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('range', ['low', 'mid', 'high'] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (x: number): Case => {
-      return makeUnaryF32Case(x, Math.log);
-    };
-
-    const runRange = (match: FloatMatch, cases: CaseList) => {
-      const cfg: Config = t.params;
-      cfg.cmpFloats = match;
-      run(t, builtin('log'), [TypeF32], TypeF32, cfg, cases);
+      return makeUnaryF32IntervalCase(x, logInterval);
     };
 
     // log's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
-    switch (t.params.range) {
-      case 'low': // [0, 0.5)
-        runRange(
-          ulpMatch(3),
-          linearRange(kValue.f32.positive.min, 0.5, 20).map(x => makeCase(x))
-        );
-        break;
-      case 'mid': // [0.5, 2.0]
-        runRange(
-          absMatch(2 ** -21),
-          linearRange(0.5, 2.0, 20).map(x => makeCase(x))
-        );
-        break;
-      case 'high': // (2.0, +∞]
-        runRange(
-          ulpMatch(3),
-          biasedRange(2.0, 2 ** 32, 1000).map(x => makeCase(x))
-        );
-        break;
-    }
+    const cases: Array<Case> = [
+      ...linearRange(kValue.f32.positive.min, 0.5, 20),
+      ...linearRange(0.5, 2.0, 20),
+      ...biasedRange(2.0, 2 ** 32, 1000),
+    ].map(x => makeCase(x));
+
+    run(t, builtin('log'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f16 tests`)
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('range', ['low', 'mid', 'high'] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -477,6 +477,20 @@ export function floorInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), op);
 }
 
+/** Calculate an acceptance interval of log(x) */
+export function logInterval(x: number | F32Interval): F32Interval {
+  const op: PointToIntervalOp = {
+    impl: (impl_x: number): F32Interval => {
+      if (x >= 0.5 && x <= 2.0) {
+        return absoluteErrorInterval(Math.log(impl_x), 2 ** -21);
+      }
+      return ulpInterval(Math.log(impl_x), 3);
+    },
+  };
+
+  return runPointOp(toInterval(x), op);
+}
+
 /** Calculate an acceptance interval of -x */
 export function negationInterval(n: number): F32Interval {
   const op: PointToIntervalOp = {


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
