### PR TITLE
Implement val:render_pass_descriptor:timestampWrite,query_index

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -889,6 +889,34 @@ g.test('timestamp_writes_location')
     t.tryRenderPass(isValid, descriptor);
   });
 
+g.test('timestampWrite,query_index')
+  .desc(`Test that querySet.count should be greater than timestampWrite.queryIndex.`)
+  .params(u => u.combine('queryIndex', [0, 1, 2, 3]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase(['timestamp-query']);
+  })
+  .fn(async t => {
+    const { queryIndex } = t.params;
+
+    const querySetCount = 2;
+
+    const timestampWrite = {
+      querySet: t.device.createQuerySet({ type: 'timestamp', count: querySetCount }),
+      queryIndex,
+      location: 'beginning' as const,
+    };
+
+    const isValid = queryIndex < querySetCount;
+
+    const colorTexture = t.createTexture();
+    const descriptor = {
+      colorAttachments: [t.getColorAttachment(colorTexture)],
+      timestampWrites: [timestampWrite],
+    };
+
+    t.tryRenderPass(isValid, descriptor);
+  });
+
 g.test('occlusionQuerySet,query_set_type')
   .desc(`Test that occlusionQuerySet must have type 'occlusion'.`)
   .params(u => u.combine('queryType', kQueryTypes))


### PR DESCRIPTION
The count of the querySet should be greater than the queryIndex
of timestampWrite. So, this PR adds a test to check if a validation
error is generated when the query index is greater than the count of
the query set.

Issue: #1618

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
