### PR TITLE
Validate a shader without an entry point is valid.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/entry_point.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/entry_point.spec.ts
@@ -133,3 +133,9 @@ fn frag_main() -> FragmentOutputs {
 `;
     t.expectCompileResult(t.params.target_stage === '', code);
   });
+
+g.test('no_entry_point_provided')
+  .desc(`Tests that a shader without an entry point is accepted`)
+  .fn(t => {
+    t.expectCompileResult(true, 'fn main() {}');
+  });


### PR DESCRIPTION
An entry point is not required, this CL adds a test where there is
no entry point point and validates it is accepted.

Fixes: #1428

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
