### PR TITLE
upgrade typescript to 4.7.4

### DIFF
--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -20,23 +20,25 @@ Whenever a new generally-useful helper is added, it should be indexed here.
 
 **See linked documentation for full helper listings.**
 
-- {@link CaseParamsBuilder} and {@link SubcaseParamsBuilder}:
+- {@link common/framework/params_builder!CaseParamsBuilder} and {@link common/framework/params_builder!SubcaseParamsBuilder}:
     Combinatorial generation of test parameters. They are iterated by the test framework at runtime.
     See `examples.spec.ts` for basic examples of how this behaves.
-    - {@link CaseParamsBuilder}: `ParamsBuilder` for adding "cases" to a test.
-    - {@link CaseParamsBuilder.beginSubcases}:
-      "Finalizes" the `CaseParamsBuilder`, returning a `SubcaseParamsBuilder`.
-    - {@link SubcaseParamsBuilder}: `ParamsBuilder` for adding "subcases" to a test.
+    - {@link common/framework/params_builder!CaseParamsBuilder}:
+        `ParamsBuilder` for adding "cases" to a test.
+    - {@link common/framework/params_builder!CaseParamsBuilder#beginSubcases}:
+        "Finalizes" the `CaseParamsBuilder`, returning a `SubcaseParamsBuilder`.
+    - {@link common/framework/params_builder!SubcaseParamsBuilder}:
+        `ParamsBuilder` for adding "subcases" to a test.
 
 ### Fixtures
 
 (Uncheck the "Inherited" box to hide inherited methods from documentation pages.)
 
-- {@link Fixture}: Base fixture for all tests.
-- {@link GPUTest}: Base fixture for WebGPU tests.
-- {@link ValidationTest}: Base fixture for WebGPU validation tests.
-- {@link ShaderValidationTest}: Base fixture for WGSL shader validation tests.
-- {@link IDLTest}:
+- {@link common/framework/fixture!Fixture}: Base fixture for all tests.
+- {@link webgpu/gpu_test!GPUTest}: Base fixture for WebGPU tests.
+- {@link webgpu/api/validation/validation_test!ValidationTest}: Base fixture for WebGPU validation tests.
+- {@link webgpu/shader/validation/shader_validation_test!ShaderValidationTest}: Base fixture for WGSL shader validation tests.
+- {@link webgpu/idl/idl_test!IDLTest}:
     Base fixture for testing the exposed interface is correct (without actually using WebGPU).
 
 ### WebGPU Helpers
@@ -49,7 +51,7 @@ Whenever a new generally-useful helper is added, it should be indexed here.
 - {@link webgpu/util/unions}: Helpers for various union typedefs in the WebGPU spec.
 - {@link webgpu/util/math}: Helpers for common math operations.
 - {@link webgpu/util/check_contents}: Check the contents of TypedArrays, with nice messages.
-    Also can be composed with {@link GPUTest.expectGPUBufferValuesPassCheck}, used to implement
+    Also can be composed with {@link webgpu/gpu_test!GPUTest#expectGPUBufferValuesPassCheck}, used to implement
     GPUBuffer checking helpers in GPUTest.
 - {@link webgpu/util/conversion}: Numeric encoding/decoding for float/unorm/snorm values, etc.
 - {@link webgpu/util/copy_to_texture}:
@@ -58,7 +60,7 @@ Whenever a new generally-useful helper is added, it should be indexed here.
     Helper functions to do color space conversion. The algorithm is the same as defined in
     CSS Color Module Level 4.
 - {@link webgpu/util/create_elements}:
-    Helpers for creating web elements like HTMLCanvasElement, OffscrrenCanvas, etc.
+    Helpers for creating web elements like HTMLCanvasElement, OffscreenCanvas, etc.
 - {@link webgpu/util/shader}: Helpers for creating fragment shader based on intended output values, plainType, and componentCount.
 - {@link webgpu/util/texture/base}: General texture-related helpers.
 - {@link webgpu/util/texture/layout}: Helpers for working with linear image data
@@ -76,10 +78,11 @@ Whenever a new generally-useful helper is added, it should be indexed here.
 - {@link common/framework/resources}: Provides the path to the `resources/` directory.
 - {@link common/util/navigator_gpu}: Finds and returns the `navigator.gpu` object or equivalent.
 - {@link common/util/util}: Miscellaneous utilities.
-    - {@link common/util/util.assert | assert}: Assert a condition, otherwise throw an exception.
-    - {@link common/util/util.unreachable | unreachable}: Assert unreachable code.
-    - {@link assertReject}, {@link resolveOnTimeout}, {@link rejectOnTimeout},
-        {@link raceWithRejectOnTimeout}, and more.
+    - {@link common/util/util!assert}: Assert a condition, otherwise throw an exception.
+    - {@link common/util/util!unreachable}: Assert unreachable code.
+    - {@link common/util/util!assertReject}, {@link common/util/util!resolveOnTimeout},
+        {@link common/util/util!rejectOnTimeout},
+        {@link common/util/util!raceWithRejectOnTimeout}, and more.
 - {@link common/util/collect_garbage}:
     Attempt to trigger garbage collection, for testing that garbage collection is not observable.
 - {@link common/util/preprocessor}: A simple template-based, non-line-based preprocessor,

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "quiet-grunt": "^0.2.3",
         "serve-index": "^1.9.1",
         "ts-node": "^9.0.0",
-        "typedoc": "^0.22.13",
+        "typedoc": "^0.23.10",
         "typescript": "~4.7.4"
       },
       "engines": {
@@ -6279,9 +6279,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
+      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -9021,25 +9021,24 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.13",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
-      "integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.12",
-        "minimatch": "^5.0.1",
+        "marked": "^4.0.18",
+        "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 14.14"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+        "typescript": "4.6.x || 4.7.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -9052,9 +9051,9 @@
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -14348,9 +14347,9 @@
       }
     },
     "marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
