### PR TITLE
Implement val:queue,writeTexture:sample_count

### DIFF
--- a/src/webgpu/api/validation/queue/writeTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/writeTexture.spec.ts
@@ -34,3 +34,30 @@ g.test('usages')
       t.device.queue.writeTexture({ texture }, data, {}, size);
     }, !isValid);
   });
+
+g.test('sample_count')
+  .desc(
+    `
+  Test that the texture sample count. Check that a validation error is generated if sample count is
+  not 1.
+  `
+  )
+  .params(u => u.combine('sampleCount', [1, 4]))
+  .fn(async t => {
+    const { sampleCount } = t.params;
+    const texture = t.device.createTexture({
+      size: { width: 16, height: 16 },
+      sampleCount,
+      format: 'bgra8unorm',
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const data = new Uint8Array(16);
+    const size = [1, 1];
+
+    const isValid = sampleCount === 1;
+
+    t.expectValidationError(() => {
+      t.device.queue.writeTexture({ texture }, data, {}, size);
+    }, !isValid);
+  });


### PR DESCRIPTION
This PR adds a test to check if a validation error is
generated when the sample count of the destination texture
is not 1.

Issue: #1692

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
