### PR TITLE
Input data generation optimization

### DIFF
--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -63,6 +63,7 @@ Whenever a new generally-useful helper is added, it should be indexed here.
     Helpers for creating web elements like HTMLCanvasElement, OffscreenCanvas, etc.
 - {@link webgpu/util/shader}: Helpers for creating fragment shader based on intended output values, plainType, and componentCount.
 - {@link webgpu/util/texture/base}: General texture-related helpers.
+- {@link webgpu/util/texture/data_generation}: Helper for generating dummy texture data.
 - {@link webgpu/util/texture/layout}: Helpers for working with linear image data
     (like in copyBufferToTexture, copyTextureToBuffer, writeTexture).
 - {@link webgpu/util/texture/subresource}: Helpers for working with texture subresource ranges.

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -19,9 +19,8 @@ import { GPUTest } from '../../../gpu_test.js';
 import { makeBufferWithContents } from '../../../util/buffer.js';
 import { align } from '../../../util/math.js';
 import { physicalMipSize } from '../../../util/texture/base.js';
+import { DataArrayGenerator } from '../../../util/texture/data_generation.js';
 import { kBytesPerRowAlignment, dataBytesForCopyOrFail } from '../../../util/texture/layout.js';
-
-import { DataArrayGenerator } from './data_generation.js';
 
 const dataGenerator = new DataArrayGenerator();
 

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -20,6 +20,7 @@ import { makeBufferWithContents } from '../../../util/buffer.js';
 import { align } from '../../../util/math.js';
 import { physicalMipSize } from '../../../util/texture/base.js';
 import { kBytesPerRowAlignment, dataBytesForCopyOrFail } from '../../../util/texture/layout.js';
+
 import { DataArrayGenerator } from './data_generation.js';
 
 const dataGenerator = new DataArrayGenerator();

--- a/src/webgpu/api/operation/command_buffer/data_generation.ts
+++ b/src/webgpu/api/operation/command_buffer/data_generation.ts
@@ -1,0 +1,69 @@
+// A helper function that generates ranges of dummy data for buffer or texture operations
+// efficiently. Tries to minimize allocations and data updates.
+export class DataArrayGenerator {
+  private dataBuffer = new Uint8Array(256);
+
+  private lastOffset = 0;
+  private lastStart = 0;
+  private lastByteSize = 0;
+
+  // Find the nearest power of two greater than or equal to the input value.
+  private nextPowerOfTwo(value: number) {
+    return 1 << 32 - Math.clz32(value-1);
+  }
+
+  private generateData(byteSize: number, start: number = 0, offset: number = 0) {
+    const prevSize = this.dataBuffer.length;
+
+    if (prevSize < byteSize) {
+      // If the requested data is larger than the allocated buffer, reallocate it to a buffer large
+      // enough to handle the new request.
+      const newData = new Uint8Array(this.nextPowerOfTwo(byteSize));
+
+      if (this.lastOffset == offset && this.lastStart == start && this.lastByteSize) {
+          // Do a fast copy of any previous data that was generated.
+          newData.set(this.dataBuffer);
+      }
+
+      this.dataBuffer = newData;
+    } else if (this.lastOffset < offset) {
+      // Ensure all values up to the offset are zeroed out.
+      this.dataBuffer.fill(0, this.lastOffset, offset);
+    }
+
+    // If the offset or start values have changed, the whole data range needs to be regenerated.
+    if (this.lastOffset != offset || this.lastStart != start) {
+      this.lastByteSize = 0;
+    }
+
+    // Generate any new values that are required
+    if (this.lastByteSize < byteSize) {
+      for (let i = this.lastByteSize; i < byteSize - offset; ++i) {
+        this.dataBuffer[i + offset] = ((i ** 3 + i + start) % 251) + 1; // Ensure data is always non-zero
+      }
+
+      this.lastOffset = offset;
+      this.lastStart = start;
+      this.lastByteSize = byteSize;
+    }
+  }
+
+  // Returns a new into the generated data that's the correct length. Because this is a view any
+  // previously returned views from the same generator will have their values overwritten as well.
+  generateView(byteSize: number, start: number = 0, offset: number = 0): Uint8Array {
+    this.generateData(byteSize, start, offset);
+
+    if (this.dataBuffer.length == byteSize) {
+      return this.dataBuffer;
+    }
+    return new Uint8Array(this.dataBuffer.buffer, 0, byteSize);
+  }
+
+  // Returns a copy of the generated data. Note that this still changes the underlying buffer, so
+  // any previously generated views will still be overwritten, but the returned copy won't reflect
+  // future generate* calls.
+  generateAndCopyView(byteSize: number, start: number = 0, offset: number = 0) {
+    this.generateData(byteSize, start, offset);
+    return this.dataBuffer.slice(0, byteSize);
+  }
+}

