### PR TITLE
val: Introduce debugMarker.spec.ts to test debug marker

### DIFF
--- a/src/webgpu/api/validation/debugMarker.spec.ts
+++ b/src/webgpu/api/validation/debugMarker.spec.ts
@@ -1,0 +1,40 @@
+export const description = `
+Test validation of pushDebugGroup, popDebugGroup, and insertDebugMarker.
+`;
+
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+
+import { ValidationTest } from './validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('push_pop_call_count_unbalance')
+  .desc(
+    `
+  Test that a validation error is generated if {push,pop} debug group call count is not paired.
+  `
+  )
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('pushCount', [1, 2, 3])
+      .combine('popCount', [1, 2, 3])
+  )
+  .fn(async t => {
+    const { pushCount, popCount } = t.params;
+
+    const encoder = t.device.createCommandEncoder();
+
+    for (let i = 0; i < pushCount; ++i) {
+      encoder.pushDebugGroup('EventStart');
+    }
+
+    encoder.insertDebugMarker('Marker');
+
+    for (let i = 0; i < popCount; ++i) {
+      encoder.popDebugGroup();
+    }
+
+    t.expectValidationError(() => {
+      encoder.finish();
+    }, pushCount !== popCount);
+  });

--- a/src/webgpu/api/validation/debugMarker.spec.ts
+++ b/src/webgpu/api/validation/debugMarker.spec.ts
@@ -6,9 +6,30 @@ import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 import { ValidationTest } from './validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+class F extends ValidationTest {
+  beginRenderPass(commandEncoder: GPUCommandEncoder): GPURenderPassEncoder {
+    const attachmentTexture = this.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    this.trackForCleanup(attachmentTexture);
+    return commandEncoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: attachmentTexture.createView(),
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+  }
+}
 
-g.test('push_pop_call_count_unbalance')
+export const g = makeTestGroup(F);
+
+g.test('push_pop_call_count_unbalance,command_encoder')
   .desc(
     `
   Test that a validation error is generated if {push,pop} debug group call count is not paired.
@@ -35,6 +56,43 @@ g.test('push_pop_call_count_unbalance')
     }
 
     t.expectValidationError(() => {
+      encoder.finish();
+    }, pushCount !== popCount);
+  });
+
+g.test('push_pop_call_count_unbalance,render_compute_pass')
+  .desc(
+    `
+  Test that a validation error is generated if {push,pop} debug group call count is not paired in
+  ComputePassEncoder and RenderPassEncoder.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('passType', ['compute', 'render'])
+      .beginSubcases()
+      .combine('pushCount', [1, 2, 3])
+      .combine('popCount', [1, 2, 3])
+  )
+  .fn(async t => {
+    const { passType, pushCount, popCount } = t.params;
+
+    const encoder = t.device.createCommandEncoder();
+
+    const pass = passType === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder);
+
+    for (let i = 0; i < pushCount; ++i) {
+      pass.pushDebugGroup('EventStart');
+    }
+
+    pass.insertDebugMarker('Marker');
+
+    for (let i = 0; i < popCount; ++i) {
+      pass.popDebugGroup();
+    }
+
+    t.expectValidationError(() => {
+      pass.end();
       encoder.finish();
     }, pushCount !== popCount);
   });


### PR DESCRIPTION
This PR introduces a new debugMarker.spec.ts file in order to test the validation of pushDebugGroup, popDebugGroup, and insertDebugMarker.

As a first test, this PR adds 'push_pop_call_count_unbalance' to ensure that a validation error is generated if the {push,pop} count is not paired.

Issue: #1928

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
