### PR TITLE
Add _mimeType for input videos in external_texture cases

### DIFF
--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -26,36 +26,42 @@ const kVideoExpectations = [
   {
     videoSource: 'red-green.webmvp8.webm',
     colorSpace: 'REC601',
+    _mimeType: 'video/webm; codecs=vp8',
     _redExpectation: new Uint8Array([0xd9, 0x00, 0x00, 0xff]),
     _greenExpectation: new Uint8Array([0x01, 0xef, 0x00, 0xff]),
   },
   {
     videoSource: 'red-green.theora.ogv',
     colorSpace: 'REC601',
+    _mimeType: 'video/ogg; codecs=theora',
     _redExpectation: new Uint8Array([0xd9, 0x00, 0x00, 0xff]),
     _greenExpectation: new Uint8Array([0x01, 0xef, 0x00, 0xff]),
   },
   {
     videoSource: 'red-green.mp4',
     colorSpace: 'REC601',
+    _mimeType: 'video/mp4; codecs=avc1.4d400c',
     _redExpectation: new Uint8Array([0xd9, 0x00, 0x00, 0xff]),
     _greenExpectation: new Uint8Array([0x01, 0xef, 0x00, 0xff]),
   },
   {
     videoSource: 'red-green.bt601.vp9.webm',
     colorSpace: 'REC601',
+    _mimeType: 'video/webm; codecs=vp9',
     _redExpectation: new Uint8Array([0xd9, 0x00, 0x00, 0xff]),
     _greenExpectation: new Uint8Array([0x01, 0xef, 0x00, 0xff]),
   },
   {
     videoSource: 'red-green.bt709.vp9.webm',
     colorSpace: 'REC709',
+    _mimeType: 'video/webm; codecs=vp9',
     _redExpectation: new Uint8Array([0xff, 0x00, 0x00, 0xff]),
     _greenExpectation: new Uint8Array([0x00, 0xff, 0x00, 0xff]),
   },
   {
     videoSource: 'red-green.bt2020.vp9.webm',
     colorSpace: 'REC2020',
+    _mimeType: 'video/webm; codecs=vp9',
     _redExpectation: new Uint8Array([0xff, 0x00, 0x00, 0xff]),
     _greenExpectation: new Uint8Array([0x00, 0xff, 0x00, 0xff]),
   },
@@ -159,6 +165,9 @@ for several combinations of video format and color space.
     const videoUrl = getResourcePath(t.params.videoSource);
     const videoElement = document.createElement('video');
     videoElement.src = videoUrl;
+    if (videoElement.canPlayType(t.params._mimeType) === '') {
+      t.skip('Video codec is not supported');
+    }
 
     await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =
@@ -246,6 +255,9 @@ TODO: Make this test work without requestVideoFrameCallback support (in waitForN
     const videoUrl = getResourcePath('red-green.webmvp8.webm');
     const videoElement = document.createElement('video');
     videoElement.src = videoUrl;
+    if (videoElement.canPlayType('video/webm; codecs=vp8') === '') {
+      t.skip('Video codec is not supported');
+    }
 
     if (!('requestVideoFrameCallback' in videoElement)) {
       t.skip('HTMLVideoElement.requestVideoFrameCallback is not supported');
@@ -338,6 +350,9 @@ compute shader, for several combinations of video format and color space.
     const videoUrl = getResourcePath(t.params.videoSource);
     const videoElement = document.createElement('video');
     videoElement.src = videoUrl;
+    if (videoElement.canPlayType(t.params._mimeType) === '') {
+      t.skip('Video codec is not supported');
+    }
 
     await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -34,6 +34,8 @@ const kVideoInfo = /* prettier-ignore */ makeTable(
   'red-green.bt709.vp9.webm'  : [    'REC709',         'video/webm; codecs=vp9'],
   'red-green.bt2020.vp9.webm' : [   'REC2020',         'video/webm; codecs=vp9']
 } as const);
+type VideoName = keyof typeof kVideoInfo;
+type VideoInfo = valueof<typeof kVideoInfo>;
 
 const kVideoExpectations = [
   {
@@ -67,9 +69,6 @@ const kVideoExpectations = [
     _greenExpectation: new Uint8Array([0x00, 0xff, 0x00, 0xff]),
   },
 ] as const;
-
-type VideoName = keyof typeof kVideoInfo;
-type VideoInfo = valueof<typeof kVideoInfo>;
 
 export const g = makeTestGroup(GPUTest);
 
@@ -152,7 +151,7 @@ function getVideoElementAndInfo(
   t: GPUTest,
   sourceType: 'VideoElement' | 'VideoFrame',
   videoName: VideoName
-): [videoElement: HTMLVideoElement, videoInfo: VideoInfo] {
+): { videoElement: HTMLVideoElement; videoInfo: VideoInfo } {
   if (sourceType === 'VideoFrame' && typeof VideoFrame === 'undefined') {
     t.skip('WebCodec is not supported');
   }
@@ -167,7 +166,7 @@ function getVideoElementAndInfo(
   const videoUrl = getResourcePath(videoName);
   videoElement.src = videoUrl;
 
-  return [videoElement, videoInfo];
+  return { videoElement, videoInfo };
 }
 
 g.test('importExternalTexture,sample')
@@ -184,7 +183,7 @@ for several combinations of video format and color space.
   )
   .fn(async t => {
     const sourceType = t.params.sourceType;
-    const [videoElement, videoInfo] = getVideoElementAndInfo(t, sourceType, t.params.videoName);
+    const { videoElement, videoInfo } = getVideoElementAndInfo(t, sourceType, t.params.videoName);
 
     await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =
@@ -265,7 +264,7 @@ TODO: Make this test work without requestVideoFrameCallback support (in waitForN
   )
   .fn(async t => {
     const sourceType = t.params.sourceType;
-    const [videoElement] = getVideoElementAndInfo(t, sourceType, 'red-green.webmvp8.webm');
+    const { videoElement } = getVideoElementAndInfo(t, sourceType, 'red-green.webmvp8.webm');
 
     if (!('requestVideoFrameCallback' in videoElement)) {
       t.skip('HTMLVideoElement.requestVideoFrameCallback is not supported');
@@ -354,7 +353,7 @@ compute shader, for several combinations of video format and color space.
   )
   .fn(async t => {
     const sourceType = t.params.sourceType;
-    const [videoElement, videoInfo] = getVideoElementAndInfo(t, sourceType, t.params.videoName);
+    const { videoElement, videoInfo } = getVideoElementAndInfo(t, sourceType, t.params.videoName);
 
     await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =


### PR DESCRIPTION
Add _mimeType for input videos in external_texture cases so that
cts could check whether current browser supported the video codecs.

It helps to skip cases if video codec is not supported in browser.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
