### PR TITLE
Add `frag_depth` builtin validation.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -16,6 +16,7 @@ export const kBuiltins = [
   { name: 'position', stage: 'vertex', io: 'out', type: 'vec4<f32>' },
   { name: 'position', stage: 'fragment', io: 'in', type: 'vec4<f32>' },
   { name: 'front_facing', stage: 'fragment', io: 'in', type: 'bool' },
+  { name: 'frag_depth', stage: 'fragment', io: 'out', type: 'f32' },
   { name: 'local_invocation_id', stage: 'compute', io: 'in', type: 'vec3<u32>' },
   { name: 'local_invocation_index', stage: 'compute', io: 'in', type: 'u32' },
   { name: 'global_invocation_id', stage: 'compute', io: 'in', type: 'vec3<u32>' },


### PR DESCRIPTION
This CL adds `frag_depth` to the list of builtin values.

Fixes: #1437

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
