### PR TITLE
op: Implement 'index_format,change_pipeline_after_setIndexBuffer' test in index_format.spec.ts

### DIFF
--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -215,6 +215,65 @@ g.test('index_format,uint32')
     t.expectGPUBufferValuesEqual(result, expectedTextureValues);
   });
 
+g.test('index_format,change_pipeline_after_setIndexBuffer')
+  .desc('Test that setting the index buffer before the pipeline works correctly.')
+  .params(u => u.combine('setPipelineBeforeSetIndexBuffer', [false, true]))
+  .fn(t => {
+    const indexOffset = 12;
+    const indexCount = 7;
+    const expectedShape = kBottomLeftTriangle;
+
+    const indexFormat16 = 'uint16';
+    const indexFormat32 = 'uint32';
+
+    const indices: number[] = [1, 2, 0, 0, 0, 0, 0, 1, 3, 0];
+    const indexBuffer = t.CreateIndexBuffer(indices, indexFormat32);
+
+    const kPrimitiveTopology = 'triangle-strip';
+    const pipeline32 = t.MakeRenderPipeline(kPrimitiveTopology, indexFormat32);
+    const pipeline16 = t.MakeRenderPipeline(kPrimitiveTopology, indexFormat16);
+
+    const colorAttachment = t.device.createTexture({
+      format: kTextureFormat,
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const result = t.device.createBuffer({
+      size: byteLength,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: colorAttachment.createView(),
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+
+    if (t.params.setPipelineBeforeSetIndexBuffer) {
+      pass.setPipeline(pipeline16);
+    }
+    pass.setIndexBuffer(indexBuffer, indexFormat32, indexOffset);
+    pass.setPipeline(pipeline32); // Set the pipeline for 'indexFormat32' again.
+    pass.drawIndexed(indexCount);
+    pass.end();
+    encoder.copyTextureToBuffer(
+      { texture: colorAttachment },
+      { buffer: result, bytesPerRow, rowsPerImage },
+      [kWidth, kHeight]
+    );
+    t.device.queue.submit([encoder.finish()]);
+
+    const expectedTextureValues = t.CreateExpectedUint8Array(expectedShape);
+    t.expectGPUBufferValuesEqual(result, expectedTextureValues);
+  });
+
 g.test('primitive_restart')
   .desc(
     `


### PR DESCRIPTION
This PR adds a new test to ensure that setting the index buffer before setting the pipeline works well. This is important for backedns where the index format is passed inside the call to setIndexBuffer because it needs to be done lazily to query the foramt from last pipeline.

Issue: #1968

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
