### PR TITLE
Add pipeline overridable constants validation tests

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -263,7 +263,7 @@ Tests calling createComputePipeline(Async) validation for compute workgroup_size
 g.test('overrides,identifier')
   .desc(
     `
-Tests calling createComputePipeline(Async) validation for override constants identifiers.
+Tests calling createComputePipeline(Async) validation for overridable constants identifiers.
 `
   )
   .params(u =>
@@ -275,11 +275,11 @@ Tests calling createComputePipeline(Async) validation for override constants ide
         { constants: { c0: 0, c1: 1 }, _success: true },
         { constants: { c9: 0 }, _success: false },
         { constants: { 1: 0 }, _success: true },
+        { constants: { c3: 0 }, _success: false }, // pipeline constant id is specified for c3
         { constants: { 2: 0 }, _success: false },
         { constants: { 1000: 0 }, _success: true },
         { constants: { 9999: 0 }, _success: false },
-        { constants: { c10: 0 }, _success: false },
-        { constants: { 1000: 0, c10: 0 }, _success: false },
+        { constants: { 1000: 0, c2: 0 }, _success: false },
       ])
   )
   .fn(async t => {
@@ -314,7 +314,7 @@ Tests calling createComputePipeline(Async) validation for override constants ide
 g.test('overrides,uninitialized')
   .desc(
     `
-Tests calling createComputePipeline(Async) validation for uninitialized override constants.
+Tests calling createComputePipeline(Async) validation for uninitialized overridable constants.
 `
   )
   .params(u =>
@@ -382,7 +382,7 @@ override z: u32 = 1u;
 g.test('overrides,workgroup_size')
   .desc(
     `
-Tests calling createComputePipeline(Async) validation for override constants used for workgroup size.
+Tests calling createComputePipeline(Async) validation for overridable constants used for workgroup size.
 `
   )
   .params(u =>
@@ -414,7 +414,7 @@ Tests calling createComputePipeline(Async) validation for override constants use
 g.test('overrides,workgroup_size,limits')
   .desc(
     `
-Tests calling createComputePipeline(Async) validation for override constants for workgroupSize exceeds device limits.
+Tests calling createComputePipeline(Async) validation for overridable constants for workgroupSize exceeds device limits.
 `
   )
   .params(u =>
@@ -465,7 +465,7 @@ Tests calling createComputePipeline(Async) validation for override constants for
 g.test('overrides,workgroup_size,limits,workgroup_storage_size')
   .desc(
     `
-Tests calling createComputePipeline(Async) validation for override constants for workgroupStorageSize exceeds device limits.
+Tests calling createComputePipeline(Async) validation for overridable constants for workgroupStorageSize exceeds device limits.
 `
   )
   .params(u =>

--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -290,18 +290,17 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
       compute: {
         module: t.device.createShaderModule({
           code: `
-          override c0: bool = true;      // type: bool
-          override c1: u32 = 0u;          // default override
-          @id(1000) override c2: u32 = 10u;  // default
-          @id(1) override c3: u32 = 11u;     // default
-          @compute @workgroup_size(1) fn main () {
-            // make sure the overridable constants are not optimized out
-            _ = u32(c0);
-            _ = u32(c1);
-            _ = u32(c2);
-            _ = u32(c3);
-          }
-          `,
+            override c0: bool = true;      // type: bool
+            override c1: u32 = 0u;          // default override
+            @id(1000) override c2: u32 = 10u;  // default
+            @id(1) override c3: u32 = 11u;     // default
+            @compute @workgroup_size(1) fn main () {
+              // make sure the overridable constants are not optimized out
+              _ = u32(c0);
+              _ = u32(c1);
+              _ = u32(c2);
+              _ = u32(c3);
+            }`,
         }),
         entryPoint: 'main',
         constants,
@@ -335,32 +334,31 @@ Tests calling createComputePipeline(Async) validation for uninitialized overrida
       compute: {
         module: t.device.createShaderModule({
           code: `
-          override c0: bool;              // type: bool
-          override c1: bool = false;      // default override
-          override c2: f32;               // type: float32
-          override c3: f32 = 0.0;         // default override
-          override c4: f32 = 4.0;         // default
-          override c5: i32;               // type: int32
-          override c6: i32 = 0;           // default override
-          override c7: i32 = 7;           // default
-          override c8: u32;               // type: uint32
-          override c9: u32 = 0u;          // default override
-          @id(1000) override c10: u32 = 10u;  // default
-          @compute @workgroup_size(1) fn main () {
-            // make sure the overridable constants are not optimized out
-            _ = u32(c0);
-            _ = u32(c1);
-            _ = u32(c2);
-            _ = u32(c3);
-            _ = u32(c4);
-            _ = u32(c5);
-            _ = u32(c6);
-            _ = u32(c7);
-            _ = u32(c8);
-            _ = u32(c9);
-            _ = u32(c10);
-          }
-          `,
+            override c0: bool;              // type: bool
+            override c1: bool = false;      // default override
+            override c2: f32;               // type: float32
+            override c3: f32 = 0.0;         // default override
+            override c4: f32 = 4.0;         // default
+            override c5: i32;               // type: int32
+            override c6: i32 = 0;           // default override
+            override c7: i32 = 7;           // default
+            override c8: u32;               // type: uint32
+            override c9: u32 = 0u;          // default override
+            @id(1000) override c10: u32 = 10u;  // default
+            @compute @workgroup_size(1) fn main () {
+              // make sure the overridable constants are not optimized out
+              _ = u32(c0);
+              _ = u32(c1);
+              _ = u32(c2);
+              _ = u32(c3);
+              _ = u32(c4);
+              _ = u32(c5);
+              _ = u32(c6);
+              _ = u32(c7);
+              _ = u32(c8);
+              _ = u32(c9);
+              _ = u32(c10);
+            }`,
         }),
         entryPoint: 'main',
         constants,
@@ -488,15 +486,14 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         compute: {
           module: t.device.createShaderModule({
             code: `
-override a: u32;
-override b: u32;
-${vec4Count <= 0 ? '' : 'var<workgroup> vec4_data: array<vec4<f32>, a>;'}
-${mat4Count <= 0 ? '' : 'var<workgroup> mat4_data: array<mat4x4<f32>, b>;'}
-@compute @workgroup_size(1) fn main() {
-  ${vec4Count <= 0 ? '' : '_ = vec4_data;'}
-  ${vec4Count <= 0 ? '' : '_ = mat4_data;'}
-}
-          `,
+              override a: u32;
+              override b: u32;
+              ${vec4Count <= 0 ? '' : 'var<workgroup> vec4_data: array<vec4<f32>, a>;'}
+              ${mat4Count <= 0 ? '' : 'var<workgroup> mat4_data: array<mat4x4<f32>, b>;'}
+              @compute @workgroup_size(1) fn main() {
+                ${vec4Count <= 0 ? '' : '_ = vec4_data;'}
+                ${vec4Count <= 0 ? '' : '_ = mat4_data;'}
+              }`,
           }),
           entryPoint: 'main',
           constants: {

--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -280,7 +280,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         { constants: { 1000: 0 }, _success: true },
         { constants: { 9999: 0 }, _success: false },
         { constants: { 1000: 0, c2: 0 }, _success: false },
-      ])
+      ] as { constants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(async t => {
     const { isAsync, constants, _success } = t.params;
@@ -324,7 +324,7 @@ Tests calling createComputePipeline(Async) validation for uninitialized overrida
         { constants: { c0: 0, c2: 0, c8: 0 }, _success: false }, // c5 is missing
         { constants: { c0: 0, c2: 0, c5: 0, c8: 0 }, _success: true },
         { constants: { c0: 0, c2: 0, c5: 0, c8: 0, c1: 0 }, _success: true },
-      ])
+      ] as { constants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(async t => {
     const { isAsync, constants, _success } = t.params;
@@ -390,7 +390,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         { constants: {}, _success: true },
         { constants: { x: 0, y: 0, z: 0 }, _success: false },
         { constants: { x: 16, y: 1, z: 1 }, _success: true },
-      ])
+      ] as { constants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(async t => {
     const { isAsync, constants, _success } = t.params;

--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -259,3 +259,257 @@ Tests calling createComputePipeline(Async) validation for compute workgroup_size
       size[2] <= t.device.limits.maxComputeWorkgroupSizeZ;
     t.doCreateComputePipelineTest(isAsync, _success, descriptor);
   });
+
+g.test('overrides,identifier')
+  .desc(
+    `
+Tests calling createComputePipeline(Async) validation for override constants identifiers.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { constants: {}, _success: true },
+        { constants: { c0: 0 }, _success: true },
+        { constants: { c0: 0, c1: 1 }, _success: true },
+        { constants: { c9: 0 }, _success: false },
+        { constants: { 1: 0 }, _success: true },
+        { constants: { 2: 0 }, _success: false },
+        { constants: { 1000: 0 }, _success: true },
+        { constants: { 9999: 0 }, _success: false },
+        { constants: { c10: 0 }, _success: false },
+        { constants: { 1000: 0, c10: 0 }, _success: false },
+      ])
+  )
+  .fn(async t => {
+    const { isAsync, constants, _success } = t.params;
+
+    const descriptor = {
+      layout: 'auto' as const,
+      compute: {
+        module: t.device.createShaderModule({
+          code: `
+          override c0: bool = true;      // type: bool
+          override c1: u32 = 0u;          // default override
+          @id(1000) override c2: u32 = 10u;  // default
+          @id(1) override c3: u32 = 11u;     // default
+          @compute @workgroup_size(1) fn main () {
+            // make sure the overridable constants are not optimized out
+            _ = u32(c0);
+            _ = u32(c1);
+            _ = u32(c2);
+            _ = u32(c3);
+          }
+          `,
+        }),
+        entryPoint: 'main',
+        constants,
+      },
+    };
+
+    t.doCreateComputePipelineTest(isAsync, _success, descriptor);
+  });
+
+g.test('overrides,uninitialized')
+  .desc(
+    `
+Tests calling createComputePipeline(Async) validation for uninitialized override constants.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { constants: {}, _success: false },
+        { constants: { c0: 0, c2: 0, c8: 0 }, _success: false }, // c5 is missing
+        { constants: { c0: 0, c2: 0, c5: 0, c8: 0 }, _success: true },
+        { constants: { c0: 0, c2: 0, c5: 0, c8: 0, c1: 0 }, _success: true },
+      ])
+  )
+  .fn(async t => {
+    const { isAsync, constants, _success } = t.params;
+
+    const descriptor = {
+      layout: 'auto' as const,
+      compute: {
+        module: t.device.createShaderModule({
+          code: `
+          override c0: bool;              // type: bool
+          override c1: bool = false;      // default override
+          override c2: f32;               // type: float32
+          override c3: f32 = 0.0;         // default override
+          override c4: f32 = 4.0;         // default
+          override c5: i32;               // type: int32
+          override c6: i32 = 0;           // default override
+          override c7: i32 = 7;           // default
+          override c8: u32;               // type: uint32
+          override c9: u32 = 0u;          // default override
+          @id(1000) override c10: u32 = 10u;  // default
+          @compute @workgroup_size(1) fn main () {
+            // make sure the overridable constants are not optimized out
+            _ = u32(c0);
+            _ = u32(c1);
+            _ = u32(c2);
+            _ = u32(c3);
+            _ = u32(c4);
+            _ = u32(c5);
+            _ = u32(c6);
+            _ = u32(c7);
+            _ = u32(c8);
+            _ = u32(c9);
+            _ = u32(c10);
+          }
+          `,
+        }),
+        entryPoint: 'main',
+        constants,
+      },
+    };
+
+    t.doCreateComputePipelineTest(isAsync, _success, descriptor);
+  });
+
+const kOverridesWorkgroupSizeShaderCode = `
+override x: u32 = 1u;
+override y: u32 = 1u;
+override z: u32 = 1u;
+@compute @workgroup_size(x, y, z) fn main () {
+  _ = 0u;
+}
+`;
+
+g.test('overrides,workgroup_size')
+  .desc(
+    `
+Tests calling createComputePipeline(Async) validation for override constants used for workgroup size.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { constants: {}, _success: true },
+        { constants: { x: 0, y: 0, z: 0 }, _success: false },
+        { constants: { x: 16, y: 1, z: 1 }, _success: true },
+      ])
+  )
+  .fn(async t => {
+    const { isAsync, constants, _success } = t.params;
+
+    const descriptor = {
+      layout: 'auto' as const,
+      compute: {
+        module: t.device.createShaderModule({
+          code: kOverridesWorkgroupSizeShaderCode,
+        }),
+        entryPoint: 'main',
+        constants,
+      },
+    };
+
+    t.doCreateComputePipelineTest(isAsync, _success, descriptor);
+  });
+
+g.test('overrides,workgroup_size,limits')
+  .desc(
+    `
+Tests calling createComputePipeline(Async) validation for override constants for workgroupSize exceeds device limits.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+  )
+  .fn(async t => {
+    const { isAsync } = t.params;
+
+    const limits = t.device.limits;
+
+    const testFn = (x: number, y: number, z: number, _success: boolean) => {
+      const descriptor = {
+        layout: 'auto' as const,
+        compute: {
+          module: t.device.createShaderModule({
+            code: kOverridesWorkgroupSizeShaderCode,
+          }),
+          entryPoint: 'main',
+          constants: {
+            x,
+            y,
+            z,
+          },
+        },
+      };
+
+      t.doCreateComputePipelineTest(isAsync, _success, descriptor);
+    };
+
+    testFn(limits.maxComputeWorkgroupSizeX, 1, 1, true);
+    testFn(limits.maxComputeWorkgroupSizeX + 1, 1, 1, false);
+    testFn(1, limits.maxComputeWorkgroupSizeY, 1, true);
+    testFn(1, limits.maxComputeWorkgroupSizeY + 1, 1, false);
+    testFn(1, 1, limits.maxComputeWorkgroupSizeZ, true);
+    testFn(1, 1, limits.maxComputeWorkgroupSizeZ + 1, false);
+    testFn(
+      limits.maxComputeWorkgroupSizeX,
+      limits.maxComputeWorkgroupSizeY,
+      limits.maxComputeWorkgroupSizeZ,
+      limits.maxComputeWorkgroupSizeX *
+        limits.maxComputeWorkgroupSizeY *
+        limits.maxComputeWorkgroupSizeZ <=
+        limits.maxComputeInvocationsPerWorkgroup
+    );
+  });
+
+g.test('overrides,workgroup_size,limits,workgroup_storage_size')
+  .desc(
+    `
+Tests calling createComputePipeline(Async) validation for override constants for workgroupStorageSize exceeds device limits.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+  )
+  .fn(async t => {
+    const { isAsync } = t.params;
+
+    const limits = t.device.limits;
+
+    const kVec4Size = 16;
+    const maxVec4Count = limits.maxComputeWorkgroupStorageSize / kVec4Size;
+    const kMat4Size = 64;
+    const maxMat4Count = limits.maxComputeWorkgroupStorageSize / kMat4Size;
+
+    const testFn = (vec4Count: number, mat4Count: number, _success: boolean) => {
+      const descriptor = {
+        layout: 'auto' as const,
+        compute: {
+          module: t.device.createShaderModule({
+            code: `
+override a: u32;
+override b: u32;
+${vec4Count <= 0 ? '' : 'var<workgroup> vec4_data: array<vec4<f32>, a>;'}
+${mat4Count <= 0 ? '' : 'var<workgroup> mat4_data: array<mat4x4<f32>, b>;'}
+@compute @workgroup_size(1) fn main() {
+  ${vec4Count <= 0 ? '' : '_ = vec4_data;'}
+  ${vec4Count <= 0 ? '' : '_ = mat4_data;'}
+}
+          `,
+          }),
+          entryPoint: 'main',
+          constants: {
+            a: vec4Count,
+            b: mat4Count,
+          },
+        },
+      };
+
+      t.doCreateComputePipelineTest(isAsync, _success, descriptor);
+    };
+
+    testFn(1, 1, true);
+    testFn(maxVec4Count + 1, 0, false);
+    testFn(0, maxMat4Count + 1, false);
+  });

--- a/src/webgpu/api/validation/render_pipeline/common.ts
+++ b/src/webgpu/api/validation/render_pipeline/common.ts
@@ -16,6 +16,7 @@ export class CreateRenderPipelineValidationTest extends ValidationTest {
       depthStencil?: GPUDepthStencilState;
       fragmentShaderCode?: string;
       noFragment?: boolean;
+      fragmentConstants?: Record<string, GPUPipelineConstantValue>;
     } = {}
   ): GPURenderPipelineDescriptor {
     const defaultTargets: GPUColorTargetState[] = [{ format: 'rgba8unorm' }];
@@ -34,6 +35,7 @@ export class CreateRenderPipelineValidationTest extends ValidationTest {
         },
       ]),
       noFragment = false,
+      fragmentConstants = {},
     } = options;
 
     return {
@@ -51,6 +53,7 @@ export class CreateRenderPipelineValidationTest extends ValidationTest {
             }),
             entryPoint: 'main',
             targets,
+            constants: fragmentConstants,
           },
       layout: this.getPipelineLayout(),
       primitive,

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -1,0 +1,189 @@
+export const description = `
+This test dedicatedly tests validation of Pipeline overridable constants of createRenderPipeline.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+
+import { CreateRenderPipelineValidationTest } from './common.js';
+
+export const g = makeTestGroup(CreateRenderPipelineValidationTest);
+
+g.test('identifier,vertex')
+  .desc(
+    `
+Tests calling createComputePipeline(Async) validation for overridable constants identifiers in vertex state.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { vertexConstants: {}, _success: true },
+        { vertexConstants: { x: 1, y: 1 }, _success: true },
+        { vertexConstants: { x: 1, y: 1, 1: 1, 1000: 1 }, _success: true },
+        { vertexConstants: { xxx: 1 }, _success: false },
+        { vertexConstants: { 1: 1 }, _success: true },
+        { vertexConstants: { 2: 1 }, _success: false },
+        { vertexConstants: { z: 1 }, _success: false }, // pipeline constant id is specified for z
+        { vertexConstants: { w: 1 }, _success: false }, // pipeline constant id is specified for w
+        { vertexConstants: { 1: 1, z: 1 }, _success: false }, // pipeline constant id is specified for z
+      ])
+  )
+  .fn(async t => {
+    const { isAsync, vertexConstants, _success } = t.params;
+
+    const descriptor = {
+      layout: 'auto',
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+              override x: f32 = 0.0;
+              override y: f32 = 0.0;
+              @id(1) override z: f32 = 0.0;
+              @id(1000) override w: f32 = 1.0;
+              @vertex fn main() -> @builtin(position) vec4<f32> {
+                return vec4<f32>(x, y, z, w);
+              }`,
+        }),
+        entryPoint: 'main',
+        constants: vertexConstants,
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `@fragment fn main() -> @location(0) vec4<f32> {
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+    };
+
+    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+  });
+
+g.test('identifier,fragment')
+  .desc(
+    `
+Tests calling createComputePipeline(Async) validation for overridable constants identifiers in fragment state.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { fragmentConstants: {}, _success: true },
+        { fragmentConstants: { r: 1, g: 1 }, _success: true },
+        { fragmentConstants: { r: 1, g: 1, 1: 1, 1000: 1 }, _success: true },
+        { fragmentConstants: { xxx: 1 }, _success: false },
+        { fragmentConstants: { 1: 1 }, _success: true },
+        { fragmentConstants: { 2: 1 }, _success: false },
+        { fragmentConstants: { b: 1 }, _success: false }, // pipeline constant id is specified for b
+        { fragmentConstants: { a: 1 }, _success: false }, // pipeline constant id is specified for a
+        { fragmentConstants: { 1: 1, b: 1 }, _success: false }, // pipeline constant id is specified for a
+      ])
+  )
+  .fn(async t => {
+    const { isAsync, fragmentConstants, _success } = t.params;
+
+    const descriptor = t.getDescriptor({
+      fragmentShaderCode: `
+        override r: f32 = 0.0;
+        override g: f32 = 0.0;
+        @id(1) override b: f32 = 0.0;
+        @id(1000) override a: f32 = 0.0;
+        @fragment fn main()
+            -> @location(0) vec4<f32> {
+            return vec4<f32>(r, g, b, a);
+        }
+          `,
+      fragmentConstants,
+    });
+
+    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+  });
+
+g.test('uninitialized,vertex')
+  .desc(
+    `
+Tests calling createComputePipeline(Async) validation for uninitialized overridable constants in vertex state.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { vertexConstants: {}, _success: false },
+        { vertexConstants: { x: 1, y: 1 }, _success: false }, // z is missing
+        { vertexConstants: { x: 1, z: 1 }, _success: true },
+        { vertexConstants: { x: 1, y: 1, z: 1, w: 1 }, _success: true },
+      ])
+  )
+  .fn(async t => {
+    const { isAsync, vertexConstants, _success } = t.params;
+
+    const descriptor = {
+      layout: 'auto',
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+              override x: f32;
+              override y: f32 = 0.0;
+              override z: f32;
+              override w: f32 = 1.0;
+              @vertex fn main() -> @builtin(position) vec4<f32> {
+                return vec4<f32>(x, y, z, w);
+              }`,
+        }),
+        entryPoint: 'main',
+        constants: vertexConstants,
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `@fragment fn main() -> @location(0) vec4<f32> {
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+    };
+
+    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+  });
+
+g.test('uninitialized,fragment')
+  .desc(
+    `
+Tests calling createComputePipeline(Async) validation for uninitialized overridable constants in fragment state.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { fragmentConstants: {}, _success: false },
+        { fragmentConstants: { r: 1, g: 1 }, _success: false }, // b is missing
+        { fragmentConstants: { r: 1, b: 1 }, _success: true },
+        { fragmentConstants: { r: 1, g: 1, b: 1, a: 1 }, _success: true },
+      ])
+  )
+  .fn(async t => {
+    const { isAsync, fragmentConstants, _success } = t.params;
+
+    const descriptor = t.getDescriptor({
+      fragmentShaderCode: `
+        override r: f32;
+        override g: f32 = 0.0;
+        override b: f32;
+        override a: f32 = 0.0;
+        @fragment fn main()
+            -> @location(0) vec4<f32> {
+            return vec4<f32>(r, g, b, a);
+        }
+          `,
+      fragmentConstants,
+    });
+
+    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+  });

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -27,12 +27,12 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         { vertexConstants: { z: 1 }, _success: false }, // pipeline constant id is specified for z
         { vertexConstants: { w: 1 }, _success: false }, // pipeline constant id is specified for w
         { vertexConstants: { 1: 1, z: 1 }, _success: false }, // pipeline constant id is specified for z
-      ])
+      ] as { vertexConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(async t => {
     const { isAsync, vertexConstants, _success } = t.params;
 
-    const descriptor = {
+    t.doCreateRenderPipelineTest(isAsync, _success, {
       layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
@@ -57,9 +57,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm' }],
       },
-    };
-
-    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+    });
   });
 
 g.test('identifier,fragment')
@@ -81,7 +79,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         { fragmentConstants: { b: 1 }, _success: false }, // pipeline constant id is specified for b
         { fragmentConstants: { a: 1 }, _success: false }, // pipeline constant id is specified for a
         { fragmentConstants: { 1: 1, b: 1 }, _success: false }, // pipeline constant id is specified for b
-      ])
+      ] as { fragmentConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(async t => {
     const { isAsync, fragmentConstants, _success } = t.params;
@@ -116,12 +114,12 @@ Tests calling createComputePipeline(Async) validation for uninitialized overrida
         { vertexConstants: { x: 1, y: 1 }, _success: false }, // z is missing
         { vertexConstants: { x: 1, z: 1 }, _success: true },
         { vertexConstants: { x: 1, y: 1, z: 1, w: 1 }, _success: true },
-      ])
+      ] as { vertexConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(async t => {
     const { isAsync, vertexConstants, _success } = t.params;
 
-    const descriptor = {
+    t.doCreateRenderPipelineTest(isAsync, _success, {
       layout: 'auto',
       vertex: {
         module: t.device.createShaderModule({
@@ -146,9 +144,7 @@ Tests calling createComputePipeline(Async) validation for uninitialized overrida
         entryPoint: 'main',
         targets: [{ format: 'rgba8unorm' }],
       },
-    };
-
-    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+    });
   });
 
 g.test('uninitialized,fragment')
@@ -165,7 +161,7 @@ Tests calling createComputePipeline(Async) validation for uninitialized overrida
         { fragmentConstants: { r: 1, g: 1 }, _success: false }, // b is missing
         { fragmentConstants: { r: 1, b: 1 }, _success: true },
         { fragmentConstants: { r: 1, g: 1, b: 1, a: 1 }, _success: true },
-      ])
+      ] as { fragmentConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(async t => {
     const { isAsync, fragmentConstants, _success } = t.params;

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-This test dedicatedly tests validation of Pipeline overridable constants of createRenderPipeline.
+This test dedicatedly tests validation of pipeline overridable constants of createRenderPipeline.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -37,13 +37,13 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
       vertex: {
         module: t.device.createShaderModule({
           code: `
-              override x: f32 = 0.0;
-              override y: f32 = 0.0;
-              @id(1) override z: f32 = 0.0;
-              @id(1000) override w: f32 = 1.0;
-              @vertex fn main() -> @builtin(position) vec4<f32> {
-                return vec4<f32>(x, y, z, w);
-              }`,
+            override x: f32 = 0.0;
+            override y: f32 = 0.0;
+            @id(1) override z: f32 = 0.0;
+            @id(1000) override w: f32 = 1.0;
+            @vertex fn main() -> @builtin(position) vec4<f32> {
+              return vec4<f32>(x, y, z, w);
+            }`,
         }),
         entryPoint: 'main',
         constants: vertexConstants,
