### PR TITLE
Implement `unpack2x16unorm` tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -7,6 +7,20 @@ Component i of the result is v ÷ 65535, where v is the interpretation of bits
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { anyOf } from '../../../../../util/compare.js';
+import {
+  f32,
+  TypeF32,
+  TypeU32,
+  TypeVec,
+  u32,
+  unpack2x16unorm,
+  vec2,
+} from '../../../../../util/conversion.js';
+import { fullU32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { allInputSources, Case, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,4 +31,18 @@ g.test('unpack')
 @const fn unpack2x16unorm(e: u32) -> vec2<f32>
 `
   )
-  .unimplemented();
+  .params(u => u.combine('inputSource', [allInputSources[1]]))
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      n = quantizeToF32(n);
+      const results = unpack2x16unorm(n);
+      return {
+        input: [u32(n)],
+        expected: anyOf(...results.map(r => vec2(f32(r[0]), f32(r[1])))),
+      };
+    };
+
+    const cases: Array<Case> = fullU32Range().map(makeCase);
+
+    await run(t, builtin('unpack2x16unorm'), [TypeU32], TypeVec(2, TypeF32), t.params, cases);
+  });

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -7,6 +7,7 @@ import {
   cartesianProduct,
   clamp,
   correctlyRoundedF16,
+  correctlyRoundedF32,
   isFiniteF16,
   isSubnormalNumberF16,
   isSubnormalNumberF32,
@@ -423,6 +424,39 @@ export function pack4x8unorm(...vals: [number, number, number, number]): number 
   }
 
   return workingDataU32[0];
+}
+
+/**
+ * Converts a u32 that has been created from packing f32s to u16s back into f32s
+ *
+ * This should implement the same behaviour as the builtin `unpack2x16unorm`
+ * from WGSL.
+ *
+ * Caller is responsible to ensuring input is a u32 value.
+ *
+ * The round trip preservation of values for packing/unpacking is not guaranteed
+ * because unpacking involves a division that is not guaranteed to be precise in
+ * f32.
+ *
+ * @returns an array of possible pair of normalized f32s that have been unpacked
+ *          from the input
+ */
+export function unpack2x16unorm(val: number): [number, number][] {
+  // Generates f32 value for a given u16 that has been unpacked from a u32.
+  const generateF32s = (n: number): number[] => {
+    return correctlyRoundedF32(n / 65535);
+  };
+
+  workingDataU32[0] = val;
+  const results = cartesianProduct(
+    generateF32s(workingDataU16[0]),
+    generateF32s(workingDataU16[1])
+  );
+  assert(
+    results.every(r => r.length === 2),
+    'cartesianProduct of 2 arrays returned an entry with not 2 elements'
+  );
+  return results as [number, number][];
 }
 
 /**

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -587,6 +587,17 @@ export function fullI32Range(
   ].map(Math.trunc);
 }
 
+/**
+ * @returns an ascending sorted array of numbers spread over the entire range of 32-bit unsigned ints
+ *
+ * Numbers are biased towards 0, and 0 is included in the range.
+ *
+ * @param count number of entries to include in the range, in addition to 0, must be greater than 0, defaults to 50
+ */
+export function fullU32Range(count: number = 50): Array<number> {
+  return [0, ...biasedRange(1, kValue.u32.max, count)].map(Math.trunc);
+}
+
 /** Short list of f32 values of interest to test against */
 const kInterestingF32Values: number[] = [
   Number.NEGATIVE_INFINITY,


### PR DESCRIPTION
Fixes #1292

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
