### PR TITLE
Implement val:queue,writeTexture:texture_state

### DIFF
--- a/src/webgpu/api/validation/queue/writeTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/writeTexture.spec.ts
@@ -2,9 +2,31 @@ export const description = `Tests writeTexture validation.`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { GPUConst } from '../../../constants.js';
+import { kResourceStates } from '../../../gpu_test.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
+
+g.test('texture_state')
+  .desc(
+    `
+  Test that the texture used for GPUQueue.writeTexture() must be valid. Tests calling writeTexture
+  with {valid, invalid, destroyed} texture.
+  `
+  )
+  .params(u => u.combine('textureState', kResourceStates))
+  .fn(async t => {
+    const { textureState } = t.params;
+    const texture = t.createTextureWithState(textureState);
+    const data = new Uint8Array(16);
+    const size = [1, 1];
+
+    const isValid = textureState === 'valid';
+
+    t.expectValidationError(() => {
+      t.device.queue.writeTexture({ texture }, data, {}, size);
+    }, !isValid);
+  });
 
 g.test('usages')
   .desc(


### PR DESCRIPTION
This PR adds a test to ensure that writeTexture
generates a validation error if the texture is
not valid.

Issue: #1692

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
