### PR TITLE
Update multisampled_validation test to check the sampleType as well

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -12,6 +12,7 @@ import {
   kShaderStageCombinations,
   kStorageTextureAccessValues,
   kTextureFormatInfo,
+  kTextureSampleTypes,
   kTextureViewDimensions,
   allBindingEntries,
   bindingTypeInfo,
@@ -179,15 +180,22 @@ g.test('visibility,VERTEX_shader_stage_storage_texture_access')
   });
 
 g.test('multisampled_validation')
-  .desc('Test that multisampling is only allowed with "2d" view dimensions.')
+  .desc(
+    `
+  Test that multisampling is only allowed if view dimensions is "2d" and the sampleType is not
+  "float".
+  `
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('viewDimension', [undefined, ...kTextureViewDimensions])
+      .combine('sampleType', kTextureSampleTypes)
   )
   .fn(async t => {
-    const { viewDimension } = t.params;
+    const { viewDimension, sampleType } = t.params;
 
-    const success = viewDimension === '2d' || viewDimension === undefined;
+    const success =
+      (viewDimension === '2d' || viewDimension === undefined) && sampleType !== 'float';
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout({
@@ -195,7 +203,7 @@ g.test('multisampled_validation')
           {
             binding: 0,
             visibility: GPUShaderStage.COMPUTE,
-            texture: { multisampled: true, viewDimension },
+            texture: { multisampled: true, viewDimension, sampleType },
           },
         ],
       });


### PR DESCRIPTION
According to the specification, sampleType should not `float` sampleType if the multisampled is true. So this test updates the `multisampled_validation` test to make the test check if a validation error is generated when the sampleType is `float`.

Issue: 885

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
