### PR TITLE
val: Implement 'pass_end_none' and 'pass_end_twice' tests

### DIFF
--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -45,7 +45,7 @@ export const g = makeTestGroup(F);
 g.test('pass_end_invalid_order')
   .desc(
     `
-  Test that beginning a  {compute,render} pass before ending the previous {compute,render} pass
+  Test that beginning a {compute,render} pass before ending the previous {compute,render} pass
   causes an error.
 
   TODO: Need to add a control case to be sure a validation error happens because of ending order.
@@ -113,4 +113,51 @@ g.test('call_after_successful_finish')
       }, IsEncoderFinished);
       encoder.finish();
     }
+  });
+
+g.test('pass_end_none')
+  .desc(
+    `
+  Test that ending a {compute,render} pass without ending the passes generates a validation error.
+  `
+  )
+  .paramsSubcasesOnly(u => u.combine('passType', ['compute', 'render']).combine('endCount', [0, 1]))
+  .fn(async t => {
+    const { passType, endCount } = t.params;
+
+    const encoder = t.device.createCommandEncoder();
+
+    const pass = passType === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder);
+
+    for (let i = 0; i < endCount; ++i) {
+      pass.end();
+    }
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, endCount === 0);
+  });
+
+g.test('pass_end_twice')
+  .desc('Test that ending a {compute,render} pass twice generates a validation error.')
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('passType', ['compute', 'render'])
+      .combine('endTwice', [false, true])
+  )
+  .fn(async t => {
+    const { passType, endTwice } = t.params;
+
+    const encoder = t.device.createCommandEncoder();
+
+    const pass = passType === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder);
+
+    pass.end();
+    if (endTwice) {
+      t.expectValidationError(() => {
+        pass.end();
+      });
+    }
+
+    encoder.finish();
   });


### PR DESCRIPTION
This PR adds new two tests to ensure that a validation error is generated if ending a pass twice or without ending a pass generates a validation error.

Issue: #1914

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
