### PR TITLE
Check shader validation before testing results (alt version)

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -732,7 +732,7 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
   ifNoGPUError(
     filter: GPUErrorFilter,
     { from, then }: { from: () => void; then: () => void | Promise<void> }
-  ) {
+  ): void {
     this.device.pushErrorScope(filter);
     from();
     const asyncError = this.device.popErrorScope();
@@ -746,7 +746,7 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
         return;
       }
 
-      then();
+      void then();
     });
   }
 

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -167,22 +167,22 @@ export function run(
     }
   })();
 
-  // Submit all the batches, then check the results.
   const checkResults: Array<() => void> = [];
-  for (let i = 0; i < cases.length; i += casesPerBatch) {
-    const batchCases = cases.slice(i, Math.min(i + casesPerBatch, cases.length));
-    const checkResult = submitBatch(
-      t,
-      expressionBuilder,
-      parameterTypes,
-      returnType,
-      batchCases,
-      cfg.inputSource
-    );
-    checkResults.push(checkResult);
-  }
-
-  checkResults.forEach(f => f());
+  t.ifNoGPUError('validation', {
+    // Submit all the batches inside the error scope
+    from: () => {
+      for (let i = 0; i < cases.length; i += casesPerBatch) {
+        const batchCases = cases.slice(i, Math.min(i + casesPerBatch, cases.length));
+        checkResults.push(
+          submitBatch(t, expressionBuilder, parameterTypes, returnType, batchCases, cfg.inputSource)
+        );
+      }
+    },
+    // Check GPU validation (shader compilation, pipeline creation, etc) before checking the results
+    then: () => {
+      checkResults.forEach(f => f());
+    },
+  });
 }
 
 /**


### PR DESCRIPTION
Alternative to #1780

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] ~Tests are properly located in the test tree.~
- [ ] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
