### PR TITLE
Add WebCodec VideoFrame as input source for GPUExternalTexture cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "serve-index": "^1.9.1",
         "ts-node": "^9.0.0",
         "typedoc": "^0.22.13",
-        "typescript": "^4.6.2"
+        "typescript": "~4.6.2"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@babel/core": "^7.17.5",
         "@babel/preset-typescript": "^7.16.7",
         "@types/babel__core": "^7.1.18",
+        "@types/dom-mediacapture-transform": "^0.1.3",
+        "@types/dom-webcodecs": "^0.1.4",
         "@types/express": "^4.17.13",
         "@types/jquery": "^3.5.14",
         "@types/morgan": "^1.9.3",
@@ -732,6 +734,21 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.3.tgz",
+      "integrity": "sha512-Zi2IOA+NFqPmqFojaOskEzUOABMHEouZg8vtwMt0MbppgTu1pOVg2zWQVvfjnCIgOj//CleXHhryvRKaykSVJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.4.tgz",
+      "integrity": "sha512-dc+xSUnCaCdi/hExZArnLhiavS3E1Rdpp2+zCI6TcmJvz4qgDPBbpvCM7DsQhwRXIIpVMHO6c3s+t+JyCSqYBA==",
+      "dev": true
     },
     "node_modules/@types/express": {
       "version": "4.17.13",
@@ -10149,6 +10166,21 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/dom-mediacapture-transform": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.3.tgz",
+      "integrity": "sha512-Zi2IOA+NFqPmqFojaOskEzUOABMHEouZg8vtwMt0MbppgTu1pOVg2zWQVvfjnCIgOj//CleXHhryvRKaykSVJw==",
+      "dev": true,
+      "requires": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "@types/dom-webcodecs": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.4.tgz",
+      "integrity": "sha512-dc+xSUnCaCdi/hExZArnLhiavS3E1Rdpp2+zCI6TcmJvz4qgDPBbpvCM7DsQhwRXIIpVMHO6c3s+t+JyCSqYBA==",
+      "dev": true
     },
     "@types/express": {
       "version": "4.17.13",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "serve-index": "^1.9.1",
     "ts-node": "^9.0.0",
     "typedoc": "^0.22.13",
-    "typescript": "^4.6.2"
+    "typescript": "~4.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "@babel/core": "^7.17.5",
     "@babel/preset-typescript": "^7.16.7",
     "@types/babel__core": "^7.1.18",
+    "@types/dom-mediacapture-transform": "^0.1.3",
+    "@types/dom-webcodecs": "^0.1.4",
     "@types/express": "^4.17.13",
     "@types/jquery": "^3.5.14",
     "@types/morgan": "^1.9.3",

--- a/src/webgpu/web_platform/copyToTexture/video.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/video.spec.ts
@@ -1,7 +1,9 @@
 export const description = `
 copyToTexture with HTMLVideoElement (and other video-type sources?).
 
-- videos with various encodings, color spaces, metadata
+- videos with various encodings/formats (webm vp8, webm vp9, ogg theora, mp4), color spaces
+  (bt.601, bt.709, bt.2020)
+- TODO: enhance with more cases with crop, rotation, etc.
 
 TODO: consider whether external_texture and copyToTexture video tests should be in the same file
 TODO: plan

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -147,12 +147,14 @@ supported video formats {vp8, vp9, ogg, mp4} and common source colorspaces {bt.6
     }
 
     const videoUrl = getResourcePath(t.params.videoSource);
-    const video = document.createElement('video');
-    video.src = videoUrl;
+    const videoElement = document.createElement('video');
+    videoElement.src = videoUrl;
 
-    await startPlayingAndWaitForVideo(video, async () => {
+    await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =
-        sourceType === 'VideoFrame' ? await getVideoFrameFromVideoElement(video) : video;
+        sourceType === 'VideoFrame'
+          ? await getVideoFrameFromVideoElement(videoElement)
+          : videoElement;
 
       const colorAttachment = t.device.createTexture({
         format: kFormat,
@@ -161,7 +163,7 @@ supported video formats {vp8, vp9, ogg, mp4} and common source colorspaces {bt.6
       });
 
       const pipeline = createExternalTextureSamplingTestPipeline(t);
-      const bindGroup = createExternalTextureSamplingTestBindGroup(t, video, pipeline);
+      const bindGroup = createExternalTextureSamplingTestBindGroup(t, source, pipeline);
 
       const commandEncoder = t.device.createCommandEncoder();
       const passEncoder = commandEncoder.beginRenderPass({
@@ -226,8 +228,8 @@ GPUExternalTexture results in an error.
     }
 
     const videoUrl = getResourcePath('red-green.webmvp8.webm');
-    const video = document.createElement('video');
-    video.src = videoUrl;
+    const videoElement = document.createElement('video');
+    videoElement.src = videoUrl;
 
     const colorAttachment = t.device.createTexture({
       format: kFormat,
@@ -259,9 +261,11 @@ GPUExternalTexture results in an error.
     };
 
     let externalTexture: GPUExternalTexture;
-    await startPlayingAndWaitForVideo(video, async () => {
+    await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =
-        sourceType === 'VideoFrame' ? await getVideoFrameFromVideoElement(video) : video;
+        sourceType === 'VideoFrame'
+          ? await getVideoFrameFromVideoElement(videoElement)
+          : videoElement;
       externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         source: source as any,
@@ -286,7 +290,7 @@ GPUExternalTexture results in an error.
 
     if (sourceType === 'VideoElement') {
       // Update new video frame.
-      await startPlayingAndWaitForVideo(video, async () => {
+      await startPlayingAndWaitForVideo(videoElement, async () => {
         // VideoFrame is updated. GPUExternalTexture imported from HTMLVideoElement should be expired.
         // Using the GPUExternalTexture should result in an error.
         const commandBuffer = useExternalTexture();
@@ -316,12 +320,14 @@ Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTextur
     }
 
     const videoUrl = getResourcePath(t.params.videoSource);
-    const video = document.createElement('video');
-    video.src = videoUrl;
+    const videoElement = document.createElement('video');
+    videoElement.src = videoUrl;
 
-    await startPlayingAndWaitForVideo(video, async () => {
+    await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =
-        sourceType === 'VideoFrame' ? await getVideoFrameFromVideoElement(video) : video;
+        sourceType === 'VideoFrame'
+          ? await getVideoFrameFromVideoElement(videoElement)
+          : videoElement;
       const externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         source: source as any,

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -307,20 +307,17 @@ g.test('importExternalTexture,compute')
     `
 Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTexture and use it in a
 compute shader, for several combinations of video format and color space.
+
+TODO: add 'VideoFrame' as an additional 'sourceType'
 `
   )
   .params(u =>
     u //
-      .combine('sourceType', ['VideoElement', 'VideoFrame'])
+      .combine('sourceType', ['VideoElement'])
       .combineWithParams(kVideoExpectations)
   )
   .fn(async t => {
     const sourceType = t.params.sourceType;
-
-    // VideoFrame as source fails the expectation. Skip these cases for now.
-    if (sourceType === 'VideoFrame') {
-      t.skip('Skip WebCodec test cases');
-    }
 
     const videoUrl = getResourcePath(t.params.videoSource);
     const videoElement = document.createElement('video');

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -136,11 +136,13 @@ g.test('importExternalTexture,sample')
     `
 Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTexture, sample from it
 for several combinations of video format and color space.
+
+TODO: add 'VideoFrame' as an additional 'sourceType'
 `
   )
   .params(u =>
     u //
-      .combine('sourceType', ['VideoElement', 'VideoFrame'])
+      .combine('sourceType', ['VideoElement'])
       .combineWithParams(kVideoExpectations)
   )
   .fn(async t => {

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -155,7 +155,7 @@ for several combinations of video format and color space.
     await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =
         sourceType === 'VideoFrame'
-          ? await getVideoFrameFromVideoElement(videoElement)
+          ? await getVideoFrameFromVideoElement(t, videoElement)
           : videoElement;
 
       const colorAttachment = t.device.createTexture({
@@ -235,7 +235,6 @@ GPUExternalTexture results in an error.
 
     if (!('requestVideoFrameCallback' in videoElement)) {
       t.skip('HTMLVideoElement.requestVideoFrameCallback is not supported');
-
     }
 
     const colorAttachment = t.device.createTexture({
@@ -271,7 +270,7 @@ GPUExternalTexture results in an error.
     await videoElement.requestVideoFrameCallback(async () => {
       const source =
         sourceType === 'VideoFrame'
-          ? await getVideoFrameFromVideoElement(videoElement)
+          ? await getVideoFrameFromVideoElement(t, videoElement)
           : videoElement;
       externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -331,7 +330,7 @@ TODO: add 'VideoFrame' as an additional 'sourceType'
     await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =
         sourceType === 'VideoFrame'
-          ? await getVideoFrameFromVideoElement(videoElement)
+          ? await getVideoFrameFromVideoElement(t, videoElement)
           : videoElement;
       const externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -218,6 +218,8 @@ Tests that GPUExternalTexture.expired is false when HTMLVideoElement is not upda
 or VideoFrame(webcodec) is alive. And it will be changed to true when imported
 HTMLVideoElement is updated or imported VideoFrame is closed. Using expired
 GPUExternalTexture results in an error.
+
+TODO: Make this test work without requestVideoFrameCallback support (in waitForNextFrame).
 `
   )
   .params(u =>

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -107,9 +107,10 @@ function createExternalTextureSamplingTestBindGroup(
 ): GPUBindGroup {
   const linearSampler = t.device.createSampler();
 
-  const externalTextureDescriptor = { source };
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  const externalTexture = t.device.importExternalTexture(externalTextureDescriptor as any);
+  const externalTexture = t.device.importExternalTexture({
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    source: source as any,
+  });
 
   const bindGroup = t.device.createBindGroup({
     layout: pipeline.getBindGroupLayout(0),
@@ -151,10 +152,11 @@ supported video formats {vp8, vp9, ogg, mp4} and common source colorspaces {bt.6
     video.src = videoUrl;
 
     await startPlayingAndWaitForVideo(video, async () => {
-      let source: HTMLVideoElement | VideoFrame | null = video;
+      let source: HTMLVideoElement | VideoFrame = video;
       if (sourceType === 'VideoFrame') {
-        source = await getVideoFrameFromVideoElement(video);
-        assert(source !== null);
+        const videoFrame = await getVideoFrameFromVideoElement(video);
+        assert(videoFrame !== null);
+        source = videoFrame;
       }
 
       const colorAttachment = t.device.createTexture({
@@ -269,8 +271,10 @@ GPUExternalTexture results in an error.
         source = await getVideoFrameFromVideoElement(video);
         assert(source !== null);
       }
-      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-      externalTexture = t.device.importExternalTexture({ source } as any);
+      externalTexture = t.device.importExternalTexture({
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        source: source as any,
+      });
       // Set `bindGroup` here, which will then be used in microtask1 and microtask3.
       bindGroup = t.device.createBindGroup({
         layout: bindGroupLayout,
@@ -330,9 +334,10 @@ Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTextur
         source = await getVideoFrameFromVideoElement(video);
         assert(source !== null);
       }
-      const externalTextureDescriptor = { source };
-      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-      const externalTexture = t.device.importExternalTexture(externalTextureDescriptor as any);
+      const externalTexture = t.device.importExternalTexture({
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        source: source as any,
+      });
 
       const outputTexture = t.device.createTexture({
         format: 'rgba8unorm',

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -14,6 +14,7 @@ import { GPUTest } from '../../gpu_test.js';
 import {
   startPlayingAndWaitForVideo,
   getVideoFrameFromVideoElement,
+  waitForNextFrame,
 } from '../../web_platform/util.js';
 
 const kHeight = 16;
@@ -267,7 +268,7 @@ GPUExternalTexture results in an error.
     };
 
     let externalTexture: GPUExternalTexture;
-    await videoElement.requestVideoFrameCallback(async () => {
+    await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =
         sourceType === 'VideoFrame'
           ? await getVideoFrameFromVideoElement(t, videoElement)
@@ -296,7 +297,7 @@ GPUExternalTexture results in an error.
 
     if (sourceType === 'VideoElement') {
       // Update new video frame.
-      await videoElement.requestVideoFrameCallback(async () => {
+      await waitForNextFrame(videoElement, () => {
         // VideoFrame is updated. GPUExternalTexture imported from HTMLVideoElement should be expired.
         // Using the GPUExternalTexture should result in an error.
         const commandBuffer = useExternalTexture();

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -151,10 +151,8 @@ supported video formats {vp8, vp9, ogg, mp4} and common source colorspaces {bt.6
     video.src = videoUrl;
 
     await startPlayingAndWaitForVideo(video, async () => {
-      let source: HTMLVideoElement | VideoFrame = video;
-      if (sourceType === 'VideoFrame') {
-        source = await getVideoFrameFromVideoElement(video);
-      }
+      const source =
+        sourceType === 'VideoFrame' ? await getVideoFrameFromVideoElement(video) : video;
 
       const colorAttachment = t.device.createTexture({
         format: kFormat,
@@ -261,12 +259,9 @@ GPUExternalTexture results in an error.
     };
 
     let externalTexture: GPUExternalTexture;
-    let source: HTMLVideoElement | VideoFrame;
     await startPlayingAndWaitForVideo(video, async () => {
-      source = video;
-      if (sourceType === 'VideoFrame') {
-        source = await getVideoFrameFromVideoElement(video);
-      }
+      const source =
+        sourceType === 'VideoFrame' ? await getVideoFrameFromVideoElement(video) : video;
       externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         source: source as any,
@@ -325,10 +320,8 @@ Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTextur
     video.src = videoUrl;
 
     await startPlayingAndWaitForVideo(video, async () => {
-      let source: HTMLVideoElement | VideoFrame = video;
-      if (sourceType === 'VideoFrame') {
-        source = await getVideoFrameFromVideoElement(video);
-      }
+      const source =
+        sourceType === 'VideoFrame' ? await getVideoFrameFromVideoElement(video) : video;
       const externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         source: source as any,

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -8,7 +8,6 @@ TODO: consider whether external_texture and copyToTexture video tests should be 
 
 import { getResourcePath } from '../../../common/framework/resources.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { assert } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
 import {
   startPlayingAndWaitForVideo,
@@ -154,9 +153,7 @@ supported video formats {vp8, vp9, ogg, mp4} and common source colorspaces {bt.6
     await startPlayingAndWaitForVideo(video, async () => {
       let source: HTMLVideoElement | VideoFrame = video;
       if (sourceType === 'VideoFrame') {
-        const videoFrame = await getVideoFrameFromVideoElement(video);
-        assert(videoFrame !== null);
-        source = videoFrame;
+        source = await getVideoFrameFromVideoElement(video);
       }
 
       const colorAttachment = t.device.createTexture({
@@ -264,12 +261,11 @@ GPUExternalTexture results in an error.
     };
 
     let externalTexture: GPUExternalTexture;
-    let source: HTMLVideoElement | VideoFrame | null;
+    let source: HTMLVideoElement | VideoFrame;
     await startPlayingAndWaitForVideo(video, async () => {
       source = video;
       if (sourceType === 'VideoFrame') {
         source = await getVideoFrameFromVideoElement(video);
-        assert(source !== null);
       }
       externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -329,10 +325,9 @@ Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTextur
     video.src = videoUrl;
 
     await startPlayingAndWaitForVideo(video, async () => {
-      let source: HTMLVideoElement | VideoFrame | null = video;
+      let source: HTMLVideoElement | VideoFrame = video;
       if (sourceType === 'VideoFrame') {
         source = await getVideoFrameFromVideoElement(video);
-        assert(source !== null);
       }
       const externalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -1,7 +1,9 @@
 export const description = `
 Tests for external textures from HTMLVideoElement (and other video-type sources?).
 
-- videos with various encodings, color spaces, metadata
+- videos with various encodings/formats (webm vp8, webm vp9, ogg theora, mp4), color spaces
+  (bt.601, bt.709, bt.2020)
+- TODO: enhance with more cases with crop, rotation, etc.
 
 TODO: consider whether external_texture and copyToTexture video tests should be in the same file
 `;
@@ -131,8 +133,8 @@ function createExternalTextureSamplingTestBindGroup(
 g.test('importExternalTexture,sample')
   .desc(
     `
-Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTexture, sample from it for all
-supported video formats {vp8, vp9, ogg, mp4} and common source colorspaces {bt.601, bt.709, bt.2020}.
+Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTexture, sample from it
+for several combinations of video format and color space.
 `
   )
   .params(u =>
@@ -303,7 +305,8 @@ GPUExternalTexture results in an error.
 g.test('importExternalTexture,compute')
   .desc(
     `
-Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTexture and use it in a compute shader.
+Tests that we can import an HTMLVideoElement/VideoFrame into a GPUExternalTexture and use it in a
+compute shader, for several combinations of video format and color space.
 `
   )
   .params(u =>

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -233,6 +233,11 @@ GPUExternalTexture results in an error.
     const videoElement = document.createElement('video');
     videoElement.src = videoUrl;
 
+    if (!('requestVideoFrameCallback' in videoElement)) {
+      t.skip('HTMLVideoElement.requestVideoFrameCallback is not supported');
+
+    }
+
     const colorAttachment = t.device.createTexture({
       format: kFormat,
       size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
@@ -263,7 +268,7 @@ GPUExternalTexture results in an error.
     };
 
     let externalTexture: GPUExternalTexture;
-    await startPlayingAndWaitForVideo(videoElement, async () => {
+    await videoElement.requestVideoFrameCallback(async () => {
       const source =
         sourceType === 'VideoFrame'
           ? await getVideoFrameFromVideoElement(videoElement)
@@ -292,7 +297,7 @@ GPUExternalTexture results in an error.
 
     if (sourceType === 'VideoElement') {
       // Update new video frame.
-      await startPlayingAndWaitForVideo(videoElement, async () => {
+      await videoElement.requestVideoFrameCallback(async () => {
         // VideoFrame is updated. GPUExternalTexture imported from HTMLVideoElement should be expired.
         // Using the GPUExternalTexture should result in an error.
         const commandBuffer = useExternalTexture();

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -1,4 +1,4 @@
-import { ErrorWithExtra, raceWithRejectOnTimeout } from '../../common/util/util.js';
+import { assert, ErrorWithExtra, raceWithRejectOnTimeout } from '../../common/util/util.js';
 
 /**
  * Starts playing a video and waits for it to be consumable.
@@ -71,11 +71,10 @@ declare global {
   }
 }
 
-export async function getVideoFrameFromVideoElement(
-  video: HTMLVideoElement
-): Promise<VideoFrame | null> {
+export async function getVideoFrameFromVideoElement(video: HTMLVideoElement): Promise<VideoFrame> {
   const track = video.captureStream().getVideoTracks()[0];
   const reader = new MediaStreamTrackProcessor({ track }).readable.getReader();
-  const result = await reader.read();
-  return result.value ?? null;
+  const videoFrame = (await reader.read()).value;
+  assert(videoFrame !== undefined, 'unable to get a VideoFrame from track 0');
+  return videoFrame;
 }

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -9,7 +9,9 @@ declare global {
   }
 
   interface HTMLVideoElement {
-    requestVideoFrameCallback(callback: (now: DOMHighResTimeStamp, metadata: unknown) => void): number;
+    requestVideoFrameCallback(
+      callback: (now: DOMHighResTimeStamp, metadata: unknown) => void
+    ): number;
   }
 }
 
@@ -127,7 +129,7 @@ export async function getVideoFrameFromVideoElement(
 function videoCallbackHelper(
   callback: () => unknown | Promise<unknown>,
   timeoutMessage: string
-): { promise: Promise<void>; callbackAndResolve(): void } {
+): { promise: Promise<void>; callbackAndResolve: () => void } {
   let callbackAndResolve: () => void;
 
   const promiseWithoutTimeout = new Promise<void>((resolve, reject) => {

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -38,8 +38,7 @@ export function startPlayingAndWaitForVideo(
       );
 
       if ('requestVideoFrameCallback' in video) {
-        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        (video as any).requestVideoFrameCallback(() => {
+        video.requestVideoFrameCallback(() => {
           callbackAndResolve();
         });
       } else {

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -63,3 +63,20 @@ export function startPlayingAndWaitForVideo(
     'Video never became ready'
   );
 }
+
+// Add captureStream() support for HTMLMediaElement from
+// https://w3c.github.io/mediacapture-fromelement/#dom-htmlmediaelement-capturestream
+declare global {
+  interface HTMLMediaElement {
+    captureStream(): MediaStream;
+  }
+}
+
+export async function getVideoFrameFromVideoElement(
+  video: HTMLVideoElement
+): Promise<VideoFrame | null> {
+  const track = video.captureStream().getVideoTracks()[0];
+  const reader = new MediaStreamTrackProcessor({ track }).readable.getReader();
+  const result = await reader.read();
+  return result.value ?? null;
+}

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -69,8 +69,8 @@ export function startPlayingAndWaitForVideo(
  * Returns a promise which resolves after `callback` (which may be async) completes.
  *
  * MAINTENANCE_TODO: Find a way to implement this for browsers without requestVideoFrameCallback as
- * well, similar to the timeWatcher path in startPlayingAndWaitForVideo.
- * If that path works well, consider getting rid of the requestVideoFrameCallback path.
+ * well, similar to the timeWatcher path in startPlayingAndWaitForVideo. If that path is proven to
+ * work well, we can consider getting rid of the requestVideoFrameCallback path.
  */
 export function waitForNextFrame(
   video: HTMLVideoElement,

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -1,6 +1,18 @@
 import { Fixture, SkipTestCase } from '../../common/framework/fixture.js';
 import { assert, ErrorWithExtra, raceWithRejectOnTimeout } from '../../common/util/util.js';
 
+declare global {
+  interface HTMLMediaElement {
+    // Add captureStream() support for HTMLMediaElement from
+    // https://w3c.github.io/mediacapture-fromelement/#dom-htmlmediaelement-capturestream
+    captureStream(): MediaStream;
+  }
+
+  interface HTMLVideoElement {
+    requestVideoFrameCallback(callback: (now: DOMHighResTimeStamp, metadata: unknown) => void): number;
+  }
+}
+
 /**
  * Starts playing a video and waits for it to be consumable.
  * Returns a promise which resolves after `callback` (which may be async) completes.
@@ -76,7 +88,10 @@ export function waitForNextFrame(
   video: HTMLVideoElement,
   callback: () => unknown | Promise<unknown>
 ): Promise<void> {
-  const { promise, callbackAndResolve } = videoCallbackHelper(callback, 'waitForNextFrame timed out');
+  const { promise, callbackAndResolve } = videoCallbackHelper(
+    callback,
+    'waitForNextFrame timed out'
+  );
 
   if ('requestVideoFrameCallback' in video) {
     video.requestVideoFrameCallback(() => {
@@ -87,14 +102,6 @@ export function waitForNextFrame(
   }
 
   return promise;
-}
-
-// Add captureStream() support for HTMLMediaElement from
-// https://w3c.github.io/mediacapture-fromelement/#dom-htmlmediaelement-capturestream
-declare global {
-  interface HTMLMediaElement {
-    captureStream?(): MediaStream;
-  }
 }
 
 export async function getVideoFrameFromVideoElement(

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -1,3 +1,4 @@
+import { Fixture } from '../../common/framework/fixture.js';
 import { assert, ErrorWithExtra, raceWithRejectOnTimeout } from '../../common/util/util.js';
 
 /**
@@ -63,16 +64,15 @@ export function startPlayingAndWaitForVideo(
   );
 }
 
-// Add captureStream() support for HTMLMediaElement from
-// https://w3c.github.io/mediacapture-fromelement/#dom-htmlmediaelement-capturestream
-declare global {
-  interface HTMLMediaElement {
-    captureStream(): MediaStream;
+export async function getVideoFrameFromVideoElement(
+  test: Fixture,
+  video: HTMLVideoElement
+): Promise<VideoFrame> {
+  if (!('captureStream' in (video as HTMLMediaElement))) {
+    test.skip('HTMLVideoElement.captureStream is not supported');
   }
-}
 
-export async function getVideoFrameFromVideoElement(video: HTMLVideoElement): Promise<VideoFrame> {
-  const track = video.captureStream().getVideoTracks()[0];
+  const track: MediaStreamVideoTrack = video.captureStream().getVideoTracks()[0];
   const reader = new MediaStreamTrackProcessor({ track }).readable.getReader();
   const videoFrame = (await reader.read()).value;
   assert(videoFrame !== undefined, 'unable to get a VideoFrame from track 0');


### PR DESCRIPTION
WebCodec is a possible input source of GPUExternalTexture. This PR
added such input source if browser supported WebCodec.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
