### PR TITLE
Add a 'storage_texture,format' test to createBindGroup.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -11,10 +11,12 @@ import {
   bindingTypeInfo,
   bufferBindingEntries,
   bufferBindingTypeInfo,
+  kAllTextureFormats,
   kBindableResources,
   kBufferBindingTypes,
   kBufferUsages,
   kLimitInfo,
+  kTextureFormatInfo,
   kTextureUsages,
   kTextureViewDimensions,
   sampledAndStorageBindingEntries,
@@ -31,6 +33,8 @@ function clone<T extends GPUTextureDescriptor>(descriptor: T): T {
 }
 
 export const g = makeTestGroup(ValidationTest);
+
+const kStorageTextureFormats = kAllTextureFormats.filter(f => kTextureFormatInfo[f].storage);
 
 g.test('binding_count_mismatch')
   .desc('Test that the number of entries must match the number of entries in the BindGroupLayout.')
@@ -745,6 +749,47 @@ g.test('storage_texture,mip_level_count')
         layout: bindGroupLayout,
       });
     }, mipLevelCount !== 1);
+  });
+
+g.test('storage_texture,format')
+  .desc(
+    `
+    Test that the format of the storage texture is equal to resource's descriptor format if the
+    BindGroup entry defines storageTexture.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('storageTextureFormat', kStorageTextureFormats)
+      .combine('resourceFormat', kStorageTextureFormats)
+  )
+  .fn(async t => {
+    const { storageTextureFormat, resourceFormat } = t.params;
+
+    const bindGroupLayout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          storageTexture: { access: 'write-only', format: storageTextureFormat },
+        },
+      ],
+    });
+
+    const texture = t.device.createTexture({
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
+      format: resourceFormat,
+      usage: GPUTextureUsage.STORAGE_BINDING,
+    });
+
+    const isValid = storageTextureFormat === resourceFormat;
+    const textureView = texture.createView({ format: resourceFormat });
+    t.expectValidationError(() => {
+      t.device.createBindGroup({
+        entries: [{ binding: 0, resource: textureView }],
+        layout: bindGroupLayout,
+      });
+    }, !isValid);
   });
 
 g.test('buffer,usage')


### PR DESCRIPTION
The specification says that the the format of the storage texture should be equal to resource's descriptor format if the BindGroup entry defines storageTexture.

So, this PR adds a new test to check if a validation error is generated if the storage texture's format is not equal to resource's descriptor format.

Issue: #884

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
