### PR TITLE
Simplify code around ULP calculations and fix subtly wrong tests

### DIFF
--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -118,17 +118,24 @@ export function isFiniteF16(n: number) {
   return n >= kValue.f16.negative.min && n <= kValue.f16.positive.max;
 }
 
+/** Should FTZ occur during calculations or not */
+export type FlushMode = 'flush' | 'no-flush';
+
 /**
  * @returns the next f32 value after |val|,
  * towards +inf if |dir| is true, otherwise towards -inf.
- * If |flush| is true, all subnormal values will be flushed to 0,
- * before processing.
- * If |flush| is false, the next subnormal will be calculated when appropriate,
+
+ * If |mpode| is 'flush', all subnormal values will be flushed to 0,
+ * before processing and for -/+0 the nextAfterF32 will be the closest normal in
+ * the correct direction.
+
+ * If |mode| is 'no-flush', the next subnormal will be calculated when appropriate,
  * and for -/+0 the nextAfterF32 will be the closest subnormal in the correct
  * direction.
+ *
  * val needs to be in [min f32, max f32]
  */
-export function nextAfterF32(val: number, dir: boolean = true, flush: boolean): Scalar {
+export function nextAfterF32(val: number, dir: boolean = true, mode: FlushMode): Scalar {
   if (Number.isNaN(val)) {
     return f32Bits(kBit.f32.nan.positive.s);
   }
@@ -146,14 +153,18 @@ export function nextAfterF32(val: number, dir: boolean = true, flush: boolean): 
     `${val} is not in the range of float32`
   );
 
-  val = flush ? flushSubnormalNumberF32(val) : val;
+  val = mode === 'flush' ? flushSubnormalNumberF32(val) : val;
 
   // -/+0 === 0 returns true
   if (val === 0) {
     if (dir) {
-      return flush ? f32Bits(kBit.f32.positive.min) : f32Bits(kBit.f32.subnormal.positive.min);
+      return mode === 'flush'
+        ? f32Bits(kBit.f32.positive.min)
+        : f32Bits(kBit.f32.subnormal.positive.min);
     } else {
-      return flush ? f32Bits(kBit.f32.negative.max) : f32Bits(kBit.f32.subnormal.negative.max);
+      return mode === 'flush'
+        ? f32Bits(kBit.f32.negative.max)
+        : f32Bits(kBit.f32.subnormal.negative.max);
     }
   }
 
@@ -176,7 +187,7 @@ export function nextAfterF32(val: number, dir: boolean = true, flush: boolean): 
     } else {
       // Round was opposite of the direction requested, so need nextAfterF32 in the requested direction.
       // This will not recurse since converted is guaranteed to be a float32 due to the conversion above.
-      const next = nextAfterF32(converted, dir, flush).value.valueOf() as number;
+      const next = nextAfterF32(converted, dir, mode).value.valueOf() as number;
       u32_result = new Uint32Array(new Float32Array([next]).buffer)[0];
     }
   }
@@ -191,20 +202,24 @@ export function nextAfterF32(val: number, dir: boolean = true, flush: boolean): 
   }
 
   const f32_result = f32Bits(u32_result);
-  return flush ? flushSubnormalScalarF32(f32_result) : f32_result;
+  return mode === 'flush' ? flushSubnormalScalarF32(f32_result) : f32_result;
 }
 
 /**
  * @returns the next f16 value after |val|,
  * towards +inf if |dir| is true, otherwise towards -inf.
- * If |flush| is true, all subnormal values will be flushed to 0,
- * before processing.
- * If |flush| is false, the next subnormal will be calculated when appropriate,
+ *
+ * If |mode| is true, all subnormal values will be flushed to 0,
+ * before processing, and for -/+0 the nextAfterF16 will be the closest normal
+ * in the correct direction
+ *
+ * If |mode| is false, the next subnormal will be calculated when appropriate,
  * and for -/+0 the nextAfterF16 will be the closest subnormal in the correct
  * direction.
+ *
  * val needs to be in [min f16, max f16]
  */
