### PR TITLE
Change from using `full` to `dense` for utility function names

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -18,8 +18,8 @@ import {
   biasedRange,
   cartesianProduct,
   correctlyRoundedF32,
-  fullF32Range,
-  fullI32Range,
+  denseF32Range,
+  denseI32Range,
   hexToF32,
   hexToF64,
   lerp,
@@ -756,7 +756,7 @@ g.test('fullF32Range')
     const neg_sub = test.params.neg_sub;
     const pos_sub = test.params.pos_sub;
     const pos_norm = test.params.pos_norm;
-    const got = fullF32Range({ neg_norm, neg_sub, pos_sub, pos_norm });
+    const got = denseF32Range({ neg_norm, neg_sub, pos_sub, pos_norm });
     const expect = test.params.expect;
 
     test.expect(
@@ -789,7 +789,7 @@ g.test('fullI32Range')
   .fn(test => {
     const neg_count = test.params.neg_count;
     const pos_count = test.params.pos_count;
-    const got = fullI32Range({ negative: neg_count, positive: pos_count });
+    const got = denseI32Range({ negative: neg_count, positive: pos_count });
     const expect = test.params.expect;
 
     test.expect(

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -12,7 +12,7 @@ import {
   remainderInterval,
   subtractionInterval,
 } from '../../../../util/f32_interval.js';
-import { kVectorTestValues } from '../../../../util/math.js';
+import { kVectorDenseTestValues } from '../../../../util/math.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../expression.js';
 
 import { binary } from './binary.js';
@@ -35,7 +35,7 @@ Accuracy: Correctly rounded
       return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 
@@ -58,7 +58,7 @@ Accuracy: Correctly rounded
       return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 
@@ -81,7 +81,7 @@ Accuracy: Correctly rounded
       return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 
@@ -104,7 +104,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
       return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 
@@ -127,7 +127,7 @@ Accuracy: Derived from x - y * trunc(x/y)
       return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1]);
     });
 

--- a/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { anyOf } from '../../../../util/compare.js';
 import { bool, f32, Scalar, TypeBool, TypeF32 } from '../../../../util/conversion.js';
-import { flushSubnormalScalarF32, kVectorTestValues } from '../../../../util/math.js';
+import { flushSubnormalScalarF32, kVectorDenseTestValues } from '../../../../util/math.js';
 import { allInputSources, Case, run } from '../expression.js';
 
 import { binary } from './binary.js';
@@ -55,7 +55,7 @@ Accuracy: Correct result
       return (lhs.value as number) === (rhs.value as number);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
 
@@ -78,7 +78,7 @@ Accuracy: Correct result
       return (lhs.value as number) !== (rhs.value as number);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
 
@@ -101,7 +101,7 @@ Accuracy: Correct result
       return (lhs.value as number) < (rhs.value as number);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
 
@@ -124,7 +124,7 @@ Accuracy: Correct result
       return (lhs.value as number) <= (rhs.value as number);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
 
@@ -147,7 +147,7 @@ Accuracy: Correct result
       return (lhs.value as number) > (rhs.value as number);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
 
@@ -170,7 +170,7 @@ Accuracy: Correct result
       return (lhs.value as number) >= (rhs.value as number);
     };
 
