### PR TITLE
Succinct the test names of render_pass_descriptor.spec.ts (2/n)

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -532,11 +532,13 @@ g.test('resolveTarget,mipmap_level_count')
     t.tryRenderPass(false, descriptor);
   });
 
-g.test('color_attachments,resolveTarget_usage')
+g.test('resolveTarget,usage')
   .desc(
     `
   Test that using a resolve target whose usage is not RENDER_ATTACHMENT is invalid for color
   attachments.
+
+  TODO: Add a control case (include vs exclude RENDER_ATTACHMENT usage)
   `
   )
   .fn(async t => {


### PR DESCRIPTION
This is the second PR to simplify the names of the existing tests
with descriptions.

Issue: #1618

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