+      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
       "dev": true
     },
     "media-typer": {
@@ -16473,15 +16472,14 @@
       }
     },
     "typedoc": {
-      "version": "0.22.13",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.13.tgz",
-      "integrity": "sha512-NHNI7Dr6JHa/I3+c62gdRNXBIyX7P33O9TafGLd07ur3MqzcKgwTvpg18EtvCLHJyfeSthAtCLpM7WkStUmDuQ==",
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
       "dev": true,
       "requires": {
-        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.12",
-        "minimatch": "^5.0.1",
+        "marked": "^4.0.18",
+        "minimatch": "^5.1.0",
         "shiki": "^0.10.1"
       },
       "dependencies": {
@@ -16495,9 +16493,9 @@
           }
         },
         "minimatch": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "serve-index": "^1.9.1",
         "ts-node": "^9.0.0",
         "typedoc": "^0.22.13",
-        "typescript": "~4.6.2"
+        "typescript": "~4.7.4"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -9064,9 +9064,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -16506,9 +16506,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,6 @@
     "serve-index": "^1.9.1",
     "ts-node": "^9.0.0",
     "typedoc": "^0.22.13",
-    "typescript": "~4.6.2"
+    "typescript": "~4.7.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "quiet-grunt": "^0.2.3",
     "serve-index": "^1.9.1",
     "ts-node": "^9.0.0",
-    "typedoc": "^0.22.13",
+    "typedoc": "^0.23.10",
     "typescript": "~4.7.4"
   }
 }

