### PR TITLE
Convert f32 binary expression tests to use pre-generated inputs

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -12,14 +12,12 @@ import {
   remainderInterval,
   subtractionInterval,
 } from '../../../../util/f32_interval.js';
-import { cartesianProduct, fullF32Range } from '../../../../util/math.js';
+import { kVectorTestValues } from '../../../../util/math.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
-
-const kTestValues: number[][] = cartesianProduct(fullF32Range(), fullF32Range());
 
 g.test('addition')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
@@ -37,7 +35,7 @@ Accuracy: Correctly rounded
       return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
     };
 
-    const cases = kTestValues.map((v: number[]) => {
+    const cases = kVectorTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 
@@ -60,7 +58,7 @@ Accuracy: Correctly rounded
       return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
     };
 
-    const cases = kTestValues.map((v: number[]) => {
+    const cases = kVectorTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 
@@ -83,7 +81,7 @@ Accuracy: Correctly rounded
       return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
     };
 
-    const cases = kTestValues.map((v: number[]) => {
+    const cases = kVectorTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 
@@ -106,7 +104,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
       return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
     };
 
-    const cases = kTestValues.map((v: number[]) => {
+    const cases = kVectorTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 
@@ -129,7 +127,7 @@ Accuracy: Derived from x - y * trunc(x/y)
       return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
     };
 
-    const cases = kTestValues.map((v: number[]) => {
+    const cases = kVectorTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 

--- a/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { anyOf } from '../../../../util/compare.js';
 import { bool, f32, Scalar, TypeBool, TypeF32 } from '../../../../util/conversion.js';
-import { flushSubnormalScalarF32, fullF32Range } from '../../../../util/math.js';
+import { flushSubnormalScalarF32, kVectorTestValues } from '../../../../util/math.js';
 import { allInputSources, Case, run } from '../expression.js';
 
 import { binary } from './binary.js';
@@ -55,12 +55,8 @@ Accuracy: Correct result
       return (lhs.value as number) === (rhs.value as number);
     };
 
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs, truthFunc));
-      });
+    const cases = kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
     });
 
     await run(t, binary('=='), [TypeF32, TypeF32], TypeBool, t.params, cases);
@@ -82,12 +78,8 @@ Accuracy: Correct result
       return (lhs.value as number) !== (rhs.value as number);
     };
 
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs, truthFunc));
-      });
+    const cases = kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
     });
 
     await run(t, binary('!='), [TypeF32, TypeF32], TypeBool, t.params, cases);
@@ -109,12 +101,8 @@ Accuracy: Correct result
       return (lhs.value as number) < (rhs.value as number);
     };
 
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs, truthFunc));
-      });
+    const cases = kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
     });
 
     await run(t, binary('<'), [TypeF32, TypeF32], TypeBool, t.params, cases);
@@ -136,12 +124,8 @@ Accuracy: Correct result
       return (lhs.value as number) <= (rhs.value as number);
     };
 
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs, truthFunc));
-      });
+    const cases = kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
     });
 
     await run(t, binary('<='), [TypeF32, TypeF32], TypeBool, t.params, cases);
@@ -163,12 +147,8 @@ Accuracy: Correct result
       return (lhs.value as number) > (rhs.value as number);
     };
 
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs, truthFunc));
-      });
+    const cases = kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
     });
 
     await run(t, binary('>'), [TypeF32, TypeF32], TypeBool, t.params, cases);
@@ -190,12 +170,8 @@ Accuracy: Correct result
       return (lhs.value as number) >= (rhs.value as number);
     };
 
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs, truthFunc));
-      });
+    const cases = kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
     });
 
     await run(t, binary('>='), [TypeF32, TypeF32], TypeBool, t.params, cases);


### PR DESCRIPTION
This PR change is a significant performance improvement for these tests, since it reduces the amount of duplicated
calculation/allocation for the raw test values and reduces the number of test cases while still getting good coverage.

The performance for my local testing environment look like this,

f32_arithmetic.spec.ts:   48.839024981s -> 11.670672481s
f32_logical.spec.ts:    1m23.881117761s -> 11.544870667s

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
