### PR TITLE
Implement `acos` f32 tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -8,6 +8,7 @@ import { kValue } from '../webgpu/util/constants.js';
 import {
   absInterval,
   absoluteErrorInterval,
+  acosInterval,
   acoshAlternativeInterval,
   acoshPrimaryInterval,
   additionInterval,
@@ -651,6 +652,35 @@ g.test('absInterval')
     t.expect(
       objectEquals(expected, got),
       `absInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('acosInterval')
+  .paramsSubcasesOnly<PointToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+      // form due to the inherited nature of the errors.
+      //
+      // The acceptance interval @ x = -1 and 1 is kAny, because sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inverseqrt
+      // The acceptance interval @ x = 0 is kAny, because atan2 is not well defined/implemented at 0.
+      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.negative.min, expected: kAny },
+      { input: -1, expected: kAny },
+      { input: -1/2, expected: [hexToF32(0x40060290), hexToF32(0x40061294)] },  // ~2π/3
+      { input: 0, expected: kAny },
+      { input: 1/2, expected: [hexToF32(0x3f85fa8f), hexToF32(0x3f861a95)] },  // ~π/3
+      { input: kValue.f32.positive.max, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAny },
+    ]
+  )
+  .fn(t => {
+    const expected = new F32Interval(...t.params.expected);
+
+    const got = acosInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `acosInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -9,7 +9,12 @@ Returns the arc cosine of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { acosInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -27,7 +32,17 @@ g.test('f32')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, acosInterval);
+    };
+
+    const cases = [
+      ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
+      ...fullF32Range(),
+    ].map(makeCase);
+    await run(t, builtin('acos'), [TypeF32], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -871,6 +871,19 @@ export function absInterval(n: number): F32Interval {
   return runPointToIntervalOp(toF32Interval(n), AbsIntervalOp);
 }
 
+const AcosIntervalOp: PointToIntervalOp = {
+  impl: limitPointToIntervalDomain(toF32Interval([-1.0, 1.0]), (n: number) => {
+    // acos(x) = atan2(sqrt(1.0 - x * x), x)
+    const y = sqrtInterval(subtractionInterval(1, multiplicationInterval(n, n)));
+    return atan2Interval(y, n);
+  }),
+};
+
+/** Calculate an acceptance interval for acos(n) */
+export function acosInterval(n: number): F32Interval {
+  return runPointToIntervalOp(toF32Interval(n), AcosIntervalOp);
+}
+
 /** All acceptance interval functions for acosh(x) */
 export const acoshIntervals: PointToInterval[] = [acoshAlternativeInterval, acoshPrimaryInterval];
 

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -873,7 +873,7 @@ export function absInterval(n: number): F32Interval {
 
 const AcosIntervalOp: PointToIntervalOp = {
   impl: limitPointToIntervalDomain(toF32Interval([-1.0, 1.0]), (n: number) => {
-    // acos(x) = atan2(sqrt(1.0 - x * x), x)
+    // acos(n) = atan2(sqrt(1.0 - n * n), n)
     const y = sqrtInterval(subtractionInterval(1, multiplicationInterval(n, n)));
     return atan2Interval(y, n);
   }),


### PR DESCRIPTION
Issue #1212

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
