### PR TITLE
Add reftests: canvas use as image source with opaque/premultiplied alpha mode

### DIFF
--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -296,7 +296,7 @@ class F extends CopyToTextureUtils {
       device,
       format: 'bgra8unorm',
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
-      compositingAlphaMode: alphaMode,
+      alphaMode,
     });
 
     // BGRA8Unorm texture
@@ -352,7 +352,7 @@ class F extends CopyToTextureUtils {
 
     // The source canvas has bgra8unorm back resource. We
     // swizzle the channels to align with 2d/webgl canvas and
-    // clear alpha to opaque when context compositingAlphaMode
+    // clear alpha to opaque when context alphaMode
     // is set to opaque (follow webgpu spec).
     for (let i = 0; i < height; ++i) {
       for (let j = 0; j < width; ++j) {
@@ -556,7 +556,7 @@ g.test('copy_contents_from_gpu_context_canvas')
 
   TODO: Actually test alphaMode = opaque.
   And do premultiply alpha in advance if the webgpu context is created
-  with compositingAlphaMode="premultiplied".
+  with alphaMode="premultiplied".
 
   Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
   of dst texture, and read the contents out to compare with the canvas contents.

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -9,7 +9,7 @@ type WriteCanvasMethod = 'draw' | 'copy';
 
 export function run(
   format: GPUTextureFormat,
-  compositingAlphaMode: GPUCanvasCompositingAlphaMode,
+  alphaMode: GPUCanvasAlphaMode,
   writeCanvasMethod: WriteCanvasMethod
 ) {
   runRefTest(async t => {
@@ -28,7 +28,7 @@ export function run(
     }
 
     // This is mimic globalAlpha in 2d context blending behavior
-    const a = compositingAlphaMode === 'opaque' ? (1.0).toFixed(1) : (0.5).toFixed(1);
+    const a = alphaMode === 'opaque' ? (1.0).toFixed(1) : (0.5).toFixed(1);
 
     let usage = 0;
     switch (writeCanvasMethod) {
@@ -43,7 +43,7 @@ export function run(
       device: t.device,
       format,
       usage,
-      compositingAlphaMode,
+      alphaMode,
     });
 
     const pipeline = t.device.createRenderPipeline({
@@ -101,7 +101,7 @@ return fragColor;
           {
             format,
             blend:
-              compositingAlphaMode === 'opaque'
+              alphaMode === 'opaque'
                 ? undefined
                 : {
                     // The blending behavior here is to mimic 2d context blending behavior

--- a/src/webgpu/web_platform/reftests/canvas_use_as_image_source.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_use_as_image_source.html.ts
@@ -1,0 +1,98 @@
+import { assert, unreachable } from '../../../common/util/util.js';
+import { kTextureFormatInfo } from '../../capability_info.js';
+import { align } from '../../util/math.js';
+
+import { runRefTest } from './gpu_ref_test.js';
+import {
+  useAsImageSource2dDrawImage,
+  useAsImageSourceToDataURL,
+  useAsImageSourceToBlob,
+  useAsImageSourceCreateImageBitmap,
+  useAsImageSourceWebGLTexImage2D,
+  useAsImageSourceWebGLTexSubImage2D,
+} from './ref/canvas_use_as_image_source_utils.html.js';
+
+const alphaValue = 0x66;
+
+export function run(
+  alphaMode: GPUCanvasAlphaMode,
+  src: HTMLCanvasElement,
+  dst_draw_image: HTMLCanvasElement,
+  dst_data_url: HTMLCanvasElement,
+  dst_blob: HTMLCanvasElement,
+  dst_create_image_bitmap: HTMLCanvasElement,
+  dst_tex_image_2d: HTMLCanvasElement,
+  dst_tex_sub_image_2d: HTMLCanvasElement
+) {
+  runRefTest(async t => {
+    const ctx = src.getContext('webgpu');
+    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+
+    const format = 'bgra8unorm';
+    ctx.configure({
+      device: t.device,
+      format,
+      usage: GPUTextureUsage.COPY_DST,
+      alphaMode,
+    });
+
+    // Write to src canvas
+    const rows = ctx.canvas.height;
+    const bytesPerPixel = kTextureFormatInfo[format].bytesPerBlock;
+    if (bytesPerPixel === undefined) {
+      unreachable();
+    }
+    const bytesPerRow = align(bytesPerPixel * ctx.canvas.width, 256);
+    const componentsPerPixel = 4;
+
+    const buffer = t.device.createBuffer({
+      mappedAtCreation: true,
+      size: rows * bytesPerRow,
+      usage: GPUBufferUsage.COPY_SRC,
+    });
+
+    const mapping = buffer.getMappedRange();
+    const data = new Uint8Array(mapping);
+    const red = new Uint8Array([0x00, 0x00, 0x66, alphaValue]);
+    const green = new Uint8Array([0x00, 0x66, 0x00, alphaValue]);
+    const blue = new Uint8Array([0x66, 0x00, 0x00, alphaValue]);
+    const yellow = new Uint8Array([0x00, 0x66, 0x66, alphaValue]);
+
+    for (let i = 0; i < ctx.canvas.width; ++i) {
+      for (let j = 0; j < ctx.canvas.height; ++j) {
+        let pixel: Uint8Array | Uint16Array;
+        if (i < ctx.canvas.width / 2) {
+          if (j < ctx.canvas.height / 2) {
+            pixel = red;
+          } else {
+            pixel = blue;
+          }
+        } else {
+          if (j < ctx.canvas.height / 2) {
+            pixel = green;
+          } else {
+            pixel = yellow;
+          }
+        }
+        data.set(pixel, (i + j * (bytesPerRow / bytesPerPixel)) * componentsPerPixel);
+      }
+    }
+    buffer.unmap();
+
+    const encoder = t.device.createCommandEncoder();
+    encoder.copyBufferToTexture({ buffer, bytesPerRow }, { texture: ctx.getCurrentTexture() }, [
+      ctx.canvas.width,
+      ctx.canvas.height,
+      1,
+    ]);
+    t.device.queue.submit([encoder.finish()]);
+
+    // Read src canvas as image source and copy to dst canvas
+    useAsImageSource2dDrawImage(src, dst_draw_image);
+    useAsImageSourceToDataURL(src, dst_data_url);
+    useAsImageSourceToBlob(src, dst_blob);
+    useAsImageSourceCreateImageBitmap(src, dst_create_image_bitmap);
+    useAsImageSourceWebGLTexImage2D(src, dst_tex_image_2d);
+    useAsImageSourceWebGLTexSubImage2D(src, dst_tex_sub_image_2d);
+  });
+}

--- a/src/webgpu/web_platform/reftests/canvas_use_as_image_source_opaque.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_use_as_image_source_opaque.https.html
@@ -1,0 +1,32 @@
+<html class="reftest-wait">
+  <title>WebGPU canvas_use_as_image_source_opaque</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta
+    name="assert"
+    content="WebGPU canvas should copy the image applying the correct alpha mode."
+  />
+  <link rel="match" href="./ref/canvas_use_as_image_source_opaque-ref.html" />
+
+  <canvas id="src" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_draw_image" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_data_url" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_blob" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_create_image_bitmap" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_tex_image_2d" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_tex_sub_image_2d" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+
+  <script src="/common/reftest-wait.js"></script>
+  <script type="module">
+    import { run } from './canvas_use_as_image_source.html.js';
+    run('opaque',
+      src,
+      dst_draw_image,
+      dst_data_url,
+      dst_blob,
+      dst_create_image_bitmap,
+      dst_tex_image_2d,
+      dst_tex_sub_image_2d,
+    );
+  </script>
+</html>

--- a/src/webgpu/web_platform/reftests/canvas_use_as_image_source_premultiplied.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_use_as_image_source_premultiplied.https.html
@@ -1,0 +1,32 @@
+<html class="reftest-wait">
+  <title>WebGPU canvas_use_as_image_source_premultiplied</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta
+    name="assert"
+    content="WebGPU canvas should copy the image applying the correct alpha mode."
+  />
+  <link rel="match" href="./ref/canvas_use_as_image_source_premultiplied-ref.html" />
+
+  <canvas id="src" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_draw_image" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_data_url" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_blob" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_create_image_bitmap" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_tex_image_2d" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_tex_sub_image_2d" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+
+  <script src="/common/reftest-wait.js"></script>
+  <script type="module">
+    import { run } from './canvas_use_as_image_source.html.js';
+    run('premultiplied',
+      src,
+      dst_draw_image,
+      dst_data_url,
+      dst_blob,
+      dst_create_image_bitmap,
+      dst_tex_image_2d,
+      dst_tex_sub_image_2d,
+    );
+  </script>
+</html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_use_as_image_source_opaque-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_use_as_image_source_opaque-ref.html
@@ -1,0 +1,44 @@
+<html>
+  <title>WebGPU canvas_use_as_image_source_opaque (ref)</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <canvas id="src" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_draw_image" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_data_url" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_blob" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_create_image_bitmap" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_tex_image_2d" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_tex_sub_image_2d" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <script type="module">
+    import { 
+      useAsImageSource2dDrawImage,
+      useAsImageSourceToDataURL,
+      useAsImageSourceToBlob,
+      useAsImageSourceCreateImageBitmap,
+      useAsImageSourceWebGLTexImage2D,
+      useAsImageSourceWebGLTexSubImage2D,
+    } from './canvas_use_as_image_source_utils.html.js'
+
+    function draw(ctx) {
+      ctx.globalAlpha = 1.0;
+      ctx.fillStyle = '#660000';
+      ctx.fillRect(0, 0, 10, 10);
+      ctx.fillStyle = '#006600';
+      ctx.fillRect(10, 0, 10, 10);
+      ctx.fillStyle = '#000066';
+      ctx.fillRect(0, 10, 10, 10);
+      ctx.fillStyle = '#666600';
+      ctx.fillRect(10, 10, 10, 10);
+    }
+
+    draw(src.getContext('2d'));
+
+    useAsImageSource2dDrawImage(src, dst_draw_image);
+    useAsImageSourceToDataURL(src, dst_data_url);
+    useAsImageSourceToBlob(src, dst_blob);
+    useAsImageSourceCreateImageBitmap(src, dst_create_image_bitmap);
+    useAsImageSourceWebGLTexImage2D(src, dst_tex_image_2d);
+    useAsImageSourceWebGLTexSubImage2D(src, dst_tex_sub_image_2d);
+    
+  </script>
+</html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_use_as_image_source_premultiplied-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_use_as_image_source_premultiplied-ref.html
@@ -1,0 +1,45 @@
+<html>
+  <title>WebGPU canvas_use_as_image_source_premultiplied (ref)</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <canvas id="src" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_draw_image" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_data_url" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_blob" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_create_image_bitmap" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_tex_image_2d" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="dst_tex_sub_image_2d" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <script type="module">
+    import {
+      useAsImageSource2dDrawImage,
+      useAsImageSourceToDataURL,
+      useAsImageSourceToBlob,
+      useAsImageSourceCreateImageBitmap,
+      useAsImageSourceWebGLTexImage2D,
+      useAsImageSourceWebGLTexSubImage2D,
+    } from './canvas_use_as_image_source_utils.html.js'
+
+    function draw(ctx) {
+      ctx.globalAlpha = 0.4;
+      // 0x66 / 0.4 = 0xff, fill with 0xff in 2d context so it's equivalent to "premultiplied" 0x66 in webgpu
+      ctx.fillStyle = '#ff0000';
+      ctx.fillRect(0, 0, 10, 10);
+      ctx.fillStyle = '#00ff00';
+      ctx.fillRect(10, 0, 10, 10);
+      ctx.fillStyle = '#0000ff';
+      ctx.fillRect(0, 10, 10, 10);
+      ctx.fillStyle = '#ffff00';
+      ctx.fillRect(10, 10, 10, 10);
+    }
+
+    draw(src.getContext('2d'));
+
+    useAsImageSource2dDrawImage(src, dst_draw_image);
+    useAsImageSourceToDataURL(src, dst_data_url);
+    useAsImageSourceToBlob(src, dst_blob);
+    useAsImageSourceCreateImageBitmap(src, dst_create_image_bitmap);
+    useAsImageSourceWebGLTexImage2D(src, dst_tex_image_2d);
+    useAsImageSourceWebGLTexSubImage2D(src, dst_tex_sub_image_2d);
+    
+  </script>
+</html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_use_as_image_source_utils.html.ts
+++ b/src/webgpu/web_platform/reftests/ref/canvas_use_as_image_source_utils.html.ts
@@ -1,0 +1,138 @@
+import { assert } from '../../../../common/util/util.js';
+
+export function useAsImageSource2dDrawImage(src: HTMLCanvasElement, dst: HTMLCanvasElement) {
+  const context2d = dst.getContext('2d') as CanvasRenderingContext2D;
+  context2d.drawImage(src, 0, 0);
+}
+
+export function useAsImageSourceToDataURL(src: HTMLCanvasElement, dst: HTMLCanvasElement) {
+  const context2d = dst.getContext('2d') as CanvasRenderingContext2D;
+  const imgFromDataUrl = new Image();
+  imgFromDataUrl.src = src.toDataURL();
+  imgFromDataUrl.onload = () => {
+    context2d.drawImage(imgFromDataUrl, 0, 0);
+  };
+}
+
+export function useAsImageSourceToBlob(src: HTMLCanvasElement, dst: HTMLCanvasElement) {
+  const context2d = dst.getContext('2d') as CanvasRenderingContext2D;
+  const imgFromBlob = new Image(src.width, src.height);
+  src.toBlob(blob => {
+    assert(blob !== null);
+    const url = URL.createObjectURL(blob);
+    imgFromBlob.src = url;
+  });
+  imgFromBlob.onload = () => {
+    context2d.drawImage(imgFromBlob, 0, 0);
+  };
+}
+
+export function useAsImageSourceCreateImageBitmap(src: HTMLCanvasElement, dst: HTMLCanvasElement) {
+  const context2d = dst.getContext('2d') as CanvasRenderingContext2D;
+  createImageBitmap(src).then(image => {
+    context2d.drawImage(image, 0, 0);
+  }, null);
+}
+
+const kVertexShaderSourceWebGL = `
+attribute vec4 a_Position;
+varying vec2 v_Texcoord;
+void main()
+{
+  v_Texcoord = (a_Position.xy + vec2(1.0, 1.0)) * 0.5;
+  v_Texcoord.y = 1.0 - v_Texcoord.y;
+  gl_Position = a_Position;
+}
+`;
+
+const kFragmentShaderSourceWebGL = `
+precision mediump float;
+varying vec2 v_Texcoord;
+uniform sampler2D u_Texture2D;
+void main() {
+  gl_FragColor = texture2D(u_Texture2D, v_Texcoord);
+}
+`;
+
+const kVertices = new Float32Array([1, 1, -1, 1, -1, -1, 1, 1, -1, -1, 1, -1]);
+
+function WebGLDrawTexQuad(gl: WebGLRenderingContext) {
+  const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+  if (vertexShader) {
+    gl.shaderSource(vertexShader, kVertexShaderSourceWebGL);
+    gl.compileShader(vertexShader);
+  } else {
+    return;
+  }
+
+  const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+  if (fragmentShader) {
+    gl.shaderSource(fragmentShader, kFragmentShaderSourceWebGL);
+    gl.compileShader(fragmentShader);
+  } else {
+    return;
+  }
+
+  const program = gl.createProgram();
+  if (!program) {
+    return;
+  }
+  gl.attachShader(program, vertexShader);
+  gl.attachShader(program, fragmentShader);
+  gl.bindAttribLocation(program, 0, 'a_Position');
+  gl.linkProgram(program);
+  gl.useProgram(program);
+
+  const vertexBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, kVertices, gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(0);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+  // Needed to sample a non-power-of-2 texture
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+
+  // Assume texture 0 slot has a texture binded
+  gl.uniform1i(gl.getUniformLocation(program, 'u_Texture2D'), 0);
+
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+  gl.drawArrays(gl.TRIANGLES, 0, 6);
+  gl.flush();
+}
+
+export function useAsImageSourceWebGLTexImage2D(src: HTMLCanvasElement, dst: HTMLCanvasElement) {
+  const gl = dst.getContext('webgl') as WebGLRenderingContext;
+
+  const texture = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, src);
+
+  WebGLDrawTexQuad(gl);
+}
+
+export function useAsImageSourceWebGLTexSubImage2D(src: HTMLCanvasElement, dst: HTMLCanvasElement) {
+  const gl = dst.getContext('webgl') as WebGLRenderingContext;
+
+  const texture = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.texImage2D(
+    gl.TEXTURE_2D,
+    0,
+    gl.RGBA,
+    src.width,
+    src.height,
+    0,
+    gl.RGBA,
+    gl.UNSIGNED_BYTE,
+    null
+  );
+  gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, src);
+
+  WebGLDrawTexQuad(gl);
+}


### PR DESCRIPTION


Issue: #1561 

Test results in current chrome canary (Win 105.0.5176.0 (Official Build) canary (64-bit)):

* canvas_use_as_image_source_opaque
![image](https://user-images.githubusercontent.com/5031596/178842650-31f58873-8e28-42c0-a366-1113b72ee76c.png)

* canvas_use_as_image_source_opaque-ref
![image](https://user-images.githubusercontent.com/5031596/178842752-919dfa90-0856-4641-ad78-1268a2465c1a.png)

Alpha channel clear issue is working at: https://chromium-review.googlesource.com/c/chromium/src/+/3749085

WebGPU to WebGL image copy with incorrect flipY is tracked at: https://bugs.chromium.org/p/chromium/issues/detail?id=1344276

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
