### PR TITLE
GPUBuffer.unmap() shouldn't fail even on unmapped or destroyed buffers

### DIFF
--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -25,7 +25,7 @@ g.test('mapAsync')
     `Test creating a large mappable buffer should produce an out-of-memory error if allocation fails.
   - The resulting buffer is an error buffer, so mapAsync rejects and produces a validation error.
   - Calling getMappedRange should throw an OperationError because the buffer is not in the mapped state.
-  - unmap() throws an OperationError if mapping failed, and otherwise should detach the ArrayBuffer.
+  - unmap() doesn't throw an error even if mapping failed, and otherwise should detach the ArrayBuffer.
 `
   )
   .params(
@@ -61,8 +61,8 @@ g.test('mapAsync')
         buffer.getMappedRange();
       });
 
-      // Should be a validation error since the buffer failed to be mapped.
-      t.expectGPUError('validation', () => buffer.unmap());
+      // Should't be a validation error even if the buffer failed to be mapped.
+      buffer.unmap();
     } else {
       await promise;
       const arraybuffer = buffer.getMappedRange();

--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -803,29 +803,25 @@ g.test('getMappedRange,disjoinRanges_many')
 
 g.test('unmap,state,unmapped')
   .desc(
-    `Test it is invalid to call unmap on a buffer that is unmapped (at creation, or after
+    `Test it is valid to call unmap on a buffer that is unmapped (at creation, or after
     mappedAtCreation or mapAsync)`
   )
   .fn(async t => {
-    // It is invalid to call unmap after creation of an unmapped buffer.
+    // It is valid to call unmap after creation of an unmapped buffer.
     {
       const buffer = t.device.createBuffer({ size: 16, usage: GPUBufferUsage.MAP_READ });
-      t.expectValidationError(() => {
-        buffer.unmap();
-      });
+      buffer.unmap();
     }
 
-    // It is invalid to call unmap after unmapping a mapAsynced buffer.
+    // It is valid to call unmap after unmapping a mapAsynced buffer.
     {
       const buffer = t.createMappableBuffer(GPUMapMode.READ, 16);
       await buffer.mapAsync(GPUMapMode.READ);
       buffer.unmap();
-      t.expectValidationError(() => {
-        buffer.unmap();
-      });
+      buffer.unmap();
     }
 
-    // It is invalid to call unmap after unmapping a mappedAtCreation buffer.
+    // It is valid to call unmap after unmapping a mappedAtCreation buffer.
     {
       const buffer = t.device.createBuffer({
         usage: GPUBufferUsage.MAP_READ,
@@ -833,38 +829,32 @@ g.test('unmap,state,unmapped')
         mappedAtCreation: true,
       });
       buffer.unmap();
-      t.expectValidationError(() => {
-        buffer.unmap();
-      });
+      buffer.unmap();
     }
   });
 
 g.test('unmap,state,destroyed')
   .desc(
-    `Test it is invalid to call unmap on a buffer that is destroyed (at creation, or after
+    `Test it is valid to call unmap on a buffer that is destroyed (at creation, or after
     mappedAtCreation or mapAsync)`
   )
   .fn(async t => {
-    // It is invalid to call unmap after destruction of an unmapped buffer.
+    // It is valid to call unmap after destruction of an unmapped buffer.
     {
       const buffer = t.device.createBuffer({ size: 16, usage: GPUBufferUsage.MAP_READ });
       buffer.destroy();
-      t.expectValidationError(() => {
-        buffer.unmap();
-      });
+      buffer.unmap();
     }
 
-    // It is invalid to call unmap after destroying a mapAsynced buffer.
+    // It is valid to call unmap after destroying a mapAsynced buffer.
     {
       const buffer = t.createMappableBuffer(GPUMapMode.READ, 16);
       await buffer.mapAsync(GPUMapMode.READ);
       buffer.destroy();
-      t.expectValidationError(() => {
-        buffer.unmap();
-      });
+      buffer.unmap();
     }
 
-    // It is invalid to call unmap after destroying a mappedAtCreation buffer.
+    // It is valid to call unmap after destroying a mappedAtCreation buffer.
     {
       const buffer = t.device.createBuffer({
         usage: GPUBufferUsage.MAP_READ,
@@ -872,9 +862,7 @@ g.test('unmap,state,destroyed')
         mappedAtCreation: true,
       });
       buffer.destroy();
-      t.expectValidationError(() => {
-        buffer.unmap();
-      });
+      buffer.unmap();
     }
   });
 


### PR DESCRIPTION
Device-timeline validation error in `GPUBuffer.unmap()` has been removed in WebGPU specification.

https://github.com/gpuweb/gpuweb/pull/3368

With this change, `GPUBuffer.unmap()` doesn't fail even on unmapped or destroyed buffers.

This commit reflects the change to the WebGPU CTS tests.




Issue: #1930 <!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
