### PR TITLE
Implement `unpack4x8unorm` tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -2636,35 +2636,47 @@ interface PointToVectorCase {
   expected: IntervalBounds[];
 }
 
-g.test('unpack4x8unormInterval')
-  .paramsSubcasesOnly<PointToVectorCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
-      // form due to the inherited nature of the errors.
-      { input: 0x00000000, expected: [[hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)]] },  // ~[0, 0, 0, 0]
-      { input: 0x000000ff, expected: [[hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)]] },  // ~[1, 0, 0, 0]
-      { input: 0x0000ff00, expected: [[hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)]] },  // ~[0, 1, 0, 0]
-      { input: 0x00ff0000, expected: [[hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF32(0x81200000), hexToF32(0x01200000)]] },  // ~[0, 0, 1, 0]
-      { input: 0xff000000, expected: [[hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)]] },  // ~[0, 0, 0, 1]
-      { input: 0x0000ffff, expected: [[hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)]] },  // ~[1, 1, 0, 0]
-      { input: 0xffff0000, expected: [[hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)]] },  // ~[0, 0, 1, 1]
-      { input: 0xff00ff00, expected: [[hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)]] },  // ~[0, 1, 0, 1]
-      { input: 0x00ff00ff, expected: [[hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF32(0x81200000), hexToF32(0x01200000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF32(0x81200000), hexToF32(0x01200000)]] },  // ~[1, 0, 1, 0]
-      { input: 0xffffffff, expected: [[hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)], [hexToF64(0x3fefffff, 0xb0000000), hexToF64(0x3ff00000, 0x28000000)]] },  // ~[1, 1, 1, 1]
-      { input: 0x80808080, expected: [[hexToF64(0x3fe0100f, 0xb0000000), hexToF64(0x3fe01010, 0x70000000)], [hexToF64(0x3fe0100f, 0xb0000000), hexToF64(0x3fe01010, 0x70000000)], [hexToF64(0x3fe0100f, 0xb0000000), hexToF64(0x3fe01010, 0x70000000)], [hexToF64(0x3fe0100f, 0xb0000000), hexToF64(0x3fe01010, 0x70000000)]] },  // ~0.50196
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Vector(t.params.expected);
+{
+  const kZeroBounds: IntervalBounds = [hexToF32(0x81200000), hexToF32(0x01200000)];
+  const kOneBounds: IntervalBounds = [
+    hexToF64(0x3fefffff, 0xb0000000),
+    hexToF64(0x3ff00000, 0x28000000),
+  ];
+  const kHalfBounds: IntervalBounds = [
+    hexToF64(0x3fe0100f, 0xb0000000),
+    hexToF64(0x3fe01010, 0x70000000),
+  ]; // ~0.50196..., due to lack of precision in u8
 
-    const got = unpack4x8unormInterval(t.params.input);
+  g.test('unpack4x8unormInterval')
+    .paramsSubcasesOnly<PointToVectorCase>(
+      // prettier-ignore
+      [
+        // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+        // form due to the inherited nature of the errors.
+        { input: 0x00000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x000000ff, expected: [kOneBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x0000ff00, expected: [kZeroBounds, kOneBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x00ff0000, expected: [kZeroBounds, kZeroBounds, kOneBounds, kZeroBounds] },
+        { input: 0xff000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kOneBounds] },
+        { input: 0x0000ffff, expected: [kOneBounds, kOneBounds, kZeroBounds, kZeroBounds] },
+        { input: 0xffff0000, expected: [kZeroBounds, kZeroBounds, kOneBounds, kOneBounds] },
+        { input: 0xff00ff00, expected: [kZeroBounds, kOneBounds, kZeroBounds, kOneBounds] },
+        { input: 0x00ff00ff, expected: [kOneBounds, kZeroBounds, kOneBounds, kZeroBounds] },
+        { input: 0xffffffff, expected: [kOneBounds, kOneBounds, kOneBounds, kOneBounds] },
+        { input: 0x80808080, expected: [kHalfBounds, kHalfBounds,kHalfBounds,kHalfBounds] },
+      ]
+    )
+    .fn(t => {
+      const expected = toF32Vector(t.params.expected);
 
-    t.expect(
-      objectEquals(expected, got),
-      `unpack4x8unormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
-    );
-  });
+      const got = unpack4x8unormInterval(t.params.input);
+
+      t.expect(
+        objectEquals(expected, got),
+        `unpack4x8unormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
+      );
+    });
+}
 
 interface VectorToIntervalCase {
   input: number[];

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -17,7 +17,7 @@ import {
   unpack2x16unorm,
   vec2,
 } from '../../../../../util/conversion.js';
-import { fullU32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { fullU32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -31,10 +31,10 @@ g.test('unpack')
 @const fn unpack2x16unorm(e: u32) -> vec2<f32>
 `
   )
-  .params(u => u.combine('inputSource', [allInputSources[1]]))
+  .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      n = quantizeToF32(n);
+      n = Math.trunc(n);
       const results = unpack2x16unorm(n);
       return {
         input: [u32(n)],

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
@@ -7,6 +7,12 @@ through 8×i+7 of e as an unsigned integer.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
+import { unpack4x8unormInterval } from '../../../../../util/f32_interval.js';
+import { fullU32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,4 +23,14 @@ g.test('unpack')
 @const fn unpack4x8unorm(e: u32) -> vec4<f32>
 `
   )
-  .unimplemented();
+  .params(u => u.combine('inputSource', [allInputSources[1]]))
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      n = Math.trunc(n);
+      return makeU32ToVectorIntervalCase(n, unpack4x8unormInterval);
+    };
+
+    const cases: Array<Case> = fullU32Range().map(makeCase);
+
+    await run(t, builtin('unpack4x8unorm'), [TypeU32], TypeVec(4, TypeF32), t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -12,11 +12,13 @@ import {
   Vector,
   VectorType,
   f32,
+  u32,
 } from '../../../util/conversion.js';
 import {
   BinaryToInterval,
   F32Interval,
   PointToInterval,
+  PointToVector,
   TernaryToInterval,
   VectorPairToInterval,
   VectorPairToVector,
@@ -696,6 +698,23 @@ export function makeVectorPairToVectorIntervalCase(
   const vectors = ops.map(o => o(param0, param1));
   return {
     input: [new Vector(param0_f32), new Vector(param1_f32)],
+    expected: anyOf(...vectors),
+  };
+}
+
+/**
+ * Generates a Case for the param and vector of intervals generator provided.
+ * The input is treated as an unsigned int.
+ * @param param the param to pass into the operation
+ * @param ops callbacks that implement generating an vector of acceptance
+ *            intervals for a vector.
+ */
+export function makeU32ToVectorIntervalCase(param: number, ...ops: PointToVector[]): Case {
+  const param_u32 = u32(param);
+
+  const vectors = ops.map(o => o(param));
+  return {
+    input: param_u32,
     expected: anyOf(...vectors),
   };
 }

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -133,7 +133,7 @@ export const kFloat32Format = { signed: 1, exponentBits: 8, mantissaBits: 23, bi
 /** FloatFormat defining IEEE754 16-bit float. */
 export const kFloat16Format = { signed: 1, exponentBits: 5, mantissaBits: 10, bias: 15 } as const;
 
-/** Once-allocated ArrayBuffer/views  to avoid overhead of allocation when converting between numeric formats */
+/** Once-allocated ArrayBuffer/views to avoid overhead of allocation when converting between numeric formats */
 const workingData = new ArrayBuffer(4);
 const workingDataU32 = new Uint32Array(workingData);
 const workingDataU16 = new Uint16Array(workingData);


### PR DESCRIPTION
Also adds in the needed infrastructure for u32->f32 vector tests

Fixes #1290


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
