### PR TITLE
Implement val:render_pass_descriptor:timestamp_writes_location

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -744,7 +744,7 @@ g.test('timestamp_writes_location')
       location: locationB,
     };
 
-    const isValid = locationA === locationB ? false : true;
+    const isValid = locationA !== locationB;
 
     const colorTexture = t.createTexture({ format: 'rgba8unorm' });
     const descriptor = {

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -713,3 +713,44 @@ g.test('multisample_render_target_formats_support_resolve')
       colorAttachments: [colorAttachment],
     });
   });
+
+g.test('timestamp_writes_location')
+  .desc('Test that entries in timestampWrites do not have the same location.')
+  .params(u =>
+    u //
+      .combine('locationA', ['beginning', 'end'] as const)
+      .combine('locationB', ['beginning', 'end'] as const)
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase(['timestamp-query']);
+  })
+  .fn(async t => {
+    const { locationA, locationB } = t.params;
+
+    const querySet = t.device.createQuerySet({
+      type: 'timestamp',
+      count: 1,
+    });
+
+    const timestampWriteA = {
+      querySet,
+      queryIndex: 0,
+      location: locationA,
+    };
+
+    const timestampWriteB = {
+      querySet,
+      queryIndex: 1,
+      location: locationB,
+    };
+
+    const isValid = locationA === locationB ? false : true;
+
+    const colorTexture = t.createTexture({ format: 'rgba8unorm' });
+    const descriptor = {
+      colorAttachments: [t.getColorAttachment(colorTexture)],
+      timestampWrites: [timestampWriteA, timestampWriteB],
+    };
+
+    t.tryRenderPass(isValid, descriptor);
+  });


### PR DESCRIPTION
No two entries in timestampWrites have the same location. So,
this PR adds a test to ensure that two timestampWrite don't
have the same location.

Issue: #1618

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
