### PR TITLE
Implement `unpack2x16snorm` tests

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -316,7 +316,7 @@ g.test('pack2x16snorm')
     const got = pack2x16snorm(inputs[0], inputs[1]);
     const expect = test.params.result;
 
-    test.expect(got === expect, `pack2x16snorm(${inputs}) returned ${got}. Expected [${expect}]`);
+    test.expect(got === expect, `pack2x16snorm(${inputs}) returned ${got}. Expected ${expect}`);
   });
 
 g.test('pack2x16unorm')
@@ -340,7 +340,7 @@ g.test('pack2x16unorm')
     const got = pack2x16unorm(inputs[0], inputs[1]);
     const expect = test.params.result;
 
-    test.expect(got === expect, `pack2x16unorm(${inputs}) returned ${got}. Expected [${expect}]`);
+    test.expect(got === expect, `pack2x16unorm(${inputs}) returned ${got}. Expected ${expect}`);
   });
 
 g.test('pack4x8snorm')
@@ -377,10 +377,7 @@ g.test('pack4x8snorm')
     const got = pack4x8snorm(inputs[0], inputs[1], inputs[2], inputs[3]);
     const expect = test.params.result;
 
-    test.expect(
-      got === expect,
-      `pack4x8snorm(${inputs}) returned ${u32(got)}. Expected [${expect}]`
-    );
+    test.expect(got === expect, `pack4x8snorm(${inputs}) returned ${u32(got)}. Expected ${expect}`);
   });
 
 g.test('pack4x8unorm')
@@ -407,5 +404,5 @@ g.test('pack4x8unorm')
     const got = pack4x8unorm(inputs[0], inputs[1], inputs[2], inputs[3]);
     const expect = test.params.result;
 
