### PR TITLE
val: Implement 'pass_end_invalid_order' test

### DIFF
--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -19,4 +19,62 @@ TODO:
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { ValidationTest } from '../validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+class F extends ValidationTest {
+  beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
+    const attachmentTexture = this.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    this.trackForCleanup(attachmentTexture);
+    return commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: attachmentTexture.createView(),
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+  }
+}
+
+export const g = makeTestGroup(F);
+
+g.test('pass_end_invalid_order')
+  .desc(
+    `
+  Test that beginning a  {compute,render} pass before ending the previous {compute,render} pass
+  causes an error.
+
+  TODO: Need to add a control case to be sure a validation error happens because of ending order.
+  `
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('pass0Type', ['compute', 'render'])
+      .combine('pass1Type', ['compute', 'render'])
+      .combine('endPasses', [[], [0], [1], [0, 1], [1, 0]])
+  )
+  .fn(async t => {
+    const { pass0Type, pass1Type, endPasses } = t.params;
+
+    const encoder = t.device.createCommandEncoder();
+
+    const firstPass =
+      pass0Type === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder);
+
+    // Begin a second pass before ending the previous pass.
+    const secondPass =
+      pass1Type === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder);
+
+    const passes = [firstPass, secondPass];
+    for (const index of endPasses) {
+      passes[index].end();
+    }
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, true);
+  });


### PR DESCRIPTION
This PR adds a new test to ensure that a validation error is generated if beginning
a second pass before ending the previous pass generates a validation error.

Issue: #1914

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
