### PR TITLE
Implement 'timestampWrites,invalid_query_set' test in beginComputePass.spec.ts

### DIFF
--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -106,6 +106,33 @@ g.test('timestampWrites,query_set_type')
     t.tryComputePass(isValid, descriptor);
   });
 
+g.test('timestampWrites,invalid_query_set')
+  .desc(`Tests that timestampWrite that has an invalid query set generates a validation error.`)
+  .params(u => u.combine('querySetState', ['valid', 'invalid'] as const))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase(['timestamp-query']);
+  })
+  .fn(async t => {
+    const { querySetState } = t.params;
+
+    const querySet = t.createQuerySetWithState(querySetState, {
+      type: 'timestamp',
+      count: 1,
+    });
+
+    const timestampWrite = {
+      querySet,
+      queryIndex: 0,
+      location: 'beginning' as const,
+    };
+
+    const descriptor = {
+      timestampWrites: [timestampWrite],
+    };
+
+    t.tryComputePass(querySetState === 'valid', descriptor);
+  });
+
 g.test('timestampWrites,query_index_count')
   .desc(`Test that querySet.count should be greater than timestampWrite.queryIndex.`)
   .params(u => u.combine('queryIndex', [0, 1, 2, 3]))


### PR DESCRIPTION
~beginComputePass method should generate a validation error if device.feature doesn't contain "timestamp-query".~

Issue: #1743

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
