### PR TITLE
Add global option noRaceWithRejectOnTimeout

### DIFF
--- a/src/common/framework/test_config.ts
+++ b/src/common/framework/test_config.ts
@@ -1,9 +1,11 @@
 export type TestConfig = {
   maxSubcasesInFlight: number;
   testHeartbeatCallback: () => void;
+  noRaceWithRejectOnTimeout: boolean;
 };
 
 export const globalTestConfig: TestConfig = {
   maxSubcasesInFlight: 500,
   testHeartbeatCallback: () => {},
+  noRaceWithRejectOnTimeout: false,
 };

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -1,4 +1,5 @@
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
+import { globalTestConfig } from '../framework/test_config.js';
 import { Logger } from '../internal/logging/logger.js';
 
 import { keysOf } from './data_tables.js';
@@ -106,6 +107,9 @@ export function rejectOnTimeout(ms: number, msg: string): Promise<never> {
  * and otherwise passes the result through.
  */
 export function raceWithRejectOnTimeout<T>(p: Promise<T>, ms: number, msg: string): Promise<T> {
+  if (globalTestConfig.noRaceWithRejectOnTimeout) {
+    return p;
+  }
   // Setup a promise that will reject after `ms` milliseconds. We cancel this timeout when
   // `p` is finalized, so the JavaScript VM doesn't hang around waiting for the timer to
   // complete, once the test runner has finished executing the tests.


### PR DESCRIPTION
This is useful when a test harness has its own timeout mechanisms and would like to bypass the builtin CTS timeouts.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
