### PR TITLE
Implement val:render_pass_descriptor:timestamp_writes_query_set_type

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -848,6 +848,47 @@ g.test('resolveTarget,format_supports_resolve')
     });
   });
 
+g.test('timestampWrites,query_set_type')
+  .desc(
+    `
+  Test that all entries of the timestampWrites must have type 'timestamp'. If all query types are
+  not 'timestamp', a validation error should be generated.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('queryTypeA', kQueryTypes)
+      .combine('queryTypeB', kQueryTypes)
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase(['timestamp-query']);
+  })
+  .fn(async t => {
+    const { queryTypeA, queryTypeB } = t.params;
+
+    const timestampWriteA = {
+      querySet: t.device.createQuerySet({ type: queryTypeA, count: 1 }),
+      queryIndex: 0,
+      location: 'beginning' as const,
+    };
+
+    const timestampWriteB = {
+      querySet: t.device.createQuerySet({ type: queryTypeB, count: 1 }),
+      queryIndex: 0,
+      location: 'end' as const,
+    };
+
+    const isValid = queryTypeA === 'timestamp' && queryTypeB === 'timestamp';
+
+    const colorTexture = t.createTexture();
+    const descriptor = {
+      colorAttachments: [t.getColorAttachment(colorTexture)],
+      timestampWrites: [timestampWriteA, timestampWriteB],
+    };
+
+    t.tryRenderPass(isValid, descriptor);
+  });
+
 g.test('timestamp_writes_location')
   .desc('Test that entries in timestampWrites do not have the same location.')
   .params(u =>


### PR DESCRIPTION
The queryType of each timestampWrite in timestampWrites should be
`timestamp`. So, this PR adds a test to check if a validation error
is generated if all query set types aren't `timestamp`.

Issue: #1618

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
