### PR TITLE
Optimized several expensive methods in texture tests

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -240,12 +240,22 @@ export const kTypedArrayBufferViewConstructors = Object.values(kTypedArrayBuffer
 function subarrayAsU8(
   buf: ArrayBuffer | TypedArrayBufferView,
   { start = 0, length }: { start?: number; length?: number }
-): Uint8Array {
+): Uint8Array | Uint8ClampedArray {
   if (buf instanceof ArrayBuffer) {
     return new Uint8Array(buf, start, length);
+  } else if (buf instanceof Uint8Array || buf instanceof Uint8ClampedArray) {
+    // Don't wrap in new views if we don't need to.
+    if (start === 0 && (length === undefined || length === buf.byteLength)) {
+      return buf;
+    }
+    return buf.subarray(start, length !== undefined ? start + length : undefined);
   } else {
-    const sub = buf.subarray(start, length !== undefined ? start + length : undefined);
-    return new Uint8Array(sub.buffer, sub.byteOffset, sub.byteLength);
+    const byteOffset = buf.byteOffset + start * buf.BYTES_PER_ELEMENT;
+    const byteLength =
+      length !== undefined
+        ? byteOffset + length * buf.BYTES_PER_ELEMENT
+        : buf.byteLength - (byteOffset - buf.byteOffset);
+    return new Uint8Array(buf.buffer, byteOffset, byteLength);
   }
 }
 

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -248,15 +248,13 @@ function subarrayAsU8(
     if (start === 0 && (length === undefined || length === buf.byteLength)) {
       return buf;
     }
-    return buf.subarray(start, length !== undefined ? start + length : undefined);
-  } else {
-    const byteOffset = buf.byteOffset + start * buf.BYTES_PER_ELEMENT;
-    const byteLength =
-      length !== undefined
-        ? byteOffset + length * buf.BYTES_PER_ELEMENT
-        : buf.byteLength - (byteOffset - buf.byteOffset);
-    return new Uint8Array(buf.buffer, byteOffset, byteLength);
   }
+  const byteOffset = buf.byteOffset + start * buf.BYTES_PER_ELEMENT;
+  const byteLength =
+    length !== undefined
+      ? byteOffset + length * buf.BYTES_PER_ELEMENT
+      : buf.byteLength - (byteOffset - buf.byteOffset);
+  return new Uint8Array(buf.buffer, byteOffset, byteLength);
 }
 
 /**

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -252,7 +252,7 @@ function subarrayAsU8(
   const byteOffset = buf.byteOffset + start * buf.BYTES_PER_ELEMENT;
   const byteLength =
     length !== undefined
-      ? byteOffset + length * buf.BYTES_PER_ELEMENT
+      ? length * buf.BYTES_PER_ELEMENT
       : buf.byteLength - (byteOffset - buf.byteOffset);
   return new Uint8Array(buf.buffer, byteOffset, byteLength);
 }

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -122,6 +122,21 @@ export function makeClampToRange(format: EncodableTextureFormat): ComponentMapFn
   return applyEach(x => clamp(x, repr.numericRange!), repr.componentOrder);
 }
 
+const smallComponentDataViews = new Map();
+function getComponentDataView(byteLength: number): DataView {
+  if (byteLength > 32) {
+    const buffer = new ArrayBuffer(byteLength);
+    return new DataView(buffer);
+  }
+  let dataView = smallComponentDataViews.get(byteLength);
+  if (!dataView) {
+    const buffer = new ArrayBuffer(byteLength);
+    dataView = new DataView(buffer);
+    smallComponentDataViews.set(byteLength, dataView);
+  }
+  return dataView;
+}
+
 /**
  * Helper function to pack components as an ArrayBuffer.
  * @param {TexelComponent[]} componentOrder - The order of the component data.
@@ -140,21 +155,26 @@ function packComponents(
   bitLengths: number | PerTexelComponent<number>,
   componentDataTypes: ComponentDataType | PerTexelComponent<ComponentDataType>
 ): ArrayBuffer {
-  const bitLengthMap =
-    typeof bitLengths === 'number' ? makePerTexelComponent(componentOrder, bitLengths) : bitLengths;
+  let bitLengthMap;
+  let totalBitLength;
+  if (typeof bitLengths === 'number') {
+    bitLengthMap = makePerTexelComponent(componentOrder, bitLengths);
+    totalBitLength = bitLengths * componentOrder.length;
+  } else {
+    bitLengthMap = bitLengths;
+    totalBitLength = Object.entries(bitLengthMap).reduce((acc, [, value]) => {
+      assert(value !== undefined);
+      return acc + value;
+    }, 0);
+  }
+  assert(totalBitLength % 8 === 0);
 
   const componentDataTypeMap =
     typeof componentDataTypes === 'string' || componentDataTypes === null
       ? makePerTexelComponent(componentOrder, componentDataTypes)
       : componentDataTypes;
 
-  const totalBitLength = Object.entries(bitLengthMap).reduce((acc, [, value]) => {
-    assert(value !== undefined);
-    return acc + value;
-  }, 0);
-  assert(totalBitLength % 8 === 0);
-
-  const data = new ArrayBuffer(totalBitLength / 8);
+  const dataView = getComponentDataView(totalBitLength / 8);
   let bitOffset = 0;
   for (const c of componentOrder) {
     const value = components[c];
@@ -172,13 +192,13 @@ function packComponents(
         if (byteOffset === bitOffset / 8 && byteLength === bitLength / 8) {
           switch (byteLength) {
             case 1:
-              new DataView(data, byteOffset, byteLength).setUint8(0, value);
+              dataView.setUint8(byteOffset, value);
               break;
             case 2:
-              new DataView(data, byteOffset, byteLength).setUint16(0, value, true);
+              dataView.setUint16(byteOffset, value, true);
               break;
             case 4:
-              new DataView(data, byteOffset, byteLength).setUint32(0, value, true);
+              dataView.setUint32(byteOffset, value, true);
               break;
             default:
               unreachable();
@@ -186,10 +206,9 @@ function packComponents(
         } else {
           // Packed representations are all 32-bit and use Uint as the data type.
           // ex.) rg10b11float, rgb10a2unorm
-          const view = new DataView(data);
-          switch (view.byteLength) {
+          switch (dataView.byteLength) {
             case 4: {
-              const currentValue = view.getUint32(0, true);
+              const currentValue = dataView.getUint32(0, true);
 
               let mask = 0xffffffff;
               const bitsToClearRight = bitOffset;
@@ -200,7 +219,7 @@ function packComponents(
 
               const newValue = (currentValue & ~mask) | (value << bitOffset);
 
-              view.setUint32(0, newValue, true);
+              dataView.setUint32(0, newValue, true);
               break;
             }
             default:
@@ -213,13 +232,13 @@ function packComponents(
         assert(byteOffset === bitOffset / 8 && byteLength === bitLength / 8);
         switch (byteLength) {
           case 1:
-            new DataView(data, byteOffset, byteLength).setInt8(0, value);
+            dataView.setInt8(byteOffset, value);
             break;
           case 2:
-            new DataView(data, byteOffset, byteLength).setInt16(0, value, true);
+            dataView.setInt16(byteOffset, value, true);
             break;
           case 4:
-            new DataView(data, byteOffset, byteLength).setInt32(0, value, true);
+            dataView.setInt32(byteOffset, value, true);
             break;
           default:
             unreachable();
@@ -229,7 +248,7 @@ function packComponents(
         assert(byteOffset === bitOffset / 8 && byteLength === bitLength / 8);
         switch (byteLength) {
           case 4:
-            new DataView(data, byteOffset, byteLength).setFloat32(0, value, true);
+            dataView.setFloat32(byteOffset, value, true);
             break;
           default:
             unreachable();
@@ -243,29 +262,59 @@ function packComponents(
     bitOffset += bitLength;
   }
 
-  return data;
+  return dataView.buffer;
 }
 
 /**
  * Unpack substrings of bits from a Uint8Array, e.g. [8,8,8,8] or [9,9,9,5].
- *
- * MAINTENANCE_TODO: Pretty slow. Could significantly optimize when `bitLengths` is 8, 16, or 32.
  */
 function unpackComponentsBits(
   componentOrder: TexelComponent[],
   byteView: Uint8Array,
   bitLengths: number | PerTexelComponent<number>
 ): PerTexelComponent<number> {
-  const bitLengthMap =
-    typeof bitLengths === 'number' ? makePerTexelComponent(componentOrder, bitLengths) : bitLengths;
+  const components = makePerTexelComponent(componentOrder, 0);
 
-  const totalBitLength = Object.entries(bitLengthMap).reduce((acc, [, value]) => {
-    assert(value !== undefined);
-    return acc + value;
-  }, 0);
+  let bitLengthMap;
+  let totalBitLength;
+  if (typeof bitLengths === 'number') {
+    let index = 0;
+    // Optimized cases for when the bit lengths are all a well aligned value.
+    switch (bitLengths) {
+      case 8:
+        for (const c of componentOrder) {
+          components[c] = byteView[index++];
+        }
+        return components;
+      case 16: {
+        const shortView = new Uint16Array(byteView.buffer, byteView.byteOffset);
+        for (const c of componentOrder) {
+          components[c] = shortView[index++];
+        }
+        return components;
+      }
+      case 32: {
+        const longView = new Uint32Array(byteView.buffer, byteView.byteOffset);
+        for (const c of componentOrder) {
+          components[c] = longView[index++];
+        }
+        return components;
+      }
+    }
+
+    bitLengthMap = makePerTexelComponent(componentOrder, bitLengths);
+    totalBitLength = bitLengths * componentOrder.length;
+  } else {
+    bitLengthMap = bitLengths;
+    totalBitLength = Object.entries(bitLengthMap).reduce((acc, [, value]) => {
+      assert(value !== undefined);
+      return acc + value;
+    }, 0);
+  }
+
   assert(totalBitLength % 8 === 0);
 
-  const components = makePerTexelComponent(componentOrder, 0);
+  const dataView = new DataView(byteView.buffer, byteView.byteOffset, byteView.byteLength);
   let bitOffset = 0;
   for (const c of componentOrder) {
     const bitLength = bitLengthMap[c];
@@ -276,16 +325,15 @@ function unpackComponentsBits(
     const byteOffset = Math.floor(bitOffset / 8);
     const byteLength = Math.ceil(bitLength / 8);
     if (byteOffset === bitOffset / 8 && byteLength === bitLength / 8) {
-      const dataView = new DataView(byteView.buffer, byteView.byteOffset + byteOffset, byteLength);
       switch (byteLength) {
         case 1:
-          value = dataView.getUint8(0);
+          value = dataView.getUint8(byteOffset);
           break;
         case 2:
-          value = dataView.getUint16(0, true);
+          value = dataView.getUint16(byteOffset, true);
           break;
         case 4:
-          value = dataView.getUint32(0, true);
+          value = dataView.getUint32(byteOffset, true);
           break;
         default:
           unreachable();
@@ -293,9 +341,8 @@ function unpackComponentsBits(
     } else {
       // Packed representations are all 32-bit and use Uint as the data type.
       // ex.) rg10b11float, rgb10a2unorm
-      const view = new DataView(byteView.buffer, byteView.byteOffset, byteView.byteLength);
-      assert(view.byteLength === 4);
-      const word = view.getUint32(0, true);
+      assert(dataView.byteLength === 4);
+      const word = dataView.getUint32(0, true);
       value = (word >>> bitOffset) & ((1 << bitLength) - 1);
     }
 

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -122,6 +122,9 @@ export function makeClampToRange(format: EncodableTextureFormat): ComponentMapFn
   return applyEach(x => clamp(x, repr.numericRange!), repr.componentOrder);
 }
 
+// MAINTENANCE_TODO: Look into exposing this map to the test fixture so that it can be GCed at the
+// end of each test group. That would allow for caching of larger buffers (though it's unclear how
+// ofter larger buffers are used by packComponents.)
 const smallComponentDataViews = new Map();
 function getComponentDataView(byteLength: number): DataView {
   if (byteLength > 32) {


### PR DESCRIPTION
In my local testing I found that running tests under
`webgpu:web_platform,copyToTexture,ImageBitmap:*` was approx.
**62% faster** with these optimizations applied. Your milage may
vary. I did not do a comprehensive evaluation of tests outside that
group to determine the performance impact on them.

Should at least partially address #1162, though there's still more
work to be done.

Optimization done primarily by running different subsets of
`webgpu:web_platform,copyToTexture,ImageBitmap:*`, profiling with
Chrome dev tools, and examining the methods that consistently
showed up as the most expensive.

Almost all of the optimizations ended up being finding ways to
avoid repeated allocations of `TypedArrays`, `ArrayBuffers`, or
`DataViews`, as those tend to be reasonably expensive and these code
paths were allocating lots and lots of small ones.

Issue: #1162

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
