### PR TITLE
Add storage_texture,layout_dimension test to createBindGroupLayout.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -316,3 +316,31 @@ g.test('max_resources_per_stage,in_pipeline_layout')
       t.device.createPipelineLayout({ bindGroupLayouts: [goodLayout, extraLayout] });
     }, newBindingCountsTowardSamePerStageLimit);
   });
+
+g.test('storage_texture,layout_dimension')
+  .desc(
+    `
+  Test that viewDimension is not cube or cube-array if storageTextureLayout is not undefined.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('viewDimension', [undefined, ...kTextureViewDimensions])
+  )
+  .fn(async t => {
+    const { viewDimension } = t.params;
+
+    const success = viewDimension !== 'cube' && viewDimension !== `cube-array`;
+
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries: [
+          {
+            binding: 0,
+            visibility: GPUShaderStage.COMPUTE,
+            storageTexture: { format: 'rgba8unorm', viewDimension },
+          },
+        ],
+      });
+    }, !success);
+  });


### PR DESCRIPTION
According to the specification, viewDimension should not be `cube` or `cube-array`
if storageTextureLayout is not undefined. So this PR adds a new test to ensure
that a validation error is generated if viewDimention is `cube` or `cube-array`
with a storageTexture.

Issue: #885

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
