### PR TITLE
Implement `unpack4x8snorm` tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -69,6 +69,7 @@ import {
   unpack2x16unormInterval,
   unpack4x8unormInterval,
   unpack2x16snormInterval,
+  unpack4x8snormInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -2716,6 +2717,47 @@ interface PointToVectorCase {
       t.expect(
         objectEquals(expected, got),
         `unpack2x16unormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
+      );
+    });
+
+  const kHalfBounds4x8snorm: IntervalBounds = [
+    hexToF64(0x3fe02040, 0x20000000),
+    hexToF64(0x3fe02041, 0x00000000),
+  ]; // ~0.50196..., due to lack of precision in i8
+  const kNegHalfBounds4x8snorm: IntervalBounds = [
+    hexToF64(0xbfdfbf7f, 0x60000000),
+    hexToF64(0xbfdfbf7e, 0x80000000),
+  ]; // ~-0.49606..., due to lack of precision in i8
+
+  g.test('unpack4x8snormInterval')
+    .paramsSubcasesOnly<PointToVectorCase>(
+      // prettier-ignore
+      [
+        // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
+        // form due to the inherited nature of the errors.
+        { input: 0x00000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x0000007f, expected: [kOneBoundsSnorm, kZeroBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x00007f00, expected: [kZeroBounds, kOneBoundsSnorm, kZeroBounds, kZeroBounds] },
+        { input: 0x007f0000, expected: [kZeroBounds, kZeroBounds, kOneBoundsSnorm, kZeroBounds] },
+        { input: 0x7f000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kOneBoundsSnorm] },
+        { input: 0x00007f7f, expected: [kOneBoundsSnorm, kOneBoundsSnorm, kZeroBounds, kZeroBounds] },
+        { input: 0x7f7f0000, expected: [kZeroBounds, kZeroBounds, kOneBoundsSnorm, kOneBoundsSnorm] },
+        { input: 0x7f007f00, expected: [kZeroBounds, kOneBoundsSnorm, kZeroBounds, kOneBoundsSnorm] },
+        { input: 0x007f007f, expected: [kOneBoundsSnorm, kZeroBounds, kOneBoundsSnorm, kZeroBounds] },
+        { input: 0x7f7f7f7f, expected: [kOneBoundsSnorm, kOneBoundsSnorm, kOneBoundsSnorm, kOneBoundsSnorm] },
+        { input: 0x81818181, expected: [kNegOneBoundsSnorm, kNegOneBoundsSnorm, kNegOneBoundsSnorm, kNegOneBoundsSnorm] },
+        { input: 0x40404040, expected: [kHalfBounds4x8snorm, kHalfBounds4x8snorm, kHalfBounds4x8snorm, kHalfBounds4x8snorm] },
+        { input: 0xc1c1c1c1, expected: [kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm] },
+      ]
+    )
+    .fn(t => {
+      const expected = toF32Vector(t.params.expected);
+
+      const got = unpack4x8snormInterval(t.params.input);
+
+      t.expect(
+        objectEquals(expected, got),
+        `unpack4x8snormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
       );
     });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
@@ -26,7 +26,6 @@ g.test('unpack')
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      n = Math.trunc(n);
       return makeU32ToVectorIntervalCase(n, unpack2x16snormInterval);
     };
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -26,7 +26,6 @@ g.test('unpack')
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      n = Math.trunc(n);
       return makeU32ToVectorIntervalCase(n, unpack2x16unormInterval);
     };
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
@@ -7,6 +7,12 @@ bits 8×i through 8×i+7 of e as a twos-complement signed integer.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
+import { unpack4x8snormInterval } from '../../../../../util/f32_interval.js';
+import { fullU32Range } from '../../../../../util/math.js';
+import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -17,4 +23,13 @@ g.test('unpack')
 @const fn unpack4x8snorm(e: u32) -> vec4<f32>
 `
   )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const makeCase = (n: number): Case => {
+      return makeU32ToVectorIntervalCase(n, unpack4x8snormInterval);
+    };
+
+    const cases: Array<Case> = fullU32Range().map(makeCase);
+
+    await run(t, builtin('unpack4x8snorm'), [TypeU32], TypeVec(4, TypeF32), t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
@@ -23,10 +23,9 @@ g.test('unpack')
 @const fn unpack4x8unorm(e: u32) -> vec4<f32>
 `
   )
-  .params(u => u.combine('inputSource', [allInputSources[1]]))
+  .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
     const makeCase = (n: number): Case => {
-      n = Math.trunc(n);
       return makeU32ToVectorIntervalCase(n, unpack4x8unormInterval);
     };
 

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -710,6 +710,7 @@ export function makeVectorPairToVectorIntervalCase(
  *            intervals for a vector.
  */
 export function makeU32ToVectorIntervalCase(param: number, ...ops: PointToVector[]): Case {
+  param = Math.trunc(param);
   const param_u32 = u32(param);
 
   const vectors = ops.map(o => o(param));

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1894,6 +1894,7 @@ const unpackDataU32 = new Uint32Array(unpackData);
 const unpackDataU16 = new Uint16Array(unpackData);
 const unpackDataU8 = new Uint8Array(unpackData);
 const unpackDataI16 = new Int16Array(unpackData);
+const unpackDataI8 = new Int8Array(unpackData);
 
 const Unpack2x16snormIntervalOp = (n: number): F32Interval => {
   return maxInterval(divisionInterval(n, 32767), -1);
@@ -1921,6 +1922,25 @@ export function unpack2x16unormInterval(n: number): F32Vector {
   );
   unpackDataU32[0] = n;
   return [Unpack2x16unormIntervalOp(unpackDataU16[0]), Unpack2x16unormIntervalOp(unpackDataU16[1])];
+}
+
+const Unpack4x8snormIntervalOp = (n: number): F32Interval => {
+  return maxInterval(divisionInterval(n, 127), -1);
+};
+
+/** Calculate an acceptance interval vector for unpack4x8snorm(x) */
+export function unpack4x8snormInterval(n: number): F32Vector {
+  assert(
+    n >= kValue.u32.min && n <= kValue.u32.max,
+    'unpack4x8snormInterval only accepts values on the bounds of u32'
+  );
+  unpackDataU32[0] = n;
+  return [
+    Unpack4x8snormIntervalOp(unpackDataI8[0]),
+    Unpack4x8snormIntervalOp(unpackDataI8[1]),
+    Unpack4x8snormIntervalOp(unpackDataI8[2]),
+    Unpack4x8snormIntervalOp(unpackDataI8[3]),
+  ];
 }
 
 const Unpack4x8unormIntervalOp = (n: number): F32Interval => {


### PR DESCRIPTION
Fixes #1289

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
