### PR TITLE
op: Introduce debug_marker.spec.ts to test operations of debug APIs

### DIFF
--- a/src/webgpu/api/operation/debug/debug_marker.spec.ts
+++ b/src/webgpu/api/operation/debug/debug_marker.spec.ts
@@ -1,0 +1,32 @@
+export const description = `
+Test operations of pushDebugGroup, popDebugGroup, and insertDebugMarker.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+import { kEncoderTypes } from '../../../util/command_buffer_maker.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('no_failure_without_debug_tool_attached')
+  .desc(
+    `
+  Test that calling a marker API without a debugging tool attached doesn't cause a failure.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('encoderType', kEncoderTypes)
+      .beginSubcases()
+      .combine('pushLabel', ['', 'Event Start'])
+      .combine('markerLabel', ['', 'Marker'])
+  )
+  .fn(async t => {
+    const { encoderType, pushLabel, markerLabel } = t.params;
+
+    const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType);
+    encoder.pushDebugGroup(pushLabel);
+    encoder.insertDebugMarker(markerLabel);
+    encoder.popDebugGroup();
+    validateFinishAndSubmit(true, true);
+  });


### PR DESCRIPTION
This PR introduces a new file to test the operation of debug APIs like pushDebugGroup, insertDebugMarker, and popDebugGroup methods.

As the first test, this PR adds a 'no_failure_without_debug_tool_attached' test to ensure calling a marker API without a debugging tool attached doesn't cause a failure.

Issue: #1928

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
