### PR TITLE
Remove a fallback value in the use of maxBindGroups value

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -114,7 +114,7 @@ g.test('state_and_binding_index')
   )
   .fn(async t => {
     const { encoderType, state, resourceType } = t.params;
-    const maxBindGroups = t.device.limits?.maxBindGroups ?? 4;
+    const maxBindGroups = t.device.limits.maxBindGroups;
 
     async function runTest(index: number) {
       const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);


### PR DESCRIPTION
The fallback value is not necessary because Chromium already implemented device.limits.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
