### PR TITLE
Implement `pack2x16unorm` tests

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -297,6 +297,7 @@ g.test('pack2x16unorm')
     { inputs: [0.1, 0.1], result: 0x199a199a },
     { inputs: [0.5, 0.5], result: 0x80008000 },
     { inputs: [0.1, 0.5], result: 0x8000199a },
+    { inputs: [10, 10], result: 0xffffffff },
 
     // Subnormals
     { inputs: [kValue.f32.subnormal.positive.max, 1], result: 0xffff0000 },

--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -17,6 +17,7 @@ import {
   kFloat16Format,
   kFloat32Format,
   pack2x16float,
+  pack2x16unorm,
   Scalar,
   u32,
   vec2,
@@ -284,4 +285,26 @@ g.test('pack2x16float')
       objectEquals(got_str.sort(), expect_str.sort()),
       `pack2x16float(${inputs}) returned [${got_str}]. Expected [${expect}]`
     );
+  });
+
+g.test('pack2x16unorm')
+  .paramsSimple([
+    // Normals
+    { inputs: [0, 0], result: 0x00000000 },
+    { inputs: [1, 0], result: 0x0000ffff },
+    { inputs: [1, 1], result: 0xffffffff },
+    { inputs: [-1, -1], result: 0x00000000 },
+    { inputs: [0.1, 0.1], result: 0x199a199a },
+    { inputs: [0.5, 0.5], result: 0x80008000 },
+    { inputs: [0.1, 0.5], result: 0x8000199a },
+
+    // Subnormals
+    { inputs: [kValue.f32.subnormal.positive.max, 1], result: 0xffff0000 },
+  ] as const)
+  .fn(test => {
+    const inputs = test.params.inputs;
+    const got = pack2x16unorm(inputs[0], inputs[1]);
+    const expect = test.params.result;
+
+    test.expect(got === expect, `pack2x16unorm(${inputs}) returned ${got}. Expected [${expect}]`);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
@@ -7,6 +7,20 @@ bits 16 × i through 16 × i + 15 of the result.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { kValue } from '../../../../../util/constants.js';
+import {
+  f32,
+  pack2x16unorm,
+  TypeF32,
+  TypeU32,
+  TypeVec,
+  u32,
+  vec2,
+} from '../../../../../util/conversion.js';
+import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { allInputSources, Case, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,4 +31,28 @@ g.test('pack')
 @const fn pack2x16unorm(e: vec2<f32>) -> u32
 `
   )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const makeCase = (x: number, y: number): Case => {
+      x = quantizeToF32(x);
+      y = quantizeToF32(y);
+      return { input: [vec2(f32(x), f32(y))], expected: u32(pack2x16unorm(x, y)) };
+    };
+
+    // Returns a value normalized to [0, 1].
+    const normalize_f32 = (n: number): number => {
+      return n > 0 ? n / kValue.f32.positive.max : n / kValue.f32.negative.min;
+    };
+
+    const numeric_range = fullF32Range();
+    const cases: Array<Case> = [];
+    numeric_range.forEach(x => {
+      numeric_range.forEach(y => {
+        cases.push(makeCase(x, y));
+        // Interesting cases are on [0, 1]
+        cases.push(makeCase(normalize_f32(x), normalize_f32(y)));
+      });
+    });
+
+    await run(t, builtin('pack2x16unorm'), [TypeVec(2, TypeF32)], TypeU32, t.params, cases);
+  });

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -323,6 +323,33 @@ export function pack2x16float(x: number, y: number): (number | undefined)[] {
 }
 
 /**
+ * Converts two normalized f32s to u16s and then packs them in a u32
+ *
+ * This should implement the same behaviour as the builtin `pack2x16unorm` from
+ * WGSL.
+ *
+ * Caller is responsible to ensuring inputs are normalized f32s
+ *
+ * @param x first f32 to be packed
+ * @param y second f32 to be packed
+ * @returns an number that is expected result of pack2x16unorm.
+ */
+export function pack2x16unorm(x: number, y: number): number {
+  // Converts f32 to u16 via the pack2x16unorm formula.
+  // FTZ is not explicitly handled, because all subnormals will produce a value
+  // between 0.5 and much less than 1, so floor goes to 0.
+  const generate_u16 = (n: number): number => {
+    return Math.floor(0.5 + 65535 * Math.min(1, Math.max(0, n)));
+  };
+  x = generate_u16(x);
+  y = generate_u16(y);
+
+  workingDataU16[0] = x;
+  workingDataU16[1] = y;
+  return workingDataU32[0];
+}
+
+/**
  * Asserts that a number is within the representable (inclusive) of the integer type with the
  * specified number of bits and signedness.
  *


### PR DESCRIPTION
Fixes #1287

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
