### PR TITLE
Implement `remainder (%)` f32 test

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -23,6 +23,7 @@ import {
   coshInterval,
   degreesInterval,
   divisionInterval,
+  dotInterval,
   expInterval,
   exp2Interval,
   F32Interval,
@@ -41,6 +42,7 @@ import {
   negationInterval,
   powInterval,
   radiansInterval,
+  remainderInterval,
   roundInterval,
   saturateInterval,
   signInterval,
@@ -53,7 +55,6 @@ import {
   tanhInterval,
   truncInterval,
   ulpInterval,
-  dotInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -1895,6 +1896,57 @@ g.test('multiplicationInterval')
     t.expect(
       objectEquals(expected, got),
       `multiplicationInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('remainderInterval')
+  .paramsSubcasesOnly<BinaryToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 1], expected: [0, 0] },
+      { input: [0, -1], expected: [0, 0] },
+      { input: [1, 1], expected: [0, 1] },
+      { input: [1, -1], expected: [0, 1] },
+      { input: [-1, 1], expected: [-1, 0] },
+      { input: [-1, -1], expected: [-1, 0] },
+      { input: [4, 2], expected: [0, 2] },
+      { input: [-4, 2], expected: [-2, 0] },
+      { input: [4, -2], expected: [0, 2] },
+      { input: [-4, -2], expected: [-2, 0] },
+      { input: [2, 4], expected: [2, 2] },
+      { input: [-2, 4], expected: [-2, -2] },
+      { input: [2, -4], expected: [2, 2] },
+      { input: [-2, -4], expected: [-2, -2] },
+
+      // 64-bit normals
+      { input: [0, 0.1], expected: [0, 0] },
+      { input: [0, -0.1], expected: [0, 0] },
+      { input: [1, 0.1], expected: [hexToF32(0xb4000000), hexToF32(0x3dccccd8)] }, // ~[0, 0.1]
+      { input: [-1, 0.1], expected: [hexToF32(0xbdccccd8), hexToF32(0x34000000)] }, // ~[-0.1, 0]
+      { input: [1, -0.1], expected: [hexToF32(0xb4000000), hexToF32(0x3dccccd8)] }, // ~[0, 0.1]
+      { input: [-1, -0.1], expected: [hexToF32(0xbdccccd8), hexToF32(0x34000000)] }, // ~[-0.1, 0]
+
+      // Denominator out of range
+      { input: [1, kValue.f32.infinity.positive], expected: kAny },
+      { input: [1, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [1, kValue.f32.positive.max], expected: kAny },
+      { input: [1, kValue.f32.negative.min], expected: kAny },
+      { input: [1, 0], expected: kAny },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: kAny },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = remainderInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `remainderInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -9,6 +9,7 @@ import {
   additionInterval,
   divisionInterval,
   multiplicationInterval,
+  remainderInterval,
   subtractionInterval,
 } from '../../../../util/f32_interval.js';
 import { cartesianProduct, fullF32Range } from '../../../../util/math.js';
@@ -112,8 +113,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
     run(t, binary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
-// Will be implemented as part larger derived accuracy task
-g.test('modulus')
+g.test('remainder')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
   .desc(
     `
@@ -121,5 +121,17 @@ Expression: x % y
 Accuracy: Derived from x - y * trunc(x/y)
 `
   )
-  .params(u => u.combine('placeHolder1', ['placeHolder2', 'placeHolder3']))
-  .unimplemented();
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
+    };
+
+    const cases = kTestValues.map((v: number[]) => {
+      return makeCase(v[0], v[1]);
+    });
+
+    run(t, binary('%'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+  });

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1115,6 +1115,18 @@ export function radiansInterval(n: number): F32Interval {
   return runPointOp(toF32Interval(n), RadiansIntervalOp);
 }
 
+const RemainderIntervalOp: BinaryToIntervalOp = {
+  impl: (x: number, y: number): F32Interval => {
+    // x % y = x - y * trunc(x/y)
+    return subtractionInterval(x, multiplicationInterval(y, truncInterval(divisionInterval(x, y))));
+  },
+};
+
+/** Calculate an acceptance interval for x % y */
+export function remainderInterval(x: number, y: number): F32Interval {
+  return runBinaryOp(toF32Interval(x), toF32Interval(y), RemainderIntervalOp);
+}
+
 const RoundIntervalOp: PointToIntervalOp = {
   impl: (n: number): F32Interval => {
     const k = Math.floor(n);
@@ -1281,6 +1293,6 @@ const TruncIntervalOp: PointToIntervalOp = {
 };
 
 /** Calculate an acceptance interval of trunc(x) */
-export function truncInterval(n: number): F32Interval {
+export function truncInterval(n: number | F32Interval): F32Interval {
   return runPointOp(toF32Interval(n), TruncIntervalOp);
 }


### PR DESCRIPTION
Issue #1763

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
