### PR TITLE
Implement val:render_pass_descriptor:timestampWrite,same_query_index

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -917,6 +917,51 @@ g.test('timestampWrite,query_index')
     t.tryRenderPass(isValid, descriptor);
   });
 
+g.test('timestampWrite,same_query_index')
+  .desc(
+    `
+  Test that timestampWrites is invalid if each entry has the same queryIndex in the same querySet.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('queryIndexA', [0, 1])
+      .combine('queryIndexB', [0, 1])
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase(['timestamp-query']);
+  })
+  .fn(async t => {
+    const { queryIndexA, queryIndexB } = t.params;
+
+    const querySet = t.device.createQuerySet({
+      type: 'timestamp',
+      count: 2,
+    });
+
+    const timestampWriteA = {
+      querySet,
+      queryIndex: queryIndexA,
+      location: 'beginning' as const,
+    };
+
+    const timestampWriteB = {
+      querySet,
+      queryIndex: queryIndexB,
+      location: 'end' as const,
+    };
+
+    const isValid = queryIndexA !== queryIndexB;
+
+    const colorTexture = t.createTexture();
+    const descriptor = {
+      colorAttachments: [t.getColorAttachment(colorTexture)],
+      timestampWrites: [timestampWriteA, timestampWriteB],
+    };
+
+    t.tryRenderPass(isValid, descriptor);
+  });
+
 g.test('occlusionQuerySet,query_set_type')
   .desc(`Test that occlusionQuerySet must have type 'occlusion'.`)
   .params(u => u.combine('queryType', kQueryTypes))


### PR DESCRIPTION
Each timestampWrite of the timestampWrites should not have the same
queiryIndex if each timestampWrite has the same querySet. So, this
PR adds a test to check if a validation error is generated when
queryIndexes are equal in the timestampWrites.

Issue: #1618

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
