### PR TITLE
wgsl: Replace module-scope 'let' with 'const'

### DIFF
--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -65,8 +65,8 @@ have unexpected values then get drawn to the color buffer, which is later checke
       var<private> kDepths: array<f32, ${kNumDepthValues}> = array<f32, ${kNumDepthValues}>(
           -1.0, -0.5, 0.0, 0.25, 0.75, 1.0, 1.5, 2.0);
 
-      let vpMin: f32 = ${kViewportMinDepth};
-      let vpMax: f32 = ${kViewportMaxDepth};
+      const vpMin: f32 = ${kViewportMinDepth};
+      const vpMax: f32 = ${kViewportMaxDepth};
 
       // Draw the points in a straight horizontal row, one per pixel.
       fn vertexX(idx: u32) -> f32 {
@@ -377,8 +377,8 @@ to be empty.`
       var<private> kDepths: array<f32, ${kNumDepthValues}> = array<f32, ${kNumDepthValues}>(
           -1.0, -0.5, 0.0, 0.25, 0.75, 1.0, 1.5, 2.0);
 
-      let vpMin: f32 = ${kViewportMinDepth};
-      let vpMax: f32 = ${kViewportMaxDepth};
+      const vpMin: f32 = ${kViewportMinDepth};
+      const vpMax: f32 = ${kViewportMaxDepth};
 
       // Draw the points in a straight horizontal row, one per pixel.
       fn vertexX(idx: u32) -> f32 {

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -763,7 +763,7 @@ const testShaderFunctions = `
  */
 const shaderEntryPoint = `
   // Change to pipeline overridable constant when possible.
-  let workgroupXSize = 256u;
+  const workgroupXSize = 256u;
   @compute @workgroup_size(workgroupXSize) fn main(
     @builtin(local_invocation_id) local_invocation_id : vec3<u32>,
     @builtin(workgroup_id) workgroup_id : vec3<u32>) {

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -112,9 +112,9 @@ g.test('inputs')
 
       ${structures}
 
-      let group_width = ${t.params.groupSize.x}u;
-      let group_height = ${t.params.groupSize.y}u;
-      let group_depth = ${t.params.groupSize.z}u;
+      const group_width = ${t.params.groupSize.x}u;
+      const group_height = ${t.params.groupSize.y}u;
+      const group_depth = ${t.params.groupSize.z}u;
 
       @compute @workgroup_size(group_width, group_height, group_depth)
       fn main(

--- a/src/webgpu/shader/validation/parse/blankspace.spec.ts
+++ b/src/webgpu/shader/validation/parse/blankspace.spec.ts
@@ -18,9 +18,9 @@ g.test('null_characters')
     if (t.params.placement === 'comment') {
       code = `// Here is a ${t.params.contains_null ? '\0' : 'Z'} character`;
     } else if (t.params.placement === 'delimiter') {
-      code = `let${t.params.contains_null ? '\0' : ' '}name : i32 = 0;`;
+      code = `const${t.params.contains_null ? '\0' : ' '}name : i32 = 0;`;
     } else if (t.params.placement === 'eol') {
-      code = `let name : i32 = 0;${t.params.contains_null ? '\0' : ''}`;
+      code = `const name : i32 = 0;${t.params.contains_null ? '\0' : ''}`;
     }
     t.expectCompileResult(!t.params.contains_null, code);
   });
@@ -45,6 +45,6 @@ g.test('blankspace')
       .beginSubcases()
   )
   .fn(t => {
-    const code = `let${t.params.blankspace[0]}ident : i32 = 0;`;
+    const code = `const${t.params.blankspace[0]}ident : i32 = 0;`;
     t.expectCompileResult(true, code);
   });

--- a/src/webgpu/shader/validation/parse/comments.spec.ts
+++ b/src/webgpu/shader/validation/parse/comments.spec.ts
@@ -56,7 +56,7 @@ g.test('line_comment_terminators')
       .beginSubcases()
   )
   .fn(t => {
-    const code = `// Line comment${t.params.blankspace[0]}let invalid_outside_comment = should_fail`;
+    const code = `// Line comment${t.params.blankspace[0]}const invalid_outside_comment = should_fail`;
 
     t.expectCompileResult([' ', '\t'].includes(t.params.blankspace[0]), code);
   });


### PR DESCRIPTION
Module-scope 'let' was has been entirely replaced with 'const'.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