-    const cases = kVectorTestValues[2].map(v => {
+    const cases = kVectorDenseTestValues[2].map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -20,7 +20,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { kBit } from '../../../../../util/constants.js';
 import { i32Bits, TypeF32, TypeI32, TypeU32, u32Bits } from '../../../../../util/conversion.js';
 import { absInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -153,7 +153,7 @@ g.test('f32')
 
     const cases: Array<Case> = [
       Number.NEGATIVE_INFINITY,
-      ...fullF32Range(),
+      ...denseF32Range(),
       Number.POSITIVE_INFINITY,
     ].map(x => makeCase(x));
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { acosInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { denseF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -39,7 +39,7 @@ g.test('f32')
 
     const cases = [
       ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
     await run(t, builtin('acos'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -15,7 +15,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { acoshIntervals } from '../../../../../util/f32_interval.js';
-import { biasedRange, fullF32Range } from '../../../../../util/math.js';
+import { biasedRange, denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -43,7 +43,7 @@ g.test('f32')
 
     const cases = [
       ...biasedRange(1, 2, 100), // x near 1 can be problematic to implement
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
     await run(t, builtin('acosh'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { asinInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { denseF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -39,7 +39,7 @@ g.test('f32')
 
     const cases = [
       ...linearRange(-1, 1, 100), // asin is defined on [-1, 1]
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
     await run(t, builtin('asin'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
@@ -14,7 +14,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { asinhInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -40,7 +40,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, asinhInterval);
     };
 
-    const cases = [...fullF32Range()].map(makeCase);
+    const cases = [...denseF32Range()].map(makeCase);
     await run(t, builtin('asinh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -12,7 +12,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { atanInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -55,7 +55,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       Math.sqrt(3),
       Number.POSITIVE_INFINITY,
 
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(x => makeCase(x));
 
     await run(t, builtin('atan'), [TypeF32], TypeF32, t.params, cases);

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { atan2Interval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -43,7 +43,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       return makeBinaryToF32IntervalCase(y, x, atan2Interval);
     };
 
-    const numeric_range = fullF32Range();
+    const numeric_range = denseF32Range();
     const cases: Array<Case> = [];
     numeric_range.forEach(y => {
       numeric_range.forEach(x => {

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -14,7 +14,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { atanhInterval } from '../../../../../util/f32_interval.js';
-import { biasedRange, fullF32Range } from '../../../../../util/math.js';
+import { biasedRange, denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -43,7 +43,7 @@ g.test('f32')
     const cases = [
       ...biasedRange(-1, -0.9, 20), // discontinuity at x = -1
       ...biasedRange(1, 0.9, 20), // discontinuity at x = 1
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
     await run(t, builtin('atanh'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -12,7 +12,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { ceilInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -51,7 +51,7 @@ g.test('f32')
       -1.0,
       -1.1,
       -1.9,
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(x => makeCase(x));
 
     await run(t, builtin('ceil'), [TypeF32], TypeF32, t.params, cases);

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -12,7 +12,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { cosInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { denseF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -48,7 +48,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       // Well defined accuracy range
       ...linearRange(-Math.PI, Math.PI, 1000),
 
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
     await run(t, builtin('cos'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { coshInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -37,7 +37,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, coshInterval);
     };
 
-    const cases = fullF32Range().map(makeCase);
+    const cases = denseF32Range().map(makeCase);
     await run(t, builtin('cosh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -10,7 +10,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { crossInterval } from '../../../../../util/f32_interval.js';
-import { kVectorTestValues } from '../../../../../util/math.js';
+import { kVectorDenseTestValues } from '../../../../../util/math.js';
 import {
   allInputSources,
   Case,
@@ -37,8 +37,8 @@ g.test('f32')
       return makeVectorPairToVectorIntervalCase(x, y, crossInterval);
     };
 
-    const cases: Case[] = kVectorTestValues[3].flatMap(i => {
-      return kVectorTestValues[3].map(j => {
+    const cases: Case[] = kVectorDenseTestValues[3].flatMap(i => {
+      return kVectorDenseTestValues[3].map(j => {
         return makeCase(i, j);
       });
     });

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { degreesInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -37,7 +37,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, degreesInterval);
     };
 
-    const cases: Array<Case> = fullF32Range().map(makeCase);
+    const cases: Array<Case> = denseF32Range().map(makeCase);
     await run(t, builtin('degrees'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
@@ -12,7 +12,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { distanceInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, kVectorSparseTestValues } from '../../../../../util/math.js';
+import { denseF32Range, kVectorSparseTestValues } from '../../../../../util/math.js';
 import {
   allInputSources,
   Case,
@@ -46,7 +46,7 @@ g.test('f32')
     const makeCase = (x: number, y: number): Case => {
       return makeBinaryToF32IntervalCase(x, y, distanceInterval);
     };
-    const cases: Case[] = fullF32Range().flatMap(i => fullF32Range().map(j => makeCase(i, j)));
+    const cases: Case[] = denseF32Range().flatMap(i => denseF32Range().map(j => makeCase(i, j)));
 
     await run(t, builtin('distance'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { dotInterval } from '../../../../../util/f32_interval.js';
-import { kVectorTestValues } from '../../../../../util/math.js';
+import { kVectorDenseTestValues } from '../../../../../util/math.js';
 import { allInputSources, Case, makeVectorPairToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -51,8 +51,8 @@ g.test('f32_vec2')
       return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
-    const cases: Case[] = kVectorTestValues[2].flatMap(i => {
-      return kVectorTestValues[2].map(j => {
+    const cases: Case[] = kVectorDenseTestValues[2].flatMap(i => {
+      return kVectorDenseTestValues[2].map(j => {
         return makeCase(i, j);
       });
     });
@@ -76,8 +76,8 @@ g.test('f32_vec3')
       return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
-    const cases: Case[] = kVectorTestValues[3].flatMap(i => {
-      return kVectorTestValues[3].map(j => {
+    const cases: Case[] = kVectorDenseTestValues[3].flatMap(i => {
+      return kVectorDenseTestValues[3].map(j => {
         return makeCase(i, j);
       });
     });
@@ -101,8 +101,8 @@ g.test('f32_vec4')
       return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
-    const cases: Case[] = kVectorTestValues[4].flatMap(i => {
-      return kVectorTestValues[4].map(j => {
+    const cases: Case[] = kVectorDenseTestValues[4].flatMap(i => {
+      return kVectorDenseTestValues[4].map(j => {
         return makeCase(i, j);
       });
     });

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { floorInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -50,7 +50,7 @@ g.test('f32')
       -1.0,
       -1.1,
       -1.9,
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(x => makeCase(x));
 
     await run(t, builtin('floor'), [TypeF32], TypeF32, t.params, cases);

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -12,7 +12,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { fractInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -52,7 +52,7 @@ g.test('f32')
       -2, // -2 -> 0
       -1.11, // ~-1.11 -> ~0.89
       -10.0001, // -10.0001 -> ~0.9999
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
 
     // prettier-ignore

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -17,8 +17,8 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { f32, i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
 import { ldexpInterval } from '../../../../../util/f32_interval.js';
 import {
-  fullF32Range,
-  fullI32Range,
+  denseF32Range,
+  denseI32Range,
   quantizeToF32,
   quantizeToI32,
 } from '../../../../../util/math.js';
@@ -56,8 +56,8 @@ g.test('f32')
     };
 
     const cases: Array<Case> = [];
-    fullF32Range().forEach(e1 => {
-      fullI32Range().forEach(e2 => {
+    denseF32Range().forEach(e1 => {
+      denseI32Range().forEach(e2 => {
         cases.push(makeCase(e1, e2));
       });
     });

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { lengthInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, kVectorTestValues } from '../../../../../util/math.js';
+import { denseF32Range, kVectorDenseTestValues } from '../../../../../util/math.js';
 import {
   allInputSources,
   Case,
@@ -45,7 +45,7 @@ g.test('f32')
     const makeCase = (x: number): Case => {
       return makeUnaryToF32IntervalCase(x, lengthInterval);
     };
-    const cases: Case[] = fullF32Range().map(makeCase);
+    const cases: Case[] = denseF32Range().map(makeCase);
 
     await run(t, builtin('length'), [TypeF32], TypeF32, t.params, cases);
   });
@@ -55,7 +55,7 @@ g.test('f32_vec2')
   .desc(`f32 tests using vec2s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[2].map(makeCaseVecF32);
+    const cases: Case[] = kVectorDenseTestValues[2].map(makeCaseVecF32);
 
     await run(t, builtin('length'), [TypeVec(2, TypeF32)], TypeF32, t.params, cases);
   });
@@ -65,7 +65,7 @@ g.test('f32_vec3')
   .desc(`f32 tests using vec3s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[3].map(makeCaseVecF32);
+    const cases: Case[] = kVectorDenseTestValues[3].map(makeCaseVecF32);
 
     await run(t, builtin('length'), [TypeVec(3, TypeF32)], TypeF32, t.params, cases);
   });
@@ -75,7 +75,7 @@ g.test('f32_vec4')
   .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[4].map(makeCaseVecF32);
+    const cases: Case[] = kVectorDenseTestValues[4].map(makeCaseVecF32);
 
     await run(t, builtin('length'), [TypeVec(4, TypeF32)], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { logInterval } from '../../../../../util/f32_interval.js';
-import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
+import { biasedRange, denseF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -50,7 +50,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       ...linearRange(kValue.f32.positive.min, 0.5, 20),
       ...linearRange(0.5, 2.0, 20),
       ...biasedRange(2.0, 2 ** 32, 1000),
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(x => makeCase(x));
 
     await run(t, builtin('log'), [TypeF32], TypeF32, t.params, cases);

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { log2Interval } from '../../../../../util/f32_interval.js';
-import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
+import { biasedRange, denseF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -50,7 +50,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       ...linearRange(kValue.f32.positive.min, 0.5, 20),
       ...linearRange(0.5, 2.0, 20),
       ...biasedRange(2.0, 2 ** 32, 1000),
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(x => makeCase(x));
 
     await run(t, builtin('log2'), [TypeF32], TypeF32, t.params, cases);

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -21,7 +21,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
 import { maxInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -104,7 +104,7 @@ g.test('f32')
     };
 
     const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
+    const numeric_range = denseF32Range();
     numeric_range.push(kValue.f32.infinity.positive, kValue.f32.infinity.negative);
     numeric_range.forEach(lhs => {
       numeric_range.forEach(rhs => {

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -20,7 +20,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
 import { minInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -103,7 +103,7 @@ g.test('f32')
     };
 
     const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
+    const numeric_range = denseF32Range();
     numeric_range.push(kValue.f32.infinity.positive, kValue.f32.infinity.negative);
     numeric_range.forEach(lhs => {
       numeric_range.forEach(rhs => {

--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -10,7 +10,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { normalizeInterval } from '../../../../../util/f32_interval.js';
-import { kVectorTestValues } from '../../../../../util/math.js';
+import { kVectorDenseTestValues } from '../../../../../util/math.js';
 import { allInputSources, Case, makeVectorToVectorIntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -35,7 +35,7 @@ g.test('f32_vec2')
   .desc(`f32 tests using vec2s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[2].map(makeCaseVecF32);
+    const cases: Case[] = kVectorDenseTestValues[2].map(makeCaseVecF32);
 
     await run(t, builtin('normalize'), [TypeVec(2, TypeF32)], TypeVec(2, TypeF32), t.params, cases);
   });
@@ -45,7 +45,7 @@ g.test('f32_vec3')
   .desc(`f32 tests using vec3s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[3].map(makeCaseVecF32);
+    const cases: Case[] = kVectorDenseTestValues[3].map(makeCaseVecF32);
 
     await run(t, builtin('normalize'), [TypeVec(3, TypeF32)], TypeVec(3, TypeF32), t.params, cases);
   });
@@ -55,7 +55,7 @@ g.test('f32_vec4')
   .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[4].map(makeCaseVecF32);
+    const cases: Case[] = kVectorDenseTestValues[4].map(makeCaseVecF32);
 
     await run(t, builtin('normalize'), [TypeVec(4, TypeF32)], TypeVec(4, TypeF32), t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { kVectorDenseTestValues, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -61,7 +61,7 @@ g.test('pack')
       return { input: [vec2(f32(x), f32(y))], expected: anyOf(...results.map(cmp)) };
     };
 
-    const cases: Array<Case> = kVectorTestValues[2].map(v => {
+    const cases: Array<Case> = kVectorDenseTestValues[2].map(v => {
       return makeCase(...(v as [number, number]));
     });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
@@ -17,7 +17,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { kVectorDenseTestValues, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -44,7 +44,7 @@ g.test('pack')
       return n / kValue.f32.positive.max;
     };
 
-    const cases: Array<Case> = kVectorTestValues[2].flatMap(v => {
+    const cases: Array<Case> = kVectorDenseTestValues[2].flatMap(v => {
       return [
         makeCase(...(v as [number, number])),
         makeCase(...(v.map(normalizeF32) as [number, number])),

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
@@ -17,7 +17,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { kVectorDenseTestValues, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -44,7 +44,7 @@ g.test('pack')
       return n > 0 ? n / kValue.f32.positive.max : n / kValue.f32.negative.min;
     };
 
-    const cases: Array<Case> = kVectorTestValues[2].flatMap(v => {
+    const cases: Array<Case> = kVectorDenseTestValues[2].flatMap(v => {
       return [
         makeCase(...(v as [number, number])),
         makeCase(...(v.map(normalizeF32) as [number, number])),

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec4,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { kVectorDenseTestValues, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -49,7 +49,7 @@ g.test('pack')
       return n / kValue.f32.positive.max;
     };
 
-    const cases: Array<Case> = kVectorTestValues[4].flatMap(v => {
+    const cases: Array<Case> = kVectorDenseTestValues[4].flatMap(v => {
       return [
         makeCase(v as [number, number, number, number]),
         makeCase(v.map(normalizeF32) as [number, number, number, number]),

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8unorm.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec4,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { kVectorDenseTestValues, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -49,7 +49,7 @@ g.test('pack')
       return n > 0 ? n / kValue.f32.positive.max : n / kValue.f32.negative.min;
     };
 
-    const cases: Array<Case> = kVectorTestValues[4].flatMap(v => {
+    const cases: Array<Case> = kVectorDenseTestValues[4].flatMap(v => {
       return [
         makeCase(v as [number, number, number, number]),
         makeCase(v.map(normalizeF32) as [number, number, number, number]),

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { powInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -38,7 +38,7 @@ g.test('f32')
     };
 
     const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
+    const numeric_range = denseF32Range();
     numeric_range.forEach(x => {
       numeric_range.forEach(y => {
         cases.push(makeCase(x, y));

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -13,7 +13,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { quantizeToF16Interval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -40,7 +40,7 @@ g.test('f32')
       kValue.f16.subnormal.positive.max,
       kValue.f16.positive.min,
       kValue.f16.positive.max,
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
 
     await run(t, builtin('quantizeToF16'), [TypeF32], TypeF32, t.params, cases);

--- a/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
@@ -12,7 +12,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { radiansInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -38,7 +38,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, radiansInterval);
     };
 
-    const cases: Array<Case> = fullF32Range().map(makeCase);
+    const cases: Array<Case> = denseF32Range().map(makeCase);
     await run(t, builtin('radians'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -14,7 +14,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { roundInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -40,7 +40,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, roundInterval);
     };
 
-    const cases = fullF32Range().map(makeCase);
+    const cases = denseF32Range().map(makeCase);
     await run(t, builtin('round'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { saturateInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { denseF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -41,7 +41,7 @@ g.test('f32')
       // Non-clamped values
       ...linearRange(0.0, 1.0, 100),
 
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
     await run(t, builtin('saturate'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { signInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -37,7 +37,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, signInterval);
     };
 
-    const cases = fullF32Range().map(makeCase);
+    const cases = denseF32Range().map(makeCase);
     await run(t, builtin('sign'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { sinInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { denseF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -47,7 +47,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
       // Well defined accuracy range
       ...linearRange(-Math.PI, Math.PI, 1000),
 
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
     await run(t, builtin('sin'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { sinhInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -37,7 +37,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, sinhInterval);
     };
 
-    const cases = fullF32Range().map(makeCase);
+    const cases = denseF32Range().map(makeCase);
     await run(t, builtin('sinh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { sqrtInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -37,7 +37,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, sqrtInterval);
     };
 
-    const cases = fullF32Range().map(makeCase);
+    const cases = denseF32Range().map(makeCase);
     await run(t, builtin('sqrt'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -12,7 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf } from '../../../../../util/compare.js';
 import { f32, TypeF32 } from '../../../../../util/conversion.js';
 import { F32Interval, stepInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { denseF32Range, quantizeToF32 } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -57,7 +57,7 @@ g.test('f32')
       };
     };
 
-    const range = fullF32Range();
+    const range = denseF32Range();
     const cases: Array<Case> = [];
     range.forEach(edge => {
       range.forEach(x => {

--- a/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { tanInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { denseF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -40,7 +40,7 @@ g.test('f32')
     const cases: Array<Case> = [
       // Defined accuracy range
       ...linearRange(-Math.PI, Math.PI, 100),
-      ...fullF32Range(),
+      ...denseF32Range(),
     ].map(makeCase);
     await run(t, builtin('tan'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { tanhInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -37,7 +37,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, tanhInterval);
     };
 
-    const cases = fullF32Range().map(makeCase);
+    const cases = denseF32Range().map(makeCase);
     await run(t, builtin('tanh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -12,7 +12,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { truncInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { denseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -38,7 +38,7 @@ g.test('f32')
       return makeUnaryToF32IntervalCase(n, truncInterval);
     };
 
-    const cases = fullF32Range().map(makeCase);
+    const cases = denseF32Range().map(makeCase);
     await run(t, builtin('trunc'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32 } from '../../../../util/conversion.js';
 import { negationInterval } from '../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../util/math.js';
+import { denseF32Range } from '../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../expression.js';
 
 import { unary } from './unary.js';
@@ -29,7 +29,7 @@ Accuracy: Correctly rounded
       return makeUnaryToF32IntervalCase(x, negationInterval);
     };
 
-    const cases = fullF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }).map(x =>
+    const cases = denseF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }).map(x =>
       makeCase(x)
     );
 

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -533,7 +533,7 @@ export function biasedRange(a: number, b: number, num_steps: number): Array<numb
  * @param counts structure param with 4 entries indicating the number of entries to be generated each region, entries
  *               must be 0 or greater.
  */
-export function fullF32Range(
+export function denseF32Range(
   counts: {
     neg_norm?: number;
     neg_sub?: number;
@@ -573,7 +573,7 @@ export function fullF32Range(
  *
  * @param counts structure param with 2 entries indicating the number of entries to be generated each region, values must be 0 or greater.
  */
-export function fullI32Range(
+export function denseI32Range(
   counts: {
     negative?: number;
     positive: number;
@@ -609,7 +609,7 @@ const kInterestingF32Values: number[] = [
 /** @returns minimal f32 values that cover the entire range of f32 behaviours
  *
  * Has specially selected values that cover edge cases, normals, and subnormals.
- * This is used instead of fullF32Range when the number of test cases being
+ * This is used instead of denseF32Range when the number of test cases being
  * generated is a super linear function of the length of f32 values which is
  * leading to time outs.
  *
@@ -633,7 +633,7 @@ export function sparseF32Range(): Array<number> {
  * vector to get a spread of testing over the entire range. This reduces the
  * number of cases being run substantially, but maintains coverage.
  */
-export const kVectorTestValues = {
+export const kVectorDenseTestValues = {
   2: sparseF32Range().flatMap(f => [
     [f, 1.0],
     [1.0, f],
@@ -664,7 +664,7 @@ export const kVectorTestValues = {
  * Minimal set of vectors, indexed by dimension, that contain interesting float
  * values.
  *
- * This is an even more stripped down version of `kVectorTestValues` for when
+ * This is an even more stripped down version of `kVectorDenseTestValues` for when
  * pairs of vectors are being tested.
  * All of the interesting floats from sparseF32 are guaranteed to be tested, but
  * not in every position.


### PR DESCRIPTION
The utility function in question generate values across the entire range of a numeric type, but do not generate every value in the range, so it can be ambiguous when reading the name if it is going to produce all possible values or a sample of values.

`dense` is clearer that it is a larger selection of values than the corresponding `sparse` functions.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
