### PR TITLE
Add timestamp_query_set,device_mismatch test to beginComputePass tests

### DIFF
--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -131,3 +131,36 @@ g.test('timestampWrites,query_index_count')
 
     t.tryComputePass(isValid, descriptor);
   });
+
+g.test('timestamp_query_set,device_mismatch')
+  .desc(
+    `
+  Tests beginComputePass cannot be called with a timestamp query set created from another device.
+  `
+  )
+  .params(u => u.combine('mismatched', [true, false]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase(['timestamp-query']);
+    t.selectMismatchedDeviceOrSkipTestCase('timestamp-query');
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
+    const device = mismatched ? t.mismatchedDevice : t.device;
+
+    const timestampQuerySet = device.createQuerySet({
+      type: 'timestamp',
+      count: 1,
+    });
+
+    const timestampWrite = {
+      querySet: timestampQuerySet,
+      queryIndex: 0,
+      location: 'beginning' as const,
+    };
+
+    const descriptor = {
+      timestampWrites: [timestampWrite],
+    };
+
+    t.tryComputePass(!mismatched, descriptor);
+  });


### PR DESCRIPTION
This PR adds a test to ensure beginComputePass cannot be called
with a timestamp query set created from another device.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
