### PR TITLE
Convert negation tests to new interval framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -17,6 +17,7 @@ import {
   F32Interval,
   floorInterval,
   ulpInterval,
+  negationInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -839,5 +840,44 @@ g.test('floorInterval')
     t.expect(
       objectEquals(expected, got),
       `floorInterval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('negationInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: [0, 0] },
+      { input: 0.1, expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] }, // ~-0.1
+      { input: 1.0, expected: [-1.0, -1.0] },
+      { input: 1.9, expected: [hexToF32(0xbff33334), plusOneULP(hexToF32(0xbff33334))] },  // ~-1.9
+      { input: -0.1, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] }, // ~0.1
+      { input: -1.0, expected: [1, 1] },
+      { input: -1.9, expected: [minusOneULP(hexToF32(0x3ff33334)), hexToF32(0x3ff33334)] },  // ~1.9
+
+      // Edge cases
+      { input: Number.POSITIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: Number.NEGATIVE_INFINITY, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+      { input: kValue.f32.positive.min, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
+      { input: kValue.f32.negative.max, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: kValue.f32.subnormal.positive.min, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: kValue.f32.subnormal.negative.min, expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: kValue.f32.subnormal.negative.max, expected: [0, kValue.f32.subnormal.positive.min] },
+    ]
+  )
+  .fn(t => {
+    const input = t.params.input;
+    const expected =
+      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+
+    const got = negationInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `negationInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -4,10 +4,10 @@ Execution Tests for the f32 arithmetic unary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { correctlyRoundedMatch } from '../../../../util/compare.js';
 import { TypeF32 } from '../../../../util/conversion.js';
+import { negationInterval } from '../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../util/math.js';
-import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../expression.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -25,18 +25,13 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
     const makeCase = (x: number): Case => {
-      return makeUnaryF32Case(x, (p: number): number => {
-        return -p;
-      });
+      return makeUnaryF32IntervalCase(x, negationInterval);
     };
 
     const cases = fullF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }).map(x =>
       makeCase(x)
     );
 
-    run(t, unary('-'), [TypeF32], TypeF32, cfg, cases);
+    run(t, unary('-'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -476,3 +476,14 @@ export function floorInterval(n: number): F32Interval {
 
   return runPointOp(toInterval(n), op);
 }
+
+/** Calculate an acceptance interval of -x */
+export function negationInterval(n: number): F32Interval {
+  const op: PointToIntervalOp = {
+    impl: (impl_n: number): F32Interval => {
+      return correctlyRoundedInterval(-impl_n);
+    },
+  };
+
+  return runPointOp(toInterval(n), op);
+}


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
