### PR TITLE
Update 'buffer,usage' test in createBindGroup.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -12,6 +12,7 @@ import {
   bufferBindingEntries,
   bufferBindingTypeInfo,
   kBindableResources,
+  kBufferBindingTypes,
   kBufferUsages,
   kTextureUsages,
   kTextureViewDimensions,
@@ -748,14 +749,17 @@ g.test('storage_texture,mip_level_count')
 g.test('buffer,usage')
   .desc(
     `
-    Test that the buffer usage contains 'uniform' if the BindGroup entry defines
-    buffer and it's type is 'uniform'.
+    Test that the buffer usage contains 'UNIFORM' if the BindGroup entry defines buffer and it's
+    type is 'uniform', and the buffer usage contains 'STORAGE' if the BindGroup entry's buffer type
+    is 'storage'|read-only-storage'.
   `
   )
   .params(u =>
     u //
+      .combine('type', kBufferBindingTypes)
       // If usage0 and usage1 are the same, the usage being test is a single usage. Otherwise, it's
       // a combined usage.
+      .beginSubcases()
       .combine('usage0', kBufferUsages)
       .combine('usage1', kBufferUsages)
       .unless(
@@ -765,7 +769,7 @@ g.test('buffer,usage')
       )
   )
   .fn(async t => {
-    const { usage0, usage1 } = t.params;
+    const { type, usage0, usage1 } = t.params;
 
     const usage = usage0 | usage1;
 
@@ -774,7 +778,7 @@ g.test('buffer,usage')
         {
           binding: 0,
           visibility: GPUShaderStage.COMPUTE,
-          buffer: { type: 'uniform' },
+          buffer: { type },
         },
       ],
     });
@@ -784,7 +788,12 @@ g.test('buffer,usage')
       usage,
     });
 
-    const isValid = GPUBufferUsage.UNIFORM & usage;
+    let isValid = false;
+    if (type === 'uniform') {
+      isValid = GPUBufferUsage.UNIFORM & usage ? true : false;
+    } else if (type === 'storage' || type === 'read-only-storage') {
+      isValid = GPUBufferUsage.STORAGE & usage ? true : false;
+    }
 
     t.expectValidationError(() => {
       t.device.createBindGroup({


### PR DESCRIPTION
This PR updates the buffer,usage test to handle the case that the buffer's
type is `storage` or `read-only-storage`. In such cases, the usage should
be STORAGE.

Issue: #884

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
