### PR TITLE
Add 'maximum_binding_limit' test to createBindGroupLayout.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -53,6 +53,39 @@ g.test('duplicate_bindings')
     }, !_valid);
   });
 
+// Need to use the maxBindingsPerBindGroup constant of GPUSupportedLimits instead of 640.
+const kMaxBindingNumber = 640;
+g.test('maximum_binding_limit')
+  .desc(
+    `
+  Test that a validation error is generated if the binding number exceeds the maximum binding limit.
+
+  TODO: Check if a higher maximum binding limit can be allowed. (e.g. 65535)
+  `
+  )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('binding', [1, 4, 8, 256, kMaxBindingNumber - 1, kMaxBindingNumber])
+  )
+  .fn(async t => {
+    const { binding } = t.params;
+    const entries: Array<GPUBindGroupLayoutEntry> = [];
+
+    entries.push({
+      binding,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage' as const },
+    });
+
+    const success = binding < kMaxBindingNumber;
+
+    t.expectValidationError(() => {
+      t.device.createBindGroupLayout({
+        entries,
+      });
+    }, !success);
+  });
+
 g.test('visibility')
   .desc(
     `

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -53,19 +53,21 @@ g.test('duplicate_bindings')
     }, !_valid);
   });
 
-// Need to use the maxBindingsPerBindGroup constant of GPUSupportedLimits instead of 640.
-const kMaxBindingNumber = 640;
+// MAINTENANCE_TODO: Move this into kLimits with the proper name after the spec PR lands.
+// https://github.com/gpuweb/gpuweb/pull/3318
+const kMaxBindingsPerBindGroup = 640;
+
 g.test('maximum_binding_limit')
   .desc(
     `
   Test that a validation error is generated if the binding number exceeds the maximum binding limit.
 
-  TODO: Check if a higher maximum binding limit can be allowed. (e.g. 65535)
+  TODO: Need to also test with higher limits enabled on the device, once we have a way to do that.
   `
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('binding', [1, 4, 8, 256, kMaxBindingNumber - 1, kMaxBindingNumber])
+      .combine('binding', [1, 4, 8, 256, kMaxBindingsPerBindGroup - 1, kMaxBindingsPerBindGroup])
   )
   .fn(async t => {
     const { binding } = t.params;
@@ -77,7 +79,7 @@ g.test('maximum_binding_limit')
       buffer: { type: 'storage' as const },
     });
 
-    const success = binding < kMaxBindingNumber;
+    const success = binding < kMaxBindingsPerBindGroup;
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout({


### PR DESCRIPTION
The specification says that the binding of each entry must be less than
640. So this PR adds a new test to ensure that a validation error is
generated if the binding number exceeds the maximum binding limit.

Issue: #885


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
