### PR TITLE
Add global test config

### DIFF
--- a/src/common/framework/test_config.ts
+++ b/src/common/framework/test_config.ts
@@ -1,0 +1,9 @@
+export type TestConfig = {
+  maxSubcasesInFlight: number;
+  testHeartbeatCallback: () => void;
+};
+
+export const globalTestConfig: TestConfig = {
+  maxSubcasesInFlight: 500,
+  testHeartbeatCallback: () => {},
+};

--- a/src/common/internal/logging/test_case_recorder.ts
+++ b/src/common/internal/logging/test_case_recorder.ts
@@ -1,4 +1,5 @@
 import { SkipTestCase, UnexpectedPassError } from '../../framework/fixture.js';
+import { globalTestConfig } from '../../framework/test_config.js';
 import { now, assert } from '../../util/util.js';
 
 import { LogMessageWithStack } from './log_message.js';
@@ -121,6 +122,7 @@ export class TestCaseRecorder {
 
   private logImpl(level: LogSeverity, name: string, baseException: unknown): void {
     assert(baseException instanceof Error, 'test threw a non-Error object');
+    globalTestConfig.testHeartbeatCallback();
     const logMessage = new LogMessageWithStack(name, baseException);
 
     // Final case status should be the "worst" of all log entries.


### PR DESCRIPTION
Useful for configuring global parameters for running tests, and for
registering hooks to receive callbacks back from the test runner.

Issue: [crbug/1340602](https://bugs.chromium.org/p/chromium/issues/detail?id=1340602)

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
