### PR TITLE
Add test to validate parsing of `@builtin`

### DIFF
--- a/src/webgpu/shader/validation/parse/builtin.spec.ts
+++ b/src/webgpu/shader/validation/parse/builtin.spec.ts
@@ -1,0 +1,37 @@
+export const description = `Validation tests for @builtin`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kValidBuiltin = new Set([
+  `@builtin(position)`,
+  `@builtin(position,)`,
+  `@ \n builtin(position)`,
+  `@/^ comment ^/builtin/^ comment ^/\n\n(\t/^comment^/position/^comment^/)`,
+]);
+const kInvalidBuiltin = new Set([
+  `@abuiltin(position)`,
+  `@builtin`,
+  `@builtin()`,
+  `@builtin position`,
+  `@builtin position)`,
+  `@builtin(position`,
+  `@builtin(position, frag_depth)`,
+  `@builtin(identifier)`,
+  `@builtin(2)`,
+]);
+
+g.test('parse')
+  .desc(`Test that @builtin is parsed correctly.`)
+  .params(u => u.combine('builtin', new Set([...kValidBuiltin, ...kInvalidBuiltin])))
+  .fn(t => {
+    const v = t.params.builtin.replace(/\^/g, '*');
+    const code = `
+@vertex
+fn main() -> ${v} vec4<f32> {
+  return vec4<f32>(.4, .2, .3, .1);
+}`;
+    t.expectCompileResult(kValidBuiltin.has(t.params.builtin), code);
+  });


### PR DESCRIPTION
This CL adds a test case for various test cases around the parsing
of `@builtin`.

Fixes: #1446

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
