### PR TITLE
Fix pack2x16float tests to correctly handle corner cases

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -236,42 +236,40 @@ expect: ${expect}`
   }
 });
 
-interface pack2x16floatCase {
-  inputs: [number, number];
-  result: (number | undefined)[];
-}
-
 g.test('pack2x16float')
-  .paramsSimple<pack2x16floatCase>([
+  .paramsSimple([
     // f16 normals
-    { inputs: [0, 0], result: [0x00000000] },
-    { inputs: [1, 0], result: [0x00003c00] },
+    { inputs: [0, 0], result: [0x00000000, 0x80000000, 0x00008000, 0x80008000] },
+    { inputs: [1, 0], result: [0x00003c00, 0x80003c00] },
     { inputs: [1, 1], result: [0x3c003c00] },
     { inputs: [-1, -1], result: [0xbc00bc00] },
-    { inputs: [10, 0], result: [0x00004900] },
-    { inputs: [-10, 0], result: [0x0000c900] },
+    { inputs: [10, 1], result: [0x3c004900] },
+    { inputs: [-10, 1], result: [0x3c00c900] },
 
     // f32 normal, but not f16 precise
-    { inputs: [1.00000011920928955078125, 0], result: [0x00003c00, 0x00003c01] },
+    { inputs: [1.00000011920928955078125, 1], result: [0x3c003c00, 0x3c003c01] },
 
     // f32 subnormals
-    { inputs: [kValue.f32.subnormal.positive.max, 0], result: [0x00000000, 0x00000001] },
     // prettier-ignore
-    { inputs: [kValue.f32.subnormal.negative.min, 0], result: [0x00008001, 0x00008000, 0x00000000] },
+    { inputs: [kValue.f32.subnormal.positive.max, 1], result: [0x3c000000, 0x3c008000, 0x3c000001] },
+    // prettier-ignore
+    { inputs: [kValue.f32.subnormal.negative.min, 1], result: [0x3c008001, 0x3c000000, 0x3c008000] },
 
     // f16 subnormals
-    { inputs: [kValue.f16.subnormal.positive.max, 0], result: [0x000003ff, 0x00000000] },
-    { inputs: [kValue.f16.subnormal.negative.min, 0], result: [0x000083ff, 0x00000000] },
+    // prettier-ignore
+    { inputs: [kValue.f16.subnormal.positive.max, 1], result: [0x3c0003ff, 0x3c000000, 0x3c008000] },
+    // prettier-ignore
+    { inputs: [kValue.f16.subnormal.negative.min, 1], result: [0x03c0083ff, 0x3c000000, 0x3c008000] },
 
     // f16 out of bounds
-    { inputs: [kValue.f16.positive.max + 1, 0], result: [undefined] },
-    { inputs: [kValue.f16.negative.min - 1, 0], result: [undefined] },
-    { inputs: [0, kValue.f16.positive.max + 1], result: [undefined] },
-    { inputs: [0, kValue.f16.negative.min - 1], result: [undefined] },
-  ])
+    { inputs: [kValue.f16.positive.max + 1, 1], result: [undefined] },
+    { inputs: [kValue.f16.negative.min - 1, 1], result: [undefined] },
+    { inputs: [1, kValue.f16.positive.max + 1], result: [undefined] },
+    { inputs: [1, kValue.f16.negative.min - 1], result: [undefined] },
+  ] as const)
   .fn(test => {
     const inputs = test.params.inputs;
-    const got = pack2x16float(...inputs);
+    const got = pack2x16float(inputs[0], inputs[1]);
     const expect = test.params.result;
 
     test.expect(

--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -268,14 +268,20 @@ g.test('pack2x16float')
     { inputs: [1, kValue.f16.negative.min - 1], result: [undefined] },
   ] as const)
   .fn(test => {
+    const toString = (data: readonly (undefined | number)[]): String[] => {
+      return data.map(d => (d !== undefined ? u32(d).toString() : 'undefined'));
+    };
+
     const inputs = test.params.inputs;
     const got = pack2x16float(inputs[0], inputs[1]);
     const expect = test.params.result;
 
+    const got_str = toString(got);
+    const expect_str = toString(expect);
+
+    // Using strings of the outputs, so they can be easily sorted, since order of the results doesn't matter.
     test.expect(
-      objectEquals(got, expect),
-      `pack2x16float(${inputs}) returned [${got.map(g =>
-        g !== undefined ? u32(g) : 'undefined'
-      )}]. Expected [${expect.map(e => (e !== undefined ? u32(e) : 'undefined'))}]`
+      objectEquals(got_str.sort(), expect_str.sort()),
+      `pack2x16float(${inputs}) returned [${got_str}]. Expected [${expect}]`
     );
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
@@ -6,11 +6,11 @@ which is then placed in bits 16 × i through 16 × i + 15 of the result.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { assert } from '../../../../../../common/util/util.js';
-import { Float16Array } from '../../../../../../external/petamoriken/float16/float16.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf, Comparator } from '../../../../../util/compare.js';
 import {
   f32,
+  pack2x16float,
   Scalar,
   TypeF32,
   TypeU32,
@@ -18,56 +18,12 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import {
-  cartesianProduct,
-  correctlyRoundedF16,
-  fullF32Range,
-  isFiniteF16,
-  quantizeToF32,
-} from '../../../../../util/math.js';
+import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
-
-/**
- * Quantize two f32s to f16 and then packs them in a u32
- *
- * This should implement the same behaviour as the builtin `pack2x16float` from
- * WGSL.
- * Caller is responsible to ensuring inputs are f32s
- *
- * @param x first f32 to be packed
- * @param y second f32 to be packed
- * @returns an array of possible results for pack2x16float. Elements are either
- *          a number or undefined.
- *          undefined indicates that any value is valid, since the input went
- *          out of bounds.
- */
-export function pack2x16float(x: number, y: number): (number | undefined)[] {
-  if (!isFiniteF16(x) || !isFiniteF16(y)) {
-    // This indicates any value is valid, so it isn't worth bothering
-    // calculating the more restrictive possibilities.
-    return [undefined];
-  }
-
-  // f32s are not guaranteed to be precisely expressible as a f16, so quantizing
-  // down may have two possible options, which are returned by
-  // correctlyRounded16.
-  const f16_pairs = cartesianProduct(correctlyRoundedF16(x), correctlyRoundedF16(y));
-  const results = new Array<number>();
-  f16_pairs.forEach(p => {
-    const buf = new ArrayBuffer(4);
-    const buf_f16 = new Float16Array(buf);
-    assert(p.length === 2, 'cartesianProduct of 2 arrays returned an entry with not 2 elements');
-    buf_f16[0] = p[0];
-    buf_f16[1] = p[1];
-
-    results.push(new Uint32Array(buf)[0].valueOf());
-  });
-  return results;
-}
 
 /**
  * @returns a custom comparator for a possible result from pack2x16float


### PR DESCRIPTION
Previous version of these tests didn't correctly account for f32 and f16 subnormals.

Test generation code has been also refactored out of the test file into conversion.ts, so that unittests could be added.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
