### PR TITLE
Add visibility,VERTEX_shader_stage_buffer_type test to createBindGroupLayout.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -76,6 +76,37 @@ g.test('visibility')
     }, !success);
   });
 
+g.test('visibility,VERTEX_shader_stage_buffer_type')
+  .desc(
+    `
+  Test that a validation error is generated if the buffer type is 'storage' when the
+  visibility of the entry includes VERTEX.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('shaderStage', kShaderStageCombinations)
+      .beginSubcases()
+      .combine('type', kBufferBindingTypes)
+  )
+  .fn(async t => {
+    const { shaderStage, type } = t.params;
+
+    const success = !(type === 'storage' && shaderStage & GPUShaderStage.VERTEX);
+
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries: [
+          {
+            binding: 0,
+            visibility: shaderStage,
+            buffer: { type },
+          },
+        ],
+      });
+    }, !success);
+  });
+
 g.test('multisampled_validation')
   .desc('Test that multisampling is only allowed with "2d" view dimensions.')
   .paramsSubcasesOnly(u =>


### PR DESCRIPTION
According to the specification, buffer's type of the entry must not be `storage`
if the entry's visibility includes VERTEX. So this PR adds a new test to ensure
that a validation error is generated if the entry's visibility is VERTEX and
the buffer type is `storage`.

Issue: #885

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
