### PR TITLE
Pass a dummy pipeline layout to createNoOpComputePipeline

### DIFF
--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -373,7 +373,7 @@ export class ValidationTest extends GPUTest {
   createErrorComputePipeline(): GPUComputePipeline {
     this.device.pushErrorScope('validation');
     const pipeline = this.device.createComputePipeline({
-      layout: 'auto',
+      layout: this.device.createPipelineLayout({ bindGroupLayouts: [] }),
       compute: {
         module: this.device.createShaderModule({
           code: '',


### PR DESCRIPTION
The tests that use createNoOpComputePipeline have been failing because
it could not convert `layout`. To avoid the test failures, this PR
passes a dummy pipeline layout to createNoOpComputePipeline.

Additionally, this PR updates the indentations of the descriptions
in the tests.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
