### PR TITLE
Use containers for alternate interval generators

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -26,7 +26,7 @@ import {
   u32,
   u32Bits,
 } from '../../../../../util/conversion.js';
-import { clampMedianInterval, clampMinMaxInterval } from '../../../../../util/f32_interval.js';
+import { clampIntervals } from '../../../../../util/f32_interval.js';
 import { allInputSources, Case, makeTernaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -143,7 +143,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number, y: number, z: number): Case => {
-      return makeTernaryF32IntervalCase(x, y, z, clampMedianInterval, clampMinMaxInterval);
+      return makeTernaryF32IntervalCase(x, y, z, ...clampIntervals);
     };
 
     const values: Array<number> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -18,7 +18,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { mixImpreciseInterval, mixPreciseInterval } from '../../../../../util/f32_interval.js';
+import { mixIntervals } from '../../../../../util/f32_interval.js';
 import { allInputSources, Case, makeTernaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -41,8 +41,7 @@ g.test('matching_f32')
   )
   .fn(async t => {
     const makeCase = (x: number, y: number, z: number): Case => {
-      // Testing against both precise and imprecise formulas, see https://github.com/gpuweb/gpuweb/issues/3260
-      return makeTernaryF32IntervalCase(x, y, z, mixPreciseInterval, mixImpreciseInterval);
+      return makeTernaryF32IntervalCase(x, y, z, ...mixIntervals);
     };
 
     const values: Array<number> = [

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -572,6 +572,9 @@ const ClampMedianIntervalOp: TernaryToIntervalOp = {
   },
 };
 
+/** All acceptance interval functions for clamp(x, y, z) */
+export const clampIntervals: TernaryToInterval[] = [clampMinMaxInterval, clampMedianInterval];
+
 /** Calculate an acceptance interval of clamp(x, y, z) via median(x, y, z) */
 export function clampMedianInterval(
   x: number | F32Interval,
@@ -822,6 +825,9 @@ const MixImpreciseIntervalOp: TernaryToIntervalOp = {
     return additionInterval(x, t);
   },
 };
+
+/** All acceptance interval functions for mix(x, y, z) */
+export const mixIntervals: TernaryToInterval[] = [mixImpreciseInterval, mixPreciseInterval];
 
 /** Calculate an acceptance interval of mix(x, y, z) using x + (y - x) * z */
 export function mixImpreciseInterval(x: number, y: number, z: number): F32Interval {


### PR DESCRIPTION
Adds arrays that contain all of the options for builtins that have
multiple interval generators. This allows the test runner code to just
use ... on the array instead of explicitly listing all of the
alternatives. This helps separate the test running code from the
interval definitions.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
