### PR TITLE
Implement `sign` f32 tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -34,6 +34,7 @@ import {
   powInterval,
   radiansInterval,
   saturateInterval,
+  signInterval,
   sinInterval,
   subtractionInterval,
   tanInterval,
@@ -1116,6 +1117,40 @@ g.test('saturateInterval')
     t.expect(
       objectEquals(expected, got),
       `saturationInterval(${n}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('signInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.negative.min, expected: [-1, -1] },
+      { input: -10, expected: [-1, -1] },
+      { input: -1, expected: [-1, -1] },
+      { input: -0.1, expected: [-1, -1] },
+      { input: kValue.f32.negative.max, expected:  [-1, -1] },
+      { input: kValue.f32.subnormal.negative.min, expected: [-1, 0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [-1, 0] },
+      { input: 0, expected: [0, 0] },
+      { input: kValue.f32.subnormal.positive.max, expected: [0, 1] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0, 1] },
+      { input: kValue.f32.positive.min, expected: [1, 1] },
+      { input: 0.1, expected: [1, 1] },
+      { input: 1, expected: [1, 1] },
+      { input: 10, expected: [1, 1] },
+      { input: kValue.f32.positive.max, expected: [1, 1] },
+      { input: kValue.f32.infinity.positive, expected: kAny },
+    ]
+  )
+  .fn(t => {
+    const input = t.params.input;
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = signInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `signInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -9,7 +9,12 @@ Returns the sign of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { signInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -27,7 +32,14 @@ g.test('f32')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryF32IntervalCase(n, signInterval);
+    };
+
+    const cases = fullF32Range().map(makeCase);
+    run(t, builtin('sign'), [TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -868,6 +868,24 @@ export function saturateInterval(n: number): F32Interval {
   return runTernaryOp(toInterval(n), toInterval(0.0), toInterval(1.0), ClampMinMaxIntervalOp);
 }
 
+const SignIntervalOp: PointToIntervalOp = {
+  impl: (n: number): F32Interval => {
+    if (n > 0.0) {
+      return correctlyRoundedInterval(1.0);
+    }
+    if (n < 0.0) {
+      return correctlyRoundedInterval(-1.0);
+    }
+
+    return correctlyRoundedInterval(0.0);
+  },
+};
+
+/** Calculate an acceptance interval of sin(x) */
+export function signInterval(n: number): F32Interval {
+  return runPointOp(toInterval(n), SignIntervalOp);
+}
+
 const SinIntervalOp: PointToIntervalOp = {
   impl: limitPointToIntervalDomain(
     kNegPiToPiInterval,


### PR DESCRIPTION
Issue #1236

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
