### PR TITLE
Make `make*ToF32IntervalCase`s more idiomatic

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -546,10 +546,8 @@ function packScalarsToVector(
  */
 export function makeUnaryToF32IntervalCase(param: number, ...ops: PointToInterval[]): Case {
   param = quantizeToF32(param);
-  const intervals: Array<F32Interval> = new Array<F32Interval>();
-  for (const op of ops) {
-    intervals.push(op(param));
-  }
+
+  const intervals = ops.map(o => o(param));
   return { input: [f32(param)], expected: anyOf(...intervals) };
 }
 
@@ -567,10 +565,8 @@ export function makeBinaryToF32IntervalCase(
 ): Case {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
-  const intervals: Array<F32Interval> = new Array<F32Interval>();
-  for (const op of ops) {
-    intervals.push(op(param0, param1));
-  }
+
+  const intervals = ops.map(o => o(param0, param1));
   return { input: [f32(param0), f32(param1)], expected: anyOf(...intervals) };
 }
 
@@ -592,10 +588,8 @@ export function makeTernaryToF32IntervalCase(
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
   param2 = quantizeToF32(param2);
-  const intervals: Array<F32Interval> = new Array<F32Interval>();
-  for (const op of ops) {
-    intervals.push(op(param0, param1, param2));
-  }
+
+  const intervals = ops.map(o => o(param0, param1, param2));
   return {
     input: [f32(param0), f32(param1), f32(param2)],
     expected: anyOf(...intervals),


### PR DESCRIPTION
These can iterations can be simplified into single-line maps, which gives the compiler the 
opportunity to optimize the allocation and is more readable.

Issue #1747

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
