### PR TITLE
Implement val:CopyExternalImageToTexture,destination_texture,dimension

### DIFF
--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -6,6 +6,7 @@ import { getResourcePath } from '../../../../../common/framework/resources.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { raceWithRejectOnTimeout, unreachable, assert } from '../../../../../common/util/util.js';
 import {
+  kTextureDimensions,
   kTextureFormatInfo,
   kTextureFormats,
   kTextureUsages,
@@ -696,6 +697,36 @@ g.test('destination_texture,sample_count')
     });
 
     t.runTest({ source: imageBitmap }, { texture: dstTexture }, copySize, sampleCount === 1);
+  });
+
+g.test('destination_texture,dimension')
+  .desc(
+    `
+  Test dst texture dimension.
+
+  Check that an error is generated when dimension is not 2d.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('dimension', kTextureDimensions)
+      .beginSubcases()
+      .combine('copySize', [
+        { width: 0, height: 0, depthOrArrayLayers: 0 },
+        { width: 1, height: 1, depthOrArrayLayers: 1 },
+      ])
+  )
+  .fn(async t => {
+    const { dimension, copySize } = t.params;
+    const imageBitmap = await t.createImageBitmap(t.getImageData(1, 1));
+    const dstTexture = t.device.createTexture({
+      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
+      dimension,
+      format: 'bgra8unorm',
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    t.runTest({ source: imageBitmap }, { texture: dstTexture }, copySize, dimension === '2d');
   });
 
 g.test('destination_texture,mipLevel')


### PR DESCRIPTION
This PR adds a test that check if an error is generated when
dimension is not 2d.

Issue: #1694

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
