### PR TITLE
Remove pushing lists of numbers through Set to guarantee uniqueness

### DIFF
--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -142,7 +142,10 @@ function toF32Vector(v: number[] | F32Vector): F32Vector {
   unreachable(`Cannot convert [${v}] to F32Vector`);
 }
 
-/** @returns the input + zero if any of the entries are subnormal, otherwise returns the input */
+/**
+ * @returns the input plus zero if any of the entries are subnormal, otherwise
+ * returns the input
+ */
 function addFlushedIfNeeded(values: number[]): number[] {
   return values.some(isSubnormalNumber) ? values.concat(0) : values;
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -6,6 +6,7 @@ import {
   correctlyRoundedF32,
   flushSubnormalNumber,
   isF32Finite,
+  isSubnormalNumber,
   oneULP,
 } from './math.js';
 
@@ -139,6 +140,11 @@ function toF32Vector(v: number[] | F32Vector): F32Vector {
     return f;
   }
   unreachable(`Cannot convert [${v}] to F32Vector`);
+}
+
+/** @returns the input + zero if any of the entries are subnormal, otherwise returns the input */
+function addFlushedIfNeeded(values: number[]): number[] {
+  return values.some(isSubnormalNumber) ? values.concat(0) : values;
 }
 
 /**
@@ -299,8 +305,8 @@ interface VectorPairToIntervalOp {
 function roundAndFlushPointToInterval(n: number, op: PointToIntervalOp) {
   assert(!Number.isNaN(n), `flush not defined for NaN`);
   const values = correctlyRoundedF32(n);
-  const inputs = new Set<number>([...values, ...values.map(flushSubnormalNumber)]);
-  const results = new Set<F32Interval>([...inputs].map(op.impl));
+  const inputs = addFlushedIfNeeded(values);
+  const results = new Set<F32Interval>(inputs.map(op.impl));
   return F32Interval.span(...results);
 }
 
@@ -322,8 +328,8 @@ function roundAndFlushBinaryToInterval(x: number, y: number, op: BinaryToInterva
   assert(!Number.isNaN(y), `flush not defined for NaN`);
   const x_values = correctlyRoundedF32(x);
   const y_values = correctlyRoundedF32(y);
-  const x_inputs = new Set<number>([...x_values, ...x_values.map(flushSubnormalNumber)]);
-  const y_inputs = new Set<number>([...y_values, ...y_values.map(flushSubnormalNumber)]);
+  const x_inputs = addFlushedIfNeeded(x_values);
+  const y_inputs = addFlushedIfNeeded(y_values);
   const intervals = new Set<F32Interval>();
   x_inputs.forEach(inner_x => {
     y_inputs.forEach(inner_y => {
@@ -357,9 +363,9 @@ function roundAndFlushTernaryToInterval(
   const x_values = correctlyRoundedF32(x);
   const y_values = correctlyRoundedF32(y);
   const z_values = correctlyRoundedF32(z);
-  const x_inputs = new Set<number>([...x_values, ...x_values.map(flushSubnormalNumber)]);
-  const y_inputs = new Set<number>([...y_values, ...y_values.map(flushSubnormalNumber)]);
-  const z_inputs = new Set<number>([...z_values, ...z_values.map(flushSubnormalNumber)]);
+  const x_inputs = addFlushedIfNeeded(x_values);
+  const y_inputs = addFlushedIfNeeded(y_values);
+  const z_inputs = addFlushedIfNeeded(z_values);
   const intervals = new Set<F32Interval>();
   // prettier-ignore
   x_inputs.forEach(inner_x => {
@@ -400,12 +406,8 @@ function roundAndFlushVectorPairToInterval(
 
   const x_rounded: number[][] = x.map(correctlyRoundedF32);
   const y_rounded: number[][] = y.map(correctlyRoundedF32);
-  const x_flushed: number[][] = x_rounded.map(i => [
-    ...new Set<number>([...i, ...i.map(flushSubnormalNumber)]),
-  ]);
-  const y_flushed: number[][] = y_rounded.map(i => [
-    ...new Set<number>([...i, ...i.map(flushSubnormalNumber)]),
-  ]);
+  const x_flushed: number[][] = x_rounded.map(addFlushedIfNeeded);
+  const y_flushed: number[][] = y_rounded.map(addFlushedIfNeeded);
   const x_inputs = cartesianProduct<number>(...x_flushed);
   const y_inputs = cartesianProduct<number>(...y_flushed);
 


### PR DESCRIPTION
Removes a number of locations where the FP framework was transforming
Array -> Set -> Array to guarantee uniqueness, and replaces them with
a helper that generates lists without duplicates.

Fixes #1778

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
