### PR TITLE
Add sample_count test to buffer_texture_copies.spec.ts

### DIFF
--- a/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
@@ -304,3 +304,43 @@ g.test('depth_stencil_format,copy_buffer_offset')
       unreachable();
     }
   });
+
+g.test('sample_count')
+  .desc(
+    `
+  Test that the texture sample count. Check that a validation error is generated if sample count is
+  not 1.
+  `
+  )
+  .params(u =>
+    u //
+      // writeTexture is handled by writeTexture.spec.ts.
+      .combine('copyType', ['CopyB2T', 'CopyT2B'] as const)
+      .beginSubcases()
+      .combine('sampleCount', [1, 4])
+  )
+  .fn(async t => {
+    const { sampleCount, copyType } = t.params;
+    const texture = t.device.createTexture({
+      size: { width: 16, height: 16 },
+      sampleCount,
+      format: 'bgra8unorm',
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+    });
+
+    const uploadBufferSize = 32;
+    const buffer = t.device.createBuffer({
+      size: uploadBufferSize,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+
+    const textureSize = { width: 1, height: 1, depthOrArrayLayers: 1 };
+
+    const isSuccess = sampleCount === 1;
+
+    if (copyType === 'CopyB2T') {
+      t.testCopyBufferToTexture({ buffer }, { texture }, textureSize, isSuccess);
+    } else if (copyType === 'CopyT2B') {
+      t.testCopyTextureToBuffer({ texture }, { buffer }, textureSize, isSuccess);
+    }
+  });


### PR DESCRIPTION
This PR adds a new test to ensure that a validation error is
generated if the sample count is not 1 when calling copyB2T
and copyT2B functions.

Issue: #1799

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