-export function nextAfterF16(val: number, dir: boolean = true, flush: boolean): Scalar {
+export function nextAfterF16(val: number, dir: boolean = true, mode: FlushMode): Scalar {
   if (Number.isNaN(val)) {
     return f16Bits(kBit.f16.nan.positive.s);
   }
@@ -222,14 +237,18 @@ export function nextAfterF16(val: number, dir: boolean = true, flush: boolean): 
     `${val} is not in the range of float16`
   );
 
-  val = flush ? flushSubnormalNumberF16(val) : val;
+  val = mode === 'flush' ? flushSubnormalNumberF16(val) : val;
 
   // -/+0 === 0 returns true
   if (val === 0) {
     if (dir) {
-      return flush ? f16Bits(kBit.f16.positive.min) : f16Bits(kBit.f16.subnormal.positive.min);
+      return mode === 'flush'
+        ? f16Bits(kBit.f16.positive.min)
+        : f16Bits(kBit.f16.subnormal.positive.min);
     } else {
-      return flush ? f16Bits(kBit.f16.negative.max) : f16Bits(kBit.f16.subnormal.negative.max);
+      return mode === 'flush'
+        ? f16Bits(kBit.f16.negative.max)
+        : f16Bits(kBit.f16.subnormal.negative.max);
     }
   }
 
@@ -252,7 +271,7 @@ export function nextAfterF16(val: number, dir: boolean = true, flush: boolean): 
     } else {
       // Round was opposite of the direction requested, so need nextAfterF16 in the requested direction.
       // This will not recurse since converted is guaranteed to be a float16 due to the conversion above.
-      const next = nextAfterF16(converted, dir, flush).value.valueOf() as number;
+      const next = nextAfterF16(converted, dir, mode).value.valueOf() as number;
       u16_result = new Uint16Array(new Float16Array([next]).buffer)[0];
     }
   }
@@ -267,7 +286,7 @@ export function nextAfterF16(val: number, dir: boolean = true, flush: boolean): 
   }
 
   const f16_result = f16Bits(u16_result);
-  return flush ? flushSubnormalScalarF16(f16_result) : f16_result;
+  return mode === 'flush' ? flushSubnormalScalarF16(f16_result) : f16_result;
 }
 
 /**
@@ -279,14 +298,14 @@ export function nextAfterF16(val: number, dir: boolean = true, flush: boolean): 
  * for a more detailed/nuanced discussion of the definition of ulp(x).
  *
  * @param target number to calculate ULP for
- * @param flush should subnormals be flushed during calculation
+ * @param mode should FTZ occuring during calculation or not
  */
