### PR TITLE
Implement `normalize` f32 tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -8,9 +8,19 @@ Returns a unit vector in the same direction as e.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
+import { normalizeInterval } from '../../../../../util/f32_interval.js';
+import { kVectorTestValues } from '../../../../../util/math.js';
+import { allInputSources, Case, makeVectorToVectorIntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+/** @returns a `normalize` Case for a vector of f32s input */
+const makeCaseVecF32 = (x: number[]): Case => {
+  return makeVectorToVectorIntervalCase(x, normalizeInterval);
+};
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -20,13 +30,35 @@ g.test('abstract_float')
   )
   .unimplemented();
 
-g.test('f32')
-  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(`f32 tests`)
-  .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
-  )
-  .unimplemented();
+g.test('f32_vec2')
+  .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')
+  .desc(`f32 tests using vec2s`)
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases: Case[] = kVectorTestValues[2].map(makeCaseVecF32);
+
+    await run(t, builtin('normalize'), [TypeVec(2, TypeF32)], TypeVec(2, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec3')
+  .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')
+  .desc(`f32 tests using vec3s`)
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases: Case[] = kVectorTestValues[3].map(makeCaseVecF32);
+
+    await run(t, builtin('normalize'), [TypeVec(3, TypeF32)], TypeVec(3, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec4')
+  .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')
+  .desc(`f32 tests using vec4s`)
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases: Case[] = kVectorTestValues[4].map(makeCaseVecF32);
+
+    await run(t, builtin('normalize'), [TypeVec(4, TypeF32)], TypeVec(4, TypeF32), t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -19,14 +19,20 @@ import {
   TernaryToInterval,
   VectorPairToInterval,
   VectorToInterval,
+  VectorToVector,
 } from '../../../util/f32_interval.js';
 import { quantizeToF32 } from '../../../util/math.js';
 
-export type Expectation = Value | F32Interval | Comparator;
+export type Expectation = Value | F32Interval | F32Interval[] | Comparator;
 
 /** Is this expectation actually a Comparator */
 function isComparator(e: Expectation): boolean {
-  return !(e instanceof F32Interval || e instanceof Scalar || e instanceof Vector);
+  return !(
+    e instanceof F32Interval ||
+    e instanceof Scalar ||
+    e instanceof Vector ||
+    e instanceof Array
+  );
 }
 
 /** Helper for converting Values to Comparators */
@@ -634,6 +640,23 @@ export function makeVectorPairToF32IntervalCase(
   const intervals = ops.map(o => o(param0, param1));
   return {
     input: [new Vector(param0_f32), new Vector(param1_f32)],
+    expected: anyOf(...intervals),
+  };
+}
+
+/**
+ * Generates a Case for the param and vector of intervals generator provided.
+ * @param param the param to pass into the operation
+ * @param ops callbacks that implement generating an vector of acceptance intervals for a
+ *            vector.
+ */
+export function makeVectorToVectorIntervalCase(param: number[], ...ops: VectorToVector[]): Case {
+  param = param.map(quantizeToF32);
+  const param_f32 = param.map(f32);
+
+  const intervals = ops.map(o => o(param));
+  return {
+    input: [new Vector(param_f32)],
     expected: anyOf(...intervals),
   };
 }


### PR DESCRIPTION
Adds support for `F32Interval[]` in the `isF32Vector` and `toF32Vector` functions.

Adds support for VectorToVector operations

Adds plumbing for Vector of floats comparisons

Also includes a renaming for some existing functions to include the `ToFoo` part to distinguish them.

Issue #1230

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
