### PR TITLE
Add non-entrypoint tests to the builtin validation.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -70,7 +70,7 @@ g.test('stage_inout')
     u
       .combineWithParams(kBuiltins)
       .combine('use_struct', [true, false] as const)
-      .combine('target_stage', ['vertex', 'fragment', 'compute'] as const)
+      .combine('target_stage', ['', 'vertex', 'fragment', 'compute'] as const)
       .combine('target_io', ['in', 'out'] as const)
       .beginSubcases()
   )
@@ -87,8 +87,9 @@ g.test('stage_inout')
     const expectation = kBuiltins.some(
       x =>
         x.name === t.params.name &&
-        x.stage === t.params.target_stage &&
-        x.io === t.params.target_io &&
+        (x.stage === t.params.target_stage ||
+          (t.params.use_struct && t.params.target_stage === '')) &&
+        (x.io === t.params.target_io || t.params.target_stage === '') &&
         x.type === t.params.type
     );
     t.expectCompileResult(expectation, code);


### PR DESCRIPTION
This CL adds tests for validation of `@builtin` on non-entrypoint functions.

Issue: #1435

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