-export function oneULP(target: number, flush: boolean = true): number {
+export function oneULP(target: number, mode: FlushMode = 'flush'): number {
   if (Number.isNaN(target)) {
     return Number.NaN;
   }
 
-  target = flush ? flushSubnormalNumberF32(target) : target;
+  target = mode === 'flush' ? flushSubnormalNumberF32(target) : target;
 
   // For values at the edge of the range or beyond ulp(x) is defined as the distance between the two nearest
   // f32 representable numbers to the appropriate edge.
@@ -300,8 +319,8 @@ export function oneULP(target: number, flush: boolean = true): number {
   //     before <= x <= after
   //     before =/= after
   //     before and after are f32 representable
-  const before = nextAfterF32(target, false, flush).value.valueOf() as number;
-  const after = nextAfterF32(target, true, flush).value.valueOf() as number;
+  const before = nextAfterF32(target, false, mode).value.valueOf() as number;
+  const after = nextAfterF32(target, true, mode).value.valueOf() as number;
   const converted: number = new Float32Array([target])[0];
   if (converted === target) {
     // |target| is f32 representable, so either before or after will be x
@@ -352,11 +371,11 @@ export function correctlyRoundedF32(n: number): number[] {
 
   if (converted > n) {
     // n_32 rounded towards +inf, so is after n
-    const other = nextAfterF32(n_32, false, false).value as number;
+    const other = nextAfterF32(n_32, false, 'no-flush').value as number;
     return [other, converted];
   } else {
     // n_32 rounded towards -inf, so is before n
-    const other = nextAfterF32(n_32, true, false).value as number;
+    const other = nextAfterF32(n_32, true, 'no-flush').value as number;
     return [converted, other];
   }
 }
@@ -401,11 +420,11 @@ export function correctlyRoundedF16(n: number): number[] {
 
   if (converted > n) {
     // n_16 rounded towards +inf, so is after n
-    const other = nextAfterF16(n_16, false, false).value as number;
+    const other = nextAfterF16(n_16, false, 'no-flush').value as number;
     return [other, converted];
   } else {
     // n_16 rounded towards -inf, so is before n
-    const other = nextAfterF16(n_16, true, false).value as number;
+    const other = nextAfterF16(n_16, true, 'no-flush').value as number;
     return [converted, other];
   }
 }

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -271,16 +271,17 @@ export function nextAfterF16(val: number, dir: boolean = true, flush: boolean): 
 }
 
 /**
- * @returns ulp(x) for a specific flushing mode
+ * @returns ulp(x), the unit of least precision for a specific number as a 32-bit float
  *
- * This is the main implementation of oneULP, which is normally what should be
- * used. This should only be called directly if a specific flushing mode is
- * required.
+ * ulp(x) is the distance between the two floating point numbers nearest x.
+ * This value is also called unit of last place, ULP, and 1 ULP.
+ * See the WGSL spec and http://www.ens-lyon.fr/LIP/Pub/Rapports/RR/RR2005/RR2005-09.pdf
+ * for a more detailed/nuanced discussion of the definition of ulp(x).
  *
  * @param target number to calculate ULP for
- * @param flush should subnormals be flushed to zero
+ * @param flush should subnormals be flushed during calculation
  */
-function oneULPImpl(target: number, flush: boolean): number {
+export function oneULP(target: number, flush: boolean = true): number {
   if (Number.isNaN(target)) {
     return Number.NaN;
   }
@@ -309,51 +310,6 @@ function oneULPImpl(target: number, flush: boolean): number {
     // |target| is not f32 representable so taking distance of neighbouring f32s.
     return after - before;
   }
-}
-
-/**
- * @returns ulp(x), the unit of least precision for a specific number as a 32-bit float
- *
- * ulp(x) is the distance between the two floating point numbers nearest x.
- * This value is also called unit of last place, ULP, and 1 ULP.
- * See the WGSL spec and http://www.ens-lyon.fr/LIP/Pub/Rapports/RR/RR2005/RR2005-09.pdf
- * for a more detailed/nuanced discussion of the definition of ulp(x).
- *
- * @param target number to calculate ULP for
- * @param flush should subnormals be flushed to zero, if not set both flushed
- *              and non-flush values are considered.
- */
-export function oneULP(target: number, flush?: boolean): number {
-  if (flush === undefined) {
-    return Math.max(oneULPImpl(target, false), oneULPImpl(target, true));
-  }
-
-  return oneULPImpl(target, flush);
-}
-
-/**
- * @returns if a number is within N * ulp(x) of a target value
- * @param val number to test
- * @param target expected number
- * @param n acceptance range
- * @param flush should subnormals be flushed to zero
- */
-export function withinULP(val: number, target: number, n: number = 1) {
-  if (Number.isNaN(val) || Number.isNaN(target)) {
-    return false;
-  }
-
-  const ulp = oneULP(target);
-  if (Number.isNaN(ulp)) {
-    return false;
-  }
-
-  if (val === target) {
-    return true;
-  }
-
-  const diff = val > target ? val - target : target - val;
-  return diff <= n * ulp;
 }
 
 /**


### PR DESCRIPTION
Due to multiple layers of control FTZ behaviour was not controlled at the top-level during some unittests, so FTZ was always assumed, which lead to tests with subtle ordering errors to be passing.

This patch simplifies the calling stack for ULP calculations, and allows tests to plumb through control of flushing behaviour as needed. The incorrect test is corrected.

Fixes #1971

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
