### PR TITLE
val: Implement 'empty_bind_group_layouts_requires_empty_bind_groups' test

### DIFF
--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -645,3 +645,51 @@ g.test('bgl_resource_type_mismatch')
       bgResourceType === plResourceType
     );
   });
+
+g.test('empty_bind_group_layouts_requires_empty_bind_groups')
+  .desc('Test that a pipeline with empty bind groups layouts requires empty bind groups to be set.')
+  .paramsSimple([
+    { bindGroupLayoutEntryCount: 4, _success: true }, // Control case
+    { bindGroupLayoutEntryCount: 3, _success: false },
+  ])
+  .fn(async t => {
+    const { bindGroupLayoutEntryCount, _success } = t.params;
+
+    const emptyBGL = t.device.createBindGroupLayout({ entries: [] });
+    const bindGroupLayouts = [];
+    for (let i = 0; i < 4; i++) {
+      bindGroupLayouts.push(emptyBGL);
+    }
+
+    const pipelineLayout = t.device.createPipelineLayout({
+      bindGroupLayouts,
+    });
+
+    const pipeline = t.device.createComputePipeline({
+      layout: pipelineLayout,
+      compute: {
+        module: t.device.createShaderModule({
+          code: '@compute @workgroup_size(1) fn main() {}',
+        }),
+        entryPoint: 'main',
+      },
+    });
+
+    const emptyBindGroup = t.device.createBindGroup({
+      layout: emptyBGL,
+      entries: [],
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    for (let i = 0; i < bindGroupLayoutEntryCount; i++) {
+      pass.setBindGroup(i, emptyBindGroup);
+    }
+    pass.dispatchWorkgroups(1);
+    pass.end();
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, !_success);
+  });


### PR DESCRIPTION
This PR implements a new test to ensure that empty bind groups should be set by setBindGroup if the pipeline has empty bind group layouts.

The test is implemented in setBindGroup.spec.ts file.

Issue: #1903

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
