### PR TITLE
Add timestamp_query_set,device_mismatch test to beginRenderPass tests

### DIFF
--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -166,3 +166,46 @@ g.test('occlusion_query_set,device_mismatch')
     const encoder = t.createEncoder('render pass', { occlusionQuerySet });
     encoder.validateFinish(!mismatched);
   });
+
+g.test('timestamp_query_set,device_mismatch')
+  .desc(
+    `
+  Tests beginRenderPass cannot be called with a timestamp query set created from another device.
+  `
+  )
+  .params(u => u.combine('mismatched', [true, false]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase(['timestamp-query']);
+    t.selectMismatchedDeviceOrSkipTestCase('timestamp-query');
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
+    const device = mismatched ? t.mismatchedDevice : t.device;
+
+    const timestampWrite = {
+      querySet: device.createQuerySet({ type: 'timestamp', count: 1 }),
+      queryIndex: 0,
+      location: 'beginning' as const,
+    };
+
+    const colorTexture = t.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const encoder = t.createEncoder('non-pass');
+    const pass = encoder.encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: colorTexture.createView(),
+          loadOp: 'load',
+          storeOp: 'store',
+        },
+      ],
+      timestampWrites: [timestampWrite],
+    });
+    pass.end();
+
+    encoder.validateFinish(!mismatched);
+  });


### PR DESCRIPTION
This PR adds a test to ensure beginRenderPass cannot be called
with a timestamp query set created from another device.

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
