### PR TITLE
Implement `trunc` f32 tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -33,14 +33,15 @@ import {
   negationInterval,
   powInterval,
   radiansInterval,
+  roundInterval,
   saturateInterval,
   signInterval,
   sinInterval,
   stepInterval,
   subtractionInterval,
   tanInterval,
+  truncInterval,
   ulpInterval,
-  roundInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -1270,6 +1271,48 @@ g.test('tanInterval')
     t.expect(
       objectEquals(expected, got),
       `tanInterval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('truncInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: [0, 0] },
+      { input: 0.1, expected: [0, 0] },
+      { input: 0.9, expected: [0, 0] },
+      { input: 1.0, expected: [1, 1] },
+      { input: 1.1, expected: [1, 1] },
+      { input: 1.9, expected: [1, 1] },
+      { input: -0.1, expected: [0, 0] },
+      { input: -0.9, expected: [0, 0] },
+      { input: -1.0, expected: [-1, -1] },
+      { input: -1.1, expected: [-1, -1] },
+      { input: -1.9, expected: [-1, -1] },
+
+      // Edge cases
+      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
+      { input: kValue.f32.positive.min, expected: [0, 0] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+      { input: kValue.f32.negative.max, expected: [0, 0] },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: [0, 0] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0, 0] },
+      { input: kValue.f32.subnormal.negative.min, expected: [0, 0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [0, 0] },
+    ]
+  )
+  .fn(t => {
+    const input = t.params.input;
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = truncInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `truncInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -10,7 +10,12 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { truncInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -28,7 +33,14 @@ g.test('f32')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryF32IntervalCase(n, truncInterval);
+    };
+
+    const cases = fullF32Range().map(makeCase);
+    run(t, builtin('trunc'), [TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -975,3 +975,14 @@ const TanIntervalOp: PointToIntervalOp = {
 export function tanInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), TanIntervalOp);
 }
+
+const TruncIntervalOp: PointToIntervalOp = {
+  impl: (n: number): F32Interval => {
+    return correctlyRoundedInterval(Math.trunc(n));
+  },
+};
+
+/** Calculate an acceptance interval of trunc(x) */
+export function truncInterval(n: number): F32Interval {
+  return runPointOp(toInterval(n), TruncIntervalOp);
+}


### PR DESCRIPTION
Issue #1243

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
