### PR TITLE
Trailing comma in `@align` should be valid.

### DIFF
--- a/src/webgpu/shader/validation/parse/align.spec.ts
+++ b/src/webgpu/shader/validation/parse/align.spec.ts
@@ -11,6 +11,7 @@ const kValidAlign = new Set([
   '@align(4)',
   '@align(4i)',
   '@align(0x4)',
+  '@align(4,)',
   '@align(1073741824)',
   '@\talign\t(4)',
   '@/^comment^/align/^comment^/(4)',
@@ -28,7 +29,6 @@ const kInvalidAlign = new Set([
   '@align(4u)',
   '@align(4f)',
   '@align(4h)',
-  '@align(4,)',
   '@align',
   '@align(0)',
   '@align(-4)',
@@ -38,7 +38,7 @@ const kInvalidAlign = new Set([
 
 g.test('missing_attribute_on_param_struct')
   .desc(`Test that @align is parsed correctly.`)
-  .params(u => u.beginSubcases().combine('align', new Set([...kValidAlign, ...kInvalidAlign])))
+  .params(u => u.combine('align', new Set([...kValidAlign, ...kInvalidAlign])))
   .fn(t => {
     const v = t.params.align.replace(/\^/g, '*');
     const code = `


### PR DESCRIPTION
This CL fixes `@align(4,)` to be considered valid as trailing commas
are permitted in attribute lists.

Issue: #1432

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
