### PR TITLE
Convert addition tests to use interval framework

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -6,8 +6,16 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { correctlyRoundedMatch, ulpMatch } from '../../../../util/compare.js';
 import { TypeF32 } from '../../../../util/conversion.js';
+import { additionInterval } from '../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range } from '../../../../util/math.js';
-import { allInputSources, Case, Config, makeBinaryF32Case, run } from '../expression.js';
+import {
+  allInputSources,
+  Case,
+  Config,
+  makeBinaryF32Case,
+  makeBinaryF32IntervalCase,
+  run,
+} from '../expression.js';
 
 import { binary } from './binary.js';
 
@@ -25,13 +33,8 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryF32Case(lhs, rhs, (l: number, r: number): number => {
-        return l + r;
-      });
+      return makeBinaryF32IntervalCase(lhs, rhs, additionInterval);
     };
 
     const cases: Array<Case> = [];
@@ -42,7 +45,7 @@ Accuracy: Correctly rounded
       });
     });
 
-    run(t, binary('+'), [TypeF32, TypeF32], TypeF32, cfg, cases);
+    run(t, binary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('subtraction')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -409,6 +409,38 @@ export function absInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), op);
 }
 
+/** Calculate an acceptance interval of x + y */
+export function additionInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
+  const inner_op = {
+    impl: (inner_x: number, inner_y: number): F32Interval => {
+      if (!isF32Finite(inner_x) && isF32Finite(inner_y)) {
+        return correctlyRoundedInterval(inner_x);
+      }
+
+      if (isF32Finite(inner_x) && !isF32Finite(inner_y)) {
+        return correctlyRoundedInterval(inner_y);
+      }
+
+      if (!isF32Finite(inner_x) && !isF32Finite(inner_y)) {
+        if (Math.sign(inner_x) === Math.sign(inner_y)) {
+          return correctlyRoundedInterval(inner_x);
+        } else {
+          return F32Interval.infinite();
+        }
+      }
+      return correctlyRoundedInterval(inner_x + inner_y);
+    },
+  };
+
+  const op: BinaryToIntervalOp = {
+    impl: (impl_x: number, impl_y: number): F32Interval => {
+      return roundAndFlushBinaryToInterval(impl_x, impl_y, inner_op);
+    },
+  };
+
+  return runBinaryOp(toInterval(x), toInterval(y), op);
+}
+
 /** Calculate an acceptance interval of atan(x) */
 export function atanInterval(n: number): F32Interval {
   const op: PointToIntervalOp = {


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
