### PR TITLE
Convert asin, acos and atanh to a filtered range when needed.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { acosInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { sourceFilteredF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -39,7 +39,7 @@ g.test('f32')
 
     const cases = [
       ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
-      ...fullF32Range(),
+      ...sourceFilteredF32Range(t.params.inputSource, -1, 1),
     ].map(makeCase);
     await run(t, builtin('acos'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { asinInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { sourceFilteredF32Range, linearRange } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -39,7 +39,7 @@ g.test('f32')
 
     const cases = [
       ...linearRange(-1, 1, 100), // asin is defined on [-1, 1]
-      ...fullF32Range(),
+      ...sourceFilteredF32Range(t.params.inputSource, -1, 1),
     ].map(makeCase);
     await run(t, builtin('asin'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -45,8 +45,21 @@ g.test('f32')
       ...biasedRange(kValue.f32.negative.less_than_one, -0.9, 20), // discontinuity at x = -1
       ...biasedRange(kValue.f32.positive.less_than_one, 0.9, 20), // discontinuity at x = 1
       ...sourceFilteredF32Range(
-        t.params.inputSource, kValue.f32.negative.less_than_one, kValue.f32.positive.less_than_one),
+        t.params.inputSource,
+        kValue.f32.negative.less_than_one,
+        kValue.f32.positive.less_than_one
+      ),
     ].map(makeCase);
+
+    // Handle the edge case of -1 and 1 when not doing const-eval
+    if (t.params.inputSource !== 'const') {
+      const edgeCases = [
+        ...biasedRange(-1, kValue.f32.negative.less_than_one, 20),
+        ...biasedRange(1, kValue.f32.positive.less_than_one, 20),
+      ].map(makeCase);
+      cases.push(...edgeCases);
+    }
+
     await run(t, builtin('atanh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -12,9 +12,10 @@ Note: The result is not mathematically meaningful when abs(e) >= 1.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { atanhInterval } from '../../../../../util/f32_interval.js';
-import { biasedRange, fullF32Range } from '../../../../../util/math.js';
+import { biasedRange, sourceFilteredF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -41,9 +42,10 @@ g.test('f32')
     };
 
     const cases = [
-      ...biasedRange(-1, -0.9, 20), // discontinuity at x = -1
-      ...biasedRange(1, 0.9, 20), // discontinuity at x = 1
-      ...fullF32Range(),
+      ...biasedRange(kValue.f32.negative.less_than_one, -0.9, 20), // discontinuity at x = -1
+      ...biasedRange(kValue.f32.positive.less_than_one, 0.9, 20), // discontinuity at x = 1
+      ...sourceFilteredF32Range(
+        t.params.inputSource, kValue.f32.negative.less_than_one, kValue.f32.positive.less_than_one),
     ].map(makeCase);
     await run(t, builtin('atanh'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -53,10 +53,7 @@ g.test('f32')
 
     // Handle the edge case of -1 and 1 when not doing const-eval
     if (t.params.inputSource !== 'const') {
-      const edgeCases = [
-        ...biasedRange(-1, kValue.f32.negative.less_than_one, 20),
-        ...biasedRange(1, kValue.f32.positive.less_than_one, 20),
-      ].map(makeCase);
+      const edgeCases = [-1, 1].map(makeCase);
       cases.push(...edgeCases);
     }
 

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -47,6 +47,7 @@ export const kBit = {
       min: 0xff7f_ffff,
       zero: 0x8000_0000,
       nearest_min: 0xff7f_fffe,
+      less_than_one: 0xbf7f_ffff,
       pi: {
         whole: 0xc04_90fdb,
         three_quarters: 0xc016_cbe4,
@@ -321,6 +322,7 @@ export const kValue = {
       max: hexToF32(kBit.f32.negative.max),
       min: hexToF32(kBit.f32.negative.min),
       nearest_min: hexToF32(kBit.f32.negative.nearest_min),
+      less_than_one: hexToF32(kBit.f32.negative.less_than_one),  // -0.999999940395
       pi: {
         whole: hexToF32(kBit.f32.negative.pi.whole),
         three_quarters: hexToF32(kBit.f32.negative.pi.three_quarters),

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -322,7 +322,7 @@ export const kValue = {
       max: hexToF32(kBit.f32.negative.max),
       min: hexToF32(kBit.f32.negative.min),
       nearest_min: hexToF32(kBit.f32.negative.nearest_min),
-      less_than_one: hexToF32(kBit.f32.negative.less_than_one),  // -0.999999940395
+      less_than_one: hexToF32(kBit.f32.negative.less_than_one), // -0.999999940395
       pi: {
         whole: hexToF32(kBit.f32.negative.pi.whole),
         three_quarters: hexToF32(kBit.f32.negative.pi.three_quarters),

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1,6 +1,7 @@
 import { assert } from '../../common/util/util.js';
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 
+import { F32Interval } from './f32_interval.js';
 import { kBit, kValue } from './constants.js';
 import {
   f16,
@@ -563,6 +564,23 @@ export function fullF32Range(
     ...linearRange(kBit.f32.positive.min, kBit.f32.positive.max, counts.pos_norm),
   ].map(Math.trunc);
   return bit_fields.map(hexToF32);
+}
+
+/**
+ * @returns an ascending sorted array of numbers.
+ *
+ * The numbers returned are based on the `full32Range` as described above. The difference comes depending
+ * on the `source` parameter. If the `source` is `const` then the numbers will be restricted to be
+ * in the range `[low, high]`. This allows filtering out a set of `f32` values which are invalid for
+ * const-evaluation but are needed to test the non-const implementation.
+ *
+ * @param source the input source for the test. If the `source` is `const` then the return will be filtered
+ * @param low the lowest f32 value to permit when filtered
+ * @param high the highest f32 value to permit when filtered
+ */
+export function sourceFilteredF32Range(source: String, low: number, high: number): Array<number> {
+  const interval = new F32Interval(low, high);
+  return fullF32Range().filter(x => source !== 'const' || interval.contains(x));
 }
 
 /**

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -13,7 +13,6 @@ import {
   kFloat32Format,
   Scalar,
 } from './conversion.js';
-import { F32Interval } from './f32_interval.js';
 
 /**
  * A multiple of 8 guaranteed to be way too large to allocate (just under 8 pebibytes).
@@ -579,8 +578,7 @@ export function fullF32Range(
  * @param high the highest f32 value to permit when filtered
  */
 export function sourceFilteredF32Range(source: String, low: number, high: number): Array<number> {
-  const interval = new F32Interval(low, high);
-  return fullF32Range().filter(x => source !== 'const' || interval.contains(x));
+  return fullF32Range().filter(x => source !== 'const' || (x >= low && x <= high));
 }
 
 /**

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1,7 +1,6 @@
 import { assert } from '../../common/util/util.js';
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 
-import { F32Interval } from './f32_interval.js';
 import { kBit, kValue } from './constants.js';
 import {
   f16,
@@ -14,6 +13,7 @@ import {
   kFloat32Format,
   Scalar,
 } from './conversion.js';
+import { F32Interval } from './f32_interval.js';
 
 /**
  * A multiple of 8 guaranteed to be way too large to allocate (just under 8 pebibytes).


### PR DESCRIPTION
When doing const-eval for the `asin` and `acos` builtins they are only defined in the `[-1, 1]` range. The `atanh` builtin is only defined in the `(-1, 1)` range. Tests outside that range fail with a validation error. When not using const-evaluation having values outside the range is useful for validation.

This CL adds a `sourceFilteredF32Range` which will clamp the F32 values if the source is `const`. The `asin`, `acos`, and `atanh` tests are updated to use the new filter.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
