### PR TITLE
Implement `pack4x8snorm` tests

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -19,6 +19,7 @@ import {
   pack2x16float,
   pack2x16snorm,
   pack2x16unorm,
+  pack4x8snorm,
   Scalar,
   u32,
   vec2,
@@ -338,4 +339,44 @@ g.test('pack2x16unorm')
     const expect = test.params.result;
 
     test.expect(got === expect, `pack2x16unorm(${inputs}) returned ${got}. Expected [${expect}]`);
+  });
+
+g.test('pack4x8snorm')
+  .paramsSimple([
+    // Normals
+    { inputs: [0, 0, 0, 0], result: 0x00000000 },
+    { inputs: [1, 0, 0, 0], result: 0x0000007f },
+    { inputs: [0, 1, 0, 0], result: 0x00007f00 },
+    { inputs: [0, 0, 1, 0], result: 0x007f0000 },
+    { inputs: [0, 0, 0, 1], result: 0x7f000000 },
+    { inputs: [1, 1, 1, 1], result: 0x7f7f7f7f },
+    { inputs: [10, 10, 10, 10], result: 0x7f7f7f7f },
+    { inputs: [-1, 0, 0, 0], result: 0x00000081 },
+    { inputs: [0, -1, 0, 0], result: 0x00008100 },
+    { inputs: [0, 0, -1, 0], result: 0x00810000 },
+    { inputs: [0, 0, 0, -1], result: 0x81000000 },
+    { inputs: [-1, -1, -1, -1], result: 0x81818181 },
+    { inputs: [-10, -10, -10, -10], result: 0x81818181 },
+    { inputs: [0.1, 0.1, 0.1, 0.1], result: 0x0d0d0d0d },
+    { inputs: [-0.1, -0.1, -0.1, -0.1], result: 0xf3f3f3f3 },
+    { inputs: [0.1, -0.1, 0.1, -0.1], result: 0xf30df30d },
+    { inputs: [0.5, 0.5, 0.5, 0.5], result: 0x40404040 },
+    { inputs: [-0.5, -0.5, -0.5, -0.5], result: 0xc1c1c1c1 },
+    { inputs: [-0.5, 0.5, -0.5, 0.5], result: 0x40c140c1 },
+    { inputs: [0.1, 0.5, 0.1, 0.5], result: 0x400d400d },
+    { inputs: [-0.1, -0.5, -0.1, -0.5], result: 0xc1f3c1f3 },
+
+    // Subnormals
+    { inputs: [kValue.f32.subnormal.positive.max, 1, 1, 1], result: 0x7f7f7f00 },
+    { inputs: [kValue.f32.subnormal.negative.min, 1, 1, 1], result: 0x7f7f7f00 },
+  ] as const)
+  .fn(test => {
+    const inputs = test.params.inputs;
+    const got = pack4x8snorm(inputs[0], inputs[1], inputs[2], inputs[3]);
+    const expect = test.params.result;
+
+    test.expect(
+      got === expect,
+      `pack4x8snorm(${inputs}) returned ${u32(got)}. Expected [${expect}]`
+    );
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
@@ -6,7 +6,23 @@ bits 8 × i through 8 × i + 7 of the result.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { assert } from '../../../../../../common/util/util.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { kValue } from '../../../../../util/constants.js';
+import {
+  f32,
+  pack4x8snorm,
+  Scalar,
+  TypeF32,
+  TypeU32,
+  TypeVec,
+  u32,
+  vec4,
+} from '../../../../../util/conversion.js';
+import { cartesianProduct, quantizeToF32, sparseF32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,4 +33,34 @@ g.test('pack')
 @const fn pack4x8snorm(e: vec4<f32>) -> u32
 `
   )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const makeCase = (vals: [number, number, number, number]): Case => {
+      const vals_f32 = new Array<Scalar>(4) as [Scalar, Scalar, Scalar, Scalar];
+      for (const idx in vals) {
+        vals[idx] = quantizeToF32(vals[idx]);
+        vals_f32[idx] = f32(vals[idx]);
+      }
+
+      return { input: [vec4(...vals_f32)], expected: u32(pack4x8snorm(...vals)) };
+    };
+
+    // Returns a value normalized to [-1, 1].
+    const normalizeF32 = (n: number): number => {
+      return n / kValue.f32.positive.max;
+    };
+
+    const numeric_range = sparseF32Range();
+    const cases: Array<Case> = [];
+    cartesianProduct(numeric_range, numeric_range, numeric_range, numeric_range).forEach(vals => {
+      assert(
+        vals.length === 4,
+        `Results of cartesianProduct of 4 numbers should be [number, number, number, number]`
+      );
+      cases.push(makeCase(vals as [number, number, number, number]));
+      // Interesting cases are on [-1, 1]
+      cases.push(makeCase(vals.map(normalizeF32) as [number, number, number, number]));
+    });
+
+    await run(t, builtin('pack4x8snorm'), [TypeVec(4, TypeF32)], TypeU32, t.params, cases);
+  });

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -139,6 +139,7 @@ const workingDataU16 = new Uint16Array(workingData);
 const workingDataI16 = new Int16Array(workingData);
 const workingDataF32 = new Float32Array(workingData);
 const workingDataF16 = new Float16Array(workingData);
+const workingDataI8 = new Int8Array(workingData);
 
 /** Bitcast u32 (represented as integer Number) to f32 (represented as floating-point Number). */
 export function float32BitsToNumber(bits: number): number {
@@ -308,10 +309,8 @@ export function pack2x16float(x: number, y: number): (number | undefined)[] {
     return [undefined];
   }
 
-  const u16_pairs = cartesianProduct(generateU16s(x), generateU16s(y));
-
   const results = new Array<number>();
-  for (const p of u16_pairs) {
+  for (const p of cartesianProduct(generateU16s(x), generateU16s(y))) {
     assert(p.length === 2, 'cartesianProduct of 2 arrays returned an entry with not 2 elements');
     workingDataU16[0] = p[0];
     workingDataU16[1] = p[1];
@@ -343,6 +342,7 @@ export function pack2x16snorm(x: number, y: number): number {
 
   workingDataI16[0] = generateI16(x);
   workingDataI16[1] = generateI16(y);
+
   return workingDataU32[0];
 }
 
@@ -368,6 +368,33 @@ export function pack2x16unorm(x: number, y: number): number {
 
   workingDataU16[0] = generateU16(x);
   workingDataU16[1] = generateU16(y);
+
+  return workingDataU32[0];
+}
+
+/**
+ * Converts four normalized f32s to i8s and then packs them in a u32
+ *
+ * This should implement the same behaviour as the builtin `pack4x8snorm` from
+ * WGSL.
+ *
+ * Caller is responsible to ensuring inputs are normalized f32s
+ *
+ * @param vals four f32s to be packed
+ * @returns a number that is expected result of pack4x8usorm.
+ */
+export function pack4x8snorm(...vals: [number, number, number, number]): number {
+  // Converts f32 to u8 via the pack4x8snorm formula.
+  // FTZ is not explicitly handled, because all subnormals will produce a value
+  // between 0 and 1, so floor goes to 0.
+  const generateI8 = (n: number): number => {
+    return Math.floor(0.5 + 127 * Math.min(1, Math.max(-1, n)));
+  };
+
+  for (const idx in vals) {
+    workingDataI8[idx] = generateI8(vals[idx]);
+  }
+
   return workingDataU32[0];
 }
 


### PR DESCRIPTION
Fixes #1284

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
