### PR TITLE
Convert `min` tests to use interval framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -22,10 +22,11 @@ import {
   logInterval,
   log2Interval,
   maxInterval,
+  minInterval,
+  multiplicationInterval,
   negationInterval,
   sinInterval,
   ulpInterval,
-  multiplicationInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -1256,6 +1257,65 @@ g.test('maxInterval')
     t.expect(
       objectEquals(expected, got),
       `maxInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('minInterval')
+  .paramsSubcasesOnly<BinaryToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: [0, 0] },
+      { input: [1, 0], expected: [0, 0] },
+      { input: [0, 1], expected: [0, 0] },
+      { input: [-1, 0], expected: [-1, -1] },
+      { input: [0, -1], expected: [-1, -1] },
+      { input: [1, 1], expected: [1, 1] },
+      { input: [1, -1], expected: [-1, -1] },
+      { input: [-1, 1], expected: [-1, -1] },
+      { input: [-1, -1], expected: [-1, -1] },
+
+      // 64-bit normals
+      { input: [0.1, 0], expected: [0, 0] },
+      { input: [0, 0.1], expected: [0, 0] },
+      { input: [-0.1, 0], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [0, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [-0.1, 0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
+
+      // 32-bit normals
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, 0] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, 0] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
+
+      // Infinities
+      { input: [0, Number.POSITIVE_INFINITY], expected: [0, 0] },
+      { input: [Number.POSITIVE_INFINITY, 0], expected: [0, 0] },
+      { input: [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: [0, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [Number.NEGATIVE_INFINITY, 0], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+
+    const expected =
+      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+
+    const got = minInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `minInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -18,16 +18,11 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { correctlyRoundedMatch } from '../../../../../util/compare.js';
-import { kBit, kValue } from '../../../../../util/constants.js';
-import {
-  i32,
-  TypeF32,
-  TypeI32,
-  TypeU32,
-  u32,
-  uint32ToFloat32,
-} from '../../../../../util/conversion.js';
-import { allInputSources, Case, Config, makeBinaryF32Case, run } from '../../expression.js';
+import { kValue } from '../../../../../util/constants.js';
+import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
+import { minInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, Config, makeBinaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -110,33 +105,20 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-
     const makeCase = (x: number, y: number): Case => {
-      return makeBinaryF32Case(x, y, Math.min);
+      return makeBinaryF32IntervalCase(x, y, minInterval);
     };
 
-    const test_values: Array<number> = [
-      uint32ToFloat32(kBit.f32.infinity.negative),
-      kValue.f32.negative.min,
-      -10.0,
-      -1.0,
-      kValue.f32.negative.max,
-      kValue.f32.subnormal.negative.min,
-      kValue.f32.subnormal.negative.max,
-      0.0,
-      kValue.f32.subnormal.positive.min,
-      kValue.f32.subnormal.positive.max,
-      kValue.f32.positive.min,
-      1.0,
-      10.0,
-      kValue.f32.positive.max,
-      uint32ToFloat32(kBit.f32.infinity.positive),
-    ];
-    const cases = generateTestCases(test_values, makeCase);
+    const cases: Array<Case> = [];
+    const numeric_range = fullF32Range();
+    numeric_range.push(kValue.f32.infinity.positive, kValue.f32.infinity.negative);
+    numeric_range.forEach(lhs => {
+      numeric_range.forEach(rhs => {
+        cases.push(makeCase(lhs, rhs));
+      });
+    });
 
-    run(t, builtin('min'), [TypeF32, TypeF32], TypeF32, cfg, cases);
+    run(t, builtin('min'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -613,6 +613,17 @@ export function maxInterval(x: number | F32Interval, y: number | F32Interval): F
   return runBinaryOp(toInterval(x), toInterval(y), op);
 }
 
+/** Calculate an acceptance interval of min(x, y) */
+export function minInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
+  const op: BinaryToIntervalOp = {
+    impl: (impl_x: number, impl_y: number): F32Interval => {
+      return correctlyRoundedInterval(Math.min(impl_x, impl_y));
+    },
+  };
+
+  return runBinaryOp(toInterval(x), toInterval(y), op);
+}
+
 /** Calculate an acceptance interval of x * y */
 export function multiplicationInterval(
   x: number | F32Interval,


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
