### PR TITLE
Add 'texture_buffer_usage' test to buffer_texture_copies.spec.ts

### DIFF
--- a/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
@@ -7,9 +7,12 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, unreachable } from '../../../../common/util/util.js';
 import {
   kDepthStencilFormats,
+  kBufferUsages,
+  kTextureUsages,
   depthStencilBufferTextureCopySupported,
   depthStencilFormatAspectSize,
 } from '../../../capability_info.js';
+import { GPUConst } from '../../../constants.js';
 import { align } from '../../../util/math.js';
 import { kBufferCopyAlignment, kBytesPerRowAlignment } from '../../../util/texture/layout.js';
 import { ValidationTest } from '../validation_test.js';
@@ -338,6 +341,58 @@ g.test('sample_count')
 
     const isSuccess = sampleCount === 1;
 
+    if (copyType === 'CopyB2T') {
+      t.testCopyBufferToTexture({ buffer }, { texture }, textureSize, isSuccess);
+    } else if (copyType === 'CopyT2B') {
+      t.testCopyTextureToBuffer({ texture }, { buffer }, textureSize, isSuccess);
+    }
+  });
+
+const kRequiredTextureUsage = {
+  CopyT2B: GPUConst.TextureUsage.COPY_SRC,
+  CopyB2T: GPUConst.TextureUsage.COPY_DST,
+};
+const kRequiredBufferUsage = {
+  CopyB2T: GPUConst.BufferUsage.COPY_SRC,
+  CopyT2B: GPUConst.BufferUsage.COPY_DST,
+};
+
+g.test('texture_buffer_usages')
+  .desc(
+    `
+  Tests calling copyTextureToBuffer or copyBufferToTexture with the texture and the buffer missed
+  COPY_SRC, COPY_DST usage respectively.
+    - texture and buffer {with, without} COPY_SRC and COPY_DST usage.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('copyType', ['CopyB2T', 'CopyT2B'] as const)
+      .beginSubcases()
+      .combine('textureUsage', kTextureUsages)
+      .expand('_textureUsageValid', p => [p.textureUsage === kRequiredTextureUsage[p.copyType]])
+      .combine('bufferUsage', kBufferUsages)
+      .expand('_bufferUsageValid', p => [p.bufferUsage === kRequiredBufferUsage[p.copyType]])
+      .filter(p => p._textureUsageValid || p._bufferUsageValid)
+  )
+  .fn(async t => {
+    const { copyType, textureUsage, _textureUsageValid, bufferUsage, _bufferUsageValid } = t.params;
+
+    const texture = t.device.createTexture({
+      size: { width: 16, height: 16 },
+      format: 'rgba8unorm',
+      usage: textureUsage,
+    });
+
+    const uploadBufferSize = 32;
+    const buffer = t.device.createBuffer({
+      size: uploadBufferSize,
+      usage: bufferUsage,
+    });
+
+    const textureSize = { width: 1, height: 1, depthOrArrayLayers: 1 };
+
+    const isSuccess = _textureUsageValid && _bufferUsageValid;
     if (copyType === 'CopyB2T') {
       t.testCopyBufferToTexture({ buffer }, { texture }, textureSize, isSuccess);
     } else if (copyType === 'CopyT2B') {


### PR DESCRIPTION
The specification says that srcTexture used by copyTextureToBuffer
should contain COPY_SRC, and destination.buffer.usage should contain
COPY_DST. On the other hand, the texture and the buffer used by
copyBufferToTexture also should contain COPY_DST and COPY_SRC
for the source's buffer and destination's texture respectively.

This PR adds a new test to ensure that a validation error is
generated if copyTextureToBuffer and copyBufferToTexture don't
use proper [texture|buffer] usages.

Issue: 1799

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
