### PR TITLE
Fix f16 hex literal testcases of having suffix "h" without "p"

### DIFF
--- a/src/webgpu/shader/validation/parse/literal.spec.ts
+++ b/src/webgpu/shader/validation/parse/literal.spec.ts
@@ -150,7 +150,6 @@ const kF16 = new Set([
   '1.1e2h', // Exponent half no sign
   '1.1E+2h', // Exponent half, plus (uppercase E)
   '2.4e-2h', // Exponent half, negative
-  '0X3h', // Hexfloat half no exponent
   '0xep2h', // Hexfloat half lower case p
   '0xEp-2h', // Hexfloat uppcase hex value
   '0x3p+2h', // Hex float half positive exponent
@@ -197,6 +196,8 @@ const kAbstractFloat = new Set([
     '1.1e+h', // Missing exponent with sign
     '1.0e+999999h', // Too large
     '0x1.0p+999999h', // Too large hex
+    '0xf.h', // Having suffix "h" without "p" or "P"
+    '0x3h', // Having suffix "h" without "p" or "P"
   ]);
 
   g.test('abstract_float')


### PR DESCRIPTION
Spec requires that in hex float literal type suffix "h" and "f", if exist, must exist in the exponent suffix part with a leading "p" or "P". Otherwise, "f" would be interpreted as mantissa, and "h" shall result in an error.

Spec: https://gpuweb.github.io/gpuweb/wgsl/#literals:~:text=somewhere%20among%20them.-,Then%20an%20optional%20exponent%20suffix%20consisting%20of%3A,-p%20or%20P




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
