### PR TITLE
Implement `refract` f32 tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -52,6 +52,7 @@ import {
   quantizeToF16Interval,
   radiansInterval,
   reflectInterval,
+  refractInterval,
   remainderInterval,
   roundInterval,
   saturateInterval,
@@ -3254,3 +3255,62 @@ g.test('faceForwardIntervals')
       `faceForwardInterval([${x}], [${y}], [${z}]) returned [${got}]. Expected [${expected}]`
     );
   });
+
+interface RefractCase {
+  input: [number[], number[], number];
+  expected: IntervalBounds[];
+}
+
+// Scope for refractInterval tests so that they can have constants for magic
+// numbers that don't pollute the global namespace or have unwieldy long names.
+{
+  const kNegativeOneBounds: IntervalBounds = [
+    hexToF64(0xbff00000, 0xc0000000),
+    hexToF64(0xbfefffff, 0x40000000),
+  ];
+
+  g.test('refractInterval')
+    .paramsSubcasesOnly<RefractCase>(
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human readable form due to the inherited nature
+      // of the errors.
+
+      // prettier-ignore
+      [
+      // k < 0
+      { input: [[1, 1], [0.1, 0], 10], expected: [[0], [0]] },
+
+      // k contains 0
+      { input: [[1, 1], [0.1, 0], 1.005038], expected: [kAny, kAny] },
+
+      // k > 0
+      // vec2
+      { input: [[1, 1], [1, 0], 1], expected: [kNegativeOneBounds, [1]] },
+      { input: [[1, -2], [3, 4], 5], expected: [[hexToF32(0x40ce87a4), hexToF32(0x40ce8840)],  // ~6.454...
+                                                [hexToF32(0xc100fae8), hexToF32(0xc100fa80)]] },  // ~-8.061...
+
+      // vec3
+      { input: [[1, 1, 1], [1, 0, 0], 1], expected: [kNegativeOneBounds, [1], [1]] },
+      { input: [[1, -2, 3], [-4, 5, -6], 7], expected: [[hexToF32(0x40d24480), hexToF32(0x40d24c00)],  // ~6.571...
+                                                        [hexToF32(0xc1576f80), hexToF32(0xc1576ad0)],  // ~-13.464...
+                                                        [hexToF32(0x41a2d9b0), hexToF32(0x41a2dc80)]] },  // ~20.356...
+
+      // vec4
+      { input: [[1, 1, 1, 1], [1, 0, 0, 0], 1], expected: [kNegativeOneBounds, [1], [1], [1]] },
+      { input: [[1, -2, 3,-4], [-5, 6, -7, 8], 9], expected: [[hexToF32(0x410ae480), hexToF32(0x410af240)],  // ~8.680...
+                                                              [hexToF32(0xc18cf7c0), hexToF32(0xc18cef80)],  // ~-17.620...
+                                                              [hexToF32(0x41d46cc0), hexToF32(0x41d47660)],  // ~26.553...
+                                                              [hexToF32(0xc20dfa80), hexToF32(0xc20df500)]] },  // ~-35.494...]
+    ]
+    )
+    .fn(t => {
+      const [i, s, r] = t.params.input;
+      const expected = toF32Vector(t.params.expected);
+
+      const got = refractInterval(i, s, r);
+      t.expect(
+        objectEquals(expected, got),
+        `refractIntervals([${i}], [${s}], ${r}) returned [${got}]. Expected [${expected}]`
+      );
+    });
+}

--- a/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
@@ -12,9 +12,34 @@ vector e3*e1- (e3* dot(e2,e1) + sqrt(k)) *e2.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { f32, TypeF32, TypeVec, Vector } from '../../../../../util/conversion.js';
+import { refractInterval } from '../../../../../util/f32_interval.js';
+import {
+  kVectorSparseTestValues,
+  quantizeToF32,
+  sparseF32Range,
+} from '../../../../../util/math.js';
+import { allInputSources, Case, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+/** @returns a `reflect` Case for a pair of vectors of f32s and a f32 input */
+const makeCaseF32 = (i: number[], s: number[], r: number): Case => {
+  i = i.map(quantizeToF32);
+  s = s.map(quantizeToF32);
+  r = quantizeToF32(r);
+
+  const i_f32 = i.map(f32);
+  const s_f32 = s.map(f32);
+  const r_f32 = f32(r);
+
+  return {
+    input: [new Vector(i_f32), new Vector(s_f32), r_f32],
+    expected: refractInterval(i, s, r),
+  };
+};
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -22,11 +47,74 @@ g.test('abstract_float')
   .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
   .unimplemented();
 
-g.test('f32')
-  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(`f32 tests`)
-  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
-  .unimplemented();
+g.test('f32_vec2')
+  .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')
+  .desc(`f32 tests using vec2s`)
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases: Case[] = kVectorSparseTestValues[2].flatMap(i => {
+      return kVectorSparseTestValues[2].flatMap(j => {
+        return sparseF32Range().map(k => {
+          return makeCaseF32(i, j, k);
+        });
+      });
+    });
+
+    await run(
+      t,
+      builtin('refract'),
+      [TypeVec(2, TypeF32), TypeVec(2, TypeF32), TypeF32],
+      TypeVec(2, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('f32_vec3')
+  .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')
+  .desc(`f32 tests using vec3s`)
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases: Case[] = kVectorSparseTestValues[3].flatMap(i => {
+      return kVectorSparseTestValues[3].flatMap(j => {
+        return sparseF32Range().map(k => {
+          return makeCaseF32(i, j, k);
+        });
+      });
+    });
+
+    await run(
+      t,
+      builtin('refract'),
+      [TypeVec(3, TypeF32), TypeVec(3, TypeF32), TypeF32],
+      TypeVec(3, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('f32_vec4')
+  .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')
+  .desc(`f32 tests using vec4s`)
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases: Case[] = kVectorSparseTestValues[4].flatMap(i => {
+      return kVectorSparseTestValues[4].flatMap(j => {
+        return sparseF32Range().map(k => {
+          return makeCaseF32(i, j, k);
+        });
+      });
+    });
+
+    await run(
+      t,
+      builtin('refract'),
+      [TypeVec(4, TypeF32), TypeVec(4, TypeF32), TypeF32],
+      TypeVec(4, TypeF32),
+      t.params,
+      cases
+    );
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')


### PR DESCRIPTION
Also introduces kAnyVector and kZeroVector to remove dynamic generation of these values.

Issue #1234

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