@@ -80,7 +80,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         { fragmentConstants: { 2: 1 }, _success: false },
         { fragmentConstants: { b: 1 }, _success: false }, // pipeline constant id is specified for b
         { fragmentConstants: { a: 1 }, _success: false }, // pipeline constant id is specified for a
-        { fragmentConstants: { 1: 1, b: 1 }, _success: false }, // pipeline constant id is specified for a
+        { fragmentConstants: { 1: 1, b: 1 }, _success: false }, // pipeline constant id is specified for b
       ])
   )
   .fn(async t => {
@@ -95,8 +95,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         @fragment fn main()
             -> @location(0) vec4<f32> {
             return vec4<f32>(r, g, b, a);
-        }
-          `,
+        }`,
       fragmentConstants,
     });
 
@@ -127,13 +126,13 @@ Tests calling createComputePipeline(Async) validation for uninitialized overrida
       vertex: {
         module: t.device.createShaderModule({
           code: `
-              override x: f32;
-              override y: f32 = 0.0;
-              override z: f32;
-              override w: f32 = 1.0;
-              @vertex fn main() -> @builtin(position) vec4<f32> {
-                return vec4<f32>(x, y, z, w);
-              }`,
+            override x: f32;
+            override y: f32 = 0.0;
+            override z: f32;
+            override w: f32 = 1.0;
+            @vertex fn main() -> @builtin(position) vec4<f32> {
+              return vec4<f32>(x, y, z, w);
+            }`,
         }),
         entryPoint: 'main',
         constants: vertexConstants,

--- a/src/webgpu/api/validation/shader_module/overrides.spec.ts
+++ b/src/webgpu/api/validation/shader_module/overrides.spec.ts
@@ -10,7 +10,7 @@ export const g = makeTestGroup(ValidationTest);
 g.test('id_conflict')
   .desc(
     `
-Tests that overrides explicit numeric identifier should not conflict.
+Tests that overrides' explicit numeric identifier should not conflict.
 `
   )
   .fn(async t => {
@@ -39,6 +39,56 @@ Tests that overrides explicit numeric identifier should not conflict.
   // make sure the overridable constants are not optimized out
   _ = c0;
   _ = c1;
+}
+          `,
+      });
+    }, true);
+  });
+
+g.test('name_conflict')
+  .desc(
+    `
+Tests that overrides' variable name should not conflict, regardless of their numeric identifiers.
+`
+  )
+  .fn(async t => {
+    t.expectValidationError(() => {
+      t.device.createShaderModule({
+        code: `
+override c0: u32;
+override c0: u32;
+
+@compute @workgroup_size(1) fn main() {
+  // make sure the overridable constants are not optimized out
+  _ = c0;
+}
+          `,
+      });
+    }, true);
+
+    t.expectValidationError(() => {
+      t.device.createShaderModule({
+        code: `
+@id(1) override c0: u32;
+override c0: u32;
+
+@compute @workgroup_size(1) fn main() {
+  // make sure the overridable constants are not optimized out
+  _ = c0;
+}
+          `,
+      });
+    }, true);
+
+    t.expectValidationError(() => {
+      t.device.createShaderModule({
+        code: `
+@id(1) override c0: u32;
+@id(2) override c0: u32;
+
+@compute @workgroup_size(1) fn main() {
+  // make sure the overridable constants are not optimized out
+  _ = c0;
 }
           `,
       });

--- a/src/webgpu/api/validation/shader_module/overrides.spec.ts
+++ b/src/webgpu/api/validation/shader_module/overrides.spec.ts
@@ -1,0 +1,46 @@
+export const description = `
+This tests overrides numeric identifiers should not conflict.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ValidationTest } from '../validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('id_conflict')
+  .desc(
+    `
+Tests that overrides explicit numeric identifier should not conflict.
+`
+  )
+  .fn(async t => {
+    t.expectValidationError(() => {
+      t.device.createShaderModule({
+        code: `
+@id(1234) override c0: u32;
+@id(4321) override c1: u32;
+
+@compute @workgroup_size(1) fn main() {
+  // make sure the overridable constants are not optimized out
+  _ = c0;
+  _ = c1;
+}
+          `,
+      });
+    }, false);
+
+    t.expectValidationError(() => {
+      t.device.createShaderModule({
+        code: `
+@id(1234) override c0: u32;
+@id(1234) override c1: u32;
+
+@compute @workgroup_size(1) fn main() {
+  // make sure the overridable constants are not optimized out
+  _ = c0;
+  _ = c1;
+}
+          `,
+      });
+    }, true);
+  });


### PR DESCRIPTION

Issue:  None

[tint:1660](https://crbug.com/tint/1660): `compute_pipeline.spec.ts: overrides,workgroup_size,limits,workgroup_storage_size` is known to fail in Chrome.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
