### PR TITLE
Use trackForCleanup() for dst texture in copyToTexture cases

### DIFF
--- a/src/webgpu/util/copy_to_texture.ts
+++ b/src/webgpu/util/copy_to_texture.ts
@@ -89,5 +89,6 @@ export class CopyToTextureUtils extends GPUTest {
       texelCompareOptions
     );
     this.eventualExpectOK(resultPromise);
+    this.trackForCleanup(dstTextureCopyView.texture);
   }
 }


### PR DESCRIPTION
Use trackForCleanup() for dst texture to destroy it explicitly.
The texture doesn't rely on GC to release helps make flaky issue
to a consistent failure one.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
