### PR TITLE
Convert `max` tests to use interval framework

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -19,16 +19,11 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { correctlyRoundedMatch } from '../../../../../util/compare.js';
-import { kBit, kValue } from '../../../../../util/constants.js';
-import {
-  i32,
-  TypeF32,
-  TypeI32,
-  TypeU32,
-  u32,
-  uint32ToFloat32,
-} from '../../../../../util/conversion.js';
-import { allInputSources, Case, Config, makeBinaryF32Case, run } from '../../expression.js';
+import { kValue } from '../../../../../util/constants.js';
+import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
+import { maxInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, Config, makeBinaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -111,33 +106,20 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
     const makeCase = (x: number, y: number): Case => {
-      return makeBinaryF32Case(x, y, Math.max);
+      return makeBinaryF32IntervalCase(x, y, maxInterval);
     };
 
-    const test_values: Array<number> = [
-      uint32ToFloat32(kBit.f32.infinity.negative),
-      kValue.f32.negative.min,
-      -10.0,
-      -1.0,
-      kValue.f32.negative.max,
-      kValue.f32.subnormal.negative.min,
-      kValue.f32.subnormal.negative.max,
-      0.0,
-      kValue.f32.subnormal.positive.min,
-      kValue.f32.subnormal.positive.max,
-      kValue.f32.positive.min,
-      1.0,
-      10.0,
-      kValue.f32.positive.max,
-      uint32ToFloat32(kBit.f32.infinity.positive),
-    ];
-    const cases = generateTestCases(test_values, makeCase);
+    const cases: Array<Case> = [];
+    const numeric_range = fullF32Range();
+    numeric_range.push(kValue.f32.infinity.positive, kValue.f32.infinity.negative);
+    numeric_range.forEach(lhs => {
+      numeric_range.forEach(rhs => {
+        cases.push(makeCase(lhs, rhs));
+      });
+    });
 
-    run(t, builtin('max'), [TypeF32, TypeF32], TypeF32, cfg, cases);
+    run(t, builtin('max'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -568,6 +568,17 @@ export function log2Interval(x: number | F32Interval): F32Interval {
   return runPointOp(toInterval(x), op);
 }
 
+/** Calculate an acceptance interval of max(x, y) */
+export function maxInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
+  const op: BinaryToIntervalOp = {
+    impl: (impl_x: number, impl_y: number): F32Interval => {
+      return correctlyRoundedInterval(Math.max(impl_x, impl_y));
+    },
+  };
+
+  return runBinaryOp(toInterval(x), toInterval(y), op);
+}
+
 /** Calculate an acceptance interval of -x */
 export function negationInterval(n: number): F32Interval {
   const op: PointToIntervalOp = {


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
