### PR TITLE
Fixup min i32 value in parsing test.

### DIFF
--- a/src/webgpu/shader/validation/parse/literal.spec.ts
+++ b/src/webgpu/shader/validation/parse/literal.spec.ts
@@ -34,7 +34,6 @@ const kI32 = new Set([
   '2147483647i', // max signed int
   '-2147483647i', // min parsable signed int
   'i32(-2147483648)', // min signed int
-
 ]);
 
 const kU32 = new Set([

--- a/src/webgpu/shader/validation/parse/literal.spec.ts
+++ b/src/webgpu/shader/validation/parse/literal.spec.ts
@@ -32,7 +32,9 @@ const kAbstractIntNegative = new Set([
 const kI32 = new Set([
   '94i', // signed number
   '2147483647i', // max signed int
-  '-2147483648i', // min signed int
+  '-2147483647i', // min parsable signed int
+  'i32(-2147483648)', // min signed int
+
 ]);
 
 const kU32 = new Set([


### PR DESCRIPTION
This CL fixes up the min parsable i32 value.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
