### PR TITLE
Update canvas_composite_alpha to test opaque alpha mode canvas composite

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -27,9 +27,6 @@ export function run(
         unreachable();
     }
 
-    // This is mimic globalAlpha in 2d context blending behavior
-    const alphaFromShader = { premultiplied: '0.5', opaque: '1.0' }[alphaMode];
-
     let usage = 0;
     switch (writeCanvasMethod) {
       case 'draw':
@@ -88,11 +85,13 @@ vec2<f32>( 0.25, 0.25),
 vec2<f32>(-0.25, -0.25),
 vec2<f32>( 0.25,  -0.25));
 
+// Alpha channel value is set to 0.5 regardless of the canvas alpha mode.
+// For 'opaque' mode, it shouldn't affect the end result, as the alpha channel should always get cleared to 1.0.
 var color = array<vec4<f32>, 4>(
-    vec4<f32>(0.4, 0.0, 0.0, ${alphaFromShader}),
-    vec4<f32>(0.0, 0.4, 0.0, ${alphaFromShader}),
-    vec4<f32>(0.0, 0.0, 0.4, ${alphaFromShader}),
-    vec4<f32>(0.4, 0.4, 0.0, ${alphaFromShader})); // 0.4 -> 0x66
+    vec4<f32>(0.4, 0.0, 0.0, 0.5),
+    vec4<f32>(0.0, 0.4, 0.0, 0.5),
+    vec4<f32>(0.0, 0.0, 0.4, 0.5),
+    vec4<f32>(0.4, 0.4, 0.0, 0.5)); // 0.4 -> 0x66
 
 var output : VertexOutput;
 output.Position = vec4<f32>(pos[VertexIndex % 6u] + offset[VertexIndex / 6u], 0.0, 1.0);


### PR DESCRIPTION
Modify the alpha channel value from 1.0 to 0.5 for 'opaque' alpha mode canvas.
Under 'opaque' mode, the alpha channel value should have no impact for the render result, as the alpha channel should always get cleared to 1.0.

With this change, the `canvas_composite_alpha_*` tests are now both testing the blending result inside the canvas, and the composite result of the canvas and other page elements at the same time. We don't need another set of reftests.

Issue: None

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
