### PR TITLE
test ~all cases of pipeline_output_targets,blend

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -254,59 +254,14 @@ g.test('pipeline_output_targets,blend')
     u
       .combine('isAsync', [false, true])
       .combine('format', ['r8unorm', 'rg8unorm', 'rgba8unorm', 'bgra8unorm'] as const)
-      .beginSubcases()
       .combine('componentCount', [1, 2, 3, 4])
+      .beginSubcases()
+      // The default srcFactor and dstFactor are 'one' and 'zero'. Override just one at a time.
       .combineWithParams([
-        // extra requirement does not apply
-        {
-          colorSrcFactor: 'one',
-          colorDstFactor: 'zero',
-          alphaSrcFactor: 'zero',
-          alphaDstFactor: 'zero',
-        },
-        {
-          colorSrcFactor: 'dst-alpha',
-          colorDstFactor: 'zero',
-          alphaSrcFactor: 'zero',
-          alphaDstFactor: 'zero',
-        },
-        // extra requirement applies, fragment output must be vec4 (contain alpha channel)
-        {
-          colorSrcFactor: 'src-alpha',
-          colorDstFactor: 'one',
-          alphaSrcFactor: 'zero',
-          alphaDstFactor: 'zero',
-        },
-        {
-          colorSrcFactor: 'one',
-          colorDstFactor: 'one-minus-src-alpha',
-          alphaSrcFactor: 'zero',
-          alphaDstFactor: 'zero',
-        },
-        {
-          colorSrcFactor: 'src-alpha-saturated',
-          colorDstFactor: 'one',
-          alphaSrcFactor: 'zero',
-          alphaDstFactor: 'zero',
-        },
-        {
-          colorSrcFactor: 'one',
-          colorDstFactor: 'zero',
-          alphaSrcFactor: 'one',
-          alphaDstFactor: 'zero',
-        },
-        {
-          colorSrcFactor: 'one',
-          colorDstFactor: 'zero',
-          alphaSrcFactor: 'zero',
-          alphaDstFactor: 'src',
-        },
-        {
-          colorSrcFactor: 'one',
-          colorDstFactor: 'zero',
-          alphaSrcFactor: 'zero',
-          alphaDstFactor: 'src-alpha',
-        },
+        ...u.combine('colorSrcFactor', kBlendFactors),
+        ...u.combine('colorDstFactor', kBlendFactors),
+        ...u.combine('alphaSrcFactor', kBlendFactors),
+        ...u.combine('alphaDstFactor', kBlendFactors),
       ] as const)
   )
   .beforeAllSubcases(t => {
@@ -332,16 +287,8 @@ g.test('pipeline_output_targets,blend')
         {
           format,
           blend: {
-            color: {
-              srcFactor: colorSrcFactor,
-              dstFactor: colorDstFactor,
-              operation: 'add',
-            },
-            alpha: {
-              srcFactor: alphaSrcFactor,
-              dstFactor: alphaDstFactor,
-              operation: 'add',
-            },
+            color: { srcFactor: colorSrcFactor, dstFactor: colorDstFactor },
+            alpha: { srcFactor: alphaSrcFactor, dstFactor: alphaDstFactor },
           },
         },
       ],
@@ -351,7 +298,7 @@ g.test('pipeline_output_targets,blend')
     });
 
     const colorBlendReadsSrcAlpha =
-      colorSrcFactor.includes('src-alpha') || colorDstFactor.includes('src-alpha');
+      colorSrcFactor?.includes('src-alpha') || colorDstFactor?.includes('src-alpha');
     const meetsExtraBlendingRequirement = !colorBlendReadsSrcAlpha || componentCount === 4;
     const _success =
       info.sampleType === sampleType &&


### PR DESCRIPTION
Just adds more cases to the pipeline_output_targets,blend test.

Passes in Chromium.

Issue: followup to #676

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
