### PR TITLE
shader/execution: Optimize "const" shader exeuction

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -297,9 +297,10 @@ function buildPipeline(
   outputBuffer: GPUBuffer
 ): [GPUComputePipeline, GPUBindGroup] {
   // wgsl declaration of output buffer and binding
+  const wgslStorageType = storageType(returnType);
   const wgslOutputs = `
 struct Output {
-  @size(${kValueStride}) value : ${storageType(returnType)}
+  @size(${kValueStride}) value : ${wgslStorageType}
 };
 @group(0) @binding(0) var<storage, read_write> outputs : array<Output, ${cases.length}>;
 `;
@@ -309,18 +310,24 @@ struct Output {
       //////////////////////////////////////////////////////////////////////////
       // Input values are constant values in the WGSL shader
       //////////////////////////////////////////////////////////////////////////
-      const wgslCases = cases.map((c, caseIdx) => {
+      const wgslValues = cases.map(c => {
         const args = parameterTypes.map((_, i) => `(${ith(c.input, i).wgsl()})`);
-        return `outputs[${caseIdx}].value = ${toStorage(returnType, expressionBuilder(args))};`;
+        return `${toStorage(returnType, expressionBuilder(args))}`;
       });
 
       // the full WGSL shader source
       const source = `
 ${wgslOutputs}
 
+const values = array<${wgslStorageType}, ${cases.length}>(
+  ${wgslValues.join(',\n  ')}
+);
+
 @compute @workgroup_size(1)
 fn main() {
-  ${wgslCases.join('\n   ')}
+  for (var i = 0u; i < ${cases.length}; i++) {
+    outputs[i].value = values[i];
+  }
 }
 `;
 


### PR DESCRIPTION
Roll the assignment of the constant values into a loop, iterating over a `const` `array`.
For FXC this can be several orders of magnitude faster (20s+ -> >100ms) (?!)

This change also enforces that the expressions are `const`, as they need to be placed into a `const` array.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
