### PR TITLE
val: Implement 'empty_bind_group_layouts_requires_empty_bind_groups,render_pass' test

### DIFF
--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -646,8 +646,12 @@ g.test('bgl_resource_type_mismatch')
     );
   });
 
-g.test('empty_bind_group_layouts_requires_empty_bind_groups')
-  .desc('Test that a pipeline with empty bind groups layouts requires empty bind groups to be set.')
+g.test('empty_bind_group_layouts_requires_empty_bind_groups,compute_pass')
+  .desc(
+    `
+  Test that a compute pipeline with empty bind groups layouts requires empty bind groups to be set.
+  `
+  )
   .paramsSimple([
     { bindGroupLayoutEntryCount: 4, _success: true }, // Control case
     { bindGroupLayoutEntryCount: 3, _success: false },
@@ -656,13 +660,13 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups')
     const { bindGroupLayoutEntryCount, _success } = t.params;
 
     const emptyBGL = t.device.createBindGroupLayout({ entries: [] });
-    const bindGroupLayouts = [];
+    const emptyBGLs = [];
     for (let i = 0; i < 4; i++) {
-      bindGroupLayouts.push(emptyBGL);
+      emptyBGLs.push(emptyBGL);
     }
 
     const pipelineLayout = t.device.createPipelineLayout({
-      bindGroupLayouts,
+      bindGroupLayouts: emptyBGLs,
     });
 
     const pipeline = t.device.createComputePipeline({
@@ -688,6 +692,82 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups')
     }
     pass.dispatchWorkgroups(1);
     pass.end();
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, !_success);
+  });
+
+g.test('empty_bind_group_layouts_requires_empty_bind_groups,render_pass')
+  .desc(
+    `
+  Test that a render pipeline with empty bind groups layouts requires empty bind groups to be set.
+  `
+  )
+  .paramsSimple([
+    { bindGroupLayoutEntryCount: 4, _success: true }, // Control case
+    { bindGroupLayoutEntryCount: 3, _success: false },
+  ])
+  .fn(async t => {
+    const { bindGroupLayoutEntryCount, _success } = t.params;
+
+    const emptyBGL = t.device.createBindGroupLayout({ entries: [] });
+    const emptyBGLs = [];
+    for (let i = 0; i < 4; i++) {
+      emptyBGLs.push(emptyBGL);
+    }
+
+    const pipelineLayout = t.device.createPipelineLayout({
+      bindGroupLayouts: emptyBGLs,
+    });
+
+    const colorFormat = 'rgba8unorm';
+    const pipeline = t.device.createRenderPipeline({
+      layout: pipelineLayout,
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `@vertex fn main() -> @builtin(position) vec4<f32> { return vec4<f32>(); }`,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `@fragment fn main() {}`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: colorFormat, writeMask: 0 }],
+      },
+    });
+
+    const emptyBindGroup = t.device.createBindGroup({
+      layout: emptyBGL,
+      entries: [],
+    });
+
+    const encoder = t.device.createCommandEncoder();
+
+    const attachmentTexture = t.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const renderPass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: attachmentTexture.createView(),
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+
+    renderPass.setPipeline(pipeline);
+    for (let i = 0; i < bindGroupLayoutEntryCount; i++) {
+      renderPass.setBindGroup(i, emptyBindGroup);
+    }
+    renderPass.end();
 
     t.expectValidationError(() => {
       encoder.finish();

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -650,6 +650,8 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,compute_pass')
   .desc(
     `
   Test that a compute pipeline with empty bind groups layouts requires empty bind groups to be set.
+
+  TODO: Also test other dispatch calls using the 'doCompute' helper in this file
   `
   )
   .paramsSimple([
@@ -690,7 +692,7 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,compute_pass')
     for (let i = 0; i < bindGroupLayoutEntryCount; i++) {
       pass.setBindGroup(i, emptyBindGroup);
     }
-    pass.dispatchWorkgroups(1);
+    pass.dispatchWorkgroups(0);
     pass.end();
 
     t.expectValidationError(() => {
@@ -702,6 +704,8 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,render_pass')
   .desc(
     `
   Test that a render pipeline with empty bind groups layouts requires empty bind groups to be set.
+
+  TODO: Also test other draw calls using the 'doRender' helper in this file
   `
   )
   .paramsSimple([
@@ -767,6 +771,7 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,render_pass')
     for (let i = 0; i < bindGroupLayoutEntryCount; i++) {
       renderPass.setBindGroup(i, emptyBindGroup);
     }
+    renderPass.draw(0);
     renderPass.end();
 
     t.expectValidationError(() => {


### PR DESCRIPTION
This PR implements a new test to ensure that a render pipeline with empty bind group layouts
requires empty bind groups should be set. The test is implemented in the
'pipeline_bind_group_compat.spec.ts' file.

Additionally, this PR updates the existing 'empty_bind_group_layouts_requires_empty_bind_groups'
slightly to separate from this test.

Issue: #1903

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
