### PR TITLE
Implement 'texture,device_mismatch' test in writeTexture.spec.ts

### DIFF
--- a/src/webgpu/api/validation/queue/writeTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/writeTexture.spec.ts
@@ -83,3 +83,28 @@ g.test('sample_count')
       t.device.queue.writeTexture({ texture }, data, {}, size);
     }, !isValid);
   });
+
+g.test('texture,device_mismatch')
+  .desc('Tests writeTexture cannot be called with a texture created from another device.')
+  .params(u => u.combine('mismatched', [true, false]))
+  .beforeAllSubcases(t => {
+    t.selectMismatchedDeviceOrSkipTestCase(undefined);
+  })
+  .fn(async t => {
+    const { mismatched } = t.params;
+    const device = mismatched ? t.mismatchedDevice : t.device;
+
+    const texture = device.createTexture({
+      size: { width: 16, height: 16 },
+      format: 'bgra8unorm',
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    t.trackForCleanup(texture);
+
+    const data = new Uint8Array(16);
+    const size = [1, 1];
+
+    t.expectValidationError(() => {
+      t.device.queue.writeTexture({ texture }, data, {}, size);
+    }, mismatched);
+  });


### PR DESCRIPTION
This PR adds texture,device_mismatch test in writeTexture.spec.ts
file in order to ensure that writeTexture function cannot be called
with a texture created from another device.

Issue: #1692

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
