### PR TITLE
compilation_info: Check offset when there is a carriage-return.

### DIFF
--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -11,7 +11,7 @@ export const g = makeTestGroup(GPUTest);
 const kValidShaderSources = [
   {
     valid: true,
-    unicode: false,
+    name: 'ascii',
     _code: `
       @vertex fn main() -> @builtin(position) vec4<f32> {
         return vec4<f32>(0.0, 0.0, 0.0, 1.0);
@@ -19,7 +19,7 @@ const kValidShaderSources = [
   },
   {
     valid: true,
-    unicode: true,
+    name: 'unicode',
     _code: `
       // 頂点シェーダー 👩‍💻
       @vertex fn main() -> @builtin(position) vec4<f32> {
@@ -31,7 +31,7 @@ const kValidShaderSources = [
 const kInvalidShaderSources = [
   {
     valid: false,
-    unicode: false,
+    name: 'ascii',
     _errorLine: 4,
     _code: `
       @vertex fn main() -> @builtin(position) vec4<f32> {
@@ -41,11 +41,24 @@ const kInvalidShaderSources = [
   },
   {
     valid: false,
-    unicode: true,
+    name: 'unicode',
     _errorLine: 5,
     _code: `
       // 頂点シェーダー 👩‍💻
       @vertex fn main() -> @builtin(position) vec4<f32> {
+        // Expected Error: unknown function 'unknown'
+        return unknown(0.0, 0.0, 0.0, 1.0);
+      }`,
+  },
+  {
+    valid: false,
+    name: 'carriage-return',
+    _errorLine: 4,
+    _code:
+      `
+      @vertex fn main() -> @builtin(position) vec4<f32> {` +
+      '\r\n' +
+      `
         // Expected Error: unknown function 'unknown'
         return unknown(0.0, 0.0, 0.0, 1.0);
       }`,


### PR DESCRIPTION
Doesn't pass in Chromium because it is a regression test for a bug I found while doing something unrelated.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
