### PR TITLE
op: Implement 'wr' test in multiple_buffers.spec.ts

### DIFF
--- a/src/webgpu/api/operation/memory_sync/buffer/multiple_buffers.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/multiple_buffers.spec.ts
@@ -110,7 +110,64 @@ g.test('wr')
     Test that the results are synchronized.
     The read should see exactly the contents written by the previous write.`
   )
-  .unimplemented();
+  .params(u =>
+    u //
+      .combine('boundary', kOperationBoundaries)
+      .expand('_context', p => kBoundaryInfo[p.boundary].contexts)
+      .expandWithParams(function* ({ _context }) {
+        for (const readOp of kAllReadOps) {
+          for (const writeOp of kAllWriteOps) {
+            if (checkOpsValidForContext([readOp, writeOp], _context)) {
+              yield {
+                readOp,
+                readContext: _context[0],
+                writeOp,
+                writeContext: _context[1],
+              };
+            }
+          }
+        }
+      })
+  )
+  .fn(async t => {
+    const { readContext, readOp, writeContext, writeOp, boundary } = t.params;
+    const helper = new OperationContextHelper(t);
+
+    const srcBuffers: GPUBuffer[] = [];
+    const dstBuffers: GPUBuffer[] = [];
+
+    const kBufferCount = 4;
+
+    for (let i = 0; i < kBufferCount; i++) {
+      const { srcBuffer, dstBuffer } = await t.createBuffersForReadOp(readOp, kSrcValue, kOpValue);
+
+      srcBuffers.push(srcBuffer);
+      dstBuffers.push(dstBuffer);
+    }
+
+    await t.createIntermediateBuffersAndTexturesForWriteOp(writeOp, 0, kOpValue);
+
+    // The write op will write the given op value into src buffers.
+    // The read op will read from src buffers and write to dst buffers based on what it reads.
+    // The write op happens before read op. So we are expecting the op value to be in the dst
+    // buffers.
+    for (let i = 0; i < kBufferCount; i++) {
+      t.encodeWriteOp(helper, writeOp, writeContext, srcBuffers[i], 0, kOpValue);
+    }
+
+    helper.ensureBoundary(boundary);
+
+    for (let i = 0; i < kBufferCount; i++) {
+      t.encodeReadOp(helper, readOp, readContext, srcBuffers[i], dstBuffers[i]);
+    }
+
+    helper.ensureSubmit();
+
+    for (let i = 0; i < kBufferCount; i++) {
+      // Only verify the value of the first element of the dstBuffer
+      t.verifyData(dstBuffers[i], kOpValue);
+    }
+  });
 
 g.test('ww')
   .desc(


### PR DESCRIPTION
This PR implements `wr` test in multiple_buffers.spec.ts to ensure that a boundary can separate operations in multiple buffers.

Issue: #897

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
