### PR TITLE
Add RENDER_ATTACHMENT usage when creating multisampled textures

### DIFF
--- a/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
@@ -324,11 +324,17 @@ g.test('sample_count')
   )
   .fn(async t => {
     const { sampleCount, copyType } = t.params;
+
+    let usage = GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST;
+    // WebGPU SPEC requires multisampled textures must have RENDER_ATTACHMENT usage.
+    if (sampleCount > 1) {
+      usage |= GPUTextureUsage.RENDER_ATTACHMENT;
+    }
     const texture = t.device.createTexture({
       size: { width: 16, height: 16 },
       sampleCount,
       format: 'bgra8unorm',
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+      usage,
     });
 
     const uploadBufferSize = 32;


### PR DESCRIPTION
This patch adds the RENDER_ATTACHMENT usage when creating multisampled
textures in validation,image_copy,buffer_texture_copies:sample_count:*
tests as WebGPU SPEC requires RENDER_ATTACHMENT usage must be specified
when we create a multisampled texture.




Issue: #1805

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
