### PR TITLE
Add tests on effective buffer binding size the fix existing tests

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -438,7 +438,7 @@ g.test('minBindingSize')
   .desc('Tests that minBindingSize is correctly enforced.')
   .paramsSubcasesOnly(u =>
     u //
-      .combine('minBindingSize', [undefined, 4, 256])
+      .combine('minBindingSize', [undefined, 8, 256])
       .expand('size', ({ minBindingSize }) =>
         minBindingSize !== undefined
           ? [minBindingSize - 4, minBindingSize, minBindingSize + 4]
@@ -1022,7 +1022,7 @@ g.test('buffer,effective_buffer_binding_size')
               kLimitInfo.minStorageBufferOffsetAlignment.default + 10,
             ]
       )
-      .combine('bindingSize', [-1, 2, 4, 6])
+      .combine('bindingSize', [undefined, 2, 4, 6])
   )
   .fn(async t => {
     const { type, offset, bufferSize, bindingSize } = t.params;
@@ -1037,7 +1037,7 @@ g.test('buffer,effective_buffer_binding_size')
       ],
     });
 
-    const effectiveBindingSize = bindingSize > 0 ? bindingSize : bufferSize - offset;
+    const effectiveBindingSize = bindingSize ?? bufferSize - offset;
     let usage, isValid;
     if (type === 'uniform') {
       usage = GPUBufferUsage.UNIFORM;
@@ -1052,10 +1052,9 @@ g.test('buffer,effective_buffer_binding_size')
       usage,
     });
 
-    const appliedBindingSize = bindingSize > 0 ? bindingSize : undefined;
     t.expectValidationError(() => {
       t.device.createBindGroup({
-        entries: [{ binding: 0, resource: { buffer, offset, size: appliedBindingSize } }],
+        entries: [{ binding: 0, resource: { buffer, offset, size: bindingSize } }],
         layout: bindGroupLayout,
       });
     }, !isValid);

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -438,7 +438,7 @@ g.test('minBindingSize')
   .desc('Tests that minBindingSize is correctly enforced.')
   .paramsSubcasesOnly(u =>
     u //
-      .combine('minBindingSize', [undefined, 8, 256])
+      .combine('minBindingSize', [undefined, 4, 8, 256])
       .expand('size', ({ minBindingSize }) =>
         minBindingSize !== undefined
           ? [minBindingSize - 4, minBindingSize, minBindingSize + 4]

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -225,7 +225,7 @@ g.test('dynamic_offsets_match_expectations_in_pass_encoder')
       .combine('useU32array', [false, true])
   )
   .fn(async t => {
-    const kBindingSize = 9;
+    const kBindingSize = 12;
 
     const bindGroupLayout = t.device.createBindGroupLayout({
       entries: [
@@ -409,7 +409,7 @@ g.test('buffer_dynamic_offsets')
   )
   .fn(async t => {
     const { type, dynamicOffset, encoderType } = t.params;
-    const kBindingSize = 9;
+    const kBindingSize = 12;
 
     const bindGroupLayout = t.device.createBindGroupLayout({
       entries: [


### PR DESCRIPTION
This patch adds a new validation test on effective buffer binding size. According to the latest WebGPU SPEC, the effective buffer binding size must be a multiple of 4 if the binding type is storage or read-only storage.

This patch also fixes the storage buffer binding size in WebGPU CTS.




Issue: #1905

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
