### PR TITLE
Remove storage write tests

### DIFF
--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -127,7 +127,6 @@ g.test('linear_memory')
     u
       .combineWithParams([
         { storageClass: 'storage', storageMode: 'read', access: 'read', dynamicOffset: false },
-        { storageClass: 'storage', storageMode: 'write', access: 'write', dynamicOffset: false },
         {
           storageClass: 'storage',
           storageMode: 'read_write',
@@ -141,7 +140,6 @@ g.test('linear_memory')
           dynamicOffset: false,
         },
         { storageClass: 'storage', storageMode: 'read', access: 'read', dynamicOffset: true },
-        { storageClass: 'storage', storageMode: 'write', access: 'write', dynamicOffset: true },
         { storageClass: 'storage', storageMode: 'read_write', access: 'read', dynamicOffset: true },
         {
           storageClass: 'storage',


### PR DESCRIPTION
WGSL does not support write only storage buffer. Remove the robust
access tests which generate write only storage buffers.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
