### PR TITLE
Convert `clamp` f32 tests to use interval framework

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -15,11 +15,8 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { anyOf, correctlyRoundedMatch } from '../../../../../util/compare.js';
-import { kBit } from '../../../../../util/constants.js';
+import { kBit, kValue } from '../../../../../util/constants.js';
 import {
-  f32,
-  f32Bits,
   i32,
   i32Bits,
   Scalar,
@@ -29,8 +26,8 @@ import {
   u32,
   u32Bits,
 } from '../../../../../util/conversion.js';
-import { isSubnormalScalar } from '../../../../../util/math.js';
-import { allInputSources, Case, Config, run } from '../../expression.js';
+import { clampMedianInterval, clampMinMaxInterval } from '../../../../../util/f32_interval.js';
+import { allInputSources, Case, makeTernaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -49,20 +46,6 @@ function calculateMinMaxClamp(ei: number, fi: number, gi: number): number {
   return Math.min(Math.max(ei, fi), gi);
 }
 
-/**
- * Calculates clamp as the median of three numbers
- *
- * Operates on indices of an ascending sorted array, instead of the actual
- * values to avoid rounding issues.
- *
- * @returns the index of the clamped value
- */
-function calculateMedianClamp(ei: number, fi: number, gi: number): number {
-  return [ei, fi, gi].sort((a, b) => {
-    return a - b;
-  })[1];
-}
-
 /** @returns a set of clamp test cases from an ascending list of integer values */
 function generateIntegerTestCases(test_values: Array<Scalar>): Array<Case> {
   const cases = new Array<Case>();
@@ -70,47 +53,8 @@ function generateIntegerTestCases(test_values: Array<Scalar>): Array<Case> {
     test_values.forEach((f, fi) => {
       test_values.forEach((g, gi) => {
         const expected_idx = calculateMinMaxClamp(ei, fi, gi);
-        const precise_expected = test_values[expected_idx];
-        const expected = isSubnormalScalar(precise_expected)
-          ? anyOf(precise_expected, f32(0.0))
-          : precise_expected;
+        const expected = test_values[expected_idx];
         cases.push({ input: [e, f, g], expected });
-      });
-    });
-  });
-  return cases;
-}
-
-/** @returns a set of clamp test cases from an ascending list of floating point values */
-function generateFloatTestCases(test_values: Array<Scalar>): Array<Case> {
-  const cases = new Array<Case>();
-  test_values.forEach((e, ei) => {
-    test_values.forEach((f, fi) => {
-      test_values.forEach((g, gi) => {
-        // Spec allows backends for floats to either return the min-max formula or median of 3 numbers
-        const expected_values: Array<Scalar> = [];
-        {
-          const expected_idx = calculateMinMaxClamp(ei, fi, gi);
-          const precise_expected = test_values[expected_idx];
-          if (!expected_values.includes(precise_expected)) {
-            expected_values.push(precise_expected);
-          }
-        }
-        {
-          const expected_idx = calculateMedianClamp(ei, fi, gi);
-          const precise_expected = test_values[expected_idx];
-          if (!expected_values.includes(precise_expected)) {
-            expected_values.push(precise_expected);
-          }
-        }
-        const contains_subnormals =
-          expected_values.filter(x => {
-            return isSubnormalScalar(x);
-          }).length > 0;
-        if (contains_subnormals) {
-          expected_values.push(f32(0.0));
-        }
-        cases.push({ input: [e, f, g], expected: anyOf(...expected_values) });
       });
     });
   });
@@ -198,37 +142,38 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
+    const makeCase = (x: number, y: number, z: number): Case => {
+      return makeTernaryF32IntervalCase(x, y, z, clampMedianInterval, clampMinMaxInterval);
+    };
 
-    // This array must be strictly increasing, since that ordering determines
-    // the expected values.
-    const test_values: Array<Scalar> = [
-      f32Bits(kBit.f32.infinity.negative),
-      f32Bits(kBit.f32.negative.min),
-      f32(-10.0),
-      f32(-1.0),
-      f32Bits(kBit.f32.negative.max),
-      f32Bits(kBit.f32.subnormal.negative.min),
-      f32Bits(kBit.f32.subnormal.negative.max),
-      f32(0.0),
-      f32Bits(kBit.f32.subnormal.positive.min),
-      f32Bits(kBit.f32.subnormal.positive.max),
-      f32Bits(kBit.f32.positive.min),
-      f32(1.0),
-      f32(10.0),
-      f32Bits(kBit.f32.positive.max),
-      f32Bits(kBit.f32.infinity.positive),
+    const values: Array<number> = [
+      Number.NEGATIVE_INFINITY,
+      kValue.f32.negative.min,
+      -10.0,
+      -1.0,
+      kValue.f32.negative.max,
+      kValue.f32.subnormal.negative.min,
+      kValue.f32.subnormal.negative.max,
+      0.0,
+      kValue.f32.subnormal.positive.min,
+      kValue.f32.subnormal.positive.max,
+      kValue.f32.positive.min,
+      1.0,
+      10.0,
+      kValue.f32.positive.max,
+      Number.POSITIVE_INFINITY,
     ];
 
-    run(
-      t,
-      builtin('clamp'),
-      [TypeF32, TypeF32, TypeF32],
-      TypeF32,
-      cfg,
-      generateFloatTestCases(test_values)
-    );
+    const cases: Array<Case> = new Array<Case>();
+    values.forEach(x => {
+      values.forEach(y => {
+        values.forEach(z => {
+          cases.push(makeCase(x, y, z));
+        });
+      });
+    });
+
+    run(t, builtin('clamp'), [TypeF32, TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../util/conversion.js';
 import {
   BinaryToInterval,
+  F32Interval,
   PointToInterval,
   TernaryToInterval,
 } from '../../../util/f32_interval.js';
@@ -588,12 +589,15 @@ export function makeBinaryF32Case(
  * Generates a Case for the param and unary interval generator provided.
  * The Case will use use an interval comparator for matching results.
  * @param param the param to pass into the unary operation
- * @param op callback that implements generating an acceptance interval for a unary operation
+ * @param ops callbacks that implement generating an acceptance interval for a unary operation
  */
-export function makeUnaryF32IntervalCase(param: number, op: PointToInterval): Case {
+export function makeUnaryF32IntervalCase(param: number, ...ops: PointToInterval[]): Case {
   param = quantizeToF32(param);
-  const interval = op(param);
-  return { input: [f32(param)], expected: intervalComparator(interval) };
+  const intervals: Array<F32Interval> = new Array<F32Interval>();
+  for (const op of ops) {
+    intervals.push(op(param));
+  }
+  return { input: [f32(param)], expected: intervalComparator(...intervals) };
 }
 
 /**
@@ -601,19 +605,22 @@ export function makeUnaryF32IntervalCase(param: number, op: PointToInterval): Ca
  * The Case will use use an interval comparator for matching results.
  * @param param0 the first param or left hand side to pass into the binary operation
  * @param param1 the second param or rhs hand side to pass into the binary operation
- * @param op callback that implements generating an acceptance interval for a binary operation
+ * @param ops callbacks that implement generating an acceptance interval for a binary operation
  */
 // Will be used in test implementations
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function makeBinaryF32IntervalCase(
   param0: number,
   param1: number,
-  op: BinaryToInterval
+  ...ops: BinaryToInterval[]
 ): Case {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
-  const interval = op(param0, param1);
-  return { input: [f32(param0), f32(param1)], expected: intervalComparator(interval) };
+  const intervals: Array<F32Interval> = new Array<F32Interval>();
+  for (const op of ops) {
+    intervals.push(op(param0, param1));
+  }
+  return { input: [f32(param0), f32(param1)], expected: intervalComparator(...intervals) };
 }
 
 /**
@@ -622,7 +629,8 @@ export function makeBinaryF32IntervalCase(
  * @param param0 the first param to pass into the ternary operation
  * @param param1 the second param to pass into the ternary operation
  * @param param2 the third param to pass into the ternary operation
- * @param op callback that implements generating an acceptance interval for a ternary operation
+ * @param ops callbacks that implement generating an acceptance interval for a
+ *           ternary operation.
  */
 // Will be used in test implementations
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -630,11 +638,17 @@ export function makeTernaryF32IntervalCase(
   param0: number,
   param1: number,
   param2: number,
-  op: TernaryToInterval
+  ...ops: TernaryToInterval[]
 ): Case {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
   param2 = quantizeToF32(param2);
-  const interval = op(param0, param1, param2);
-  return { input: [f32(param0), f32(param1), f32(param2)], expected: intervalComparator(interval) };
+  const intervals: Array<F32Interval> = new Array<F32Interval>();
+  for (const op of ops) {
+    intervals.push(op(param0, param1, param2));
+  }
+  return {
+    input: [f32(param0), f32(param1), f32(param2)],
+    expected: intervalComparator(...intervals),
+  };
 }

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -62,17 +62,22 @@ export function correctlyRoundedMatch(): FloatMatch {
 }
 
 /**
- * @returns a FloatMatch that return true iff |got| is contained in the interval |i|.
+ * @returns a FloatMatch that return true iff |got| is contained in any of the intervals.
  *
  * The standard |expected| parameter is ignored.
  *
  * NB: This will be removed at the end of transition to the new FP testing framework.
  *
- * @param i interval to test the |got| value against.
+ * @param intervals array of intervals to test the |got| value against.
  */
-export function intervalMatch(i: F32Interval): FloatMatch {
+export function intervalMatch(...intervals: F32Interval[]): FloatMatch {
   return (got, _) => {
-    return i.contains(got);
+    for (const i of intervals) {
+      if (i.contains(got)) {
+        return true;
+      }
+    }
+    return false;
   };
 }
 
@@ -189,12 +194,12 @@ export function ulpComparator(x: number, target: Scalar, n: (x: number) => numbe
   };
 }
 
-/** @returns a Comparator that checks whether a result is contained within a target interval
+/** @returns a Comparator that checks whether a result is contained within the target intervals
  *
  * NB: This will be removed at the end of transition to the new FP testing framework.
  */
-export function intervalComparator(i: F32Interval): Comparator {
-  const match = intervalMatch(i);
+export function intervalComparator(...intervals: F32Interval[]): Comparator {
+  const match = intervalMatch(...intervals);
   return (got, _) => {
     // The second param is ignored by match
     const cmp = compare(got, f32(0.0), match);
@@ -204,7 +209,7 @@ export function intervalComparator(i: F32Interval): Comparator {
     return {
       matched: false,
       got: got.toString(),
-      expected: `within ${i}`,
+      expected: `within ${intervals}`,
     };
   };
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -514,6 +514,48 @@ export function ceilInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), CeilIntervalOp);
 }
 
+const ClampMedianIntervalOp: TernaryToIntervalOp = {
+  impl: (x: number, y: number, z: number): F32Interval => {
+    return correctlyRoundedInterval(
+      // Default sort is string sort, so have to implement numeric comparison.
+      // Cannot use the b-a one liner, because that assumes no infinities.
+      [x, y, z].sort((a, b) => {
+        if (a < b) {
+          return -1;
+        }
+        if (a > b) {
+          return 1;
+        }
+        return 0;
+      })[1]
+    );
+  },
+};
+
+/** Calculate an acceptance interval of clamp(x, y, z) via median(x, y, z) */
+export function clampMedianInterval(
+  x: number | F32Interval,
+  y: number | F32Interval,
+  z: number | F32Interval
+): F32Interval {
+  return runTernaryOp(toInterval(x), toInterval(y), toInterval(z), ClampMedianIntervalOp);
+}
+
+const ClampMinMaxIntervalOp: TernaryToIntervalOp = {
+  impl: (x: number, low: number, high: number): F32Interval => {
+    return correctlyRoundedInterval(Math.min(Math.max(x, low), high));
+  },
+};
+
+/** Calculate an acceptance interval of clamp(x, high, low) via min(max(x, low), high) */
+export function clampMinMaxInterval(
+  x: number | F32Interval,
+  low: number | F32Interval,
+  high: number | F32Interval
+): F32Interval {
+  return runTernaryOp(toInterval(x), toInterval(low), toInterval(high), ClampMinMaxIntervalOp);
+}
+
 const CosIntervalOp: PointToIntervalOp = {
   impl: (n: number): F32Interval => {
     return kValue.f32.negative.pi.whole <= n && n <= kValue.f32.positive.pi.whole


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
