### PR TITLE
Submit all shader batches before checking for results

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -172,9 +172,11 @@ export function run(
     }
   })();
 
+  // Submit all the batches, then check the results.
+  const checkResults: Array<() => void> = [];
   for (let i = 0; i < cases.length; i += casesPerBatch) {
     const batchCases = cases.slice(i, Math.min(i + casesPerBatch, cases.length));
-    runBatch(
+    const checkResult = submitBatch(
       t,
       expressionBuilder,
       parameterTypes,
@@ -183,12 +185,15 @@ export function run(
       cfg.inputSource,
       cmpFloats
     );
+    checkResults.push(checkResult);
   }
+
+  checkResults.forEach(f => f());
 }
 
 /**
- * Runs the list of expression tests. The input data must fit within the buffer
- * binding limits of the given inputSource.
+ * Submits the list of expression tests. The input data must fit within the
+ * buffer binding limits of the given inputSource.
  * @param t the GPUTest
  * @param expressionBuilder the expression builder function
  * @param parameterTypes the list of expression parameter types
@@ -196,8 +201,9 @@ export function run(
  * @param cases list of test cases that fit within the binding limits of the device
  * @param inputSource the source of the input values
  * @param cmpFloats the method to compare floating point numbers
+ * @returns a function that checks the results are as expected
  */
-function runBatch(
+function submitBatch(
   t: GPUTest,
   expressionBuilder: ExpressionBuilder,
   parameterTypes: Array<Type>,
@@ -205,7 +211,7 @@ function runBatch(
   cases: CaseList,
   inputSource: InputSource,
   cmpFloats: FloatMatch
-) {
+): () => void {
   // Construct a buffer to hold the results of the expression tests
   const outputBufferSize = cases.length * kValueStride;
   const outputBuffer = t.device.createBuffer({
@@ -231,35 +237,38 @@ function runBatch(
 
   t.queue.submit([encoder.finish()]);
 
-  const checkExpectation = (outputData: Uint8Array) => {
-    // Read the outputs from the output buffer
-    const outputs = new Array<Value>(cases.length);
-    for (let i = 0; i < cases.length; i++) {
-      outputs[i] = returnType.read(outputData, i * kValueStride);
-    }
+  // Return a function that can check the results of the shader
+  return () => {
+    const checkExpectation = (outputData: Uint8Array) => {
+      // Read the outputs from the output buffer
+      const outputs = new Array<Value>(cases.length);
+      for (let i = 0; i < cases.length; i++) {
+        outputs[i] = returnType.read(outputData, i * kValueStride);
+      }
 
-    // The list of expectation failures
-    const errs: string[] = [];
+      // The list of expectation failures
+      const errs: string[] = [];
 
-    // For each case...
-    for (let caseIdx = 0; caseIdx < cases.length; caseIdx++) {
-      const c = cases[caseIdx];
-      const got = outputs[caseIdx];
-      const cmp = toComparator(c.expected)(got, cmpFloats);
-      if (!cmp.matched) {
-        errs.push(`(${c.input instanceof Array ? c.input.join(', ') : c.input})
+      // For each case...
+      for (let caseIdx = 0; caseIdx < cases.length; caseIdx++) {
+        const c = cases[caseIdx];
+        const got = outputs[caseIdx];
+        const cmp = toComparator(c.expected)(got, cmpFloats);
+        if (!cmp.matched) {
+          errs.push(`(${c.input instanceof Array ? c.input.join(', ') : c.input})
     returned: ${cmp.got}
     expected: ${cmp.expected}`);
+        }
       }
-    }
 
-    return errs.length > 0 ? new Error(errs.join('\n\n')) : undefined;
+      return errs.length > 0 ? new Error(errs.join('\n\n')) : undefined;
+    };
+
+    t.expectGPUBufferValuesPassCheck(outputBuffer, checkExpectation, {
+      type: Uint8Array,
+      typedLength: outputBufferSize,
+    });
   };
-
-  t.expectGPUBufferValuesPassCheck(outputBuffer, checkExpectation, {
-    type: Uint8Array,
-    typedLength: outputBufferSize,
-  });
 }
 
 /**


### PR DESCRIPTION
For tests that submit multiple batches, ensure that all shaders are submitted before attempting to pull and check the results.

Allows parallelization between the GPU and CPU.

For the particularly slow `atan2` test, the timings are:


|  Time reduction | ~0.85x |
|-|-|
|  Without change | 1.65213984764s |
|  With change |    1.3956103941s |

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