--- a/src/common/framework/params_builder.ts
+++ b/src/common/framework/params_builder.ts
@@ -146,7 +146,7 @@ export class CaseParamsBuilder<CaseP extends {}>
     return this.cases();
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   expandWithParams<NewP extends {}>(
     expander: (_: Merged<{}, CaseP>) => Iterable<NewP>
   ): CaseParamsBuilder<Merged<CaseP, NewP>> {
@@ -154,7 +154,7 @@ export class CaseParamsBuilder<CaseP extends {}>
     return new CaseParamsBuilder(() => newGenerator({}));
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   expand<NewPKey extends string, NewPValue>(
     key: NewPKey,
     expander: (_: Merged<{}, CaseP>) => Iterable<NewPValue>
@@ -166,7 +166,7 @@ export class CaseParamsBuilder<CaseP extends {}>
     });
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   combineWithParams<NewP extends {}>(
     newParams: Iterable<NewP>
   ): CaseParamsBuilder<Merged<CaseP, NewP>> {
@@ -181,7 +181,7 @@ export class CaseParamsBuilder<CaseP extends {}>
     return this.expandWithParams(() => newParams);
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   combine<NewPKey extends string, NewPValue>(
     key: NewPKey,
     values: Iterable<NewPValue>
@@ -191,13 +191,13 @@ export class CaseParamsBuilder<CaseP extends {}>
     return this.combineWithParams(mapped);
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   filter(pred: (_: Merged<{}, CaseP>) => boolean): CaseParamsBuilder<CaseP> {
     const newGenerator = filterGenerator(this.cases, pred);
     return new CaseParamsBuilder(() => newGenerator({}));
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   unless(pred: (_: Merged<{}, CaseP>) => boolean): CaseParamsBuilder<CaseP> {
     return this.filter(x => !pred(x));
   }
@@ -252,14 +252,14 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
     }
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   expandWithParams<NewP extends {}>(
     expander: (_: Merged<CaseP, SubcaseP>) => Iterable<NewP>
   ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, NewP>> {
     return new SubcaseParamsBuilder(this.cases, expanderGenerator(this.subcases, expander));
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   expand<NewPKey extends string, NewPValue>(
     key: NewPKey,
     expander: (_: Merged<CaseP, SubcaseP>) => Iterable<NewPValue>
@@ -272,7 +272,7 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
     });
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   combineWithParams<NewP extends {}>(
     newParams: Iterable<NewP>
   ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, NewP>> {
@@ -280,7 +280,7 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
     return this.expandWithParams(() => newParams);
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   combine<NewPKey extends string, NewPValue>(
     key: NewPKey,
     values: Iterable<NewPValue>
@@ -289,12 +289,12 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
     return this.expand(key, () => values);
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   filter(pred: (_: Merged<CaseP, SubcaseP>) => boolean): SubcaseParamsBuilder<CaseP, SubcaseP> {
     return new SubcaseParamsBuilder(this.cases, filterGenerator(this.subcases, pred));
   }
 
-  /** @inheritdoc */
+  /** @inheritDoc */
   unless(pred: (_: Merged<CaseP, SubcaseP>) => boolean): SubcaseParamsBuilder<CaseP, SubcaseP> {
     return this.filter(x => !pred(x));
   }

--- a/src/common/util/preprocessor.ts
+++ b/src/common/util/preprocessor.ts
@@ -105,7 +105,7 @@ class EndIf extends Directive {
  * ```
  *
  * @param strings - The array of constant string chunks of the template string.
- * @param ...values - The array of interpolated ${} values within the template string.
+ * @param ...values - The array of interpolated `${}` values within the template string.
  */
 export function pp(
   strings: TemplateStringsArray,

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -151,8 +151,8 @@ g.test('canvas_configuration')
     const { format, canvasType, enable_required_feature } = t.params;
 
     const canvas = createCanvas(t, canvasType, 2, 2);
-    const ctx = canvas.getContext('webgpu' as const);
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     const canvasConf = {
       device: t.device,
@@ -200,8 +200,8 @@ g.test('canvas_configuration_view_formats')
     const { viewFormats, canvasType, enable_required_feature } = t.params;
 
     const canvas = createCanvas(t, canvasType, 2, 2);
-    const ctx = canvas.getContext('webgpu' as const);
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     const canvasConf = {
       device: t.device,

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -195,7 +195,7 @@ export class ValidationTest extends GPUTest {
   }
 
   /**
-   * Return an arbitrary object of the specified {@link BindableResource} type
+   * Return an arbitrary object of the specified {@link webgpu/capability_info!BindableResource} type
    * (e.g. `'errorBuf'`, `'nonFiltSamp'`, `sampledTexMS`, etc.)
    */
   getBindingResource(bindingType: BindableResource): GPUBindingResource {

--- a/src/webgpu/util/color_space_conversion.ts
+++ b/src/webgpu/util/color_space_conversion.ts
@@ -133,7 +133,7 @@ function XYZ_to_lin_P3(XYZ: Array<Array<number>>) {
 }
 
 /**
- * @returns the converted pixels in {R: number, G: number, B: number, A: number}.
+ * @returns the converted pixels in `{R: number, G: number, B: number, A: number}`.
  *
  * Follow conversion steps in CSS Color Module Level 4
  * https://drafts.csswg.org/css-color/#predefined-to-predefined
@@ -164,7 +164,7 @@ export function displayP3ToSrgb(pixel: {
   return pixel;
 }
 /**
- * @returns the converted pixels in {R: number, G: number, B: number, A: number}.
+ * @returns the converted pixels in `{R: number, G: number, B: number, A: number}`.
  *
  * Follow conversion steps in CSS Color Module Level 4
  * https://drafts.csswg.org/css-color/#predefined-to-predefined

--- a/src/webgpu/util/shader.ts
+++ b/src/webgpu/util/shader.ts
@@ -48,7 +48,8 @@ export function getPlainTypeInfo(sampleType: GPUTextureSampleType): keyof typeof
 
 /**
  * Build a fragment shader based on output value and types
- * e.g. write to color target 0 a vec4<f32>(1.0, 0.0, 1.0, 1.0) and color target 2 a vec2<u32>(1, 2)
+ * e.g. write to color target 0 a `vec4<f32>(1.0, 0.0, 1.0, 1.0)` and color target 2 a `vec2<u32>(1, 2)`
+ * ```
  * outputs: [
  *   {
  *     values: [1, 0, 1, 1],,
@@ -62,8 +63,10 @@ export function getPlainTypeInfo(sampleType: GPUTextureSampleType): keyof typeof
  *     componentCount: 2,
  *   },
  * ]
+ * ```
  *
  * return:
+ * ```
  * struct Outputs {
  *     @location(0) o1 : vec4<f32>,
  *     @location(2) o3 : vec2<u32>,
@@ -71,6 +74,7 @@ export function getPlainTypeInfo(sampleType: GPUTextureSampleType): keyof typeof
  * @fragment fn main() -> Outputs {
  *     return Outputs(vec4<f32>(1.0, 0.0, 1.0, 1.0), vec4<u32>(1, 2));
  * }
+ * ```
  * @param outputs the shader outputs for each location attribute
  * @returns the fragment shader string
  */

--- a/src/webgpu/util/texture/subresource.ts
+++ b/src/webgpu/util/texture/subresource.ts
@@ -1,10 +1,10 @@
-/** A range of indices expressed as { begin, count }. */
+/** A range of indices expressed as `{ begin, count }`. */
 export interface BeginCountRange {
   begin: number;
   count: number;
 }
 
-/* A range of indices, expressed as { begin, end }. */
+/* A range of indices, expressed as `{ begin, end }`. */
 export interface BeginEndRange {
   begin: number;
   end: number;
@@ -43,7 +43,7 @@ export class SubresourceRange {
   }
 
   /**
-   * Iterates over the "rectangle" of { mip level, array layer } pairs represented by the range.
+   * Iterates over the "rectangle" of `{ level, layer }` pairs represented by the range.
    */
   *each(): Generator<{ level: number; layer: number }> {
     for (let level = this.mipRange.begin; level < this.mipRange.end; ++level) {

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -598,7 +598,7 @@ export type TexelRepresentationInfo = {
   /** Decode the data representation into the shader values. ex.) unorm8 255 -> float 1.0 */
   // MAINTENANCE_TODO: Replace with bitsToNumber?
   readonly decode: ComponentMapFn;
-  /** Pack texel component values into an ArrayBuffer. ex.) rg8unorm {r: 0, g: 255} -> 0xFF00 */
+  /** Pack texel component values into an ArrayBuffer. ex.) rg8unorm `{r: 0, g: 255}` -> 0xFF00 */
   // MAINTENANCE_TODO: Replace with packBits?
   readonly pack: ComponentPackFn;
 

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -32,8 +32,8 @@ g.test('defaults')
   .fn(async t => {
     const { canvasType } = t.params;
     const canvas = createCanvas(t, canvasType, 2, 2);
-    const ctx = canvas.getContext('webgpu' as const);
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     ctx.configure({
       device: t.device,
@@ -64,8 +64,8 @@ g.test('device')
   .fn(async t => {
     const { canvasType } = t.params;
     const canvas = createCanvas(t, canvasType, 2, 2);
-    const ctx = canvas.getContext('webgpu' as const);
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     // Calling configure without a device should throw.
     t.shouldThrow(true, () => {
@@ -119,8 +119,8 @@ g.test('format')
   .fn(async t => {
     const { canvasType, format } = t.params;
     const canvas = createCanvas(t, canvasType, 2, 2);
-    const ctx = canvas.getContext('webgpu' as const);
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     // Would prefer to use kCanvasTextureFormats.includes(format), but that's giving TS errors.
     let validFormat = false;
@@ -168,8 +168,8 @@ g.test('usage')
   .fn(async t => {
     const { canvasType, usage } = t.params;
     const canvas = createCanvas(t, canvasType, 2, 2);
-    const ctx = canvas.getContext('webgpu' as const);
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     ctx.configure({
       device: t.device,
@@ -278,8 +278,8 @@ g.test('alpha_mode')
   .fn(async t => {
     const { canvasType, alphaMode } = t.params;
     const canvas = createCanvas(t, canvasType, 2, 2);
-    const ctx = canvas.getContext('webgpu' as const);
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     ctx.configure({
       device: t.device,

--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -11,8 +11,8 @@ import { kAllCanvasTypes, createCanvas, CanvasType } from '../../util/create_ele
 class GPUContextTest extends GPUTest {
   initCanvasContext(canvasType: CanvasType = 'onscreen'): GPUCanvasContext {
     const canvas = createCanvas(this, canvasType, 2, 2);
-    const ctx = canvas.getContext('webgpu' as const);
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     ctx.configure({
       device: this.device,
@@ -37,8 +37,8 @@ g.test('configured')
   )
   .fn(async t => {
     const canvas = createCanvas(t, t.params.canvasType, 2, 2);
-    const ctx = canvas.getContext('webgpu' as const);
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     // Calling getCurrentTexture prior to configuration should throw an exception.
     t.shouldThrow(true, () => {

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -43,8 +43,8 @@ async function initCanvasContent(
   canvasType: CanvasType
 ): Promise<HTMLCanvasElement | OffscreenCanvas> {
   const canvas = createCanvas(t, canvasType, 2, 2);
-  const ctx = canvas.getContext('webgpu' as const);
-  assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+  const ctx = canvas.getContext('webgpu');
+  assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
   ctx.configure({
     device: t.device,

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -286,7 +286,7 @@ class F extends CopyToTextureUtils {
 
     const gpuContext = canvas.getContext('webgpu');
 
-    if (gpuContext === null) {
+    if (!(gpuContext instanceof GPUCanvasContext)) {
       this.skip(canvasType + ' canvas webgpu context not available');
     }
 

--- a/src/webgpu/web_platform/reftests/canvas_complex.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_complex.html.ts
@@ -704,7 +704,7 @@ fn main(@builtin(global_invocation_id) GlobalInvocationID : vec3<u32>) {
 
     for (const { cvs, writeCanvasMethod } of targets) {
       const ctx = cvs.getContext('webgpu');
-      assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+      assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
       let usage: GPUTextureUsageFlags;
       switch (writeCanvasMethod) {

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -14,7 +14,7 @@ export function run(
 ) {
   runRefTest(async t => {
     const ctx = cvs.getContext('webgpu');
-    assert(ctx !== null, 'Failed to get WebGPU context from canvas');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
     switch (format) {
       case 'bgra8unorm':

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -7,12 +7,6 @@ declare global {
     // https://w3c.github.io/mediacapture-fromelement/#dom-htmlmediaelement-capturestream
     captureStream(): MediaStream;
   }
-
-  interface HTMLVideoElement {
-    requestVideoFrameCallback(
-      callback: (now: DOMHighResTimeStamp, metadata: unknown) => void
-    ): number;
-  }
 }
 
 /**


### PR DESCRIPTION
Not entirely clear why upgrading caused type narrowing to fail in these
cases, but it's easy to fix.

Issue: none

<hr>

**Requirements for PR author:**

- [x] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [x] ~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] ~Tests are properly located in the test tree.~
- [x] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [x] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
