### PR TITLE
Implement val:render_pass_descriptor:depth_stencil_attachment_depth_clear_value

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -717,6 +717,35 @@ g.test('depth_stencil_attachment')
     t.tryRenderPass(isValid, descriptor);
   });
 
+g.test('depth_stencil_attachment,depth_clear_value')
+  .desc(
+    `
+  Test that depthClearValue is invalid if the value is out of the range(0.0 and 1.0) when
+  depthLoadOp is 'clear'.
+  `
+  )
+  .paramsSimple([
+    { depthClearValue: -1.0 },
+    { depthClearValue: 0.0 },
+    { depthClearValue: 0.5 },
+    { depthClearValue: 1.0 },
+    { depthClearValue: 1.5 },
+  ])
+  .fn(t => {
+    const { depthClearValue } = t.params;
+
+    const depthStencilTexture = t.createTexture({ format: 'depth24plus-stencil8' });
+    const depthStencilAttachment = t.getDepthStencilAttachment(depthStencilTexture);
+    depthStencilAttachment.depthClearValue = depthClearValue;
+
+    const descriptor = {
+      colorAttachments: [t.getColorAttachment(t.createTexture())],
+      depthStencilAttachment,
+    };
+
+    t.tryRenderPass(depthClearValue >= 0.0 && depthClearValue <= 1.0, descriptor);
+  });
+
 g.test('multisample_render_target_formats_support_resolve')
   .params(u =>
     u


### PR DESCRIPTION
If depthLoadOp of depthStencilAttachment is "clear", depthClearValue
must be between 0.0 and 1.0. So, this PR adds a test to check if
depthClearValue is invalid if the value is out of the range.

Issue: #1618

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
