### PR TITLE
Rename `make*F32IntervalCase` to `make*ToF32IntervalCase`

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -12,7 +12,7 @@ import {
   subtractionInterval,
 } from '../../../../util/f32_interval.js';
 import { cartesianProduct, fullF32Range } from '../../../../util/math.js';
-import { allInputSources, Case, makeBinaryF32IntervalCase, run } from '../expression.js';
+import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
@@ -33,7 +33,7 @@ Accuracy: Correctly rounded
   )
   .fn(async t => {
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryF32IntervalCase(lhs, rhs, additionInterval);
+      return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
     };
 
     const cases = kTestValues.map((v: number[]) => {
@@ -56,7 +56,7 @@ Accuracy: Correctly rounded
   )
   .fn(async t => {
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryF32IntervalCase(lhs, rhs, subtractionInterval);
+      return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
     };
 
     const cases = kTestValues.map((v: number[]) => {
@@ -79,7 +79,7 @@ Accuracy: Correctly rounded
   )
   .fn(async t => {
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryF32IntervalCase(lhs, rhs, multiplicationInterval);
+      return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
     };
 
     const cases = kTestValues.map((v: number[]) => {
@@ -102,7 +102,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
   )
   .fn(async t => {
     const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryF32IntervalCase(lhs, rhs, divisionInterval);
+      return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
     };
 
     const cases = kTestValues.map((v: number[]) => {

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -21,7 +21,7 @@ import { kBit } from '../../../../../util/constants.js';
 import { i32Bits, TypeF32, TypeI32, TypeU32, u32Bits } from '../../../../../util/conversion.js';
 import { absInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -148,7 +148,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, absInterval);
+      return makeUnaryToF32IntervalCase(x, absInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -16,7 +16,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { acoshIntervals } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -38,7 +38,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, ...acoshIntervals);
+      return makeUnaryToF32IntervalCase(n, ...acoshIntervals);
     };
 
     const cases = [

--- a/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
@@ -15,7 +15,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { asinhInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -37,7 +37,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, asinhInterval);
+      return makeUnaryToF32IntervalCase(n, asinhInterval);
     };
 
     const cases = [...fullF32Range()].map(makeCase);

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -13,7 +13,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { atanInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -41,7 +41,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .fn(async t => {
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, atanInterval);
+      return makeUnaryToF32IntervalCase(x, atanInterval);
     };
     const cases: Array<Case> = [
       // Known values

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { atan2Interval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeBinaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -40,7 +40,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .fn(async t => {
     const makeCase = (y: number, x: number): Case => {
-      return makeBinaryF32IntervalCase(y, x, atan2Interval);
+      return makeBinaryToF32IntervalCase(y, x, atan2Interval);
     };
 
     const numeric_range = fullF32Range();

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -15,7 +15,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { atanhInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -37,7 +37,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, atanhInterval);
+      return makeUnaryToF32IntervalCase(n, atanhInterval);
     };
 
     const cases = [

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -13,7 +13,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { ceilInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,7 +35,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, ceilInterval);
+      return makeUnaryToF32IntervalCase(x, ceilInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -28,7 +28,7 @@ import {
 } from '../../../../../util/conversion.js';
 import { clampIntervals } from '../../../../../util/f32_interval.js';
 import { sparseF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeTernaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeTernaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -144,7 +144,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number, y: number, z: number): Case => {
-      return makeTernaryF32IntervalCase(x, y, z, ...clampIntervals);
+      return makeTernaryToF32IntervalCase(x, y, z, ...clampIntervals);
     };
 
     const values = sparseF32Range();

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -13,7 +13,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { cosInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -41,7 +41,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, cosInterval);
+      return makeUnaryToF32IntervalCase(n, cosInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { coshInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, coshInterval);
+      return makeUnaryToF32IntervalCase(n, coshInterval);
     };
 
     const cases = fullF32Range().map(makeCase);

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { degreesInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, degreesInterval);
+      return makeUnaryToF32IntervalCase(n, degreesInterval);
     };
 
     const cases: Array<Case> = fullF32Range().map(makeCase);

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { dotInterval } from '../../../../../util/f32_interval.js';
 import { sparseF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeVectorPairF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeVectorPairToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -77,7 +77,7 @@ g.test('f32_vec2')
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
     const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairF32IntervalCase(x, y, dotInterval);
+      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
     const cases: Case[] = kVectorTestValues[2].flatMap(i => {
@@ -95,7 +95,7 @@ g.test('f32_vec3')
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
     const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairF32IntervalCase(x, y, dotInterval);
+      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
     const cases: Case[] = kVectorTestValues[3].flatMap(i => {
@@ -113,7 +113,7 @@ g.test('f32_vec4')
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
     const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairF32IntervalCase(x, y, dotInterval);
+      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
     const cases: Case[] = kVectorTestValues[4].flatMap(i => {

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -13,7 +13,7 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { expInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,7 +35,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, expInterval);
+      return makeUnaryToF32IntervalCase(x, expInterval);
     };
 
     // floor(ln(max f32 value)) = 88, so exp(88) will be within range of a f32, but exp(89) will not

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -13,7 +13,7 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { exp2Interval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,7 +35,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, exp2Interval);
+      return makeUnaryToF32IntervalCase(x, exp2Interval);
     };
 
     // floor(log2(max f32 value)) = 127, so exp2(127) will be within range of a f32, but exp2(128) will not

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { floorInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, floorInterval);
+      return makeUnaryToF32IntervalCase(x, floorInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -13,7 +13,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { fractInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,7 +35,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, fractInterval);
+      return makeUnaryToF32IntervalCase(x, fractInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -13,7 +13,7 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { inverseSqrtInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,7 +35,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, inverseSqrtInterval);
+      return makeUnaryToF32IntervalCase(x, inverseSqrtInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -48,7 +48,7 @@ g.test('f32')
   .fn(async t => {
     const makeCase = (e1: number, e2: number): Case => {
       // Due to the heterogeneous types of the params to ldexp (f32 & i32),
-      // makeBinaryF32IntervalCase cannot be used here.
+      // makeBinaryToF32IntervalCase cannot be used here.
       e1 = quantizeToF32(e1);
       e2 = quantizeToI32(e2);
       const expected = ldexpInterval(e1, e2);

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -13,7 +13,7 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { logInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -42,7 +42,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, logInterval);
+      return makeUnaryToF32IntervalCase(x, logInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -13,7 +13,7 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { log2Interval } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -42,7 +42,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   .fn(async t => {
     // [1]: Need to decide what the ground-truth is.
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, log2Interval);
+      return makeUnaryToF32IntervalCase(x, log2Interval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -22,7 +22,7 @@ import { kValue } from '../../../../../util/constants.js';
 import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
 import { maxInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeBinaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -100,7 +100,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number, y: number): Case => {
-      return makeBinaryF32IntervalCase(x, y, maxInterval);
+      return makeBinaryToF32IntervalCase(x, y, maxInterval);
     };
 
     const cases: Array<Case> = [];

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -21,7 +21,7 @@ import { kValue } from '../../../../../util/constants.js';
 import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
 import { minInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeBinaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -99,7 +99,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number, y: number): Case => {
-      return makeBinaryF32IntervalCase(x, y, minInterval);
+      return makeBinaryToF32IntervalCase(x, y, minInterval);
     };
 
     const cases: Array<Case> = [];

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -19,7 +19,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { mixIntervals } from '../../../../../util/f32_interval.js';
 import { sparseF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeTernaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeTernaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -41,7 +41,7 @@ g.test('matching_f32')
   )
   .fn(async t => {
     const makeCase = (x: number, y: number, z: number): Case => {
-      return makeTernaryF32IntervalCase(x, y, z, ...mixIntervals);
+      return makeTernaryToF32IntervalCase(x, y, z, ...mixIntervals);
     };
 
     const values = sparseF32Range();

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { powInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeBinaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (x: number, y: number): Case => {
-      return makeBinaryF32IntervalCase(x, y, powInterval);
+      return makeBinaryToF32IntervalCase(x, y, powInterval);
     };
 
     const cases: Array<Case> = [];

--- a/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
@@ -13,7 +13,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { radiansInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,7 +35,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, radiansInterval);
+      return makeUnaryToF32IntervalCase(n, radiansInterval);
     };
 
     const cases: Array<Case> = fullF32Range().map(makeCase);

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -15,7 +15,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { roundInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -37,7 +37,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, roundInterval);
+      return makeUnaryToF32IntervalCase(n, roundInterval);
     };
 
     const cases = fullF32Range().map(makeCase);

--- a/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { saturateInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, saturateInterval);
+      return makeUnaryToF32IntervalCase(n, saturateInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { signInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, signInterval);
+      return makeUnaryToF32IntervalCase(n, signInterval);
     };
 
     const cases = fullF32Range().map(makeCase);

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { sinInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -40,7 +40,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, sinInterval);
+      return makeUnaryToF32IntervalCase(n, sinInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { sinhInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, sinhInterval);
+      return makeUnaryToF32IntervalCase(n, sinhInterval);
     };
 
     const cases = fullF32Range().map(makeCase);

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { sqrtInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, sqrtInterval);
+      return makeUnaryToF32IntervalCase(n, sqrtInterval);
     };
 
     const cases = fullF32Range().map(makeCase);

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -38,7 +38,7 @@ g.test('f32')
     const oneInterval = new F32Interval(1, 1);
 
     // stepInterval's return value isn't always interpreted as an acceptance
-    // interval, so makeBinaryF32IntervalCase cannot be used here.
+    // interval, so makeBinaryToF32IntervalCase cannot be used here.
     // See the comment block on stepInterval for more details
     const makeCase = (edge: number, x: number): Case => {
       edge = quantizeToF32(edge);

--- a/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { tanInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, tanInterval);
+      return makeUnaryToF32IntervalCase(n, tanInterval);
     };
 
     const cases: Array<Case> = [

--- a/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { tanhInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, tanhInterval);
+      return makeUnaryToF32IntervalCase(n, tanhInterval);
     };
 
     const cases = fullF32Range().map(makeCase);

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -13,7 +13,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { truncInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,7 +35,7 @@ g.test('f32')
   )
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      return makeUnaryF32IntervalCase(n, truncInterval);
+      return makeUnaryToF32IntervalCase(n, truncInterval);
     };
 
     const cases = fullF32Range().map(makeCase);

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -536,7 +536,7 @@ function packScalarsToVector(
  * @param param the param to pass into the unary operation
  * @param ops callbacks that implement generating an acceptance interval for a unary operation
  */
-export function makeUnaryF32IntervalCase(param: number, ...ops: PointToInterval[]): Case {
+export function makeUnaryToF32IntervalCase(param: number, ...ops: PointToInterval[]): Case {
   param = quantizeToF32(param);
   const intervals: Array<F32Interval> = new Array<F32Interval>();
   for (const op of ops) {
@@ -552,7 +552,7 @@ export function makeUnaryF32IntervalCase(param: number, ...ops: PointToInterval[
  * @param param1 the second param or rhs hand side to pass into the binary operation
  * @param ops callbacks that implement generating an acceptance interval for a binary operation
  */
-export function makeBinaryF32IntervalCase(
+export function makeBinaryToF32IntervalCase(
   param0: number,
   param1: number,
   ...ops: BinaryToInterval[]
@@ -575,7 +575,7 @@ export function makeBinaryF32IntervalCase(
  * @param ops callbacks that implement generating an acceptance interval for a
  *           ternary operation.
  */
-export function makeTernaryF32IntervalCase(
+export function makeTernaryToF32IntervalCase(
   param0: number,
   param1: number,
   param2: number,
@@ -601,7 +601,7 @@ export function makeTernaryF32IntervalCase(
  * @param ops callbacks that implement generating an acceptance interval for a
  *            pair of vectors.
  */
-export function makeVectorPairF32IntervalCase(
+export function makeVectorPairToF32IntervalCase(
   param0: number[],
   param1: number[],
   ...ops: VectorPairToInterval[]

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -7,7 +7,7 @@ import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32 } from '../../../../util/conversion.js';
 import { negationInterval } from '../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../util/math.js';
-import { allInputSources, Case, makeUnaryF32IntervalCase, run } from '../expression.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -26,7 +26,7 @@ Accuracy: Correctly rounded
   )
   .fn(async t => {
     const makeCase = (x: number): Case => {
-      return makeUnaryF32IntervalCase(x, negationInterval);
+      return makeUnaryToF32IntervalCase(x, negationInterval);
     };
 
     const cases = fullF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }).map(x =>


### PR DESCRIPTION
Fixes #1774

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
