### PR TITLE
Add support for multiple intervals to FP testing framework

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../util/conversion.js';
 import {
   BinaryToInterval,
+  F32Interval,
   PointToInterval,
   TernaryToInterval,
 } from '../../../util/f32_interval.js';
@@ -588,12 +589,15 @@ export function makeBinaryF32Case(
  * Generates a Case for the param and unary interval generator provided.
  * The Case will use use an interval comparator for matching results.
  * @param param the param to pass into the unary operation
- * @param op callback that implements generating an acceptance interval for a unary operation
+ * @param ops callbacks that implement generating an acceptance interval for a unary operation
  */
-export function makeUnaryF32IntervalCase(param: number, op: PointToInterval): Case {
+export function makeUnaryF32IntervalCase(param: number, ...ops: PointToInterval[]): Case {
   param = quantizeToF32(param);
-  const interval = op(param);
-  return { input: [f32(param)], expected: intervalComparator(interval) };
+  const intervals: Array<F32Interval> = new Array<F32Interval>();
+  for (const op of ops) {
+    intervals.push(op(param));
+  }
+  return { input: [f32(param)], expected: intervalComparator(...intervals) };
 }
 
 /**
@@ -601,19 +605,22 @@ export function makeUnaryF32IntervalCase(param: number, op: PointToInterval): Ca
  * The Case will use use an interval comparator for matching results.
  * @param param0 the first param or left hand side to pass into the binary operation
  * @param param1 the second param or rhs hand side to pass into the binary operation
- * @param op callback that implements generating an acceptance interval for a binary operation
+ * @param ops callbacks that implement generating an acceptance interval for a binary operation
  */
 // Will be used in test implementations
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function makeBinaryF32IntervalCase(
   param0: number,
   param1: number,
-  op: BinaryToInterval
+  ...ops: BinaryToInterval[]
 ): Case {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
-  const interval = op(param0, param1);
-  return { input: [f32(param0), f32(param1)], expected: intervalComparator(interval) };
+  const intervals: Array<F32Interval> = new Array<F32Interval>();
+  for (const op of ops) {
+    intervals.push(op(param0, param1));
+  }
+  return { input: [f32(param0), f32(param1)], expected: intervalComparator(...intervals) };
 }
 
 /**
@@ -622,7 +629,8 @@ export function makeBinaryF32IntervalCase(
  * @param param0 the first param to pass into the ternary operation
  * @param param1 the second param to pass into the ternary operation
  * @param param2 the third param to pass into the ternary operation
- * @param op callback that implements generating an acceptance interval for a ternary operation
+ * @param ops callbacks that implement generating an acceptance interval for a
+ *           ternary operation.
  */
 // Will be used in test implementations
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -630,11 +638,17 @@ export function makeTernaryF32IntervalCase(
   param0: number,
   param1: number,
   param2: number,
-  op: TernaryToInterval
+  ...ops: TernaryToInterval[]
 ): Case {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
   param2 = quantizeToF32(param2);
-  const interval = op(param0, param1, param2);
-  return { input: [f32(param0), f32(param1), f32(param2)], expected: intervalComparator(interval) };
+  const intervals: Array<F32Interval> = new Array<F32Interval>();
+  for (const op of ops) {
+    intervals.push(op(param0, param1, param2));
+  }
+  return {
+    input: [f32(param0), f32(param1), f32(param2)],
+    expected: intervalComparator(...intervals),
+  };
 }

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -62,17 +62,22 @@ export function correctlyRoundedMatch(): FloatMatch {
 }
 
 /**
- * @returns a FloatMatch that return true iff |got| is contained in the interval |i|.
+ * @returns a FloatMatch that return true iff |got| is contained in any of the intervals.
  *
  * The standard |expected| parameter is ignored.
  *
  * NB: This will be removed at the end of transition to the new FP testing framework.
  *
- * @param i interval to test the |got| value against.
+ * @param intervals array of intervals to test the |got| value against.
  */
-export function intervalMatch(i: F32Interval): FloatMatch {
+export function intervalMatch(...intervals: F32Interval[]): FloatMatch {
   return (got, _) => {
-    return i.contains(got);
+    for (const i of intervals) {
+      if (i.contains(got)) {
+        return true;
+      }
+    }
+    return false;
   };
 }
 
@@ -189,12 +194,12 @@ export function ulpComparator(x: number, target: Scalar, n: (x: number) => numbe
   };
 }
 
-/** @returns a Comparator that checks whether a result is contained within a target interval
+/** @returns a Comparator that checks whether a result is contained within the target intervals
  *
  * NB: This will be removed at the end of transition to the new FP testing framework.
  */
-export function intervalComparator(i: F32Interval): Comparator {
-  const match = intervalMatch(i);
+export function intervalComparator(...intervals: F32Interval[]): Comparator {
+  const match = intervalMatch(...intervals);
   return (got, _) => {
     // The second param is ignored by match
     const cmp = compare(got, f32(0.0), match);
@@ -204,7 +209,7 @@ export function intervalComparator(i: F32Interval): Comparator {
     return {
       matched: false,
       got: got.toString(),
-      expected: `within ${i}`,
+      expected: `within ${intervals}`,
     };
   };
 }


### PR DESCRIPTION
This change handles situations that require multiple discrete
intervals by having the test specify multiple interval generators when
invoking make*Case. This means that for cases like clamp, there will
need to be two generators, clampMedianInterval and clampMinMaxInterval
that will be passed in.

The upshot is that the code and interfaces in f32_interval.ts do not
need to handle multiple interval returns, so the complexity is
isolated to expression.ts, which should be simplified once the old
framework code can be removed.

Fixes #1641

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
