### PR TITLE
Revert "Use let declarations for literal input in shader,execution,expression"

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -320,12 +320,12 @@ struct Output {
       const source = `
 ${wgslOutputs}
 
+const values = array<${wgslStorageType}, ${cases.length}>(
+  ${wgslValues.join(',\n  ')}
+);
+
 @compute @workgroup_size(1)
 fn main() {
-  let values = array<${wgslStorageType}, ${cases.length}>(
-    ${wgslValues.join(',\n    ')}
-  );
-
   for (var i = 0u; i < ${cases.length}; i++) {
     outputs[i].value = values[i];
   }


### PR DESCRIPTION
Reverts gpuweb/cts#1788

Currently test cases with `inputSource` being `const` are mean to cover the creation-time constant evaluation, so they must have literal inputs, and used in `const` declarations to make sure that they are creation-time evaluated. The PR, which use `let` instead of `const`, make the test cases check runtime evaluation instead.