### PR TITLE
Make F32Interval unittests more idiomatic

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -28,6 +28,7 @@ import {
   F32Interval,
   floorInterval,
   fractInterval,
+  IntervalBounds,
   inverseSqrtInterval,
   ldexpInterval,
   logInterval,
@@ -61,7 +62,7 @@ import { UnitTest } from './unit_test.js';
 export const g = makeTestGroup(UnitTest);
 
 /** Bounds indicating an expectation of an interval of all possible values */
-const kAny: [number, number] = [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY];
+const kAny: IntervalBounds = [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY];
 
 /** @returns a number N * ULP greater than the provided number */
 function plusNULP(x: number, n: number): number {
@@ -83,9 +84,24 @@ function minusOneULP(x: number): number {
   return minusNULP(x, 1);
 }
 
+/** @returns the expected IntervalBounds adjusted by the given error function
+ *
+ * @param expected the bounds to be adjusted
+ * @param error error function to adjust the bounds via
+ */
+function applyError(expected: IntervalBounds, error: (n: number) => number): IntervalBounds {
+  if (expected !== kAny) {
+    const begin = expected[0];
+    const end = expected.length === 2 ? expected[1] : begin;
+    expected = [begin - error(begin), end + error(end)];
+  }
+
+  return expected;
+}
+
 interface ConstructorCase {
-  input: [number, number];
-  expected: [number, number];
+  input: IntervalBounds;
+  expected: IntervalBounds;
 }
 
 g.test('constructor')
@@ -96,9 +112,9 @@ g.test('constructor')
       { input: [0, 10], expected: [0, 10]},
       { input: [-5, 0], expected: [-5, 0]},
       { input: [-5, 10], expected: [-5, 10]},
-      { input: [0, 0], expected: [0, 0]},
-      { input: [10, 10], expected: [10, 10]},
-      { input: [-5, -5], expected: [-5, -5]},
+      { input: [0], expected: [0]},
+      { input: [10], expected: [10]},
+      { input: [-5], expected: [-5]},
 
       // Edges
       { input: [0, kValue.f32.positive.max], expected: [0, kValue.f32.positive.max]},
@@ -117,18 +133,15 @@ g.test('constructor')
     ]
   )
   .fn(t => {
-    const [input_begin, input_end] = t.params.input;
-    const [expected_begin, expected_end] = t.params.expected;
-
-    const i = new F32Interval(input_begin, input_end);
+    const i = new F32Interval(...t.params.input);
     t.expect(
-      i.begin === expected_begin && i.end === expected_end,
-      `F32Interval(${input_begin}, ${input_end}) returned ${i}. Expected [${expected_begin}, ${expected_end}`
+      objectEquals(i.bounds(), t.params.expected),
+      `F32Interval([${t.params.input}]) returned ${i}. Expected [${t.params.expected}]`
     );
   });
 
 interface ContainsNumberCase {
-  bounds: [number, number];
+  bounds: IntervalBounds;
   value: number;
   expected: boolean;
 }
@@ -153,13 +166,13 @@ g.test('contains_number')
     { bounds: [-5, 10], value: -10, expected: false },
 
     // Point
-    { bounds: [0, 0], value: 0, expected: true },
-    { bounds: [0, 0], value: 10, expected: false },
-    { bounds: [0, 0], value: -1000, expected: false },
-    { bounds: [10, 10], value: 10, expected: true },
-    { bounds: [10, 10], value: 0, expected: false },
-    { bounds: [10, 10], value: -10, expected: false },
-    { bounds: [10, 10], value: 11, expected: false },
+    { bounds: [0], value: 0, expected: true },
+    { bounds: [0], value: 10, expected: false },
+    { bounds: [0], value: -1000, expected: false },
+    { bounds: [10], value: 10, expected: true },
+    { bounds: [10], value: 0, expected: false },
+    { bounds: [10], value: -10, expected: false },
+    { bounds: [10], value: 11, expected: false },
 
     // Upper infinity
     { bounds: [0, kValue.f32.infinity.positive], value: kValue.f32.positive.min, expected: true },
@@ -247,8 +260,8 @@ g.test('contains_number')
   });
 
 interface ContainsIntervalCase {
-  lhs: [number, number];
-  rhs: [number, number];
+  lhs: IntervalBounds;
+  rhs: IntervalBounds;
   expected: boolean;
 }
 
@@ -257,7 +270,7 @@ g.test('contains_interval')
     // prettier-ignore
     [
       // Common usage
-      { lhs: [-10, 10], rhs: [0, 0], expected: true},
+      { lhs: [-10, 10], rhs: [0], expected: true},
       { lhs: [-10, 10], rhs: [-1, 0], expected: true},
       { lhs: [-10, 10], rhs: [0, 2], expected: true},
       { lhs: [-10, 10], rhs: [-1, 2], expected: true},
@@ -267,7 +280,7 @@ g.test('contains_interval')
       { lhs: [-10, 10], rhs: [-100, 10], expected: false},
 
       // Upper infinity
-      { lhs: [0, kValue.f32.infinity.positive], rhs: [0, 0], expected: true},
+      { lhs: [0, kValue.f32.infinity.positive], rhs: [0], expected: true},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [-1, 0], expected: false},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [0, 1], expected: true},
       { lhs: [0, kValue.f32.infinity.positive], rhs: [0, kValue.f32.positive.max], expected: true},
@@ -276,7 +289,7 @@ g.test('contains_interval')
       { lhs: [0, kValue.f32.infinity.positive], rhs: [Number.NEGATIVE_INFINITY, kValue.f32.infinity.positive], expected: false},
 
       // Lower infinity
-      { lhs: [kValue.f32.infinity.negative, 0], rhs: [0, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, 0], rhs: [0], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [-1, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.negative.min, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [0, 1], expected: false},
@@ -285,7 +298,7 @@ g.test('contains_interval')
       { lhs: [kValue.f32.infinity.negative, 0], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
 
       // Full infinity
-      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, 0], expected: true},
+      { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0], expected: true},
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [-1, 0], expected: true},
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, 1], expected: true},
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [0, kValue.f32.infinity.positive], expected: true},
@@ -295,7 +308,7 @@ g.test('contains_interval')
       { lhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: true},
 
       // Maximum f32 boundary
-      { lhs: [0, kValue.f32.positive.max], rhs: [0, 0], expected: true},
+      { lhs: [0, kValue.f32.positive.max], rhs: [0], expected: true},
       { lhs: [0, kValue.f32.positive.max], rhs: [-1, 0], expected: false},
       { lhs: [0, kValue.f32.positive.max], rhs: [0, 1], expected: true},
       { lhs: [0, kValue.f32.positive.max], rhs: [0, kValue.f32.positive.max], expected: true},
@@ -313,7 +326,7 @@ g.test('contains_interval')
       { lhs: [kValue.f32.negative.min, 0], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
 
       // Out of range high
-      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, 0], expected: true},
+      { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0], expected: true},
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [-1, 0], expected: false},
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, 1], expected: true},
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [0, kValue.f32.positive.max], expected: true},
@@ -322,7 +335,7 @@ g.test('contains_interval')
       { lhs: [0, 2 * kValue.f32.positive.max], rhs: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: false},
 
       // Out of range low
-      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [0, 0], expected: true},
+      { lhs: [2 * kValue.f32.negative.min, 0], rhs: [0], expected: true},
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [-1, 0], expected: true},
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [kValue.f32.negative.min, 0], expected: true},
       { lhs: [2 * kValue.f32.negative.min, 0], rhs: [0, 1], expected: false},
@@ -341,8 +354,8 @@ g.test('contains_interval')
   });
 
 interface SpanCase {
-  intervals: Array<[number, number]>;
-  expected: [number, number];
+  intervals: IntervalBounds[];
+  expected: IntervalBounds;
 }
 
 g.test('span')
@@ -384,7 +397,7 @@ g.test('span')
 
 interface CorrectlyRoundedCase {
   value: number;
-  expected: [number, number];
+  expected: IntervalBounds;
 }
 
 g.test('correctlyRoundedInterval')
@@ -394,10 +407,10 @@ g.test('correctlyRoundedInterval')
       // Edge Cases
       { value: kValue.f32.infinity.positive, expected: kAny },
       { value: kValue.f32.infinity.negative, expected: kAny },
