### PR TITLE
Add 'buffer,resource_binding_size' to createBindGroup.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -858,3 +858,66 @@ g.test('buffer,resource_offset')
       });
     }, !isValid);
   });
+
+g.test('buffer,resource_binding_size')
+  .desc(
+    `
+    Test that the buffer binding size of the BindGroup entry is equal to or less than limits.
+    'maxUniformBufferBindingSize|maxStorageBufferBindingSize' if the BindGroup entry defines
+    buffer and the buffer type is 'uniform|storage|read-only-storage'.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('type', kBufferBindingTypes)
+      .beginSubcases()
+      // Test a size of 1 to ensure there's no alignment requirement,
+      // then values just within and just above the limit.
+      .expand('bindingSize', ({ type }) =>
+        type === 'uniform'
+          ? [
+              1,
+              kLimitInfo.maxUniformBufferBindingSize.default,
+              kLimitInfo.maxUniformBufferBindingSize.default + 1,
+            ]
+          : [
+              1,
+              kLimitInfo.maxStorageBufferBindingSize.default,
+              kLimitInfo.maxStorageBufferBindingSize.default + 1,
+            ]
+      )
+  )
+  .fn(async t => {
+    const { type, bindingSize } = t.params;
+
+    const bindGroupLayout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type },
+        },
+      ],
+    });
+
+    let usage, isValid;
+    if (type === 'uniform') {
+      usage = GPUBufferUsage.UNIFORM;
+      isValid = bindingSize <= kLimitInfo.maxUniformBufferBindingSize.default;
+    } else {
+      usage = GPUBufferUsage.STORAGE;
+      isValid = bindingSize <= kLimitInfo.maxStorageBufferBindingSize.default;
+    }
+
+    const buffer = t.device.createBuffer({
+      size: kLimitInfo.maxStorageBufferBindingSize.default,
+      usage,
+    });
+
+    t.expectValidationError(() => {
+      t.device.createBindGroup({
+        entries: [{ binding: 0, resource: { buffer, size: bindingSize } }],
+        layout: bindGroupLayout,
+      });
+    }, !isValid);
+  });


### PR DESCRIPTION
The specification says that the resource binding size should be equal to or less than
limits.'maxUniformBufferBindingSize|maxStorageBufferBindingSize' if the BindGroup
entry defines buffer and the buffer type is 'uniform|storage|read-only-storage'.

So this PR adds a test to check if a validation error is generated if the binding
size is greater than limits.'maxUniformBufferBindingSize|maxStorageBufferBindingSize'.

Issue: #884

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
