### PR TITLE
Expand map_detach test for buffer should detach on device.destroy

### DIFF
--- a/src/webgpu/api/operation/buffers/map_detach.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_detach.spec.ts
@@ -4,6 +4,8 @@ export const description = `
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { getGPU } from '../../../../common/util/navigator_gpu.js';
+import { assert } from '../../../../common/util/util.js';
 import { GPUConst } from '../../../constants.js';
 import { GPUTest } from '../../../gpu_test.js';
 
@@ -14,7 +16,8 @@ g.test('while_mapped')
     `
     Test that a mapped buffers are able to properly detach.
     - Tests {mappable, unmappable mapAtCreation, mappable mapAtCreation}
-    - Tests while {mapped, mapped at creation, mapped at creation then unmapped and mapped again}`
+    - Tests while {mapped, mapped at creation, mapped at creation then unmapped and mapped again}
+    - When {unmap, destroy, unmap && destory, device.destroy} is called`
   )
   .paramsSubcasesOnly(u =>
     u
@@ -36,12 +39,20 @@ g.test('while_mapped')
         { unmap: true, destroy: false },
         { unmap: false, destroy: true },
         { unmap: true, destroy: true },
+        { unmap: false, destroy: false, deviceDestroy: true },
       ])
       .unless(p => p.mappedAtCreation === false && p.mapMode === undefined)
   )
   .fn(async t => {
-    const { usage, mapMode, mappedAtCreation, unmap, destroy } = t.params;
-    const buffer = t.device.createBuffer({
+    const { usage, mapMode, mappedAtCreation, unmap, destroy, deviceDestroy } = t.params;
+
+    let device: GPUDevice = t.device;
+    if (deviceDestroy) {
+      const adapter = await getGPU().requestAdapter();
+      assert(adapter !== null);
+      device = await adapter.requestDevice();
+    }
+    const buffer = device.createBuffer({
       size: 4,
       usage,
       mappedAtCreation,
@@ -61,6 +72,7 @@ g.test('while_mapped')
 
     if (unmap) buffer.unmap();
     if (destroy) buffer.destroy();
+    if (deviceDestroy) device.destroy();
 
     t.expect(arrayBuffer.byteLength === 0, 'ArrayBuffer should be detached');
     t.expect(view.byteLength === 0, 'ArrayBufferView should be detached');


### PR DESCRIPTION


Issue: [#1697](https://github.com/gpuweb/cts/issues/1697)

Chrome impl coming at https://chromium-review.googlesource.com/c/chromium/src/+/3773616

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
