### PR TITLE
Add GPURenderPassDescriptor.maxDrawCount test plan

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -744,6 +744,6 @@ and checks whether GPUCommandEncoder.finish() causes a validation error.
       .combine('bundleSecondHalf', [false, true])
       .combine('maxDrawCount', [0, 1, 4, 16])
       .beginSubcases()
-      .expand('drawCount', p => [0, p.maxDrawCount, p.maxDrawCount + 1])
+      .expand('drawCount', p => new Set([0, p.maxDrawCount, p.maxDrawCount + 1]))
   )
   .unimplemented();

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -732,7 +732,8 @@ GPURenderPassDescriptor.maxDrawCount causes validation error on
 GPUCommandEncoder.finish(). The test sets specified maxDrawCount,
 calls specified draw call specified times with or without bundles,
 and checks whether GPUCommandEncoder.finish() causes a validation error.
-    - x= whether use bundles for first/second draw calls
+    - x= whether to use a bundle for the first half of the draw calls
+    - x= whether to use a bundle for the second half of the draw calls
     - x= several different draw counts
     - x= several different maxDrawCounts
 `
@@ -743,6 +744,6 @@ and checks whether GPUCommandEncoder.finish() causes a validation error.
       .combine('bundleSecondHalf', [false, true])
       .combine('maxDrawCount', [0, 1, 4, 16])
       .beginSubcases()
-      .expand('drawCount', p => [p.maxDrawCount, p.maxDrawCount + 1])
+      .expand('drawCount', p => [0, p.maxDrawCount, p.maxDrawCount + 1])
   )
   .unimplemented();

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -723,3 +723,24 @@ In this test we test that only the last setting for a buffer slot take account.
 `
   )
   .unimplemented();
+
+g.test(`max_draw_count`)
+  .desc(
+    `
+In this test we test that draw count which exceeds GPURenderPassDescriptor.maxDrawCount
+causes validation error on GPUCommandEncoder.finish(). The test sets specified maxDrawCount,
+calls specified draw call specified times, and checks whether GPUCommandEncoder.finish()
+causes a validation error.
+    - x= all draw types
+    - draw count {0, 1, 2, 10}
+    - max draw count {0, 1, 2, 10}
+TODO: Missing test case Bundle
+`
+  )
+  .params(u =>
+    u
+      .combine('drawType', ['draw', 'drawIndexed', 'drawIndirect', 'drawIndexedIndirect', 'all'])
+      .combine('drawCount', [0, 1, 2, 10])
+      .combine('maxDrawCount', [0, 1, 2, 10])
+  )
+  .unimplemented();

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -727,20 +727,22 @@ In this test we test that only the last setting for a buffer slot take account.
 g.test(`max_draw_count`)
   .desc(
     `
-In this test we test that draw count which exceeds GPURenderPassDescriptor.maxDrawCount
-causes validation error on GPUCommandEncoder.finish(). The test sets specified maxDrawCount,
-calls specified draw call specified times, and checks whether GPUCommandEncoder.finish()
-causes a validation error.
-    - x= all draw types
-    - draw count {0, 1, 2, 10}
-    - max draw count {0, 1, 2, 10}
-TODO: Missing test case Bundle
+In this test we test that draw count which exceeds
+GPURenderPassDescriptor.maxDrawCount causes validation error on
+GPUCommandEncoder.finish(). The test sets specified maxDrawCount,
+calls specified draw call specified times with or without bundles,
+and checks whether GPUCommandEncoder.finish() causes a validation error.
+    - x= whether use bundles for first/second draw calls
+    - x= several different draw counts
+    - x= several different maxDrawCounts
 `
   )
   .params(u =>
     u
-      .combine('drawType', ['draw', 'drawIndexed', 'drawIndirect', 'drawIndexedIndirect', 'all'])
-      .combine('drawCount', [0, 1, 2, 10])
-      .combine('maxDrawCount', [0, 1, 2, 10])
+      .combine('bundleFirstHalf', [false, true])
+      .combine('bundleSecondHalf', [false, true])
+      .combine('maxDrawCount', [0, 1, 4, 16])
+      .beginSubcases()
+      .expand('drawCount', p => [p.maxDrawCount, p.maxDrawCount + 1])
   )
   .unimplemented();


### PR DESCRIPTION
Issue: #1613 

This PR adds a test plan for `GPURenderPassDescriptor.maxDrawCount`.

The new test checks that draw count which exceeds `GPURenderPassDescriptor.maxDrawCount` causes validation error on `GPUCommandEncoder.finish()`.

The test sets specified maxDrawCount, calls specified draw call specified times, and checks whether `GPUCommandEncoder.finish()` causes a validation error.

Test implementation example:

```
u
  .combine('drawType', ['draw', 'drawIndexed', 'drawIndirect', 'drawIndexedIndirect', 'all'])
  .combine('drawCount', [0, 1, 2, 10])
  .combine('maxDrawCount', [0, 1, 2, 10])

...

const countMultiplier = drawType === 'all' ? 4 : 1;
const commandEncoder = t.device.createCommandEncoder();
const renderPassEncoder = commandEncoder.beginRenderPass({
  maxDrawCount: maxDrawCount * countMultiplier,
  ...
});

...

for (let i = 0; i < drawCount; i++) {
  if (drawType === 'draw' || drawType === 'all') {
    renderPassEncoder.draw(3);
  }
  if (drawType === 'drawIndexed' || drawType === 'all') {
    renderPassEncoder.drawIndexed(3);
  }
  if (drawType === 'drawIndirect' || drawType === 'all') { 
    renderPassEncoder.drawIndirect(indirectBuffer, 0);
  }
  if (drawType === 'drawIndexedIndirect' || drawType === 'all') {
    renderPassEncoder.drawIndexedIndirect(indexedIndirectBuffer, 0);
  }
}

renderPassEncoder.end();
t.expectValidationError(() => {
  commandEncoder.finish();
}, drawCount * countMultiplier > maxDrawCount * countMultiplier);
```

Some thoughts:
- Missing test case in this PR, Bundle. I'm thinking a simple and good coverage test cases with bundles because all possible combinations with bundles can be too many; draw type in a bundle, draw type out of a bundle, how many draw calls in a bundle, how many bundles, and so on.
- The draw call and max draw call combinations `[0, 1, 2, 10]` are not deeply thought yet. I just picked zero, the minumum value except for zero, and some others. For saving testing time, I didn't choose large numbers and many combinations.
- @Kangz I'm not sure if I followed your comment in https://dawn-review.googlesource.com/c/dawn/+/94821/comments/1b673e53_f829ad1b especially "Test don't check adverserialy". Does the combination in the test plan satisfy?

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
