### PR TITLE
Add rg11b10ufloat-renderable validation test plan

### DIFF
--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -16,9 +16,7 @@ sampleCount > 1, iff rg11b10ufloat-renderable feature is enabled.
 `
   )
   .params(u =>
-    u
-      .combine('usage', [0, GPUConst.TextureUsage.RENDER_ATTACHMENT])
-      .combine('sampleCount', [1, 4])
+    u.combine('usage', [0, GPUConst.TextureUsage.RENDER_ATTACHMENT]).combine('sampleCount', [1, 4])
   )
   .unimplemented();
 

--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -47,7 +47,7 @@ g.test('create_render_pipeline')
   .desc(
     `
 Test that it is valid to create render pipeline with rg11b10ufloat texture format
-in descriptor.fragment.targets if rg11b10ufloat-renderable feature is enabled.
+in descriptor.fragment.targets iff rg11b10ufloat-renderable feature is enabled.
 `
   )
   .unimplemented();

--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -1,0 +1,53 @@
+export const description = `
+Tests for capabilities added by rg11b10ufloat-renderable flag.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ValidationTest } from '../validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('create_texture_render_attachment')
+  .desc(
+    `
+Test that it is valid to create texture with rg11b10ufloat texture format and
+RENDER_ATTACHMENT usage is valid if rg11b10ufloat-renderable feature is enabled.
+`
+  )
+  .unimplemented();
+
+g.test('create_texture_multisampling')
+  .desc(
+    `
+Test that it is valid to create texture with rg11b10ufloat texture format and
+sampleCount > 1 if rg11b10ufloat-renderable feature is enabled.
+`
+  )
+  .unimplemented();
+
+g.test('begin_render_pass')
+  .desc(
+    `
+Test that it is valid to begin render pass with rg11b10ufloat texture format
+if rg11b10ufloat-renderable feature is enabled.
+`
+  )
+  .unimplemented();
+
+g.test('begin_render_bundle_encoder')
+  .desc(
+    `
+Test that it is valid to begin render bundle encoder with rg11b10ufloat texture
+format if rg11b10ufloat-renderable feature is enabled.
+`
+  )
+  .unimplemented();
+
+g.test('create_render_pipeline')
+  .desc(
+    `
+Test that it is valid to create render pipeline with rg11b10ufloat texture format
+in descriptor.fragment.targets if rg11b10ufloat-renderable feature is enabled.
+`
+  )
+  .unimplemented();

--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -38,7 +38,7 @@ g.test('begin_render_bundle_encoder')
   .desc(
     `
 Test that it is valid to begin render bundle encoder with rg11b10ufloat texture
-format if rg11b10ufloat-renderable feature is enabled.
+format iff rg11b10ufloat-renderable feature is enabled.
 `
   )
   .unimplemented();

--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -16,7 +16,6 @@ sampleCount > 1, iff rg11b10ufloat-renderable feature is enabled.
   )
   .params(u =>
     u
-      .combine('enabled', [false, true])
       .combine('usage', [0, GPUConst.TextureUsage.RENDER_ATTACHMENT])
       .combine('sampleCount', [1, 4])
   )

--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -29,7 +29,7 @@ g.test('begin_render_pass')
   .desc(
     `
 Test that it is valid to begin render pass with rg11b10ufloat texture format
-if rg11b10ufloat-renderable feature is enabled.
+iff rg11b10ufloat-renderable feature is enabled.
 `
   )
   .unimplemented();

--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -7,21 +7,18 @@ import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
 
-g.test('create_texture_render_attachment')
+g.test('create_texture')
   .desc(
     `
-Test that it is valid to create texture with rg11b10ufloat texture format and
-RENDER_ATTACHMENT usage is valid if rg11b10ufloat-renderable feature is enabled.
+Test that it is valid to create rg11b10ufloat texture with RENDER_ATTACHMENT usage and/or
+sampleCount > 1, iff rg11b10ufloat-renderable feature is enabled.
 `
   )
-  .unimplemented();
-
-g.test('create_texture_multisampling')
-  .desc(
-    `
-Test that it is valid to create texture with rg11b10ufloat texture format and
-sampleCount > 1 if rg11b10ufloat-renderable feature is enabled.
-`
+  .params(u =>
+    u
+      .combine('enabled', [false, true])
+      .combine('usage', [0, GPUConst.TextureUsage.RENDER_ATTACHMENT])
+      .combine('sampleCount', [1, 4])
   )
   .unimplemented();
 

--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -3,6 +3,7 @@ Tests for capabilities added by rg11b10ufloat-renderable flag.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUConst } from '../../../constants.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);


### PR DESCRIPTION


Issue: #1874<!-- Fill in the issue number here. See docs/intro/life_of.md -->

This PR adds `rg11b10ufloat-renderable` validation test plan.

The validation test is for capabilities added by `rg11b10ufloat-renderable` feature. The `rg11b10ufloat-renderable` feature allows `rg11b10ufloat` texture format to be used with`RENDER_ATTACHMENT` usage and to be multisampled.

https://gpuweb.github.io/gpuweb/#rg11b10ufloat-renderable

So I picked validation tests related `RENDER_ATTACHMENT` usage and multisampling from the WebGPU spec. Let me know if I have missed anything.

Ideally `rg11b10ufloat-renderable` should be tested with `capability_info.ts` table but it has some problems now. Instead we should just write one-off tests and improve the test later.

So I added a new test file `src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts`. We can just remove this file when we will imptove the test by integrating with `capability_info.ts` later.

Please also see: #1874

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
