### PR TITLE
Update f32 tests to handle returning undefined for infinity

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -3,7 +3,7 @@ F32Interval unit tests.
 `;
 
 import { makeTestGroup } from '../common/framework/test_group.js';
-import { assert, objectEquals } from '../common/util/util.js';
+import { objectEquals } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
 import {
   absInterval,
@@ -40,15 +40,8 @@ import { UnitTest } from './unit_test.js';
 
 export const g = makeTestGroup(UnitTest);
 
-/** Convert a pair of numbers in an array to a F32Interval
- *
- * Used for fluently specifying test params as `[a, b]` instead of
- * `new F32Interval(a, b)`
- */
-function arrayToInterval(bounds: [number, number]): F32Interval {
-  const [begin, end] = bounds;
-  return new F32Interval(begin, end);
-}
+/** Bounds indicating an expectation of an interval of all possible values */
+const kAny: [number, number] = [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY];
 
 /** @returns a number N * ULP greater than the provided number */
 function plusNULP(x: number, n: number): number {
@@ -100,7 +93,7 @@ g.test('constructor')
       // Infinities
       { input: [0, kValue.f32.infinity.positive], expected: [0, Number.POSITIVE_INFINITY]},
       { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, 0]},
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]},
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny},
     ]
   )
   .fn(t => {
@@ -151,59 +144,59 @@ g.test('contains_number')
     // Upper infinity
     { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.positive.min, expected: true },
     { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.positive.max, expected: true },
-    { bounds: [0, kValue.f32.infinity.positive], value: Number.POSITIVE_INFINITY, expected: true },
+    { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.infinity.positive, expected: true },
     { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.negative.min, expected: false },
     { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.negative.max, expected: false },
-    { bounds: [0, kValue.f32.infinity.positive], value: Number.NEGATIVE_INFINITY, expected: false },
+    { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.infinity.negative, expected: false },
 
     // Lower infinity
     { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.positive.min, expected: false },
     { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.positive.max, expected: false },
-    { bounds: [kValue.f32.infinity.negative, 0], value: Number.POSITIVE_INFINITY, expected: false },
+    { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.infinity.positive, expected: false },
     { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.negative.min, expected: true },
     { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.negative.max, expected: true },
-    { bounds: [kValue.f32.infinity.negative, 0], value: Number.NEGATIVE_INFINITY, expected: true },
+    { bounds: [kValue.f32.infinity.negative, 0], value: kValue.f32.infinity.negative, expected: true },
 
     // Full infinity
     { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.positive.min, expected: true },
     { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.positive.max, expected: true },
-    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: Number.POSITIVE_INFINITY, expected: true },
+    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.infinity.positive, expected: true },
     { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.negative.min, expected: true },
     { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.negative.max, expected: true },
-    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: Number.NEGATIVE_INFINITY, expected: true },
+    { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: kValue.f32.infinity.negative, expected: true },
     { bounds: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], value: Number.NaN, expected: true },
 
     // Maximum f32 boundary
     { bounds: [0, kValue.f32.positive.max], value: kValue.f32.positive.min, expected: true },
     { bounds: [0, kValue.f32.positive.max], value: kValue.f32.positive.max, expected: true },
-    { bounds: [0, kValue.f32.positive.max], value: Number.POSITIVE_INFINITY, expected: false },
+    { bounds: [0, kValue.f32.positive.max], value: kValue.f32.infinity.positive, expected: false },
     { bounds: [0, kValue.f32.positive.max], value: kValue.f32.negative.min, expected: false },
     { bounds: [0, kValue.f32.positive.max], value: kValue.f32.negative.max, expected: false },
-    { bounds: [0, kValue.f32.positive.max], value: Number.NEGATIVE_INFINITY, expected: false },
+    { bounds: [0, kValue.f32.positive.max], value: kValue.f32.infinity.negative, expected: false },
 
     // Minimum f32 boundary
     { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.positive.min, expected: false },
     { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.positive.max, expected: false },
-    { bounds: [kValue.f32.negative.min, 0], value: Number.POSITIVE_INFINITY, expected: false },
+    { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.infinity.positive, expected: false },
     { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.negative.min, expected: true },
     { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.negative.max, expected: true },
-    { bounds: [kValue.f32.negative.min, 0], value: Number.NEGATIVE_INFINITY, expected: false },
+    { bounds: [kValue.f32.negative.min, 0], value: kValue.f32.infinity.negative, expected: false },
 
     // Out of range high
     { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.positive.min, expected: true },
     { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.positive.max, expected: true },
-    { bounds: [0, 2 * kValue.f32.positive.max], value: Number.POSITIVE_INFINITY, expected: false },
+    { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.infinity.positive, expected: false },
     { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.negative.min, expected: false },
     { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.negative.max, expected: false },
-    { bounds: [0, 2 * kValue.f32.positive.max], value: Number.NEGATIVE_INFINITY, expected: false },
+    { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.infinity.negative, expected: false },
 
     // Out of range low
     { bounds: [2 * kValue.f32.negative.min, 0], value: kValue.f32.positive.min, expected: false },
     { bounds: [2 * kValue.f32.negative.min, 0], value: kValue.f32.positive.max, expected: false },
-    { bounds: [2 * kValue.f32.negative.min, 0], value: Number.POSITIVE_INFINITY, expected: false },
+    { bounds: [2 * kValue.f32.negative.min, 0], value: kValue.f32.infinity.positive, expected: false },
     { bounds: [2 * kValue.f32.negative.min, 0], value: kValue.f32.negative.min, expected: true },
     { bounds: [2 * kValue.f32.negative.min, 0], value: kValue.f32.negative.max, expected: true },
-    { bounds: [2 * kValue.f32.negative.min, 0], value: Number.NEGATIVE_INFINITY, expected: false },
+    { bounds: [2 * kValue.f32.negative.min, 0], value: kValue.f32.infinity.negative, expected: false },
 
     // Subnormals
     { bounds: [0, kValue.f32.positive.min], value: kValue.f32.subnormal.positive.min, expected: true },
@@ -225,7 +218,7 @@ g.test('contains_number')
     ]
   )
   .fn(t => {
-    const i = arrayToInterval(t.params.bounds);
+    const i = new F32Interval(...t.params.bounds);
     const value = t.params.value;
     const expected = t.params.expected;
 
@@ -258,69 +251,69 @@ g.test('contains_interval')
       { lhs: [0, kValue.f32.infinity.positive], rhs: [-1, 0], expected: false},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [0, 1], expected: true},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [0, kValue.f32.positive.max], expected: true},
-      { lhs: [0, kValue.f32.infinity.positive], rhs: [0, Number.POSITIVE_INFINITY], expected: true},
-      { lhs: [0, kValue.f32.infinity.positive], rhs: [100, Number.POSITIVE_INFINITY], expected: true},
-      { lhs: [0, kValue.f32.infinity.positive], rhs: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: false},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [0, kValue.f32.infinity.positive], expected: true},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [100, kValue.f32.infinity.positive], expected: true},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [Number.NEGATIVE_INFINITY, kValue.f32.infinity.positive], expected: false},
 
       // Lower infinity
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [0, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [-1, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.negative.min, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [0, 1], expected: false},
-      { lhs: [kValue.f32.infinity.negative, 0], rhs: [Number.NEGATIVE_INFINITY, 0], expected: true},
-      { lhs: [kValue.f32.infinity.negative, 0], rhs: [Number.NEGATIVE_INFINITY, -100 ], expected: true},
-      { lhs: [kValue.f32.infinity.negative, 0], rhs: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: false},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, -100 ], expected: true},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
 
       // Full infinity
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [-1, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, 1], expected: true},
-      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, Number.POSITIVE_INFINITY], expected: true},
-      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [100, Number.POSITIVE_INFINITY], expected: true},
-      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [Number.NEGATIVE_INFINITY, 0], expected: true},
-      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [Number.NEGATIVE_INFINITY, -100 ], expected: true},
-      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, kValue.f32.infinity.positive], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [100, kValue.f32.infinity.positive], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, -100 ], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: true},
 
       // Maximum f32 boundary
       { lhs: [0, kValue.f32.positive.max], rhs: [0, 0], expected: true},
       { lhs: [0, kValue.f32.positive.max], rhs: [-1, 0], expected: false},
       { lhs: [0, kValue.f32.positive.max], rhs: [0, 1], expected: true},
       { lhs: [0, kValue.f32.positive.max], rhs: [0, kValue.f32.positive.max], expected: true},
-      { lhs: [0, kValue.f32.positive.max], rhs: [0, Number.POSITIVE_INFINITY], expected: false},
-      { lhs: [0, kValue.f32.positive.max], rhs: [100, Number.POSITIVE_INFINITY], expected: false},
-      { lhs: [0, kValue.f32.positive.max], rhs: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: false},
+      { lhs: [0, kValue.f32.positive.max], rhs: [0, kValue.f32.infinity.positive], expected: false},
+      { lhs: [0, kValue.f32.positive.max], rhs: [100, kValue.f32.infinity.positive], expected: false},
+      { lhs: [0, kValue.f32.positive.max], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
 
       // Minimum f32 boundary
       { lhs: [kValue.f32.negative.min, 0], rhs: [0, 0], expected: true},
       { lhs: [kValue.f32.negative.min, 0], rhs: [-1, 0], expected: true},
       { lhs: [kValue.f32.negative.min, 0], rhs: [kValue.f32.negative.min, 0], expected: true},
       { lhs: [kValue.f32.negative.min, 0], rhs: [0, 1], expected: false},
-      { lhs: [kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, 0], expected: false},
-      { lhs: [kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, -100 ], expected: false},
-      { lhs: [kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: false},
+      { lhs: [kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, 0], expected: false},
+      { lhs: [kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, -100 ], expected: false},
+      { lhs: [kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
 
       // Out of range high
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, 0], expected: true},
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [-1, 0], expected: false},
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, 1], expected: true},
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, kValue.f32.positive.max], expected: true},
-      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, Number.POSITIVE_INFINITY], expected: false},
-      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [100, Number.POSITIVE_INFINITY], expected: false},
-      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: false},
+      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, kValue.f32.infinity.positive], expected: false},
+      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [100, kValue.f32.infinity.positive], expected: false},
+      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
 
       // Out of range low
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [0, 0], expected: true},
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [-1, 0], expected: true},
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [kValue.f32.negative.min, 0], expected: true},
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [0, 1], expected: false},
-      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, 0], expected: false},
-      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, -100 ], expected: false},
-      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: false},
+      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, 0], expected: false},
+      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, -100 ], expected: false},
+      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
     ]
   )
   .fn(t => {
-    const lhs = arrayToInterval(t.params.lhs);
-    const rhs = arrayToInterval(t.params.rhs);
+    const lhs = new F32Interval(...t.params.lhs);
+    const rhs = new F32Interval(...t.params.rhs);
     const expected = t.params.expected;
 
     const got = lhs.contains(rhs);
@@ -350,7 +343,7 @@ g.test('span')
       { intervals: [[2, 5], [0, 1]], expected: [0, 5]},
       { intervals: [[0, 2], [1, 5]], expected: [0, 5]},
       { intervals: [[0, 5], [1, 2]], expected: [0, 5]},
-      { intervals: [[kValue.f32.infinity.negative, 0], [0, kValue.f32.infinity.positive]], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]},
+      { intervals: [[kValue.f32.infinity.negative, 0], [0, kValue.f32.infinity.positive]], expected: kAny},
 
       // Multiple Intervals
       { intervals: [[0, 1], [2, 3], [4, 5]], expected: [0, 5]},
@@ -359,8 +352,8 @@ g.test('span')
     ]
   )
   .fn(t => {
-    const intervals = t.params.intervals.map(arrayToInterval);
-    const expected = arrayToInterval(t.params.expected);
+    const intervals = t.params.intervals.map(x => new F32Interval(...x));
+    const expected = new F32Interval(...t.params.expected);
 
     const got = F32Interval.span(...intervals);
     t.expect(
@@ -379,8 +372,8 @@ g.test('correctlyRoundedInterval')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, expected: kAny },
+      { value: kValue.f32.infinity.negative, expected: kAny },
       { value: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { value: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
       { value: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
@@ -418,7 +411,7 @@ g.test('correctlyRoundedInterval')
   )
   .fn(t => {
     const value = t.params.value;
-    const expected = arrayToInterval(t.params.expected);
+    const expected = new F32Interval(...t.params.expected);
 
     const got = correctlyRoundedInterval(value);
     t.expect(
@@ -438,21 +431,21 @@ g.test('absoluteErrorInterval')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, error: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.positive, error: 2 ** -11, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.positive, error: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, error: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, error: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, error: 0, expected: kAny },
+      { value: kValue.f32.infinity.positive, error: 2 ** -11, expected: kAny },
+      { value: kValue.f32.infinity.positive, error: 1, expected: kAny },
+      { value: kValue.f32.infinity.negative, error: 0, expected: kAny },
+      { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: kAny },
+      { value: kValue.f32.infinity.negative, error: 1, expected: kAny },
       { value: kValue.f32.positive.max, error: 0, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { value: kValue.f32.positive.max, error: 2 ** -11, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { value: kValue.f32.positive.max, error: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.max, error: kValue.f32.positive.max, expected: kAny },
       { value: kValue.f32.positive.min, error: 0, expected: [kValue.f32.positive.min,  kValue.f32.positive.min] },
       { value: kValue.f32.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
       { value: kValue.f32.positive.min, error: 1, expected: [-1, 1] },
       { value: kValue.f32.negative.min, error: 0, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
       { value: kValue.f32.negative.min, error: 2 ** -11, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { value: kValue.f32.negative.min, error: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.negative.min, error: kValue.f32.positive.max, expected: kAny },
       { value: kValue.f32.negative.max, error: 0, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
       { value: kValue.f32.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
       { value: kValue.f32.negative.max, error: 1, expected: [-1, 1] },
@@ -494,7 +487,7 @@ g.test('absoluteErrorInterval')
   .fn(t => {
     const value = t.params.value;
     const error = t.params.error;
-    const expected = arrayToInterval(t.params.expected);
+    const expected = new F32Interval(...t.params.expected);
 
     const got = absoluteErrorInterval(value, error);
     t.expect(
@@ -514,21 +507,21 @@ g.test('ulpInterval')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, num_ulp: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.positive, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.positive, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, num_ulp: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, num_ulp: 0, expected: kAny },
+      { value: kValue.f32.infinity.positive, num_ulp: 1, expected: kAny },
+      { value: kValue.f32.infinity.positive, num_ulp: 4096, expected: kAny },
+      { value: kValue.f32.infinity.negative, num_ulp: 0, expected: kAny },
+      { value: kValue.f32.infinity.negative, num_ulp: 1, expected: kAny },
+      { value: kValue.f32.infinity.negative, num_ulp: 4096, expected: kAny },
       { value: kValue.f32.positive.max, num_ulp: 0, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { value: kValue.f32.positive.max, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.positive.max, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.max, num_ulp: 1, expected: kAny },
+      { value: kValue.f32.positive.max, num_ulp: 4096, expected: kAny },
       { value: kValue.f32.positive.min, num_ulp: 0, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
       { value: kValue.f32.positive.min, num_ulp: 1, expected: [0, plusOneULP(kValue.f32.positive.min)] },
       { value: kValue.f32.positive.min, num_ulp: 4096, expected: [0, plusNULP(kValue.f32.positive.min, 4096)] },
       { value: kValue.f32.negative.min, num_ulp: 0, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { value: kValue.f32.negative.min, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.negative.min, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.negative.min, num_ulp: 1, expected: kAny },
+      { value: kValue.f32.negative.min, num_ulp: 4096, expected: kAny },
       { value: kValue.f32.negative.max, num_ulp: 0, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
       { value: kValue.f32.negative.max, num_ulp: 1, expected: [minusOneULP(kValue.f32.negative.max), 0] },
       { value: kValue.f32.negative.max, num_ulp: 4096, expected: [minusNULP(kValue.f32.negative.max, 4096), 0] },
@@ -570,7 +563,7 @@ g.test('ulpInterval')
   .fn(t => {
     const value = t.params.value;
     const num_ulp = t.params.num_ulp;
-    const expected = arrayToInterval(t.params.expected);
+    const expected = new F32Interval(...t.params.expected);
 
     const got = ulpInterval(value, num_ulp);
     t.expect(
@@ -581,19 +574,7 @@ g.test('ulpInterval')
 
 interface PointToIntervalCase {
   input: number;
-  // If expected is an Array of two values, the test should interpret them as
-  // human readable begin/end values that need to be adjusted for the error
-  // calculation specific to the function being tested.
-  // This is to facilitate writing tests in a fluent manner, i.e. being able to
-  // express a expectation as `plusOneULP(π/2)` instead of
-  // `π/2 + ULP(π/2) + 4096 * ULP(π/2 + ULP(π/2))`
-  //
-  // If expected is an F32Interval, it is to be interpreted as an exact value,
-  // with no additional processing. This is to allow for expressing specific
-  // cases with human readable values that would require effectively
-  // implementing the entire interval system under test to accommodate them in
-  // the test error calculation.
-  expected: [number, number] | F32Interval;
+  expected: [number, number];
 }
 
 g.test('absInterval')
@@ -607,8 +588,8 @@ g.test('absInterval')
       { input: -0.1, expected: [hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)] },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAny },
       { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
       { input: kValue.f32.negative.min, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
@@ -630,8 +611,7 @@ g.test('absInterval')
   )
   .fn(t => {
     const input = t.params.input;
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = absInterval(input);
     t.expect(
@@ -644,7 +624,7 @@ g.test('atanInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: kAny },
       { input: hexToF32(0xbfddb3d7), expected: [kValue.f32.negative.pi.third, plusOneULP(kValue.f32.negative.pi.third)] }, // x = -√3
       { input: -1, expected: [kValue.f32.negative.pi.quarter, plusOneULP(kValue.f32.negative.pi.quarter)] },
       { input: hexToF32(0xbf13cd3a), expected: [kValue.f32.negative.pi.sixth, plusOneULP(kValue.f32.negative.pi.sixth)] },  // x = -1/√3
@@ -652,7 +632,7 @@ g.test('atanInterval')
       { input: hexToF32(0x3f13cd3a), expected: [minusOneULP(kValue.f32.positive.pi.sixth), kValue.f32.positive.pi.sixth] },  // x = 1/√3
       { input: 1, expected: [minusOneULP(kValue.f32.positive.pi.quarter), kValue.f32.positive.pi.quarter] },
       { input: hexToF32(0x3fddb3d7), expected: [minusOneULP(kValue.f32.positive.pi.third), kValue.f32.positive.pi.third] }, // x = √3
-      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: kAny },
     ]
   )
   .fn(t => {
@@ -661,13 +641,11 @@ g.test('atanInterval')
     };
 
     const input = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error(begin), end + error(end)]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error(begin), end + error(end)];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = atanInterval(input);
     t.expect(
@@ -693,8 +671,8 @@ g.test('ceilInterval')
       { input: -1.9, expected: [-1, -1] },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAny },
       { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { input: kValue.f32.positive.min, expected: [1, 1] },
       { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
@@ -711,8 +689,7 @@ g.test('ceilInterval')
   )
   .fn(t => {
     const input = t.params.input;
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = ceilInterval(input);
     t.expect(
@@ -729,28 +706,26 @@ g.test('cosInterval')
       // and x as a f32 is sufficiently large, such that the high slope of f @ x causes the results to be substantially
       // different, so instead of getting 0 you get a value on the order of 10^-8 away from 0, thus difficult to express
       // in a human readable manner.
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.negative.min, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.negative.min, expected: kAny },
       { input: kValue.f32.negative.pi.whole, expected: [-1, plusOneULP(-1)] },
       { input: kValue.f32.negative.pi.third, expected: [minusOneULP(1/2), 1/2] },
       { input: 0, expected: [1, 1] },
       { input: kValue.f32.positive.pi.third, expected: [minusOneULP(1/2), 1/2] },
       { input: kValue.f32.positive.pi.whole, expected: [-1, plusOneULP(-1)] },
-      { input: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.positive.max, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAny },
     ]
   )
   .fn(t => {
     const error = 2 ** -11;
 
     const input = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error, end + error]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error, end + error];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = cosInterval(input);
     t.expect(
@@ -763,10 +738,10 @@ g.test('expInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: kAny },
       { input: 0, expected: [1,1] },
       { input: 1, expected: [kValue.f32.positive.e, plusOneULP(kValue.f32.positive.e)] },
-      { input: 89, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: 89, expected: kAny },
     ]
   )
   .fn(t => {
@@ -776,13 +751,11 @@ g.test('expInterval')
     };
 
     const input = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error(input, begin), end + error(input, end)]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error(input, begin), end + error(input, end)];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = expInterval(input);
     t.expect(
@@ -795,10 +768,10 @@ g.test('exp2Interval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: kAny },
       { input: 0, expected: [1,1] },
       { input: 1, expected: [2, 2] },
-      { input: 128, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: 128, expected: kAny },
     ]
   )
   .fn(t => {
@@ -808,13 +781,11 @@ g.test('exp2Interval')
     };
 
     const input = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error(input, begin), end + error(input, end)]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error(input, begin), end + error(input, end)];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = exp2Interval(input);
     t.expect(
@@ -840,8 +811,8 @@ g.test('floorInterval')
       { input: -1.9, expected: [-2, -2] },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAny },
       { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { input: kValue.f32.positive.min, expected: [0, 0] },
       { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
@@ -858,8 +829,7 @@ g.test('floorInterval')
   )
   .fn(t => {
     const input = t.params.input;
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = floorInterval(input);
     t.expect(
@@ -883,8 +853,8 @@ g.test('fractInterval')
       { input: -1.1, expected: [hexToF64(0x3feccccc, 0xc0000000), hexToF64(0x3feccccd, 0x00000000), ] }, // ~0.9
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAny },
       { input: kValue.f32.positive.max, expected: [0, 0] },
       { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
       { input: kValue.f32.negative.min, expected: [0, 0] },
@@ -893,8 +863,7 @@ g.test('fractInterval')
   )
   .fn(t => {
     const input = t.params.input;
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = fractInterval(input);
     t.expect(
@@ -907,13 +876,13 @@ g.test('inverseSqrtInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: -1, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: 0, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: -1, expected: kAny },
+      { input: 0, expected: kAny },
       { input: 0.04, expected: [minusOneULP(5), plusOneULP(5)] },
       { input: 1, expected: [1, 1] },
       { input: 100, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
       { input: kValue.f32.positive.max, expected: [hexToF32(0x1f800000), plusNULP(hexToF32(0x1f800000), 2)] },  // ~5.421...e-20, i.e. 1/√max f32
-      { input: kValue.f32.infinity.positive, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: kValue.f32.infinity.positive, expected: kAny },
     ]
   )
   .fn(t => {
@@ -922,13 +891,11 @@ g.test('inverseSqrtInterval')
     };
 
     const input = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error(input, begin), end + error(input, end)]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error(input, begin), end + error(input, end)];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = inverseSqrtInterval(input);
     t.expect(
@@ -941,8 +908,8 @@ g.test('logInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: -1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: -1, expected: kAny },
+      { input: 0, expected: kAny },
       { input: 1, expected: [0, 0] },
       { input: kValue.f32.positive.e, expected: [minusOneULP(1), 1] },
       { input: kValue.f32.positive.max, expected: [minusOneULP(hexToF32(0x42b17218)), hexToF32(0x42b17218)] },  // ~88.72...
@@ -957,13 +924,11 @@ g.test('logInterval')
     };
 
     const input = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error(input, begin), end + error(input, end)]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error(input, begin), end + error(input, end)];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = logInterval(input);
     t.expect(
@@ -976,8 +941,8 @@ g.test('log2Interval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: -1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: -1, expected: kAny },
+      { input: 0, expected: kAny },
       { input: 1, expected: [0, 0] },
       { input: 2, expected: [1, 1] },
       { input: kValue.f32.positive.max, expected: [minusOneULP(128), 128] },
@@ -992,13 +957,11 @@ g.test('log2Interval')
     };
 
     const input = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error(input, begin), end + error(input, end)]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error(input, begin), end + error(input, end)];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = log2Interval(input);
     t.expect(
@@ -1020,8 +983,8 @@ g.test('negationInterval')
       { input: -1.9, expected: [minusOneULP(hexToF32(0x3ff33334)), hexToF32(0x3ff33334)] },  // ~1.9
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAny },
       { input: kValue.f32.positive.max, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
       { input: kValue.f32.positive.min, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
       { input: kValue.f32.negative.min, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
@@ -1036,8 +999,7 @@ g.test('negationInterval')
   )
   .fn(t => {
     const input = t.params.input;
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = negationInterval(input);
     t.expect(
@@ -1054,26 +1016,24 @@ g.test('sinInterval')
       // as a f32 is sufficiently large, such that the high slope of f @ x causes the results to be substantially
       // different, so instead of getting 0 you get a value on the order of 10^-8 away from it, thus difficult to
       // express in a human readable manner.
-      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.negative.min, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.negative.min, expected: kAny },
       { input: kValue.f32.negative.pi.half, expected: [-1, plusOneULP(-1)] },
       { input: 0, expected: [0, 0] },
       { input: kValue.f32.positive.pi.half, expected: [minusOneULP(1), 1] },
-      { input: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.positive.max, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAny },
     ]
   )
   .fn(t => {
     const error = 2 ** -11;
 
     const input = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error, end + error]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error, end + error];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = sinInterval(input);
     t.expect(
@@ -1095,24 +1055,21 @@ g.test('tanInterval')
       // dividing an interval by another interval and applying an error function to that. This complexity is why the
       // entire interval framework was developed.
       // The examples here have been manually traced to confirm the expectation values are correct.
-      { input: kValue.f32.infinity.negative, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: kValue.f32.negative.min, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: kValue.f32.negative.pi.whole, expected: arrayToInterval([hexToF64(0xbf4002bc, 0x90000000), hexToF64(0x3f400144, 0xf0000000)]) },  // ~0.0
-      { input: kValue.f32.negative.pi.half, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: 0, expected: arrayToInterval([hexToF64(0xbf400200, 0xb0000000), hexToF64(0x3f400200, 0xb0000000)]) },  // ~0.0
-      { input: kValue.f32.positive.pi.half, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: kValue.f32.positive.pi.whole, expected: arrayToInterval([hexToF64(0xbf400144, 0xf0000000), hexToF64(0x3f4002bc, 0x90000000)]) },  // ~0.0
-      { input: kValue.f32.positive.max, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: kValue.f32.infinity.positive, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.negative.pi.whole, expected: [hexToF64(0xbf4002bc, 0x90000000), hexToF64(0x3f400144, 0xf0000000)] },  // ~0.0
+      { input: kValue.f32.negative.pi.half, expected: kAny },
+      { input: 0, expected: [hexToF64(0xbf400200, 0xb0000000), hexToF64(0x3f400200, 0xb0000000)] },  // ~0.0
+      { input: kValue.f32.positive.pi.half, expected: kAny },
+      { input: kValue.f32.positive.pi.whole, expected: [hexToF64(0xbf400144, 0xf0000000), hexToF64(0x3f4002bc, 0x90000000)] },  // ~0.0
+      { input: kValue.f32.positive.max, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAny },
     ]
   )
   .fn(t => {
     const input = t.params.input;
-    assert(
-      !(t.params.expected instanceof Array),
-      'Expectations for tanInterval must be expressed precisely as F32Intervals'
-    );
-    const expected: F32Interval = t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
+
     const got = tanInterval(input);
     t.expect(
       objectEquals(expected, got),
@@ -1124,20 +1081,7 @@ interface BinaryToIntervalCase {
   // input is a pair of independent values, not an range, so should not be
   // converted to a F32Interval.
   input: [number, number];
-
-  // If expected is an Array of two values, the test should interpret them as
-  // human readable begin/end values that need to be adjusted for the error
-  // calculation specific to the function being tested.
-  // This is to facilitate writing tests in a fluent manner, i.e. being able to
-  // express a expectation as `plusOneULP(π/2)` instead of
-  // `π/2 + ULP(π/2) + 4096 * ULP(π/2 + ULP(π/2))`
-  //
-  // If expected is an F32Interval, it is to be interpreted as an exact value,
-  // with no additional processing. This is to allow for expressing specific
-  // cases with human readable values that would require effectively
-  // implementing the entire interval system under test to accommodate them in
-  // the test error calculation.
-  expected: [number, number] | F32Interval;
+  expected: [number, number];
 }
 
 g.test('additionInterval')
@@ -1176,21 +1120,19 @@ g.test('additionInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]},
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAny},
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
-
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = additionInterval(x, y);
     t.expect(
@@ -1212,30 +1154,30 @@ g.test('atan2Interval')
       { input: [1, hexToF32(0x3fddb3d7)], expected: [minusOneULP(kValue.f32.positive.pi.sixth), kValue.f32.positive.pi.sixth] },  // x = √3
       { input: [1, 1], expected: [minusOneULP(kValue.f32.positive.pi.quarter), kValue.f32.positive.pi.quarter] },
       { input: [hexToF32(0x3fddb3d7), 1], expected: [minusOneULP(kValue.f32.positive.pi.third), kValue.f32.positive.pi.third] },  // y = √3
-      { input: [Number.POSITIVE_INFINITY, 1], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: [Number.POSITIVE_INFINITY, 1], expected: kAny },
 
       // positive y, negative x
       { input: [1, -1], expected: [minusOneULP(kValue.f32.positive.pi.three_quarters), kValue.f32.positive.pi.three_quarters] },
-      { input: [Number.POSITIVE_INFINITY, -1], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: [Number.POSITIVE_INFINITY, -1], expected: kAny },
 
       // negative y, negative x
       { input: [-1, -1], expected: [kValue.f32.negative.pi.three_quarters, plusOneULP(kValue.f32.negative.pi.three_quarters)] },
-      { input: [Number.NEGATIVE_INFINITY, -1], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: [Number.NEGATIVE_INFINITY, -1], expected: kAny },
 
       // negative y, positive x
       { input: [-1, 1], expected: [kValue.f32.negative.pi.quarter, plusOneULP(kValue.f32.negative.pi.quarter)] },
-      { input: [Number.NEGATIVE_INFINITY, 1], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: [Number.NEGATIVE_INFINITY, 1], expected: kAny },
 
       // Discontinuity @ y = 0
-      { input: [0, 0], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: [0, 0], expected: kAny },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: kAny },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: kAny },
       { input: [0, kValue.f32.positive.min], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
       { input: [0, kValue.f32.negative.max], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
       { input: [0, kValue.f32.positive.max], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
       { input: [0, kValue.f32.negative.min], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
-      { input: [0, kValue.f32.infinity.positive], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: [0, kValue.f32.infinity.negative], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: [0, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.negative], expected: kAny },
     ]
   )
   .fn(t => {
@@ -1244,13 +1186,11 @@ g.test('atan2Interval')
     };
 
     const [y, x] = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error(begin), end + error(end)]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error(begin), end + error(end)];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = atan2Interval(y, x);
     t.expect(
@@ -1284,15 +1224,15 @@ g.test('divisionInterval')
       { input: [-1, -0.1], expected: [minusOneULP(10), plusOneULP(10)] },
 
       // Denominator out of range
-      { input: [1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [1, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [1, kValue.f32.positive.max], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [1, kValue.f32.negative.min], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [1, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [1, kValue.f32.infinity.positive], expected: kAny },
+      { input: [1, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [1, kValue.f32.positive.max], expected: kAny },
+      { input: [1, kValue.f32.negative.min], expected: kAny },
+      { input: [1, 0], expected: kAny },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: kAny },
     ]
   )
   .fn(t => {
@@ -1301,13 +1241,11 @@ g.test('divisionInterval')
     };
 
     const [x, y] = t.params.input;
-    let expected: F32Interval;
-    if (t.params.expected instanceof Array) {
+    if (t.params.expected !== kAny) {
       const [begin, end] = t.params.expected;
-      expected = arrayToInterval([begin - error(begin), end + error(end)]);
-    } else {
-      expected = t.params.expected;
+      t.params.expected = [begin - error(begin), end + error(end)];
     }
+    const expected = new F32Interval(...t.params.expected);
 
     const got = divisionInterval(x, y);
     t.expect(
@@ -1352,21 +1290,19 @@ g.test('maxInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [0, 0] },
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
-
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = maxInterval(x, y);
     t.expect(
@@ -1411,21 +1347,19 @@ g.test('minInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
-
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = minInterval(x, y);
     t.expect(
@@ -1468,29 +1402,27 @@ g.test('multiplicationInterval')
       { input: [-0.1, -0.1], expected: [minusNULP(hexToF32(0x3c23d70a), 2), plusOneULP(hexToF32(0x3c23d70a))] },  // ~0.01
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [-1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [1, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [-1, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive], expected: kAny },
+      { input: [1, kValue.f32.infinity.positive], expected: kAny },
+      { input: [-1, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.negative], expected: kAny },
+      { input: [1, kValue.f32.infinity.negative], expected: kAny },
+      { input: [-1, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
 
       // Edge of f32
-      { input: [kValue.f32.positive.max, kValue.f32.positive.max], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.negative.min, kValue.f32.negative.min], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.positive.max, kValue.f32.negative.min], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.negative.min, kValue.f32.positive.max], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.positive.max, kValue.f32.positive.max], expected: kAny },
+      { input: [kValue.f32.negative.min, kValue.f32.negative.min], expected: kAny },
+      { input: [kValue.f32.positive.max, kValue.f32.negative.min], expected: kAny },
+      { input: [kValue.f32.negative.min, kValue.f32.positive.max], expected: kAny },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
-
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = multiplicationInterval(x, y);
     t.expect(
@@ -1535,21 +1467,19 @@ g.test('subtractionInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [0, kValue.f32.subnormal.positive.max] },
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
-
-    const expected =
-      t.params.expected instanceof Array ? arrayToInterval(t.params.expected) : t.params.expected;
+    const expected = new F32Interval(...t.params.expected);
 
     const got = subtractionInterval(x, y);
     t.expect(
@@ -1597,16 +1527,15 @@ g.test('clampMedianInterval')
       { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
 
       // Infinities
-      { input: [0, 1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
     ]
   )
   .fn(t => {
     const [x, y, z] = t.params.input;
-
-    const expected = arrayToInterval(t.params.expected);
+    const expected = new F32Interval(...t.params.expected);
 
     const got = clampMedianInterval(x, y, z);
     t.expect(
@@ -1649,16 +1578,15 @@ g.test('clampMinMaxInterval')
       { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
 
       // Infinities
-      { input: [0, 1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
     ]
   )
   .fn(t => {
     const [x, y, z] = t.params.input;
-
-    const expected = arrayToInterval(t.params.expected);
+    const expected = new F32Interval(...t.params.expected);
 
     const got = clampMinMaxInterval(x, y, z);
     t.expect(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -93,9 +93,9 @@ g.test('constructor')
       { input: [kValue.f32.negative.min, kValue.f32.positive.max], expected: [kValue.f32.negative.min, kValue.f32.positive.max]},
 
       // Out of range
-      { input: [0, 2 * kValue.f32.positive.max], expected: [0, Number.POSITIVE_INFINITY]},
-      { input: [2 * kValue.f32.negative.min, 0], expected: [Number.NEGATIVE_INFINITY, 0]},
-      { input: [2 * kValue.f32.negative.min, 2 * kValue.f32.positive.max], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]},
+      { input: [0, 2 * kValue.f32.positive.max], expected: [0, 2 * kValue.f32.positive.max]},
+      { input: [2 * kValue.f32.negative.min, 0], expected: [2 * kValue.f32.negative.min, 0]},
+      { input: [2 * kValue.f32.negative.min, 2 * kValue.f32.positive.max], expected: [2 * kValue.f32.negative.min, 2 * kValue.f32.positive.max]},
 
       // Infinities
       { input: [0, kValue.f32.infinity.positive], expected: [0, Number.POSITIVE_INFINITY]},
@@ -192,7 +192,7 @@ g.test('contains_number')
     // Out of range high
     { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.positive.min, expected: true },
     { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.positive.max, expected: true },
-    { bounds: [0, 2 * kValue.f32.positive.max], value: Number.POSITIVE_INFINITY, expected: true },
+    { bounds: [0, 2 * kValue.f32.positive.max], value: Number.POSITIVE_INFINITY, expected: false },
     { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.negative.min, expected: false },
     { bounds: [0, 2 * kValue.f32.positive.max], value: kValue.f32.negative.max, expected: false },
     { bounds: [0, 2 * kValue.f32.positive.max], value: Number.NEGATIVE_INFINITY, expected: false },
@@ -203,7 +203,7 @@ g.test('contains_number')
     { bounds: [2 * kValue.f32.negative.min, 0], value: Number.POSITIVE_INFINITY, expected: false },
     { bounds: [2 * kValue.f32.negative.min, 0], value: kValue.f32.negative.min, expected: true },
     { bounds: [2 * kValue.f32.negative.min, 0], value: kValue.f32.negative.max, expected: true },
-    { bounds: [2 * kValue.f32.negative.min, 0], value: Number.NEGATIVE_INFINITY, expected: true },
+    { bounds: [2 * kValue.f32.negative.min, 0], value: Number.NEGATIVE_INFINITY, expected: false },
 
     // Subnormals
     { bounds: [0, kValue.f32.positive.min], value: kValue.f32.subnormal.positive.min, expected: true },
@@ -304,8 +304,8 @@ g.test('contains_interval')
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [-1, 0], expected: false},
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, 1], expected: true},
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, kValue.f32.positive.max], expected: true},
-      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, Number.POSITIVE_INFINITY], expected: true},
-      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [100, Number.POSITIVE_INFINITY], expected: true},
+      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, Number.POSITIVE_INFINITY], expected: false},
+      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [100, Number.POSITIVE_INFINITY], expected: false},
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: false},
 
       // Out of range low
@@ -313,8 +313,8 @@ g.test('contains_interval')
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [-1, 0], expected: true},
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [kValue.f32.negative.min, 0], expected: true},
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [0, 1], expected: false},
-      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, 0], expected: true},
-      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, -100 ], expected: true},
+      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, 0], expected: false},
+      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, -100 ], expected: false},
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: false},
     ]
   )
@@ -379,8 +379,8 @@ g.test('correctlyRoundedInterval')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { value: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { value: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
       { value: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
@@ -438,21 +438,21 @@ g.test('absoluteErrorInterval')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, error: 0, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.positive, error: 2 ** -11, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.positive, error: 1, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, error: 0, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { value: kValue.f32.infinity.negative, error: 1, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: kValue.f32.infinity.positive, error: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, error: 2 ** -11, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, error: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, error: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, error: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { value: kValue.f32.positive.max, error: 0, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { value: kValue.f32.positive.max, error: 2 ** -11, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { value: kValue.f32.positive.max, error: kValue.f32.positive.max, expected: [0, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.max, error: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { value: kValue.f32.positive.min, error: 0, expected: [kValue.f32.positive.min,  kValue.f32.positive.min] },
       { value: kValue.f32.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
       { value: kValue.f32.positive.min, error: 1, expected: [-1, 1] },
       { value: kValue.f32.negative.min, error: 0, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
       { value: kValue.f32.negative.min, error: 2 ** -11, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { value: kValue.f32.negative.min, error: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, 0] },
+      { value: kValue.f32.negative.min, error: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { value: kValue.f32.negative.max, error: 0, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
       { value: kValue.f32.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
       { value: kValue.f32.negative.max, error: 1, expected: [-1, 1] },
@@ -514,21 +514,21 @@ g.test('ulpInterval')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, num_ulp: 0, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.positive, num_ulp: 1, expected: [minusOneULP(kValue.f32.positive.max), Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.positive, num_ulp: 4096, expected: [minusNULP(kValue.f32.positive.max, 4096), Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, num_ulp: 0, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { value: kValue.f32.infinity.negative, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, plusOneULP(kValue.f32.negative.min)] },
-      { value: kValue.f32.infinity.negative, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, plusNULP(kValue.f32.negative.min, 4096)] },
+      { value: kValue.f32.infinity.positive, num_ulp: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, num_ulp: 0, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { value: kValue.f32.positive.max, num_ulp: 0, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { value: kValue.f32.positive.max, num_ulp: 1, expected: [minusOneULP(kValue.f32.positive.max), Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.positive.max, num_ulp: 4096, expected: [minusNULP(kValue.f32.positive.max, 4096), Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.max, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.positive.max, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { value: kValue.f32.positive.min, num_ulp: 0, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
       { value: kValue.f32.positive.min, num_ulp: 1, expected: [0, plusOneULP(kValue.f32.positive.min)] },
       { value: kValue.f32.positive.min, num_ulp: 4096, expected: [0, plusNULP(kValue.f32.positive.min, 4096)] },
       { value: kValue.f32.negative.min, num_ulp: 0, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { value: kValue.f32.negative.min, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, plusOneULP(kValue.f32.negative.min)] },
-      { value: kValue.f32.negative.min, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, plusNULP(kValue.f32.negative.min, 4096)] },
+      { value: kValue.f32.negative.min, num_ulp: 1, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.negative.min, num_ulp: 4096, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { value: kValue.f32.negative.max, num_ulp: 0, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
       { value: kValue.f32.negative.max, num_ulp: 1, expected: [minusOneULP(kValue.f32.negative.max), 0] },
       { value: kValue.f32.negative.max, num_ulp: 4096, expected: [minusNULP(kValue.f32.negative.max, 4096), 0] },
@@ -607,8 +607,8 @@ g.test('absInterval')
       { input: -0.1, expected: [hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)] },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: kValue.f32.infinity.negative, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
       { input: kValue.f32.negative.min, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
@@ -644,7 +644,7 @@ g.test('atanInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: Number.NEGATIVE_INFINITY, expected: [kValue.f32.negative.pi.half, plusOneULP(kValue.f32.negative.pi.half)] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: hexToF32(0xbfddb3d7), expected: [kValue.f32.negative.pi.third, plusOneULP(kValue.f32.negative.pi.third)] }, // x = -√3
       { input: -1, expected: [kValue.f32.negative.pi.quarter, plusOneULP(kValue.f32.negative.pi.quarter)] },
       { input: hexToF32(0xbf13cd3a), expected: [kValue.f32.negative.pi.sixth, plusOneULP(kValue.f32.negative.pi.sixth)] },  // x = -1/√3
@@ -652,7 +652,7 @@ g.test('atanInterval')
       { input: hexToF32(0x3f13cd3a), expected: [minusOneULP(kValue.f32.positive.pi.sixth), kValue.f32.positive.pi.sixth] },  // x = 1/√3
       { input: 1, expected: [minusOneULP(kValue.f32.positive.pi.quarter), kValue.f32.positive.pi.quarter] },
       { input: hexToF32(0x3fddb3d7), expected: [minusOneULP(kValue.f32.positive.pi.third), kValue.f32.positive.pi.third] }, // x = √3
-      { input: Number.POSITIVE_INFINITY, expected: [minusOneULP(kValue.f32.positive.pi.half), kValue.f32.positive.pi.half] },
+      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -693,8 +693,8 @@ g.test('ceilInterval')
       { input: -1.9, expected: [-1, -1] },
 
       // Edge cases
-      { input: Number.POSITIVE_INFINITY, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { input: kValue.f32.positive.min, expected: [1, 1] },
       { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
@@ -729,7 +729,7 @@ g.test('cosInterval')
       // and x as a f32 is sufficiently large, such that the high slope of f @ x causes the results to be substantially
       // different, so instead of getting 0 you get a value on the order of 10^-8 away from 0, thus difficult to express
       // in a human readable manner.
-      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: kValue.f32.negative.min, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: kValue.f32.negative.pi.whole, expected: [-1, plusOneULP(-1)] },
       { input: kValue.f32.negative.pi.third, expected: [minusOneULP(1/2), 1/2] },
@@ -737,7 +737,7 @@ g.test('cosInterval')
       { input: kValue.f32.positive.pi.third, expected: [minusOneULP(1/2), 1/2] },
       { input: kValue.f32.positive.pi.whole, expected: [-1, plusOneULP(-1)] },
       { input: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: Number.POSITIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -763,10 +763,10 @@ g.test('expInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: 0, expected: [1,1] },
       { input: 1, expected: [kValue.f32.positive.e, plusOneULP(kValue.f32.positive.e)] },
-      { input: 89, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: 89, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -795,10 +795,10 @@ g.test('exp2Interval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: 0, expected: [1,1] },
       { input: 1, expected: [2, 2] },
-      { input: 128, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: 128, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -840,8 +840,8 @@ g.test('floorInterval')
       { input: -1.9, expected: [-2, -2] },
 
       // Edge cases
-      { input: Number.POSITIVE_INFINITY, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
       { input: kValue.f32.positive.min, expected: [0, 0] },
       { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
@@ -883,8 +883,8 @@ g.test('fractInterval')
       { input: -1.1, expected: [hexToF64(0x3feccccc, 0xc0000000), hexToF64(0x3feccccd, 0x00000000), ] }, // ~0.9
 
       // Edge cases
-      { input: Number.POSITIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]  },
+      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: kValue.f32.positive.max, expected: [0, 0] },
       { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
       { input: kValue.f32.negative.min, expected: [0, 0] },
@@ -913,7 +913,7 @@ g.test('inverseSqrtInterval')
       { input: 1, expected: [1, 1] },
       { input: 100, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
       { input: kValue.f32.positive.max, expected: [hexToF32(0x1f800000), plusNULP(hexToF32(0x1f800000), 2)] },  // ~5.421...e-20, i.e. 1/√max f32
-      { input: Number.POSITIVE_INFINITY, expected: [0, plusNULP(hexToF32(0x1f800000), 2)] },
+      { input: kValue.f32.infinity.positive, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
     ]
   )
   .fn(t => {
@@ -1020,8 +1020,8 @@ g.test('negationInterval')
       { input: -1.9, expected: [minusOneULP(hexToF32(0x3ff33334)), hexToF32(0x3ff33334)] },  // ~1.9
 
       // Edge cases
-      { input: Number.POSITIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: Number.NEGATIVE_INFINITY, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: kValue.f32.positive.max, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
       { input: kValue.f32.positive.min, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
       { input: kValue.f32.negative.min, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
@@ -1054,13 +1054,13 @@ g.test('sinInterval')
       // as a f32 is sufficiently large, such that the high slope of f @ x causes the results to be substantially
       // different, so instead of getting 0 you get a value on the order of 10^-8 away from it, thus difficult to
       // express in a human readable manner.
-      { input: Number.NEGATIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: kValue.f32.negative.min, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: kValue.f32.negative.pi.half, expected: [-1, plusOneULP(-1)] },
       { input: 0, expected: [0, 0] },
       { input: kValue.f32.positive.pi.half, expected: [minusOneULP(1), 1] },
       { input: kValue.f32.positive.max, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: Number.POSITIVE_INFINITY, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: kValue.f32.infinity.positive, expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -1095,7 +1095,7 @@ g.test('tanInterval')
       // dividing an interval by another interval and applying an error function to that. This complexity is why the
       // entire interval framework was developed.
       // The examples here have been manually traced to confirm the expectation values are correct.
-      { input: Number.NEGATIVE_INFINITY, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: kValue.f32.infinity.negative, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
       { input: kValue.f32.negative.min, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
       { input: kValue.f32.negative.pi.whole, expected: arrayToInterval([hexToF64(0xbf4002bc, 0x90000000), hexToF64(0x3f400144, 0xf0000000)]) },  // ~0.0
       { input: kValue.f32.negative.pi.half, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
@@ -1103,7 +1103,7 @@ g.test('tanInterval')
       { input: kValue.f32.positive.pi.half, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
       { input: kValue.f32.positive.pi.whole, expected: arrayToInterval([hexToF64(0xbf400144, 0xf0000000), hexToF64(0x3f4002bc, 0x90000000)]) },  // ~0.0
       { input: kValue.f32.positive.max, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
-      { input: Number.POSITIVE_INFINITY, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: kValue.f32.infinity.positive, expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
     ]
   )
   .fn(t => {
@@ -1176,14 +1176,14 @@ g.test('additionInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
 
       // Infinities
-      { input: [0, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.POSITIVE_INFINITY, 0], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [0, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.NEGATIVE_INFINITY, 0], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]},
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -1212,19 +1212,19 @@ g.test('atan2Interval')
       { input: [1, hexToF32(0x3fddb3d7)], expected: [minusOneULP(kValue.f32.positive.pi.sixth), kValue.f32.positive.pi.sixth] },  // x = √3
       { input: [1, 1], expected: [minusOneULP(kValue.f32.positive.pi.quarter), kValue.f32.positive.pi.quarter] },
       { input: [hexToF32(0x3fddb3d7), 1], expected: [minusOneULP(kValue.f32.positive.pi.third), kValue.f32.positive.pi.third] },  // y = √3
-      { input: [Number.POSITIVE_INFINITY, 1], expected: [minusOneULP(kValue.f32.positive.pi.half), kValue.f32.positive.pi.half] },
+      { input: [Number.POSITIVE_INFINITY, 1], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
 
       // positive y, negative x
       { input: [1, -1], expected: [minusOneULP(kValue.f32.positive.pi.three_quarters), kValue.f32.positive.pi.three_quarters] },
-      { input: [Number.POSITIVE_INFINITY, -1], expected: [minusOneULP(kValue.f32.positive.pi.half), kValue.f32.positive.pi.half] },
+      { input: [Number.POSITIVE_INFINITY, -1], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
 
       // negative y, negative x
       { input: [-1, -1], expected: [kValue.f32.negative.pi.three_quarters, plusOneULP(kValue.f32.negative.pi.three_quarters)] },
-      { input: [Number.NEGATIVE_INFINITY, -1], expected: [kValue.f32.negative.pi.half, plusOneULP(kValue.f32.negative.pi.half)] },
+      { input: [Number.NEGATIVE_INFINITY, -1], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
 
       // negative y, positive x
       { input: [-1, 1], expected: [kValue.f32.negative.pi.quarter, plusOneULP(kValue.f32.negative.pi.quarter)] },
-      { input: [Number.NEGATIVE_INFINITY, 1], expected: [kValue.f32.negative.pi.half, plusOneULP(kValue.f32.negative.pi.half)] },
+      { input: [Number.NEGATIVE_INFINITY, 1], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
 
       // Discontinuity @ y = 0
       { input: [0, 0], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
@@ -1234,8 +1234,8 @@ g.test('atan2Interval')
       { input: [0, kValue.f32.negative.max], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
       { input: [0, kValue.f32.positive.max], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
       { input: [0, kValue.f32.negative.min], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
-      { input: [0, Number.POSITIVE_INFINITY], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
-      { input: [0, Number.NEGATIVE_INFINITY], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
+      { input: [0, kValue.f32.infinity.positive], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
+      { input: [0, kValue.f32.infinity.negative], expected: arrayToInterval([Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]) },
     ]
   )
   .fn(t => {
@@ -1284,11 +1284,11 @@ g.test('divisionInterval')
       { input: [-1, -0.1], expected: [minusOneULP(10), plusOneULP(10)] },
 
       // Denominator out of range
-      { input: [1, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [1, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [1, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: [1, kValue.f32.positive.max], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: [1, kValue.f32.negative.min], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
       { input: [1, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
@@ -1352,14 +1352,14 @@ g.test('maxInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [0, 0] },
 
       // Infinities
-      { input: [0, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.POSITIVE_INFINITY, 0], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [0, Number.NEGATIVE_INFINITY], expected: [0, 0] },
-      { input: [Number.NEGATIVE_INFINITY, 0], expected: [0, 0] },
-      { input: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -1411,14 +1411,14 @@ g.test('minInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
 
       // Infinities
-      { input: [0, Number.POSITIVE_INFINITY], expected: [0, 0] },
-      { input: [Number.POSITIVE_INFINITY, 0], expected: [0, 0] },
-      { input: [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [0, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.NEGATIVE_INFINITY, 0], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -1468,22 +1468,22 @@ g.test('multiplicationInterval')
       { input: [-0.1, -0.1], expected: [minusNULP(hexToF32(0x3c23d70a), 2), plusOneULP(hexToF32(0x3c23d70a))] },  // ~0.01
 
       // Infinities
-      { input: [0, Number.POSITIVE_INFINITY], expected: [0, 0] },
-      { input: [1, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [-1, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [0, Number.NEGATIVE_INFINITY], expected: [0, 0] },
-      { input: [1, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [-1, Number.NEGATIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [-1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [1, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [-1, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
 
       // Edge of f32
-      { input: [kValue.f32.positive.max, kValue.f32.positive.max], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.negative.min, kValue.f32.negative.min], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [kValue.f32.positive.max, kValue.f32.negative.min], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [kValue.f32.negative.min, kValue.f32.positive.max], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [kValue.f32.positive.max, kValue.f32.positive.max], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.negative.min, kValue.f32.negative.min], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.positive.max, kValue.f32.negative.min], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.negative.min, kValue.f32.positive.max], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -1535,14 +1535,14 @@ g.test('subtractionInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [0, kValue.f32.subnormal.positive.max] },
 
       // Infinities
-      { input: [0, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.POSITIVE_INFINITY, 0], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [0, Number.NEGATIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.NEGATIVE_INFINITY, 0], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
-      { input: [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -1597,10 +1597,10 @@ g.test('clampMedianInterval')
       { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
 
       // Infinities
-      { input: [0, 1, Number.POSITIVE_INFINITY], expected: [1, 1] },
-      { input: [0, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {
@@ -1649,10 +1649,10 @@ g.test('clampMinMaxInterval')
       { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
 
       // Infinities
-      { input: [0, 1, Number.POSITIVE_INFINITY], expected: [1, 1] },
-      { input: [0, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY], expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { input: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY], expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY] },
     ]
   )
   .fn(t => {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -93,7 +93,7 @@ const kNegPiToPiInterval = new F32Interval(
   kValue.f32.positive.pi.whole
 );
 
-/** F32Interval of values greater than 0 */
+/** F32Interval of values greater than 0 and less than or equal to f32 max */
 const kGreaterThanZeroInterval = new F32Interval(
   kValue.f32.subnormal.positive.min,
   kValue.f32.positive.max

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -13,13 +13,9 @@ import {
 export class F32Interval {
   public readonly begin: number;
   public readonly end: number;
-  private static _infinite: F32Interval;
+  private static _undefined: F32Interval;
 
   /** Constructor
-   *
-   * Bounds that are out of range for F32 are converted to appropriate edge or
-   * infinity values, so that all values above/below the f32 range are lumped
-   * together.
    *
    * @param begin number indicating the lower bound of the interval
    * @param end number indicating the upper bound of the interval
@@ -28,21 +24,8 @@ export class F32Interval {
     assert(!Number.isNaN(begin) && !Number.isNaN(end), `bounds need to be non-NaN`);
     assert(begin <= end, `begin (${begin}) must be equal or before end (${end})`);
 
-    if (begin === Number.NEGATIVE_INFINITY || begin < kValue.f32.negative.min) {
-      this.begin = Number.NEGATIVE_INFINITY;
-    } else if (begin === Number.POSITIVE_INFINITY || begin > kValue.f32.positive.max) {
-      this.begin = kValue.f32.positive.max;
-    } else {
-      this.begin = begin;
-    }
-
-    if (end === Number.POSITIVE_INFINITY || end > kValue.f32.positive.max) {
-      this.end = Number.POSITIVE_INFINITY;
-    } else if (end === Number.NEGATIVE_INFINITY || end < kValue.f32.negative.min) {
-      this.end = kValue.f32.negative.min;
-    } else {
-      this.end = end;
-    }
+    this.begin = begin;
+    this.end = end;
   }
 
   /** @returns if a point or interval is completely contained by this interval
@@ -54,7 +37,7 @@ export class F32Interval {
    */
   public contains(n: number | F32Interval): boolean {
     if (Number.isNaN(n)) {
-      // Being the infinite interval indicates that the accuracy is not defined
+      // Being the undefined interval indicates that the accuracy is not defined
       // for this test, so the test is just checking that this input doesn't
       // cause the implementation to misbehave, so NaN is acceptable.
       return this.begin === Number.NEGATIVE_INFINITY && this.end === Number.POSITIVE_INFINITY;
@@ -66,6 +49,11 @@ export class F32Interval {
   /** @returns if this interval contains a single point */
   public isPoint(): boolean {
     return this.begin === this.end;
+  }
+
+  /** @returns if this interval only contains f32 finite values */
+  public isFinite(): boolean {
+    return isF32Finite(this.begin) && isF32Finite(this.end);
   }
 
   /** @returns an interval with the tightest bounds that includes all provided intervals */
@@ -85,15 +73,15 @@ export class F32Interval {
     return `[${this.begin}, ${this.end}]`;
   }
 
-  /** @returns a singleton for the infinite interval
+  /** @returns a singleton for the undefined interval
    * This interval is used in situations where accuracy is not defined, so any
    * result is valid.
    */
-  public static infinite(): F32Interval {
-    if (this._infinite === undefined) {
-      this._infinite = new F32Interval(Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
+  public static undefined(): F32Interval {
+    if (this._undefined === undefined) {
+      this._undefined = new F32Interval(Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
     }
-    return this._infinite;
+    return this._undefined;
   }
 }
 
@@ -115,18 +103,18 @@ export interface PointToInterval {
 }
 
 /** Operation used to implement a PointToInterval */
-interface PointToIntervalOp {
+export interface PointToIntervalOp {
   /** @returns acceptance interval for a function at point x */
-  impl: (x: number) => F32Interval;
+  impl: PointToInterval;
 
   /**
    * Calculates where in the domain defined by x the min/max extrema of impl
    * occur and returns a span of those points to be used as the domain instead.
    *
-   * If not defined the ends of the existing domain are assumed to be the
-   * extrema.
+   * If the result is not defined the ends of the existing domain are assumed to
+   * be the extrema.
    *
-   * This is only implemented for functions that meet all of the following
+   * This is only implemented for subclasses that meet all of the following
    * criteria:
    *   a) non-monotonic
    *   b) used in inherited accuracy calculations
@@ -134,6 +122,9 @@ interface PointToIntervalOp {
    *      i.e. fooInterval takes in x: number | F32Interval, not x: number
    */
   extrema?: (x: F32Interval) => F32Interval;
+
+  /** @returns an additional interval that inputs need to be within. If not defined, they are only tested for being finite. */
+  domain?: F32Interval;
 }
 
 /**
@@ -163,6 +154,9 @@ interface BinaryToIntervalOp {
    *   c) need to take in an interval for b)
    */
   extrema?: (x: F32Interval, y: F32Interval) => [F32Interval, F32Interval];
+
+  /** @returns additional intervals that inputs need to be within. If not defined, they are only tested for being finite. */
+  domain?: { x: F32Interval[]; y: F32Interval[] };
 }
 
 /**
@@ -181,6 +175,9 @@ interface TernaryToIntervalOp {
   // All current ternary operations that are used in inheritance (clamp*) are
   // monotonic, so extrema calculation isn't needed. Re-using the Op interface
   // pattern for symmetry with the other operations
+
+  // All current ternary operations have a domain of the full f32 space, so a domain? override is not currently
+  // provided.
 }
 
 /** Converts a point to an acceptance interval, using a specific function
@@ -188,6 +185,7 @@ interface TernaryToIntervalOp {
  * This handles correctly rounding and flushing inputs as needed.
  * Duplicate inputs are pruned before invoking op.impl.
  * op.extrema is invoked before this point in the call stack.
+ * op.domain is tested before this point in the call stack.
  *
  * @param n value to flush & round then invoke op.impl on
  * @param op operation defining the function being run
@@ -207,6 +205,7 @@ function roundAndFlushPointToInterval(n: number, op: PointToIntervalOp) {
  * Duplicate inputs are pruned before invoking op.impl.
  * All unique combinations of x & y are run.
  * op.extrema is invoked before this point in the call stack.
+ * op.domain is tested before this point in the call stack.
  *
  * @param x first param to flush & round then invoke op.impl on
  * @param y second param to flush & round then invoke op.impl on
@@ -234,7 +233,6 @@ function roundAndFlushBinaryToInterval(x: number, y: number, op: BinaryToInterva
  * This handles correctly rounding and flushing inputs as needed.
  * Duplicate inputs are pruned before invoking op.impl.
  * All unique combinations of x, y & z are run.
- * op.extrema is invoked before this point in the call stack.
  *
  * @param x first param to flush & round then invoke op.impl on
  * @param y second param to flush & round then invoke op.impl on
@@ -283,17 +281,25 @@ function roundAndFlushTernaryToInterval(
  * @returns a span over all of the outputs of op.impl
  */
 function runPointOp(x: F32Interval, op: PointToIntervalOp): F32Interval {
-  if (x.isPoint()) {
-    return roundAndFlushPointToInterval(x.begin, op);
+  if (!x.isFinite()) {
+    return F32Interval.undefined();
   }
 
   if (op.extrema !== undefined) {
     x = op.extrema(x);
   }
-  return F32Interval.span(
+
+  if (op.domain !== undefined) {
+    if (!op.domain.contains(x)) {
+      return F32Interval.undefined();
+    }
+  }
+
+  const result = F32Interval.span(
     roundAndFlushPointToInterval(x.begin, op),
     roundAndFlushPointToInterval(x.end, op)
   );
+  return result.isFinite() ? result : F32Interval.undefined();
 }
 
 /** Calculate the acceptance interval for a binary function over an interval
@@ -306,29 +312,36 @@ function runPointOp(x: F32Interval, op: PointToIntervalOp): F32Interval {
  * @param op operation defining the function being run
  * @returns a span over all of the outputs of op.impl
  */
-// Will be used in test implementations
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function runBinaryOp(x: F32Interval, y: F32Interval, op: BinaryToIntervalOp): F32Interval {
+  if (!x.isFinite() || !y.isFinite()) {
+    return F32Interval.undefined();
+  }
+
   if (op.extrema !== undefined) {
     [x, y] = op.extrema(x, y);
   }
+
+  if (op.domain !== undefined) {
+    if (!op.domain.x.some(d => d.contains(x)) || !op.domain.y.some(d => d.contains(y))) {
+      return F32Interval.undefined();
+    }
+  }
+
   const x_values = new Set<number>([x.begin, x.end]);
   const y_values = new Set<number>([y.begin, y.end]);
 
-  const results = new Set<F32Interval>();
+  const outputs = new Set<F32Interval>();
   x_values.forEach(inner_x => {
     y_values.forEach(inner_y => {
-      results.add(roundAndFlushBinaryToInterval(inner_x, inner_y, op));
+      outputs.add(roundAndFlushBinaryToInterval(inner_x, inner_y, op));
     });
   });
 
-  return F32Interval.span(...results);
+  const result = F32Interval.span(...outputs);
+  return result.isFinite() ? result : F32Interval.undefined();
 }
 
 /** Calculate the acceptance interval for a ternary function over an interval
- *
- * The provided domain intervals may be adjusted if the operation defines an
- * extrema function.
  *
  * @param x first input domain interval
  * @param y second input domain interval
@@ -336,29 +349,33 @@ function runBinaryOp(x: F32Interval, y: F32Interval, op: BinaryToIntervalOp): F3
  * @param op operation defining the function being run
  * @returns a span over all of the outputs of op.impl
  */
-// Will be used in test implementations
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function runTernaryOp(
   x: F32Interval,
   y: F32Interval,
   z: F32Interval,
   op: TernaryToIntervalOp
 ): F32Interval {
+  if (!x.isFinite() || !y.isFinite() || !z.isFinite()) {
+    return F32Interval.undefined();
+  }
+
   const x_values = new Set<number>([x.begin, x.end]);
   const y_values = new Set<number>([y.begin, y.end]);
   const z_values = new Set<number>([z.begin, z.end]);
-  const results = new Set<F32Interval>();
+  const outputs = new Set<F32Interval>();
   x_values.forEach(inner_x => {
     y_values.forEach(inner_y => {
       z_values.forEach(inner_z => {
-        results.add(roundAndFlushTernaryToInterval(inner_x, inner_y, inner_z, op));
+        outputs.add(roundAndFlushTernaryToInterval(inner_x, inner_y, inner_z, op));
       });
     });
   });
 
-  return F32Interval.span(...results);
+  const result = F32Interval.span(...outputs);
+  return result.isFinite() ? result : F32Interval.undefined();
 }
 
+/** Defines a PointToIntervalOp for an interval of the correctly rounded values around the point */
 const CorrectlyRoundedIntervalOp: PointToIntervalOp = {
   impl: (n: number) => {
     assert(!Number.isNaN(n), `absolute not defined for NaN`);
@@ -368,37 +385,44 @@ const CorrectlyRoundedIntervalOp: PointToIntervalOp = {
 
 /** @returns an interval of the correctly rounded values around the point */
 export function correctlyRoundedInterval(n: number): F32Interval {
-  return roundAndFlushPointToInterval(n, CorrectlyRoundedIntervalOp);
+  return runPointOp(toInterval(n), CorrectlyRoundedIntervalOp);
 }
 
 /** @returns a PointToIntervalOp for [n - error_range, n + error_range] */
 function AbsoluteErrorIntervalOp(error_range: number): PointToIntervalOp {
-  return {
-    impl: (n: number) => {
-      if (!isF32Finite(n)) {
-        return toInterval(n);
-      }
-
-      assert(!Number.isNaN(n), `absolute not defined for NaN`);
-      return new F32Interval(n - error_range, n + error_range);
+  const op: PointToIntervalOp = {
+    impl: (_: number) => {
+      return F32Interval.undefined();
     },
   };
+
+  if (isF32Finite(error_range)) {
+    op.impl = (n: number) => {
+      assert(!Number.isNaN(n), `absolute error not defined for NaN`);
+      return new F32Interval(n - error_range, n + error_range);
+    };
+  }
+
+  return op;
 }
 
 /** @returns an interval of the absolute error around the point */
 export function absoluteErrorInterval(n: number, error_range: number): F32Interval {
   error_range = Math.abs(error_range);
-  return roundAndFlushPointToInterval(n, AbsoluteErrorIntervalOp(error_range));
+  return runPointOp(toInterval(n), AbsoluteErrorIntervalOp(error_range));
 }
 
 /** @returns a PointToIntervalOp for [n - numULP * ULP(n), n + numULP * ULP(n)] */
 function ULPIntervalOp(numULP: number): PointToIntervalOp {
-  return {
-    impl: (n: number) => {
-      if (!isF32Finite(n)) {
-        assert(!Number.isNaN(n), `ULP not defined for NaN`);
-        return toInterval(n);
-      }
+  const op: PointToIntervalOp = {
+    impl: (_: number) => {
+      return F32Interval.undefined();
+    },
+  };
+
+  if (isF32Finite(numULP)) {
+    op.impl = (n: number) => {
+      assert(!Number.isNaN(n), `ULP error not defined for NaN`);
 
       const ulp = oneULP(n);
       const begin = n - numULP * ulp;
@@ -408,18 +432,20 @@ function ULPIntervalOp(numULP: number): PointToIntervalOp {
         Math.min(begin, flushSubnormalNumber(begin)),
         Math.max(end, flushSubnormalNumber(end))
       );
-    },
-  };
+    };
+  }
+
+  return op;
 }
 
 /** @returns an interval of N * ULP around the point */
 export function ulpInterval(n: number, numULP: number): F32Interval {
   numULP = Math.abs(numULP);
-  return roundAndFlushPointToInterval(n, ULPIntervalOp(numULP));
+  return runPointOp(toInterval(n), ULPIntervalOp(numULP));
 }
 
 const AbsIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
+  impl: (n: number) => {
     return correctlyRoundedInterval(Math.abs(n));
   },
 };
@@ -429,30 +455,9 @@ export function absInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), AbsIntervalOp);
 }
 
-const AdditionInnerOp = {
-  impl: (x: number, y: number): F32Interval => {
-    if (!isF32Finite(x) && isF32Finite(y)) {
-      return correctlyRoundedInterval(x);
-    }
-
-    if (isF32Finite(x) && !isF32Finite(y)) {
-      return correctlyRoundedInterval(y);
-    }
-
-    if (!isF32Finite(x) && !isF32Finite(y)) {
-      if (Math.sign(x) === Math.sign(y)) {
-        return correctlyRoundedInterval(x);
-      } else {
-        return F32Interval.infinite();
-      }
-    }
-    return correctlyRoundedInterval(x + y);
-  },
-};
-
 const AdditionIntervalOp: BinaryToIntervalOp = {
   impl: (x: number, y: number): F32Interval => {
-    return roundAndFlushBinaryToInterval(x, y, AdditionInnerOp);
+    return correctlyRoundedInterval(x + y);
   },
 };
 
@@ -462,7 +467,7 @@ export function additionInterval(x: number | F32Interval, y: number | F32Interva
 }
 
 const AtanIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
+  impl: (n: number) => {
     return ulpInterval(Math.atan(n), 4096);
   },
 };
@@ -477,7 +482,7 @@ const Atan2IntervalOp: BinaryToIntervalOp = {
     const numULP = 4096;
     if (y === 0) {
       if (x === 0) {
-        return F32Interval.infinite();
+        return F32Interval.undefined();
       } else {
         return F32Interval.span(
           ulpInterval(kValue.f32.negative.pi.whole, numULP),
@@ -558,10 +563,9 @@ export function clampMinMaxInterval(
 
 const CosIntervalOp: PointToIntervalOp = {
   impl: (n: number): F32Interval => {
-    return kValue.f32.negative.pi.whole <= n && n <= kValue.f32.positive.pi.whole
-      ? absoluteErrorInterval(Math.cos(n), 2 ** -11)
-      : F32Interval.infinite();
+    return absoluteErrorInterval(Math.cos(n), 2 ** -11);
   },
+  domain: new F32Interval(kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole),
 };
 
 /** Calculate an acceptance interval of cos(x) */
@@ -573,33 +577,24 @@ const DivisionIntervalOp: BinaryToIntervalOp = {
   impl: (x: number, y: number): F32Interval => {
     assert(
       !isSubnormalNumber(y),
-      `divisionInterval impl should never receive y === 0 or flush(y) === 0`
+      `DivisionIntervalOp.impl should never receive y === 0 or flush(y) === 0`
     );
     return ulpInterval(x / y, 2.5);
+  },
+  domain: {
+    x: [new F32Interval(kValue.f32.negative.min, kValue.f32.positive.max)],
+    y: [new F32Interval(-(2 ** 126), -(2 ** -126)), new F32Interval(2 ** -126, 2 ** 126)],
   },
 };
 
 /** Calculate an acceptance interval of x / y */
 export function divisionInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
-  {
-    const Y = toInterval(y);
-    const lower_bound = 2 ** -126;
-    const upper_bound = 2 ** 126;
-    // division accuracy is not defined outside of |denominator| on [2 ** -126, 2 ** 126]
-    if (
-      !new F32Interval(-upper_bound, -lower_bound).contains(Y) &&
-      !new F32Interval(lower_bound, upper_bound).contains(Y)
-    ) {
-      return F32Interval.infinite();
-    }
-  }
-
   return runBinaryOp(toInterval(x), toInterval(y), DivisionIntervalOp);
 }
 
 const ExpIntervalOp: PointToIntervalOp = {
-  impl: (x: number): F32Interval => {
-    return ulpInterval(Math.exp(x), 3 + 2 * Math.abs(x));
+  impl: (n: number): F32Interval => {
+    return ulpInterval(Math.exp(n), 3 + 2 * Math.abs(n));
   },
 };
 
@@ -609,8 +604,8 @@ export function expInterval(x: number | F32Interval): F32Interval {
 }
 
 const Exp2IntervalOp: PointToIntervalOp = {
-  impl: (x: number): F32Interval => {
-    return ulpInterval(Math.pow(2, x), 3 + 2 * Math.abs(x));
+  impl: (n: number): F32Interval => {
+    return ulpInterval(Math.pow(2, n), 3 + 2 * Math.abs(n));
   },
 };
 
@@ -653,12 +648,10 @@ export function fractInterval(n: number): F32Interval {
 
 const InverseSqrtIntervalOp: PointToIntervalOp = {
   impl: (n: number): F32Interval => {
-    if (n <= 0) {
-      // 1 / sqrt(n) for n <= 0 is not meaningfully defined for real f32
-      return F32Interval.infinite();
-    }
     return ulpInterval(1 / Math.sqrt(n), 2);
   },
+  // 1/sqrt(x) is not defined for x <= 0
+  domain: new F32Interval(kValue.f32.subnormal.positive.min, kValue.f32.positive.max),
 };
 
 /** Calculate an acceptance interval of inverseSqrt(x) */
@@ -667,17 +660,14 @@ export function inverseSqrtInterval(n: number | F32Interval): F32Interval {
 }
 
 const LogIntervalOp: PointToIntervalOp = {
-  impl: (x: number): F32Interval => {
-    // log is not defined in the real plane for x <= 0
-    if (x <= 0.0) {
-      return F32Interval.infinite();
+  impl: (n: number): F32Interval => {
+    if (n >= 0.5 && n <= 2.0) {
+      return absoluteErrorInterval(Math.log(n), 2 ** -21);
     }
-
-    if (x >= 0.5 && x <= 2.0) {
-      return absoluteErrorInterval(Math.log(x), 2 ** -21);
-    }
-    return ulpInterval(Math.log(x), 3);
+    return ulpInterval(Math.log(n), 3);
   },
+  // log(x) is not defined for x <= 0
+  domain: new F32Interval(kValue.f32.subnormal.positive.min, kValue.f32.positive.max),
 };
 
 /** Calculate an acceptance interval of log(x) */
@@ -686,17 +676,14 @@ export function logInterval(x: number | F32Interval): F32Interval {
 }
 
 const Log2IntervalOp: PointToIntervalOp = {
-  impl: (x: number): F32Interval => {
-    // log2 is not defined in the real plane for x <= 0
-    if (x <= 0.0) {
-      return F32Interval.infinite();
+  impl: (n: number): F32Interval => {
+    if (n >= 0.5 && n <= 2.0) {
+      return absoluteErrorInterval(Math.log2(n), 2 ** -21);
     }
-
-    if (x >= 0.5 && x <= 2.0) {
-      return absoluteErrorInterval(Math.log2(x), 2 ** -21);
-    }
-    return ulpInterval(Math.log2(x), 3);
+    return ulpInterval(Math.log2(n), 3);
   },
+  // log2(x) is not defined for x <= 0
+  domain: new F32Interval(kValue.f32.subnormal.positive.min, kValue.f32.positive.max),
 };
 
 /** Calculate an acceptance interval of log2(x) */
@@ -728,17 +715,6 @@ export function minInterval(x: number | F32Interval, y: number | F32Interval): F
 
 const MultiplicationInnerOp = {
   impl: (x: number, y: number): F32Interval => {
-    if (x === 0 || y === 0) {
-      return correctlyRoundedInterval(0);
-    }
-
-    const appropriate_infinity =
-      Math.sign(x) === Math.sign(y) ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
-
-    if (!isF32Finite(x) || !isF32Finite(y)) {
-      return correctlyRoundedInterval(appropriate_infinity);
-    }
-
     return correctlyRoundedInterval(x * y);
   },
 };
@@ -770,10 +746,9 @@ export function negationInterval(n: number): F32Interval {
 
 const SinIntervalOp: PointToIntervalOp = {
   impl: (n: number): F32Interval => {
-    return kValue.f32.negative.pi.whole <= n && n <= kValue.f32.positive.pi.whole
-      ? absoluteErrorInterval(Math.sin(n), 2 ** -11)
-      : F32Interval.infinite();
+    return absoluteErrorInterval(Math.sin(n), 2 ** -11);
   },
+  domain: new F32Interval(kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole),
 };
 
 /** Calculate an acceptance interval of sin(x) */
@@ -783,22 +758,6 @@ export function sinInterval(n: number): F32Interval {
 
 const SubtractionInnerOp: BinaryToIntervalOp = {
   impl: (x: number, y: number): F32Interval => {
-    if (!isF32Finite(x) && isF32Finite(y)) {
-      return correctlyRoundedInterval(x);
-    }
-
-    if (isF32Finite(x) && !isF32Finite(y)) {
-      const result = Math.sign(y) > 0 ? Number.NEGATIVE_INFINITY : Number.POSITIVE_INFINITY;
-      return correctlyRoundedInterval(result);
-    }
-
-    if (!isF32Finite(x) && !isF32Finite(y)) {
-      if (Math.sign(x) === -Math.sign(y)) {
-        return correctlyRoundedInterval(x);
-      } else {
-        return F32Interval.infinite();
-      }
-    }
     return correctlyRoundedInterval(x - y);
   },
 };

--- a/src/webgpu/util/pretty_diff_tables.ts
+++ b/src/webgpu/util/pretty_diff_tables.ts
@@ -2,7 +2,7 @@ import { range } from '../../common/util/util.js';
 
 /**
  * Pretty-prints a "table" of cell values (each being `number | string`), right-aligned.
- * Each row may be any iterator, including lazily-generated (potentially undefined) rows.
+ * Each row may be any iterator, including lazily-generated (potentially infinite) rows.
  *
  * The first argument is the printing options:
  *  - fillToWidth: Keep printing columns (as long as there is data) until this width is passed.

--- a/src/webgpu/util/pretty_diff_tables.ts
+++ b/src/webgpu/util/pretty_diff_tables.ts
@@ -2,7 +2,7 @@ import { range } from '../../common/util/util.js';
 
 /**
  * Pretty-prints a "table" of cell values (each being `number | string`), right-aligned.
- * Each row may be any iterator, including lazily-generated (potentially infinite) rows.
+ * Each row may be any iterator, including lazily-generated (potentially undefined) rows.
  *
  * The first argument is the printing options:
  *  - fillToWidth: Keep printing columns (as long as there is data) until this width is passed.


### PR DESCRIPTION
The WGSL spec has been clarified to allow implementations to return
undefined values when they do not implement handling infinity. For CTS
tests this means that anytime infinity is encountered it may
potentially turn into an undefined value. In general terms this means
that acceptance intervals for certains cases need to loosened, and a
bunch of corner cases related to clamping infinities can be removed.

This is a big monolithic change, because the alternate would be
creating a parallel framework infrastructure with the new behaviour,
and rewriting tests piecemeal to use the new framework. Which I am
currently already in the process of doing wrt migration to the
interval framework. Having 3 different testing frameworks live at the
same time seems like a recipe for disaster.

Highlights of this change:
- F32Interval.infinity() has been renamed F32Interval.undefined()
- Infinity clamping behaviour in the F32Interval constructor is gone
- *ToIntervalOp.impl is no longer responsible for checking if inputs
  are valid
- *ToIntervalOp.domain? property has been added to allow for operation
  definitions to specify additional constraints on the inputs, run*Op
  actually tests these limits
- run*Op is now responsible for checking that inputs/outputs of
  operations are finite, otherwise returning undefined
- Usages of Number.POSITIVE/NEGATIVE_INFINITY on the input side of
  unit tests related to generating intervals have been change to
  kValue.f32.infinity.positive/negative, for consistency and since
  Number.* is a f64 value

Fixes #1642

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
