### PR TITLE
Add storage_texture,formats test to createBindGroupLayout.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -385,6 +385,8 @@ g.test('storage_texture,formats')
   .desc(
     `
   Test that a validation error is generated if the format doesn't support the storage usage.
+
+  TODO: Test "bgra8unorm" with the "bgra8unorm-storage" feature.
   `
   )
   .params(u => u.combine('format', kAllTextureFormats))

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -7,9 +7,11 @@ TODO: make sure tests are complete.
 import { kUnitCaseParamsBuilder } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
+  kAllTextureFormats,
   kShaderStages,
   kShaderStageCombinations,
   kStorageTextureAccessValues,
+  kTextureFormatInfo,
   kTextureViewDimensions,
   allBindingEntries,
   bindingTypeInfo,
@@ -377,4 +379,31 @@ g.test('storage_texture,layout_dimension')
         ],
       });
     }, !success);
+  });
+
+g.test('storage_texture,formats')
+  .desc(
+    `
+  Test that a validation error is generated if the format doesn't support the storage usage.
+  `
+  )
+  .params(u => u.combine('format', kAllTextureFormats))
+  .beforeAllSubcases(t => {
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+  })
+  .fn(async t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries: [
+          {
+            binding: 0,
+            visibility: GPUShaderStage.COMPUTE,
+            storageTexture: { format },
+          },
+        ],
+      });
+    }, !info.storage);
   });


### PR DESCRIPTION
According to the specification, the storageTextureLayout.format must
be a format that can support storage usage if the storageTextureLayout
is not undefined. So this PR adds a new test to ensure that a validation
error is generated if a format used by the storageTextureLayout doesn't
support the storage usage.

Issue: #885

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
