### PR TITLE
Add context configuration tests

### DIFF
--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -1,10 +1,290 @@
 export const description = `
 Tests for GPUCanvasContext.configure.
 
-TODO: Test all options of configure.
+TODO:
+- Test colorSpace
+- Test viewFormats
 `;
 
-import { Fixture } from '../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { assert } from '../../../common/util/util.js';
+import {
+  kAllTextureFormats,
+  kCanvasTextureFormats,
+  kTextureFormatInfo,
+  kTextureUsages,
+} from '../../capability_info.js';
+import { GPUConst } from '../../constants.js';
+import { GPUTest } from '../../gpu_test.js';
+import { kAllCanvasTypes, createCanvas } from '../../util/create_elements.js';
 
-export const g = makeTestGroup(Fixture);
+export const g = makeTestGroup(GPUTest);
+
+g.test('defaults')
+  .desc(
+    `
+    Ensure that the defaults for GPUCanvasConfiguration are correct.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('canvasType', kAllCanvasTypes)
+  )
+  .fn(async t => {
+    const { canvasType } = t.params;
+    const canvas = createCanvas(t, canvasType, 2, 2);
+    const ctx = canvas.getContext('webgpu' as const);
+    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+
+    ctx.configure({
+      device: t.device,
+      format: 'rgba8unorm',
+    });
+
+    const currentTexture = ctx.getCurrentTexture();
+    t.expect(currentTexture.format === 'rgba8unorm');
+    t.expect(currentTexture.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect(currentTexture.dimension === '2d');
+    t.expect(currentTexture.width === canvas.width);
+    t.expect(currentTexture.height === canvas.height);
+    t.expect(currentTexture.depthOrArrayLayers === 1);
+    t.expect(currentTexture.mipLevelCount === 1);
+    t.expect(currentTexture.sampleCount === 1);
+  });
+
+g.test('device')
+  .desc(
+    `
+    Ensure that configure reacts appropriately to various device states.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('canvasType', kAllCanvasTypes)
+  )
+  .fn(async t => {
+    const { canvasType } = t.params;
+    const canvas = createCanvas(t, canvasType, 2, 2);
+    const ctx = canvas.getContext('webgpu' as const);
+    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+
+    // Calling configure without a device should throw.
+    t.shouldThrow(true, () => {
+      ctx.configure({
+        format: 'rgba8unorm',
+      } as GPUCanvasConfiguration);
+    });
+
+    // Device is not configured, so getCurrentTexture will throw.
+    t.shouldThrow(true, () => {
+      ctx.getCurrentTexture();
+    });
+
+    // Calling configure with a device should succeed.
+    ctx.configure({
+      device: t.device,
+      format: 'rgba8unorm',
+    });
+
+    // getCurrentTexture will succeed with a valid device.
+    ctx.getCurrentTexture();
+
+    // Unconfiguring should cause the device to be cleared.
+    ctx.unconfigure();
+    t.shouldThrow(true, () => {
+      ctx.getCurrentTexture();
+    });
+
+    // Should be able to successfully configure again after unconfiguring.
+    ctx.configure({
+      device: t.device,
+      format: 'rgba8unorm',
+    });
+    ctx.getCurrentTexture();
+  });
+
+g.test('format')
+  .desc(
+    `
+    Ensure that only valid texture formats are allowed when calling configure.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('canvasType', kAllCanvasTypes)
+      .combine('format', kAllTextureFormats)
+  )
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    const formatInfo = kTextureFormatInfo[format];
+    t.selectDeviceOrSkipTestCase(formatInfo.feature);
+  })
+  .fn(async t => {
+    const { canvasType, format } = t.params;
+    const canvas = createCanvas(t, canvasType, 2, 2);
+    const ctx = canvas.getContext('webgpu' as const);
+    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+
+    const validFormat = kCanvasTextureFormats.includes(format);
+
+    t.expectValidationError(() => {
+      ctx.configure({
+        device: t.device,
+        format,
+      });
+    }, !validFormat);
+
+    t.expectValidationError(() => {
+      // Should always return a texture, whether the configured format was valid or not.
+      const currentTexture = ctx.getCurrentTexture();
+      t.expect(currentTexture instanceof GPUTexture);
+    }, !validFormat);
+  });
+
+g.test('usage')
+  .desc(
+    `
+    Ensure that only valid texture usage combinations are allowed when calling configure.
+
+    TODO: Verify STORAGE_BINDING, COPY_SRC, and COPY_DST binding usages.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('canvasType', kAllCanvasTypes)
+      .beginSubcases()
+      .expand('usage', p => {
+        const usageSet = new Set<number>();
+        for (const usage0 of kTextureUsages) {
+          for (const usage1 of kTextureUsages) {
+            usageSet.add(usage0 | usage1);
+          }
+        }
+        return usageSet;
+      })
+  )
+  .fn(async t => {
+    const { canvasType, usage } = t.params;
+    const canvas = createCanvas(t, canvasType, 2, 2);
+    const ctx = canvas.getContext('webgpu' as const);
+    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+
+    ctx.configure({
+      device: t.device,
+      format: 'rgba8unorm',
+      usage,
+    });
+
+    const currentTexture = ctx.getCurrentTexture();
+    t.expect(currentTexture instanceof GPUTexture);
+    t.expect(currentTexture.usage === usage);
+
+    // Try to use the texture with the given usage
+
+    if (usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) {
+      const encoder = t.device.createCommandEncoder();
+      const pass = encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: currentTexture.createView(),
+            clearValue: [1.0, 0.0, 0.0, 1.0],
+            loadOp: 'clear',
+            storeOp: 'store',
+          },
+        ],
+      });
+      pass.end();
+      t.device.queue.submit([encoder.finish()]);
+    }
+
+    if (usage & GPUConst.TextureUsage.TEXTURE_BINDING) {
+      const bgl = t.device.createBindGroupLayout({
+        entries: [
+          {
+            binding: 0,
+            visibility: GPUShaderStage.FRAGMENT,
+            texture: {},
+          },
+        ],
+      });
+
+      t.device.createBindGroup({
+        layout: bgl,
+        entries: [
+          {
+            binding: 0,
+            resource: currentTexture.createView(),
+          },
+        ],
+      });
+    }
+
+    if (usage & GPUConst.TextureUsage.STORAGE_BINDING) {
+      const bgl = t.device.createBindGroupLayout({
+        entries: [
+          {
+            binding: 0,
+            visibility: GPUShaderStage.FRAGMENT,
+            storageTexture: { access: 'write-only', format: currentTexture.format },
+          },
+        ],
+      });
+
+      t.device.createBindGroup({
+        layout: bgl,
+        entries: [
+          {
+            binding: 0,
+            resource: currentTexture.createView(),
+          },
+        ],
+      });
+    }
+
+    if (usage & GPUConst.TextureUsage.COPY_DST) {
+      const rgbaData = new Uint8Array([255, 0, 0, 255]);
+
+      t.device.queue.writeTexture({ texture: currentTexture }, rgbaData, {}, [1, 1, 1]);
+    }
+
+    if (usage & GPUConst.TextureUsage.COPY_SRC) {
+      const size = [currentTexture.width, currentTexture.height, 1];
+      const dstTexture = t.device.createTexture({
+        format: currentTexture.format,
+        usage: GPUTextureUsage.COPY_DST,
+        size,
+      });
+
+      const encoder = t.device.createCommandEncoder();
+      encoder.copyTextureToTexture({ texture: currentTexture }, { texture: dstTexture }, size);
+      t.device.queue.submit([encoder.finish()]);
+    }
+  });
+
+g.test('alpha_mode')
+  .desc(
+    `
+    Ensure that all valid alphaMode values are allowed when calling configure.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('canvasType', kAllCanvasTypes)
+      .beginSubcases()
+      .combine('alphaMode', ['opaque', 'premultiplied'] as const)
+  )
+  .fn(async t => {
+    const { canvasType, alphaMode } = t.params;
+    const canvas = createCanvas(t, canvasType, 2, 2);
+    const ctx = canvas.getContext('webgpu' as const);
+    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+
+    ctx.configure({
+      device: t.device,
+      format: 'rgba8unorm',
+      alphaMode,
+    });
+
+    const currentTexture = ctx.getCurrentTexture();
+    t.expect(currentTexture instanceof GPUTexture);
+  });


### PR DESCRIPTION
Tests passing various attributes to the GPUContextCreation
dictionary and ensuring that, when valid, the textures produced
honor the configuration settings.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
