### PR TITLE
Implement `round` f32 tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -12,7 +12,12 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { roundInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -30,7 +35,14 @@ g.test('f32')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryF32IntervalCase(n, roundInterval);
+    };
+
+    const cases = fullF32Range().map(makeCase);
+    run(t, builtin('round'), [TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -857,6 +857,31 @@ export function radiansInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), RadiansIntervalOp);
 }
 
+const RoundIntervalOp: PointToIntervalOp = {
+  impl: (n: number): F32Interval => {
+    const k = Math.floor(n);
+    const diff_before = n - k;
+    const diff_after = k + 1 - n;
+    if (diff_before < diff_after) {
+      return correctlyRoundedInterval(k);
+    } else if (diff_before > diff_after) {
+      return correctlyRoundedInterval(k + 1);
+    }
+
+    // n is in the middle of two integers.
+    // The tie breaking rule is 'k if k is even, k + 1 if k is odd'
+    if (k % 2 === 0) {
+      return correctlyRoundedInterval(k);
+    }
+    return correctlyRoundedInterval(k + 1);
+  },
+};
+
+/** Calculate an acceptance interval of round(x) */
+export function roundInterval(n: number): F32Interval {
+  return runPointOp(toInterval(n), RoundIntervalOp);
+}
+
 /**
  * Calculate an acceptance interval of saturate(n) as clamp(n, 0.0, 1.0)
  *


### PR DESCRIPTION
Issue #1235

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
