### PR TITLE
Correct the order of params in `atan2` logging message

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1232,7 +1232,7 @@ g.test('atan2Interval')
     const got = atan2Interval(y, x);
     t.expect(
       objectEquals(expected, got),
-      `atan2Interval(${x}, ${y}) returned ${got}. Expected ${expected}`
+      `atan2Interval(${y}, ${x}) returned ${got}. Expected ${expected}`
     );
   });
 


### PR DESCRIPTION
Issue #1680
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
