### PR TITLE
Style and bug fixes in device_mismatch tests

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -91,9 +91,9 @@ g.test('shader_module,device_mismatch')
   .fn(async t => {
     const { isAsync, mismatched } = t.params;
 
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const module = device.createShaderModule({
+    const module = sourceDevice.createShaderModule({
       code: '@compute @workgroup_size(1) fn main() {}',
     });
 
@@ -118,9 +118,9 @@ g.test('pipeline_layout,device_mismatch')
   })
   .fn(async t => {
     const { isAsync, mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const layout = device.createPipelineLayout({ bindGroupLayouts: [] });
+    const layout = sourceDevice.createPipelineLayout({ bindGroupLayouts: [] });
 
     const descriptor = {
       layout,

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -583,9 +583,9 @@ g.test('bind_group_layout,device_mismatch')
   .fn(async t => {
     const mismatched = t.params.mismatched;
 
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const bgl = device.createBindGroupLayout({
+    const bgl = sourceDevice.createBindGroupLayout({
       entries: [
         {
           binding: 0,
@@ -1004,7 +1004,7 @@ g.test('sampler,device_mismatch')
   .fn(async t => {
     const { mismatched } = t.params;
 
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
     const bindGroupLayout = t.device.createBindGroupLayout({
       entries: [
@@ -1016,7 +1016,7 @@ g.test('sampler,device_mismatch')
       ],
     });
 
-    const sampler = device.createSampler();
+    const sampler = sourceDevice.createSampler();
     t.expectValidationError(() => {
       t.device.createBindGroup({
         entries: [{ binding: 0, resource: sampler }],

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -997,7 +997,7 @@ g.test('buffer,resource_binding_size')
 
 g.test('sampler,device_mismatch')
   .desc(`Tests createBindGroup cannot be called with a sampler created from another device.`)
-  .params(u => u.combine('mismatched', [true, false]))
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
   .beforeAllSubcases(t => {
     t.selectMismatchedDeviceOrSkipTestCase(undefined);
   })

--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -138,7 +138,7 @@ g.test('timestamp_query_set,device_mismatch')
   Tests beginComputePass cannot be called with a timestamp query set created from another device.
   `
   )
-  .params(u => u.combine('mismatched', [true, false]))
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase(['timestamp-query']);
     t.selectMismatchedDeviceOrSkipTestCase('timestamp-query');

--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -145,9 +145,9 @@ g.test('timestamp_query_set,device_mismatch')
   })
   .fn(async t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const timestampQuerySet = device.createQuerySet({
+    const timestampQuerySet = sourceDevice.createQuerySet({
       type: 'timestamp',
       count: 1,
     });

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -173,7 +173,7 @@ g.test('timestamp_query_set,device_mismatch')
   Tests beginRenderPass cannot be called with a timestamp query set created from another device.
   `
   )
-  .params(u => u.combine('mismatched', [true, false]))
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase(['timestamp-query']);
     t.selectMismatchedDeviceOrSkipTestCase('timestamp-query');

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -155,9 +155,9 @@ g.test('occlusion_query_set,device_mismatch')
   })
   .fn(async t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const occlusionQuerySet = device.createQuerySet({
+    const occlusionQuerySet = sourceDevice.createQuerySet({
       type: 'occlusion',
       count: 1,
     });
@@ -180,10 +180,10 @@ g.test('timestamp_query_set,device_mismatch')
   })
   .fn(async t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
     const timestampWrite = {
-      querySet: device.createQuerySet({ type: 'timestamp', count: 1 }),
+      querySet: sourceDevice.createQuerySet({ type: 'timestamp', count: 1 }),
       queryIndex: 0,
       location: 'beginning' as const,
     };

--- a/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
@@ -62,10 +62,10 @@ g.test('buffer,device_mismatch')
   })
   .fn(async t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
     const size = 8;
 
-    const buffer = device.createBuffer({
+    const buffer = sourceDevice.createBuffer({
       size,
       usage: GPUBufferUsage.COPY_DST,
     });

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -71,12 +71,12 @@ g.test('pipeline,device_mismatch')
   })
   .fn(async t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const pipeline = device.createComputePipeline({
+    const pipeline = sourceDevice.createComputePipeline({
       layout: 'auto',
       compute: {
-        module: device.createShaderModule({
+        module: sourceDevice.createShaderModule({
           code: '@compute @workgroup_size(1) fn main() {}',
         }),
         entryPoint: 'main',
@@ -192,9 +192,9 @@ g.test('indirect_dispatch_buffer,device_mismatch')
 
     const pipeline = t.createNoOpComputePipeline();
 
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const buffer = device.createBuffer({
+    const buffer = sourceDevice.createBuffer({
       size: 16,
       usage: GPUBufferUsage.INDIRECT,
     });

--- a/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
@@ -107,17 +107,16 @@ g.test('buffer,device_mismatch')
   })
   .fn(async t => {
     const { srcMismatched, dstMismatched } = t.params;
-    const mismatched = srcMismatched || dstMismatched;
 
-    const device = mismatched ? t.mismatchedDevice : t.device;
-
-    const srcBuffer = device.createBuffer({
+    const srcBufferDevice = srcMismatched ? t.mismatchedDevice : t.device;
+    const srcBuffer = srcBufferDevice.createBuffer({
       size: 16,
       usage: GPUBufferUsage.COPY_SRC,
     });
     t.trackForCleanup(srcBuffer);
 
-    const dstBuffer = device.createBuffer({
+    const dstBufferDevice = dstMismatched ? t.mismatchedDevice : t.device;
+    const dstBuffer = dstBufferDevice.createBuffer({
       size: 16,
       usage: GPUBufferUsage.COPY_DST,
     });
@@ -129,7 +128,7 @@ g.test('buffer,device_mismatch')
       dstBuffer,
       dstOffset: 0,
       copySize: 8,
-      expectation: mismatched ? 'FinishError' : 'Success',
+      expectation: srcMismatched || dstMismatched ? 'FinishError' : 'Success',
     });
   });
 

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -124,20 +124,20 @@ g.test('texture,device_mismatch')
   })
   .fn(async t => {
     const { srcMismatched, dstMismatched } = t.params;
-    const mismatched = srcMismatched || dstMismatched;
 
-    const device = mismatched ? t.mismatchedDevice : t.device;
     const size = { width: 4, height: 4, depthOrArrayLayers: 1 };
     const format = 'rgba8unorm';
 
-    const srcTexture = device.createTexture({
+    const srcTextureDevice = srcMismatched ? t.mismatchedDevice : t.device;
+    const srcTexture = srcTextureDevice.createTexture({
       size,
       format,
       usage: GPUTextureUsage.COPY_SRC,
     });
     t.trackForCleanup(srcTexture);
 
-    const dstTexture = device.createTexture({
+    const dstTextureDevice = dstMismatched ? t.mismatchedDevice : t.device;
+    const dstTexture = dstTextureDevice.createTexture({
       size,
       format,
       usage: GPUTextureUsage.COPY_DST,
@@ -148,7 +148,7 @@ g.test('texture,device_mismatch')
       { texture: srcTexture },
       { texture: dstTexture },
       { width: 1, height: 1, depthOrArrayLayers: 1 },
-      mismatched ? 'FinishError' : 'Success'
+      srcMismatched || dstMismatched ? 'FinishError' : 'Success'
     );
   });
 

--- a/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
@@ -61,9 +61,9 @@ g.test('indirect_buffer,device_mismatch')
   .fn(async t => {
     const { encoderType, indexed, mismatched } = t.params;
 
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const indirectBuffer = device.createBuffer({
+    const indirectBuffer = sourceDevice.createBuffer({
       size: 256,
       usage: GPUBufferUsage.INDIRECT,
     });

--- a/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
@@ -38,9 +38,9 @@ g.test('index_buffer,device_mismatch')
   })
   .fn(async t => {
     const { encoderType, mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const indexBuffer = device.createBuffer({
+    const indexBuffer = sourceDevice.createBuffer({
       size: 16,
       usage: GPUBufferUsage.INDEX,
     });

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -36,18 +36,18 @@ g.test('pipeline,device_mismatch')
   })
   .fn(async t => {
     const { encoderType, mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const pipeline = device.createRenderPipeline({
+    const pipeline = sourceDevice.createRenderPipeline({
       layout: 'auto',
       vertex: {
-        module: device.createShaderModule({
+        module: sourceDevice.createShaderModule({
           code: `@vertex fn main() -> @builtin(position) vec4<f32> { return vec4<f32>(); }`,
         }),
         entryPoint: 'main',
       },
       fragment: {
-        module: device.createShaderModule({
+        module: sourceDevice.createShaderModule({
           code: '@fragment fn main() {}',
         }),
         entryPoint: 'main',

--- a/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
@@ -64,9 +64,9 @@ g.test('vertex_buffer,device_mismatch')
   })
   .fn(async t => {
     const { encoderType, mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const vertexBuffer = device.createBuffer({
+    const vertexBuffer = sourceDevice.createBuffer({
       size: 16,
       usage: GPUBufferUsage.VERTEX,
     });

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -149,14 +149,14 @@ g.test('bind_group,device_mismatch')
   })
   .fn(async t => {
     const { encoderType, useU32Array, mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const buffer = device.createBuffer({
+    const buffer = sourceDevice.createBuffer({
       size: 4,
       usage: GPUBufferUsage.STORAGE,
     });
 
-    const layout = device.createBindGroupLayout({
+    const layout = sourceDevice.createBindGroupLayout({
       entries: [
         {
           binding: 0,
@@ -166,7 +166,7 @@ g.test('bind_group,device_mismatch')
       ],
     });
 
-    const bindGroup = device.createBindGroup({
+    const bindGroup = sourceDevice.createBindGroup({
       layout,
       entries: [
         {

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -143,9 +143,9 @@ g.test('timestamp_query,device_mismatch')
   })
   .fn(async t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const querySet = device.createQuerySet({
+    const querySet = sourceDevice.createQuerySet({
       type: 'timestamp',
       count: 2,
     });

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -158,24 +158,24 @@ g.test('query_set_buffer,device_mismatch')
   })
   .fn(async t => {
     const { querySetMismatched, bufferMismatched } = t.params;
-    const mismatched = querySetMismatched || bufferMismatched;
 
-    const device = mismatched ? t.mismatchedDevice : t.device;
-    const queryCout = 1;
+    const kQueryCount = 1;
 
-    const querySet = device.createQuerySet({
+    const querySetDevice = querySetMismatched ? t.mismatchedDevice : t.device;
+    const querySet = querySetDevice.createQuerySet({
       type: 'occlusion',
-      count: queryCout,
+      count: kQueryCount,
     });
     t.trackForCleanup(querySet);
 
-    const buffer = device.createBuffer({
-      size: queryCout * 8,
+    const bufferDevice = bufferMismatched ? t.mismatchedDevice : t.device;
+    const buffer = bufferDevice.createBuffer({
+      size: kQueryCount * 8,
       usage: GPUBufferUsage.QUERY_RESOLVE,
     });
     t.trackForCleanup(buffer);
 
     const encoder = t.createEncoder('non-pass');
-    encoder.encoder.resolveQuerySet(querySet, 0, queryCout, buffer, 0);
-    encoder.validateFinish(!mismatched);
+    encoder.encoder.resolveQuerySet(querySet, 0, kQueryCount, buffer, 0);
+    encoder.validateFinish(!(querySetMismatched || bufferMismatched));
   });

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -39,22 +39,21 @@ g.test('device_mismatch')
   })
   .fn(async t => {
     const { bundle0Mismatched, bundle1Mismatched } = t.params;
-    const mismatched = bundle0Mismatched || bundle1Mismatched;
-
-    const device = mismatched ? t.mismatchedDevice : t.device;
 
     const descriptor: GPURenderBundleEncoderDescriptor = {
       colorFormats: ['rgba8unorm'],
     };
-    const bundle0Encoder = device.createRenderBundleEncoder(descriptor);
-    const bundle0 = bundle0Encoder.finish();
-    const bundle1Encoder = device.createRenderBundleEncoder(descriptor);
-    const bundle1 = bundle1Encoder.finish();
+
+    const bundle0Device = bundle0Mismatched ? t.mismatchedDevice : t.device;
+    const bundle0 = bundle0Device.createRenderBundleEncoder(descriptor).finish();
+
+    const bundle1Device = bundle1Mismatched ? t.mismatchedDevice : t.device;
+    const bundle1 = bundle1Device.createRenderBundleEncoder(descriptor).finish();
 
     const encoder = t.createEncoder('render pass');
     encoder.encoder.executeBundles([bundle0, bundle1]);
 
-    encoder.validateFinish(!mismatched);
+    encoder.validateFinish(!(bundle0Mismatched || bundle1Mismatched));
   });
 
 g.test('color_formats_mismatch')

--- a/src/webgpu/api/validation/image_copy/buffer_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/buffer_related.spec.ts
@@ -67,9 +67,9 @@ g.test('buffer,device_mismatch')
   })
   .fn(async t => {
     const { method, mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const buffer = device.createBuffer({
+    const buffer = sourceDevice.createBuffer({
       size: 16,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -76,9 +76,9 @@ g.test('texture,device_mismatch')
   })
   .fn(async t => {
     const { method, mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const texture = device.createTexture({
+    const texture = sourceDevice.createTexture({
       size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -635,10 +635,10 @@ g.test('destination_texture,device_mismatch')
   })
   .fn(async t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
     const copySize = { width: 1, height: 1, depthOrArrayLayers: 1 };
 
-    const texture = device.createTexture({
+    const texture = sourceDevice.createTexture({
       size: copySize,
       format: 'rgba8unorm',
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -184,9 +184,9 @@ g.test('buffer,device_mismatch')
   })
   .fn(async t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const buffer = device.createBuffer({
+    const buffer = sourceDevice.createBuffer({
       size: 16,
       usage: GPUBufferUsage.COPY_DST,
     });

--- a/src/webgpu/api/validation/queue/writeTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/writeTexture.spec.ts
@@ -86,7 +86,7 @@ g.test('sample_count')
 
 g.test('texture,device_mismatch')
   .desc('Tests writeTexture cannot be called with a texture created from another device.')
-  .params(u => u.combine('mismatched', [true, false]))
+  .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
   .beforeAllSubcases(t => {
     t.selectMismatchedDeviceOrSkipTestCase(undefined);
   })

--- a/src/webgpu/api/validation/queue/writeTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/writeTexture.spec.ts
@@ -92,9 +92,9 @@ g.test('texture,device_mismatch')
   })
   .fn(async t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const texture = device.createTexture({
+    const texture = sourceDevice.createTexture({
       size: { width: 16, height: 16 },
       format: 'bgra8unorm',
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,

--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -330,10 +330,10 @@ g.test('render_pass_and_bundle,device_mismatch')
   })
   .fn(t => {
     const { mismatched } = t.params;
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
     const format = 'r16float';
-    const bundleEncoder = device.createRenderBundleEncoder({
+    const bundleEncoder = sourceDevice.createRenderBundleEncoder({
       colorFormats: [format],
     });
     const bundle = bundleEncoder.finish();

--- a/src/webgpu/api/validation/render_pipeline/misc.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/misc.spec.ts
@@ -68,9 +68,9 @@ g.test('pipeline_layout,device_mismatch')
   .fn(async t => {
     const { isAsync, mismatched } = t.params;
 
-    const device = mismatched ? t.mismatchedDevice : t.device;
+    const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const layout = device.createPipelineLayout({ bindGroupLayouts: [] });
+    const layout = sourceDevice.createPipelineLayout({ bindGroupLayouts: [] });
 
     const format = 'rgba8unorm';
     const descriptor = {


### PR DESCRIPTION
**Stack of three separate commits which may be reviewed separately if desired.**

- Rename "device" to "sourceDevice" in device_mismatch tests, for clarity
- Fix incorrect device selection for various creation calls in 4 device_mismatch tests
- Make "mismatched" a subcase param consistently across all of the device_mismatch tests

Issue: none

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] ~Tests are properly located in the test tree.~
- [ ] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
