### PR TITLE
Add execution tests for logical binary operations

### DIFF
--- a/src/webgpu/shader/execution/evaluation_order.spec.ts
+++ b/src/webgpu/shader/execution/evaluation_order.spec.ts
@@ -225,6 +225,22 @@ g.test('binary_logical')
         'return i32(r);',
       _result: 1,
     },
+    {
+      name: 'NoShortCircuit_And',
+      _body:
+        // rhs should execute
+        'let t = (a != 2) & (mul(&a, 10) == 20);' + //
+        'return a;',
+      _result: 20,
+    },
+    {
+      name: 'NoShortCircuit_Or',
+      _body:
+        // rhs should execute
+        'let t = (a == 2) | (mul(&a, 10) == 20);' + //
+        'return a;',
+      _result: 20,
+    },
   ])
   .fn(t => run(t, t.params._body, t.params._result));
 

--- a/src/webgpu/shader/execution/expression/binary/binary.ts
+++ b/src/webgpu/shader/execution/expression/binary/binary.ts
@@ -1,6 +1,9 @@
 import { ExpressionBuilder } from '../expression.js';
 
-/* @returns an ExpressionBuilder that evaluates the binary operation */
+/* @returns an ExpressionBuilder that evaluates a binary operation */
 export function binary(op: string): ExpressionBuilder {
-  return values => `(${values.join(op)})`;
+  return values => {
+    const values_str = values.map(v => `(${v})`);
+    return `(${values_str.join(op)})`;
+  };
 }

--- a/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
@@ -78,7 +78,6 @@ Logical "or". Component-wise when T is a vector. Evaluates both e1 and e2.
     await run(t, binary('|'), [TypeBool, TypeBool], TypeBool, t.params, cases);
   });
 
-// Short circuiting behaviour is not tested here, it is covered in src/webgpu/shader/execution/evaluation_order.spec.ts
 g.test('or_short_circuit')
   .specURL('https://www.w3.org/TR/WGSL/#logical-expr')
   .desc(

--- a/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
@@ -1,0 +1,98 @@
+export const description = `
+Execution Tests for the boolean binary logical expression operations
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { bool, TypeBool } from '../../../../util/conversion.js';
+import { allInputSources, run } from '../expression.js';
+
+import { binary } from './binary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('and')
+  .specURL('https://www.w3.org/TR/WGSL/#logical-expr')
+  .desc(
+    `
+Expression: e1 & e2
+Logical "and". Component-wise when T is a vector. Evaluates both e1 and e2.
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = [
+      { input: [bool(false), bool(false)], expected: bool(false) },
+      { input: [bool(true), bool(false)], expected: bool(false) },
+      { input: [bool(false), bool(true)], expected: bool(false) },
+      { input: [bool(true), bool(true)], expected: bool(true) },
+    ];
+
+    await run(t, binary('&'), [TypeBool, TypeBool], TypeBool, t.params, cases);
+  });
+
+// Short circuiting behaviour is not tested here, it is covered in src/webgpu/shader/execution/evaluation_order.spec.ts
+g.test('and_short_circuit')
+  .specURL('https://www.w3.org/TR/WGSL/#logical-expr')
+  .desc(
+    `
+Expression: e1 && e2
+short_circuiting "and". Yields true if both e1 and e2 are true; evaluates e2 only if e1 is true.
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = [
+      { input: [bool(false), bool(false)], expected: bool(false) },
+      { input: [bool(true), bool(false)], expected: bool(false) },
+      { input: [bool(false), bool(true)], expected: bool(false) },
+      { input: [bool(true), bool(true)], expected: bool(true) },
+    ];
+
+    await run(t, binary('&&'), [TypeBool, TypeBool], TypeBool, t.params, cases);
+  });
+
+g.test('or')
+  .specURL('https://www.w3.org/TR/WGSL/#logical-expr')
+  .desc(
+    `
+Expression: e1 | e2
+Logical "or". Component-wise when T is a vector. Evaluates both e1 and e2.
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = [
+      { input: [bool(false), bool(false)], expected: bool(false) },
+      { input: [bool(true), bool(false)], expected: bool(true) },
+      { input: [bool(false), bool(true)], expected: bool(true) },
+      { input: [bool(true), bool(true)], expected: bool(true) },
+    ];
+
+    await run(t, binary('|'), [TypeBool, TypeBool], TypeBool, t.params, cases);
+  });
+
+// Short circuiting behaviour is not tested here, it is covered in src/webgpu/shader/execution/evaluation_order.spec.ts
+g.test('or_short_circuit')
+  .specURL('https://www.w3.org/TR/WGSL/#logical-expr')
+  .desc(
+    `
+Expression: e1 || e2
+short_circuiting "and". Yields true if both e1 and e2 are true; evaluates e2 only if e1 is true.
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = [
+      { input: [bool(false), bool(false)], expected: bool(false) },
+      { input: [bool(true), bool(false)], expected: bool(true) },
+      { input: [bool(false), bool(true)], expected: bool(true) },
+      { input: [bool(true), bool(true)], expected: bool(true) },
+    ];
+
+    await run(t, binary('||'), [TypeBool, TypeBool], TypeBool, t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
@@ -11,6 +11,9 @@ import { binary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
 
+// Short circuiting vs no short circuiting is not tested here, it is covered in
+// src/webgpu/shader/execution/evaluation_order.spec.ts
+
 g.test('and')
   .specURL('https://www.w3.org/TR/WGSL/#logical-expr')
   .desc(
@@ -33,7 +36,6 @@ Logical "and". Component-wise when T is a vector. Evaluates both e1 and e2.
     await run(t, binary('&'), [TypeBool, TypeBool], TypeBool, t.params, cases);
   });
 
-// Short circuiting behaviour is not tested here, it is covered in src/webgpu/shader/execution/evaluation_order.spec.ts
 g.test('and_short_circuit')
   .specURL('https://www.w3.org/TR/WGSL/#logical-expr')
   .desc(


### PR DESCRIPTION
This covers `and` (`&`), `and` with short-circuiting (`&&`), `or`(`|`), and `or` with short-circuiting (`||`)

Short circuiting is tested in existing tests, which are referenced in the source file.

This also required changes to how the expression builder operated to bind the `!= 0u` for converting bools coming out of storage to just the param.

Issue #1868

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
