### PR TITLE
Convert pack* tests to use generated vectors for inputs

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -61,12 +61,8 @@ g.test('pack')
       return { input: [vec2(f32(x), f32(y))], expected: anyOf(...results.map(cmp)) };
     };
 
-    const numeric_range = fullF32Range();
-    const cases: Array<Case> = [];
-    numeric_range.forEach(x => {
-      numeric_range.forEach(y => {
-        cases.push(makeCase(x, y));
-      });
+    const cases: Array<Case> = kVectorTestValues[2].map(v => {
+      return makeCase(...(v as [number, number]));
     });
 
     await run(t, builtin('pack2x16float'), [TypeVec(2, TypeF32)], TypeU32, t.params, cases);

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
@@ -17,7 +17,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -44,14 +44,11 @@ g.test('pack')
       return n / kValue.f32.positive.max;
     };
 
-    const numeric_range = fullF32Range();
-    const cases: Array<Case> = [];
-    numeric_range.forEach(x => {
-      numeric_range.forEach(y => {
-        cases.push(makeCase(x, y));
-        // Interesting cases are on [-1, 1]
-        cases.push(makeCase(normalizeF32(x), normalizeF32(y)));
-      });
+    const cases: Array<Case> = kVectorTestValues[2].flatMap(v => {
+      return [
+        makeCase(...(v as [number, number])),
+        makeCase(...(v.map(normalizeF32) as [number, number])),
+      ];
     });
 
     await run(t, builtin('pack2x16snorm'), [TypeVec(2, TypeF32)], TypeU32, t.params, cases);

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
@@ -17,7 +17,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -44,14 +44,11 @@ g.test('pack')
       return n > 0 ? n / kValue.f32.positive.max : n / kValue.f32.negative.min;
     };
 
-    const numeric_range = fullF32Range();
-    const cases: Array<Case> = [];
-    numeric_range.forEach(x => {
-      numeric_range.forEach(y => {
-        cases.push(makeCase(x, y));
-        // Interesting cases are on [0, 1]
-        cases.push(makeCase(normalizeF32(x), normalizeF32(y)));
-      });
+    const cases: Array<Case> = kVectorTestValues[2].flatMap(v => {
+      return [
+        makeCase(...(v as [number, number])),
+        makeCase(...(v.map(normalizeF32) as [number, number])),
+      ];
     });
 
     await run(t, builtin('pack2x16unorm'), [TypeVec(2, TypeF32)], TypeU32, t.params, cases);

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
@@ -6,7 +6,6 @@ bits 8 × i through 8 × i + 7 of the result.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { assert } from '../../../../../../common/util/util.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import {
@@ -19,7 +18,7 @@ import {
   u32,
   vec4,
 } from '../../../../../util/conversion.js';
-import { cartesianProduct, quantizeToF32, sparseF32Range } from '../../../../../util/math.js';
+import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -50,16 +49,11 @@ g.test('pack')
       return n / kValue.f32.positive.max;
     };
 
-    const numeric_range = sparseF32Range();
-    const cases: Array<Case> = [];
-    cartesianProduct(numeric_range, numeric_range, numeric_range, numeric_range).forEach(vals => {
-      assert(
-        vals.length === 4,
-        `Results of cartesianProduct of 4 numbers should be [number, number, number, number]`
-      );
-      cases.push(makeCase(vals as [number, number, number, number]));
-      // Interesting cases are on [-1, 1]
-      cases.push(makeCase(vals.map(normalizeF32) as [number, number, number, number]));
+    const cases: Array<Case> = kVectorTestValues[4].flatMap(v => {
+      return [
+        makeCase(v as [number, number, number, number]),
+        makeCase(v.map(normalizeF32) as [number, number, number, number]),
+      ];
     });
 
     await run(t, builtin('pack4x8snorm'), [TypeVec(4, TypeF32)], TypeU32, t.params, cases);


### PR DESCRIPTION
This is a significant performance benefit because it requires less computation by the individual tests, since this is using a common set of inputs that are generated at startup, and it also reduces the number of tests being run by using a sparser, but still covering set of inputs.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
