### PR TITLE
Fix quantizeToF16 tests to not test overflow cases for const input source

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -40,8 +40,11 @@ g.test('f32')
       kValue.f16.subnormal.positive.max,
       kValue.f16.positive.min,
       kValue.f16.positive.max,
-      ...fullF32Range(),
     ].map(makeCase);
+
+    if (t.params.inputSource !== 'const') {
+      cases.push(...fullF32Range().map(makeCase));
+    }
 
     await run(t, builtin('quantizeToF16'), [TypeF32], TypeF32, t.params, cases);
   });


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
