### PR TITLE
webgpu/shader/execution: Reduce `const` case batch size

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -162,7 +162,7 @@ export function run(
   const casesPerBatch = (function () {
     switch (cfg.inputSource) {
       case 'const':
-        return 256; // Arbitrary limit, to ensure shaders aren't too large
+        return 64; // Arbitrary limit, to ensure shaders aren't too large
       case 'uniform':
         return Math.floor(
           t.device.limits.maxUniformBufferBindingSize / (parameterTypes.length * kValueStride)

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -141,7 +141,7 @@ export interface ExpressionBuilder {
  * @param cfg test configuration values
  * @param cases list of test cases
  */
-export function run(
+export async function run(
   t: GPUTest,
   expressionBuilder: ExpressionBuilder,
   parameterTypes: Array<Type>,
@@ -175,29 +175,36 @@ export function run(
     }
   })();
 
-  // Submit all the batches inside an error scope.
-  // Note: there is no async work between "push" and "pop" so this is safe to
-  // run concurrently with itself (in other subcases).
-  t.device.pushErrorScope('validation');
-
-  const checkResults: Array<() => void> = [];
+  // Submit all the cases in batches, each in a separate error scope.
+  const checkResults: Array<Promise<void>> = [];
   for (let i = 0; i < cases.length; i += casesPerBatch) {
     const batchCases = cases.slice(i, Math.min(i + casesPerBatch, cases.length));
+
+    t.device.pushErrorScope('validation');
+
+    const checkBatch = submitBatch(
+      t,
+      expressionBuilder,
+      parameterTypes,
+      returnType,
+      batchCases,
+      cfg.inputSource
+    );
+
     checkResults.push(
-      submitBatch(t, expressionBuilder, parameterTypes, returnType, batchCases, cfg.inputSource)
+      // Check GPU validation (shader compilation, pipeline creation, etc) before checking the batch results.
+      t.device.popErrorScope().then(error => {
+        if (error === null) {
+          checkBatch();
+        } else {
+          t.fail(error.message);
+        }
+      })
     );
   }
 
-  // Check GPU validation (shader compilation, pipeline creation, etc) before checking the results.
-  return t.device.popErrorScope().then(error => {
-    if (error !== null) {
-      t.fail(error.message);
-      return;
-    }
-
-    // Check the results
-    checkResults.forEach(f => f());
-  });
+  // Check the results
+  await Promise.all(checkResults);
 }
 
 /**


### PR DESCRIPTION
Reduce the batch size to avoid timeouts with Chromium's CTS runner.

We trigger a heartbeat between each batch, so by increasing the granularity of these batches, we should avoid whole-test timeouts.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
