### PR TITLE
val: Add a control case to 'pass_end_invalid_order' test

### DIFF
--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -17,6 +17,7 @@ TODO:
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { objectEquals } from '../../../../common/util/util.js';
 import { ValidationTest } from '../validation_test.js';
 
 class F extends ValidationTest {
@@ -47,23 +48,25 @@ g.test('pass_end_invalid_order')
     `
   Test that beginning a  {compute,render} pass before ending the previous {compute,render} pass
   causes an error.
-
-  TODO: Need to add a control case to be sure a validation error happens because of ending order.
   `
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
       .combine('pass0Type', ['compute', 'render'])
       .combine('pass1Type', ['compute', 'render'])
+      .beginSubcases()
+      .combine('firstPassEnd', [true, false])
       .combine('endPasses', [[], [0], [1], [0, 1], [1, 0]])
   )
   .fn(async t => {
-    const { pass0Type, pass1Type, endPasses } = t.params;
+    const { pass0Type, pass1Type, firstPassEnd, endPasses } = t.params;
 
     const encoder = t.device.createCommandEncoder();
 
     const firstPass =
       pass0Type === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder);
+
+    if (firstPassEnd) firstPass.end();
 
     // Begin a second pass before ending the previous pass.
     const secondPass =
@@ -74,9 +77,12 @@ g.test('pass_end_invalid_order')
       passes[index].end();
     }
 
+    // If {endPasses} is '[1]' and {firstPass} ends, it's a control case.
+    const valid = firstPassEnd && objectEquals(endPasses, [1]);
+
     t.expectValidationError(() => {
       encoder.finish();
-    }, true);
+    }, !valid);
   });
 
 g.test('call_after_successful_finish')


### PR DESCRIPTION
This PR adds a control case to 'pass_end_invalid_order' test since a validation test needs to have a control case.

Issue: #1914

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