--- a/src/webgpu/api/operation/command_buffer/data_generation.ts
+++ b/src/webgpu/api/operation/command_buffer/data_generation.ts
@@ -9,7 +9,7 @@ export class DataArrayGenerator {
 
   // Find the nearest power of two greater than or equal to the input value.
   private nextPowerOfTwo(value: number) {
-    return 1 << 32 - Math.clz32(value-1);
+    return 1 << (32 - Math.clz32(value - 1));
   }
 
   private generateData(byteSize: number, start: number = 0, offset: number = 0) {
@@ -20,9 +20,9 @@ export class DataArrayGenerator {
       // enough to handle the new request.
       const newData = new Uint8Array(this.nextPowerOfTwo(byteSize));
 
-      if (this.lastOffset == offset && this.lastStart == start && this.lastByteSize) {
-          // Do a fast copy of any previous data that was generated.
-          newData.set(this.dataBuffer);
+      if (this.lastOffset === offset && this.lastStart === start && this.lastByteSize) {
+        // Do a fast copy of any previous data that was generated.
+        newData.set(this.dataBuffer);
       }
 
       this.dataBuffer = newData;
@@ -32,7 +32,7 @@ export class DataArrayGenerator {
     }
 
     // If the offset or start values have changed, the whole data range needs to be regenerated.
-    if (this.lastOffset != offset || this.lastStart != start) {
+    if (this.lastOffset !== offset || this.lastStart !== start) {
       this.lastByteSize = 0;
     }
 
@@ -53,7 +53,7 @@ export class DataArrayGenerator {
   generateView(byteSize: number, start: number = 0, offset: number = 0): Uint8Array {
     this.generateData(byteSize, start, offset);
 
-    if (this.dataBuffer.length == byteSize) {
+    if (this.dataBuffer.length === byteSize) {
       return this.dataBuffer;
     }
     return new Uint8Array(this.dataBuffer.buffer, 0, byteSize);

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -63,6 +63,7 @@ import {
   kBytesPerRowAlignment,
   TextureCopyLayout,
 } from '../../../util/texture/layout.js';
+import { DataArrayGenerator } from './data_generation.js';
 
 interface TextureCopyViewWithRequiredOrigin {
   texture: GPUTexture;
@@ -121,6 +122,9 @@ const kExcludedFormats: Set<SizedTextureFormat> = new Set([
 ]);
 const kWorkingColorTextureFormats = kColorTextureFormats.filter(x => !kExcludedFormats.has(x));
 
+const dataGenerator = new DataArrayGenerator();
+const altDataGenerator = new DataArrayGenerator();
+
 class ImageCopyTest extends GPUTest {
   /** Offset for a particular texel in the linear texture data */
   getTexelOffsetInBytes(
@@ -171,10 +175,13 @@ class ImageCopyTest extends GPUTest {
   }
 
   generateData(byteSize: number, start: number = 0, offset: number = 0): Uint8Array {
+    return altDataGenerator.generateView(byteSize, start, offset);
+
     const arr = new Uint8Array(byteSize);
-    for (let i = 0; i < byteSize; ++i) {
+    arr.set(altDataGenerator.generateView(byteSize, start, offset));
+    /*for (let i = 0; i < byteSize; ++i) {
       arr[i + offset] = (i ** 3 + i + start) % 251;
-    }
+    }*/
     return arr;
   }
 
@@ -386,7 +393,7 @@ class ImageCopyTest extends GPUTest {
     // The alignment is necessary because we need to copy and map data from this buffer.
     const bufferSize = align(expected.byteLength, 4);
     // The start value ensures generated data here doesn't match the expected data.
-    const bufferData = this.generateData(bufferSize, 17);
+    const bufferData = altDataGenerator.generateAndCopyView(bufferSize, 17);
 
     const buffer = this.makeBufferWithContents(
       bufferData,
@@ -565,7 +572,7 @@ class ImageCopyTest extends GPUTest {
     });
     this.trackForCleanup(texture);
 
-    const data = this.generateData(dataSize);
+    const data = dataGenerator.generateView(dataSize);
 
     switch (checkMethod) {
       case 'PartialCopyT2B': {
@@ -645,7 +652,7 @@ class ImageCopyTest extends GPUTest {
     this.trackForCleanup(srcTexture);
 
     const copySize = [textureSize[0] >> mipLevel, textureSize[1] >> mipLevel, textureSize[2]];
-    const initialData = this.generateData(
+    const initialData = dataGenerator.generateView(
       align(initialDataSize, kBufferSizeAlignment),
       0,
       initialDataOffset
@@ -714,7 +721,7 @@ class ImageCopyTest extends GPUTest {
 
     // Initialize srcTexture with queue.writeTexture()
     const copySize = [textureSize[0] >> mipLevel, textureSize[1] >> mipLevel, textureSize[2]];
-    const initialData = this.generateData(
+    const initialData = dataGenerator.generateView(
       align(copySize[0] * copySize[1] * copySize[2], kBufferSizeAlignment)
     );
     this.queue.writeTexture(

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -63,6 +63,7 @@ import {
   kBytesPerRowAlignment,
   TextureCopyLayout,
 } from '../../../util/texture/layout.js';
+
 import { DataArrayGenerator } from './data_generation.js';
 
 interface TextureCopyViewWithRequiredOrigin {

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -56,6 +56,7 @@ import {
 import { GPUTest } from '../../../gpu_test.js';
 import { makeBufferWithContents } from '../../../util/buffer.js';
 import { align } from '../../../util/math.js';
+import { DataArrayGenerator } from '../../../util/texture/data_generation.js';
 import {
   bytesInACompleteRow,
   dataBytesForCopyOrFail,
@@ -63,8 +64,6 @@ import {
   kBytesPerRowAlignment,
   TextureCopyLayout,
 } from '../../../util/texture/layout.js';
-
-import { DataArrayGenerator } from './data_generation.js';
 
 interface TextureCopyViewWithRequiredOrigin {
   texture: GPUTexture;
@@ -173,17 +172,6 @@ class ImageCopyTest extends GPUTest {
         };
       }
     }
-  }
-
-  generateData(byteSize: number, start: number = 0, offset: number = 0): Uint8Array {
-    return altDataGenerator.generateView(byteSize, start, offset);
-
-    const arr = new Uint8Array(byteSize);
-    arr.set(altDataGenerator.generateView(byteSize, start, offset));
-    /*for (let i = 0; i < byteSize; ++i) {
-      arr[i + offset] = (i ** 3 + i + start) % 251;
-    }*/
-    return arr;
   }
 
   /**

--- a/src/webgpu/util/texture/data_generation.ts
+++ b/src/webgpu/util/texture/data_generation.ts
@@ -1,5 +1,7 @@
-// A helper function that generates ranges of dummy data for buffer or texture operations
-// efficiently. Tries to minimize allocations and data updates.
+/**
+ * A helper class that generates ranges of dummy data for buffer or texture operations
+ * efficiently. Tries to minimize allocations and data updates.
+ */
 export class DataArrayGenerator {
   private dataBuffer = new Uint8Array(256);
 
@@ -7,7 +9,7 @@ export class DataArrayGenerator {
   private lastStart = 0;
   private lastByteSize = 0;
 
-  // Find the nearest power of two greater than or equal to the input value.
+  /** Find the nearest power of two greater than or equal to the input value. */
   private nextPowerOfTwo(value: number) {
     return 1 << (32 - Math.clz32(value - 1));
   }
@@ -48,8 +50,14 @@ export class DataArrayGenerator {
     }
   }
 
-  // Returns a new into the generated data that's the correct length. Because this is a view any
-  // previously returned views from the same generator will have their values overwritten as well.
+  /**
+   * Returns a new view into the generated data that's the correct length. Because this is a view
+   * previously returned views from the same generator will have their values overwritten as well.
+   * @param {number} byteSize - Number of bytes the returned view should contain.
+   * @param {number} [start] - The value of the first element generated in the view.
+   * @param {number} [offset] - Offset of the generated data within the view. Preceeding values will be 0.
+   * @returns {Uint8Array} A new Uint8Array view into the generated data.
+   */
   generateView(byteSize: number, start: number = 0, offset: number = 0): Uint8Array {
     this.generateData(byteSize, start, offset);
 
@@ -59,9 +67,15 @@ export class DataArrayGenerator {
     return new Uint8Array(this.dataBuffer.buffer, 0, byteSize);
   }
 
-  // Returns a copy of the generated data. Note that this still changes the underlying buffer, so
-  // any previously generated views will still be overwritten, but the returned copy won't reflect
-  // future generate* calls.
+  /**
+   * Returns a copy of the generated data. Note that this still changes the underlying buffer, so
+   * any previously generated views will still be overwritten, but the returned copy won't reflect
+   * future generate* calls.
+   * @param {number} byteSize - Number of bytes the returned array should contain.
+   * @param {number} [start] - The value of the first element generated in the view.
+   * @param {number} [offset] - Offset of the generated data within the view. Preceeding values will be 0.
+   * @returns {Uint8Array} A new Uint8Array copy of the generated data.
+   */
   generateAndCopyView(byteSize: number, start: number = 0, offset: number = 0) {
     this.generateData(byteSize, start, offset);
     return this.dataBuffer.slice(0, byteSize);


### PR DESCRIPTION
Issue: #1757

<hr>

WIP change, still need to apply the same optimization to `generate_data` in `image_copy.spec.ts` and do a bit more cleanup.

Initial results show that this change takes running the full suite of `copyTextureToTexture` tests **from 71s to 20s on my machine.** 