### PR TITLE
Refactor *SubnormalNumber to not depend on *SubnormalScalar

### DIFF
--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -35,7 +35,7 @@ export function clamp(n: number, { min, max }: { min: number; max: number }): nu
 
 /** @returns 0 if |val| is a subnormal f32 number, otherwise returns |val| */
 export function flushSubnormalNumber(val: number): number {
-  return val > kValue.f32.negative.max && val < kValue.f32.positive.min ? 0 : val;
+  return isSubnormalNumber(val) ? 0 : val;
 }
 
 /** @returns 0 if |val| is a subnormal f32 number, otherwise returns |val| */
@@ -62,7 +62,7 @@ export function isSubnormalScalar(val: Scalar): boolean {
 
 /** Utility to pass TS numbers into |isSubnormalNumber| */
 export function isSubnormalNumber(val: number): boolean {
-  return isSubnormalScalar(f32(val));
+  return val > kValue.f32.negative.max && val < kValue.f32.positive.min;
 }
 
 /** @returns if number is in the finite range of f32 */


### PR DESCRIPTION

Issue #1749

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
