### PR TITLE
webgpu/shader/execution: Check validation before testing results

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
@@ -72,7 +72,7 @@ Bitwise-or. Component-wise when T is a vector.
         });
       }
     }
-    run(t, binary('|'), [type, type], type, t.params, cases);
+    await run(t, binary('|'), [type, type], type, t.params, cases);
   });
 
 g.test('bitwise_and')
@@ -144,7 +144,7 @@ Bitwise-and. Component-wise when T is a vector.
         });
       }
     }
-    run(t, binary('&'), [type, type], type, t.params, cases);
+    await run(t, binary('&'), [type, type], type, t.params, cases);
   });
 
 g.test('bitwise_exclusive_or')
@@ -216,5 +216,5 @@ Bitwise-exclusive-or. Component-wise when T is a vector.
         });
       }
     }
-    run(t, binary('^'), [type, type], type, t.params, cases);
+    await run(t, binary('^'), [type, type], type, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -40,7 +40,7 @@ Accuracy: Correctly rounded
       return makeCase(v[0], v[1]);
     });
 
-    run(t, binary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, binary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('subtraction')
@@ -63,7 +63,7 @@ Accuracy: Correctly rounded
       return makeCase(v[0], v[1]);
     });
 
-    run(t, binary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, binary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('multiplication')
@@ -86,7 +86,7 @@ Accuracy: Correctly rounded
       return makeCase(v[0], v[1]);
     });
 
-    run(t, binary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, binary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('division')
@@ -109,7 +109,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
       return makeCase(v[0], v[1]);
     });
 
-    run(t, binary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, binary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 // Will be implemented as part larger derived accuracy task

--- a/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
@@ -63,7 +63,7 @@ Accuracy: Correct result
       });
     });
 
-    run(t, binary('=='), [TypeF32, TypeF32], TypeBool, t.params, cases);
+    await run(t, binary('=='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
 g.test('not_equals')
@@ -90,7 +90,7 @@ Accuracy: Correct result
       });
     });
 
-    run(t, binary('!='), [TypeF32, TypeF32], TypeBool, t.params, cases);
+    await run(t, binary('!='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
 g.test('less_than')
@@ -117,7 +117,7 @@ Accuracy: Correct result
       });
     });
 
-    run(t, binary('<'), [TypeF32, TypeF32], TypeBool, t.params, cases);
+    await run(t, binary('<'), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
 g.test('less_equals')
@@ -144,7 +144,7 @@ Accuracy: Correct result
       });
     });
 
-    run(t, binary('<='), [TypeF32, TypeF32], TypeBool, t.params, cases);
+    await run(t, binary('<='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
 g.test('greater_than')
@@ -171,7 +171,7 @@ Accuracy: Correct result
       });
     });
 
-    run(t, binary('>'), [TypeF32, TypeF32], TypeBool, t.params, cases);
+    await run(t, binary('>'), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
 g.test('greater_equals')
@@ -198,5 +198,5 @@ Accuracy: Correct result
       });
     });
 
