### PR TITLE
Fix a wrong bit operation to decide the validation in indirect_dispatch_buffer,usage

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -240,12 +240,11 @@ g.test('indirect_dispatch_buffer,usage')
     });
     t.trackForCleanup(buffer);
 
-    const isValid = GPUBufferUsage.INDIRECT | bufferUsage;
+    const success = (GPUBufferUsage.INDIRECT & bufferUsage) !== 0;
 
-    const { encoder } = t.createEncoder('compute pass');
+    const { encoder, validateFinish } = t.createEncoder('compute pass');
     encoder.setPipeline(pipeline);
 
-    t.expectValidationError(() => {
-      encoder.dispatchWorkgroupsIndirect(buffer, 0);
-    }, !isValid);
+    encoder.dispatchWorkgroupsIndirect(buffer, 0);
+    validateFinish(success);
   });


### PR DESCRIPTION
The indirect_dispatch_buffer,usage test has been deciding the validation of
the buffer usage through OR operator between INDIRECT and |bufferUsage|.
The operation has decided that all usages are valid and it's not the purpose
of the test. So this PR replaces `|` operator with `&` operator to fix
the problem.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
