### PR TITLE
not_lost_on_gc: use assertNotSettledWithinTime instead of raceWithRejectOnTimeout

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -123,6 +123,27 @@ export function raceWithRejectOnTimeout<T>(p: Promise<T>, ms: number, msg: strin
 }
 
 /**
+ * Takes a promise `p` and returns a new one which rejects if `p` resolves or rejects,
+ * and otherwise resolves after the specified time.
+ */
+export function assertNotSettledWithinTime(
+  p: Promise<unknown>,
+  ms: number,
+  msg: string
+): Promise<undefined> {
+  // Rejects regardless of whether p resolves or rejects.
+  const rejectWhenSettled = p.then(() => Promise.reject(new Error(msg)));
+  // Resolves after `ms` milliseconds.
+  const timeoutPromise = new Promise<undefined>(resolve => {
+    const handle = timeout(() => {
+      resolve(undefined);
+    }, ms);
+    p.finally(() => clearTimeout(handle));
+  });
+  return Promise.race([rejectWhenSettled, timeoutPromise]);
+}
+
+/**
  * Returns a `Promise.reject()`, but also registers a dummy `.catch()` handler so it doesn't count
  * as an uncaught promise rejection in the runtime.
  */

--- a/src/webgpu/api/operation/device/lost.spec.ts
+++ b/src/webgpu/api/operation/device/lost.spec.ts
@@ -6,7 +6,7 @@ import { Fixture } from '../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { attemptGarbageCollection } from '../../../../common/util/collect_garbage.js';
 import { getGPU } from '../../../../common/util/navigator_gpu.js';
-import { assert, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
+import { assert, assertNotSettledWithinTime, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
 
 class DeviceLostTests extends Fixture {
   // Default timeout for waiting for device lost is 2 seconds.
@@ -44,7 +44,7 @@ g.test('not_lost_on_gc')
       const lost = (await adapter.requestDevice()).lost;
       return { lost };
     })();
-    t.shouldReject('Error', t.getDeviceLostWithTimeout(lost), 'device was unexpectedly lost');
+    await assertNotSettledWithinTime(lost, t.kDeviceLostTimeoutMS, 'device was unexpectedly lost');
 
     await attemptGarbageCollection();
   });

--- a/src/webgpu/api/operation/device/lost.spec.ts
+++ b/src/webgpu/api/operation/device/lost.spec.ts
@@ -6,7 +6,11 @@ import { Fixture } from '../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { attemptGarbageCollection } from '../../../../common/util/collect_garbage.js';
 import { getGPU } from '../../../../common/util/navigator_gpu.js';
-import { assert, assertNotSettledWithinTime, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
+import {
+  assert,
+  assertNotSettledWithinTime,
+  raceWithRejectOnTimeout,
+} from '../../../../common/util/util.js';
 
 class DeviceLostTests extends Fixture {
   // Default timeout for waiting for device lost is 2 seconds.


### PR DESCRIPTION

Issue: #1840

<hr>

**Requirements for PR author:**

- [ ] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] ~Tests are properly located in the test tree.~
- [ ] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
