### PR TITLE
Implement `sqrt` f32 tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -39,6 +39,7 @@ import {
   saturateInterval,
   signInterval,
   sinInterval,
+  sqrtInterval,
   stepInterval,
   subtractionInterval,
   tanInterval,
@@ -1238,6 +1239,32 @@ g.test('sinInterval')
     t.expect(
       objectEquals(expected, got),
       `sinInterval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('sqrtInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+      // form due to the inherited nature of the errors.
+      { input: -1, expected: kAny },
+      { input: 0, expected: kAny },
+      { input: 0.01, expected: [hexToF64(0x3fb99998, 0xb0000000), hexToF64(0x3fb9999a, 0x70000000)] },  // ~0.1
+      { input: 1, expected: [hexToF64(0x3fefffff, 0x70000000), hexToF64(0x3ff00000, 0x90000000)] },  // ~1
+      { input: 4, expected: [hexToF64(0x3fffffff, 0x70000000), hexToF64(0x40000000, 0x90000000)] },  // ~2
+      { input: 100, expected: [hexToF64(0x4023ffff, 0x70000000), hexToF64(0x40240000, 0xb0000000)] },  // ~10
+      { input: kValue.f32.infinity.positive, expected: kAny },
+    ]
+  )
+  .fn(t => {
+    const input = t.params.input;
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = sqrtInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `sqrtInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -9,7 +9,12 @@ Returns the square root of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { sqrtInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -27,7 +32,14 @@ g.test('f32')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryF32IntervalCase(n, sqrtInterval);
+    };
+
+    const cases = fullF32Range().map(makeCase);
+    run(t, builtin('sqrt'), [TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -963,6 +963,17 @@ const StepIntervalOp: BinaryToIntervalOp = {
   },
 };
 
+const SqrtIntervalOp: PointToIntervalOp = {
+  impl: (n: number): F32Interval => {
+    return divisionInterval(1.0, inverseSqrtInterval(n));
+  },
+};
+
+/** Calculate an acceptance interval of sqrt(x) */
+export function sqrtInterval(n: number): F32Interval {
+  return runPointOp(toInterval(n), SqrtIntervalOp);
+}
+
 /** Calculate an acceptance 'interval' for step(edge, x)
  *
  * step only returns two possible values, so its interval requires special


### PR DESCRIPTION
Issue #1239

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
