### PR TITLE
Fix testing of the offset in image_copy,layout_related:required_bytes…

### DIFF
--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -169,7 +169,7 @@ Test the computation of requiredBytesInCopy by computing the minimum data size f
         );
       })
       .unless(p => p.dimension === '1d' && (p.copyHeightInBlocks > 1 || p.copyDepth > 1))
-      .expand('bufferOffset', p => {
+      .expand('offset', p => {
         const info = kTextureFormatInfo[p.format];
         if (info.depth || info.stencil) {
           return [p._offsetMultiplier * 4];
@@ -183,7 +183,7 @@ Test the computation of requiredBytesInCopy by computing the minimum data size f
   })
   .fn(async t => {
     const {
-      bufferOffset,
+      offset,
       bytesPerRowPadding,
       rowsPerImagePaddingInBlocks,
       copyWidthInBlocks,
@@ -207,7 +207,7 @@ Test the computation of requiredBytesInCopy by computing the minimum data size f
       bytesPerRowPadding * bytesPerRowAlignment;
     const copySize = { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth };
 
-    const layout = { bufferOffset, bytesPerRow, rowsPerImage };
+    const layout = { offset, bytesPerRow, rowsPerImage };
     const minDataSize = dataBytesForCopyOrFail({ layout, format, copySize, method });
 
     const texture = t.createAlignedTexture(format, copySize, undefined, dimension);


### PR DESCRIPTION
…_in_copy




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

Tested that it passes in Chromium after the validation in Chromium is fixed.

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
