### PR TITLE
Implement val:queue:writeTexture:usage

### DIFF
--- a/src/webgpu/api/validation/queue/writeTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/writeTexture.spec.ts
@@ -1,0 +1,36 @@
+export const description = `Tests writeTexture validation.`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUConst } from '../../../constants.js';
+import { ValidationTest } from '../validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('usages')
+  .desc(
+    `
+  Tests calling writeTexture with the texture missed COPY_DST usage.
+    - texture {with, without} COPY DST usage
+  `
+  )
+  .paramsSubcasesOnly([
+    { usage: GPUConst.TextureUsage.COPY_DST }, // control case
+    { usage: GPUConst.TextureUsage.STORAGE_BINDING },
+    { usage: GPUConst.TextureUsage.STORAGE_BINDING | GPUConst.TextureUsage.COPY_SRC },
+    { usage: GPUConst.TextureUsage.STORAGE_BINDING | GPUConst.TextureUsage.COPY_DST },
+  ])
+  .fn(async t => {
+    const { usage } = t.params;
+    const texture = t.device.createTexture({
+      size: { width: 16, height: 16 },
+      usage,
+      format: 'rgba8unorm' as const,
+    });
+    const data = new Uint8Array(16);
+    const size = [1, 1];
+
+    const isValid = usage & GPUConst.TextureUsage.COPY_DST ? true : false;
+    t.expectValidationError(() => {
+      t.device.queue.writeTexture({ texture }, data, {}, size);
+    }, !isValid);
+  });


### PR DESCRIPTION
This PR adds a test to check if calling writeTexture with COPY_DST
is valid.

Issue: #1692

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
