### PR TITLE
Convert `inverseSqrt` tests to use interval framework

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -9,11 +9,11 @@ Returns the reciprocal of sqrt(e). Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ulpMatch } from '../../../../../util/compare.js';
-import { kBit, kValue } from '../../../../../util/constants.js';
-import { f32, f32Bits, TypeF32 } from '../../../../../util/conversion.js';
+import { kValue } from '../../../../../util/constants.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { inverseSqrtInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, Config, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,24 +34,18 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    // [1]: Need to decide what the ground-truth is.
     const makeCase = (x: number): Case => {
-      return { input: f32(x), expected: f32(1 / Math.sqrt(x)) };
+      return makeUnaryF32IntervalCase(x, inverseSqrtInterval);
     };
 
-    // Well defined cases
     const cases: Array<Case> = [
-      { input: f32Bits(kBit.f32.infinity.positive), expected: f32(0) },
-      { input: f32(1), expected: f32(1) },
       // 0 < x <= 1 linearly spread
-      ...linearRange(kValue.f32.positive.min, 1, 100).map(x => makeCase(x)),
+      ...linearRange(kValue.f32.positive.min, 1, 100),
       // 1 <= x < 2^32, biased towards 1
-      ...biasedRange(1, 2 ** 32, 1000).map(x => makeCase(x)),
-    ];
+      ...biasedRange(1, 2 ** 32, 1000),
+    ].map(x => makeCase(x));
 
-    const cfg: Config = t.params;
-    cfg.cmpFloats = ulpMatch(2);
-    run(t, builtin('inverseSqrt'), [TypeF32], TypeF32, cfg, cases);
+    run(t, builtin('inverseSqrt'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -574,6 +574,21 @@ export function floorInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), op);
 }
 
+/** Calculate an acceptance interval of inverseSqrt(x) */
+export function inverseSqrtInterval(n: number | F32Interval): F32Interval {
+  const op: PointToIntervalOp = {
+    impl: (impl_n: number): F32Interval => {
+      if (impl_n <= 0) {
+        // 1 / sqrt(n) for n <= 0 is not meaningfully defined for real f32
+        return F32Interval.infinite();
+      }
+      return ulpInterval(1 / Math.sqrt(impl_n), 2);
+    },
+  };
+
+  return runPointOp(toInterval(n), op);
+}
+
 /** Calculate an acceptance interval of log(x) */
 export function logInterval(x: number | F32Interval): F32Interval {
   const op: PointToIntervalOp = {


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