-      { value: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { value: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { value: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
-      { value: kValue.f32.negative.max, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
+      { value: kValue.f32.positive.max, expected: [kValue.f32.positive.max] },
+      { value: kValue.f32.negative.min, expected: [kValue.f32.negative.min] },
+      { value: kValue.f32.positive.min, expected: [kValue.f32.positive.min] },
+      { value: kValue.f32.negative.max, expected: [kValue.f32.negative.max] },
 
       // 32-bit subnormals
       { value: kValue.f32.subnormal.positive.min, expected: [0, kValue.f32.subnormal.positive.min] },
@@ -413,10 +426,10 @@ g.test('correctlyRoundedInterval')
 
       // 32-bit normals
       { value: 0, expected: [0, 0] },
-      { value: hexToF32(0x03800000), expected: [hexToF32(0x03800000), hexToF32(0x03800000)] },
-      { value: hexToF32(0x03800001), expected: [hexToF32(0x03800001), hexToF32(0x03800001)] },
-      { value: hexToF32(0x83800000), expected: [hexToF32(0x83800000), hexToF32(0x83800000)] },
-      { value: hexToF32(0x83800001), expected: [hexToF32(0x83800001), hexToF32(0x83800001)] },
+      { value: hexToF32(0x03800000), expected: [hexToF32(0x03800000)] },
+      { value: hexToF32(0x03800001), expected: [hexToF32(0x03800001)] },
+      { value: hexToF32(0x83800000), expected: [hexToF32(0x83800000)] },
+      { value: hexToF32(0x83800001), expected: [hexToF32(0x83800001)] },
 
       // 64-bit normals
       { value: hexToF64(0x3ff00000, 0x00000001), expected: [hexToF32(0x3f800000), hexToF32(0x3f800001)] },
@@ -430,20 +443,19 @@ g.test('correctlyRoundedInterval')
     ]
   )
   .fn(t => {
-    const value = t.params.value;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = correctlyRoundedInterval(value);
+    const got = correctlyRoundedInterval(t.params.value);
     t.expect(
       objectEquals(expected, got),
-      `correctlyRoundedInterval(${value}) returned ${got}. Expected ${expected}`
+      `correctlyRoundedInterval(${t.params.value}) returned ${got}. Expected ${expected}`
     );
   });
 
 interface AbsoluteErrorCase {
   value: number;
   error: number;
-  expected: [number, number];
+  expected: IntervalBounds;
 }
 
 g.test('absoluteErrorInterval')
@@ -457,16 +469,16 @@ g.test('absoluteErrorInterval')
       { value: kValue.f32.infinity.negative, error: 0, expected: kAny },
       { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: kAny },
       { value: kValue.f32.infinity.negative, error: 1, expected: kAny },
-      { value: kValue.f32.positive.max, error: 0, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { value: kValue.f32.positive.max, error: 2 ** -11, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
+      { value: kValue.f32.positive.max, error: 0, expected: [kValue.f32.positive.max] },
+      { value: kValue.f32.positive.max, error: 2 ** -11, expected: [kValue.f32.positive.max] },
       { value: kValue.f32.positive.max, error: kValue.f32.positive.max, expected: kAny },
-      { value: kValue.f32.positive.min, error: 0, expected: [kValue.f32.positive.min,  kValue.f32.positive.min] },
+      { value: kValue.f32.positive.min, error: 0, expected: [kValue.f32.positive.min] },
       { value: kValue.f32.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
       { value: kValue.f32.positive.min, error: 1, expected: [-1, 1] },
-      { value: kValue.f32.negative.min, error: 0, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { value: kValue.f32.negative.min, error: 2 ** -11, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+      { value: kValue.f32.negative.min, error: 0, expected: [kValue.f32.negative.min] },
+      { value: kValue.f32.negative.min, error: 2 ** -11, expected: [kValue.f32.negative.min] },
       { value: kValue.f32.negative.min, error: kValue.f32.positive.max, expected: kAny },
-      { value: kValue.f32.negative.max, error: 0, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
+      { value: kValue.f32.negative.max, error: 0, expected: [kValue.f32.negative.max] },
       { value: kValue.f32.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
       { value: kValue.f32.negative.max, error: 1, expected: [-1, 1] },
 
@@ -499,27 +511,25 @@ g.test('absoluteErrorInterval')
       { value: hexToF64(0x800fffff, 0xfffffffe), error: 1, expected: [-1, 1] },
 
       // Zero
-      { value: 0, error: 0, expected: [0, 0] },
+      { value: 0, error: 0, expected: [0] },
       { value: 0, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
       { value: 0, error: 1, expected: [-1, 1] },
     ]
   )
   .fn(t => {
-    const value = t.params.value;
-    const error = t.params.error;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = absoluteErrorInterval(value, error);
+    const got = absoluteErrorInterval(t.params.value, t.params.error);
     t.expect(
       objectEquals(expected, got),
-      `absoluteErrorInterval(${value}, ${error}) returned ${got}. Expected ${expected}`
+      `absoluteErrorInterval(${t.params.value}, ${t.params.error}) returned ${got}. Expected ${expected}`
     );
   });
 
 interface ULPCase {
   value: number;
   num_ulp: number;
-  expected: [number, number];
+  expected: IntervalBounds;
 }
 
 g.test('ulpInterval')
@@ -533,16 +543,16 @@ g.test('ulpInterval')
       { value: kValue.f32.infinity.negative, num_ulp: 0, expected: kAny },
       { value: kValue.f32.infinity.negative, num_ulp: 1, expected: kAny },
       { value: kValue.f32.infinity.negative, num_ulp: 4096, expected: kAny },
-      { value: kValue.f32.positive.max, num_ulp: 0, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
+      { value: kValue.f32.positive.max, num_ulp: 0, expected: [kValue.f32.positive.max] },
       { value: kValue.f32.positive.max, num_ulp: 1, expected: kAny },
       { value: kValue.f32.positive.max, num_ulp: 4096, expected: kAny },
-      { value: kValue.f32.positive.min, num_ulp: 0, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
+      { value: kValue.f32.positive.min, num_ulp: 0, expected: [kValue.f32.positive.min] },
       { value: kValue.f32.positive.min, num_ulp: 1, expected: [0, plusOneULP(kValue.f32.positive.min)] },
       { value: kValue.f32.positive.min, num_ulp: 4096, expected: [0, plusNULP(kValue.f32.positive.min, 4096)] },
-      { value: kValue.f32.negative.min, num_ulp: 0, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+      { value: kValue.f32.negative.min, num_ulp: 0, expected: [kValue.f32.negative.min] },
       { value: kValue.f32.negative.min, num_ulp: 1, expected: kAny },
       { value: kValue.f32.negative.min, num_ulp: 4096, expected: kAny },
-      { value: kValue.f32.negative.max, num_ulp: 0, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
+      { value: kValue.f32.negative.max, num_ulp: 0, expected: [kValue.f32.negative.max] },
       { value: kValue.f32.negative.max, num_ulp: 1, expected: [minusOneULP(kValue.f32.negative.max), 0] },
       { value: kValue.f32.negative.max, num_ulp: 4096, expected: [minusNULP(kValue.f32.negative.max, 4096), 0] },
 
@@ -575,26 +585,24 @@ g.test('ulpInterval')
       { value: hexToF64(0x800fffff, 0xfffffffe), num_ulp: 4096, expected: [minusNULP(kValue.f32.subnormal.negative.max, 4096), plusNULP(0, 4096)] },
 
       // Zero
-      { value: 0, num_ulp: 0, expected: [0, 0] },
+      { value: 0, num_ulp: 0, expected: [0] },
       { value: 0, num_ulp: 1, expected: [minusOneULP(0), plusOneULP(0)] },
       { value: 0, num_ulp: 4096, expected: [minusNULP(0, 4096), plusNULP(0, 4096)] },
     ]
   )
   .fn(t => {
-    const value = t.params.value;
-    const num_ulp = t.params.num_ulp;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = ulpInterval(value, num_ulp);
+    const got = ulpInterval(t.params.value, t.params.num_ulp);
     t.expect(
       objectEquals(expected, got),
-      `ulpInterval(${value}, ${num_ulp}) returned ${got}. Expected ${expected}`
+      `ulpInterval(${t.params.value}, ${t.params.num_ulp}) returned ${got}. Expected ${expected}`
     );
   });
 
 interface PointToIntervalCase {
   input: number;
-  expected: [number, number];
+  expected: IntervalBounds;
 }
 
 g.test('absInterval')
@@ -602,18 +610,18 @@ g.test('absInterval')
     // prettier-ignore
     [
       // Common usages
-      { input: 1, expected: [1, 1] },
-      { input: -1, expected: [1, 1] },
+      { input: 1, expected: [1] },
+      { input: -1, expected: [1] },
       { input: 0.1, expected: [hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)] },
       { input: -0.1, expected: [hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)] },
 
       // Edge cases
       { input: kValue.f32.infinity.positive, expected: kAny },
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
-      { input: kValue.f32.negative.min, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { input: kValue.f32.negative.max, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max] },
+      { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.positive.max] },
+      { input: kValue.f32.negative.max, expected: [kValue.f32.positive.min] },
 
       // 32-bit subnormals
       { input: kValue.f32.subnormal.positive.max, expected: [0, kValue.f32.subnormal.positive.max] },
@@ -626,17 +634,16 @@ g.test('absInterval')
       { input: hexToF64(0x800fffff, 0xffffffff), expected: [0, kValue.f32.subnormal.positive.min] },
 
       // Zero
-      { input: 0, expected: [0, 0]},
+      { input: 0, expected: [0]},
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = absInterval(input);
+    const got = absInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `absInterval(${input}) returned ${got}. Expected ${expected}`
+      `absInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -658,13 +665,12 @@ g.test('acoshAlternativeInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = acoshAlternativeInterval(input);
+    const got = acoshAlternativeInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `acoshInterval(${input}) returned ${got}. Expected ${expected}`
+      `acoshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -686,13 +692,12 @@ g.test('acoshPrimaryInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = acoshPrimaryInterval(input);
+    const got = acoshPrimaryInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `acoshInterval(${input}) returned ${got}. Expected ${expected}`
+      `acoshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -712,13 +717,12 @@ g.test('asinhInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = asinhInterval(input);
+    const got = asinhInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `asinhInterval(${input}) returned ${got}. Expected ${expected}`
+      `asinhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -730,7 +734,7 @@ g.test('atanInterval')
       { input: hexToF32(0xbfddb3d7), expected: [kValue.f32.negative.pi.third, plusOneULP(kValue.f32.negative.pi.third)] }, // x = -√3
       { input: -1, expected: [kValue.f32.negative.pi.quarter, plusOneULP(kValue.f32.negative.pi.quarter)] },
       { input: hexToF32(0xbf13cd3a), expected: [kValue.f32.negative.pi.sixth, plusOneULP(kValue.f32.negative.pi.sixth)] },  // x = -1/√3
-      { input: 0, expected: [0, 0] },
+      { input: 0, expected: [0] },
       { input: hexToF32(0x3f13cd3a), expected: [minusOneULP(kValue.f32.positive.pi.sixth), kValue.f32.positive.pi.sixth] },  // x = 1/√3
       { input: 1, expected: [minusOneULP(kValue.f32.positive.pi.quarter), kValue.f32.positive.pi.quarter] },
       { input: hexToF32(0x3fddb3d7), expected: [minusOneULP(kValue.f32.positive.pi.third), kValue.f32.positive.pi.third] }, // x = √3
@@ -738,21 +742,17 @@ g.test('atanInterval')
     ]
   )
   .fn(t => {
-    const error = (x: number): number => {
-      return 4096 * oneULP(x);
+    const error = (n: number): number => {
+      return 4096 * oneULP(n);
     };
 
-    const input = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error(begin), end + error(end)];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
-    const got = atanInterval(input);
+    const got = atanInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `atanInterval(${input}) returned ${got}. Expected ${expected}`
+      `atanInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -774,13 +774,12 @@ g.test('atanhInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = atanhInterval(input);
+    const got = atanhInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `atanhInterval(${input}) returned ${got}. Expected ${expected}`
+      `atanhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -788,43 +787,42 @@ g.test('ceilInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: 0, expected: [0, 0] },
-      { input: 0.1, expected: [1, 1] },
-      { input: 0.9, expected: [1, 1] },
-      { input: 1.0, expected: [1, 1] },
-      { input: 1.1, expected: [2, 2] },
-      { input: 1.9, expected: [2, 2] },
-      { input: -0.1, expected: [0, 0] },
-      { input: -0.9, expected: [0, 0] },
-      { input: -1.0, expected: [-1, -1] },
-      { input: -1.1, expected: [-1, -1] },
-      { input: -1.9, expected: [-1, -1] },
+      { input: 0, expected: [0] },
+      { input: 0.1, expected: [1] },
+      { input: 0.9, expected: [1] },
+      { input: 1.0, expected: [1] },
+      { input: 1.1, expected: [2] },
+      { input: 1.9, expected: [2] },
+      { input: -0.1, expected: [0] },
+      { input: -0.9, expected: [0] },
+      { input: -1.0, expected: [-1] },
+      { input: -1.1, expected: [-1] },
+      { input: -1.9, expected: [-1] },
 
       // Edge cases
       { input: kValue.f32.infinity.positive, expected: kAny },
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { input: kValue.f32.positive.min, expected: [1, 1] },
-      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { input: kValue.f32.negative.max, expected: [0, 0] },
-      { input: kValue.powTwo.to30, expected: [kValue.powTwo.to30, kValue.powTwo.to30] },
-      { input: -kValue.powTwo.to30, expected: [-kValue.powTwo.to30, -kValue.powTwo.to30] },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max] },
+      { input: kValue.f32.positive.min, expected: [1] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min] },
+      { input: kValue.f32.negative.max, expected: [0] },
+      { input: kValue.powTwo.to30, expected: [kValue.powTwo.to30] },
+      { input: -kValue.powTwo.to30, expected: [-kValue.powTwo.to30] },
 
       // 32-bit subnormals
       { input: kValue.f32.subnormal.positive.max, expected: [0, 1] },
       { input: kValue.f32.subnormal.positive.min, expected: [0, 1] },
-      { input: kValue.f32.subnormal.negative.min, expected: [0, 0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [0, 0] },
+      { input: kValue.f32.subnormal.negative.min, expected: [0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [0] },
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = ceilInterval(input);
+    const got = ceilInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `ceilInterval(${input}) returned ${got}. Expected ${expected}`
+      `ceilInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -848,19 +846,17 @@ g.test('cosInterval')
     ]
   )
   .fn(t => {
-    const error = 2 ** -11;
+    const error = (_: number): number => {
+      return 2 ** -11;
+    };
 
-    const input = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error, end + error];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
-    const got = cosInterval(input);
+    const got = cosInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `cosInterval(${input}) returned ${got}. Expected ${expected}`
+      `cosInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -880,13 +876,12 @@ g.test('coshInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = coshInterval(input);
+    const got = coshInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `coshInterval(${input}) returned ${got}. Expected ${expected}`
+      `coshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -902,7 +897,7 @@ g.test('degreesInterval')
       { input: kValue.f32.negative.pi.third, expected: [minusOneULP(-60), plusOneULP(-60)] },
       { input: kValue.f32.negative.pi.quarter, expected: [minusOneULP(-45), plusOneULP(-45)] },
       { input: kValue.f32.negative.pi.sixth, expected: [minusOneULP(-30), plusOneULP(-30)] },
-      { input: 0, expected: [0, 0] },
+      { input: 0, expected: [0] },
       { input: kValue.f32.positive.pi.sixth, expected: [minusOneULP(30), plusOneULP(30)] },
       { input: kValue.f32.positive.pi.quarter, expected: [minusOneULP(45), plusOneULP(45)] },
       { input: kValue.f32.positive.pi.third, expected: [minusOneULP(60), plusOneULP(60)] },
@@ -914,13 +909,12 @@ g.test('degreesInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = degreesInterval(input);
+    const got = degreesInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `degreesInterval(${input}) returned ${got}. Expected ${expected}`
+      `degreesInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -929,28 +923,24 @@ g.test('expInterval')
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: 0, expected: [1,1] },
+      { input: 0, expected: [1] },
       { input: 1, expected: [kValue.f32.positive.e, plusOneULP(kValue.f32.positive.e)] },
       { input: 89, expected: kAny },
     ]
   )
   .fn(t => {
-    const error = (input: number, result: number): number => {
-      const n = 3 + 2 * Math.abs(input);
-      return n * oneULP(result);
+    const error = (x: number): number => {
+      const n = 3 + 2 * Math.abs(t.params.input);
+      return n * oneULP(x);
     };
 
-    const input = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error(input, begin), end + error(input, end)];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
-    const got = expInterval(input);
+    const got = expInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `expInterval(${input}) returned ${got}. Expected ${expected}`
+      `expInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -959,28 +949,24 @@ g.test('exp2Interval')
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: 0, expected: [1,1] },
-      { input: 1, expected: [2, 2] },
+      { input: 0, expected: [1] },
+      { input: 1, expected: [2] },
       { input: 128, expected: kAny },
     ]
   )
   .fn(t => {
-    const error = (input: number, result: number): number => {
-      const n = 3 + 2 * Math.abs(input);
-      return n * oneULP(result);
+    const error = (x: number): number => {
+      const n = 3 + 2 * Math.abs(t.params.input);
+      return n * oneULP(x);
     };
 
-    const input = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error(input, begin), end + error(input, end)];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
-    const got = exp2Interval(input);
+    const got = exp2Interval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `exp2Interval(${input}) returned ${got}. Expected ${expected}`
+      `exp2Interval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -988,43 +974,42 @@ g.test('floorInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: 0, expected: [0, 0] },
-      { input: 0.1, expected: [0, 0] },
-      { input: 0.9, expected: [0, 0] },
-      { input: 1.0, expected: [1, 1] },
-      { input: 1.1, expected: [1, 1] },
-      { input: 1.9, expected: [1, 1] },
-      { input: -0.1, expected: [-1, -1] },
-      { input: -0.9, expected: [-1, -1] },
-      { input: -1.0, expected: [-1, -1] },
-      { input: -1.1, expected: [-2, -2] },
-      { input: -1.9, expected: [-2, -2] },
+      { input: 0, expected: [0] },
+      { input: 0.1, expected: [0] },
+      { input: 0.9, expected: [0] },
+      { input: 1.0, expected: [1] },
+      { input: 1.1, expected: [1] },
+      { input: 1.9, expected: [1] },
+      { input: -0.1, expected: [-1] },
+      { input: -0.9, expected: [-1] },
+      { input: -1.0, expected: [-1] },
+      { input: -1.1, expected: [-2] },
+      { input: -1.9, expected: [-2] },
 
       // Edge cases
       { input: kValue.f32.infinity.positive, expected: kAny },
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { input: kValue.f32.positive.min, expected: [0, 0] },
-      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { input: kValue.f32.negative.max, expected: [-1, -1] },
-      { input: kValue.powTwo.to30, expected: [kValue.powTwo.to30, kValue.powTwo.to30] },
-      { input: -kValue.powTwo.to30, expected: [-kValue.powTwo.to30, -kValue.powTwo.to30] },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max] },
+      { input: kValue.f32.positive.min, expected: [0] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min] },
+      { input: kValue.f32.negative.max, expected: [-1] },
+      { input: kValue.powTwo.to30, expected: [kValue.powTwo.to30] },
+      { input: -kValue.powTwo.to30, expected: [-kValue.powTwo.to30] },
 
       // 32-bit subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: [0, 0] },
-      { input: kValue.f32.subnormal.positive.min, expected: [0, 0] },
+      { input: kValue.f32.subnormal.positive.max, expected: [0] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0] },
       { input: kValue.f32.subnormal.negative.min, expected: [-1, 0] },
       { input: kValue.f32.subnormal.negative.max, expected: [-1, 0] },
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = floorInterval(input);
+    const got = floorInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `floorInterval(${input}) returned ${got}. Expected ${expected}`
+      `floorInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1032,33 +1017,32 @@ g.test('fractInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: 0, expected: [0, 0] },
+      { input: 0, expected: [0] },
       { input: 0.1, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] }, // ~0.1
       { input: 0.9, expected: [hexToF32(0x3f666666), plusOneULP(hexToF32(0x3f666666))] },  // ~0.9
-      { input: 1.0, expected: [0.0, 0.0] },
+      { input: 1.0, expected: [0] },
       { input: 1.1, expected: [hexToF64(0x3fb99998, 0x00000000), hexToF64(0x3fb9999a, 0x00000000)] }, // ~0.1
       { input: -0.1, expected: [hexToF32(0x3f666666), plusOneULP(hexToF32(0x3f666666))] },  // ~0.9
       { input: -0.9, expected: [hexToF64(0x3fb99999, 0x00000000), hexToF64(0x3fb9999a, 0x00000000)] }, // ~0.1
-      { input: -1.0, expected: [0.0, 0.0] },
+      { input: -1.0, expected: [0] },
       { input: -1.1, expected: [hexToF64(0x3feccccc, 0xc0000000), hexToF64(0x3feccccd, 0x00000000), ] }, // ~0.9
 
       // Edge cases
       { input: kValue.f32.infinity.positive, expected: kAny },
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.positive.max, expected: [0, 0] },
+      { input: kValue.f32.positive.max, expected: [0] },
       { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
-      { input: kValue.f32.negative.min, expected: [0, 0] },
+      { input: kValue.f32.negative.min, expected: [0] },
       { input: kValue.f32.negative.max, expected: [kValue.f32.positive.less_than_one, 1.0] },
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = fractInterval(input);
+    const got = fractInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `fractInterval(${input}) returned ${got}. Expected ${expected}`
+      `fractInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1069,28 +1053,24 @@ g.test('inverseSqrtInterval')
       { input: -1, expected: kAny },
       { input: 0, expected: kAny },
       { input: 0.04, expected: [minusOneULP(5), plusOneULP(5)] },
-      { input: 1, expected: [1, 1] },
+      { input: 1, expected: [1] },
       { input: 100, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
       { input: kValue.f32.positive.max, expected: [hexToF32(0x1f800000), plusNULP(hexToF32(0x1f800000), 2)] },  // ~5.421...e-20, i.e. 1/√max f32
       { input: kValue.f32.infinity.positive, expected: kAny },
     ]
   )
   .fn(t => {
-    const error = (input: number, result: number): number => {
-      return 2 * oneULP(result);
+    const error = (n: number): number => {
+      return 2 * oneULP(n);
     };
 
-    const input = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error(input, begin), end + error(input, end)];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
-    const got = inverseSqrtInterval(input);
+    const got = inverseSqrtInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `inverseSqrtInterval(${input}) returned ${got}. Expected ${expected}`
+      `inverseSqrtInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1100,30 +1080,26 @@ g.test('logInterval')
     [
       { input: -1, expected: kAny },
       { input: 0, expected: kAny },
-      { input: 1, expected: [0, 0] },
+      { input: 1, expected: [0] },
       { input: kValue.f32.positive.e, expected: [minusOneULP(1), 1] },
       { input: kValue.f32.positive.max, expected: [minusOneULP(hexToF32(0x42b17218)), hexToF32(0x42b17218)] },  // ~88.72...
     ]
   )
   .fn(t => {
-    const error = (input: number, result: number): number => {
-      if (input >= 0.5 && input <= 2.0) {
+    const error = (n: number): number => {
+      if (t.params.input >= 0.5 && t.params.input <= 2.0) {
         return 2 ** -21;
       }
-      return 3 * oneULP(result);
+      return 3 * oneULP(n);
     };
 
-    const input = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error(input, begin), end + error(input, end)];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
-    const got = logInterval(input);
+    const got = logInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `logInterval(${input}) returned ${got}. Expected ${expected}`
+      `logInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1133,30 +1109,26 @@ g.test('log2Interval')
     [
       { input: -1, expected: kAny },
       { input: 0, expected: kAny },
-      { input: 1, expected: [0, 0] },
-      { input: 2, expected: [1, 1] },
+      { input: 1, expected: [0] },
+      { input: 2, expected: [1] },
       { input: kValue.f32.positive.max, expected: [minusOneULP(128), 128] },
     ]
   )
   .fn(t => {
-    const error = (input: number, result: number): number => {
-      if (input >= 0.5 && input <= 2.0) {
+    const error = (n: number): number => {
+      if (t.params.input >= 0.5 && t.params.input <= 2.0) {
         return 2 ** -21;
       }
-      return 3 * oneULP(result);
+      return 3 * oneULP(n);
     };
 
-    const input = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error(input, begin), end + error(input, end)];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
-    const got = log2Interval(input);
+    const got = log2Interval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `log2Interval(${input}) returned ${got}. Expected ${expected}`
+      `log2Interval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1164,21 +1136,21 @@ g.test('negationInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: 0, expected: [0, 0] },
+      { input: 0, expected: [0] },
       { input: 0.1, expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] }, // ~-0.1
-      { input: 1.0, expected: [-1.0, -1.0] },
+      { input: 1.0, expected: [-1.0] },
       { input: 1.9, expected: [hexToF32(0xbff33334), plusOneULP(hexToF32(0xbff33334))] },  // ~-1.9
       { input: -0.1, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] }, // ~0.1
-      { input: -1.0, expected: [1, 1] },
+      { input: -1.0, expected: [1] },
       { input: -1.9, expected: [minusOneULP(hexToF32(0x3ff33334)), hexToF32(0x3ff33334)] },  // ~1.9
 
       // Edge cases
       { input: kValue.f32.infinity.positive, expected: kAny },
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.positive.max, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { input: kValue.f32.positive.min, expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
-      { input: kValue.f32.negative.min, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { input: kValue.f32.negative.max, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.negative.min] },
+      { input: kValue.f32.positive.min, expected: [kValue.f32.negative.max] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.positive.max] },
+      { input: kValue.f32.negative.max, expected: [kValue.f32.positive.min] },
 
       // 32-bit subnormals
       { input: kValue.f32.subnormal.positive.max, expected: [kValue.f32.subnormal.negative.min, 0] },
@@ -1188,13 +1160,12 @@ g.test('negationInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = negationInterval(input);
+    const got = negationInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `negationInterval(${input}) returned ${got}. Expected ${expected}`
+      `negationInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1209,7 +1180,7 @@ g.test('radiansInterval')
       { input: -60, expected: [minusOneULP(kValue.f32.negative.pi.third), plusOneULP(kValue.f32.negative.pi.third)] },
       { input: -45, expected: [minusOneULP(kValue.f32.negative.pi.quarter), plusOneULP(kValue.f32.negative.pi.quarter)] },
       { input: -30, expected: [minusOneULP(kValue.f32.negative.pi.sixth), plusOneULP(kValue.f32.negative.pi.sixth)] },
-      { input: 0, expected: [0, 0] },
+      { input: 0, expected: [0] },
       { input: 30, expected: [minusOneULP(kValue.f32.positive.pi.sixth), plusOneULP(kValue.f32.positive.pi.sixth)] },
       { input: 45, expected: [minusOneULP(kValue.f32.positive.pi.quarter), plusOneULP(kValue.f32.positive.pi.quarter)] },
       { input: 60, expected: [minusOneULP(kValue.f32.positive.pi.third), plusOneULP(kValue.f32.positive.pi.third)] },
@@ -1220,13 +1191,12 @@ g.test('radiansInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = radiansInterval(input);
+    const got = radiansInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `radiansInterval(${input}) returned ${got}. Expected ${expected}`
+      `radiansInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1234,47 +1204,46 @@ g.test('roundInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: 0, expected: [0, 0] },
-      { input: 0.1, expected: [0, 0] },
-      { input: 0.5, expected: [0, 0] },  // Testing tie breaking
-      { input: 0.9, expected: [1, 1] },
-      { input: 1.0, expected: [1, 1] },
-      { input: 1.1, expected: [1, 1] },
-      { input: 1.5, expected: [2, 2] },  // Testing tie breaking
-      { input: 1.9, expected: [2, 2] },
-      { input: -0.1, expected: [0, 0] },
-      { input: -0.5, expected: [0, 0] },  // Testing tie breaking
-      { input: -0.9, expected: [-1, -1] },
-      { input: -1.0, expected: [-1, -1] },
-      { input: -1.1, expected: [-1, -1] },
-      { input: -1.5, expected: [-2, -2] },  // Testing tie breaking
-      { input: -1.9, expected: [-2, -2] },
+      { input: 0, expected: [0] },
+      { input: 0.1, expected: [0] },
+      { input: 0.5, expected: [0] },  // Testing tie breaking
+      { input: 0.9, expected: [1] },
+      { input: 1.0, expected: [1] },
+      { input: 1.1, expected: [1] },
+      { input: 1.5, expected: [2] },  // Testing tie breaking
+      { input: 1.9, expected: [2] },
+      { input: -0.1, expected: [0] },
+      { input: -0.5, expected: [0] },  // Testing tie breaking
+      { input: -0.9, expected: [-1] },
+      { input: -1.0, expected: [-1] },
+      { input: -1.1, expected: [-1] },
+      { input: -1.5, expected: [-2] },  // Testing tie breaking
+      { input: -1.9, expected: [-2] },
 
       // Edge cases
       { input: kValue.f32.infinity.positive, expected: kAny },
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { input: kValue.f32.positive.min, expected: [0, 0] },
-      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { input: kValue.f32.negative.max, expected: [0, 0] },
-      { input: kValue.powTwo.to30, expected: [kValue.powTwo.to30, kValue.powTwo.to30] },
-      { input: -kValue.powTwo.to30, expected: [-kValue.powTwo.to30, -kValue.powTwo.to30] },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max] },
+      { input: kValue.f32.positive.min, expected: [0] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min] },
+      { input: kValue.f32.negative.max, expected: [0] },
+      { input: kValue.powTwo.to30, expected: [kValue.powTwo.to30] },
+      { input: -kValue.powTwo.to30, expected: [-kValue.powTwo.to30] },
 
       // 32-bit subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: [0, 0] },
-      { input: kValue.f32.subnormal.positive.min, expected: [0, 0] },
-      { input: kValue.f32.subnormal.negative.min, expected: [0, 0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [0, 0] },
+      { input: kValue.f32.subnormal.positive.max, expected: [0] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0] },
+      { input: kValue.f32.subnormal.negative.min, expected: [0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [0] },
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = roundInterval(input);
+    const got = roundInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `roundInterval(${input}) returned ${got}. Expected ${expected}`
+      `roundInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1283,24 +1252,24 @@ g.test('saturateInterval')
     // prettier-ignore
     [
       // Normals
-      { input: 0, expected: [0, 0] },
-      { input: 1, expected: [1.0, 1.0] },
-      { input: -0.1, expected: [0, 0] },
-      { input: -1, expected: [0, 0] },
-      { input: -10, expected: [0, 0] },
+      { input: 0, expected: [0] },
+      { input: 1, expected: [1.0] },
+      { input: -0.1, expected: [0] },
+      { input: -1, expected: [0] },
+      { input: -10, expected: [0] },
       { input: 0.1, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: 10, expected: [1.0, 1.0] },
-      { input: 11.1, expected: [1.0, 1.0] },
-      { input: kValue.f32.positive.max, expected: [1.0, 1.0] },
-      { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
-      { input: kValue.f32.negative.max, expected: [0.0, 0.0] },
-      { input: kValue.f32.negative.min, expected: [0.0, 0.0] },
+      { input: 10, expected: [1.0] },
+      { input: 11.1, expected: [1.0] },
+      { input: kValue.f32.positive.max, expected: [1.0] },
+      { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min] },
+      { input: kValue.f32.negative.max, expected: [0.0] },
+      { input: kValue.f32.negative.min, expected: [0.0] },
 
       // Subnormals
       { input: kValue.f32.subnormal.positive.max, expected: [0.0, kValue.f32.subnormal.positive.max] },
       { input: kValue.f32.subnormal.positive.min, expected: [0.0, kValue.f32.subnormal.positive.min] },
-      { input: kValue.f32.subnormal.negative.min, expected: [0.0, 0.0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [0.0, 0.0] },
+      { input: kValue.f32.subnormal.negative.min, expected: [0.0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [0.0] },
 
       // Infinities
       { input: kValue.f32.infinity.positive, expected: kAny },
@@ -1308,13 +1277,12 @@ g.test('saturateInterval')
     ]
   )
   .fn(t => {
-    const n = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = saturateInterval(n);
+    const got = saturateInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `saturationInterval(${n}) returned ${got}. Expected ${expected}`
+      `saturationInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1323,32 +1291,31 @@ g.test('signInterval')
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: [-1, -1] },
-      { input: -10, expected: [-1, -1] },
-      { input: -1, expected: [-1, -1] },
-      { input: -0.1, expected: [-1, -1] },
-      { input: kValue.f32.negative.max, expected:  [-1, -1] },
+      { input: kValue.f32.negative.min, expected: [-1] },
+      { input: -10, expected: [-1] },
+      { input: -1, expected: [-1] },
+      { input: -0.1, expected: [-1] },
+      { input: kValue.f32.negative.max, expected:  [-1] },
       { input: kValue.f32.subnormal.negative.min, expected: [-1, 0] },
       { input: kValue.f32.subnormal.negative.max, expected: [-1, 0] },
-      { input: 0, expected: [0, 0] },
+      { input: 0, expected: [0] },
       { input: kValue.f32.subnormal.positive.max, expected: [0, 1] },
       { input: kValue.f32.subnormal.positive.min, expected: [0, 1] },
-      { input: kValue.f32.positive.min, expected: [1, 1] },
-      { input: 0.1, expected: [1, 1] },
-      { input: 1, expected: [1, 1] },
-      { input: 10, expected: [1, 1] },
-      { input: kValue.f32.positive.max, expected: [1, 1] },
+      { input: kValue.f32.positive.min, expected: [1] },
+      { input: 0.1, expected: [1] },
+      { input: 1, expected: [1] },
+      { input: 10, expected: [1] },
+      { input: kValue.f32.positive.max, expected: [1] },
       { input: kValue.f32.infinity.positive, expected: kAny },
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = signInterval(input);
+    const got = signInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `signInterval(${input}) returned ${got}. Expected ${expected}`
+      `signInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1363,26 +1330,24 @@ g.test('sinInterval')
       { input: kValue.f32.infinity.negative, expected: kAny },
       { input: kValue.f32.negative.min, expected: kAny },
       { input: kValue.f32.negative.pi.half, expected: [-1, plusOneULP(-1)] },
-      { input: 0, expected: [0, 0] },
+      { input: 0, expected: [0] },
       { input: kValue.f32.positive.pi.half, expected: [minusOneULP(1), 1] },
       { input: kValue.f32.positive.max, expected: kAny },
       { input: kValue.f32.infinity.positive, expected: kAny },
     ]
   )
   .fn(t => {
-    const error = 2 ** -11;
+    const error = (_: number): number => {
+      return 2 ** -11;
+    };
 
-    const input = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error, end + error];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
-    const got = sinInterval(input);
+    const got = sinInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `sinInterval(${input}) returned ${got}. Expected ${expected}`
+      `sinInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1402,13 +1367,12 @@ g.test('sinhInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = sinhInterval(input);
+    const got = sinhInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `sinhInterval(${input}) returned ${got}. Expected ${expected}`
+      `sinhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1428,13 +1392,12 @@ g.test('sqrtInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = sqrtInterval(input);
+    const got = sqrtInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `sqrtInterval(${input}) returned ${got}. Expected ${expected}`
+      `sqrtInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1463,13 +1426,12 @@ g.test('tanInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = tanInterval(input);
+    const got = tanInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `tanInterval(${input}) returned ${got}. Expected ${expected}`
+      `tanInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1489,13 +1451,12 @@ g.test('tanhInterval')
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = tanhInterval(input);
+    const got = tanhInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `tanhInterval(${input}) returned ${got}. Expected ${expected}`
+      `tanhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1503,41 +1464,40 @@ g.test('truncInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: 0, expected: [0, 0] },
-      { input: 0.1, expected: [0, 0] },
-      { input: 0.9, expected: [0, 0] },
-      { input: 1.0, expected: [1, 1] },
-      { input: 1.1, expected: [1, 1] },
-      { input: 1.9, expected: [1, 1] },
-      { input: -0.1, expected: [0, 0] },
-      { input: -0.9, expected: [0, 0] },
-      { input: -1.0, expected: [-1, -1] },
-      { input: -1.1, expected: [-1, -1] },
-      { input: -1.9, expected: [-1, -1] },
+      { input: 0, expected: [0] },
+      { input: 0.1, expected: [0] },
+      { input: 0.9, expected: [0] },
+      { input: 1.0, expected: [1] },
+      { input: 1.1, expected: [1] },
+      { input: 1.9, expected: [1] },
+      { input: -0.1, expected: [0] },
+      { input: -0.9, expected: [0] },
+      { input: -1.0, expected: [-1] },
+      { input: -1.1, expected: [-1] },
+      { input: -1.9, expected: [-1] },
 
       // Edge cases
       { input: kValue.f32.infinity.positive, expected: kAny },
       { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { input: kValue.f32.positive.min, expected: [0, 0] },
-      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
-      { input: kValue.f32.negative.max, expected: [0, 0] },
+      { input: kValue.f32.positive.max, expected: [kValue.f32.positive.max] },
+      { input: kValue.f32.positive.min, expected: [0] },
+      { input: kValue.f32.negative.min, expected: [kValue.f32.negative.min] },
+      { input: kValue.f32.negative.max, expected: [0] },
 
       // 32-bit subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: [0, 0] },
-      { input: kValue.f32.subnormal.positive.min, expected: [0, 0] },
-      { input: kValue.f32.subnormal.negative.min, expected: [0, 0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [0, 0] },
+      { input: kValue.f32.subnormal.positive.max, expected: [0] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0] },
+      { input: kValue.f32.subnormal.negative.min, expected: [0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [0] },
     ]
   )
   .fn(t => {
-    const input = t.params.input;
     const expected = new F32Interval(...t.params.expected);
 
-    const got = truncInterval(input);
+    const got = truncInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `truncInterval(${input}) returned ${got}. Expected ${expected}`
+      `truncInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -1545,7 +1505,7 @@ interface BinaryToIntervalCase {
   // input is a pair of independent values, not an range, so should not be
   // converted to a F32Interval.
   input: [number, number];
-  expected: [number, number];
+  expected: IntervalBounds;
 }
 
 g.test('additionInterval')
@@ -1553,15 +1513,15 @@ g.test('additionInterval')
     // prettier-ignore
     [
       // 32-bit normals
-      { input: [0, 0], expected: [0, 0] },
-      { input: [1, 0], expected: [1, 1] },
-      { input: [0, 1], expected: [1, 1] },
-      { input: [-1, 0], expected: [-1, -1] },
-      { input: [0, -1], expected: [-1, -1] },
-      { input: [1, 1], expected: [2, 2] },
-      { input: [1, -1], expected: [0, 0] },
-      { input: [-1, 1], expected: [0, 0] },
-      { input: [-1, -1], expected: [-2, -2] },
+      { input: [0, 0], expected: [0] },
+      { input: [1, 0], expected: [1] },
+      { input: [0, 1], expected: [1] },
+      { input: [-1, 0], expected: [-1] },
+      { input: [0, -1], expected: [-1] },
+      { input: [1, 1], expected: [2] },
+      { input: [1, -1], expected: [0] },
+      { input: [-1, 1], expected: [0] },
+      { input: [-1, -1], expected: [-2] },
 
       // 64-bit normals
       { input: [0.1, 0], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
@@ -1645,15 +1605,12 @@ g.test('atan2Interval')
     ]
   )
   .fn(t => {
-    const error = (x: number): number => {
-      return 4096 * oneULP(x);
+    const error = (n: number): number => {
+      return 4096 * oneULP(n);
     };
 
     const [y, x] = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error(begin), end + error(end)];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
     const got = atan2Interval(y, x);
@@ -1668,20 +1625,20 @@ g.test('divisionInterval')
     // prettier-ignore
     [
       // 32-bit normals
-      { input: [0, 1], expected: [0, 0] },
-      { input: [0, -1], expected: [0, 0] },
-      { input: [1, 1], expected: [1, 1] },
-      { input: [1, -1], expected: [-1, -1] },
-      { input: [-1, 1], expected: [-1, -1] },
-      { input: [-1, -1], expected: [1, 1] },
-      { input: [4, 2], expected: [2, 2] },
-      { input: [-4, 2], expected: [-2, -2] },
-      { input: [4, -2], expected: [-2, -2] },
-      { input: [-4, -2], expected: [2, 2] },
+      { input: [0, 1], expected: [0] },
+      { input: [0, -1], expected: [0] },
+      { input: [1, 1], expected: [1] },
+      { input: [1, -1], expected: [-1] },
+      { input: [-1, 1], expected: [-1] },
+      { input: [-1, -1], expected: [1] },
+      { input: [4, 2], expected: [2] },
+      { input: [-4, 2], expected: [-2] },
+      { input: [4, -2], expected: [-2] },
+      { input: [-4, -2], expected: [2] },
 
       // 64-bit normals
-      { input: [0, 0.1], expected: [0, 0] },
-      { input: [0, -0.1], expected: [0, 0] },
+      { input: [0, 0.1], expected: [0] },
+      { input: [0, -0.1], expected: [0] },
       { input: [1, 0.1], expected: [minusOneULP(10), plusOneULP(10)] },
       { input: [-1, 0.1], expected: [minusOneULP(-10), plusOneULP(-10)] },
       { input: [1, -0.1], expected: [minusOneULP(-10), plusOneULP(-10)] },
@@ -1700,15 +1657,12 @@ g.test('divisionInterval')
     ]
   )
   .fn(t => {
-    const error = (x: number): number => {
-      return 2.5 * oneULP(x);
+    const error = (n: number): number => {
+      return 2.5 * oneULP(n);
     };
 
     const [x, y] = t.params.input;
-    if (t.params.expected !== kAny) {
-      const [begin, end] = t.params.expected;
-      t.params.expected = [begin - error(begin), end + error(end)];
-    }
+    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
     const got = divisionInterval(x, y);
@@ -1723,29 +1677,29 @@ g.test('ldexpInterval')
     // prettier-ignore
     [
       // 32-bit normals
-      { input: [0, 0], expected: [0, 0] },
-      { input: [0, 1], expected: [0, 0] },
-      { input: [0, -1], expected: [0, 0] },
-      { input: [1, 1], expected: [2, 2] },
-      { input: [1, -1], expected: [0.5, 0.5] },
-      { input: [-1, 1], expected: [-2, -2] },
-      { input: [-1, -1], expected: [-0.5, -0.5] },
+      { input: [0, 0], expected: [0] },
+      { input: [0, 1], expected: [0] },
+      { input: [0, -1], expected: [0] },
+      { input: [1, 1], expected: [2] },
+      { input: [1, -1], expected: [0.5] },
+      { input: [-1, 1], expected: [-2] },
+      { input: [-1, -1], expected: [-0.5] },
 
       // 64-bit normals
-      { input: [0, 0.1], expected: [0, 0] },
-      { input: [0, -0.1], expected: [0, 0] },
+      { input: [0, 0.1], expected: [0] },
+      { input: [0, -0.1], expected: [0] },
       { input: [1.0000000001, 1], expected: [2, plusNULP(2, 2)] },  // ~2, additional ULP error due to first param not being f32 precise
       { input: [-1.0000000001, 1], expected: [minusNULP(-2, 2), -2] },  // ~-2, additional ULP error due to first param not being f32 precise
 
       // Edge Cases
-      { input: [1.9999998807907104, 127], expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
-      { input: [1, -126], expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
+      { input: [1.9999998807907104, 127], expected: [kValue.f32.positive.max] },
+      { input: [1, -126], expected: [kValue.f32.positive.min] },
       { input: [0.9999998807907104, -126], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [1.1920928955078125e-07, -126], expected: [0, kValue.f32.subnormal.positive.min] },
       { input: [-1.1920928955078125e-07, -126], expected: [kValue.f32.subnormal.negative.max, 0] },
       { input: [-0.9999998807907104, -126], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [-1, -126], expected: [kValue.f32.negative.max, kValue.f32.negative.max] },
-      { input: [-1.9999998807907104, 127], expected: [kValue.f32.negative.min, kValue.f32.negative.min] },
+      { input: [-1, -126], expected: [kValue.f32.negative.max] },
+      { input: [-1.9999998807907104, 127], expected: [kValue.f32.negative.min] },
 
       // Out of Bounds
       { input: [1, 128], expected: kAny },
@@ -1772,21 +1726,21 @@ g.test('maxInterval')
     // prettier-ignore
     [
       // 32-bit normals
-      { input: [0, 0], expected: [0, 0] },
-      { input: [1, 0], expected: [1, 1] },
-      { input: [0, 1], expected: [1, 1] },
-      { input: [-1, 0], expected: [0, 0] },
-      { input: [0, -1], expected: [0, 0] },
-      { input: [1, 1], expected: [1, 1] },
-      { input: [1, -1], expected: [1, 1] },
-      { input: [-1, 1], expected: [1, 1] },
-      { input: [-1, -1], expected: [-1, -1] },
+      { input: [0, 0], expected: [0] },
+      { input: [1, 0], expected: [1] },
+      { input: [0, 1], expected: [1] },
+      { input: [-1, 0], expected: [0] },
+      { input: [0, -1], expected: [0] },
+      { input: [1, 1], expected: [1] },
+      { input: [1, -1], expected: [1] },
+      { input: [-1, 1], expected: [1] },
+      { input: [-1, -1], expected: [-1] },
 
       // 64-bit normals
       { input: [0.1, 0], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
       { input: [0, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, 0], expected: [0, 0] },
-      { input: [0, -0.1], expected: [0, 0] },
+      { input: [-0.1, 0], expected: [0] },
+      { input: [0, -0.1], expected: [0] },
       { input: [0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
       { input: [0.1, -0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
       { input: [-0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
@@ -1797,10 +1751,10 @@ g.test('maxInterval')
       { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
       { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [0, 0] },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [0, 0] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [0, 0] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [0] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [0] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [0] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [0] },
 
       // Infinities
       { input: [0, kValue.f32.infinity.positive], expected: kAny },
@@ -1829,19 +1783,19 @@ g.test('minInterval')
     // prettier-ignore
     [
       // 32-bit normals
-      { input: [0, 0], expected: [0, 0] },
-      { input: [1, 0], expected: [0, 0] },
-      { input: [0, 1], expected: [0, 0] },
-      { input: [-1, 0], expected: [-1, -1] },
-      { input: [0, -1], expected: [-1, -1] },
-      { input: [1, 1], expected: [1, 1] },
-      { input: [1, -1], expected: [-1, -1] },
-      { input: [-1, 1], expected: [-1, -1] },
-      { input: [-1, -1], expected: [-1, -1] },
+      { input: [0, 0], expected: [0] },
+      { input: [1, 0], expected: [0] },
+      { input: [0, 1], expected: [0] },
+      { input: [-1, 0], expected: [-1] },
+      { input: [0, -1], expected: [-1] },
+      { input: [1, 1], expected: [1] },
+      { input: [1, -1], expected: [-1] },
+      { input: [-1, 1], expected: [-1] },
+      { input: [-1, -1], expected: [-1] },
 
       // 64-bit normals
-      { input: [0.1, 0], expected: [0, 0] },
-      { input: [0, 0.1], expected: [0, 0] },
+      { input: [0.1, 0], expected: [0] },
+      { input: [0, 0.1], expected: [0] },
       { input: [-0.1, 0], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
       { input: [0, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
       { input: [0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
@@ -1850,10 +1804,10 @@ g.test('minInterval')
       { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
 
       // 32-bit normals
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, 0] },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, 0] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, 0] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [0] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [0] },
       { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
       { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
       { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
@@ -1886,29 +1840,29 @@ g.test('multiplicationInterval')
     // prettier-ignore
     [
       // 32-bit normals
-      { input: [0, 0], expected: [0, 0] },
-      { input: [1, 0], expected: [0, 0] },
-      { input: [0, 1], expected: [0, 0] },
-      { input: [-1, 0], expected: [0, 0] },
-      { input: [0, -1], expected: [0, 0] },
-      { input: [1, 1], expected: [1, 1] },
-      { input: [1, -1], expected: [-1, -1] },
-      { input: [-1, 1], expected: [-1, -1] },
-      { input: [-1, -1], expected: [1, 1] },
-      { input: [2, 1], expected: [2, 2] },
-      { input: [1, -2], expected: [-2, -2] },
-      { input: [-2, 1], expected: [-2, -2] },
-      { input: [-2, -1], expected: [2, 2] },
-      { input: [2, 2], expected: [4, 4] },
-      { input: [2, -2], expected: [-4, -4] },
-      { input: [-2, 2], expected: [-4, -4] },
-      { input: [-2, -2], expected: [4, 4] },
+      { input: [0, 0], expected: [0] },
+      { input: [1, 0], expected: [0] },
+      { input: [0, 1], expected: [0] },
+      { input: [-1, 0], expected: [0] },
+      { input: [0, -1], expected: [0] },
+      { input: [1, 1], expected: [1] },
+      { input: [1, -1], expected: [-1] },
+      { input: [-1, 1], expected: [-1] },
+      { input: [-1, -1], expected: [1] },
+      { input: [2, 1], expected: [2] },
+      { input: [1, -2], expected: [-2] },
+      { input: [-2, 1], expected: [-2] },
+      { input: [-2, -1], expected: [2] },
+      { input: [2, 2], expected: [4] },
+      { input: [2, -2], expected: [-4] },
+      { input: [-2, 2], expected: [-4] },
+      { input: [-2, -2], expected: [4] },
 
       // 64-bit normals
-      { input: [0.1, 0], expected: [0, 0] },
-      { input: [0, 0.1], expected: [0, 0] },
-      { input: [-0.1, 0], expected: [0, 0] },
-      { input: [0, -0.1], expected: [0, 0] },
+      { input: [0.1, 0], expected: [0] },
+      { input: [0, 0.1], expected: [0] },
+      { input: [-0.1, 0], expected: [0] },
+      { input: [0, -0.1], expected: [0] },
       { input: [0.1, 0.1], expected: [minusNULP(hexToF32(0x3c23d70a), 2), plusOneULP(hexToF32(0x3c23d70a))] },  // ~0.01
       { input: [0.1, -0.1], expected: [minusOneULP(hexToF32(0xbc23d70a)), plusNULP(hexToF32(0xbc23d70a), 2)] },  // ~-0.01
       { input: [-0.1, 0.1], expected: [minusOneULP(hexToF32(0xbc23d70a)), plusNULP(hexToF32(0xbc23d70a), 2)] },  // ~-0.01
@@ -1982,54 +1936,54 @@ g.test('stepInterval')
     // prettier-ignore
     [
       // 32-bit normals
-      { input: [0, 0], expected: [1, 1] },
-      { input: [1, 1], expected: [1, 1] },
-      { input: [0, 1], expected: [1, 1] },
-      { input: [1, 0], expected: [0, 0] },
-      { input: [-1, -1], expected: [1, 1] },
-      { input: [0, -1], expected: [0, 0] },
-      { input: [-1, 0], expected: [1, 1] },
-      { input: [-1, 1], expected: [1, 1] },
-      { input: [1, -1], expected: [0, 0] },
+      { input: [0, 0], expected: [1] },
+      { input: [1, 1], expected: [1] },
+      { input: [0, 1], expected: [1] },
+      { input: [1, 0], expected: [0] },
+      { input: [-1, -1], expected: [1] },
+      { input: [0, -1], expected: [0] },
+      { input: [-1, 0], expected: [1] },
+      { input: [-1, 1], expected: [1] },
+      { input: [1, -1], expected: [0] },
 
       // 64-bit normals
       { input: [0.1, 0.1], expected: [0, 1] },
-      { input: [0, 0.1], expected: [1, 1] },
-      { input: [0.1, 0], expected: [0, 0] },
-      { input: [0.1, 1], expected: [1, 1] },
-      { input: [1, 0.1], expected: [0, 0] },
+      { input: [0, 0.1], expected: [1] },
+      { input: [0.1, 0], expected: [0] },
+      { input: [0.1, 1], expected: [1] },
+      { input: [1, 0.1], expected: [0] },
       { input: [-0.1, -0.1], expected: [0, 1] },
-      { input: [0, -0.1], expected: [0, 0] },
-      { input: [-0.1, 0], expected: [1, 1] },
-      { input: [-0.1, -1], expected: [0, 0] },
-      { input: [-1, -0.1], expected: [1, 1] },
+      { input: [0, -0.1], expected: [0] },
+      { input: [-0.1, 0], expected: [1] },
+      { input: [-0.1, -1], expected: [0] },
+      { input: [-1, -0.1], expected: [1] },
 
       // Subnormals
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [1, 1] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [1, 1] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [1] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [1] },
       { input: [0, kValue.f32.subnormal.negative.max], expected: [0, 1] },
       { input: [0, kValue.f32.subnormal.negative.min], expected: [0, 1] },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: [0, 0] },
-      { input: [1, kValue.f32.subnormal.positive.min], expected: [0, 0] },
-      { input: [1, kValue.f32.subnormal.negative.max], expected: [0, 0] },
-      { input: [1, kValue.f32.subnormal.negative.min], expected: [0, 0] },
-      { input: [-1, kValue.f32.subnormal.positive.max], expected: [1, 1] },
-      { input: [-1, kValue.f32.subnormal.positive.min], expected: [1, 1] },
-      { input: [-1, kValue.f32.subnormal.negative.max], expected: [1, 1] },
-      { input: [-1, kValue.f32.subnormal.negative.min], expected: [1, 1] },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: [0] },
+      { input: [1, kValue.f32.subnormal.positive.min], expected: [0] },
+      { input: [1, kValue.f32.subnormal.negative.max], expected: [0] },
+      { input: [1, kValue.f32.subnormal.negative.min], expected: [0] },
+      { input: [-1, kValue.f32.subnormal.positive.max], expected: [1] },
+      { input: [-1, kValue.f32.subnormal.positive.min], expected: [1] },
+      { input: [-1, kValue.f32.subnormal.negative.max], expected: [1] },
+      { input: [-1, kValue.f32.subnormal.negative.min], expected: [1] },
       { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, 1] },
       { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, 1] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [1, 1] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [1, 1] },
-      { input: [kValue.f32.subnormal.positive.max, 1], expected: [1, 1] },
-      { input: [kValue.f32.subnormal.positive.min, 1], expected: [1, 1] },
-      { input: [kValue.f32.subnormal.negative.max, 1], expected: [1, 1] },
-      { input: [kValue.f32.subnormal.negative.min, 1], expected: [1, 1] },
-      { input: [kValue.f32.subnormal.positive.max, -1], expected: [0, 0] },
-      { input: [kValue.f32.subnormal.positive.min, -1], expected: [0, 0] },
-      { input: [kValue.f32.subnormal.negative.max, -1], expected: [0, 0] },
-      { input: [kValue.f32.subnormal.negative.min, -1], expected: [0, 0] },
-      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [1, 1] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [1] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [1] },
+      { input: [kValue.f32.subnormal.positive.max, 1], expected: [1] },
+      { input: [kValue.f32.subnormal.positive.min, 1], expected: [1] },
+      { input: [kValue.f32.subnormal.negative.max, 1], expected: [1] },
+      { input: [kValue.f32.subnormal.negative.min, 1], expected: [1] },
+      { input: [kValue.f32.subnormal.positive.max, -1], expected: [0] },
+      { input: [kValue.f32.subnormal.positive.min, -1], expected: [0] },
+      { input: [kValue.f32.subnormal.negative.max, -1], expected: [0] },
+      { input: [kValue.f32.subnormal.negative.min, -1], expected: [0] },
+      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [1] },
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min], expected: [0, 1] },
 
       // Infinities
@@ -2059,15 +2013,15 @@ g.test('subtractionInterval')
     // prettier-ignore
     [
       // 32-bit normals
-      { input: [0, 0], expected: [0, 0] },
-      { input: [1, 0], expected: [1, 1] },
-      { input: [0, 1], expected: [-1, -1] },
-      { input: [-1, 0], expected: [-1, -1] },
-      { input: [0, -1], expected: [1, 1] },
-      { input: [1, 1], expected: [0, 0] },
-      { input: [1, -1], expected: [2, 2] },
-      { input: [-1, 1], expected: [-2, -2] },
-      { input: [-1, -1], expected: [0, 0] },
+      { input: [0, 0], expected: [0] },
+      { input: [1, 0], expected: [1] },
+      { input: [0, 1], expected: [-1] },
+      { input: [-1, 0], expected: [-1] },
+      { input: [0, -1], expected: [1] },
+      { input: [1, 1], expected: [0] },
+      { input: [1, -1], expected: [2] },
+      { input: [-1, 1], expected: [-2] },
+      { input: [-1, -1], expected: [0] },
 
       // 64-bit normals
       { input: [0.1, 0], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
@@ -2113,7 +2067,7 @@ g.test('subtractionInterval')
 
 interface TernaryToIntervalCase {
   input: [number, number, number];
-  expected: [number, number];
+  expected: IntervalBounds;
 }
 
 g.test('clampMedianInterval')
@@ -2121,33 +2075,33 @@ g.test('clampMedianInterval')
     // prettier-ignore
     [
       // Normals
-      { input: [0, 0, 0], expected: [0, 0] },
-      { input: [1, 0, 0], expected: [0, 0] },
-      { input: [0, 1, 0], expected: [0, 0] },
-      { input: [0, 0, 1], expected: [0, 0] },
-      { input: [1, 0, 1], expected: [1, 1] },
-      { input: [1, 1, 0], expected: [1, 1] },
-      { input: [0, 1, 1], expected: [1, 1] },
-      { input: [1, 1, 1], expected: [1, 1] },
-      { input: [1, 10, 100], expected: [10, 10] },
-      { input: [10, 1, 100], expected: [10, 10] },
-      { input: [100, 1, 10], expected: [10, 10] },
-      { input: [-10, 1, 100], expected: [1, 1] },
-      { input: [10, 1, -100], expected: [1, 1] },
-      { input: [-10, 1, -100], expected: [-10, -10] },
-      { input: [-10, -10, -10], expected: [-10, -10] },
+      { input: [0, 0, 0], expected: [0] },
+      { input: [1, 0, 0], expected: [0] },
+      { input: [0, 1, 0], expected: [0] },
+      { input: [0, 0, 1], expected: [0] },
+      { input: [1, 0, 1], expected: [1] },
+      { input: [1, 1, 0], expected: [1] },
+      { input: [0, 1, 1], expected: [1] },
+      { input: [1, 1, 1], expected: [1] },
+      { input: [1, 10, 100], expected: [10] },
+      { input: [10, 1, 100], expected: [10] },
+      { input: [100, 1, 10], expected: [10] },
+      { input: [-10, 1, 100], expected: [1] },
+      { input: [10, 1, -100], expected: [1] },
+      { input: [-10, 1, -100], expected: [-10] },
+      { input: [-10, -10, -10], expected: [-10] },
 
       // Subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0, 0], expected: [0, 0] },
-      { input: [0, kValue.f32.subnormal.positive.max, 0], expected: [0, 0] },
-      { input: [0, 0, kValue.f32.subnormal.positive.max], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.positive.max, 0, 0], expected: [0] },
+      { input: [0, kValue.f32.subnormal.positive.max, 0], expected: [0] },
+      { input: [0, 0, kValue.f32.subnormal.positive.max], expected: [0] },
       { input: [kValue.f32.subnormal.positive.max, 0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [0, kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.min, kValue.f32.subnormal.negative.max], expected: [0, kValue.f32.subnormal.positive.min] },
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: [kValue.f32.positive.max, kValue.f32.positive.max] },
+      { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: [kValue.f32.positive.max] },
 
       // Infinities
       { input: [0, 1, kValue.f32.infinity.positive], expected: kAny },
@@ -2172,28 +2126,28 @@ g.test('clampMinMaxInterval')
     // prettier-ignore
     [
       // Normals
-      { input: [0, 0, 0], expected: [0, 0] },
-      { input: [1, 0, 0], expected: [0, 0] },
-      { input: [0, 1, 0], expected: [0, 0] },
-      { input: [0, 0, 1], expected: [0, 0] },
-      { input: [1, 0, 1], expected: [1, 1] },
-      { input: [1, 1, 0], expected: [0, 0] },
-      { input: [0, 1, 1], expected: [1, 1] },
-      { input: [1, 1, 1], expected: [1, 1] },
-      { input: [1, 10, 100], expected: [10, 10] },
-      { input: [10, 1, 100], expected: [10, 10] },
-      { input: [100, 1, 10], expected: [10, 10] },
-      { input: [-10, 1, 100], expected: [1, 1] },
-      { input: [10, 1, -100], expected: [-100, -100] },
-      { input: [-10, 1, -100], expected: [-100, -100] },
-      { input: [-10, -10, -10], expected: [-10, -10] },
+      { input: [0, 0, 0], expected: [0] },
+      { input: [1, 0, 0], expected: [0] },
+      { input: [0, 1, 0], expected: [0] },
+      { input: [0, 0, 1], expected: [0] },
+      { input: [1, 0, 1], expected: [1] },
+      { input: [1, 1, 0], expected: [0] },
+      { input: [0, 1, 1], expected: [1] },
+      { input: [1, 1, 1], expected: [1] },
+      { input: [1, 10, 100], expected: [10] },
+      { input: [10, 1, 100], expected: [10] },
+      { input: [100, 1, 10], expected: [10] },
+      { input: [-10, 1, 100], expected: [1] },
+      { input: [10, 1, -100], expected: [-100] },
+      { input: [-10, 1, -100], expected: [-100] },
+      { input: [-10, -10, -10], expected: [-10] },
 
       // Subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0, 0], expected: [0, 0] },
-      { input: [0, kValue.f32.subnormal.positive.max, 0], expected: [0, 0] },
-      { input: [0, 0, kValue.f32.subnormal.positive.max], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.positive.max, 0, 0], expected: [0] },
+      { input: [0, kValue.f32.subnormal.positive.max, 0], expected: [0] },
+      { input: [0, 0, kValue.f32.subnormal.positive.max], expected: [0] },
       { input: [kValue.f32.subnormal.positive.max, 0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, 0], expected: [0, 0] },
+      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, 0], expected: [0] },
       { input: [0, kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.min, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
@@ -2225,49 +2179,49 @@ g.test('mixImpreciseInterval')
       // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
       // form due to the inherited nature of the errors.
       // [0.0, 1.0] cases
-      { input: [0.0, 1.0, -1.0], expected: [-1.0, -1.0] },
-      { input: [0.0, 1.0, 0.0], expected: [0.0, 0.0] },
+      { input: [0.0, 1.0, -1.0], expected: [-1.0] },
+      { input: [0.0, 1.0, 0.0], expected: [0.0] },
       { input: [0.0, 1.0, 0.1], expected: [hexToF64(0x3fb99999,0x80000000), hexToF64(0x3fb99999,0xa0000000)] },  // ~0.1
-      { input: [0.0, 1.0, 0.5], expected: [0.5, 0.5] },
+      { input: [0.0, 1.0, 0.5], expected: [0.5] },
       { input: [0.0, 1.0, 0.9], expected: [hexToF64(0x3feccccc,0xc0000000), hexToF64(0x3feccccc,0xe0000000)] },  // ~0.9
-      { input: [0.0, 1.0, 1.0], expected: [1.0, 1.0] },
-      { input: [0.0, 1.0, 2.0], expected: [2.0, 2.0] },
+      { input: [0.0, 1.0, 1.0], expected: [1.0] },
+      { input: [0.0, 1.0, 2.0], expected: [2.0] },
 
       // [1.0, 0.0] cases
-      { input: [1.0, 0.0, -1.0], expected: [2.0, 2.0] },
-      { input: [1.0, 0.0, 0.0], expected: [1.0, 1.0] },
+      { input: [1.0, 0.0, -1.0], expected: [2.0] },
+      { input: [1.0, 0.0, 0.0], expected: [1.0] },
       { input: [1.0, 0.0, 0.1], expected: [hexToF64(0x3feccccc,0xc0000000), hexToF64(0x3feccccc,0xe0000000)] },  // ~0.9
-      { input: [1.0, 0.0, 0.5], expected: [0.5, 0.5] },
+      { input: [1.0, 0.0, 0.5], expected: [0.5] },
       { input: [1.0, 0.0, 0.9], expected: [hexToF64(0x3fb99999,0x00000000), hexToF64(0x3fb9999a,0x00000000)] },  // ~0.1
-      { input: [1.0, 0.0, 1.0], expected: [0.0, 0.0] },
-      { input: [1.0, 0.0, 2.0], expected: [-1.0, -1.0] },
+      { input: [1.0, 0.0, 1.0], expected: [0.0] },
+      { input: [1.0, 0.0, 2.0], expected: [-1.0] },
 
       // [0.0, 10.0] cases
-      { input: [0.0, 10.0, -1.0], expected: [-10.0, -10.0] },
-      { input: [0.0, 10.0, 0.0], expected: [0.0, 0.0] },
+      { input: [0.0, 10.0, -1.0], expected: [-10.0] },
+      { input: [0.0, 10.0, 0.0], expected: [0.0] },
       { input: [0.0, 10.0, 0.1], expected: [hexToF64(0x3fefffff,0xe0000000), hexToF64(0x3ff00000,0x20000000)] },  // ~1
-      { input: [0.0, 10.0, 0.5], expected: [5.0, 5.0] },
+      { input: [0.0, 10.0, 0.5], expected: [5.0] },
       { input: [0.0, 10.0, 0.9], expected: [hexToF64(0x4021ffff,0xe0000000), hexToF64(0x40220000,0x20000000)] },  // ~9
-      { input: [0.0, 10.0, 1.0], expected: [10.0, 10.0] },
-      { input: [0.0, 10.0, 2.0], expected: [20.0, 20.0] },
+      { input: [0.0, 10.0, 1.0], expected: [10.0] },
+      { input: [0.0, 10.0, 2.0], expected: [20.0] },
 
       // [2.0, 10.0] cases
-      { input: [2.0, 10.0, -1.0], expected: [-6.0, -6.0] },
-      { input: [2.0, 10.0, 0.0], expected: [2.0, 2.0] },
+      { input: [2.0, 10.0, -1.0], expected: [-6.0] },
+      { input: [2.0, 10.0, 0.0], expected: [2.0] },
       { input: [2.0, 10.0, 0.1], expected: [hexToF64(0x40066666,0x60000000), hexToF64(0x40066666,0x80000000)] },  // ~2.8
-      { input: [2.0, 10.0, 0.5], expected: [6.0, 6.0] },
+      { input: [2.0, 10.0, 0.5], expected: [6.0] },
       { input: [2.0, 10.0, 0.9], expected: [hexToF64(0x40226666,0x60000000), hexToF64(0x40226666,0x80000000)] },  // ~9.2
-      { input: [2.0, 10.0, 1.0], expected: [10.0, 10.0] },
-      { input: [2.0, 10.0, 2.0], expected: [18.0, 18.0] },
+      { input: [2.0, 10.0, 1.0], expected: [10.0] },
+      { input: [2.0, 10.0, 2.0], expected: [18.0] },
 
       // [-1.0, 1.0] cases
-      { input: [-1.0, 1.0, -2.0], expected: [-5.0, -5.0] },
-      { input: [-1.0, 1.0, 0.0], expected: [-1.0, -1.0] },
+      { input: [-1.0, 1.0, -2.0], expected: [-5.0] },
+      { input: [-1.0, 1.0, 0.0], expected: [-1.0] },
       { input: [-1.0, 1.0, 0.1], expected: [hexToF64(0xbfe99999,0xa0000000), hexToF64(0xbfe99999,0x80000000)] },  // ~-0.8
-      { input: [-1.0, 1.0, 0.5], expected: [0.0, 0.0] },
+      { input: [-1.0, 1.0, 0.5], expected: [0.0] },
       { input: [-1.0, 1.0, 0.9], expected: [hexToF64(0x3fe99999,0x80000000), hexToF64(0x3fe99999,0xc0000000)] },  // ~0.8
-      { input: [-1.0, 1.0, 1.0], expected: [1.0, 1.0] },
-      { input: [-1.0, 1.0, 2.0], expected: [3.0, 3.0] },
+      { input: [-1.0, 1.0, 1.0], expected: [1.0] },
+      { input: [-1.0, 1.0, 2.0], expected: [3.0] },
 
       // Infinities
       { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kAny },
@@ -2282,7 +2236,7 @@ g.test('mixImpreciseInterval')
       { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kAny },
 
       // Showing how precise and imprecise versions diff
-      { input: [kValue.f32.negative.min, 10.0, 1.0], expected: [0.0, 0.0]},
+      { input: [kValue.f32.negative.min, 10.0, 1.0], expected: [0.0]},
     ]
   )
   .fn(t => {
@@ -2303,49 +2257,49 @@ g.test('mixPreciseInterval')
       // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
       // form due to the inherited nature of the errors.
       // [0.0, 1.0] cases
-      { input: [0.0, 1.0, -1.0], expected: [-1.0, -1.0] },
-      { input: [0.0, 1.0, 0.0], expected: [0.0, 0.0] },
+      { input: [0.0, 1.0, -1.0], expected: [-1.0] },
+      { input: [0.0, 1.0, 0.0], expected: [0.0] },
       { input: [0.0, 1.0, 0.1], expected: [hexToF64(0x3fb99999,0x80000000), hexToF64(0x3fb99999,0xa0000000)] },  // ~0.1
-      { input: [0.0, 1.0, 0.5], expected: [0.5, 0.5] },
+      { input: [0.0, 1.0, 0.5], expected: [0.5] },
       { input: [0.0, 1.0, 0.9], expected: [hexToF64(0x3feccccc,0xc0000000), hexToF64(0x3feccccc,0xe0000000)] },  // ~0.9
-      { input: [0.0, 1.0, 1.0], expected: [1.0, 1.0] },
-      { input: [0.0, 1.0, 2.0], expected: [2.0, 2.0] },
+      { input: [0.0, 1.0, 1.0], expected: [1.0] },
+      { input: [0.0, 1.0, 2.0], expected: [2.0] },
 
       // [1.0, 0.0] cases
-      { input: [1.0, 0.0, -1.0], expected: [2.0, 2.0] },
-      { input: [1.0, 0.0, 0.0], expected: [1.0, 1.0] },
+      { input: [1.0, 0.0, -1.0], expected: [2.0] },
+      { input: [1.0, 0.0, 0.0], expected: [1.0] },
       { input: [1.0, 0.0, 0.1], expected: [hexToF64(0x3feccccc,0xc0000000), hexToF64(0x3feccccc,0xe0000000)] },  // ~0.9
-      { input: [1.0, 0.0, 0.5], expected: [0.5, 0.5] },
+      { input: [1.0, 0.0, 0.5], expected: [0.5] },
       { input: [1.0, 0.0, 0.9], expected: [hexToF64(0x3fb99999,0x00000000), hexToF64(0x3fb9999a,0x00000000)] },  // ~0.1
-      { input: [1.0, 0.0, 1.0], expected: [0.0, 0.0] },
-      { input: [1.0, 0.0, 2.0], expected: [-1.0, -1.0] },
+      { input: [1.0, 0.0, 1.0], expected: [0.0] },
+      { input: [1.0, 0.0, 2.0], expected: [-1.0] },
 
       // [0.0, 10.0] cases
-      { input: [0.0, 10.0, -1.0], expected: [-10.0, -10.0] },
-      { input: [0.0, 10.0, 0.0], expected: [0.0, 0.0] },
+      { input: [0.0, 10.0, -1.0], expected: [-10.0] },
+      { input: [0.0, 10.0, 0.0], expected: [0.0] },
       { input: [0.0, 10.0, 0.1], expected: [hexToF64(0x3fefffff,0xe0000000), hexToF64(0x3ff00000,0x20000000)] },  // ~1
-      { input: [0.0, 10.0, 0.5], expected: [5.0, 5.0] },
+      { input: [0.0, 10.0, 0.5], expected: [5.0] },
       { input: [0.0, 10.0, 0.9], expected: [hexToF64(0x4021ffff,0xe0000000), hexToF64(0x40220000,0x20000000)] },  // ~9
-      { input: [0.0, 10.0, 1.0], expected: [10.0, 10.0] },
-      { input: [0.0, 10.0, 2.0], expected: [20.0, 20.0] },
+      { input: [0.0, 10.0, 1.0], expected: [10.0] },
+      { input: [0.0, 10.0, 2.0], expected: [20.0] },
 
       // [2.0, 10.0] cases
-      { input: [2.0, 10.0, -1.0], expected: [-6.0, -6.0] },
-      { input: [2.0, 10.0, 0.0], expected: [2.0, 2.0] },
+      { input: [2.0, 10.0, -1.0], expected: [-6.0] },
+      { input: [2.0, 10.0, 0.0], expected: [2.0] },
       { input: [2.0, 10.0, 0.1], expected: [hexToF64(0x40066666,0x40000000), hexToF64(0x40066666,0x80000000)] },  // ~2.8
-      { input: [2.0, 10.0, 0.5], expected: [6.0, 6.0] },
+      { input: [2.0, 10.0, 0.5], expected: [6.0] },
       { input: [2.0, 10.0, 0.9], expected: [hexToF64(0x40226666,0x40000000), hexToF64(0x40226666,0xa0000000)] },  // ~9.2
-      { input: [2.0, 10.0, 1.0], expected: [10.0, 10.0] },
-      { input: [2.0, 10.0, 2.0], expected: [18.0, 18.0] },
+      { input: [2.0, 10.0, 1.0], expected: [10.0] },
+      { input: [2.0, 10.0, 2.0], expected: [18.0] },
 
       // [-1.0, 1.0] cases
-      { input: [-1.0, 1.0, -2.0], expected: [-5.0, -5.0] },
-      { input: [-1.0, 1.0, 0.0], expected: [-1.0, -1.0] },
+      { input: [-1.0, 1.0, -2.0], expected: [-5.0] },
+      { input: [-1.0, 1.0, 0.0], expected: [-1.0] },
       { input: [-1.0, 1.0, 0.1], expected: [hexToF64(0xbfe99999,0xc0000000), hexToF64(0xbfe99999,0x80000000)] },  // ~-0.8
-      { input: [-1.0, 1.0, 0.5], expected: [0.0, 0.0] },
+      { input: [-1.0, 1.0, 0.5], expected: [0.0] },
       { input: [-1.0, 1.0, 0.9], expected: [hexToF64(0x3fe99999,0x80000000), hexToF64(0x3fe99999,0xc0000000)] },  // ~0.8
-      { input: [-1.0, 1.0, 1.0], expected: [1.0, 1.0] },
-      { input: [-1.0, 1.0, 2.0], expected: [3.0, 3.0] },
+      { input: [-1.0, 1.0, 1.0], expected: [1.0] },
+      { input: [-1.0, 1.0, 2.0], expected: [3.0] },
 
       // Infinities
       { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kAny },
@@ -2360,7 +2314,7 @@ g.test('mixPreciseInterval')
       { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kAny },
 
       // Showing how precise and imprecise versions diff
-      { input: [kValue.f32.negative.min, 10.0, 1.0], expected: [10.0, 10.0]},
+      { input: [kValue.f32.negative.min, 10.0, 1.0], expected: [10.0]},
     ]
   )
   .fn(t => {
@@ -2376,7 +2330,7 @@ g.test('mixPreciseInterval')
 
 interface VectorPairToIntervalCase {
   input: [number[], number[]];
-  expected: [number, number];
+  expected: IntervalBounds;
 }
 
 g.test('dotInterval')
@@ -2384,30 +2338,30 @@ g.test('dotInterval')
     // prettier-ignore
     [
       // vec2
-      {input: [[1.0, 0.0], [1.0, 0.0]], expected: [1.0, 1.0]},
-      {input: [[0.0, 1.0], [0.0, 1.0]], expected: [1.0, 1.0]},
-      {input: [[1.0, 1.0], [1.0, 1.0]], expected: [2.0, 2.0]},
-      {input: [[-1.0, -1.0], [-1.0, -1.0]], expected: [2.0, 2.0]},
-      {input: [[-1.0, 1.0], [1.0, -1.0]], expected: [-2.0, -2.0]},
+      {input: [[1.0, 0.0], [1.0, 0.0]], expected: [1.0] },
+      {input: [[0.0, 1.0], [0.0, 1.0]], expected: [1.0] },
+      {input: [[1.0, 1.0], [1.0, 1.0]], expected: [2.0] },
+      {input: [[-1.0, -1.0], [-1.0, -1.0]], expected: [2.0] },
+      {input: [[-1.0, 1.0], [1.0, -1.0]], expected: [-2.0] },
       {input: [[0.1, 0.0], [1.0, 0.0]], expected: [hexToF64(0x3fb99999, 0x80000000), hexToF64(0x3fb99999, 0xa0000000)]},  // ~0.1
 
       // vec3
-      {input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [1.0, 1.0]},
-      {input: [[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]], expected: [1.0, 1.0]},
-      {input: [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]], expected: [1.0, 1.0]},
-      {input: [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], expected: [3.0, 3.0]},
-      {input: [[-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]], expected: [3.0, 3.0]},
-      {input: [[1.0, -1.0, -1.0], [-1.0, 1.0, -1.0]], expected: [-1.0, -1.0]},
+      {input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [1.0] },
+      {input: [[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]], expected: [1.0] },
+      {input: [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]], expected: [1.0] },
+      {input: [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], expected: [3.0] },
+      {input: [[-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]], expected: [3.0] },
+      {input: [[1.0, -1.0, -1.0], [-1.0, 1.0, -1.0]], expected: [-1.0] },
       {input: [[0.1, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [hexToF64(0x3fb99999, 0x80000000), hexToF64(0x3fb99999, 0xa0000000)]},  // ~0.1
 
       // vec4
-      {input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [1.0, 1.0]},
-      {input: [[0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], expected: [1.0, 1.0]},
-      {input: [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0]], expected: [1.0, 1.0]},
-      {input: [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]], expected: [1.0, 1.0]},
-      {input: [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]], expected: [4.0, 4.0]},
-      {input: [[-1.0, -1.0, -1.0, -1.0], [-1.0, -1.0, -1.0, -1.0]], expected: [4.0, 4.0]},
-      {input: [[-1.0, 1.0, -1.0, 1.0], [1.0, -1.0, 1.0, -1.0]], expected: [-4.0, -4.0]},
+      {input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [1.0] },
+      {input: [[0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], expected: [1.0] },
+      {input: [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0]], expected: [1.0] },
+      {input: [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]], expected: [1.0] },
+      {input: [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]], expected: [4.0] },
+      {input: [[-1.0, -1.0, -1.0, -1.0], [-1.0, -1.0, -1.0, -1.0]], expected: [4.0] },
+      {input: [[-1.0, 1.0, -1.0, 1.0], [1.0, -1.0, 1.0, -1.0]], expected: [-4.0] },
       {input: [[0.1, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb99999, 0x80000000), hexToF64(0x3fb99999, 0xa0000000)]},  // ~0.1
     ]
   )

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -9,6 +9,14 @@ import {
   oneULP,
 } from './math.js';
 
+/**
+ * Representation of bounds for an interval as an array with either one or two
+ * elements. Single element indicates that the interval is a single point. For
+ * two elements, the first is the lower bound of the interval and the second is
+ * the upper bound.
+ */
+export type IntervalBounds = [number] | [number, number];
+
 /** Represents a closed interval in the f32 range */
 export class F32Interval {
   public readonly begin: number;
@@ -21,7 +29,7 @@ export class F32Interval {
    *               end of the interval, or a single element array indicating the
    *               interval is a point
    */
-  public constructor(...bounds: [number] | [number, number]) {
+  public constructor(...bounds: IntervalBounds) {
     const [begin, end] = bounds.length === 2 ? bounds : [bounds[0], bounds[0]];
     assert(!Number.isNaN(begin) && !Number.isNaN(end), `bounds need to be non-NaN`);
     assert(begin <= end, `bounds[0] (${begin}) must be less than or equal to bounds[1]  (${end})`);
@@ -31,7 +39,7 @@ export class F32Interval {
   }
 
   /** @returns begin and end if non-point interval, otherwise just begin */
-  public bounds(): [number] | [number, number] {
+  public bounds(): IntervalBounds {
     return this.isPoint() ? [this.begin] : [this.begin, this.end];
   }
 


### PR DESCRIPTION
Adds a type `IntervalBounds` to represent the `[number]|[number, number]`
that can be passed into the `F32Interval` constructor. This is
propagated to `f32_interval.spec.ts` to replace how bounds are
represented there.

This allows for replacing duplicated entry bounds with a single value, 
i.e. [0, 0] -> [0].

Additionally there is a bunch of cleanup done with having common
error handling and removing patterns where elements of t.params are
being unpack into a variable, but never transformed.

Fixes #1762
Issue #1747

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
