### PR TITLE
Implement api,validation,capability_checks,features,texture_formats:canvas_configuration_view_formats

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -205,7 +205,7 @@ g.test('canvas_configuration_view_formats')
 
     const canvasConf = {
       device: t.device,
-      format: 'bgra8unorm' as GPUTextureFormat,
+      format: 'bgra8unorm' as const,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
       viewFormats: viewFormats as GPUTextureFormat[],
     };

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -171,6 +171,56 @@ g.test('canvas_configuration')
     }
   });
 
+g.test('canvas_configuration_view_formats')
+  .desc(
+    `
+  Test that configuring a canvas with view formats throws an exception if the required optional
+  feature is not enabled. Otherwise, a validation error should be generated instead of throwing an
+  exception.
+  `
+  )
+  .params(u =>
+    u
+      .combine('viewFormats', [
+        ...kOptionalTextureFormats.map(format => [format]),
+        ['bgra8unorm', 'bc1-rgba-unorm'],
+        ['bc1-rgba-unorm', 'bgra8unorm'],
+      ])
+      .combine('canvasType', kAllCanvasTypes)
+      .combine('enable_required_feature', [true, false])
+  )
+  .beforeAllSubcases(t => {
+    const { viewFormats, enable_required_feature } = t.params;
+
+    if (enable_required_feature) {
+      t.selectDeviceForTextureFormatOrSkipTestCase(viewFormats as GPUTextureFormat[]);
+    }
+  })
+  .fn(async t => {
+    const { viewFormats, canvasType, enable_required_feature } = t.params;
+
+    const canvas = createCanvas(t, canvasType, 2, 2);
+    const ctx = canvas.getContext('webgpu' as const);
+    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+
+    const canvasConf = {
+      device: t.device,
+      format: 'bgra8unorm' as GPUTextureFormat,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+      viewFormats: viewFormats as GPUTextureFormat[],
+    };
+
+    if (enable_required_feature) {
+      t.expectValidationError(() => {
+        ctx.configure(canvasConf);
+      });
+    } else {
+      t.shouldThrow('TypeError', () => {
+        ctx.configure(canvasConf);
+      });
+    }
+  });
+
 g.test('storage_texture_binding_layout')
   .desc(
     `


### PR DESCRIPTION
This PR adds the canvas_configuration_view_formats test in
'api,validation,capability_checks,features,texture_formats:*' in order to
if GPUCanvasContext.configure throws an exception if the required optional feature
is not enabled as well as if the view formats of the given GPUCanvasConfiguration
is not valid.

Issue: #1592

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
