### PR TITLE
Generate full range of `atan2` cases

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -95,7 +95,6 @@ Accuracy: Correctly rounded
         cases.push(makeCase(lhs, rhs));
       });
     });
-
     run(t, binary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -45,11 +45,9 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
     const numeric_range = fullF32Range();
     const cases: Array<Case> = [];
-    numeric_range.forEach((y, y_idx) => {
-      numeric_range.forEach((x, x_idx) => {
-        if (x_idx >= y_idx) {
-          cases.push(makeCase(y, x));
-        }
+    numeric_range.forEach(y => {
+      numeric_range.forEach(x => {
+        cases.push(makeCase(y, x));
       });
     });
 


### PR DESCRIPTION

Issue: #1678

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