-    run(t, binary('>='), [TypeF32, TypeF32], TypeBool, t.params, cases);
+    await run(t, binary('>='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -42,7 +42,7 @@ g.test('u32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    run(t, builtin('abs'), [TypeU32], TypeU32, t.params, [
+    await run(t, builtin('abs'), [TypeU32], TypeU32, t.params, [
       // Min and Max u32
       { input: u32Bits(kBit.u32.min), expected: u32Bits(kBit.u32.min) },
       { input: u32Bits(kBit.u32.max), expected: u32Bits(kBit.u32.max) },
@@ -89,7 +89,7 @@ g.test('i32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    run(t, builtin('abs'), [TypeI32], TypeI32, t.params, [
+    await run(t, builtin('abs'), [TypeI32], TypeI32, t.params, [
       // Min and max i32
       // If e evaluates to the largest negative value, then the result is e.
       { input: i32Bits(kBit.i32.negative.min), expected: i32Bits(kBit.i32.negative.min) },
@@ -157,7 +157,7 @@ g.test('f32')
       Number.POSITIVE_INFINITY,
     ].map(x => makeCase(x));
 
-    run(t, builtin('abs'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('abs'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -45,7 +45,7 @@ g.test('f32')
       ...biasedRange(1, 2, 100), // x near 1 can be problematic to implement
       ...fullF32Range(),
     ].map(makeCase);
-    run(t, builtin('acosh'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('acosh'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/all.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/all.spec.ts
@@ -88,5 +88,5 @@ g.test('bool')
     };
     const overload = overloads[t.params.overload];
 
-    run(t, builtin('all'), [overload.type], TypeBool, t.params, overload.cases);
+    await run(t, builtin('all'), [overload.type], TypeBool, t.params, overload.cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/any.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/any.spec.ts
@@ -88,5 +88,5 @@ g.test('bool')
     };
     const overload = overloads[t.params.overload];
 
-    run(t, builtin('any'), [overload.type], TypeBool, t.params, overload.cases);
+    await run(t, builtin('any'), [overload.type], TypeBool, t.params, overload.cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
@@ -41,7 +41,7 @@ g.test('f32')
     };
 
     const cases = [...fullF32Range()].map(makeCase);
-    run(t, builtin('asinh'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('asinh'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -58,7 +58,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       ...fullF32Range(),
     ].map(x => makeCase(x));
 
-    run(t, builtin('atan'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('atan'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -51,7 +51,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       });
     });
 
-    run(t, builtin('atan2'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('atan2'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -45,7 +45,7 @@ g.test('f32')
       ...biasedRange(1, 0.9, 20), // discontinuity at x = 1
       ...fullF32Range(),
     ].map(makeCase);
-    run(t, builtin('atanh'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('atanh'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -54,7 +54,7 @@ g.test('f32')
       ...fullF32Range(),
     ].map(x => makeCase(x));
 
-    run(t, builtin('ceil'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('ceil'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -88,7 +88,7 @@ g.test('u32')
       u32Bits(kBit.u32.max),
     ];
 
-    run(
+    await run(
       t,
       builtin('clamp'),
       [TypeU32, TypeU32, TypeU32],
@@ -118,7 +118,7 @@ g.test('i32')
       i32Bits(kBit.i32.positive.max),
     ];
 
-    run(
+    await run(
       t,
       builtin('clamp'),
       [TypeI32, TypeI32, TypeI32],
@@ -157,7 +157,7 @@ g.test('f32')
       });
     });
 
-    run(t, builtin('clamp'), [TypeF32, TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('clamp'), [TypeF32, TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -50,7 +50,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
       ...fullF32Range(),
     ].map(makeCase);
-    run(t, builtin('cos'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('cos'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -38,7 +38,7 @@ g.test('f32')
     };
 
     const cases = fullF32Range().map(makeCase);
-    run(t, builtin('cosh'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('cosh'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/countLeadingZeros.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countLeadingZeros.spec.ts
@@ -27,7 +27,7 @@ g.test('u32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('countLeadingZeros'), [TypeU32], TypeU32, cfg, [
+    await run(t, builtin('countLeadingZeros'), [TypeU32], TypeU32, cfg, [
       // Zero
       { input: u32Bits(0b00000000000000000000000000000000), expected: u32(32) },
 
@@ -142,7 +142,7 @@ g.test('i32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('countLeadingZeros'), [TypeI32], TypeI32, cfg, [
+    await run(t, builtin('countLeadingZeros'), [TypeI32], TypeI32, cfg, [
       // Zero
       { input: i32Bits(0b00000000000000000000000000000000), expected: i32(32) },
 

--- a/src/webgpu/shader/execution/expression/call/builtin/countOneBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countOneBits.spec.ts
@@ -26,7 +26,7 @@ g.test('u32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('countOneBits'), [TypeU32], TypeU32, cfg, [
+    await run(t, builtin('countOneBits'), [TypeU32], TypeU32, cfg, [
       // Zero
       { input: u32Bits(0b00000000000000000000000000000000), expected: u32(0) },
 
@@ -141,7 +141,7 @@ g.test('i32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('countOneBits'), [TypeI32], TypeI32, cfg, [
+    await run(t, builtin('countOneBits'), [TypeI32], TypeI32, cfg, [
       // Zero
       { input: i32Bits(0b00000000000000000000000000000000), expected: i32(0) },
 

--- a/src/webgpu/shader/execution/expression/call/builtin/countTrailingZeros.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/countTrailingZeros.spec.ts
@@ -27,7 +27,7 @@ g.test('u32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('countTrailingZeros'), [TypeU32], TypeU32, cfg, [
+    await run(t, builtin('countTrailingZeros'), [TypeU32], TypeU32, cfg, [
       // Zero
       { input: u32Bits(0b00000000000000000000000000000000), expected: u32(32) },
 
@@ -142,7 +142,7 @@ g.test('i32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('countTrailingZeros'), [TypeI32], TypeI32, cfg, [
+    await run(t, builtin('countTrailingZeros'), [TypeI32], TypeI32, cfg, [
       // Zero
       { input: i32Bits(0b00000000000000000000000000000000), expected: i32(32) },
 

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -38,7 +38,7 @@ g.test('f32')
     };
 
     const cases: Array<Case> = fullF32Range().map(makeCase);
-    run(t, builtin('degrees'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('degrees'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -86,7 +86,14 @@ g.test('f32_vec2')
       });
     });
 
-    run(t, builtin('dot'), [TypeVec(2, TypeF32), TypeVec(2, TypeF32)], TypeF32, t.params, cases);
+    await run(
+      t,
+      builtin('dot'),
+      [TypeVec(2, TypeF32), TypeVec(2, TypeF32)],
+      TypeF32,
+      t.params,
+      cases
+    );
   });
 
 g.test('f32_vec3')
@@ -104,7 +111,14 @@ g.test('f32_vec3')
       });
     });
 
-    run(t, builtin('dot'), [TypeVec(3, TypeF32), TypeVec(3, TypeF32)], TypeF32, t.params, cases);
+    await run(
+      t,
+      builtin('dot'),
+      [TypeVec(3, TypeF32), TypeVec(3, TypeF32)],
+      TypeF32,
+      t.params,
+      cases
+    );
   });
 
 g.test('f32_vec4')
@@ -122,7 +136,14 @@ g.test('f32_vec4')
       });
     });
 
-    run(t, builtin('dot'), [TypeVec(4, TypeF32), TypeVec(4, TypeF32)], TypeF32, t.params, cases);
+    await run(
+      t,
+      builtin('dot'),
+      [TypeVec(4, TypeF32), TypeVec(4, TypeF32)],
+      TypeF32,
+      t.params,
+      cases
+    );
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -49,7 +49,7 @@ g.test('f32')
       ...linearRange(89, 709, 10), // Overflows f32, but not f64
     ].map(x => makeCase(x));
 
-    run(t, builtin('exp'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('exp'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -49,7 +49,7 @@ g.test('f32')
       ...linearRange(128, 1023, 10), // Overflows f32, but not f64
     ].map(x => makeCase(x));
 
-    run(t, builtin('exp2'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('exp2'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
@@ -87,7 +87,7 @@ g.test('u32')
       0b00000000001010101010100000000000
     );
 
-    run(t, builtin('extractBits'), [T, TypeU32, TypeU32], T, cfg, [
+    await run(t, builtin('extractBits'), [T, TypeU32, TypeU32], T, cfg, [
       { input: [all_0, u32(0), u32(32)], expected: all_0 },
       { input: [all_0, u32(1), u32(10)], expected: all_0 },
       { input: [all_0, u32(2), u32(5)], expected: all_0 },
@@ -225,7 +225,7 @@ g.test('i32')
       0b00000000001010101010100000000000
     );
 
-    run(t, builtin('extractBits'), [T, TypeU32, TypeU32], T, cfg, [
+    await run(t, builtin('extractBits'), [T, TypeU32, TypeU32], T, cfg, [
       { input: [all_0, u32(0), u32(32)], expected: all_0 },
       { input: [all_0, u32(1), u32(10)], expected: all_0 },
       { input: [all_0, u32(2), u32(5)], expected: all_0 },

--- a/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
@@ -31,7 +31,7 @@ g.test('u32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('firstLeadingBit'), [TypeU32], TypeU32, cfg, [
+    await run(t, builtin('firstLeadingBit'), [TypeU32], TypeU32, cfg, [
       // Zero
       { input: u32Bits(0b00000000000000000000000000000000), expected: u32(-1) },
 
@@ -146,7 +146,7 @@ g.test('i32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('firstLeadingBit'), [TypeI32], TypeI32, cfg, [
+    await run(t, builtin('firstLeadingBit'), [TypeI32], TypeI32, cfg, [
       // Zero
       { input: i32Bits(0b00000000000000000000000000000000), expected: i32(-1) },
 

--- a/src/webgpu/shader/execution/expression/call/builtin/firstTrailingBit.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/firstTrailingBit.spec.ts
@@ -27,7 +27,7 @@ g.test('u32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('firstTrailingBit'), [TypeU32], TypeU32, cfg, [
+    await run(t, builtin('firstTrailingBit'), [TypeU32], TypeU32, cfg, [
       // Zero
       { input: u32Bits(0b00000000000000000000000000000000), expected: u32(-1) },
 
@@ -142,7 +142,7 @@ g.test('i32')
   )
   .fn(async t => {
     const cfg: Config = t.params;
-    run(t, builtin('firstTrailingBit'), [TypeI32], TypeI32, cfg, [
+    await run(t, builtin('firstTrailingBit'), [TypeI32], TypeI32, cfg, [
       // Zero
       { input: i32Bits(0b00000000000000000000000000000000), expected: i32(-1) },
 

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -53,7 +53,7 @@ g.test('f32')
       ...fullF32Range(),
     ].map(x => makeCase(x));
 
-    run(t, builtin('floor'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('floor'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -56,7 +56,7 @@ g.test('f32')
     ].map(makeCase);
 
     // prettier-ignore
-    run(t, builtin('fract'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('fract'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/insertBits.spec.ts
@@ -92,7 +92,7 @@ g.test('integer')
       0b01010101010101010101010101010101
     );
 
-    run(t, builtin('insertBits'), [T, T, TypeU32, TypeU32], T, cfg, [
+    await run(t, builtin('insertBits'), [T, T, TypeU32, TypeU32], T, cfg, [
       { input: [all_0, all_0, u32(0), u32(32)], expected: all_0 },
       { input: [all_0, all_0, u32(1), u32(10)], expected: all_0 },
       { input: [all_0, all_0, u32(2), u32(5)], expected: all_0 },

--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -45,7 +45,7 @@ g.test('f32')
       ...biasedRange(1, 2 ** 32, 1000),
     ].map(x => makeCase(x));
 
-    run(t, builtin('inverseSqrt'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('inverseSqrt'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -61,7 +61,7 @@ g.test('f32')
         cases.push(makeCase(e1, e2));
       });
     });
-    run(t, builtin('ldexp'), [TypeF32, TypeI32], TypeF32, t.params, cases);
+    await run(t, builtin('ldexp'), [TypeF32, TypeI32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -53,7 +53,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       ...fullF32Range(),
     ].map(x => makeCase(x));
 
-    run(t, builtin('log'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('log'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -53,7 +53,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       ...fullF32Range(),
     ].map(x => makeCase(x));
 
-    run(t, builtin('log2'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('log2'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -64,7 +64,7 @@ g.test('u32')
     const test_values: Array<number> = [0, 1, 2, 0x70000000, 0x80000000, 0xffffffff];
     const cases = generateTestCases(test_values, makeCase);
 
-    run(t, builtin('max'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(t, builtin('max'), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('i32')
@@ -81,7 +81,7 @@ g.test('i32')
     const test_values: Array<number> = [-0x70000000, -2, -1, 0, 1, 2, 0x70000000];
     const cases = generateTestCases(test_values, makeCase);
 
-    run(t, builtin('max'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(t, builtin('max'), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('abstract_float')
@@ -112,7 +112,7 @@ g.test('f32')
       });
     });
 
-    run(t, builtin('max'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('max'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -63,7 +63,7 @@ g.test('u32')
     const test_values: Array<number> = [0, 1, 2, 0x70000000, 0x80000000, 0xffffffff];
     const cases = generateTestCases(test_values, makeCase);
 
-    run(t, builtin('min'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(t, builtin('min'), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('i32')
@@ -80,7 +80,7 @@ g.test('i32')
     const test_values: Array<number> = [-0x70000000, -2, -1, 0, 1, 2, 0x70000000];
     const cases = generateTestCases(test_values, makeCase);
 
-    run(t, builtin('min'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(t, builtin('min'), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('abstract_float')
@@ -111,7 +111,7 @@ g.test('f32')
       });
     });
 
-    run(t, builtin('min'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('min'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -53,7 +53,7 @@ g.test('matching_f32')
         });
       });
     });
-    run(t, builtin('mix'), [TypeF32, TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('mix'), [TypeF32, TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('matching_f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -45,7 +45,7 @@ g.test('f32')
       });
     });
 
-    run(t, builtin('pow'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('pow'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
@@ -39,7 +39,7 @@ g.test('f32')
     };
 
     const cases: Array<Case> = fullF32Range().map(makeCase);
-    run(t, builtin('radians'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('radians'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/reverseBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reverseBits.spec.ts
@@ -26,7 +26,7 @@ g.test('u32')
   .fn(async t => {
     const cfg: Config = t.params;
     // prettier-ignore
-    run(t, builtin('reverseBits'), [TypeU32], TypeU32, cfg, [
+    await run(t, builtin('reverseBits'), [TypeU32], TypeU32, cfg, [
       // Zero
       { input: u32Bits(0b00000000000000000000000000000000), expected: u32Bits(0b00000000000000000000000000000000) },
 
@@ -142,7 +142,7 @@ g.test('i32')
   .fn(async t => {
     const cfg: Config = t.params;
     // prettier-ignore
-    run(t, builtin('reverseBits'), [TypeI32], TypeI32, cfg, [
+    await run(t, builtin('reverseBits'), [TypeI32], TypeI32, cfg, [
       // Zero
       { input: i32Bits(0b00000000000000000000000000000000), expected: i32Bits(0b00000000000000000000000000000000) },
 

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -41,7 +41,7 @@ g.test('f32')
     };
 
     const cases = fullF32Range().map(makeCase);
-    run(t, builtin('round'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('round'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
@@ -43,7 +43,7 @@ g.test('f32')
 
       ...fullF32Range(),
     ].map(makeCase);
-    run(t, builtin('saturate'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('saturate'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
@@ -120,7 +120,7 @@ g.test('scalar')
     };
     const overload = overloads[t.params.overload];
 
-    run(
+    await run(
       t,
       builtin('select'),
       [overload.type, overload.type, TypeBool],
@@ -218,7 +218,7 @@ g.test('vector')
       }
     }
 
-    run(
+    await run(
       t,
       builtin('select'),
       [tests.dataType, tests.dataType, tests.boolType],

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -38,7 +38,7 @@ g.test('f32')
     };
 
     const cases = fullF32Range().map(makeCase);
-    run(t, builtin('sign'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('sign'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -49,7 +49,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
 
       ...fullF32Range(),
     ].map(makeCase);
-    run(t, builtin('sin'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('sin'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -38,7 +38,7 @@ g.test('f32')
     };
 
     const cases = fullF32Range().map(makeCase);
-    run(t, builtin('sinh'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('sinh'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -38,7 +38,7 @@ g.test('f32')
     };
 
     const cases = fullF32Range().map(makeCase);
-    run(t, builtin('sqrt'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('sqrt'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -65,7 +65,7 @@ g.test('f32')
       });
     });
 
-    run(t, builtin('step'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('step'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
@@ -42,7 +42,7 @@ g.test('f32')
       ...linearRange(-Math.PI, Math.PI, 100),
       ...fullF32Range(),
     ].map(makeCase);
-    run(t, builtin('tan'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('tan'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
@@ -38,7 +38,7 @@ g.test('f32')
     };
 
     const cases = fullF32Range().map(makeCase);
-    run(t, builtin('tanh'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('tanh'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -39,7 +39,7 @@ g.test('f32')
     };
 
     const cases = fullF32Range().map(makeCase);
-    run(t, builtin('trunc'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, builtin('trunc'), [TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('f16')

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -33,5 +33,5 @@ Accuracy: Correctly rounded
       makeCase(x)
     );
 
-    run(t, unary('-'), [TypeF32], TypeF32, t.params, cases);
+    await run(t, unary('-'), [TypeF32], TypeF32, t.params, cases);
   });


### PR DESCRIPTION
Check that the shaders compiled, pipelines created, workgroups dispatched, etc, before attempting to inspect the shader output.

For shaders that are not currently compiling, this massively reduces the amount of error spam, as we no longer spew an error per failed expression case, or which some calls to `run()` contain thousands.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
