### PR TITLE
Implement the writeTimestamp test to expect an exception

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
@@ -65,7 +65,7 @@ g.test('writeTimestamp')
     const { featureContainsTimestampQuery } = t.params;
 
     const querySet = t.device.createQuerySet({
-      type: 'timestamp',
+      type: featureContainsTimestampQuery ? 'timestamp' : 'occlusion',
       count: 1,
     });
     const encoder = t.createEncoder('non-pass');

--- a/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/query_types.spec.ts
@@ -42,3 +42,35 @@ g.test('createQuerySet')
       t.device.createQuerySet({ type, count });
     });
   });
+
+g.test('writeTimestamp')
+  .desc(
+    `
+  Tests that writing a timestamp throws a type error exception if the features don't contain
+  'timestamp-query'.
+  `
+  )
+  .params(u => u.combine('featureContainsTimestampQuery', [false, true]))
+  .beforeAllSubcases(t => {
+    const { featureContainsTimestampQuery } = t.params;
+
+    const requiredFeatures: GPUFeatureName[] = [];
+    if (featureContainsTimestampQuery) {
+      requiredFeatures.push('timestamp-query');
+    }
+
+    t.selectDeviceOrSkipTestCase({ requiredFeatures });
+  })
+  .fn(async t => {
+    const { featureContainsTimestampQuery } = t.params;
+
+    const querySet = t.device.createQuerySet({
+      type: 'timestamp',
+      count: 1,
+    });
+    const encoder = t.createEncoder('non-pass');
+
+    t.shouldThrow(featureContainsTimestampQuery ? false : 'TypeError', () => {
+      encoder.encoder.writeTimestamp(querySet, 0);
+    });
+  });


### PR DESCRIPTION
This PR adds a new writeTimestamp test to check if it throws
a type error exception when the features don't contain
'timestamp-query'.

Issue: #919 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
