### PR TITLE
Make `render_pass_descriptor:resolveTarget,usage` test a valid case together

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -11,6 +11,7 @@ import {
   kRenderableColorTextureFormats,
   kTextureFormatInfo,
 } from '../../../capability_info.js';
+import { GPUConst } from '../../../constants.js';
 import { ValidationTest } from '../validation_test.js';
 
 class F extends ValidationTest {
@@ -537,15 +538,19 @@ g.test('resolveTarget,usage')
     `
   Test that using a resolve target whose usage is not RENDER_ATTACHMENT is invalid for color
   attachments.
-
-  TODO: Add a control case (include vs exclude RENDER_ATTACHMENT usage)
   `
   )
+  .paramsSimple([
+    { usage: GPUConst.TextureUsage.COPY_SRC | GPUConst.TextureUsage.COPY_DST },
+    { usage: GPUConst.TextureUsage.STORAGE_BINDING | GPUConst.TextureUsage.TEXTURE_BINDING },
+    { usage: GPUConst.TextureUsage.STORAGE_BINDING | GPUConst.TextureUsage.STORAGE },
+    { usage: GPUConst.TextureUsage.RENDER_ATTACHMENT | GPUConst.TextureUsage.TEXTURE_BINDING },
+  ])
   .fn(async t => {
+    const { usage } = t.params;
+
     const multisampledColorTexture = t.createTexture({ sampleCount: 4 });
-    const resolveTargetTexture = t.createTexture({
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
-    });
+    const resolveTargetTexture = t.createTexture({ usage });
 
     const colorAttachment = t.getColorAttachment(multisampledColorTexture);
     colorAttachment.resolveTarget = resolveTargetTexture.createView();
@@ -554,7 +559,8 @@ g.test('resolveTarget,usage')
       colorAttachments: [colorAttachment],
     };
 
-    t.tryRenderPass(false, descriptor);
+    const isValid = usage & GPUConst.TextureUsage.RENDER_ATTACHMENT ? true : false;
+    t.tryRenderPass(isValid, descriptor);
   });
 
 g.test('resolveTarget,error_state')


### PR DESCRIPTION
 The `resolveTarget,usage` test has only tested an invalid case
(COPY_SRC | COPY_DST). So this PR adds more cases to check if
the resolveTarget usage is valid.

Issue: #1618

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
