### PR TITLE
val: Use doCompute,doRender helpers in empty_bind_group_layouts_requires_empty_bind_groups.* tests

### DIFF
--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -652,16 +652,18 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,compute_pass')
   Test that a compute pipeline with empty bind groups layouts requires empty bind groups to be set.
   `
   )
-  .paramsSimple([
-    { bindGroupLayoutEntryCount: 4, _success: true }, // Control case
-    { bindGroupLayoutEntryCount: 3, _success: false },
-  ])
+  .params(u =>
+    u
+      .combine('bindGroupLayoutEntryCount', [3, 4])
+      .combine('computeCommand', ['dispatchIndirect', 'dispatch'] as const)
+  )
   .fn(async t => {
-    const { bindGroupLayoutEntryCount, _success } = t.params;
+    const { bindGroupLayoutEntryCount, computeCommand } = t.params;
 
+    const emptyBGLCount = 4;
     const emptyBGL = t.device.createBindGroupLayout({ entries: [] });
     const emptyBGLs = [];
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < emptyBGLCount; i++) {
       emptyBGLs.push(emptyBGL);
     }
 
@@ -690,12 +692,15 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,compute_pass')
     for (let i = 0; i < bindGroupLayoutEntryCount; i++) {
       computePass.setBindGroup(i, emptyBindGroup);
     }
-    t.doCompute(computePass, 'dispatch', true);
+
+    t.doCompute(computePass, computeCommand, true);
     computePass.end();
+
+    const success = bindGroupLayoutEntryCount === emptyBGLCount;
 
     t.expectValidationError(() => {
       encoder.finish();
-    }, !_success);
+    }, !success);
   });
 
 g.test('empty_bind_group_layouts_requires_empty_bind_groups,render_pass')
@@ -704,16 +709,23 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,render_pass')
   Test that a render pipeline with empty bind groups layouts requires empty bind groups to be set.
   `
   )
-  .paramsSimple([
-    { bindGroupLayoutEntryCount: 4, _success: true }, // Control case
-    { bindGroupLayoutEntryCount: 3, _success: false },
-  ])
+  .params(u =>
+    u
+      .combine('bindGroupLayoutEntryCount', [3, 4])
+      .combine('renderCommand', [
+        'draw',
+        'drawIndexed',
+        'drawIndirect',
+        'drawIndexedIndirect',
+      ] as const)
+  )
   .fn(async t => {
-    const { bindGroupLayoutEntryCount, _success } = t.params;
+    const { bindGroupLayoutEntryCount, renderCommand } = t.params;
 
+    const emptyBGLCount = 4;
     const emptyBGL = t.device.createBindGroupLayout({ entries: [] });
     const emptyBGLs = [];
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < emptyBGLCount; i++) {
       emptyBGLs.push(emptyBGL);
     }
 
@@ -767,10 +779,12 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,render_pass')
     for (let i = 0; i < bindGroupLayoutEntryCount; i++) {
       renderPass.setBindGroup(i, emptyBindGroup);
     }
-    t.doRender(renderPass, 'draw', true);
+    t.doRender(renderPass, renderCommand, true);
     renderPass.end();
+
+    const success = bindGroupLayoutEntryCount === emptyBGLCount;
 
     t.expectValidationError(() => {
       encoder.finish();
-    }, !_success);
+    }, !success);
   });

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -650,8 +650,6 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,compute_pass')
   .desc(
     `
   Test that a compute pipeline with empty bind groups layouts requires empty bind groups to be set.
-
-  TODO: Also test other dispatch calls using the 'doCompute' helper in this file
   `
   )
   .paramsSimple([
@@ -687,13 +685,13 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,compute_pass')
     });
 
     const encoder = t.device.createCommandEncoder();
-    const pass = encoder.beginComputePass();
-    pass.setPipeline(pipeline);
+    const computePass = encoder.beginComputePass();
+    computePass.setPipeline(pipeline);
     for (let i = 0; i < bindGroupLayoutEntryCount; i++) {
-      pass.setBindGroup(i, emptyBindGroup);
+      computePass.setBindGroup(i, emptyBindGroup);
     }
-    pass.dispatchWorkgroups(0);
-    pass.end();
+    t.doCompute(computePass, 'dispatch', true);
+    computePass.end();
 
     t.expectValidationError(() => {
       encoder.finish();
@@ -704,8 +702,6 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,render_pass')
   .desc(
     `
   Test that a render pipeline with empty bind groups layouts requires empty bind groups to be set.
-
-  TODO: Also test other draw calls using the 'doRender' helper in this file
   `
   )
   .paramsSimple([
@@ -771,7 +767,7 @@ g.test('empty_bind_group_layouts_requires_empty_bind_groups,render_pass')
     for (let i = 0; i < bindGroupLayoutEntryCount; i++) {
       renderPass.setBindGroup(i, emptyBindGroup);
     }
-    renderPass.draw(0);
+    t.doRender(renderPass, 'draw', true);
     renderPass.end();
 
     t.expectValidationError(() => {


### PR DESCRIPTION
We can simply call doCompute, doRender helper methods instead of calling dispatchWorkgroups and draw functions.

Issue: #1903

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
