### PR TITLE
Update `atan2` F32 tests to account for atan based implementations

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1649,47 +1649,44 @@ g.test('atan2Interval')
   .paramsSubcasesOnly<BinaryToIntervalCase>(
     // prettier-ignore
     [
-      // Not all of the common cases for each of the quadrants are iterated here, b/c π is not precisely expressible as
-      // a f32, so fractions like 5* π/6 require special constants for each value. Positive x & y are tested using
-      // values that already have constants, and then the other quadrants are spot checked.
+      // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+      // form due to the inherited nature of the errors.
+
+      // The positive x & y quadrant is tested in more detail, and the other quadrants are spot checked that values are
+      // pointing in the right direction.
 
       // positive y, positive x
-      { input: [1, hexToF32(0x3fddb3d7)], expected: [minusOneULP(kValue.f32.positive.pi.sixth), kValue.f32.positive.pi.sixth] },  // x = √3
-      { input: [1, 1], expected: [minusOneULP(kValue.f32.positive.pi.quarter), kValue.f32.positive.pi.quarter] },
-      { input: [hexToF32(0x3fddb3d7), 1], expected: [minusOneULP(kValue.f32.positive.pi.third), kValue.f32.positive.pi.third] },  // y = √3
+      { input: [1, hexToF32(0x3fddb3d7)], expected: [hexToF64(0x3fe0bf51, 0xe0000000), hexToF64(0x3fe0c352, 0xa0000000)] },  // x = √3, expected = ~π/6
+      { input: [1, 1], expected: [hexToF64(0x3fe91ffb, 0x20000000), hexToF64(0x3fe923fb, 0xa0000000)] },  // expected = ~π/4
+      { input: [hexToF32(0x3fddb3d7), 1], expected: [hexToF64(0x3ff0bf52, 0x00000000), hexToF64(0x3ff0c352, 0x60000000)] },  // y = √3, expected = ~π/3
       { input: [Number.POSITIVE_INFINITY, 1], expected: kAny },
 
       // positive y, negative x
-      { input: [1, -1], expected: [minusOneULP(kValue.f32.positive.pi.three_quarters), kValue.f32.positive.pi.three_quarters] },
+      { input: [1, -1], expected: [hexToF64(0x4002d8fc, 0x60000000), hexToF64(0x4002d9fc, 0xa0000000)] },  // expected = ~3/4 * π
       { input: [Number.POSITIVE_INFINITY, -1], expected: kAny },
 
       // negative y, negative x
-      { input: [-1, -1], expected: [kValue.f32.negative.pi.three_quarters, plusOneULP(kValue.f32.negative.pi.three_quarters)] },
+      { input: [-1, -1], expected: [hexToF64(0xc002d9fc, 0xa0000000), hexToF64(0xc002d8fc, 0x60000000)] },  // expected = ~-3/4 * π
       { input: [Number.NEGATIVE_INFINITY, -1], expected: kAny },
 
       // negative y, positive x
-      { input: [-1, 1], expected: [kValue.f32.negative.pi.quarter, plusOneULP(kValue.f32.negative.pi.quarter)] },
+      { input: [-1, 1], expected: [hexToF64(0xbfe923fb, 0xa0000000), hexToF64(0xbfe91ffb, 0x20000000)] },  // expected = ~-π/4
       { input: [Number.NEGATIVE_INFINITY, 1], expected: kAny },
 
       // Discontinuity @ y = 0
       { input: [0, 0], expected: kAny },
       { input: [0, kValue.f32.subnormal.positive.max], expected: kAny },
       { input: [0, kValue.f32.subnormal.negative.min], expected: kAny },
-      { input: [0, kValue.f32.positive.min], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
-      { input: [0, kValue.f32.negative.max], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
-      { input: [0, kValue.f32.positive.max], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
-      { input: [0, kValue.f32.negative.min], expected: [kValue.f32.negative.pi.whole, kValue.f32.positive.pi.whole] },
+      { input: [0, kValue.f32.positive.min], expected: [hexToF64(0xc00923fb, 0x60000000), hexToF64(0x400923fb, 0x60000000)] },  // expected = [~-π, ~π]
+      { input: [0, kValue.f32.negative.max], expected: [hexToF64(0xc00923fb, 0x60000000), hexToF64(0x400923fb, 0x60000000)] },  // expected = [~-π, ~π]
+      { input: [0, kValue.f32.positive.max], expected: [hexToF64(0xc00923fb, 0x60000000), hexToF64(0x400923fb, 0x60000000)] },  // expected = [~-π, ~π]
+      { input: [0, kValue.f32.negative.min], expected: [hexToF64(0xc00923fb, 0x60000000), hexToF64(0x400923fb, 0x60000000)] },  // expected = [~-π, ~π]
       { input: [0, kValue.f32.infinity.positive], expected: kAny },
       { input: [0, kValue.f32.infinity.negative], expected: kAny },
     ]
   )
   .fn(t => {
-    const error = (n: number): number => {
-      return 4096 * oneULP(n);
-    };
-
     const [y, x] = t.params.input;
-    t.params.expected = applyError(t.params.expected, error);
     const expected = new F32Interval(...t.params.expected);
 
     const got = atan2Interval(y, x);

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1673,16 +1673,19 @@ g.test('atan2Interval')
       { input: [-1, 1], expected: [hexToF64(0xbfe923fb, 0xa0000000), hexToF64(0xbfe91ffb, 0x20000000)] },  // expected = ~-π/4
       { input: [Number.NEGATIVE_INFINITY, 1], expected: kAny },
 
-      // Discontinuity @ y = 0
+      // Discontinuity @ origin (0,0)
       { input: [0, 0], expected: kAny },
       { input: [0, kValue.f32.subnormal.positive.max], expected: kAny },
       { input: [0, kValue.f32.subnormal.negative.min], expected: kAny },
-      { input: [0, kValue.f32.positive.min], expected: [hexToF64(0xc00923fb, 0x60000000), hexToF64(0x400923fb, 0x60000000)] },  // expected = [~-π, ~π]
-      { input: [0, kValue.f32.negative.max], expected: [hexToF64(0xc00923fb, 0x60000000), hexToF64(0x400923fb, 0x60000000)] },  // expected = [~-π, ~π]
-      { input: [0, kValue.f32.positive.max], expected: [hexToF64(0xc00923fb, 0x60000000), hexToF64(0x400923fb, 0x60000000)] },  // expected = [~-π, ~π]
-      { input: [0, kValue.f32.negative.min], expected: [hexToF64(0xc00923fb, 0x60000000), hexToF64(0x400923fb, 0x60000000)] },  // expected = [~-π, ~π]
+      { input: [0, kValue.f32.positive.min], expected: kAny },
+      { input: [0, kValue.f32.negative.max], expected: kAny },
+      { input: [0, kValue.f32.positive.max], expected: kAny },
+      { input: [0, kValue.f32.negative.min], expected: kAny },
       { input: [0, kValue.f32.infinity.positive], expected: kAny },
       { input: [0, kValue.f32.infinity.negative], expected: kAny },
+      { input: [0, 1], expected: kAny },
+      { input: [kValue.f32.subnormal.positive.max, 1], expected: kAny },
+      { input: [kValue.f32.subnormal.negative.min, 1], expected: kAny },
     ]
   )
   .fn(t => {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -844,7 +844,7 @@ const AtanIntervalOp: PointToIntervalOp = {
 };
 
 /** Calculate an acceptance interval of atan(x) */
-export function atanInterval(n: number): F32Interval {
+export function atanInterval(n: number | F32Interval): F32Interval {
   return runPointToIntervalOp(toF32Interval(n), AtanIntervalOp);
 }
 

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -850,20 +850,41 @@ export function atanInterval(n: number): F32Interval {
 
 const Atan2IntervalOp: BinaryToIntervalOp = {
   impl: (y: number, x: number): F32Interval => {
-    const numULP = 4096;
-    if (y === 0) {
-      if (x === 0) {
-        return F32Interval.any();
-      } else {
-        return F32Interval.span(
-          ulpInterval(kValue.f32.negative.pi.whole, numULP),
-          ulpInterval(kValue.f32.positive.pi.whole, numULP)
-        );
-      }
+    if (x === 0) {
+      // atan2 is not defined meaningfully here
+      return F32Interval.any();
     }
-    return ulpInterval(Math.atan2(y, x), numULP);
+
+    // y/x == 0, [-π, π]
+    if (y === 0) {
+      // For x > 0 atan2 is supposed to be 0, and for x < 0 atan2 is -π or π depending on the direction y/x approaches
+      // 0.
+      // Because implementations will be be calculating this via numeric approximations that will vary slightly around
+      // 0 and subnormals, it is very difficult to write a rule for accuracy here without just dictating a specific
+      // implementation. Instead if the value is at y/x = 0, then the result should be in [-π, π], plus 4096 ULP from
+      // atan.
+      return F32Interval.span(
+        ulpInterval(kValue.f32.negative.pi.whole, 4096),
+        ulpInterval(kValue.f32.positive.pi.whole, 4096)
+      );
+    }
+
+    const atan_yx = atanInterval(divisionInterval(y, x));
+    // x > 0, atan(y/x)
+    if (x > 0) {
+      return atan_yx;
+    }
+
+    // x < 0, y > 0, atan(y/x) + π
+    if (y > 0) {
+      return additionInterval(atan_yx, kValue.f32.positive.pi.whole);
+    }
+
+    // x < 0, y < 0, atan(y/x) - π
+    return subtractionInterval(atan_yx, kValue.f32.positive.pi.whole);
   },
   extrema: (y: F32Interval, x: F32Interval): [F32Interval, F32Interval] => {
+    // There is discontinuity + undefined behaviour at y/x = 0 that will dominate the accuracy
     if (y.contains(0)) {
       if (x.contains(0)) {
         return [toF32Interval(0), toF32Interval(0)];

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -850,23 +850,14 @@ export function atanInterval(n: number): F32Interval {
 
 const Atan2IntervalOp: BinaryToIntervalOp = {
   impl: (y: number, x: number): F32Interval => {
+    // y/x is not defined meaningfully here
     if (x === 0) {
-      // atan2 is not defined meaningfully here
       return F32Interval.any();
     }
 
-    // y/x == 0, [-π, π]
-    if (y === 0) {
-      // For x > 0 atan2 is supposed to be 0, and for x < 0 atan2 is -π or π depending on the direction y/x approaches
-      // 0.
-      // Because implementations will be be calculating this via numeric approximations that will vary slightly around
-      // 0 and subnormals, it is very difficult to write a rule for accuracy here without just dictating a specific
-      // implementation. Instead if the value is at y/x = 0, then the result should be in [-π, π], plus 4096 ULP from
-      // atan.
-      return F32Interval.span(
-        ulpInterval(kValue.f32.negative.pi.whole, 4096),
-        ulpInterval(kValue.f32.positive.pi.whole, 4096)
-      );
+    // atan2's accuracy is only defined if y is normal
+    if (isSubnormalNumberF32(y)) {
+      return F32Interval.any();
     }
 
     const atan_yx = atanInterval(divisionInterval(y, x));


### PR DESCRIPTION
Used atan(y/x) as the basis for atan2 accuracy, since this will be less accurate than having a direct atan2 instruction.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
