### PR TITLE
Add rg11b10ufloat-renderable feature requestDevice test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/offscreencanvas": "^2019.6.4",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "0.1.21",
+        "@webgpu/types": "0.1.22",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1244,9 +1244,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
-      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.22.tgz",
+      "integrity": "sha512-RrohwhHOIlczHX8q10AHYaegfeFIgQBLhHj4IKFWv8wb29annYz8jbl2citFiA1XbRnAU1ZozEvRJCiZZu4fkA==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -10514,9 +10514,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
-      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.22.tgz",
+      "integrity": "sha512-RrohwhHOIlczHX8q10AHYaegfeFIgQBLhHj4IKFWv8wb29annYz8jbl2citFiA1XbRnAU1ZozEvRJCiZZu4fkA==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/offscreencanvas": "^2019.6.4",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "0.1.21",
+    "@webgpu/types": "0.1.22",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/validation/error_scope.spec.ts
+++ b/src/webgpu/api/validation/error_scope.spec.ts
@@ -63,6 +63,8 @@ class ErrorScopeTests extends Fixture {
         return error instanceof GPUOutOfMemoryError;
       case 'validation':
         return error instanceof GPUValidationError;
+      case 'internal':
+        return error instanceof GPUInternalError;
     }
   }
 

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -1061,6 +1061,7 @@ export const kFeatureNameInfo: {
   'indirect-first-instance': {},
   'shader-f16': {},
   'bgra8unorm-storage': {},
+  'rg11b10ufloat-renderable': {},
 };
 /** List of all GPUFeatureName values. */
 export const kFeatureNames = keysOf(kFeatureNameInfo);

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -72,7 +72,8 @@ export const kErrorScopeFilterInfo: {
   readonly [k in GPUErrorFilter]: {};
 } = /* prettier-ignore */ {
   'out-of-memory': {},
-  'validation': {},
+  'validation':    {},
+  'internal':      {},
 };
 /** List of all GPUTextureAspect values. */
 export const kErrorScopeFilters = keysOf(kErrorScopeFilterInfo);


### PR DESCRIPTION


Issue: #1874 <!-- Fill in the issue number here. See docs/intro/life_of.md -->

This PR adds a `requestDevice` test with `requiredFeatures: ['rg11b10ufloat-renderable']` parameter.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
