### PR TITLE
Fix extractBits tests to not test overflow cases for const input source

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/extractBits.spec.ts
@@ -87,7 +87,7 @@ g.test('u32')
       0b00000000001010101010100000000000
     );
 
-    await run(t, builtin('extractBits'), [T, TypeU32, TypeU32], T, cfg, [
+    const cases = [
       { input: [all_0, u32(0), u32(32)], expected: all_0 },
       { input: [all_0, u32(1), u32(10)], expected: all_0 },
       { input: [all_0, u32(2), u32(5)], expected: all_0 },
@@ -165,27 +165,35 @@ g.test('u32')
       { input: [low_1, u32(0), u32(1)], expected: low_1 },
       { input: [high_1, u32(31), u32(1)], expected: low_1 },
 
-      // End overflow
-      { input: [low_1, u32(0), u32(99)], expected: low_1 },
-      { input: [high_1, u32(31), u32(99)], expected: low_1 },
-      { input: [pattern, u32(0), u32(99)], expected: pattern },
-      {
-        input: [pattern, u32(14), u32(99)],
-        expected: V(
-          0b00000000000000000000000001110111,
-          0b00000000000000111111111110000000,
-          0b00000000000000000000000101010101,
-          0b00000000000000000000000010101010
-        ),
-      },
-
       // Zero count
       { input: [all_1, u32(0), u32(0)], expected: all_0 },
       { input: [all_0, u32(0), u32(0)], expected: all_0 },
       { input: [low_1, u32(0), u32(0)], expected: all_0 },
       { input: [high_1, u32(31), u32(0)], expected: all_0 },
       { input: [pattern, u32(0), u32(0)], expected: all_0 },
-    ]);
+    ];
+
+    if (t.params.inputSource !== 'const') {
+      cases.push(
+        ...[
+          // End overflow
+          { input: [low_1, u32(0), u32(99)], expected: low_1 },
+          { input: [high_1, u32(31), u32(99)], expected: low_1 },
+          { input: [pattern, u32(0), u32(99)], expected: pattern },
+          {
+            input: [pattern, u32(14), u32(99)],
+            expected: V(
+              0b00000000000000000000000001110111,
+              0b00000000000000111111111110000000,
+              0b00000000000000000000000101010101,
+              0b00000000000000000000000010101010
+            ),
+          },
+        ]
+      );
+    }
+
+    await run(t, builtin('extractBits'), [T, TypeU32, TypeU32], T, cfg, cases);
   });
 
 g.test('i32')
@@ -225,7 +233,7 @@ g.test('i32')
       0b00000000001010101010100000000000
     );
 
-    await run(t, builtin('extractBits'), [T, TypeU32, TypeU32], T, cfg, [
+    const cases = [
       { input: [all_0, u32(0), u32(32)], expected: all_0 },
       { input: [all_0, u32(1), u32(10)], expected: all_0 },
       { input: [all_0, u32(2), u32(5)], expected: all_0 },
@@ -297,25 +305,33 @@ g.test('i32')
       { input: [low_1, u32(0), u32(1)], expected: all_1 },
       { input: [high_1, u32(31), u32(1)], expected: all_1 },
 
-      // End overflow
-      { input: [low_1, u32(0), u32(99)], expected: low_1 },
-      { input: [high_1, u32(31), u32(99)], expected: all_1 },
-      { input: [pattern, u32(0), u32(99)], expected: pattern },
-      {
-        input: [pattern, u32(14), u32(99)],
-        expected: V(
-          0b00000000000000000000000001110111,
-          0b11111111111111111111111110000000,
-          0b00000000000000000000000101010101,
-          0b00000000000000000000000010101010
-        ),
-      },
-
       // Zero count
       { input: [all_1, u32(0), u32(0)], expected: all_0 },
       { input: [all_0, u32(0), u32(0)], expected: all_0 },
       { input: [low_1, u32(0), u32(0)], expected: all_0 },
       { input: [high_1, u32(31), u32(0)], expected: all_0 },
       { input: [pattern, u32(0), u32(0)], expected: all_0 },
-    ]);
+    ];
+
+    if (t.params.inputSource !== 'const') {
+      cases.push(
+        ...[
+          // End overflow
+          { input: [low_1, u32(0), u32(99)], expected: low_1 },
+          { input: [high_1, u32(31), u32(99)], expected: all_1 },
+          { input: [pattern, u32(0), u32(99)], expected: pattern },
+          {
+            input: [pattern, u32(14), u32(99)],
+            expected: V(
+              0b00000000000000000000000001110111,
+              0b11111111111111111111111110000000,
+              0b00000000000000000000000101010101,
+              0b00000000000000000000000010101010
+            ),
+          },
+        ]
+      );
+    }
+
+    await run(t, builtin('extractBits'), [T, TypeU32, TypeU32], T, cfg, cases);
   });


### PR DESCRIPTION
Issue: #1957
