### PR TITLE
Minor clean up in life_of.md

### DIFF
--- a/docs/intro/life_of.md
+++ b/docs/intro/life_of.md
@@ -10,7 +10,7 @@ Filing new draft issues in the CTS project tracker is very lightweight.
 Anyone with access should do this eagerly, to ensure no testing ideas are forgotten.
 (And if you don't have access, just file a regular issue.)
 
-1. Enter a draft issue with "Status" "New (not in repo)" is in the
+1. Enter a draft issue with "Status: New (not in repo)" in the
     [CTS project tracker](https://github.com/orgs/gpuweb/projects/3) with any available info
     (notes/plans to ensure full test coverage of the change). The source of this may be:
 


### PR DESCRIPTION
I think `"Status: New (not in repo)"` would be more straightforward than `"Status" "New (not in repo)"`? And `is` can be dropped, if I'm right?