### PR TITLE
Implement `acosh` f32 tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -8,6 +8,8 @@ import { kValue } from '../webgpu/util/constants.js';
 import {
   absInterval,
   absoluteErrorInterval,
+  acoshAlternativeInterval,
+  acoshPrimaryInterval,
   additionInterval,
   atanInterval,
   atan2Interval,
@@ -16,6 +18,7 @@ import {
   clampMinMaxInterval,
   correctlyRoundedInterval,
   cosInterval,
+  coshInterval,
   degreesInterval,
   divisionInterval,
   expInterval,
@@ -46,7 +49,6 @@ import {
   tanInterval,
   truncInterval,
   ulpInterval,
-  coshInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -631,6 +633,62 @@ g.test('absInterval')
     t.expect(
       objectEquals(expected, got),
       `absInterval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('acoshAlternativeInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+      // form due to the inherited nature of the errors.
+      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.negative.min, expected: kAny },
+      { input: -1, expected: kAny },
+      { input: 0, expected: kAny },
+      { input: 1, expected: kAny },  // 1/0 occurs in inverseSqrt in this formulation
+      { input: 1.1, expected: [hexToF64(0x3fdc6368, 0x80000000), hexToF64(0x3fdc636f, 0x20000000)] },  // ~0.443..., differs from the primary in the later digits
+      { input: 10, expected: [hexToF64(0x4007f21e, 0x40000000), hexToF64(0x4007f21f, 0x60000000)] },  // ~2.993...
+      { input: kValue.f32.positive.max, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAny },
+    ]
+  )
+  .fn(t => {
+    const input = t.params.input;
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = acoshAlternativeInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `acoshInterval(${input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('acoshPrimaryInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+      // form due to the inherited nature of the errors.
+      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.negative.min, expected: kAny },
+      { input: -1, expected: kAny },
+      { input: 0, expected: kAny },
+      { input: 1, expected: kAny },  // 1/0 occurs in inverseSqrt in this formulation
+      { input: 1.1, expected: [hexToF64(0x3fdc6368, 0x20000000), hexToF64(0x3fdc636f, 0x80000000)] }, // ~0.443..., differs from the alternative in the later digits
+      { input: 10, expected: [hexToF64(0x4007f21e, 0x40000000), hexToF64(0x4007f21f, 0x60000000)] },  // ~2.993...
+      { input: kValue.f32.positive.max, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAny },
+    ]
+  )
+  .fn(t => {
+    const input = t.params.input;
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = acoshPrimaryInterval(input);
+    t.expect(
+      objectEquals(expected, got),
+      `acoshInterval(${input}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -15,7 +15,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { acoshIntervals } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { biasedRange, fullF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -41,7 +41,10 @@ g.test('f32')
       return makeUnaryF32IntervalCase(n, ...acoshIntervals);
     };
 
-    const cases = fullF32Range().map(makeCase);
+    const cases = [
+      ...biasedRange(1, 2, 100), // x near 1 can be problematic to implement
+      ...fullF32Range(),
+    ].map(makeCase);
     run(t, builtin('acosh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -13,7 +13,12 @@ Note: The result is not mathematically meaningful when e < 1.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { acoshIntervals } from '../../../../../util/f32_interval.js';
+import { fullF32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -31,7 +36,14 @@ g.test('f32')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryF32IntervalCase(n, ...acoshIntervals);
+    };
+
+    const cases = fullF32Range().map(makeCase);
+    run(t, builtin('acosh'), [TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -490,7 +490,7 @@ export function absInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), AbsIntervalOp);
 }
 
-/** All acceptance interval functions foracosh(x) */
+/** All acceptance interval functions for acosh(x) */
 export const acoshIntervals: PointToInterval[] = [acoshAlternativeInterval, acoshPrimaryInterval];
 
 const AcoshAlternativeIntervalOp: PointToIntervalOp = {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -490,6 +490,40 @@ export function absInterval(n: number): F32Interval {
   return runPointOp(toInterval(n), AbsIntervalOp);
 }
 
+/** All acceptance interval functions foracosh(x) */
+export const acoshIntervals: PointToInterval[] = [acoshAlternativeInterval, acoshPrimaryInterval];
+
+const AcoshAlternativeIntervalOp: PointToIntervalOp = {
+  impl: (x: number): F32Interval => {
+    // acosh(x) = log(x + sqrt((x + 1.0f) * (x - 1.0)))
+    const inner_value = multiplicationInterval(
+      additionInterval(x, 1.0),
+      subtractionInterval(x, 1.0)
+    );
+    const sqrt_value = sqrtInterval(inner_value);
+    return logInterval(additionInterval(x, sqrt_value));
+  },
+};
+
+/** Calculate an acceptance interval of acosh(x) using log(x + sqrt((x + 1.0f) * (x - 1.0))) */
+export function acoshAlternativeInterval(x: number | F32Interval): F32Interval {
+  return runPointOp(toInterval(x), AcoshAlternativeIntervalOp);
+}
+
+const AcoshPrimaryIntervalOp: PointToIntervalOp = {
+  impl: (x: number): F32Interval => {
+    // acosh(x) = log(x + sqrt(x * x - 1.0))
+    const inner_value = subtractionInterval(multiplicationInterval(x, x), 1.0);
+    const sqrt_value = sqrtInterval(inner_value);
+    return logInterval(additionInterval(x, sqrt_value));
+  },
+};
+
+/** Calculate an acceptance interval of acosh(x) using log(x + sqrt(x * x - 1.0)) */
+export function acoshPrimaryInterval(x: number | F32Interval): F32Interval {
+  return runPointOp(toInterval(x), AcoshPrimaryIntervalOp);
+}
+
 const AdditionIntervalOp: BinaryToIntervalOp = {
   impl: (x: number, y: number): F32Interval => {
     return correctlyRoundedInterval(x + y);
@@ -996,7 +1030,7 @@ const SqrtIntervalOp: PointToIntervalOp = {
 };
 
 /** Calculate an acceptance interval of sqrt(x) */
-export function sqrtInterval(n: number): F32Interval {
+export function sqrtInterval(n: number | F32Interval): F32Interval {
   return runPointOp(toInterval(n), SqrtIntervalOp);
 }
 


### PR DESCRIPTION
Issue #1221

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
