### PR TITLE
Implement `unpack2x16float` tests

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -286,7 +286,7 @@ g.test('pack2x16float')
     // Using strings of the outputs, so they can be easily sorted, since order of the results doesn't matter.
     test.expect(
       objectEquals(got_str.sort(), expect_str.sort()),
-      `pack2x16float(${inputs}) returned [${got_str}]. Expected [${expect}]`
+      `pack2x16float(${inputs}) returned [${got_str}]. Expected [${expect_str}]`
     );
   });
 

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -66,10 +66,11 @@ import {
   toF32Vector,
   truncInterval,
   ulpInterval,
-  unpack2x16unormInterval,
-  unpack4x8unormInterval,
+  unpack2x16floatInterval,
   unpack2x16snormInterval,
+  unpack2x16unormInterval,
   unpack4x8snormInterval,
+  unpack4x8unormInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -2688,6 +2689,44 @@ interface PointToVectorCase {
       t.expect(
         objectEquals(expected, got),
         `unpack2x16snormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
+      );
+    });
+
+  g.test('unpack2x16floatInterval')
+    .paramsSubcasesOnly<PointToVectorCase>(
+      // prettier-ignore
+      [
+        // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+        // form due to the inherited nature of the errors.
+        // f16 normals
+        { input: 0x00000000, expected: [[0], [0]] },
+        { input: 0x80000000, expected: [[0], [0]] },
+        { input: 0x00008000, expected: [[0], [0]] },
+        { input: 0x80008000, expected: [[0], [0]] },
+        { input: 0x00003c00, expected: [[1], [0]] },
+        { input: 0x3c000000, expected: [[0], [1]] },
+        { input: 0x3c003c00, expected: [[1], [1]] },
+        { input: 0xbc00bc00, expected: [[-1], [-1]] },
+        { input: 0x49004900, expected: [[10], [10]] },
+        { input: 0xc900c900, expected: [[-10], [-10]] },
+
+        // f16 subnormals
+        { input: 0x000003ff, expected: [[0, kValue.f16.subnormal.positive.max], [0]] },
+        { input: 0x000083ff, expected: [[kValue.f16.subnormal.negative.min, 0], [0]] },
+
+        // f16 out of bounds
+        { input: 0x7c000000, expected: [kAny, kAny] },
+        { input: 0xffff0000, expected: [kAny, kAny] },
+      ]
+    )
+    .fn(t => {
+      const expected = toF32Vector(t.params.expected);
+
+      const got = unpack2x16floatInterval(t.params.input);
+
+      t.expect(
+        objectEquals(expected, got),
+        `unpack2x16floatInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
       );
     });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
@@ -7,6 +7,12 @@ interpretation of bits 16×i through 16×i+15 of e as an IEEE-754 binary16 value
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
+import { unpack2x16floatInterval } from '../../../../../util/f32_interval.js';
+import { fullU32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,4 +23,13 @@ g.test('unpack')
 @const fn unpack2x16float(e: u32) -> vec2<f32>
 `
   )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      return makeU32ToVectorIntervalCase(n, unpack2x16floatInterval);
+    };
+
+    const cases: Array<Case> = fullU32Range().map(makeCase);
+
+    await run(t, builtin('unpack2x16float'), [TypeU32], TypeVec(2, TypeF32), t.params, cases);
+  });

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1,4 +1,5 @@
 import { assert, unreachable } from '../../common/util/util.js';
+import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 
 import { kValue } from './constants.js';
 import {
@@ -6,6 +7,7 @@ import {
   correctlyRoundedF16,
   correctlyRoundedF32,
   flushSubnormalNumberF32,
+  isFiniteF16,
   isFiniteF32,
   isSubnormalNumberF16,
   isSubnormalNumberF32,
@@ -1894,6 +1896,29 @@ const unpackDataU16 = new Uint16Array(unpackData);
 const unpackDataU8 = new Uint8Array(unpackData);
 const unpackDataI16 = new Int16Array(unpackData);
 const unpackDataI8 = new Int8Array(unpackData);
+const unpackDataF16 = new Float16Array(unpackData);
+
+/** Calculate an acceptance interval vector for unpack2x16float(x) */
+export function unpack2x16floatInterval(n: number): F32Vector {
+  assert(
+    n >= kValue.u32.min && n <= kValue.u32.max,
+    'unpack2x16floatInterval only accepts values on the bounds of u32'
+  );
+  unpackDataU32[0] = n;
+  if (unpackDataF16.some(f => !isFiniteF16(f))) {
+    return [F32Interval.any(), F32Interval.any()];
+  }
+
+  const result: F32Vector = [
+    quantizeToF16Interval(unpackDataF16[0]),
+    quantizeToF16Interval(unpackDataF16[1]),
+  ];
+
+  if (result.some(r => !r.isFinite())) {
+    return [F32Interval.any(), F32Interval.any()];
+  }
+  return result;
+}
 
 const Unpack2x16snormIntervalOp = (n: number): F32Interval => {
   return maxInterval(divisionInterval(n, 32767), -1);


### PR DESCRIPTION
Fixes #1293

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
