### PR TITLE
Expand readbackFromWebGPUCanvas test with alphaMode

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -253,7 +253,7 @@ export const kRenderableColorTextureFormats = kRegularTextureFormats.filter(
 export const kCanvasTextureFormats = ['bgra8unorm', 'rgba8unorm', 'rgba16float'] as const;
 
 // The alpha mode for canvas context.
-export const kCanvasAlphaMode = ['opaque', 'premultiplied'] as const;
+export const kCanvasAlphaModes = ['opaque', 'premultiplied'] as const;
 
 /** Per-GPUTextureFormat info. */
 // Exists just for documentation. Otherwise could be inferred by `makeTable`.

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -252,6 +252,9 @@ export const kRenderableColorTextureFormats = kRegularTextureFormats.filter(
 // The formats of GPUTextureFormat for canvas context.
 export const kCanvasTextureFormats = ['bgra8unorm', 'rgba8unorm', 'rgba16float'] as const;
 
+// The alpha mode for canvas context.
+export const kCanvasAlphaMode = ['opaque', 'premultiplied'] as const;
+
 /** Per-GPUTextureFormat info. */
 // Exists just for documentation. Otherwise could be inferred by `makeTable`.
 // MAINTENANCE_TODO: Refactor this to separate per-aspect data for multi-aspect formats. In particular:

--- a/src/webgpu/util/create_elements.ts
+++ b/src/webgpu/util/create_elements.ts
@@ -1,6 +1,12 @@
 import { Fixture } from '../../common/framework/fixture.js';
 import { unreachable } from '../../common/util/util.js';
 
+// TESTING_TODO: This should expand to more canvas types (which will enhance a bunch of tests):
+// - canvas element not in dom
+// - canvas element in dom
+// - offscreen canvas from transferControlToOffscreen from canvas not in dom
+// - offscreen canvas from transferControlToOffscreen from canvas in dom
+// - offscreen canvas from new OffscreenCanvas
 export const kAllCanvasTypes = ['onscreen', 'offscreen'] as const;
 export type CanvasType = typeof kAllCanvasTypes[number];
 

--- a/src/webgpu/util/create_elements.ts
+++ b/src/webgpu/util/create_elements.ts
@@ -4,6 +4,11 @@ import { unreachable } from '../../common/util/util.js';
 export const kAllCanvasTypes = ['onscreen', 'offscreen'] as const;
 export type CanvasType = typeof kAllCanvasTypes[number];
 
+type CanvasForCanvasType<T extends CanvasType> = {
+  onscreen: HTMLCanvasElement;
+  offscreen: OffscreenCanvas;
+}[T];
+
 /** Valid contextId for HTMLCanvasElement/OffscreenCanvas,
  *  spec: https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext
  */
@@ -30,30 +35,27 @@ export function canCopyFromCanvasContext(contextName: CanvasContext) {
 }
 
 /** Create HTMLCanvas/OffscreenCanvas. */
-export function createCanvas(
+export function createCanvas<T extends CanvasType>(
   test: Fixture,
-  canvasType: 'onscreen' | 'offscreen',
+  canvasType: T,
   width: number,
   height: number
-): HTMLCanvasElement | OffscreenCanvas {
-  let canvas: HTMLCanvasElement | OffscreenCanvas;
+): CanvasForCanvasType<T> {
   if (canvasType === 'onscreen') {
     if (typeof document !== 'undefined') {
-      canvas = createOnscreenCanvas(test, width, height);
+      return createOnscreenCanvas(test, width, height) as CanvasForCanvasType<T>;
     } else {
       test.skip('Cannot create HTMLCanvasElement');
     }
   } else if (canvasType === 'offscreen') {
     if (typeof OffscreenCanvas !== 'undefined') {
-      canvas = createOffscreenCanvas(test, width, height);
+      return createOffscreenCanvas(test, width, height) as CanvasForCanvasType<T>;
     } else {
       test.skip('Cannot create an OffscreenCanvas');
     }
   } else {
     unreachable();
   }
-
-  return canvas;
 }
 
 /** Create HTMLCanvasElement. */

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -122,7 +122,10 @@ function readPixelsFrom2DCanvasAndCompare(
 g.test('onscreenCanvas,snapshot')
   .desc(
     `
-    Ensure snapshot of canvas with WebGPU context is correct
+    Ensure snapshot of canvas with WebGPU context is correct with
+    - various WebGPU canvas texture formats
+    - WebGPU canvas alpha mode = {"opaque", "premultiplied"}
+    - snapshot methods = {convertToBlob, transferToImageBitmap, createImageBitmap}
 
     TODO: Snapshot canvas to jpeg, webp and other mime type and
           different quality. Maybe we should test them in reftest.
@@ -173,7 +176,10 @@ g.test('onscreenCanvas,snapshot')
 g.test('offscreenCanvas,snapshot')
   .desc(
     `
-    Ensure snapshot of offscreenCanvas with WebGPU context is correct
+    Ensure snapshot of offscreenCanvas with WebGPU context is correct with
+    - various WebGPU canvas texture formats
+    - WebGPU canvas alpha mode = {"opaque", "premultiplied"}
+    - snapshot methods = {convertToBlob, transferToImageBitmap, createImageBitmap}
 
     TODO: Snapshot offscreenCanvas to jpeg, webp and other mime type and
           different quality. Maybe we should test them in reftest.
@@ -230,7 +236,10 @@ g.test('offscreenCanvas,snapshot')
 g.test('onscreenCanvas,uploadToWebGL')
   .desc(
     `
-    Ensure upload WebGPU context canvas to webgl texture is correct.
+    Ensure upload WebGPU context canvas to webgl texture is correct with
+    - various WebGPU canvas texture formats
+    - WebGPU canvas alpha mode = {"opaque", "premultiplied"}
+    - upload methods = {texImage2D, texSubImage2D}
     `
   )
   .params(u =>
@@ -291,7 +300,11 @@ g.test('onscreenCanvas,uploadToWebGL')
 g.test('drawTo2DCanvas')
   .desc(
     `
-    Ensure draw WebGPU context canvas to 2d context canvas/offscreenCanvas is correct.
+    Ensure draw WebGPU context canvas to 2d context canvas/offscreenCanvas is correct with
+    - various WebGPU canvas texture formats
+    - WebGPU canvas alpha mode = {"opaque", "premultiplied"}
+    - WebGPU canvas type = {"onscreen", "offscreen"}
+    - 2d canvas type = {"onscreen", "offscreen"}
     `
   )
   .params(u =>

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -23,8 +23,8 @@ export const g = makeTestGroup(GPUTest);
 // Given a pixel value of RGBA = (0x66, 0, 0, 0x66) in the source WebGPU canvas,
 // For alphaMode = opaque, the copy output should be RGBA = (0x66, 0, 0, 0xff)
 // For alphaMode = premultiplied, the copy output should be RGBA = (0xff, 0, 0, 0x66)
-const pixelValue = 0x66;
-const pixelValueFloat = 0x66 / 0xff; // 0.4
+const kPixelValue = 0x66;
+const kPixelValueFloat = 0x66 / 0xff; // 0.4
 
 // Use four pixels rectangle for the test:
 // blue: top-left;
@@ -34,17 +34,17 @@ const pixelValueFloat = 0x66 / 0xff; // 0.4
 const expect = {
   /* prettier-ignore */
   'opaque': new Uint8ClampedArray([
-    0, 0, pixelValue, 0xff, // blue
-    0, pixelValue, 0, 0xff, // green
-    pixelValue, 0, 0, 0xff, // red
-    pixelValue, pixelValue, 0, 0xff, // yellow
+    0, 0, kPixelValue, 0xff, // blue
+    0, kPixelValue, 0, 0xff, // green
+    kPixelValue, 0, 0, 0xff, // red
+    kPixelValue, kPixelValue, 0, 0xff, // yellow
   ]),
   /* prettier-ignore */
   'premultiplied': new Uint8ClampedArray([
-    0, 0, 0xff, pixelValue, // blue
-    0, 0xff, 0, pixelValue, // green
-    0xff, 0, 0, pixelValue, // red
-    0xff, 0xff, 0, pixelValue, // yellow
+    0, 0, 0xff, kPixelValue, // blue
+    0, 0xff, 0, kPixelValue, // green
+    0xff, 0, 0, kPixelValue, // red
+    0xff, 0xff, 0, kPixelValue, // yellow
   ]),
 };
 
@@ -88,10 +88,10 @@ async function initCanvasContent<T extends CanvasType>(
     );
   };
 
-  clearOnePixel([0, 0], [0, 0, pixelValueFloat, pixelValueFloat]);
-  clearOnePixel([1, 0], [0, pixelValueFloat, 0, pixelValueFloat]);
-  clearOnePixel([0, 1], [pixelValueFloat, 0, 0, pixelValueFloat]);
-  clearOnePixel([1, 1], [pixelValueFloat, pixelValueFloat, 0, pixelValueFloat]);
+  clearOnePixel([0, 0], [0, 0, kPixelValueFloat, kPixelValueFloat]);
+  clearOnePixel([1, 0], [0, kPixelValueFloat, 0, kPixelValueFloat]);
+  clearOnePixel([0, 1], [kPixelValueFloat, 0, 0, kPixelValueFloat]);
+  clearOnePixel([1, 1], [kPixelValueFloat, kPixelValueFloat, 0, kPixelValueFloat]);
 
   t.device.queue.submit([encoder.finish()]);
   tempTexture.destroy();

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -53,12 +53,12 @@ const expect = {
   ]),
 };
 
-async function initCanvasContent(
+async function initCanvasContent<T extends CanvasType>(
   t: GPUTest,
   format: GPUTextureFormat,
   alphaMode: GPUCanvasAlphaMode,
-  canvasType: CanvasType
-): Promise<HTMLCanvasElement | OffscreenCanvas> {
+  canvasType: T
+) {
   const canvas = createCanvas(t, canvasType, 2, 2);
   const ctx = canvas.getContext('webgpu' as const);
   assert(ctx !== null, 'Failed to get WebGPU context from canvas');
@@ -140,12 +140,7 @@ g.test('onscreenCanvas,snapshot')
       .combine('snapshotType', ['toDataURL', 'toBlob', 'imageBitmap'])
   )
   .fn(async t => {
-    const canvas = (await initCanvasContent(
-      t,
-      t.params.format,
-      t.params.alphaMode,
-      'onscreen'
-    )) as HTMLCanvasElement;
+    const canvas = await initCanvasContent(t, t.params.format, t.params.alphaMode, 'onscreen');
 
     let snapshot: HTMLImageElement | ImageBitmap;
     switch (t.params.snapshotType) {
@@ -196,12 +191,12 @@ g.test('offscreenCanvas,snapshot')
       .combine('snapshotType', ['convertToBlob', 'transferToImageBitmap', 'imageBitmap'])
   )
   .fn(async t => {
-    const offscreenCanvas = (await initCanvasContent(
+    const offscreenCanvas = await initCanvasContent(
       t,
       t.params.format,
       t.params.alphaMode,
       'offscreen'
-    )) as OffscreenCanvas;
+    );
 
     let snapshot: HTMLImageElement | ImageBitmap;
     switch (t.params.snapshotType) {
@@ -252,12 +247,7 @@ g.test('onscreenCanvas,uploadToWebGL')
   )
   .fn(async t => {
     const { format, webgl, upload } = t.params;
-    const canvas = (await initCanvasContent(
-      t,
-      format,
-      t.params.alphaMode,
-      'onscreen'
-    )) as HTMLCanvasElement;
+    const canvas = await initCanvasContent(t, format, t.params.alphaMode, 'onscreen');
 
     const expectCanvas: HTMLCanvasElement = createOnscreenCanvas(t, canvas.width, canvas.height);
     const gl = expectCanvas.getContext(webgl) as WebGLRenderingContext | WebGL2RenderingContext;

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -1,12 +1,7 @@
 export const description = `
 Tests for readback from WebGPU Canvas.
 
-TODO: implement all canvas types:
-- canvas element not in dom
-- canvas element in dom
-- offscreen canvas from transferControlToOffscreen from canvas not in dom
-- offscreen canvas from transferControlToOffscreen from canvas in dom
-- offscreen canvas from new OffscreenCanvas
+TODO: implement all canvas types, see TODO on kCanvasTypes.
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -11,7 +11,7 @@ TODO: implement all canvas types:
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { assert, raceWithRejectOnTimeout, unreachable } from '../../../common/util/util.js';
-import { kCanvasAlphaMode, kCanvasTextureFormats } from '../../capability_info.js';
+import { kCanvasAlphaModes, kCanvasTextureFormats } from '../../capability_info.js';
 import { GPUTest } from '../../gpu_test.js';
 import { checkElementsEqual } from '../../util/check_contents.js';
 import {
@@ -136,7 +136,7 @@ g.test('onscreenCanvas,snapshot')
   .params(u =>
     u //
       .combine('format', kCanvasTextureFormats)
-      .combine('alphaMode', kCanvasAlphaMode)
+      .combine('alphaMode', kCanvasAlphaModes)
       .combine('snapshotType', ['toDataURL', 'toBlob', 'imageBitmap'])
   )
   .fn(async t => {
@@ -187,7 +187,7 @@ g.test('offscreenCanvas,snapshot')
   .params(u =>
     u //
       .combine('format', kCanvasTextureFormats)
-      .combine('alphaMode', kCanvasAlphaMode)
+      .combine('alphaMode', kCanvasAlphaModes)
       .combine('snapshotType', ['convertToBlob', 'transferToImageBitmap', 'imageBitmap'])
   )
   .fn(async t => {
@@ -241,7 +241,7 @@ g.test('onscreenCanvas,uploadToWebGL')
   .params(u =>
     u //
       .combine('format', kCanvasTextureFormats)
-      .combine('alphaMode', kCanvasAlphaMode)
+      .combine('alphaMode', kCanvasAlphaModes)
       .combine('webgl', ['webgl', 'webgl2'])
       .combine('upload', ['texImage2D', 'texSubImage2D'])
   )
@@ -302,7 +302,7 @@ g.test('drawTo2DCanvas')
   .params(u =>
     u //
       .combine('format', kCanvasTextureFormats)
-      .combine('alphaMode', kCanvasAlphaMode)
+      .combine('alphaMode', kCanvasAlphaModes)
       .combine('webgpuCanvasType', kAllCanvasTypes)
       .combine('canvas2DType', kAllCanvasTypes)
   )

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -28,7 +28,7 @@ class F extends CopyToTextureUtils {
     const canvas = createCanvas(this, 'onscreen', width, height);
 
     let canvasContext = null;
-    canvasContext = canvas.getContext('2d', { colorSpace }) as CanvasRenderingContext2D | null;
+    canvasContext = canvas.getContext('2d', { colorSpace });
 
     if (canvasContext === null) {
       this.skip('onscreen canvas 2d context not available');


### PR DESCRIPTION
Issue: #1561

Chrome fails `format="rgba16float";alphaMode="opaque"` because of copyTextureForBrowser for rgba16float not yet implemented [crbug.com/dawn/856](https://bugs.chromium.org/p/dawn/issues/detail?id=856#c12).

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
