### PR TITLE
Convert `ldexp` tests to use interval framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -33,6 +33,7 @@ import {
   sinInterval,
   subtractionInterval,
   ulpInterval,
+  ldexpInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -1248,6 +1249,55 @@ g.test('divisionInterval')
     const expected = new F32Interval(...t.params.expected);
 
     const got = divisionInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `divisionInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('ldexpInterval')
+  .paramsSubcasesOnly<BinaryToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: [0, 0] },
+      { input: [0, 1], expected: [0, 0] },
+      { input: [0, -1], expected: [0, 0] },
+      { input: [1, 1], expected: [2, 2] },
+      { input: [1, -1], expected: [0.5, 0.5] },
+      { input: [-1, 1], expected: [-2, -2] },
+      { input: [-1, -1], expected: [-0.5, -0.5] },
+
+      // 64-bit normals
+      { input: [0, 0.1], expected: [0, 0] },
+      { input: [0, -0.1], expected: [0, 0] },
+      { input: [1.0000000001, 1], expected: [2, plusNULP(2, 2)] },  // ~2, additional ULP error due to first param not being f32 precise
+      { input: [-1.0000000001, 1], expected: [minusNULP(-2, 2), -2] },  // ~-2, additional ULP error due to first param not being f32 precise
+
+      // Edge Cases
+      { input: [1.9999998807907104, 127], expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
+      { input: [1, -126], expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
+      { input: [0.9999998807907104, -126], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [1.1920928955078125e-07, -126], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [-1.1920928955078125e-07, -126], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [-0.9999998807907104, -126], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [-1, -126], expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
+      { input: [-1.9999998807907104, 127], expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+
+      // Out of Bounds
+      { input: [1, 128], expected: kAny },
+      { input: [-1, 128], expected: kAny },
+      { input: [100, 126], expected: kAny },
+      { input: [-100, 126], expected: kAny },
+      { input: [kValue.f32.positive.max, kValue.i32.positive.max], expected: kAny },
+      { input: [kValue.f32.negative.min, kValue.i32.positive.max], expected: kAny },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = ldexpInterval(x, y);
     t.expect(
       objectEquals(expected, got),
       `divisionInterval(${x}, ${y}) returned ${got}. Expected ${expected}`

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -14,11 +14,16 @@ Returns e1 * 2^e2. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { correctlyRoundedMatch } from '../../../../../util/compare.js';
-import { kValue } from '../../../../../util/constants.js';
+import { intervalComparator } from '../../../../../util/compare.js';
 import { f32, i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
-import { biasedRange, linearRange, quantizeToI32 } from '../../../../../util/math.js';
-import { allInputSources, Case, Config, run } from '../../expression.js';
+import { ldexpInterval } from '../../../../../util/f32_interval.js';
+import {
+  fullF32Range,
+  fullI32Range,
+  quantizeToF32,
+  quantizeToI32,
+} from '../../../../../util/math.js';
+import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -42,50 +47,22 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const truthFunc = (e1: number, e2: number): Case | undefined => {
-      const i32_e2 = quantizeToI32(e2);
-      const result = e1 * Math.pow(2, i32_e2);
-      // Unclear what the expected behaviour for values that overflow f32 bounds, see https://github.com/gpuweb/gpuweb/issues/2631
-      if (!Number.isFinite(result)) {
-        return undefined;
-      } else if (result > kValue.f32.positive.max) {
-        return undefined;
-      } else if (result < kValue.f32.positive.min) {
-        return undefined;
-      }
-      return { input: [f32(e1), i32(e2)], expected: f32(result) };
+    const makeCase = (e1: number, e2: number): Case => {
+      // Due to the heterogeneous types of the params to ldexp (f32 & i32),
+      // makeBinaryF32IntervalCase cannot be used here.
+      e1 = quantizeToF32(e1);
+      e2 = quantizeToI32(e2);
+      const expected = ldexpInterval(e1, e2);
+      return { input: [f32(e1), i32(e2)], expected: intervalComparator(expected) };
     };
 
-    const e1_range: Array<number> = [
-      //  -2^32 < x <= -1, biased towards -1
-      ...biasedRange(-1, -(2 ** 32), 50),
-      // -1 <= x <= 0, linearly spread
-      ...linearRange(-1, 0, 20),
-      // 0 <= x <= -1, linearly spread
-      ...linearRange(0, 1, 20),
-      // 1 <= x < 2^32, biased towards 1
-      ...biasedRange(1, 2 ** 32, 50),
-    ];
-
-    const e2_range: Array<number> = [
-      // -127 < x <= 0, biased towards 0
-      ...biasedRange(0, -127, 20).map(x => Math.round(x)),
-      // 0 <= x < 128, biased towards 0
-      ...biasedRange(0, 128, 20).map(x => Math.round(x)),
-    ];
-
     const cases: Array<Case> = [];
-    e1_range.forEach(e1 => {
-      e2_range.forEach(e2 => {
-        const c = truthFunc(e1, e2);
-        if (c !== undefined) {
-          cases.push(c);
-        }
+    fullF32Range().forEach(e1 => {
+      fullI32Range().forEach(e2 => {
+        cases.push(makeCase(e1, e2));
       });
     });
-    const cfg: Config = t.params;
-    cfg.cmpFloats = correctlyRoundedMatch();
-    run(t, builtin('ldexp'), [TypeF32, TypeI32], TypeF32, cfg, cases);
+    run(t, builtin('ldexp'), [TypeF32, TypeI32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -607,8 +607,6 @@ export function makeUnaryF32IntervalCase(param: number, ...ops: PointToInterval[
  * @param param1 the second param or rhs hand side to pass into the binary operation
  * @param ops callbacks that implement generating an acceptance interval for a binary operation
  */
-// Will be used in test implementations
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function makeBinaryF32IntervalCase(
   param0: number,
   param1: number,
@@ -632,8 +630,6 @@ export function makeBinaryF32IntervalCase(
  * @param ops callbacks that implement generating an acceptance interval for a
  *           ternary operation.
  */
-// Will be used in test implementations
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function makeTernaryF32IntervalCase(
   param0: number,
   param1: number,

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -705,6 +705,35 @@ export function inverseSqrtInterval(n: number | F32Interval): F32Interval {
   return runPointOp(toInterval(n), InverseSqrtIntervalOp);
 }
 
+const LdexpIntervalOp: BinaryToIntervalOp = {
+  impl: limitBinaryToIntervalDomain(
+    // Implementing SPIR-V's more restrictive domain until
+    // https://github.com/gpuweb/gpuweb/issues/3134 is resolved
+    {
+      x: new F32Interval(kValue.f32.negative.min, kValue.f32.positive.max),
+      y: [new F32Interval(-126, 128)],
+    },
+    (e1: number, e2: number): F32Interval => {
+      // Though the spec says the result of ldexp(e1, e2) = e1 * 2 ^ e2, the
+      // accuracy is listed as correctly rounded to the true value, so the
+      // inheritance framework does not need to be invoked to determine bounds.
+      // Instead the value at a higher precision is calculated and passed to
+      // correctlyRoundedInterval.
+      const result = e1 * 2 ** e2;
+      if (Number.isNaN(result)) {
+        // Overflowed TS's number type, so definitely out of bounds for f32
+        return F32Interval.any();
+      }
+      return correctlyRoundedInterval(result);
+    }
+  ),
+};
+
+/** Calculate an acceptance interval of ldexp(e1, e2) */
+export function ldexpInterval(e1: number, e2: number): F32Interval {
+  return roundAndFlushBinaryToInterval(e1, e2, LdexpIntervalOp);
+}
+
 const LogIntervalOp: PointToIntervalOp = {
   impl: limitPointToIntervalDomain(
     kGreaterThanZeroInterval,

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -454,6 +454,28 @@ export function fullF32Range(
 }
 
 /**
+ * @returns an ascending sorted array of numbers spread over the entire range of 32-bit signed ints
+ *
+ * Numbers are divided into 2 regions: negatives, and positives, with their spreads biased towards 0
+ * Zero is included in range.
+ *
+ * @param counts structure param with 2 entries indicating the number of entries to be generated each region, values must be 0 or greater.
+ */
+export function fullI32Range(
+  counts: {
+    negative?: number;
+    positive: number;
+  } = { positive: 50 }
+): Array<number> {
+  counts.negative = counts.negative === undefined ? counts.positive : counts.negative;
+  return [
+    ...biasedRange(kValue.i32.negative.max, kValue.i32.negative.min, counts.negative),
+    0,
+    ...biasedRange(kValue.i32.positive.min, kValue.i32.positive.max, counts.positive),
+  ];
+}
+
+/**
  * @returns the result matrix in Array<Array<number>> type.
  *
  * Matrix multiplication. A is m x n and B is n x p. Returns


### PR DESCRIPTION
Issue #792

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
