### PR TITLE
Implement val:render_pass_descriptor:occlusion_query_set_type

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -8,6 +8,7 @@ TODO: review for completeness
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import {
   kDepthStencilFormats,
+  kQueryTypes,
   kRenderableColorTextureFormats,
   kTextureFormatInfo,
 } from '../../../capability_info.js';
@@ -858,5 +859,31 @@ g.test('timestamp_writes_location')
       timestampWrites: [timestampWriteA, timestampWriteB],
     };
 
+    t.tryRenderPass(isValid, descriptor);
+  });
+
+g.test('occlusionQuerySet,query_set_type')
+  .desc(`Test that occlusionQuerySet must have type 'occlusion'.`)
+  .params(u => u.combine('queryType', kQueryTypes))
+  .beforeAllSubcases(t => {
+    if (t.params.queryType === 'timestamp') {
+      t.selectDeviceOrSkipTestCase(['timestamp-query']);
+    }
+  })
+  .fn(async t => {
+    const { queryType } = t.params;
+
+    const querySet = t.device.createQuerySet({
+      type: queryType,
+      count: 1,
+    });
+
+    const colorTexture = t.createTexture();
+    const descriptor = {
+      colorAttachments: [t.getColorAttachment(colorTexture)],
+      occlusionQuerySet: querySet,
+    };
+
+    const isValid = queryType === 'occlusion';
     t.tryRenderPass(isValid, descriptor);
   });


### PR DESCRIPTION
If occlusionQuerySet is not null, the type should be occlusion.
So, this PR adds a test to check if the type is invalid if the
type is not occlusion.

Issue: #1618

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
