### PR TITLE
Clarify comments in ULP code

### DIFF
--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -171,16 +171,19 @@ function oneULPImpl(target: number, flush: boolean): number {
     return kValue.f32.negative.nearest_min - kValue.f32.negative.min;
   }
 
-  // ulp(x) is min(b-a), where a <= x <= b, a =/= b, a and b are f32 representable
-  const b = nextAfter(target, true, flush).value.valueOf() as number;
-  const a = nextAfter(target, false, flush).value.valueOf() as number;
+  // ulp(x) is min(after - before), where
+  //     before <= x <= after
+  //     before =/= after
+  //     before and after are f32 representable
+  const before = nextAfter(target, false, flush).value.valueOf() as number;
+  const after = nextAfter(target, true, flush).value.valueOf() as number;
   const converted: number = new Float32Array([target])[0];
   if (converted === target) {
-    // |target| is f32 representable, so either either a or b will be x
-    return Math.min(target - a, b - target);
+    // |target| is f32 representable, so either before or after will be x
+    return Math.min(target - before, after - target);
   } else {
     // |target| is not f32 representable so taking distance of neighbouring f32s.
-    return b - a;
+    return after - before;
   }
 }
 


### PR DESCRIPTION
Currently the documentation uses a and b as variables in the
explanation which can be confusing, since a is the value before x and
b is the value after x.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
