### PR TITLE
Test zero levels or layers is invalid in render_pass,resolve:resolve_attachment

### DIFF
--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -22,7 +22,7 @@ Test various validation behaviors when a resolveTarget is provided.
 - resolve target must have exactly one subresource:
     - base mip level {0, >0}, mip level count {1, >1}.
     - base array layer {0, >0}, array layer count {1, >1}.
-    - TODO: test zero subresources
+- resolve target GPUTextureView is invalid
 - resolve source and target have different formats.
     - rgba8unorm -> {bgra8unorm, rgba8unorm-srgb}
     - {bgra8unorm, rgba8unorm-srgb} -> rgba8unorm
@@ -46,6 +46,8 @@ Test various validation behaviors when a resolveTarget is provided.
       resolveTargetWidth: 4,
       _valid: true,
     },
+    // a validation error should be created when resolveTarget is invalid.
+    { resolveTargetInvalid: true, _valid: false },
     // a validation error should be created when mip count > 1
     { resolveTargetViewMipCount: 2, _valid: false },
     {
@@ -81,6 +83,7 @@ Test various validation behaviors when a resolveTarget is provided.
       colorAttachmentSamples = 4,
       resolveTargetSamples = 1,
       resolveTargetUsage = GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+      resolveTargetInvalid = false,
       resolveTargetViewMipCount = 1,
       resolveTargetViewBaseMipLevel = 0,
       resolveTargetViewArrayLayerCount = 1,
@@ -101,8 +104,8 @@ Test various validation behaviors when a resolveTarget is provided.
         colorAttachmentSlot < kNumColorAttachments;
         colorAttachmentSlot++
       ) {
-        // resolveSlot === colorAttachmentSlot denotes the color attachment slot that contains the color attachment with resolve
-        // target.
+        // resolveSlot === colorAttachmentSlot denotes the color attachment slot that contains the
+        // color attachment with resolve target.
         if (resolveSlot === colorAttachmentSlot) {
           // Create the color attachment with resolve target with the configurable parameters.
           const resolveSourceColorAttachment = t.device.createTexture({
@@ -133,13 +136,15 @@ Test various validation behaviors when a resolveTarget is provided.
             view: resolveSourceColorAttachment.createView(),
             loadOp: 'load',
             storeOp: 'discard',
-            resolveTarget: resolveTarget.createView({
-              dimension: resolveTargetViewArrayLayerCount === 1 ? '2d' : '2d-array',
-              mipLevelCount: resolveTargetViewMipCount,
-              arrayLayerCount: resolveTargetViewArrayLayerCount,
-              baseMipLevel: resolveTargetViewBaseMipLevel,
-              baseArrayLayer: resolveTargetViewBaseArrayLayer,
-            }),
+            resolveTarget: resolveTargetInvalid
+              ? t.getErrorTextureView()
+              : resolveTarget.createView({
+                  dimension: resolveTargetViewArrayLayerCount === 1 ? '2d' : '2d-array',
+                  mipLevelCount: resolveTargetViewMipCount,
+                  arrayLayerCount: resolveTargetViewArrayLayerCount,
+                  baseMipLevel: resolveTargetViewBaseMipLevel,
+                  baseArrayLayer: resolveTargetViewBaseArrayLayer,
+                }),
           });
         } else {
           // Create a basic texture to fill other color attachment slots. This texture's dimensions


### PR DESCRIPTION
This PR adds test cases that check mipsLevelCount: 0 and arrayLayerCount: 0
to the render_pass,resolve:resolve_attachment test. A validation error should
be generated if resolveTargetViewMipCount or resolveTargetViewArrayLayerCount
is 0.

Issue: #1599 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
