### PR TITLE
Use common `sparseF32Range` instead of defining it multiple different places

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -15,7 +15,7 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { kBit, kValue } from '../../../../../util/constants.js';
+import { kBit } from '../../../../../util/constants.js';
 import {
   i32,
   i32Bits,
@@ -27,6 +27,7 @@ import {
   u32Bits,
 } from '../../../../../util/conversion.js';
 import { clampIntervals } from '../../../../../util/f32_interval.js';
+import { sparseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeTernaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -146,25 +147,8 @@ g.test('f32')
       return makeTernaryF32IntervalCase(x, y, z, ...clampIntervals);
     };
 
-    const values: Array<number> = [
-      Number.NEGATIVE_INFINITY,
-      kValue.f32.negative.min,
-      -10.0,
-      -1.0,
-      kValue.f32.negative.max,
-      kValue.f32.subnormal.negative.min,
-      kValue.f32.subnormal.negative.max,
-      0.0,
-      kValue.f32.subnormal.positive.min,
-      kValue.f32.subnormal.positive.max,
-      kValue.f32.positive.min,
-      1.0,
-      10.0,
-      kValue.f32.positive.max,
-      Number.POSITIVE_INFINITY,
-    ];
-
-    const cases: Array<Case> = new Array<Case>();
+    const values = sparseF32Range();
+    const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {
         values.forEach(z => {

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -9,33 +9,14 @@ Returns the dot product of e1 and e2.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { kValue } from '../../../../../util/constants.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { dotInterval } from '../../../../../util/f32_interval.js';
+import { sparseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeVectorPairF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
-
-/** Values of interest to test against */
-const kFloatTestValues: Array<number> = [
-  Number.NEGATIVE_INFINITY,
-  kValue.f32.negative.min,
-  -10.0,
-  -1.0,
-  kValue.f32.negative.max,
-  kValue.f32.subnormal.negative.min,
-  kValue.f32.subnormal.negative.max,
-  0.0,
-  kValue.f32.subnormal.positive.min,
-  kValue.f32.subnormal.positive.max,
-  kValue.f32.positive.min,
-  1.0,
-  10.0,
-  kValue.f32.positive.max,
-  Number.POSITIVE_INFINITY,
-];
 
 /**
  * Set of vectors, indexed by dimension, that contain interesting float values
@@ -49,16 +30,16 @@ const kFloatTestValues: Array<number> = [
  * number of cases being run substantially, but maintains coverage.
  */
 const kVectorTestValues = {
-  2: kFloatTestValues.flatMap(f => [
+  2: sparseF32Range().flatMap(f => [
     [f, 1.0],
     [1.0, f],
   ]),
-  3: kFloatTestValues.flatMap(f => [
+  3: sparseF32Range().flatMap(f => [
     [f, 1.0, 2.0],
     [1.0, f, 2.0],
     [1.0, 2.0, f],
   ]),
-  4: kFloatTestValues.flatMap(f => [
+  4: sparseF32Range().flatMap(f => [
     [f, 1.0, 2.0, 3.0],
     [1.0, f, 2.0, 3.0],
     [1.0, 2.0, f, 3.0],
@@ -128,7 +109,7 @@ g.test('f32_vec3')
 
 g.test('f32_vec4')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
-  .desc(`f32 tests using vec3s`)
+  .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
     const makeCase = (x: number[], y: number[]): Case => {

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -16,9 +16,9 @@ Same as mix(e1,e2,T2(e3)).
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { mixIntervals } from '../../../../../util/f32_interval.js';
+import { sparseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeTernaryF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -44,24 +44,7 @@ g.test('matching_f32')
       return makeTernaryF32IntervalCase(x, y, z, ...mixIntervals);
     };
 
-    const values: Array<number> = [
-      Number.NEGATIVE_INFINITY,
-      kValue.f32.negative.min,
-      -10.0,
-      -1.0,
-      kValue.f32.negative.max,
-      kValue.f32.subnormal.negative.min,
-      kValue.f32.subnormal.negative.max,
-      0.0,
-      kValue.f32.subnormal.positive.min,
-      kValue.f32.subnormal.positive.max,
-      kValue.f32.positive.min,
-      1.0,
-      10.0,
-      kValue.f32.positive.max,
-      Number.POSITIVE_INFINITY,
-    ];
-
+    const values = sparseF32Range();
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -419,12 +419,16 @@ export function biasedRange(a: number, b: number, num_steps: number): Array<numb
 }
 
 /**
- * @returns an ascending sorted array of numbers spread over the entire range of 32-bit floats
+ * @returns a ascending sorted array of numbers spread over the entire range of 32-bit floats
  *
  * Numbers are divided into 4 regions: negative normals, negative subnormals, positive subnormals & positive normals.
  * Zero is included. The normal number regions are biased towards zero, and the subnormal regions are linearly spread.
  *
- * @param counts structure param with 4 entries indicating the number of entries to be generated each region, values must be 0 or greater.
+ * This function is intended to provide dense coverage of the f32 range, for a minimal list of values to use to cover
+ * f32 behaviour, use sparseF32Range instead.
+ *
+ * @param counts structure param with 4 entries indicating the number of entries to be generated each region, entries
+ *               must be 0 or greater.
  */
 export function fullF32Range(
   counts: {
@@ -473,6 +477,41 @@ export function fullI32Range(
     0,
     ...biasedRange(kValue.i32.positive.min, kValue.i32.positive.max, counts.positive),
   ];
+}
+
+/** Short list of f32 values of interest to test against */
+const kInterestingF32Values: Array<number> = [
+  Number.NEGATIVE_INFINITY,
+  kValue.f32.negative.min,
+  -10.0,
+  -1.0,
+  kValue.f32.negative.max,
+  kValue.f32.subnormal.negative.min,
+  kValue.f32.subnormal.negative.max,
+  0.0,
+  kValue.f32.subnormal.positive.min,
+  kValue.f32.subnormal.positive.max,
+  kValue.f32.positive.min,
+  1.0,
+  10.0,
+  kValue.f32.positive.max,
+  Number.POSITIVE_INFINITY,
+];
+
+/** @returns minimal f32 values that cover the entire range of f32 behaviours
+ *
+ * Has specially selected values that cover edge cases, normals, and subnormals.
+ * This is used instead of fullF32Range when the number of test cases being
+ * generated is a super linear function of the length of f32 values which is
+ * leading to time outs.
+ *
+ * These values have been chosen to attempt to test the widest range of f32
+ * behaviours in the lowest number of entries, so may potentially miss function
+ * specific values of interest. If there are known values of interest they
+ * should be appended to this list in the test generation code.
+ */
+export function sparseF32Range(): Array<number> {
+  return kInterestingF32Values;
 }
 
 /**

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -419,7 +419,7 @@ export function biasedRange(a: number, b: number, num_steps: number): Array<numb
 }
 
 /**
- * @returns a ascending sorted array of numbers spread over the entire range of 32-bit floats
+ * @returns an ascending sorted array of numbers spread over the entire range of 32-bit floats
  *
  * Numbers are divided into 4 regions: negative normals, negative subnormals, positive subnormals & positive normals.
  * Zero is included. The normal number regions are biased towards zero, and the subnormal regions are linearly spread.


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