-    test.expect(got === expect, `pack4x8unorm(${inputs}) returned ${got}. Expected [${expect}]`);
+    test.expect(got === expect, `pack4x8unorm(${inputs}) returned ${got}. Expected ${expect}`);
   });

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -68,6 +68,7 @@ import {
   ulpInterval,
   unpack2x16unormInterval,
   unpack4x8unormInterval,
+  unpack2x16snormInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -2641,10 +2642,53 @@ interface PointToVectorCase {
 // that don't pollute the global namespace or have unwieldy long names.
 {
   const kZeroBounds: IntervalBounds = [hexToF32(0x81200000), hexToF32(0x01200000)];
-  const kOneBounds: IntervalBounds = [
+  const kOneBoundsSnorm: IntervalBounds = [
+    hexToF64(0x3fefffff, 0xa0000000),
+    hexToF64(0x3ff00000, 0x40000000),
+  ];
+  const kOneBoundsUnorm: IntervalBounds = [
     hexToF64(0x3fefffff, 0xb0000000),
     hexToF64(0x3ff00000, 0x28000000),
   ];
+  const kNegOneBoundsSnorm: IntervalBounds = [
+    hexToF64(0xbff00000, 0x00000000),
+    hexToF64(0xbfefffff, 0xa0000000),
+  ];
+
+  const kHalfBounds2x16snorm: IntervalBounds = [
+    hexToF64(0x3fe0001f, 0xa0000000),
+    hexToF64(0x3fe00020, 0x80000000),
+  ]; // ~0.5..., due to lack of precision in i16
+  const kNegHalfBounds2x16snorm: IntervalBounds = [
+    hexToF64(0xbfdfffc0, 0x60000000),
+    hexToF64(0xbfdfffbf, 0x80000000),
+  ]; // ~-0.5..., due to lack of precision in i16
+
+  g.test('unpack2x16snormInterval')
+    .paramsSubcasesOnly<PointToVectorCase>(
+      // prettier-ignore
+      [
+        // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+        // form due to the inherited nature of the errors.
+        { input: 0x00000000, expected: [kZeroBounds, kZeroBounds] },
+        { input: 0x00007fff, expected: [kOneBoundsSnorm, kZeroBounds] },
+        { input: 0x7fff0000, expected: [kZeroBounds, kOneBoundsSnorm] },
+        { input: 0x7fff7fff, expected: [kOneBoundsSnorm, kOneBoundsSnorm] },
+        { input: 0x80018001, expected: [kNegOneBoundsSnorm, kNegOneBoundsSnorm] },
+        { input: 0x40004000, expected: [kHalfBounds2x16snorm, kHalfBounds2x16snorm] },
+        { input: 0xc001c001, expected: [kNegHalfBounds2x16snorm, kNegHalfBounds2x16snorm] },
+      ]
+    )
+    .fn(t => {
+      const expected = toF32Vector(t.params.expected);
+
+      const got = unpack2x16snormInterval(t.params.input);
+
+      t.expect(
+        objectEquals(expected, got),
+        `unpack2x16snormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
+      );
+    });
 
   const kHalfBounds2x16unorm: IntervalBounds = [
     hexToF64(0x3fe0000f, 0xb0000000),
@@ -2658,9 +2702,9 @@ interface PointToVectorCase {
       // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
       // form due to the inherited nature of the errors.
       { input: 0x00000000, expected: [kZeroBounds, kZeroBounds] },
-      { input: 0x0000ffff, expected: [kOneBounds, kZeroBounds] },
-      { input: 0xffff0000, expected: [kZeroBounds, kOneBounds] },
-      { input: 0xffffffff, expected: [kOneBounds, kOneBounds] },
+      { input: 0x0000ffff, expected: [kOneBoundsUnorm, kZeroBounds] },
+      { input: 0xffff0000, expected: [kZeroBounds, kOneBoundsUnorm] },
+      { input: 0xffffffff, expected: [kOneBoundsUnorm, kOneBoundsUnorm] },
       { input: 0x80008000, expected: [kHalfBounds2x16unorm, kHalfBounds2x16unorm] },
     ]
     )
@@ -2687,15 +2731,15 @@ interface PointToVectorCase {
         // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
         // form due to the inherited nature of the errors.
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
-        { input: 0x000000ff, expected: [kOneBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
-        { input: 0x0000ff00, expected: [kZeroBounds, kOneBounds, kZeroBounds, kZeroBounds] },
-        { input: 0x00ff0000, expected: [kZeroBounds, kZeroBounds, kOneBounds, kZeroBounds] },
-        { input: 0xff000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kOneBounds] },
-        { input: 0x0000ffff, expected: [kOneBounds, kOneBounds, kZeroBounds, kZeroBounds] },
-        { input: 0xffff0000, expected: [kZeroBounds, kZeroBounds, kOneBounds, kOneBounds] },
-        { input: 0xff00ff00, expected: [kZeroBounds, kOneBounds, kZeroBounds, kOneBounds] },
-        { input: 0x00ff00ff, expected: [kOneBounds, kZeroBounds, kOneBounds, kZeroBounds] },
-        { input: 0xffffffff, expected: [kOneBounds, kOneBounds, kOneBounds, kOneBounds] },
+        { input: 0x000000ff, expected: [kOneBoundsUnorm, kZeroBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x0000ff00, expected: [kZeroBounds, kOneBoundsUnorm, kZeroBounds, kZeroBounds] },
+        { input: 0x00ff0000, expected: [kZeroBounds, kZeroBounds, kOneBoundsUnorm, kZeroBounds] },
+        { input: 0xff000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kOneBoundsUnorm] },
+        { input: 0x0000ffff, expected: [kOneBoundsUnorm, kOneBoundsUnorm, kZeroBounds, kZeroBounds] },
+        { input: 0xffff0000, expected: [kZeroBounds, kZeroBounds, kOneBoundsUnorm, kOneBoundsUnorm] },
+        { input: 0xff00ff00, expected: [kZeroBounds, kOneBoundsUnorm, kZeroBounds, kOneBoundsUnorm] },
+        { input: 0x00ff00ff, expected: [kOneBoundsUnorm, kZeroBounds, kOneBoundsUnorm, kZeroBounds] },
+        { input: 0xffffffff, expected: [kOneBoundsUnorm, kOneBoundsUnorm, kOneBoundsUnorm, kOneBoundsUnorm] },
         { input: 0x80808080, expected: [kHalfBounds4x8unorm, kHalfBounds4x8unorm, kHalfBounds4x8unorm, kHalfBounds4x8unorm] },
       ]
     )

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
@@ -7,6 +7,12 @@ of bits 16×i through 16×i+15 of e as a twos-complement signed integer.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
+import { unpack2x16snormInterval } from '../../../../../util/f32_interval.js';
+import { fullU32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,4 +23,14 @@ g.test('unpack')
 @const fn unpack2x16snorm(e: u32) -> vec2<f32>
 `
   )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      n = Math.trunc(n);
+      return makeU32ToVectorIntervalCase(n, unpack2x16snormInterval);
+    };
+
+    const cases: Array<Case> = fullU32Range().map(makeCase);
+
+    await run(t, builtin('unpack2x16snorm'), [TypeU32], TypeVec(2, TypeF32), t.params, cases);
+  });

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1,7 +1,6 @@
 import { assert, unreachable } from '../../common/util/util.js';
 
 import { kValue } from './constants.js';
-import { f64 } from './conversion.js';
 import {
   cartesianProduct,
   correctlyRoundedF16,
@@ -82,7 +81,7 @@ export class F32Interval {
 
   /** @returns a string representation for logging purposes */
   public toString(): string {
-    return `[${this.bounds().map(f64)}]`;
+    return `[${this.bounds()}]`;
   }
 
   /** @returns a singleton for interval of all possible values


### PR DESCRIPTION
Fixes #1291

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
