### PR TITLE
Implement 'render_bundle_commands' test in encoder_open_state.spec.ts

### DIFF
--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -1,8 +1,6 @@
 export const description = `
 Validation tests to all commands of GPUCommandEncoder, GPUComputePassEncoder, and
 GPURenderPassEncoder when the encoder is not finished.
-
-TODO: Equivalent tests for GPURenderBundleEncoder.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -102,6 +100,27 @@ const kRenderPassEncoderCommandInfo: {
   insertDebugMarker: {},
 };
 const kRenderPassEncoderCommands = keysOf(kRenderPassEncoderCommandInfo);
+
+type RenderBundleEncoderCommands = keyof Omit<
+  GPURenderBundleEncoder,
+  '__brand' | 'label' | 'finish'
+>;
+const kRenderBundleEncoderCommandInfo: {
+  readonly [k in RenderBundleEncoderCommands]: {};
+} = {
+  draw: {},
+  drawIndexed: {},
+  drawIndexedIndirect: {},
+  drawIndirect: {},
+  setPipeline: {},
+  setBindGroup: {},
+  setIndexBuffer: {},
+  setVertexBuffer: {},
+  pushDebugGroup: {},
+  popDebugGroup: {},
+  insertDebugMarker: {},
+};
+const kRenderBundleEncoderCommands = keysOf(kRenderBundleEncoderCommandInfo);
 
 // MAINTENANCE_TODO: remove the deprecated 'dispatch' and 'dispatchIndirect' here once they're
 // removed from `@webgpu/types`.
@@ -385,6 +404,102 @@ g.test('render_pass_commands')
         case 'insertDebugMarker':
           {
             encoder.insertDebugMarker('marker');
+          }
+          break;
+        default:
+          unreachable();
+      }
+    }, finishBeforeCommand);
+  });
+
+g.test('render_bundle_commands')
+  .desc(
+    `
+    Test that functions of GPURenderBundleEncoder generate a validation error if the encoder or the
+    pass is already finished.
+  `
+  )
+  .params(u =>
+    u
+      .combine('command', kRenderBundleEncoderCommands)
+      .beginSubcases()
+      .combine('finishBeforeCommand', [false, true])
+  )
+  .fn(t => {
+    const { command, finishBeforeCommand } = t.params;
+
+    const buffer = t.device.createBuffer({
+      size: 12,
+      usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+    });
+
+    const pipeline = t.createRenderPipelineForTest();
+
+    const bindGroup = t.createBindGroupForTest();
+
+    const bundleEncoder = t.device.createRenderBundleEncoder({
+      colorFormats: ['rgba8unorm'],
+    });
+
+    if (finishBeforeCommand) {
+      bundleEncoder.finish();
+    }
+
+    t.expectValidationError(() => {
+      switch (command) {
+        case 'draw':
+          {
+            bundleEncoder.draw(1);
+          }
+          break;
+        case 'drawIndexed':
+          {
+            bundleEncoder.drawIndexed(1);
+          }
+          break;
+        case 'drawIndexedIndirect':
+          {
+            bundleEncoder.drawIndexedIndirect(buffer, 0);
+          }
+          break;
+        case 'drawIndirect':
+          {
+            bundleEncoder.drawIndirect(buffer, 1);
+          }
+          break;
+        case 'setPipeline':
+          {
+            bundleEncoder.setPipeline(pipeline);
+          }
+          break;
+        case 'setBindGroup':
+          {
+            bundleEncoder.setBindGroup(0, bindGroup);
+          }
+          break;
+        case 'setIndexBuffer':
+          {
+            bundleEncoder.setIndexBuffer(buffer, 'uint32');
+          }
+          break;
+        case 'setVertexBuffer':
+          {
+            bundleEncoder.setVertexBuffer(1, buffer);
+          }
+          break;
+        case 'pushDebugGroup':
+          {
+            bundleEncoder.pushDebugGroup('group');
+          }
+          break;
+        case 'popDebugGroup':
+          {
+            bundleEncoder.popDebugGroup();
+          }
+          break;
+        case 'insertDebugMarker':
+          {
+            bundleEncoder.insertDebugMarker('marker');
           }
           break;
         default:


### PR DESCRIPTION
This PR adds a new 'render_bundle_commands' to test all commands of GPURenderBundleEncoder after the encoder was already finished.

Issue: #1914

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
