### PR TITLE
Fix linter warning in CI

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -133,5 +133,5 @@ Accuracy: Derived from x - y * trunc(x/y)
       return makeCase(v[0], v[1]);
     });
 
-    run(t, binary('%'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, binary('%'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });


### PR DESCRIPTION
Specific warning:
```
/home/runner/work/cts/cts/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
Warning:   136:5  warning  Promises must be handled appropriately or explicitly marked as ignored with the `void` operator  @typescript-eslint/no-floating-promises
```

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
