### PR TITLE
Add 'VideoFrame' in 'SourceType' for external_texture cts

### DIFF
--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -10,10 +10,10 @@ TODO: consider whether external_texture and copyToTexture video tests should be 
 
 import { getResourcePath } from '../../../common/framework/resources.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { unreachable } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
 import {
   startPlayingAndWaitForVideo,
+  getVideoColorSpaceInit,
   getVideoFrameFromVideoElement,
   waitForNextFrame,
 } from '../../web_platform/util.js';
@@ -136,26 +136,6 @@ function createExternalTextureSamplingTestBindGroup(
   });
 
   return bindGroup;
-}
-
-type VideoColorSpaceName = 'REC601' | 'REC709' | 'REC2020';
-
-function getVideoColorSpaceInit(colorSpaceName: VideoColorSpaceName): VideoColorSpaceInit {
-  switch (colorSpaceName) {
-    case 'REC601':
-      return {
-        primaries: 'smpte170m',
-        transfer: 'smpte170m',
-        matrix: 'smpte170m',
-        fullRange: false,
-      };
-    case 'REC709':
-      return { primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: false };
-    case 'REC2020':
-      return { primaries: 'bt709', transfer: 'iec61966-2-1', matrix: 'rgb', fullRange: true };
-    default:
-      unreachable();
-  }
 }
 
 g.test('importExternalTexture,sample')

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -1,5 +1,10 @@
 import { Fixture, SkipTestCase } from '../../common/framework/fixture.js';
-import { assert, ErrorWithExtra, raceWithRejectOnTimeout } from '../../common/util/util.js';
+import {
+  assert,
+  ErrorWithExtra,
+  raceWithRejectOnTimeout,
+  unreachable,
+} from '../../common/util/util.js';
 
 declare global {
   interface HTMLMediaElement {
@@ -106,15 +111,30 @@ export function waitForNextFrame(
   return promise;
 }
 
+type VideoColorSpaceName = 'REC601' | 'REC709' | 'REC2020';
+
+export function getVideoColorSpaceInit(colorSpaceName: VideoColorSpaceName): VideoColorSpaceInit {
+  switch (colorSpaceName) {
+    case 'REC601':
+      return {
+        primaries: 'smpte170m',
+        transfer: 'smpte170m',
+        matrix: 'smpte170m',
+        fullRange: false,
+      };
+    case 'REC709':
+      return { primaries: 'bt709', transfer: 'bt709', matrix: 'bt709', fullRange: false };
+    case 'REC2020':
+      return { primaries: 'bt709', transfer: 'iec61966-2-1', matrix: 'rgb', fullRange: true };
+    default:
+      unreachable();
+  }
+}
+
 export async function getVideoFrameFromVideoElement(
   test: Fixture,
   video: HTMLVideoElement,
-  colorSpace: VideoColorSpaceInit = {
-    primaries: 'bt709',
-    transfer: 'bt709',
-    matrix: 'bt709',
-    fullRange: false,
-  }
+  colorSpace: VideoColorSpaceInit = getVideoColorSpaceInit('REC709')
 ): Promise<VideoFrame> {
   if (video.captureStream === undefined) {
     test.skip('HTMLVideoElement.captureStream is not supported');


### PR DESCRIPTION
Current cts uses HTMLVideoElement.captureStream() to get a stream and
generate VideoFrame from it. But these VideoFrame doesn't contains valid
color space info.
This PR copy the content of such VideoFrame into ArrayBuffer and wrap it
with correct color space info into another VideoFrame.This makes current
importExternalTexture cts works with VideoFrame.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
