### PR TITLE
Implement `reflect` f32 tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
@@ -2,16 +2,31 @@ export const description = `
 Execution tests for the 'reflect' builtin function
 
 T is vecN<AbstractFloat>, vecN<f32>, or vecN<f16>
-@const fn reflect(e1: T ,e2: T ) -> T
+@const fn reflect(e1: T, e2: T ) -> T
 For the incident vector e1 and surface orientation e2, returns the reflection
 direction e1-2*dot(e2,e1)*e2.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
+import { reflectInterval } from '../../../../../util/f32_interval.js';
+import { kVectorSparseTestValues } from '../../../../../util/math.js';
+import {
+  allInputSources,
+  Case,
+  makeVectorPairToVectorIntervalCase,
+  run,
+} from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+/** @returns a `reflect` Case for a pair of vectors of f32s input */
+const makeCaseVecF32 = (x: number[], y: number[]): Case => {
+  return makeVectorPairToVectorIntervalCase(x, y, reflectInterval);
+};
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -19,11 +34,62 @@ g.test('abstract_float')
   .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
-g.test('f32')
-  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(`f32 tests`)
-  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
-  .unimplemented();
+g.test('f32_vec2')
+  .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')
+  .desc(`f32 tests using vec2s`)
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases: Case[] = kVectorSparseTestValues[2].flatMap(i =>
+      kVectorSparseTestValues[2].map(j => makeCaseVecF32(i, j))
+    );
+
+    await run(
+      t,
+      builtin('reflect'),
+      [TypeVec(2, TypeF32), TypeVec(2, TypeF32)],
+      TypeVec(2, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('f32_vec3')
+  .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')
+  .desc(`f32 tests using vec3s`)
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases: Case[] = kVectorSparseTestValues[3].flatMap(i =>
+      kVectorSparseTestValues[3].map(j => makeCaseVecF32(i, j))
+    );
+
+    await run(
+      t,
+      builtin('reflect'),
+      [TypeVec(3, TypeF32), TypeVec(3, TypeF32)],
+      TypeVec(3, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('f32_vec4')
+  .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')
+  .desc(`f32 tests using vec4s`)
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases: Case[] = kVectorSparseTestValues[4].flatMap(i =>
+      kVectorSparseTestValues[4].map(j => makeCaseVecF32(i, j))
+    );
+
+    await run(
+      t,
+      builtin('reflect'),
+      [TypeVec(4, TypeF32), TypeVec(4, TypeF32)],
+      TypeVec(4, TypeF32),
+      t.params,
+      cases
+    );
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1575,6 +1575,31 @@ export function radiansInterval(n: number): F32Interval {
   return runPointToIntervalOp(toF32Interval(n), RadiansIntervalOp);
 }
 
+const ReflectIntervalOp: VectorPairToVectorOp = {
+  impl: (x: number[], y: number[]): F32Vector => {
+    assert(
+      x.length === y.length,
+      `ReflectIntervalOp received x (${x}) and y (${y}) with different numbers of elements`
+    );
+
+    // reflect(x, y) = x - 2.0 * dot(x, y) * y
+    //               = x - t * y, t = 2.0 * dot(x, y)
+    // x = incident vector
+    // y = normal of reflecting surface
+    const t = multiplicationInterval(2.0, dotInterval(x, y));
+    const rhs = toF32Vector(y.map(j => multiplicationInterval(t, j)));
+    return runBinaryToIntervalOpComponentWise(toF32Vector(x), rhs, SubtractionIntervalOp);
+  },
+};
+
+export function reflectInterval(x: number[], y: number[]): F32Vector {
+  assert(
+    x.length === y.length,
+    `reflect is only defined for vectors with the same number of elements`
+  );
+  return runVectorPairToVectorOp(toF32Vector(x), toF32Vector(y), ReflectIntervalOp);
+}
+
 const RemainderIntervalOp: BinaryToIntervalOp = {
   impl: (x: number, y: number): F32Interval => {
     // x % y = x - y * trunc(x/y)


### PR DESCRIPTION
Issue #1233

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
