### PR TITLE
Guard against writeTimestamp() calls without the proper feature

### DIFF
--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -89,8 +89,15 @@ Tests that write timestamp to all types of query set on all possible encoders:
       .expand('queryIndex', p => (p.type === 'timestamp' ? [0, 2] : [0]))
   )
   .beforeAllSubcases(t => {
+    const { type } = t.params;
+
     // writeTimestamp is only available for devices that enable the 'timestamp-query' feature.
-    t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
+    const queryTypes: GPUQueryType[] = ['timestamp'];
+    if (type !== 'timestamp') {
+      queryTypes.push(type);
+    }
+
+    t.selectDeviceForQueryTypeOrSkipTestCase(queryTypes);
   })
   .fn(async t => {
     const { type, queryIndex } = t.params;

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -89,10 +89,8 @@ Tests that write timestamp to all types of query set on all possible encoders:
       .expand('queryIndex', p => (p.type === 'timestamp' ? [0, 2] : [0]))
   )
   .beforeAllSubcases(t => {
-    const { type } = t.params;
-    if (type) {
-      t.selectDeviceForQueryTypeOrSkipTestCase(type);
-    }
+    // writeTimestamp is only available for devices that enable the 'timestamp-query' feature.
+    t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
   })
   .fn(async t => {
     const { type, queryIndex } = t.params;

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -673,8 +673,15 @@ Tests encoding and finishing a writeTimestamp command on destroyed device.
       .combine('awaitLost', [true, false])
   )
   .beforeAllSubcases(t => {
+    const { type } = t.params;
+
     // writeTimestamp is only available for devices that enable the 'timestamp-query' feature.
-    t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
+    const queryTypes: GPUQueryType[] = ['timestamp'];
+    if (type !== 'timestamp') {
+      queryTypes.push(type);
+    }
+
+    t.selectDeviceForQueryTypeOrSkipTestCase(queryTypes);
   })
   .fn(async t => {
     const { type, stage, awaitLost } = t.params;

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -673,8 +673,8 @@ Tests encoding and finishing a writeTimestamp command on destroyed device.
       .combine('awaitLost', [true, false])
   )
   .beforeAllSubcases(t => {
-    const { type } = t.params;
-    t.selectDeviceForQueryTypeOrSkipTestCase(type);
+    // writeTimestamp is only available for devices that enable the 'timestamp-query' feature.
+    t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
   })
   .fn(async t => {
     const { type, stage, awaitLost } = t.params;


### PR DESCRIPTION
writeTimestamp is specced to throw immediately if called when the
'timestamp-query' feature is not enabled. This change ensures that
any tests that call writeTimestamp() are skipped unless the device
enables 'timestamp-query'.

These tests started failing in Chrome once we began throwing
exceptions when the feature wasn't enabled, as the spec requires.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
