### PR TITLE
Convert `sin` tests to use interval framework

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -9,10 +9,10 @@ Returns the sine of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { absMatch } from '../../../../../util/compare.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, Config, makeUnaryF32Case, run } from '../../expression.js';
+import { sinInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -39,17 +39,17 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    // [1]: Need to decide what the ground-truth is.
-    const makeCase = (x: number): Case => {
-      return makeUnaryF32Case(x, Math.sin);
+    const makeCase = (n: number): Case => {
+      return makeUnaryF32IntervalCase(n, sinInterval);
     };
 
-    // Spec defines accuracy on [-π, π]
-    const cases = linearRange(-Math.PI, Math.PI, 1000).map(x => makeCase(x));
+    const cases: Array<Case> = [
+      // Well defined accuracy range
+      ...linearRange(-Math.PI, Math.PI, 1000),
 
-    const cfg: Config = t.params;
-    cfg.cmpFloats = absMatch(2 ** -11);
-    run(t, builtin('sin'), [TypeF32], TypeF32, cfg, cases);
+      ...fullF32Range(),
+    ].map(makeCase);
+    run(t, builtin('sin'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -487,3 +487,16 @@ export function negationInterval(n: number): F32Interval {
 
   return runPointOp(toInterval(n), op);
 }
+
+/** Calculate an acceptance interval of sin(x) */
+export function sinInterval(n: number): F32Interval {
+  const op: PointToIntervalOp = {
+    impl: (impl_n: number): F32Interval => {
+      return kValue.f32.negative.pi.whole <= impl_n && impl_n <= kValue.f32.positive.pi.whole
+        ? absoluteErrorInterval(Math.sin(impl_n), 2 ** -11)
+        : F32Interval.infinite();
+    },
+  };
+
+  return runPointOp(toInterval(n), op);
+}


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
