### PR TITLE
Implement `step` f32 tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -34,6 +34,7 @@ import {
   powInterval,
   tanInterval,
   sinInterval,
+  stepInterval,
   subtractionInterval,
   ulpInterval,
 } from '../webgpu/util/f32_interval.js';
@@ -1547,6 +1548,83 @@ g.test('powInterval')
     t.expect(
       objectEquals(expected, got),
       `powInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('stepInterval')
+  .paramsSubcasesOnly<BinaryToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: [1, 1] },
+      { input: [1, 1], expected: [1, 1] },
+      { input: [0, 1], expected: [1, 1] },
+      { input: [1, 0], expected: [0, 0] },
+      { input: [-1, -1], expected: [1, 1] },
+      { input: [0, -1], expected: [0, 0] },
+      { input: [-1, 0], expected: [1, 1] },
+      { input: [-1, 1], expected: [1, 1] },
+      { input: [1, -1], expected: [0, 0] },
+
+      // 64-bit normals
+      { input: [0.1, 0.1], expected: [0, 1] },
+      { input: [0, 0.1], expected: [1, 1] },
+      { input: [0.1, 0], expected: [0, 0] },
+      { input: [0.1, 1], expected: [1, 1] },
+      { input: [1, 0.1], expected: [0, 0] },
+      { input: [-0.1, -0.1], expected: [0, 1] },
+      { input: [0, -0.1], expected: [0, 0] },
+      { input: [-0.1, 0], expected: [1, 1] },
+      { input: [-0.1, -1], expected: [0, 0] },
+      { input: [-1, -0.1], expected: [1, 1] },
+
+      // Subnormals
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [1, 1] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [1, 1] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [0, 1] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [0, 1] },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: [0, 0] },
+      { input: [1, kValue.f32.subnormal.positive.min], expected: [0, 0] },
+      { input: [1, kValue.f32.subnormal.negative.max], expected: [0, 0] },
+      { input: [1, kValue.f32.subnormal.negative.min], expected: [0, 0] },
+      { input: [-1, kValue.f32.subnormal.positive.max], expected: [1, 1] },
+      { input: [-1, kValue.f32.subnormal.positive.min], expected: [1, 1] },
+      { input: [-1, kValue.f32.subnormal.negative.max], expected: [1, 1] },
+      { input: [-1, kValue.f32.subnormal.negative.min], expected: [1, 1] },
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, 1] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, 1] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [1, 1] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [1, 1] },
+      { input: [kValue.f32.subnormal.positive.max, 1], expected: [1, 1] },
+      { input: [kValue.f32.subnormal.positive.min, 1], expected: [1, 1] },
+      { input: [kValue.f32.subnormal.negative.max, 1], expected: [1, 1] },
+      { input: [kValue.f32.subnormal.negative.min, 1], expected: [1, 1] },
+      { input: [kValue.f32.subnormal.positive.max, -1], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.positive.min, -1], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.negative.max, -1], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.negative.min, -1], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [1, 1] },
+      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min], expected: [0, 1] },
+
+      // Infinities
+      { input: [0, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+    ]
+  )
+  .fn(t => {
+    const [edge, x] = t.params.input;
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = stepInterval(edge, x);
+    t.expect(
+      objectEquals(expected, got),
+      `stepInterval(${edge}, ${x}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -9,7 +9,13 @@ Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { anyOf } from '../../../../../util/compare.js';
+import { f32, TypeF32 } from '../../../../../util/conversion.js';
+import { F32Interval, stepInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { allInputSources, Case, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -27,7 +33,40 @@ g.test('f32')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const zeroInterval = new F32Interval(0, 0);
+    const oneInterval = new F32Interval(1, 1);
+
+    // stepInterval's return value isn't always interpreted as an acceptance
+    // interval, so makeBinaryF32IntervalCase cannot be used here.
+    // See the comment block on stepInterval for more details
+    const makeCase = (edge: number, x: number): Case => {
+      edge = quantizeToF32(edge);
+      x = quantizeToF32(x);
+      const expected = stepInterval(edge, x);
+
+      // [0, 0], [1, 1], or [-∞, +∞] cases
+      if (expected.isPoint() || !expected.isFinite()) {
+        return { input: [f32(edge), f32(x)], expected };
+      }
+
+      // [0, 1] case
+      return {
+        input: [f32(edge), f32(x)],
+        expected: anyOf(zeroInterval, oneInterval),
+      };
+    };
+
+    const range = fullF32Range();
+    const cases: Array<Case> = [];
+    range.forEach(edge => {
+      range.forEach(x => {
+        cases.push(makeCase(edge, x));
+      });
+    });
+
+    run(t, builtin('step'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -860,6 +860,29 @@ export function sinInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), SinIntervalOp);
 }
 
+const StepIntervalOp: BinaryToIntervalOp = {
+  impl: (edge: number, x: number): F32Interval => {
+    if (edge <= x) {
+      return correctlyRoundedInterval(1.0);
+    }
+    return correctlyRoundedInterval(0.0);
+  },
+};
+
+/** Calculate an acceptance 'interval' for step(edge, x)
+ *
+ * step only returns two possible values, so its interval requires special
+ * interpretation in CTS tests.
+ * This interval will be one of four values: [0, 0], [0, 1], [1, 1] & [-∞, +∞].
+ * [0, 0] and [1, 1] indicate that the correct answer in point they encapsulate.
+ * [0, 1] should not be treated as a span, i.e. 0.1 is acceptable, but instead
+ * indicate either 0.0 or 1.0 are acceptable answers.
+ * [-∞, +∞] is treated as the any interval, since an undefined or infinite value was passed in.
+ */
+export function stepInterval(edge: number, x: number): F32Interval {
+  return runBinaryOp(toInterval(edge), toInterval(x), StepIntervalOp);
+}
+
 const SubtractionInnerOp: BinaryToIntervalOp = {
   impl: (x: number, y: number): F32Interval => {
     return correctlyRoundedInterval(x - y);


### PR DESCRIPTION
Issue #1240

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
