### PR TITLE
Add visibility,VERTEX_shader_stage_storage_texture_access test to createBindGroupLayout.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -9,6 +9,7 @@ import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
   kShaderStages,
   kShaderStageCombinations,
+  kStorageTextureAccessValues,
   kTextureViewDimensions,
   allBindingEntries,
   bindingTypeInfo,
@@ -101,6 +102,39 @@ g.test('visibility,VERTEX_shader_stage_buffer_type')
             binding: 0,
             visibility: shaderStage,
             buffer: { type },
+          },
+        ],
+      });
+    }, !success);
+  });
+
+g.test('visibility,VERTEX_shader_stage_storage_texture_access')
+  .desc(
+    `
+  Test that a validation error is generated if the access value is 'write-only' when the
+  visibility of the entry includes VERTEX.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('shaderStage', kShaderStageCombinations)
+      .beginSubcases()
+      .combine('access', [undefined, ...kStorageTextureAccessValues])
+  )
+  .fn(async t => {
+    const { shaderStage, access } = t.params;
+
+    const success = !(
+      (access ?? 'write-only') === 'write-only' && shaderStage & GPUShaderStage.VERTEX
+    );
+
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries: [
+          {
+            binding: 0,
+            visibility: shaderStage,
+            storageTexture: { access, format: 'rgba8unorm' },
           },
         ],
       });


### PR DESCRIPTION
According to the specification, the storageTexture.access of the entry must not be
"write-only" if the entry's visibility includes VERTEX. So this PR adds a new test
to ensure that a validation error is generated if the entry's visibility is VERTEX
and the storageTexture.access is "write-only".

Issue: #885

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
