### PR TITLE
Update compositingAlphaMode -> alphaMode

### DIFF
--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -238,7 +238,7 @@ class F extends CopyToTextureUtils {
 
     const alphaValue = 153;
     // colorValue can just always = alphaValue now, because readback will clear it to
-    // 255 if opaque. Need to try this and verify it.
+    // 255 if opaque.
     const colorValue = alphaValue;
 
     // BGRA8Unorm texture

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -296,7 +296,7 @@ class F extends CopyToTextureUtils {
       device,
       format: 'bgra8unorm',
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
-      compositingAlphaMode: alphaMode,
+      alphaMode,
     });
 
     // BGRA8Unorm texture
@@ -352,7 +352,7 @@ class F extends CopyToTextureUtils {
 
     // The source canvas has bgra8unorm back resource. We
     // swizzle the channels to align with 2d/webgl canvas and
-    // clear alpha to opaque when context compositingAlphaMode
+    // clear alpha to opaque when context alphaMode
     // is set to opaque (follow webgpu spec).
     for (let i = 0; i < height; ++i) {
       for (let j = 0; j < width; ++j) {
@@ -556,7 +556,7 @@ g.test('copy_contents_from_gpu_context_canvas')
 
   TODO: Actually test alphaMode = opaque.
   And do premultiply alpha in advance if the webgpu context is created
-  with compositingAlphaMode="premultiplied".
+  with alphaMode="premultiplied".
 
   Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
   of dst texture, and read the contents out to compare with the canvas contents.

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -237,15 +237,9 @@ class F extends CopyToTextureUtils {
     const rectHeight = Math.floor(height / 2);
 
     const alphaValue = 153;
-    // TODO: I think colorValue can just always = alphaValue now, because readback will clear it to
+    // colorValue can just always = alphaValue now, because readback will clear it to
     // 255 if opaque. Need to try this and verify it.
-    // (Prior to the compositingAlphaMode->alphaMode change, I think the coverage here was just
-    // not as good. Ideally we would have been testing the results of an 'opaque' canvas with
-    // transparent data in it, which then would have produced a transparent readback, and now will
-    // produce an opaque readback.)
-    //
-    // const colorValue = alphaValue;
-    const colorValue = { premultiplied: alphaValue, opaque: 255 }[alphaMode];
+    const colorValue = alphaValue;
 
     // BGRA8Unorm texture
     const initialData = new Uint8ClampedArray(4 * width * height);

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -237,8 +237,10 @@ class F extends CopyToTextureUtils {
     const rectHeight = Math.floor(height / 2);
 
     const alphaValue = 153;
-    // colorValue can just always = alphaValue now, because readback will clear it to
-    // 255 if opaque.
+    // Always output [153, 153, 153, 153]. When the alphaMode is...
+    //   - premultiplied: the readback is CSS `rgba(255, 255, 255, 60%)`.
+    //   - opaque: the readback is CSS `rgba(153, 153, 153, 100%)`.
+    // getExpectedReadbackForWebGPUCanvas matches this.
     const colorValue = alphaValue;
 
     // BGRA8Unorm texture

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -24,7 +24,7 @@ class F extends CopyToTextureUtils {
     colorSpace: 'srgb' | 'display-p3';
   }): {
     canvas: HTMLCanvasElement | OffscreenCanvas;
-    canvasContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    expectedSourceData: Uint8ClampedArray;
   } {
     const canvas = createCanvas(this, 'onscreen', width, height);
 
@@ -105,7 +105,10 @@ class F extends CopyToTextureUtils {
     const ctx = canvasContext as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
     ctx.putImageData(imageData, 0, 0);
 
-    return { canvas, canvasContext };
+    return {
+      canvas,
+      expectedSourceData: this.getExpectedReadbackFor2DCanvas(canvasContext, width, height),
+    };
   }
 
   // MAINTENANCE_TODO: Cache the generated canvas to avoid duplicated initialization.
@@ -119,7 +122,7 @@ class F extends CopyToTextureUtils {
     height: number;
   }): {
     canvas: HTMLCanvasElement | OffscreenCanvas;
-    canvasContext: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D;
+    expectedSourceData: Uint8ClampedArray;
   } {
     const canvas = createCanvas(this, canvasType, width, height);
 
@@ -133,10 +136,13 @@ class F extends CopyToTextureUtils {
     const ctx = canvasContext;
     this.paint2DCanvas(ctx, width, height, 0.6);
 
-    return { canvas, canvasContext };
+    return {
+      canvas,
+      expectedSourceData: this.getExpectedReadbackFor2DCanvas(canvasContext, width, height),
+    };
   }
 
-  paint2DCanvas(
+  private paint2DCanvas(
     ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
     width: number,
     height: number,
@@ -174,7 +180,7 @@ class F extends CopyToTextureUtils {
     premultiplied: boolean;
   }): {
     canvas: HTMLCanvasElement | OffscreenCanvas;
-    canvasContext: WebGLRenderingContext | WebGL2RenderingContext;
+    expectedSourceData: Uint8ClampedArray;
   } {
     const canvas = createCanvas(this, canvasType, width, height);
 
@@ -216,10 +222,13 @@ class F extends CopyToTextureUtils {
     gl.clearColor(colorValue, colorValue, colorValue, alphaValue);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    return { canvas, canvasContext: gl };
+    return {
+      canvas,
+      expectedSourceData: this.getExpectedReadbackForWebGLCanvas(gl, width, height),
+    };
   }
 
-  getInitGPUCanvasData(
+  private getDataToInitSourceWebGPUCanvas(
     width: number,
     height: number,
     alphaMode: GPUCanvasAlphaMode
@@ -228,7 +237,15 @@ class F extends CopyToTextureUtils {
     const rectHeight = Math.floor(height / 2);
 
     const alphaValue = 153;
-    const colorValue = alphaMode === 'premultiplied' ? alphaValue : 255;
+    // TODO: I think colorValue can just always = alphaValue now, because readback will clear it to
+    // 255 if opaque. Need to try this and verify it.
+    // (Prior to the compositingAlphaMode->alphaMode change, I think the coverage here was just
+    // not as good. Ideally we would have been testing the results of an 'opaque' canvas with
+    // transparent data in it, which then would have produced a transparent readback, and now will
+    // produce an opaque readback.)
+    //
+    // const colorValue = alphaValue;
+    const colorValue = { premultiplied: alphaValue, opaque: 255 }[alphaMode];
 
     // BGRA8Unorm texture
     const initialData = new Uint8ClampedArray(4 * width * height);
@@ -272,7 +289,7 @@ class F extends CopyToTextureUtils {
     return initialData;
   }
 
-  initGPUCanvasContent({
+  initSourceWebGPUCanvas({
     device,
     canvasType,
     width,
@@ -286,6 +303,7 @@ class F extends CopyToTextureUtils {
     alphaMode: GPUCanvasAlphaMode;
   }): {
     canvas: HTMLCanvasElement | OffscreenCanvas;
+    expectedSourceData: Uint8ClampedArray;
   } {
     const canvas = createCanvas(this, canvasType, width, height);
 
@@ -303,7 +321,7 @@ class F extends CopyToTextureUtils {
     });
 
     // BGRA8Unorm texture
-    const initialData = this.getInitGPUCanvasData(width, height, alphaMode);
+    const initialData = this.getDataToInitSourceWebGPUCanvas(width, height, alphaMode);
     const canvasTexture = gpuContext.getCurrentTexture();
     device.queue.writeTexture(
       { texture: canvasTexture },
@@ -319,10 +337,13 @@ class F extends CopyToTextureUtils {
       }
     );
 
-    return { canvas };
+    return {
+      canvas,
+      expectedSourceData: this.getExpectedReadbackForWebGPUCanvas(width, height, alphaMode),
+    };
   }
 
-  getSourceCanvas2DContent(
+  private getExpectedReadbackFor2DCanvas(
     context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
     width: number,
     height: number
@@ -331,7 +352,7 @@ class F extends CopyToTextureUtils {
     return context.getImageData(0, 0, width, height).data;
   }
 
-  getSourceCanvasGLContent(
+  private getExpectedReadbackForWebGLCanvas(
     gl: WebGLRenderingContext | WebGL2RenderingContext,
     width: number,
     height: number
@@ -344,14 +365,14 @@ class F extends CopyToTextureUtils {
     return this.doFlipY(sourcePixels, width, height, bytesPerPixel);
   }
 
-  calculateSourceContentOnCPU(
+  private getExpectedReadbackForWebGPUCanvas(
     width: number,
     height: number,
     alphaMode: GPUCanvasAlphaMode
   ): Uint8ClampedArray {
     const bytesPerPixel = 4;
 
-    const rgbaPixels = this.getInitGPUCanvasData(width, height, alphaMode);
+    const rgbaPixels = this.getDataToInitSourceWebGPUCanvas(width, height, alphaMode);
 
     // The source canvas has bgra8unorm back resource. We
     // swizzle the channels to align with 2d/webgl canvas and
@@ -374,8 +395,8 @@ class F extends CopyToTextureUtils {
   }
 
   doCopyContentsTest(
-    canvas: HTMLCanvasElement | OffscreenCanvas,
-    sourcePixels: Uint8ClampedArray,
+    source: HTMLCanvasElement | OffscreenCanvas,
+    expectedSourceImage: Uint8ClampedArray,
     p: {
       width: number;
       height: number;
@@ -402,8 +423,8 @@ class F extends CopyToTextureUtils {
 
     // For 2d canvas, get expected pixels with getImageData(), which returns unpremultiplied
     // values.
-    const expTexelView = this.getExpectedPixels(
-      sourcePixels,
+    const expectedDestinationImage = this.getExpectedPixels(
+      expectedSourceImage,
       p.width,
       p.height,
       expFormat,
@@ -415,14 +436,14 @@ class F extends CopyToTextureUtils {
     );
 
     this.doTestAndCheckResult(
-      { source: canvas, origin: { x: 0, y: 0 }, flipY: p.srcDoFlipYDuringCopy },
+      { source, origin: { x: 0, y: 0 }, flipY: p.srcDoFlipYDuringCopy },
       {
         texture: dst,
         origin: { x: 0, y: 0 },
         colorSpace: 'srgb',
         premultipliedAlpha: p.dstPremultiplied,
       },
-      expTexelView,
+      expectedDestinationImage,
       { width: p.width, height: p.height, depthOrArrayLayers: 1 },
       // 1.0 and 0.6 are representable precisely by all formats except rgb10a2unorm, but
       // allow diffs of 1ULP since that's the generally-appropriate threshold.
@@ -476,14 +497,13 @@ g.test('copy_contents_from_2d_context_canvas')
   .fn(async t => {
     const { width, height, canvasType, dstAlphaMode } = t.params;
 
-    const { canvas, canvasContext } = t.init2DCanvasContent({
+    const { canvas, expectedSourceData } = t.init2DCanvasContent({
       canvasType,
       width,
       height,
     });
-    const sourcePixels = t.getSourceCanvas2DContent(canvasContext, width, height);
 
-    t.doCopyContentsTest(canvas, sourcePixels, {
+    t.doCopyContentsTest(canvas, expectedSourceData, {
       srcPremultiplied: false,
       dstPremultiplied: dstAlphaMode === 'premultiplied',
       ...t.params,
@@ -538,16 +558,15 @@ g.test('copy_contents_from_gl_context_canvas')
   .fn(async t => {
     const { width, height, canvasType, contextName, srcPremultiplied, dstAlphaMode } = t.params;
 
-    const { canvas, canvasContext } = t.initGLCanvasContent({
+    const { canvas, expectedSourceData } = t.initGLCanvasContent({
       canvasType,
       contextName,
       width,
       height,
       premultiplied: srcPremultiplied,
     });
-    const sourcePixels = t.getSourceCanvasGLContent(canvasContext, width, height);
 
-    t.doCopyContentsTest(canvas, sourcePixels, {
+    t.doCopyContentsTest(canvas, expectedSourceData, {
       dstPremultiplied: dstAlphaMode === 'premultiplied',
       ...t.params,
     });
@@ -581,7 +600,7 @@ g.test('copy_contents_from_gpu_context_canvas')
   - Valid canvas type
   - Source WebGPU Canvas lives in the same GPUDevice or different GPUDevice as test
   - Valid dstColorFormat of copyExternalImageToTexture()
-  - Valid source image alphaMode
+  - TODO: test more source image alphaMode
   - Valid dest alphaMode
   - Valid 'flipY' config in 'GPUImageCopyExternalImage'(named 'srcDoFlipYDuringCopy' in cases)
   - TODO: color space tests need to be added
@@ -616,16 +635,15 @@ g.test('copy_contents_from_gpu_context_canvas')
     } = t.params;
 
     const device = srcAndDstInSameGPUDevice ? t.device : t.mismatchedDevice;
-    const { canvas } = t.initGPUCanvasContent({
+    const { canvas: source, expectedSourceData } = t.initSourceWebGPUCanvas({
       device,
       canvasType,
       width,
       height,
       alphaMode: srcAlphaMode,
     });
-    const sourcePixels = t.calculateSourceContentOnCPU(width, height, srcAlphaMode);
 
-    t.doCopyContentsTest(canvas, sourcePixels, {
+    t.doCopyContentsTest(source, expectedSourceData, {
       srcPremultiplied: srcAlphaMode === 'premultiplied',
       dstPremultiplied: dstAlphaMode === 'premultiplied',
       ...t.params,
@@ -688,7 +706,7 @@ g.test('color_space_conversion')
       dstPremultiplied,
       srcDoFlipYDuringCopy,
     } = t.params;
-    const { canvas, canvasContext } = t.init2DCanvasContentWithColorSpace({
+    const { canvas, expectedSourceData } = t.init2DCanvasContentWithColorSpace({
       width,
       height,
       colorSpace: srcColorSpace,
@@ -701,10 +719,8 @@ g.test('color_space_conversion')
         GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
-    const sourcePixels = t.getSourceCanvas2DContent(canvasContext, width, height);
-
-    const expTexelView = t.getExpectedPixels(
-      sourcePixels,
+    const expectedDestinationImage = t.getExpectedPixels(
+      expectedSourceData,
       width,
       height,
       // copyExternalImageToTexture does not perform gamma-encoding into `-srgb` formats.
@@ -737,7 +753,7 @@ g.test('color_space_conversion')
         colorSpace: dstColorSpace,
         premultipliedAlpha: dstPremultiplied,
       },
-      expTexelView,
+      expectedDestinationImage,
       { width, height, depthOrArrayLayers: 1 },
       texelCompareOptions
     );

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -111,7 +111,7 @@ function createExternalTextureSamplingTestBindGroup(
 
   const externalTexture = t.device.importExternalTexture({
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    source,
+    source: source as any,
   });
 
   const bindGroup = t.device.createBindGroup({
@@ -279,7 +279,7 @@ TODO: Make this test work without requestVideoFrameCallback support (in waitForN
           : videoElement;
       externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        source,
+        source: source as any,
       });
       // Set `bindGroup` here, which will then be used in microtask1 and microtask3.
       bindGroup = t.device.createBindGroup({
@@ -339,7 +339,7 @@ TODO: add 'VideoFrame' as an additional 'sourceType'
           : videoElement;
       const externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        source,
+        source: source as any,
       });
 
       const outputTexture = t.device.createTexture({

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -111,7 +111,7 @@ function createExternalTextureSamplingTestBindGroup(
 
   const externalTexture = t.device.importExternalTexture({
     /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-    source: source as any,
+    source,
   });
 
   const bindGroup = t.device.createBindGroup({
@@ -279,7 +279,7 @@ TODO: Make this test work without requestVideoFrameCallback support (in waitForN
           : videoElement;
       externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        source: source as any,
+        source,
       });
       // Set `bindGroup` here, which will then be used in microtask1 and microtask3.
       bindGroup = t.device.createBindGroup({
@@ -339,7 +339,7 @@ TODO: add 'VideoFrame' as an additional 'sourceType'
           : videoElement;
       const externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        source: source as any,
+        source,
       });
 
       const outputTexture = t.device.createTexture({

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -28,7 +28,7 @@ export function run(
     }
 
     // This is mimic globalAlpha in 2d context blending behavior
-    const a = alphaMode === 'opaque' ? (1.0).toFixed(1) : (0.5).toFixed(1);
+    const alphaFromShader = { premultiplied: '0.5', opaque: '1.0' }[alphaMode];
 
     let usage = 0;
     switch (writeCanvasMethod) {
@@ -45,6 +45,22 @@ export function run(
       usage,
       alphaMode,
     });
+
+    // The blending behavior here is to mimic 2d context blending behavior
+    // of drawing rects in order
+    // https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_srcover
+    const kBlendStateSourceOver = {
+      color: {
+        srcFactor: 'src-alpha',
+        dstFactor: 'one-minus-src-alpha',
+        operation: 'add',
+      },
+      alpha: {
+        srcFactor: 'one',
+        dstFactor: 'one-minus-src-alpha',
+        operation: 'add',
+      },
+    } as const;
 
     const pipeline = t.device.createRenderPipeline({
       layout: 'auto',
@@ -73,10 +89,10 @@ vec2<f32>(-0.25, -0.25),
 vec2<f32>( 0.25,  -0.25));
 
 var color = array<vec4<f32>, 4>(
-    vec4<f32>(0.4, 0.0, 0.0, ${a}),
-    vec4<f32>(0.0, 0.4, 0.0, ${a}),
-    vec4<f32>(0.0, 0.0, 0.4, ${a}),
-    vec4<f32>(0.4, 0.4, 0.0, ${a})); // 0.4 -> 0x66
+    vec4<f32>(0.4, 0.0, 0.0, ${alphaFromShader}),
+    vec4<f32>(0.0, 0.4, 0.0, ${alphaFromShader}),
+    vec4<f32>(0.0, 0.0, 0.4, ${alphaFromShader}),
+    vec4<f32>(0.4, 0.4, 0.0, ${alphaFromShader})); // 0.4 -> 0x66
 
 var output : VertexOutput;
 output.Position = vec4<f32>(pos[VertexIndex % 6u] + offset[VertexIndex / 6u], 0.0, 1.0);
@@ -100,24 +116,7 @@ return fragColor;
         targets: [
           {
             format,
-            blend:
-              alphaMode === 'opaque'
-                ? undefined
-                : {
-                    // The blending behavior here is to mimic 2d context blending behavior
-                    // of drawing rects in order
-                    // https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_srcover
-                    color: {
-                      srcFactor: 'src-alpha',
-                      dstFactor: 'one-minus-src-alpha',
-                      operation: 'add',
-                    },
-                    alpha: {
-                      srcFactor: 'one',
-                      dstFactor: 'one-minus-src-alpha',
-                      operation: 'add',
-                    },
-                  },
+            blend: { premultiplied: kBlendStateSourceOver, opaque: undefined }[alphaMode],
           },
         ],
       },

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -9,7 +9,7 @@ type WriteCanvasMethod = 'draw' | 'copy';
 
 export function run(
   format: GPUTextureFormat,
-  compositingAlphaMode: GPUCanvasCompositingAlphaMode,
+  alphaMode: GPUCanvasAlphaMode,
   writeCanvasMethod: WriteCanvasMethod
 ) {
   runRefTest(async t => {
@@ -28,7 +28,7 @@ export function run(
     }
 
     // This is mimic globalAlpha in 2d context blending behavior
-    const a = compositingAlphaMode === 'opaque' ? (1.0).toFixed(1) : (0.5).toFixed(1);
+    const a = alphaMode === 'opaque' ? (1.0).toFixed(1) : (0.5).toFixed(1);
 
     let usage = 0;
     switch (writeCanvasMethod) {
@@ -43,7 +43,7 @@ export function run(
       device: t.device,
       format,
       usage,
-      compositingAlphaMode,
+      alphaMode,
     });
 
     const pipeline = t.device.createRenderPipeline({
@@ -101,7 +101,7 @@ return fragColor;
           {
             format,
             blend:
-              compositingAlphaMode === 'opaque'
+              alphaMode === 'opaque'
                 ? undefined
                 : {
                     // The blending behavior here is to mimic 2d context blending behavior


### PR DESCRIPTION
Issue: #1561

Split from https://github.com/gpuweb/cts/pull/1657

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
