### PR TITLE
Add more texture usages to image_copy,texture_related:usage test

### DIFF
--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -115,6 +115,7 @@ The texture must have the appropriate COPY_SRC/COPY_DST usage.
       // a combined usage.
       .combine('usage0', kTextureUsages)
       .combine('usage1', kTextureUsages)
+      // RENDER_ATTACHMENT is not valid with 1d and 3d textures.
       .unless(
         ({ usage0, usage1, dimension }) =>
           ((usage0 | usage1) & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 &&

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -7,6 +7,7 @@ import {
   kSizedTextureFormats,
   kTextureDimensions,
   kTextureFormatInfo,
+  kTextureUsages,
   textureDimensionAndFormatCompatible,
 } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
@@ -98,8 +99,7 @@ The texture must have the appropriate COPY_SRC/COPY_DST usage.
 - for various copy methods
 - for various dimensions
 - for various usages
-
-TODO: update to test all texture usages`
+`
   )
   .params(u =>
     u
@@ -111,15 +111,20 @@ TODO: update to test all texture usages`
         { dimension: '3d', size: [4, 4, 3] },
       ] as const)
       .beginSubcases()
-      .combine('usage', [
-        GPUConst.TextureUsage.COPY_SRC | GPUConst.TextureUsage.TEXTURE_BINDING,
-        GPUConst.TextureUsage.COPY_DST | GPUConst.TextureUsage.TEXTURE_BINDING,
-        GPUConst.TextureUsage.COPY_SRC | GPUConst.TextureUsage.COPY_DST,
-      ])
+      // If usage0 and usage1 are the same, the usage being test is a single usage. Otherwise, it's
+      // a combined usage.
+      .combine('usage0', kTextureUsages)
+      .combine('usage1', kTextureUsages)
+      .unless(
+        ({ usage0, usage1, dimension }) =>
+          ((usage0 | usage1) & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 &&
+          (dimension === '1d' || dimension === '3d')
+      )
   )
   .fn(async t => {
-    const { usage, method, size, dimension } = t.params;
+    const { usage0, usage1, method, size, dimension } = t.params;
 
+    const usage = usage0 | usage1;
     const texture = t.device.createTexture({
       size,
       dimension,


### PR DESCRIPTION
This PR adds more texture usages(STORAGE_BINDING, TEXTURE_BINDING)
to the subcases of the texture_related:usage test.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
