### PR TITLE
Update val:CopyExternalImageToTexture:OOB,source

### DIFF
--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -45,23 +45,35 @@ interface WithDstOriginMipLevel extends WithMipLevel {
 }
 
 // Helper function to generate copySize for src OOB test
-function generateCopySizeForSrcOOB({ srcOrigin }: { srcOrigin: Required<GPUOrigin2DDict> }) {
+function generateCopySizeForSrcOOB({ srcOrigin }: { srcOrigin: Required<GPUOrigin3DDict> }) {
   // OOB origin fails even with no-op copy.
-  if (srcOrigin.x > kDefaultWidth || srcOrigin.y > kDefaultHeight) {
+  if (srcOrigin.x > kDefaultWidth || srcOrigin.y > kDefaultHeight || srcOrigin.z > kDefaultDepth) {
     return [{ width: 0, height: 0, depthOrArrayLayers: 0 }];
   }
 
   const justFitCopySize = {
     width: kDefaultWidth - srcOrigin.x,
     height: kDefaultHeight - srcOrigin.y,
-    depthOrArrayLayers: 1,
+    depthOrArrayLayers: kDefaultDepth - srcOrigin.z,
   };
 
   return [
     justFitCopySize, // correct size, maybe no-op copy.
-    { width: justFitCopySize.width + 1, height: justFitCopySize.height, depthOrArrayLayers: 1 }, // OOB in width
-    { width: justFitCopySize.width, height: justFitCopySize.height + 1, depthOrArrayLayers: 1 }, // OOB in height
-    { width: justFitCopySize.width, height: justFitCopySize.height, depthOrArrayLayers: 2 }, // OOB in depthOrArrayLayers
+    {
+      width: justFitCopySize.width + 1,
+      height: justFitCopySize.height,
+      depthOrArrayLayers: justFitCopySize.depthOrArrayLayers,
+    }, // OOB in width
+    {
+      width: justFitCopySize.width,
+      height: justFitCopySize.height + 1,
+      depthOrArrayLayers: justFitCopySize.depthOrArrayLayers,
+    }, // OOB in height
+    {
+      width: justFitCopySize.width,
+      height: justFitCopySize.height,
+      depthOrArrayLayers: justFitCopySize.depthOrArrayLayers + 1,
+    }, // OOB in depthOrArrayLayers
   ];
 }
 
@@ -816,12 +828,14 @@ g.test('OOB,source')
   .paramsSubcasesOnly(u =>
     u
       .combine('srcOrigin', [
-        { x: 0, y: 0 }, // origin is on top-left
-        { x: kDefaultWidth - 1, y: 0 }, // x near the border
-        { x: 0, y: kDefaultHeight - 1 }, // y is near the border
-        { x: kDefaultWidth, y: kDefaultHeight }, // origin is on bottom-right
-        { x: kDefaultWidth + 1, y: 0 }, // x is too large
-        { x: 0, y: kDefaultHeight + 1 }, // y is too large
+        { x: 0, y: 0, z: 0 }, // origin is on top-left
+        { x: kDefaultWidth - 1, y: 0, z: 0 }, // x near the border
+        { x: 0, y: kDefaultHeight - 1, z: 0 }, // y is near the border
+        { x: kDefaultWidth, y: kDefaultHeight, z: 0 }, // origin is on bottom-right
+        { x: 0, y: 0, z: kDefaultDepth },
+        { x: kDefaultWidth + 1, y: 0, z: 0 }, // x is too large
+        { x: 0, y: kDefaultHeight + 1, z: 0 }, // y is too large
+        { x: 0, y: 0, z: kDefaultDepth + 1 }, // z is too large
       ])
       .expand('copySize', generateCopySizeForSrcOOB)
   )
@@ -844,7 +858,7 @@ g.test('OOB,source')
     if (
       srcOrigin.x + copySize.width > kDefaultWidth ||
       srcOrigin.y + copySize.height > kDefaultHeight ||
-      copySize.depthOrArrayLayers > 1
+      srcOrigin.z + copySize.depthOrArrayLayers > 1
     ) {
       success = false;
     }


### PR DESCRIPTION
According to the specification, an operation error happens if
'source.origin.z + copySize.depthOrArrayLayers' is greater than 1.
But, the existing test has been testing it with 'copySize.depthOrArrayLayers'
is greater than 1.

So this CL updates the check to 'source.origin.z + copySize.depthOrArrayLayers'
to meet the specification.

Issue: #1738

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
