### PR TITLE
Implement 'index_range' test in getBindGroupLayout.spec.ts

### DIFF
--- a/src/webgpu/api/validation/getBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/getBindGroupLayout.spec.ts
@@ -1,0 +1,70 @@
+export const description = `
+  getBindGroupLayout validation tests.
+`;
+
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+
+import { ValidationTest } from './validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('index_range,explicit_layout')
+  .desc(
+    `
+  Test that a validation error is generated if the index exceeds the size of the bind group layouts
+  using a pipeline with an explicit layout.
+  `
+  )
+  .params(u => u.combine('index', [0, 1, 2, 3, 4, 5]))
+  .fn(async t => {
+    const { index } = t.params;
+
+    const pipelineBindGroupLayouts = t.device.createBindGroupLayout({
+      entries: [],
+    });
+
+    const kBindGroupLayoutsSizeInPipelineLayout = 1;
+    const pipelineLayout = t.device.createPipelineLayout({
+      bindGroupLayouts: [pipelineBindGroupLayouts],
+    });
+
+    const pipeline = t.device.createRenderPipeline({
+      layout: pipelineLayout,
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+            @vertex
+            fn main()-> @builtin(position) vec4<f32> {
+              return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `
+            @fragment
+            fn main() -> @location(0) vec4<f32> {
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+    });
+
+    const shouldError = index >= kBindGroupLayoutsSizeInPipelineLayout;
+
+    t.expectValidationError(() => {
+      pipeline.getBindGroupLayout(index);
+    }, shouldError);
+  });
+
+g.test('index_range,auto_layout')
+  .desc(
+    `
+  Test that a validation error is generated if the index exceeds the size of the bind group layouts
+  using a pipeline with an auto layout.
+  `
+  )
+  .unimplemented();


### PR DESCRIPTION
According to the specification, the index of getBindGroupLayout should not exceed the size of the bind group layouts. So this PR implements a new test to ensure it.

Issue: #1891

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
