### PR TITLE
shader/execution: Add heartbeats to expression tests

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -1,3 +1,4 @@
+import { globalTestConfig } from '../../../../common/framework/test_config.js';
 import { assert } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { compare, Comparator, anyOf } from '../../../util/compare.js';
@@ -235,6 +236,9 @@ function submitBatch(
   pass.dispatchWorkgroups(1);
   pass.end();
 
+  // Heartbeat to ensure CTS runners know we're alive.
+  globalTestConfig.testHeartbeatCallback();
+
   t.queue.submit([encoder.finish()]);
 
   // Return a function that can check the results of the shader
@@ -263,6 +267,9 @@ function submitBatch(
 
       return errs.length > 0 ? new Error(errs.join('\n\n')) : undefined;
     };
+
+    // Heartbeat to ensure CTS runners know we're alive.
+    globalTestConfig.testHeartbeatCallback();
 
     t.expectGPUBufferValuesPassCheck(outputBuffer, checkExpectation, {
       type: Uint8Array,


### PR DESCRIPTION
These tests dispatch and check batches of cases, which can take substantial time on some targets. Add explicit heartbeats to the `submitBatch` logic, between batches, so the runner knows that stuff is still happening.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
