### PR TITLE
Implement `distance` f32 tests

### DIFF
--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -176,7 +176,7 @@ function spanF32Vector(...vectors: F32Vector[]): F32Vector {
  * returns the input
  */
 function addFlushedIfNeeded(values: number[]): number[] {
-  return values.some(isSubnormalNumberF32) ? values.concat(0) : values;
+  return values.some(v => v !== 0 && isSubnormalNumberF32(v)) ? values.concat(0) : values;
 }
 
 /**
@@ -791,6 +791,36 @@ function runVectorPairToVectorOp(x: F32Vector, y: F32Vector, op: VectorPairToVec
   return result.every(e => e.isFinite()) ? result : toF32Vector(x.map(_ => F32Interval.any()));
 }
 
+/**
+ * Calculate the vector of acceptance intervals by running a scalar operation
+ * component-wise over a pair vectors.
+ *
+ * This is used for situations where a component-wise operation, like vector
+ * subtraction, is needed as part of a inherited accuracy, but the top-level
+ * operation test don't require an explicit vector definition of the function,
+ * due to the generated vectorize tests being sufficient.
+ *
+ * @param x first input domain intervals vector
+ * @param y second input domain intervals vector
+ * @param op scalar operation to be run component-wise
+ * @returns a vector of intervals with the outputs of op.impl
+ */
+function runBinaryToIntervalOpComponentWise(
+  x: F32Vector,
+  y: F32Vector,
+  op: BinaryToIntervalOp
+): F32Vector {
+  assert(
+    x.length === y.length,
+    `runBinaryToIntervalOpComponentWise requires vectors of the same length`
+  );
+  return toF32Vector(
+    x.map((i, idx) => {
+      return runBinaryToIntervalOp(i, y[idx], op);
+    })
+  );
+}
+
 /** Defines a PointToIntervalOp for an interval of the correctly rounded values around the point */
 const CorrectlyRoundedIntervalOp: PointToIntervalOp = {
   impl: (n: number) => {
@@ -1123,6 +1153,36 @@ export function degreesInterval(n: number): F32Interval {
   return runPointToIntervalOp(toF32Interval(n), DegreesIntervalOp);
 }
 
+const DistanceIntervalScalarOp: BinaryToIntervalOp = {
+  impl: (x: number, y: number): F32Interval => {
+    return lengthInterval(subtractionInterval(x, y));
+  },
+};
+
+const DistanceIntervalVectorOp: VectorPairToIntervalOp = {
+  impl: (x: number[], y: number[]): F32Interval => {
+    return lengthInterval(
+      runBinaryToIntervalOpComponentWise(toF32Vector(x), toF32Vector(y), SubtractionIntervalOp)
+    );
+  },
+};
+
+/** Calculate an acceptance interval of distance(x, y) */
+export function distanceInterval(x: number | number[], y: number | number[]): F32Interval {
+  if (x instanceof Array && y instanceof Array) {
+    assert(
+      x.length === y.length,
+      `distanceInterval requires both params to have the same number of elements`
+    );
+    return runVectorPairToIntervalOp(toF32Vector(x), toF32Vector(y), DistanceIntervalVectorOp);
+  } else if (!(x instanceof Array) && !(y instanceof Array)) {
+    return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), DistanceIntervalScalarOp);
+  }
+  unreachable(
+    `distanceInterval requires both params to both the same type, either scalars or vectors`
+  );
+}
+
 const DivisionIntervalOp: BinaryToIntervalOp = {
   impl: limitBinaryToIntervalDomain(
     {
@@ -1153,7 +1213,11 @@ export function divisionInterval(x: number | F32Interval, y: number | F32Interva
 const DotIntervalOp: VectorPairToIntervalOp = {
   impl: (x: number[], y: number[]): F32Interval => {
     // dot(x, y) = sum of x[i] * y[i]
-    const multiplications: F32Interval[] = x.map((_, i) => multiplicationInterval(x[i], y[i]));
+    const multiplications = runBinaryToIntervalOpComponentWise(
+      toF32Vector(x),
+      toF32Vector(y),
+      MultiplicationIntervalOp
+    );
     return multiplications.reduce((previous, current) => additionInterval(previous, current));
   },
 };
@@ -1260,18 +1324,24 @@ export function ldexpInterval(e1: number, e2: number): F32Interval {
   return roundAndFlushBinaryToInterval(e1, e2, LdexpIntervalOp);
 }
 
-const LengthIntervalOp: VectorToIntervalOp = {
+const LengthIntervalScalarOp: PointToIntervalOp = {
+  impl: (n: number): F32Interval => {
+    return sqrtInterval(multiplicationInterval(n, n));
+  },
+};
+
+const LengthIntervalVectorOp: VectorToIntervalOp = {
   impl: (n: number[]): F32Interval => {
     return sqrtInterval(dotInterval(n, n));
   },
 };
 
 /** Calculate an acceptance interval of length(x) */
-export function lengthInterval(n: number | number[]): F32Interval {
+export function lengthInterval(n: number | F32Interval | number[] | F32Vector): F32Interval {
   if (n instanceof Array) {
-    return runVectorToIntervalOp(toF32Vector(n), LengthIntervalOp);
+    return runVectorToIntervalOp(toF32Vector(n), LengthIntervalVectorOp);
   } else {
-    return sqrtInterval(multiplicationInterval(n, n));
+    return runPointToIntervalOp(toF32Interval(n), LengthIntervalScalarOp);
   }
 }
 
@@ -1631,15 +1701,9 @@ export function stepInterval(edge: number, x: number): F32Interval {
   return runBinaryToIntervalOp(toF32Interval(edge), toF32Interval(x), StepIntervalOp);
 }
 
-const SubtractionInnerOp: BinaryToIntervalOp = {
-  impl: (x: number, y: number): F32Interval => {
-    return correctlyRoundedInterval(x - y);
-  },
-};
-
 const SubtractionIntervalOp: BinaryToIntervalOp = {
   impl: (x: number, y: number): F32Interval => {
-    return roundAndFlushBinaryToInterval(x, y, SubtractionInnerOp);
+    return correctlyRoundedInterval(x - y);
   },
 };
 

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -661,6 +661,30 @@ export const kVectorTestValues = {
 };
 
 /**
+ * Minimal set of vectors, indexed by dimension, that contain interesting float
+ * values.
+ *
+ * This is an even more stripped down version of `kVectorTestValues` for when
+ * pairs of vectors are being tested.
+ * All of the interesting floats from sparseF32 are guaranteed to be tested, but
+ * not in every position.
+ */
+export const kVectorSparseTestValues = {
+  2: sparseF32Range().map((f, idx) => [idx % 2 === 0 ? f : idx, idx % 2 === 1 ? f : -idx]),
+  3: sparseF32Range().map((f, idx) => [
+    idx % 3 === 0 ? f : idx,
+    idx % 3 === 1 ? f : -idx,
+    idx % 3 === 2 ? f : idx,
+  ]),
+  4: sparseF32Range().map((f, idx) => [
+    idx % 4 === 0 ? f : idx,
+    idx % 4 === 1 ? f : -idx,
+    idx % 4 === 2 ? f : idx,
+    idx % 4 === 3 ? f : -idx,
+  ]),
+};
+
+/**
  * @returns the result matrix in Array<Array<number>> type.
  *
  * Matrix multiplication. A is m x n and B is n x p. Returns


### PR DESCRIPTION
This covers both scalar and vector inputs.

This also include an improvement for addFlushIfNeeded, which was flushing even when the value was 0. This was causing a lot of duplicate branches to be run for inputs. It doesn't functionally change the results, but significantly speeds them up.

Issue #1217

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
