### PR TITLE
Refactor binary arithmetic tests to use common test values

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -11,12 +11,14 @@ import {
   multiplicationInterval,
   subtractionInterval,
 } from '../../../../util/f32_interval.js';
-import { biasedRange, fullF32Range } from '../../../../util/math.js';
+import { cartesianProduct, fullF32Range } from '../../../../util/math.js';
 import { allInputSources, Case, makeBinaryF32IntervalCase, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
+
+const kTestValues: number[][] = cartesianProduct(fullF32Range(), fullF32Range());
 
 g.test('addition')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
@@ -34,12 +36,8 @@ Accuracy: Correctly rounded
       return makeBinaryF32IntervalCase(lhs, rhs, additionInterval);
     };
 
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs));
-      });
+    const cases = kTestValues.map((v: number[]) => {
+      return makeCase(v[0], v[1]);
     });
 
     run(t, binary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
@@ -61,12 +59,8 @@ Accuracy: Correctly rounded
       return makeBinaryF32IntervalCase(lhs, rhs, subtractionInterval);
     };
 
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs));
-      });
+    const cases = kTestValues.map((v: number[]) => {
+      return makeCase(v[0], v[1]);
     });
 
     run(t, binary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
@@ -88,13 +82,10 @@ Accuracy: Correctly rounded
       return makeBinaryF32IntervalCase(lhs, rhs, multiplicationInterval);
     };
 
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs));
-      });
+    const cases = kTestValues.map((v: number[]) => {
+      return makeCase(v[0], v[1]);
     });
+
     run(t, binary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -114,14 +105,8 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
       return makeBinaryF32IntervalCase(lhs, rhs, divisionInterval);
     };
 
-    const cases: Array<Case> = [];
-    const lhs_range = fullF32Range();
-    const rhs_range = biasedRange(2 ** -126, 2 ** 126, 200);
-
-    lhs_range.forEach(lhs => {
-      rhs_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs));
-      });
+    const cases = kTestValues.map((v: number[]) => {
+      return makeCase(v[0], v[1]);
     });
 
     run(t, binary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);


### PR DESCRIPTION
This patch moves all of the test values up ointo a constant at the top
of the file, and then has each test map makeCase as needed. This also
resolves the issue with division not being tested over the whole
range.

Fixes #1764

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
