### PR TITLE
Update align tests for const expressions.

### DIFF
--- a/src/webgpu/shader/validation/parse/align.spec.ts
+++ b/src/webgpu/shader/validation/parse/align.spec.ts
@@ -13,7 +13,7 @@ const kValidAlign = new Set([
   '@align(0x4)',
   '@align(4,)',
   '@align(i_val)',
-  '@align(i_val + 4 - 3)',
+  '@align(i_val + 4 - 6)',
   '@align(1073741824)',
   '@\talign\t(4)',
   '@/^comment^/align/^comment^/(4)',

--- a/src/webgpu/shader/validation/parse/align.spec.ts
+++ b/src/webgpu/shader/validation/parse/align.spec.ts
@@ -12,6 +12,8 @@ const kValidAlign = new Set([
   '@align(4i)',
   '@align(0x4)',
   '@align(4,)',
+  '@align(i_val)',
+  '@align(i_val + 4 - 3)',
   '@align(1073741824)',
   '@\talign\t(4)',
   '@/^comment^/align/^comment^/(4)',
@@ -24,7 +26,8 @@ const kInvalidAlign = new Set([
   '@align(4, 2)',
   '@align(4,)',
   '@align(3)', // Not a power of 2
-  '@align(val)',
+  '@align(u_val)',
+  '@align(f_val)',
   '@align(1.0)',
   '@align(4u)',
   '@align(4f)',
@@ -42,7 +45,9 @@ g.test('missing_attribute_on_param_struct')
   .fn(t => {
     const v = t.params.align.replace(/\^/g, '*');
     const code = `
-const val: i32 = 4;
+const i_val: i32 = 4;
+const u_val: u32 = 4;
+const f_val: f32 = 4.2;
 struct B {
   ${v} a: i32,
 }


### PR DESCRIPTION
This Cl updates the align shader test to allow for const expressions as the align value. Tests are added to verify the const value must be an i32.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
