### PR TITLE
Implement val:render_pass_descriptor:occlusion_query_set_type

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -713,3 +713,26 @@ g.test('multisample_render_target_formats_support_resolve')
       colorAttachments: [colorAttachment],
     });
   });
+
+g.test('occlusion_query_set_type')
+  .desc('Test that occlusion query set only works if the type is occlusion')
+  .paramsSimple([
+    { querySetState: 'valid' as const, queryType: 'occlusion', _success: true },
+    { querySetState: 'invalid' as const, queryType: 'timestamp', _success: false },
+  ])
+  .fn(async t => {
+    const { querySetState, queryType, _success } = t.params;
+
+    const querySet = t.createQuerySetWithState(querySetState, {
+      type: queryType as GPUQueryType,
+      count: 2,
+    });
+
+    const colorTexture = t.createTexture({ format: 'rgba8unorm' });
+    const descriptor = {
+      colorAttachments: [t.getColorAttachment(colorTexture)],
+      occlusionQuerySet: querySet,
+    };
+
+    t.tryRenderPass(_success, descriptor);
+  });


### PR DESCRIPTION
If this.occlusionQuerySet is not null, occlusionQuerySet.type must
be occlusion. So, this PR adds a test to ensure that occlusionQuerySet
only works if the type is 'occlusion'.

Issue: #1618

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
