### PR TITLE
Add test to allow builtin values as identifiers

### DIFF
--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -253,7 +253,7 @@ g.test('missing_vertex_position')
 
 g.test('reuse_builtin_name')
   .desc(`Test that a builtin name can be used in different contexts`)
-  .params( u =>
+  .params(u =>
     u
       .combineWithParams(kBuiltins)
       .combine('use', ['type_name', 'struct', 'function', 'module-var', 'function-var'])
@@ -269,7 +269,7 @@ g.test('reuse_builtin_name')
     } else if (t.params.use === `module-var`) {
       code += `const ${t.params.name} = 1;`;
     } else if (t.params.use === `function-var`) {
-      code += `fn test() { let ${t.params.name} = 1; }`
+      code += `fn test() { let ${t.params.name} = 1; }`;
     }
     t.expectCompileResult(true, code);
   });

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -250,3 +250,26 @@ g.test('missing_vertex_position')
     // Expect to pass only when using @builtin(position).
     t.expectCompileResult(t.params.attribute === '@builtin(position)', code);
   });
+
+g.test('reuse_builtin_name')
+  .desc(`Test that a builtin name can be used in different contexts`)
+  .params( u =>
+    u
+      .combineWithParams(kBuiltins)
+      .combine('use', ['type_name', 'struct', 'function', 'module-var', 'function-var'])
+  )
+  .fn(t => {
+    let code = '';
+    if (t.params.use === 'type_name') {
+      code += `type ${t.params.name} = i32;`;
+    } else if (t.params.use === `struct`) {
+      code += `struct ${t.params.name} { i: f32, }`;
+    } else if (t.params.use === `function`) {
+      code += `fn ${t.params.name}() {}`;
+    } else if (t.params.use === `module-var`) {
+      code += `const ${t.params.name} = 1;`;
+    } else if (t.params.use === `function-var`) {
+      code += `fn test() { let ${t.params.name} = 1; }`
+    }
+    t.expectCompileResult(true, code);
+  });


### PR DESCRIPTION
This CL updates the builtin tests to verify that builtin value names
(e.g. position, sample_mask) can be used as function names, struct
names, type aliases, etc.

Fixes: #1443

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
