### PR TITLE
Use let declarations for literal input in shader,execution,expression

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -320,12 +320,12 @@ struct Output {
       const source = `
 ${wgslOutputs}
 
-const values = array<${wgslStorageType}, ${cases.length}>(
-  ${wgslValues.join(',\n  ')}
-);
-
 @compute @workgroup_size(1)
 fn main() {
+  let values = array<${wgslStorageType}, ${cases.length}>(
+    ${wgslValues.join(',\n    ')}
+  );
+
   for (var i = 0u; i < ${cases.length}; i++) {
     outputs[i].value = values[i];
   }


### PR DESCRIPTION
This PR make the shader,execution,expression tests to use `let` declarations rather than global scope `const` declarations for holding the built-in results with literal input. Such modification ensure most webgpu:shader,execution,expression,call,builtin,*:inputSource="const";* cases pass in Chrome.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
