### PR TITLE
Convert subtraction tests to use interval framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -27,6 +27,7 @@ import {
   negationInterval,
   sinInterval,
   ulpInterval,
+  subtractionInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -1381,5 +1382,64 @@ g.test('multiplicationInterval')
     t.expect(
       objectEquals(expected, got),
       `multiplicationInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('subtractionInterval')
+  .paramsSubcasesOnly<BinaryToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: [0, 0] },
+      { input: [1, 0], expected: [1, 1] },
+      { input: [0, 1], expected: [-1, -1] },
+      { input: [-1, 0], expected: [-1, -1] },
+      { input: [0, -1], expected: [1, 1] },
+      { input: [1, 1], expected: [0, 0] },
+      { input: [1, -1], expected: [2, 2] },
+      { input: [-1, 1], expected: [-2, -2] },
+      { input: [-1, -1], expected: [0, 0] },
+
+      // 64-bit normals
+      { input: [0.1, 0], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0, 0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [-0.1, 0], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [0, -0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULP(hexToF32(0x3dcccccd))] },  // ~0.0
+      { input: [0.1, -0.1], expected: [minusOneULP(hexToF32(0x3e4ccccd)), hexToF32(0x3e4ccccd)] }, // ~0.2
+      { input: [-0.1, 0.1], expected: [hexToF32(0xbe4ccccd), plusOneULP(hexToF32(0xbe4ccccd))] },  // ~-0.2
+      { input: [-0.1, -0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULP(hexToF32(0x3dcccccd))] }, // ~0
+
+      // // 32-bit normals
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [0, kValue.f32.subnormal.positive.max] },
+
+      // Infinities
+      { input: [0, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [Number.POSITIVE_INFINITY, 0], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, Number.NEGATIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: [Number.NEGATIVE_INFINITY, 0], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+
+    const expected =
+      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+
+    const got = subtractionInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `subtractionInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
     );
   });

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -4,22 +4,15 @@ Execution Tests for the f32 arithmetic binary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { correctlyRoundedMatch } from '../../../../util/compare.js';
 import { TypeF32 } from '../../../../util/conversion.js';
 import {
   additionInterval,
   divisionInterval,
   multiplicationInterval,
+  subtractionInterval,
 } from '../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range } from '../../../../util/math.js';
-import {
-  allInputSources,
-  Case,
-  Config,
-  makeBinaryF32Case,
-  makeBinaryF32IntervalCase,
-  run,
-} from '../expression.js';
+import { allInputSources, Case, makeBinaryF32IntervalCase, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
@@ -64,13 +57,8 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryF32Case(lhs, rhs, (l: number, r: number): number => {
-        return l - r;
-      });
+      return makeBinaryF32IntervalCase(lhs, rhs, subtractionInterval);
     };
 
     const cases: Array<Case> = [];
@@ -81,7 +69,7 @@ Accuracy: Correctly rounded
       });
     });
 
-    run(t, binary('-'), [TypeF32, TypeF32], TypeF32, cfg, cases);
+    run(t, binary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('multiplication')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -680,3 +680,36 @@ export function sinInterval(n: number): F32Interval {
 
   return runPointOp(toInterval(n), op);
 }
+
+/** Calculate an acceptance interval of x - y */
+export function subtractionInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
+  const inner_op: BinaryToIntervalOp = {
+    impl: (inner_x: number, inner_y: number): F32Interval => {
+      if (!isF32Finite(inner_x) && isF32Finite(inner_y)) {
+        return correctlyRoundedInterval(inner_x);
+      }
+
+      if (isF32Finite(inner_x) && !isF32Finite(inner_y)) {
+        const result = Math.sign(inner_y) > 0 ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY;
+        return correctlyRoundedInterval(result);
+      }
+
+      if (!isF32Finite(inner_x) && !isF32Finite(inner_y)) {
+        if (Math.sign(inner_x) === -Math.sign(inner_y)) {
+          return correctlyRoundedInterval(inner_x);
+        } else {
+          return F32Interval.infinite();
+        }
+      }
+      return correctlyRoundedInterval(inner_x - inner_y);
+    },
+  };
+
+  const op: BinaryToIntervalOp = {
+    impl: (impl_x: number, impl_y: number): F32Interval => {
+      return roundAndFlushBinaryToInterval(impl_x, impl_y, inner_op);
+    },
+  };
+
+  return runBinaryOp(toInterval(x), toInterval(y), op);
+}


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
