### PR TITLE
Handle error from division in unpack2x16unorm

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -23,7 +23,6 @@ import {
   pack4x8unorm,
   Scalar,
   u32,
-  unpack2x16unorm,
   vec2,
   vec3,
   vec4,
@@ -409,33 +408,4 @@ g.test('pack4x8unorm')
     const expect = test.params.result;
 
     test.expect(got === expect, `pack4x8unorm(${inputs}) returned ${got}. Expected [${expect}]`);
-  });
-
-g.test('unpack2x16unorm')
-  .paramsSimple([
-    { input: 0x00000000, results: [[0, 0]] },
-    { input: 0x0000ffff, results: [[1, 0]] },
-    { input: 0xffff0000, results: [[0, 1]] },
-    { input: 0xffffffff, results: [[1, 1]] },
-    {
-      input: 0x80008000,
-      results: [
-        [f32Bits(0x3f000080).value as number, f32Bits(0x3f000080).value as number],
-        [f32Bits(0x3f000080).value as number, f32Bits(0x3f000081).value as number],
-        [f32Bits(0x3f000081).value as number, f32Bits(0x3f000080).value as number],
-        [f32Bits(0x3f000081).value as number, f32Bits(0x3f000081).value as number],
-      ], // ~0.5
-    },
-  ] as const)
-  .fn(test => {
-    const input = test.params.input;
-    const got = unpack2x16unorm(input)
-      .map(g => `[${g.map(f32).toString()}]`)
-      .sort();
-    const expect = test.params.results.map(e => `[${e.map(f32).toString()}]`).sort();
-
-    test.expect(
-      objectEquals(got, expect),
-      `unpack2x16unorm(${input}) returned [${got}]. Expected [${expect}]`
-    );
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -7,18 +7,10 @@ Component i of the result is v ÷ 65535, where v is the interpretation of bits
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { anyOf } from '../../../../../util/compare.js';
-import {
-  f32,
-  TypeF32,
-  TypeU32,
-  TypeVec,
-  u32,
-  unpack2x16unorm,
-  vec2,
-} from '../../../../../util/conversion.js';
+import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
+import { unpack2x16unormInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, run } from '../../expression.js';
+import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,11 +27,7 @@ g.test('unpack')
   .fn(async t => {
     const makeCase = (n: number): Case => {
       n = Math.trunc(n);
-      const results = unpack2x16unorm(n);
-      return {
-        input: [u32(n)],
-        expected: anyOf(...results.map(r => vec2(f32(r[0]), f32(r[1])))),
-      };
+      return makeU32ToVectorIntervalCase(n, unpack2x16unormInterval);
     };
 
     const cases: Array<Case> = fullU32Range().map(makeCase);

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -7,7 +7,6 @@ import {
   cartesianProduct,
   clamp,
   correctlyRoundedF16,
-  correctlyRoundedF32,
   isFiniteF16,
   isSubnormalNumberF16,
   isSubnormalNumberF32,
@@ -133,7 +132,12 @@ export const kFloat32Format = { signed: 1, exponentBits: 8, mantissaBits: 23, bi
 /** FloatFormat defining IEEE754 16-bit float. */
 export const kFloat16Format = { signed: 1, exponentBits: 5, mantissaBits: 10, bias: 15 } as const;
 
-/** Once-allocated ArrayBuffer/views to avoid overhead of allocation when converting between numeric formats */
+/**
+ * Once-allocated ArrayBuffer/views to avoid overhead of allocation when converting between numeric formats
+ *
+ * workingData* is shared between multiple functions in this file, so to avoid re-entrancy problems, make sure in
+ * functions that use it that they don't call themselves or other functions that use workingData*.
+ */
 const workingData = new ArrayBuffer(4);
 const workingDataU32 = new Uint32Array(workingData);
 const workingDataU16 = new Uint16Array(workingData);
@@ -424,39 +428,6 @@ export function pack4x8unorm(...vals: [number, number, number, number]): number 
   }
 
   return workingDataU32[0];
-}
-
-/**
- * Converts a u32 that has been created from packing f32s to u16s back into f32s
- *
- * This should implement the same behaviour as the builtin `unpack2x16unorm`
- * from WGSL.
- *
- * Caller is responsible to ensuring input is a u32 value.
- *
- * The round trip preservation of values for packing/unpacking is not guaranteed
- * because unpacking involves a division that is not guaranteed to be precise in
- * f32.
- *
- * @returns an array of possible pair of normalized f32s that have been unpacked
- *          from the input
- */
-export function unpack2x16unorm(val: number): [number, number][] {
-  // Generates f32 value for a given u16 that has been unpacked from a u32.
-  const generateF32s = (n: number): number[] => {
-    return correctlyRoundedF32(n / 65535);
-  };
-
-  workingDataU32[0] = val;
-  const results = cartesianProduct(
-    generateF32s(workingDataU16[0]),
-    generateF32s(workingDataU16[1])
-  );
-  assert(
-    results.every(r => r.length === 2),
-    'cartesianProduct of 2 arrays returned an entry with not 2 elements'
-  );
-  return results as [number, number][];
 }
 
 /**

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1883,23 +1883,38 @@ export function truncInterval(n: number | F32Interval): F32Interval {
   return runPointToIntervalOp(toF32Interval(n), TruncIntervalOp);
 }
 
-/** Once-allocated ArrayBuffer/views to avoid overhead of allocation when converting between numeric formats */
-const unpack4x8unormData = new ArrayBuffer(4);
-const unpack4x8unormDataU32 = new Uint32Array(unpack4x8unormData);
-const unpack4x8unormDataU8 = new Uint8Array(unpack4x8unormData);
-
 /**
- * Calculate an acceptance interval vector for unpack4x8unorm(x) */
+ * Once-allocated ArrayBuffer/views to avoid overhead of allocation when converting between numeric formats
+ *
+ * unpackData* is shared between all of the unpack*Interval functions, so to avoid re-entrancy problems, they should
+ * not call each other or themselves directly or indirectly.
+ * */
+const unpackData = new ArrayBuffer(4);
+const unpackDataU32 = new Uint32Array(unpackData);
+const unpackDataU16 = new Uint16Array(unpackData);
+const unpackDataU8 = new Uint8Array(unpackData);
+
+/** Calculate an acceptance interval vector for unpack2x16unorm(x) */
+export function unpack2x16unormInterval(n: number): F32Vector {
+  assert(
+    n >= kValue.u32.min && n <= kValue.u32.max,
+    'unpack2x16unormInterval only accepts values on the bounds of u32'
+  );
+  unpackDataU32[0] = n;
+  return [divisionInterval(unpackDataU16[0], 65535), divisionInterval(unpackDataU16[1], 65535)];
+}
+
+/** Calculate an acceptance interval vector for unpack4x8unorm(x) */
 export function unpack4x8unormInterval(n: number): F32Vector {
   assert(
     n >= kValue.u32.min && n <= kValue.u32.max,
     'unpack4x8unormInterval only accepts values on the bounds of u32'
   );
-  unpack4x8unormDataU32[0] = n;
+  unpackDataU32[0] = n;
   return [
-    divisionInterval(unpack4x8unormDataU8[0], 255),
-    divisionInterval(unpack4x8unormDataU8[1], 255),
-    divisionInterval(unpack4x8unormDataU8[2], 255),
-    divisionInterval(unpack4x8unormDataU8[3], 255),
+    divisionInterval(unpackDataU8[0], 255),
+    divisionInterval(unpackDataU8[1], 255),
+    divisionInterval(unpackDataU8[2], 255),
+    divisionInterval(unpackDataU8[3], 255),
   ];
 }


### PR DESCRIPTION
The current implementation of this test does not correctly account for
error introduced from performing a division. This is corrected by
converting the test to be a PointToVector test and using the existing
numeric testing framework code instead of a bespoke solution.

Issue #1292

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
