### PR TITLE
Implement 'sampler,compare_function_with_binding_type' test in createBindGroup.spec.ts

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -15,7 +15,9 @@ import {
   kBindableResources,
   kBufferBindingTypes,
   kBufferUsages,
+  kCompareFunctions,
   kLimitInfo,
+  kSamplerBindingTypes,
   kTextureFormatInfo,
   kTextureUsages,
   kTextureViewDimensions,
@@ -988,6 +990,46 @@ g.test('buffer,resource_binding_size')
     t.expectValidationError(() => {
       t.device.createBindGroup({
         entries: [{ binding: 0, resource: { buffer, size: bindingSize } }],
+        layout: bindGroupLayout,
+      });
+    }, !isValid);
+  });
+
+g.test('sampler,compare_function_with_binding_type')
+  .desc(
+    `
+  Test that the sampler of the BindGroup has a 'compareFunction' value if the sampler type of the
+  BindGroupLayout is 'comparison'. Other sampler types should not have 'compare' field in
+  the descriptor of the sampler.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('bgType', kSamplerBindingTypes)
+      .beginSubcases()
+      .combine('compareFunction', [undefined, ...kCompareFunctions])
+  )
+  .fn(async t => {
+    const { bgType, compareFunction } = t.params;
+
+    const bindGroupLayout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: { type: bgType },
+        },
+      ],
+    });
+
+    const isValid =
+      bgType === 'comparison' ? compareFunction !== undefined : compareFunction === undefined;
+
+    const sampler = t.device.createSampler({ compare: compareFunction });
+
+    t.expectValidationError(() => {
+      t.device.createBindGroup({
+        entries: [{ binding: 0, resource: sampler }],
         layout: bindGroupLayout,
       });
     }, !isValid);


### PR DESCRIPTION
This PR adds a new 'sampler,compare_function_with_binding_type' test to createBindGroup.spec.ts in order to ensure that a validation error is generated if the compare field value exists according to the bidning group type.

Issue: #884

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
