### PR TITLE
Track all the resources with trackForCleanup in copy and resource ini…

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyBufferToBuffer.spec.ts
@@ -38,6 +38,7 @@ g.test('single')
       size: dstBufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
+    t.trackForCleanup(dst);
 
     const encoder = t.device.createCommandEncoder();
     encoder.copyBufferToBuffer(src, srcOffset, dst, dstOffset, copySize);
@@ -95,6 +96,7 @@ g.test('copy_order')
       size: srcData.length * 4,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
+    t.trackForCleanup(dst);
 
     const encoder = t.device.createCommandEncoder();
     encoder.copyBufferToBuffer(src, 0, dst, 0, 16);

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -88,6 +88,7 @@ class F extends GPUTest {
       mipLevelCount,
     };
     const srcTexture = this.device.createTexture(srcTextureDesc);
+    this.trackForCleanup(srcTexture);
     const dstTextureDesc: GPUTextureDescriptor = {
       dimension,
       size: dstTextureSize,
@@ -96,6 +97,7 @@ class F extends GPUTest {
       mipLevelCount,
     };
     const dstTexture = this.device.createTexture(dstTextureDesc);
+    this.trackForCleanup(dstTexture);
 
     // Fill the whole subresource of srcTexture at srcCopyLevel with initialSrcData.
     const initialSrcData = this.GetInitialDataPerMipLevel(
@@ -192,6 +194,7 @@ class F extends GPUTest {
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     };
     const dstBuffer = this.device.createBuffer(dstBufferDesc);
+    this.trackForCleanup(dstBuffer);
 
     encoder.copyTextureToBuffer(
       { texture: dstTexture, mipLevel: dstCopyLevel },
@@ -294,6 +297,7 @@ class F extends GPUTest {
       size: outputBufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
+    this.trackForCleanup(outputBuffer);
     const encoder = this.device.createCommandEncoder();
     encoder.copyTextureToBuffer(
       {
@@ -483,6 +487,7 @@ class F extends GPUTest {
       size: copySize,
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
+    this.trackForCleanup(outputColorTexture);
     const encoder = this.device.createCommandEncoder();
     for (let dstCopyLayer = 0; dstCopyLayer < copySize[2]; ++dstCopyLayer) {
       // If the depth value is not expected, the color of outputColorTexture will remain Red after
@@ -1142,6 +1147,7 @@ g.test('copy_depth_stencil')
         GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
       mipLevelCount: srcCopyLevel + 1,
     });
+    t.trackForCleanup(sourceTexture);
     const destinationTexture = t.device.createTexture({
       format,
       size: [
@@ -1153,6 +1159,7 @@ g.test('copy_depth_stencil')
         GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
       mipLevelCount: dstCopyLevel + 1,
     });
+    t.trackForCleanup(destinationTexture);
 
     let initialStencilData: undefined | Uint8Array = undefined;
     if (kTextureFormatInfo[format].stencil) {
@@ -1234,6 +1241,7 @@ g.test('copy_multisampled_color')
         GPUTextureUsage.RENDER_ATTACHMENT,
       sampleCount: kSampleCount,
     });
+    t.trackForCleanup(sourceTexture);
     const destinationTexture = t.device.createTexture({
       format: kColorFormat,
       size: textureSize,
@@ -1243,6 +1251,7 @@ g.test('copy_multisampled_color')
         GPUTextureUsage.RENDER_ATTACHMENT,
       sampleCount: kSampleCount,
     });
+    t.trackForCleanup(destinationTexture);
 
     // Initialize sourceTexture with a draw call.
     const renderPipelineForInit = t.device.createRenderPipeline({
@@ -1370,6 +1379,7 @@ g.test('copy_multisampled_color')
       size: textureSize,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
+    t.trackForCleanup(expectedOutputTexture);
     const validationEncoder = t.device.createCommandEncoder();
     const renderPassForValidation = validationEncoder.beginRenderPass({
       colorAttachments: [
@@ -1416,12 +1426,14 @@ g.test('copy_multisampled_depth')
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
       sampleCount: kSampleCount,
     });
+    t.trackForCleanup(sourceTexture);
     const destinationTexture = t.device.createTexture({
       format: kDepthFormat,
       size: textureSize,
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
       sampleCount: kSampleCount,
     });
+    t.trackForCleanup(destinationTexture);
 
     const vertexState: GPUVertexState = {
       module: t.device.createShaderModule({
@@ -1515,11 +1527,13 @@ g.test('copy_multisampled_depth')
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
       sampleCount: kSampleCount,
     });
+    t.trackForCleanup(multisampledColorTexture);
     const colorTextureAsResolveTarget = t.device.createTexture({
       format: kColorFormat,
       size: textureSize,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
+    t.trackForCleanup(colorTextureAsResolveTarget);
 
     const encoderForVerify = t.device.createCommandEncoder();
     const renderPassForVerify = encoderForVerify.beginRenderPass({

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -429,6 +429,7 @@ class ImageCopyTest extends GPUTest {
       size: align(byteLength, 4), // this is necessary because we need to copy and map data from this buffer
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
+    this.trackForCleanup(buffer);
 
     const encoder = this.device.createCommandEncoder();
     encoder.copyTextureToBuffer(
@@ -562,6 +563,7 @@ class ImageCopyTest extends GPUTest {
       mipLevelCount: mipLevel + 1,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
+    this.trackForCleanup(texture);
 
     const data = this.generateData(dataSize);
 
@@ -640,6 +642,7 @@ class ImageCopyTest extends GPUTest {
       format,
       mipLevelCount: mipLevel + 1,
     });
+    this.trackForCleanup(srcTexture);
 
     const copySize = [textureSize[0] >> mipLevel, textureSize[1] >> mipLevel, textureSize[2]];
     const initialData = this.generateData(
@@ -707,6 +710,7 @@ class ImageCopyTest extends GPUTest {
       format,
       mipLevelCount: mipLevel + 1,
     });
+    this.trackForCleanup(srcTexture);
 
     // Initialize srcTexture with queue.writeTexture()
     const copySize = [textureSize[0] >> mipLevel, textureSize[1] >> mipLevel, textureSize[2]];
@@ -735,6 +739,7 @@ class ImageCopyTest extends GPUTest {
       size: outputBufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
+    this.trackForCleanup(outputBuffer);
     const encoder = this.device.createCommandEncoder();
     encoder.copyTextureToBuffer(
       { texture: srcTexture, aspect: 'stencil-only', mipLevel },
@@ -899,6 +904,7 @@ class ImageCopyTest extends GPUTest {
       size: outputTextureSize,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
+    this.trackForCleanup(outputTexture);
 
     for (
       let stencilTextureLayer = 0;
@@ -954,6 +960,7 @@ class ImageCopyTest extends GPUTest {
         size: copyFromOutputTextureLayout.byteLength,
         usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
       });
+      this.trackForCleanup(outputStagingBuffer);
       encoder.copyTextureToBuffer(
         {
           texture: outputTexture,
@@ -1000,6 +1007,7 @@ class ImageCopyTest extends GPUTest {
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
       format: 'r32float',
     });
+    this.trackForCleanup(inputTexture);
     this.queue.writeTexture(
       { texture: inputTexture },
       initialData,
@@ -1144,6 +1152,7 @@ class ImageCopyTest extends GPUTest {
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
       mipLevelCount: mipLevel + 1,
     });
+    this.trackForCleanup(depthTexture);
     this.initializeDepthAspectWithRendering(depthTexture, format, copySize, mipLevel, initialData);
 
     // Copy the depth aspect of the texture into the destination buffer.
@@ -1165,6 +1174,7 @@ class ImageCopyTest extends GPUTest {
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
       size: destinationBufferSize,
     });
+    this.trackForCleanup(destinationBuffer);
     const copyEncoder = this.device.createCommandEncoder();
     copyEncoder.copyTextureToBuffer(
       {

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -179,6 +179,7 @@ the buffer, the remaining part of that buffer will be initialized to 0.`
       size: bufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
+    t.trackForCleanup(buffer);
 
     const copySize = 12;
     const writeData = new Uint8Array(copySize);
@@ -207,6 +208,7 @@ have already been initialized to 0.`
       size: bufferSize,
       usage: bufferUsage,
     });
+    t.trackForCleanup(buffer);
 
     await buffer.mapAsync(mapMode);
     const readData = new Uint8Array(buffer.getMappedRange());
@@ -236,6 +238,7 @@ already been initialized to 0.`
       size: bufferSize,
       usage: bufferUsage,
     });
+    t.trackForCleanup(buffer);
 
     const expectedData = new Uint8Array(bufferSize);
     {
@@ -270,6 +273,7 @@ array buffer of getMappedRange() and the GPUBuffer itself have all been initiali
       size: bufferSize,
       usage: bufferUsage,
     });
+    t.trackForCleanup(buffer);
 
     const mapped = new Uint8Array(buffer.getMappedRange());
     for (let i = 0; i < bufferSize; ++i) {
@@ -303,6 +307,7 @@ array buffer of getMappedRange() and the GPUBuffer itself have all been initiali
       size: bufferSize,
       usage: bufferUsage,
     });
+    t.trackForCleanup(buffer);
 
     const expectedData = new Uint8Array(bufferSize);
     {
@@ -332,6 +337,7 @@ CopyBufferToBuffer(), the contents of the GPUBuffer have already been initialize
       size: bufferSize,
       usage: bufferUsage,
     });
+    t.trackForCleanup(buffer);
 
     const expectedData = new Uint8Array(bufferSize);
     // copyBufferToBuffer() is called inside t.CheckGPUBufferContent().
@@ -354,6 +360,7 @@ CopyBufferToTexture(), the contents of the GPUBuffer have already been initializ
       format: dstTextureFormat,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
+    t.trackForCleanup(dstTexture);
     const layout = getTextureCopyLayout(dstTextureFormat, '2d', textureSize);
     const srcBufferSize = layout.byteLength + bufferOffset;
     const srcBufferUsage = GPUBufferUsage.COPY_SRC;
@@ -361,6 +368,7 @@ CopyBufferToTexture(), the contents of the GPUBuffer have already been initializ
       size: srcBufferSize,
       usage: srcBufferUsage,
     });
+    t.trackForCleanup(srcBuffer);
 
     const encoder = t.device.createCommandEncoder();
     encoder.copyBufferToTexture(
@@ -397,6 +405,7 @@ remaining part of it will be initialized to 0.`
       size: bufferSize,
       usage: bufferUsage,
     });
+    t.trackForCleanup(dstBuffer);
 
     const querySet = t.device.createQuerySet({ type: 'occlusion', count: 1 });
     const encoder = t.device.createCommandEncoder();
@@ -434,6 +443,7 @@ remaining part of it will be initialized to 0.`
       size: textureSize,
       mipLevelCount: copyMipLevel + 1,
     });
+    t.trackForCleanup(srcTexture);
 
     const bytesPerRow = 256;
     const layout = getTextureCopyLayout(srcTextureFormat, '2d', textureSize, {
@@ -447,6 +457,7 @@ remaining part of it will be initialized to 0.`
       size: dstBufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
+    t.trackForCleanup(dstBuffer);
 
     const encoder = t.device.createCommandEncoder();
 
@@ -505,6 +516,7 @@ g.test('uniform_buffer')
       size: bufferOffset + boundBufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM,
     });
+    t.trackForCleanup(buffer);
 
     const computeShaderModule = t.device.createShaderModule({
       code: `
@@ -540,6 +552,7 @@ g.test('readonly_storage_buffer')
       size: bufferOffset + boundBufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
     });
+    t.trackForCleanup(buffer);
 
     const computeShaderModule = t.device.createShaderModule({
       code: `
@@ -575,6 +588,7 @@ g.test('storage_buffer')
       size: bufferOffset + boundBufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
     });
+    t.trackForCleanup(buffer);
 
     const computeShaderModule = t.device.createShaderModule({
       code: `
@@ -633,12 +647,14 @@ g.test('vertex_buffer')
       size: bufferSize,
       usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_SRC,
     });
+    t.trackForCleanup(vertexBuffer);
 
     const outputTexture = t.device.createTexture({
       format: 'rgba8unorm',
       size: [1, 1, 1],
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
+    t.trackForCleanup(outputTexture);
 
     const encoder = t.device.createCommandEncoder();
     const renderPass = encoder.beginRenderPass({
@@ -698,12 +714,14 @@ GPUBuffer, all the contents in that GPUBuffer have been initialized to 0.`
       size: bufferSize,
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_SRC,
     });
+    t.trackForCleanup(indexBuffer);
 
     const outputTexture = t.device.createTexture({
       format: 'rgba8unorm',
       size: [1, 1, 1],
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
+    t.trackForCleanup(outputTexture);
 
     const encoder = t.device.createCommandEncoder();
     const renderPass = encoder.beginRenderPass({
@@ -763,12 +781,14 @@ have been initialized to 0.`
       size: bufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
     });
+    t.trackForCleanup(indirectBuffer);
 
     const outputTexture = t.device.createTexture({
       format: 'rgba8unorm',
       size: [1, 1, 1],
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
+    t.trackForCleanup(outputTexture);
 
     // Initialize outputTexture to green.
     const encoder = t.device.createCommandEncoder();
@@ -791,6 +811,7 @@ have been initialized to 0.`
         size: 4,
         usage: GPUBufferUsage.INDEX,
       });
+      t.trackForCleanup(indexBuffer);
       renderPass.setIndexBuffer(indexBuffer, 'uint16');
       renderPass.drawIndexedIndirect(indirectBuffer, bufferOffset);
     } else {
@@ -836,6 +857,7 @@ g.test('indirect_buffer_for_dispatch_indirect')
       size: bufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT,
     });
+    t.trackForCleanup(indirectBuffer);
 
     const outputTexture = t.device.createTexture({
       format: 'rgba8unorm',
@@ -845,6 +867,7 @@ g.test('indirect_buffer_for_dispatch_indirect')
         GPUTextureUsage.RENDER_ATTACHMENT |
         GPUTextureUsage.STORAGE_BINDING,
     });
+    t.trackForCleanup(outputTexture);
 
     // Initialize outputTexture to green.
     const encoder = t.device.createCommandEncoder();

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -61,6 +61,7 @@ class F extends GPUTest {
       size: [1, 1, 1],
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
     });
+    this.trackForCleanup(outputTexture);
     const bindGroup = this.device.createBindGroup({
       layout: computePipeline.getBindGroupLayout(0),
       entries: [

--- a/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_copy.ts
@@ -47,6 +47,7 @@ export const checkContentsByTextureCopy: CheckContents = (
       format: params.format,
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
     });
+    t.trackForCleanup(dst);
 
     const commandEncoder = t.device.createCommandEncoder();
     commandEncoder.copyTextureToTexture(

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -593,6 +593,7 @@ g.test('uninitialized_texture_is_zero')
       mipLevelCount: t.params.mipLevelCount,
       sampleCount: t.params.sampleCount,
     });
+    t.trackForCleanup(texture);
 
     if (t.params.canaryOnCreation) {
       // Initialize some subresources with canary values


### PR DESCRIPTION
…t tests

This patch tracks all the buffers and textures with trackForCleanup()
in copy and resource_init tests so that these resources can be safely
destroyed after running the tests instead of being destroyed by GC.
Without this patch the resources that are not tracked will be destroyed
at a random moment with GC, which will introduce many flaky test failures
that are caused by the issues with resource.destroy().




Issue: #1752

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
