### PR TITLE
Add tests to `fullI32Range`

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -12,6 +12,7 @@ import {
   correctlyRounded,
   correctlyRoundedF32,
   fullF32Range,
+  fullI32Range,
   hexToF32,
   hexToF64,
   lerp,
@@ -1183,6 +1184,39 @@ g.test('fullF32Range')
     test.expect(
       compareArrayOfNumbers(got, expect),
       `fullF32Range(${neg_norm}, ${neg_sub}, ${pos_sub}, ${pos_norm}) returned [${got}]. Expected [${expect}]`
+    );
+  });
+
+interface fullI32RangeCase {
+  neg_count: number;
+  pos_count: number;
+  expect: Array<number>;
+}
+
+g.test('fullI32Range')
+  .paramsSimple<fullI32RangeCase>(
+    // prettier-ignore
+    [
+      { neg_count: 0, pos_count: 0, expect: [0] },
+      { neg_count: 1, pos_count: 0, expect: [kValue.i32.negative.min, 0] },
+      { neg_count: 2, pos_count: 0, expect: [kValue.i32.negative.min, -1, 0] },
+      { neg_count: 3, pos_count: 0, expect: [kValue.i32.negative.min, -1610612736, -1, 0] },
+      { neg_count: 0, pos_count: 1, expect: [0, 1] },
+      { neg_count: 0, pos_count: 2, expect: [0, 1, kValue.i32.positive.max] },
+      { neg_count: 0, pos_count: 3, expect: [0, 1, 536870912, kValue.i32.positive.max] },
+      { neg_count: 1, pos_count: 1, expect: [kValue.i32.negative.min, 0, 1] },
+      { neg_count: 2, pos_count: 2, expect: [kValue.i32.negative.min, -1, 0, 1, kValue.i32.positive.max ] },
+    ]
+  )
+  .fn(test => {
+    const neg_count = test.params.neg_count;
+    const pos_count = test.params.pos_count;
+    const got = fullI32Range({ negative: neg_count, positive: pos_count });
+    const expect = test.params.expect;
+
+    test.expect(
+      compareArrayOfNumbers(got, expect),
+      `fullI32Range(${neg_count}, ${pos_count}) returned [${got}]. Expected [${expect}]`
     );
   });
 

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -482,10 +482,10 @@ export function fullI32Range(
 ): Array<number> {
   counts.negative = counts.negative === undefined ? counts.positive : counts.negative;
   return [
-    ...biasedRange(kValue.i32.negative.max, kValue.i32.negative.min, counts.negative).reverse(),
+    ...biasedRange(kValue.i32.negative.min, -1, counts.negative),
     0,
-    ...biasedRange(kValue.i32.positive.min, kValue.i32.positive.max, counts.positive),
-  ];
+    ...biasedRange(1, kValue.i32.positive.max, counts.positive),
+  ].map(Math.trunc);
 }
 
 /** Short list of f32 values of interest to test against */


### PR DESCRIPTION
This exposes an issue with the ldexp tests that I have documented in
https://github.com/gpuweb/cts/issues/1791

Fixes #1785

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
