### PR TITLE
Add 'render_pass_and_bundle,device_mismatch' test to attachment_compatibility.spec.ts

### DIFF
--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -322,6 +322,31 @@ g.test('render_pass_and_bundle,sample_count')
     validateFinishAndSubmit(renderSampleCount === bundleSampleCount, true);
   });
 
+g.test('render_pass_and_bundle,device_mismatch')
+  .desc('Test that render passes cannot be called with bundles created from another device.')
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
+  .beforeAllSubcases(t => {
+    t.selectMismatchedDeviceOrSkipTestCase(undefined);
+  })
+  .fn(t => {
+    const { mismatched } = t.params;
+    const device = mismatched ? t.mismatchedDevice : t.device;
+
+    const format = 'r16float';
+    const bundleEncoder = device.createRenderBundleEncoder({
+      colorFormats: [format],
+    });
+    const bundle = bundleEncoder.finish();
+
+    const { encoder, validateFinishAndSubmit } = t.createEncoder('non-pass');
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [t.createColorAttachment(format)],
+    });
+    pass.executeBundles([bundle]);
+    pass.end();
+    validateFinishAndSubmit(!mismatched, true);
+  });
+
 g.test('render_pass_or_bundle_and_pipeline,color_format')
   .desc(
     `


### PR DESCRIPTION
This PR adds a test to ensure that render passes cannot be called with bundles created from another device.

Issue: #912

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
