### PR TITLE
Add `smoothstep` F32 Tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -48,6 +48,7 @@ import {
   signInterval,
   sinInterval,
   sinhInterval,
+  smoothStepInterval,
   sqrtInterval,
   stepInterval,
   subtractionInterval,
@@ -2377,6 +2378,60 @@ g.test('mixPreciseInterval')
     t.expect(
       objectEquals(expected, got),
       `mixPreciseInterval(${x}, ${y}, ${z}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('smoothStepInterval')
+  .paramsSubcasesOnly<TernaryToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+      // form due to the inherited nature of the errors.
+      // Normals
+      { input: [0, 1, 0], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, 1, 1], expected: [hexToF32(0x3f7ffffa), hexToF32(0x3f800003)] },  // ~1
+      { input: [0, 1, 10], expected: [1] },
+      { input: [0, 1, -10], expected: [0] },
+      { input: [0, 2, 1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
+      { input: [0, 2, 0.5], expected: [hexToF32(0x3e1ffffb), hexToF32(0x3e200007)] },  // ~0.15625...
+      { input: [2, 0, 1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
+      { input: [2, 0, 1.5], expected: [hexToF32(0x3e1ffffb), hexToF32(0x3e200007)] },  // ~0.15625...
+      { input: [0, 100, 50], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
+      { input: [0, 100, 25], expected: [hexToF32(0x3e1ffffb), hexToF32(0x3e200007)] },  // ~0.15625...
+      { input: [0, -2, -1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
+      { input: [0, -2, -0.5], expected: [hexToF32(0x3e1ffffb), hexToF32(0x3e200007)] },  // ~0.15625...
+
+      // Subnormals
+      { input: [0, 2, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, 2, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, 2, kValue.f32.subnormal.negative.max], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, 2, kValue.f32.subnormal.negative.min], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [kValue.f32.subnormal.positive.max, 2, 1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
+      { input: [kValue.f32.subnormal.positive.min, 2, 1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
+      { input: [kValue.f32.subnormal.negative.max, 2, 1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
+      { input: [kValue.f32.subnormal.negative.min, 2, 1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
+      { input: [0, kValue.f32.subnormal.positive.max, 1], expected: kAny },
+      { input: [0, kValue.f32.subnormal.positive.min, 1], expected: kAny },
+      { input: [0, kValue.f32.subnormal.negative.max, 1], expected: kAny },
+      { input: [0, kValue.f32.subnormal.negative.min, 1], expected: kAny },
+
+      // Infinities
+      { input: [0, 2, Number.POSITIVE_INFINITY], expected: kAny },
+      { input: [0, 2, Number.NEGATIVE_INFINITY], expected: kAny },
+      { input: [Number.POSITIVE_INFINITY, 2, 1], expected: kAny },
+      { input: [Number.NEGATIVE_INFINITY, 2, 1], expected: kAny },
+      { input: [0, Number.POSITIVE_INFINITY, 1], expected: kAny },
+      { input: [0, Number.NEGATIVE_INFINITY, 1], expected: kAny },
+    ]
+  )
+  .fn(t => {
+    const [low, high, x] = t.params.input;
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = smoothStepInterval(low, high, x);
+    t.expect(
+      objectEquals(expected, got),
+      `smoothStepInterval(${low}, ${high}, ${x}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -147,6 +147,7 @@ g.test('f32')
       return makeTernaryToF32IntervalCase(x, y, z, ...clampIntervals);
     };
 
+    // Using sparseF32Range since this will generate N^3 test cases
     const values = sparseF32Range();
     const cases: Array<Case> = [];
     values.forEach(x => {

--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -11,7 +11,12 @@ For scalar T, the result is t * t * (3.0 - 2.0 * t), where t = clamp((x - low) /
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { smoothStepInterval } from '../../../../../util/f32_interval.js';
+import { sparseF32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeTernaryToF32IntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -29,7 +34,24 @@ g.test('f32')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const makeCase = (x: number, y: number, z: number): Case => {
+      return makeTernaryToF32IntervalCase(x, y, z, smoothStepInterval);
+    };
+
+    // Using sparseF32Range since this will generate N^3 test cases
+    const values = sparseF32Range();
+    const cases: Array<Case> = [];
+    values.forEach(x => {
+      values.forEach(y => {
+        values.forEach(z => {
+          cases.push(makeCase(x, y, z));
+        });
+      });
+    });
+
+    await run(t, builtin('smoothstep'), [TypeF32, TypeF32, TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')


### PR DESCRIPTION
Issue #1238

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
