### PR TITLE
Properly handle potential FTZ in quantizeToF16 tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1294,13 +1294,13 @@ g.test('quantizeToF16Interval')
       { input: -1, expected: [-1] },
       { input: -0.1, expected: [hexToF32(0xbdcce000), hexToF32(0xbdccc000)] },  // ~-0.1
       { input: kValue.f16.negative.max, expected: [kValue.f16.negative.max] },
-      { input: kValue.f16.subnormal.negative.min, expected: [kValue.f16.subnormal.negative.min] },
-      { input: kValue.f16.subnormal.negative.max, expected: [kValue.f16.subnormal.negative.max] },
+      { input: kValue.f16.subnormal.negative.min, expected: [kValue.f16.subnormal.negative.min, 0] },
+      { input: kValue.f16.subnormal.negative.max, expected: [kValue.f16.subnormal.negative.max, 0] },
       { input: kValue.f32.subnormal.negative.max, expected: [kValue.f16.subnormal.negative.max, 0] },
       { input: 0, expected: [0] },
       { input: kValue.f32.subnormal.positive.min, expected: [0, kValue.f16.subnormal.positive.min] },
-      { input: kValue.f16.subnormal.positive.min, expected: [kValue.f16.subnormal.positive.min] },
-      { input: kValue.f16.subnormal.positive.max, expected: [kValue.f16.subnormal.positive.max] },
+      { input: kValue.f16.subnormal.positive.min, expected: [0, kValue.f16.subnormal.positive.min] },
+      { input: kValue.f16.subnormal.positive.max, expected: [0, kValue.f16.subnormal.positive.max] },
       { input: kValue.f16.positive.min, expected: [kValue.f16.positive.min] },
       { input: 0.1, expected: [hexToF32(0x3dccc000), hexToF32(0x3dcce000)] },  // ~0.1
       { input: 1, expected: [1] },


### PR DESCRIPTION
Fixes #1946

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
