### PR TITLE
Change .origin in GPUImageCopyExternalImage from 3D to 2D

### DIFF
--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -45,16 +45,16 @@ interface WithDstOriginMipLevel extends WithMipLevel {
 }
 
 // Helper function to generate copySize for src OOB test
-function generateCopySizeForSrcOOB({ srcOrigin }: { srcOrigin: Required<GPUOrigin3DDict> }) {
+function generateCopySizeForSrcOOB({ srcOrigin }: { srcOrigin: Required<GPUOrigin2DDict> }) {
   // OOB origin fails even with no-op copy.
-  if (srcOrigin.x > kDefaultWidth || srcOrigin.y > kDefaultHeight || srcOrigin.z > kDefaultDepth) {
+  if (srcOrigin.x > kDefaultWidth || srcOrigin.y > kDefaultHeight) {
     return [{ width: 0, height: 0, depthOrArrayLayers: 0 }];
   }
 
   const justFitCopySize = {
     width: kDefaultWidth - srcOrigin.x,
     height: kDefaultHeight - srcOrigin.y,
-    depthOrArrayLayers: kDefaultDepth - srcOrigin.z,
+    depthOrArrayLayers: 1,
   };
 
   return [
@@ -828,14 +828,12 @@ g.test('OOB,source')
   .paramsSubcasesOnly(u =>
     u
       .combine('srcOrigin', [
-        { x: 0, y: 0, z: 0 }, // origin is on top-left
-        { x: kDefaultWidth - 1, y: 0, z: 0 }, // x near the border
-        { x: 0, y: kDefaultHeight - 1, z: 0 }, // y is near the border
-        { x: kDefaultWidth, y: kDefaultHeight, z: 0 }, // origin is on bottom-right
-        { x: 0, y: 0, z: kDefaultDepth },
-        { x: kDefaultWidth + 1, y: 0, z: 0 }, // x is too large
-        { x: 0, y: kDefaultHeight + 1, z: 0 }, // y is too large
-        { x: 0, y: 0, z: kDefaultDepth + 1 }, // z is too large
+        { x: 0, y: 0 }, // origin is on top-left
+        { x: kDefaultWidth - 1, y: 0 }, // x near the border
+        { x: 0, y: kDefaultHeight - 1 }, // y is near the border
+        { x: kDefaultWidth, y: kDefaultHeight }, // origin is on bottom-right
+        { x: kDefaultWidth + 1, y: 0 }, // x is too large
+        { x: 0, y: kDefaultHeight + 1 }, // y is too large
       ])
       .expand('copySize', generateCopySizeForSrcOOB)
   )
@@ -858,7 +856,7 @@ g.test('OOB,source')
     if (
       srcOrigin.x + copySize.width > kDefaultWidth ||
       srcOrigin.y + copySize.height > kDefaultHeight ||
-      srcOrigin.z + copySize.depthOrArrayLayers > 1
+      copySize.depthOrArrayLayers > 1
     ) {
       success = false;
     }


### PR DESCRIPTION
This PR changes sourceOrigin in GPUImageCopyTexture from 3D to 2D
which follows the spec.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
