### PR TITLE
Improve resource_usages,texture,in_pass_encoder tests

### DIFF
--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -316,9 +316,11 @@ export class ValidationTest extends GPUTest {
   }
 
   /** Return a GPURenderPipeline with default options and no-op vertex and fragment shaders. */
-  createNoOpRenderPipeline(): GPURenderPipeline {
+  createNoOpRenderPipeline(
+    layout: GPUPipelineLayout | GPUAutoLayoutMode = 'auto'
+  ): GPURenderPipeline {
     return this.device.createRenderPipeline({
-      layout: 'auto',
+      layout,
       vertex: {
         module: this.device.createShaderModule({
           code: this.getNoOpShaderCode('VERTEX'),


### PR DESCRIPTION
Fix some issues I saw while reviewing #1598.

**Each commit may be viewed separately for easier reading.**

> Rewrite usage validation scope tests 
> 
> There was at least one bug in these tests not caught because they lacked control cases, and other confusing things because of how they were split up.
> 
> - `validation_scope,no_draw_or_dispatch` and `validation_scope,same_draw_or_dispatch` are replaced by `scope,basic,compute` and `scope,basic,render`.
> - `validation_scope,different_draws_or_dispatches` and `validation_scope,different_passes` are replaced by `scope,pass_boundary,compute` and `scope,pass_boundary,render`.
> 
> There is some overlap with other tests, but that's OK.
> 
> Also:
> 
> - Small refactor to `shader_stages_and_visibility` to make it easier to read.

> Split shader_stages_and_visibility and add control cases

Issue: #923

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
