### PR TITLE
Test line comments at EOF.

### DIFF
--- a/src/webgpu/shader/validation/parse/comments.spec.ts
+++ b/src/webgpu/shader/validation/parse/comments.spec.ts
@@ -25,6 +25,18 @@ parameters
     t.expectCompileResult(true, code);
   });
 
+g.test('line_comment_eof')
+  .desc(`Test that line comments can come at EOF.`)
+  .fn(t => {
+    const code = `
+@fragment
+fn main() -> @location(0) vec4<f32> {
+  return vec4<f32>(.4, .2, .3, .1);
+}
+// line comments are OK at EOF...`;
+    t.expectCompileResult(true, code);
+  });
+
 g.test('line_comment_terminators')
   .desc(`Test that line comments are terminated by any blankspace other than space and \t`)
   .params(u =>


### PR DESCRIPTION
This CL adds a test for line comments which terminate at EOF.

Fixes #1431

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
