### PR TITLE
Add a query_set_type test to beginComputePass tests

### DIFF
--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -105,3 +105,29 @@ g.test('timestampWrites,query_set_type')
 
     t.tryComputePass(isValid, descriptor);
   });
+
+g.test('timestampWrites,query_index_count')
+  .desc(`Test that querySet.count should be greater than timestampWrite.queryIndex.`)
+  .params(u => u.combine('queryIndex', [0, 1, 2, 3]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase(['timestamp-query']);
+  })
+  .fn(async t => {
+    const { queryIndex } = t.params;
+
+    const querySetCount = 2;
+
+    const timestampWrite = {
+      querySet: t.device.createQuerySet({ type: 'timestamp', count: querySetCount }),
+      queryIndex,
+      location: 'beginning' as const,
+    };
+
+    const isValid = queryIndex < querySetCount;
+
+    const descriptor = {
+      timestampWrites: [timestampWrite],
+    };
+
+    t.tryComputePass(isValid, descriptor);
+  });


### PR DESCRIPTION
This PR adds a `timestampWrites,query_set_type` test to
beginComputePass.spec.ts in order to check if a validation
error is generated when all query types are not timestamp.

Additionally, this PR adds tryComputePass utility method to
avoid using duplicated validation checks.

Issue: #1743


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
