### PR TITLE
Optimize shader expression by caching the cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 *.tmp.txt
 /docs/tsdoc/
 
+# Cache files
+/standalone/data
+
 # Created by https://www.gitignore.io/api/linux,macos,windows,node
 # Edit at https://www.gitignore.io/?templates=linux,macos,windows,node
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,10 @@ module.exports = function (grunt) {
         cmd: 'node',
         args: ['tools/gen_wpt_cts_html', 'out-wpt/cts.https.html', 'src/common/templates/cts.https.html'],
       },
+      'generate-cache': {
+        cmd: 'node',
+        args: ['tools/gen_cache', 'out/data', 'src/webgpu'],
+      },
       unittest: {
         cmd: 'node',
         args: ['tools/run_node', 'unittests:*'],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "fix": "grunt fix",
     "unittest": "grunt unittest",
     "gen_wpt_cts_html": "node tools/gen_wpt_cts_html",
+    "gen_cache": "node tools/gen_cache",
     "tsdoc": "grunt run:tsdoc",
     "start": "node tools/dev_server",
     "dev": "node tools/dev_server"

--- a/src/common/framework/data_cache.ts
+++ b/src/common/framework/data_cache.ts
@@ -1,0 +1,120 @@
+/**
+ * Utilities to improve the performance of the CTS, by caching data that is
+ * expensive to build using a two-level cache (in-memory, pre-computed file).
+ */
+
+interface DataStore {
+  load(path: string): Promise<string>;
+}
+
+/** Logger is a basic debug logger function */
+export type Logger = (s: string) => void;
+
+/** DataCache is an interface to a data store used to hold cached data */
+export class DataCache {
+  /** setDataStore() sets the backing data store used by the data cache */
+  public setStore(dataStore: DataStore) {
+    this.dataStore = dataStore;
+  }
+
+  /** setDebugLogger() sets the verbose logger */
+  public setDebugLogger(logger: Logger) {
+    this.debugLogger = logger;
+  }
+
+  /**
+   * fetch() retrieves cacheable data from the data cache, first checking the
+   * in-memory cache, then the data store (if specified), then resorting to
+   * building the data and storing it in the cache.
+   */
+  public async fetch<Data>(cacheable: Cacheable<Data>): Promise<Data> {
+    // First check the in-memory cache
+    let data = this.cache.get(cacheable.path);
+    if (data !== undefined) {
+      this.log('in-memory cache hit');
+      return Promise.resolve(data as Data);
+    }
+    this.log('in-memory cache miss');
+    // In in-memory cache miss.
+    // Next, try the data store.
+    if (this.dataStore !== null && !this.unavailableFiles.has(cacheable.path)) {
+      let serialized: string | undefined;
+      try {
+        serialized = await this.dataStore.load(cacheable.path);
+        this.log('loaded serialized');
+      } catch (err) {
+        // not found in data store
+        this.log(`failed to load (${cacheable.path}): ${err}`);
+        this.unavailableFiles.add(cacheable.path);
+      }
+      if (serialized !== undefined) {
+        this.log(`deserializing`);
+        data = cacheable.deserialize(serialized);
+        this.cache.set(cacheable.path, data);
+        return data as Data;
+      }
+    }
+    // Not found anywhere. Build the data, and cache for future lookup.
+    this.log(`cache: building (${cacheable.path})`);
+    data = await cacheable.build();
+    this.cache.set(cacheable.path, data);
+    return data as Data;
+  }
+
+  private log(msg: string) {
+    if (this.debugLogger !== null) {
+      this.debugLogger(`DataCache: ${msg}`);
+    }
+  }
+
+  private cache = new Map<string, unknown>();
+  private unavailableFiles = new Set<string>();
+  private dataStore: DataStore | null = null;
+  private debugLogger: Logger | null = null;
+}
+
+/** The data cache */
+export const dataCache = new DataCache();
+
+/** true if the current process is building the cache */
+let isBuildingDataCache = false;
+
+/** @returns true if the data cache is currently being built */
+export function getIsBuildingDataCache() {
+  return isBuildingDataCache;
+}
+
+/** Sets whether the data cache is currently being built */
+export function setIsBuildingDataCache(value = true) {
+  isBuildingDataCache = value;
+}
+
+/**
+ * Cacheable is the interface to something that can be stored into the
+ * DataCache.
+ * The 'npm run gen_cache' tool will look for module-scope variables of this
+ * interface, with the name `d`.
+ */
+export interface Cacheable<Data> {
+  /** the globally unique path for the cacheable data */
+  readonly path: string;
+
+  /**
+   * build() builds the cacheable data.
+   * This is assumed to be an expensive operation and will only happen if the
+   * cache does not already contain the built data.
+   */
+  build(): Promise<Data>;
+
+  /**
+   * serialize() transforms `data` to a string (usually JSON encoded) so that it
+   * can be stored in a text cache file.
+   */
+  serialize(data: Data): string;
+
+  /**
+   * deserialize() is the inverse of serialize(), transforming the string back
+   * to the Data object.
+   */
+  deserialize(serialized: string): Data;
+}

--- a/src/common/runtime/server.ts
+++ b/src/common/runtime/server.ts
@@ -1,8 +1,10 @@
 /* eslint no-console: "off" */
 
+import * as fs from 'fs';
 import * as http from 'http';
 import { AddressInfo } from 'net';
 
+import { dataCache } from '../framework/data_cache.js';
 import { DefaultTestFileLoader } from '../internal/file_loader.js';
 import { prettyPrintLog } from '../internal/logging/log_message.js';
 import { Logger } from '../internal/logging/logger.js';
@@ -20,6 +22,7 @@ function usage(rc: number): never {
   console.log(`  tools/run_${sys.type} [OPTIONS...]`);
   console.log('Options:');
   console.log('  --colors             Enable ANSI colors in output.');
+  console.log('  --data               Path to the data cache directory.');
   console.log('  --verbose            Print result/log of every test as it runs.');
   console.log('  --gpu-provider       Path to node module that provides the GPU implementation.');
   console.log('  --gpu-provider-flag  Flag to set on the gpu-provider as <flag>=<value>');
@@ -48,8 +51,9 @@ if (!sys.existsSync('src/common/runtime/cmdline.ts')) {
 
 Colors.enabled = false;
 
-let debug = false;
+let verbose = false;
 let gpuProviderModule: GPUProviderModule | undefined = undefined;
+let dataPath: string | undefined = undefined;
 
 const gpuProviderFlags: string[] = [];
 for (let i = 0; i < sys.args.length; ++i) {
@@ -57,6 +61,8 @@ for (let i = 0; i < sys.args.length; ++i) {
   if (a.startsWith('-')) {
     if (a === '--colors') {
       Colors.enabled = true;
+    } else if (a === '--data') {
+      dataPath = sys.args[++i];
     } else if (a === '--gpu-provider') {
       const modulePath = sys.args[++i];
       gpuProviderModule = require(modulePath);
@@ -65,7 +71,9 @@ for (let i = 0; i < sys.args.length; ++i) {
     } else if (a === '--help') {
       usage(1);
     } else if (a === '--verbose') {
-      debug = true;
+      verbose = true;
+    } else {
+      console.log(`unrecognised flag: ${a}`);
     }
   }
 }
@@ -74,8 +82,27 @@ if (gpuProviderModule) {
   setGPUProvider(() => gpuProviderModule!.create(gpuProviderFlags));
 }
 
+if (dataPath !== undefined) {
+  dataCache.setStore({
+    load: (path: string) => {
+      return new Promise<string>((resolve, reject) => {
+        fs.readFile(`${dataPath}/${path}`, 'utf8', (err, data) => {
+          if (err !== null) {
+            reject(err.message);
+          } else {
+            resolve(data);
+          }
+        });
+      });
+    },
+  });
+}
+if (verbose) {
+  dataCache.setDebugLogger(console.log);
+}
+
 (async () => {
-  Logger.globalDebugMode = debug;
+  Logger.globalDebugMode = verbose;
   const log = new Logger();
   const testcases = allWebGPUTestcases();
 

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -1,5 +1,6 @@
 // Implements the standalone test runner (see also: /standalone/index.html).
 
+import { dataCache } from '../framework/data_cache.js';
 import { setBaseResourcePath } from '../framework/resources.js';
 import { DefaultTestFileLoader } from '../internal/file_loader.js';
 import { Logger } from '../internal/logging/logger.js';
@@ -31,6 +32,16 @@ const worker = optionEnabled('worker') ? new TestWorker(debug) : undefined;
 
 const autoCloseOnPass = document.getElementById('autoCloseOnPass') as HTMLInputElement;
 const resultsVis = document.getElementById('resultsVis')!;
+
+dataCache.setStore({
+  load: async (path: string) => {
+    const response = await fetch(`data/${path}`);
+    if (!response.ok) {
+      return Promise.reject(response.statusText);
+    }
+    return await response.text();
+  },
+});
 
 interface SubtreeResult {
   pass: number;

--- a/src/common/tools/gen_cache.ts
+++ b/src/common/tools/gen_cache.ts
@@ -1,0 +1,120 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as process from 'process';
+
+import { Cacheable, dataCache, setIsBuildingDataCache } from '../framework/data_cache.js';
+
+function usage(rc: number): void {
+  console.error(`Usage: tools/gen_cache [options] [OUT_DIR] [SUITE_DIRS...]
+
+For each suite in SUITE_DIRS, pre-compute data that is expensive to generate
+at runtime and store it under OUT_DIR. If the data file is found then the
+DataCache will load this instead of building the expensive data at CTS runtime.
+
+Options:
+  --help          Print this message and exit.
+`);
+  process.exit(rc);
+}
+
+const argv = process.argv;
+if (argv.indexOf('--help') !== -1) {
+  usage(0);
+}
+
+if (argv.length < 4) {
+  usage(0);
+}
+
+const outRootDir = argv[2];
+
+dataCache.setStore({
+  load: (path: string) => {
+    return new Promise<string>((resolve, reject) => {
+      fs.readFile(`data/${path}`, 'utf8', (err, data) => {
+        if (err !== null) {
+          reject(err.message);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+  },
+});
+setIsBuildingDataCache();
+
+void (async () => {
+  for (const suiteDir of argv.slice(3)) {
+    await build(suiteDir);
+  }
+})();
+
+const specFileSuffix = __filename.endsWith('.ts') ? '.spec.ts' : '.spec.js';
+
+async function crawlFilesRecursively(dir: string): Promise<string[]> {
+  const subpathInfo = await Promise.all(
+    (await fs.promises.readdir(dir)).map(async d => {
+      const p = path.join(dir, d);
+      const stats = await fs.promises.stat(p);
+      return {
+        path: p,
+        isDirectory: stats.isDirectory(),
+        isFile: stats.isFile(),
+      };
+    })
+  );
+
+  const files = subpathInfo
+    .filter(i => i.isFile && i.path.endsWith(specFileSuffix))
+    .map(i => i.path);
+
+  return files.concat(
+    await subpathInfo
+      .filter(i => i.isDirectory)
+      .map(i => crawlFilesRecursively(i.path))
+      .reduce(async (a, b) => (await a).concat(await b), Promise.resolve([]))
+  );
+}
+
+async function build(suiteDir: string) {
+  if (!fs.existsSync(suiteDir)) {
+    console.error(`Could not find ${suiteDir}`);
+    process.exit(1);
+  }
+
+  // Crawl files and convert paths to be POSIX-style, relative to suiteDir.
+  const filesToEnumerate = (await crawlFilesRecursively(suiteDir)).sort();
+
+  const cacheablePathToTS = new Map<string, string>();
+
+  for (const file of filesToEnumerate) {
+    if (file.endsWith(specFileSuffix)) {
+      const pathWithoutExtension = file.substring(0, file.length - specFileSuffix.length);
+      const mod = await import(`../../../${pathWithoutExtension}.spec.js`);
+      if (mod.d?.serialize !== undefined) {
+        const cacheable = mod.d as Cacheable<unknown>;
+
+        {
+          // Check for collisions
+          const existing = cacheablePathToTS.get(cacheable.path);
+          if (existing !== undefined) {
+            console.error(
+              `error: Cacheable '${cacheable.path}' is emitted by both:
+    '${existing}'
+and
+    '${file}'`
+            );
+            process.exit(1);
+          }
+          cacheablePathToTS.set(cacheable.path, file);
+        }
+
+        const data = await cacheable.build();
+        const serialized = cacheable.serialize(data);
+        const outPath = `${outRootDir}/data/${cacheable.path}`;
+        fs.mkdirSync(path.dirname(outPath), { recursive: true });
+        fs.writeFileSync(outPath, serialized);
+      }
+    }
+  }
+}

--- a/src/unittests/serialization.spec.ts
+++ b/src/unittests/serialization.spec.ts
@@ -1,0 +1,228 @@
+export const description = `Unit tests for data cache serialization`;
+
+import { getIsBuildingDataCache, setIsBuildingDataCache } from '../common/framework/data_cache.js';
+import { makeTestGroup } from '../common/internal/test_group.js';
+import { objectEquals } from '../common/util/util.js';
+import {
+  deserializeExpectation,
+  serializeExpectation,
+} from '../webgpu/shader/execution/expression/case_cache.js';
+import { anyOf, deserializeComparator, SerializedComparator } from '../webgpu/util/compare.js';
+import { kValue } from '../webgpu/util/constants.js';
+import {
+  bool,
+  deserializeValue,
+  f16,
+  f32,
+  i16,
+  i32,
+  i8,
+  serializeValue,
+  u16,
+  u32,
+  u8,
+  vec2,
+  vec3,
+  vec4,
+} from '../webgpu/util/conversion.js';
+import {
+  deserializeF32Interval,
+  F32Interval,
+  serializeF32Interval,
+} from '../webgpu/util/f32_interval.js';
+
+import { UnitTest } from './unit_test.js';
+
+export const g = makeTestGroup(UnitTest);
+
+g.test('value').fn(t => {
+  for (const value of [
+    u32(kValue.u32.min + 0),
+    u32(kValue.u32.min + 1),
+    u32(kValue.u32.min + 2),
+    u32(kValue.u32.max - 2),
+    u32(kValue.u32.max - 1),
+    u32(kValue.u32.max - 0),
+
+    u16(kValue.u16.min + 0),
+    u16(kValue.u16.min + 1),
+    u16(kValue.u16.min + 2),
+    u16(kValue.u16.max - 2),
+    u16(kValue.u16.max - 1),
+    u16(kValue.u16.max - 0),
+
+    u8(kValue.u8.min + 0),
+    u8(kValue.u8.min + 1),
+    u8(kValue.u8.min + 2),
+    u8(kValue.u8.max - 2),
+    u8(kValue.u8.max - 1),
+    u8(kValue.u8.max - 0),
+
+    i32(kValue.i32.negative.min + 0),
+    i32(kValue.i32.negative.min + 1),
+    i32(kValue.i32.negative.min + 2),
+    i32(kValue.i32.negative.max - 2),
+    i32(kValue.i32.negative.max - 1),
+    i32(kValue.i32.positive.min - 0),
+    i32(kValue.i32.positive.min + 1),
+    i32(kValue.i32.positive.min + 2),
+    i32(kValue.i32.positive.max - 2),
+    i32(kValue.i32.positive.max - 1),
+    i32(kValue.i32.positive.max - 0),
+
+    i16(kValue.i16.negative.min + 0),
+    i16(kValue.i16.negative.min + 1),
+    i16(kValue.i16.negative.min + 2),
+    i16(kValue.i16.negative.max - 2),
+    i16(kValue.i16.negative.max - 1),
+    i16(kValue.i16.positive.min + 0),
+    i16(kValue.i16.positive.min + 1),
+    i16(kValue.i16.positive.min + 2),
+    i16(kValue.i16.positive.max - 2),
+    i16(kValue.i16.positive.max - 1),
+    i16(kValue.i16.positive.max - 0),
+
+    i8(kValue.i8.negative.min + 0),
+    i8(kValue.i8.negative.min + 1),
+    i8(kValue.i8.negative.min + 2),
+    i8(kValue.i8.negative.max - 2),
+    i8(kValue.i8.negative.max - 1),
+    i8(kValue.i8.positive.min + 0),
+    i8(kValue.i8.positive.min + 1),
+    i8(kValue.i8.positive.min + 2),
+    i8(kValue.i8.positive.max - 2),
+    i8(kValue.i8.positive.max - 1),
+    i8(kValue.i8.positive.max - 0),
+
+    f32(0),
+    f32(-0),
+    f32(1),
+    f32(-1),
+    f32(0.5),
+    f32(-0.5),
+    f32(kValue.f32.positive.max),
+    f32(kValue.f32.positive.min),
+    f32(kValue.f32.subnormal.positive.max),
+    f32(kValue.f32.subnormal.positive.min),
+    f32(kValue.f32.subnormal.negative.max),
+    f32(kValue.f32.subnormal.negative.min),
+    f32(kValue.f32.infinity.positive),
+    f32(kValue.f32.infinity.negative),
+
+    f16(0),
+    f16(-0),
+    f16(1),
+    f16(-1),
+    f16(0.5),
+    f16(-0.5),
+    f16(kValue.f32.positive.max),
+    f16(kValue.f32.positive.min),
+    f16(kValue.f32.subnormal.positive.max),
+    f16(kValue.f32.subnormal.positive.min),
+    f16(kValue.f32.subnormal.negative.max),
+    f16(kValue.f32.subnormal.negative.min),
+    f16(kValue.f32.infinity.positive),
+    f16(kValue.f32.infinity.negative),
+
+    bool(true),
+    bool(false),
+
+    vec2(f32(1), f32(2)),
+    vec3(u32(1), u32(2), u32(3)),
+    vec4(bool(false), bool(true), bool(false), bool(true)),
+  ]) {
+    const serialized = serializeValue(value);
+    const deserialized = deserializeValue(serialized);
+    t.expect(
+      objectEquals(value, deserialized),
+      `value ${value} -> serialize -> deserialize -> ${deserialized}`
+    );
+  }
+});
+
+g.test('f32_interval').fn(t => {
+  for (const interval of [
+    new F32Interval(0),
+    new F32Interval(-0),
+    new F32Interval(1),
+    new F32Interval(-1),
+    new F32Interval(0.5),
+    new F32Interval(-0.5),
+    new F32Interval(kValue.f32.positive.max),
+    new F32Interval(kValue.f32.positive.min),
+    new F32Interval(kValue.f32.subnormal.positive.max),
+    new F32Interval(kValue.f32.subnormal.positive.min),
+    new F32Interval(kValue.f32.subnormal.negative.max),
+    new F32Interval(kValue.f32.subnormal.negative.min),
+    new F32Interval(kValue.f32.infinity.positive),
+    new F32Interval(kValue.f32.infinity.negative),
+
+    new F32Interval(-0, 0),
+    new F32Interval(-1, 1),
+    new F32Interval(-0.5, 0.5),
+    new F32Interval(kValue.f32.positive.min, kValue.f32.positive.max),
+    new F32Interval(kValue.f32.subnormal.positive.min, kValue.f32.subnormal.positive.max),
+    new F32Interval(kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max),
+    new F32Interval(kValue.f32.infinity.negative, kValue.f32.infinity.positive),
+  ]) {
+    const serialized = serializeF32Interval(interval);
+    const deserialized = deserializeF32Interval(serialized);
+    t.expect(
+      objectEquals(interval, deserialized),
+      `interval ${interval} -> serialize -> deserialize -> ${deserialized}`
+    );
+  }
+});
+
+g.test('expression_expectation').fn(t => {
+  for (const expectation of [
+    // Value
+    f32(123),
+    vec2(f32(1), f32(2)),
+    // Interval
+    new F32Interval(-0.5, 0.5),
+    new F32Interval(kValue.f32.positive.min, kValue.f32.positive.max),
+    // Intervals
+    [new F32Interval(-8.0, 0.5), new F32Interval(2.0, 4.0)],
+  ]) {
+    const serialized = serializeExpectation(expectation);
+    const deserialized = deserializeExpectation(serialized);
+    t.expect(
+      objectEquals(expectation, deserialized),
+      `expectation ${expectation} -> serialize -> deserialize -> ${deserialized}`
+    );
+  }
+});
+
+/**
+ * Temporarily enabled building of the data cache.
+ * Required for Comparators to serialize.
+ */
+function enableBuildingDataCache(f: () => void) {
+  const wasBuildingDataCache = getIsBuildingDataCache();
+  setIsBuildingDataCache(true);
+  f();
+  setIsBuildingDataCache(wasBuildingDataCache);
+}
+
+g.test('anyOf').fn(t => {
+  enableBuildingDataCache(() => {
+    for (const c of [
+      {
+        comparator: anyOf(i32(123)),
+        testCases: [f32(0), f32(10), f32(122), f32(123), f32(124), f32(200)],
+      },
+    ]) {
+      const serialized = c.comparator as SerializedComparator;
+      const deserialized = deserializeComparator(serialized);
+      for (const val of c.testCases) {
+        const got = deserialized(val);
+        const expect = c.comparator(val);
+        t.expect(
+          got.matched === expect.matched,
+          `comparator(${val}): got: ${expect.matched}, expect: ${got.matched}`
+        );
+      }
+    }
+  });
+});

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -13,11 +13,60 @@ import {
   subtractionInterval,
 } from '../../../../util/f32_interval.js';
 import { kVectorTestValues } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('binary/f32_arithmetic', {
+  addition: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+  subtraction: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+  multiplication: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+  division: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+  remainder: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+});
 
 g.test('addition')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
@@ -31,14 +80,7 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1]);
-    });
-
+    const cases = await d.get('addition');
     await run(t, binary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -54,14 +96,7 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1]);
-    });
-
+    const cases = await d.get('subtraction');
     await run(t, binary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -77,14 +112,7 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1]);
-    });
-
+    const cases = await d.get('multiplication');
     await run(t, binary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -100,14 +128,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1]);
-    });
-
+    const cases = await d.get('division');
     await run(t, binary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -123,13 +144,6 @@ Accuracy: Derived from x - y * trunc(x/y)
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1]);
-    });
-
+    const cases = await d.get('remainder');
     await run(t, binary('%'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
@@ -7,6 +7,7 @@ import { GPUTest } from '../../../../gpu_test.js';
 import { anyOf } from '../../../../util/compare.js';
 import { bool, f32, Scalar, TypeBool, TypeF32 } from '../../../../util/conversion.js';
 import { flushSubnormalScalarF32, kVectorTestValues } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, Case, run } from '../expression.js';
 
 import { binary } from './binary.js';
@@ -39,6 +40,63 @@ function makeCase(
   return { input: [f32_lhs, f32_rhs], expected: anyOf(...expected) };
 }
 
+export const d = makeCaseCache('binary/f32_logical', {
+  equals: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) === (rhs.value as number);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  not_equals: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) !== (rhs.value as number);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  less_than: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) < (rhs.value as number);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  less_equals: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) <= (rhs.value as number);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  greater_than: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) > (rhs.value as number);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  greater_equals: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) >= (rhs.value as number);
+    };
+
+    return kVectorTestValues[2].map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+});
+
 g.test('equals')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
   .desc(
@@ -51,14 +109,7 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
-      return (lhs.value as number) === (rhs.value as number);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1], truthFunc);
-    });
-
+    const cases = await d.get('equals');
     await run(t, binary('=='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -74,14 +125,7 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
-      return (lhs.value as number) !== (rhs.value as number);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1], truthFunc);
-    });
-
+    const cases = await d.get('not_equals');
     await run(t, binary('!='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -97,14 +141,7 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
-      return (lhs.value as number) < (rhs.value as number);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1], truthFunc);
-    });
-
+    const cases = await d.get('less_than');
     await run(t, binary('<'), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -120,14 +157,7 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
-      return (lhs.value as number) <= (rhs.value as number);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1], truthFunc);
-    });
-
+    const cases = await d.get('less_equals');
     await run(t, binary('<='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -143,14 +173,7 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
-      return (lhs.value as number) > (rhs.value as number);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1], truthFunc);
-    });
-
+    const cases = await d.get('greater_than');
     await run(t, binary('>'), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -166,13 +189,6 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
-      return (lhs.value as number) >= (rhs.value as number);
-    };
-
-    const cases = kVectorTestValues[2].map(v => {
-      return makeCase(v[0], v[1], truthFunc);
-    });
-
+    const cases = await d.get('greater_equals');
     await run(t, binary('>='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -12,11 +12,35 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { acosInterval } from '../../../../../util/f32_interval.js';
 import { sourceFilteredF32Range, linearRange } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('acos', {
+  f32_const: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, acosInterval);
+    };
+
+    return [
+      ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
+      ...sourceFilteredF32Range('const', -1, 1),
+    ].map(makeCase);
+  },
+  f32_non_const: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, acosInterval);
+    };
+
+    return [
+      ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
+      ...sourceFilteredF32Range('storage', -1, 1),
+    ].map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,14 +57,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, acosInterval);
-    };
-
-    const cases = [
-      ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
-      ...sourceFilteredF32Range(t.params.inputSource, -1, 1),
-    ].map(makeCase);
+    const cases = await d.get(t.params.inputSource === 'const' ? 'f32_const' : 'f32_non_const');
     await run(t, builtin('acos'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -16,11 +16,25 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { acoshIntervals } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('acosh', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, ...acoshIntervals);
+    };
+
+    return [
+      ...biasedRange(1, 2, 100), // x near 1 can be problematic to implement
+      ...fullF32Range(),
+    ].map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -37,14 +51,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, ...acoshIntervals);
-    };
-
-    const cases = [
-      ...biasedRange(1, 2, 100), // x near 1 can be problematic to implement
-      ...fullF32Range(),
-    ].map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('acosh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
@@ -15,11 +15,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { asinhInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('asinh', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, asinhInterval);
+    };
+
+    return [...fullF32Range()].map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -36,11 +47,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, asinhInterval);
-    };
-
-    const cases = [...fullF32Range()].map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('asinh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -13,11 +13,35 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { atanInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('atan', {
+  f32: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, atanInterval);
+    };
+
+    return [
+      // Known values
+      Number.NEGATIVE_INFINITY,
+      -Math.sqrt(3),
+      -1,
+      -1 / Math.sqrt(3),
+      0,
+      1,
+      1 / Math.sqrt(3),
+      Math.sqrt(3),
+      Number.POSITIVE_INFINITY,
+
+      ...fullF32Range(),
+    ].map(x => makeCase(x));
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -40,24 +64,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, atanInterval);
-    };
-    const cases: Array<Case> = [
-      // Known values
-      Number.NEGATIVE_INFINITY,
-      -Math.sqrt(3),
-      -1,
-      -1 / Math.sqrt(3),
-      0,
-      1,
-      1 / Math.sqrt(3),
-      Math.sqrt(3),
-      Number.POSITIVE_INFINITY,
-
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
-
+    const cases = await d.get('f32');
     await run(t, builtin('atan'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -13,11 +13,36 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { ceilInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('ceil', {
+  f32: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, ceilInterval);
+    };
+
+    return [
+      // Small positive numbers
+      0.1,
+      0.9,
+      1.0,
+      1.1,
+      1.9,
+      // Small negative numbers
+      -0.1,
+      -0.9,
+      -1.0,
+      -1.1,
+      -1.9,
+      ...fullF32Range(),
+    ].map(x => makeCase(x));
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -34,26 +59,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, ceilInterval);
-    };
-
-    const cases: Array<Case> = [
-      // Small positive numbers
-      0.1,
-      0.9,
-      1.0,
-      1.1,
-      1.9,
-      // Small negative numbers
-      -0.1,
-      -0.9,
-      -1.0,
-      -1.1,
-      -1.9,
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
-
+    const cases = await d.get('f32');
     await run(t, builtin('ceil'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -28,11 +28,63 @@ import {
 } from '../../../../../util/conversion.js';
 import { clampIntervals } from '../../../../../util/f32_interval.js';
 import { sparseF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeTernaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('clamp', {
+  u32: () => {
+    // This array must be strictly increasing, since that ordering determines
+    // the expected values.
+    const test_values: Array<Scalar> = [
+      u32Bits(kBit.u32.min),
+      u32(1),
+      u32(2),
+      u32(0x70000000),
+      u32(0x80000000),
+      u32Bits(kBit.u32.max),
+    ];
+
+    return generateIntegerTestCases(test_values);
+  },
+  i32: () => {
+    // This array must be strictly increasing, since that ordering determines
+    // the expected values.
+    const test_values: Array<Scalar> = [
+      i32Bits(kBit.i32.negative.min),
+      i32(-2),
+      i32(-1),
+      i32(0),
+      i32(1),
+      i32(2),
+      i32Bits(0x70000000),
+      i32Bits(kBit.i32.positive.max),
+    ];
+
+    return generateIntegerTestCases(test_values);
+  },
+  f32: () => {
+    const makeCase = (x: number, y: number, z: number): Case => {
+      return makeTernaryToF32IntervalCase(x, y, z, ...clampIntervals);
+    };
+
+    // Using sparseF32Range since this will generate N^3 test cases
+    const values = sparseF32Range();
+    const cases: Array<Case> = [];
+    values.forEach(x => {
+      values.forEach(y => {
+        values.forEach(z => {
+          cases.push(makeCase(x, y, z));
+        });
+      });
+    });
+
+    return cases;
+  },
+});
 
 /**
  * Calculates clamp using the min-max formula.
@@ -77,25 +129,8 @@ g.test('u32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    // This array must be strictly increasing, since that ordering determines
-    // the expected values.
-    const test_values: Array<Scalar> = [
-      u32Bits(kBit.u32.min),
-      u32(1),
-      u32(2),
-      u32(0x70000000),
-      u32(0x80000000),
-      u32Bits(kBit.u32.max),
-    ];
-
-    await run(
-      t,
-      builtin('clamp'),
-      [TypeU32, TypeU32, TypeU32],
-      TypeU32,
-      t.params,
-      generateIntegerTestCases(test_values)
-    );
+    const cases = await d.get('u32');
+    await run(t, builtin('clamp'), [TypeU32, TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('i32')
@@ -105,27 +140,8 @@ g.test('i32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    // This array must be strictly increasing, since that ordering determines
-    // the expected values.
-    const test_values: Array<Scalar> = [
-      i32Bits(kBit.i32.negative.min),
-      i32(-2),
-      i32(-1),
-      i32(0),
-      i32(1),
-      i32(2),
-      i32Bits(0x70000000),
-      i32Bits(kBit.i32.positive.max),
-    ];
-
-    await run(
-      t,
-      builtin('clamp'),
-      [TypeI32, TypeI32, TypeI32],
-      TypeI32,
-      t.params,
-      generateIntegerTestCases(test_values)
-    );
+    const cases = await d.get('i32');
+    await run(t, builtin('clamp'), [TypeI32, TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('abstract_float')
@@ -143,21 +159,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number, y: number, z: number): Case => {
-      return makeTernaryToF32IntervalCase(x, y, z, ...clampIntervals);
-    };
-
-    // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range();
-    const cases: Array<Case> = [];
-    values.forEach(x => {
-      values.forEach(y => {
-        values.forEach(z => {
-          cases.push(makeCase(x, y, z));
-        });
-      });
-    });
-
+    const cases = await d.get('f32');
     await run(t, builtin('clamp'), [TypeF32, TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -13,11 +13,27 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { cosInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('cos', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, cosInterval);
+    };
+
+    return [
+      // Well defined accuracy range
+      ...linearRange(-Math.PI, Math.PI, 1000),
+
+      ...fullF32Range(),
+    ].map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -40,16 +56,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, cosInterval);
-    };
-
-    const cases: Array<Case> = [
-      // Well defined accuracy range
-      ...linearRange(-Math.PI, Math.PI, 1000),
-
-      ...fullF32Range(),
-    ].map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('cos'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -12,11 +12,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { coshInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('cosh', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, coshInterval);
+    };
+
+    return fullF32Range().map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,11 +44,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, coshInterval);
-    };
-
-    const cases = fullF32Range().map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('cosh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -11,6 +11,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { crossInterval } from '../../../../../util/f32_interval.js';
 import { kVectorTestValues } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
   Case,
@@ -21,6 +22,20 @@ import {
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('cross', {
+  f32: () => {
+    const makeCase = (x: number[], y: number[]): Case => {
+      return makeVectorPairToVectorIntervalCase(x, y, crossInterval);
+    };
+
+    return kVectorTestValues[3].flatMap(i => {
+      return kVectorTestValues[3].map(j => {
+        return makeCase(i, j);
+      });
+    });
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,15 +48,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairToVectorIntervalCase(x, y, crossInterval);
-    };
-
-    const cases: Case[] = kVectorTestValues[3].flatMap(i => {
-      return kVectorTestValues[3].map(j => {
-        return makeCase(i, j);
-      });
-    });
+    const cases = await d.get('f32');
 
     await run(
       t,

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -12,11 +12,21 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { degreesInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('degrees', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, degreesInterval);
+    };
+    return fullF32Range().map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,11 +43,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, degreesInterval);
-    };
-
-    const cases: Array<Case> = fullF32Range().map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('degrees'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
@@ -13,6 +13,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { distanceInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, kVectorSparseTestValues } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
   Case,
@@ -24,6 +25,30 @@ import {
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('distance', {
+  f32: () => {
+    const makeCase = (x: number, y: number): Case => {
+      return makeBinaryToF32IntervalCase(x, y, distanceInterval);
+    };
+    return fullF32Range().flatMap(i => fullF32Range().map(j => makeCase(i, j)));
+  },
+  f32_vec2: () => {
+    return kVectorSparseTestValues[2].flatMap(i =>
+      kVectorSparseTestValues[2].map(j => makeCaseVecF32(i, j))
+    );
+  },
+  f32_vec3: () => {
+    return kVectorSparseTestValues[3].flatMap(i =>
+      kVectorSparseTestValues[3].map(j => makeCaseVecF32(i, j))
+    );
+  },
+  f32_vec4: () => {
+    return kVectorSparseTestValues[4].flatMap(i =>
+      kVectorSparseTestValues[4].map(j => makeCaseVecF32(i, j))
+    );
+  },
+});
 
 /** @returns a `distance` Case for a pair of vectors of f32s input */
 const makeCaseVecF32 = (x: number[], y: number[]): Case => {
@@ -43,11 +68,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (x: number, y: number): Case => {
-      return makeBinaryToF32IntervalCase(x, y, distanceInterval);
-    };
-    const cases: Case[] = fullF32Range().flatMap(i => fullF32Range().map(j => makeCase(i, j)));
-
+    const cases = await d.get('f32');
     await run(t, builtin('distance'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -56,10 +77,7 @@ g.test('f32_vec2')
   .desc(`f32 tests using vec2s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[2].flatMap(i =>
-      kVectorSparseTestValues[2].map(j => makeCaseVecF32(i, j))
-    );
-
+    const cases = await d.get('f32_vec2');
     await run(
       t,
       builtin('distance'),
@@ -75,10 +93,7 @@ g.test('f32_vec3')
   .desc(`f32 tests using vec3s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[3].flatMap(i =>
-      kVectorSparseTestValues[3].map(j => makeCaseVecF32(i, j))
-    );
-
+    const cases = await d.get('f32_vec3');
     await run(
       t,
       builtin('distance'),
@@ -94,10 +109,7 @@ g.test('f32_vec4')
   .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[4].flatMap(i =>
-      kVectorSparseTestValues[4].map(j => makeCaseVecF32(i, j))
-    );
-
+    const cases = await d.get('f32_vec4');
     await run(
       t,
       builtin('distance'),

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -12,11 +12,48 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { dotInterval } from '../../../../../util/f32_interval.js';
 import { kVectorTestValues } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeVectorPairToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('dot', {
+  f32_vec2: () => {
+    const makeCase = (x: number[], y: number[]): Case => {
+      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
+    };
+
+    return kVectorTestValues[2].flatMap(i => {
+      return kVectorTestValues[2].map(j => {
+        return makeCase(i, j);
+      });
+    });
+  },
+  f32_vec3: () => {
+    const makeCase = (x: number[], y: number[]): Case => {
+      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
+    };
+
+    return kVectorTestValues[3].flatMap(i => {
+      return kVectorTestValues[3].map(j => {
+        return makeCase(i, j);
+      });
+    });
+  },
+  f32_vec4: () => {
+    const makeCase = (x: number[], y: number[]): Case => {
+      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
+    };
+
+    return kVectorTestValues[4].flatMap(i => {
+      return kVectorTestValues[4].map(j => {
+        return makeCase(i, j);
+      });
+    });
+  },
+});
 
 g.test('abstract_int')
   .specURL('https://www.w3.org/TR/WGSL/#vector-builtin-functions')
@@ -47,16 +84,7 @@ g.test('f32_vec2')
   .desc(`f32 tests using vec2s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
-    };
-
-    const cases: Case[] = kVectorTestValues[2].flatMap(i => {
-      return kVectorTestValues[2].map(j => {
-        return makeCase(i, j);
-      });
-    });
-
+    const cases = await d.get('f32_vec2');
     await run(
       t,
       builtin('dot'),
@@ -72,16 +100,7 @@ g.test('f32_vec3')
   .desc(`f32 tests using vec3s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
-    };
-
-    const cases: Case[] = kVectorTestValues[3].flatMap(i => {
-      return kVectorTestValues[3].map(j => {
-        return makeCase(i, j);
-      });
-    });
-
+    const cases = await d.get('f32_vec3');
     await run(
       t,
       builtin('dot'),
@@ -97,16 +116,7 @@ g.test('f32_vec4')
   .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
-    };
-
-    const cases: Case[] = kVectorTestValues[4].flatMap(i => {
-      return kVectorTestValues[4].map(j => {
-        return makeCase(i, j);
-      });
-    });
-
+    const cases = await d.get('f32_vec4');
     await run(
       t,
       builtin('dot'),

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -13,11 +13,31 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { expInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('exp', {
+  f32: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, expInterval);
+    };
+
+    // floor(ln(max f32 value)) = 88, so exp(88) will be within range of a f32, but exp(89) will not
+    // floor(ln(max f64 value)) = 709, so exp(709) can be handled by the testing framework, but exp(710) will misbehave
+    return [
+      0, // Returns 1 by definition
+      -89, // Returns subnormal value
+      kValue.f32.negative.min, // Closest to returning 0 as possible
+      ...biasedRange(kValue.f32.negative.max, -88, 100),
+      ...biasedRange(kValue.f32.positive.min, 88, 100),
+      ...linearRange(89, 709, 10), // Overflows f32, but not f64
+    ].map(x => makeCase(x));
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -34,21 +54,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, expInterval);
-    };
-
-    // floor(ln(max f32 value)) = 88, so exp(88) will be within range of a f32, but exp(89) will not
-    // floor(ln(max f64 value)) = 709, so exp(709) can be handled by the testing framework, but exp(710) will misbehave
-    const cases: Array<Case> = [
-      0, // Returns 1 by definition
-      -89, // Returns subnormal value
-      kValue.f32.negative.min, // Closest to returning 0 as possible
-      ...biasedRange(kValue.f32.negative.max, -88, 100),
-      ...biasedRange(kValue.f32.positive.min, 88, 100),
-      ...linearRange(89, 709, 10), // Overflows f32, but not f64
-    ].map(x => makeCase(x));
-
+    const cases = await d.get('f32');
     await run(t, builtin('exp'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -13,11 +13,31 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { exp2Interval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('exp2', {
+  f32: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, exp2Interval);
+    };
+
+    // floor(log2(max f32 value)) = 127, so exp2(127) will be within range of a f32, but exp2(128) will not
+    // floor(ln(max f64 value)) = 1023, so exp2(1023) can be handled by the testing framework, but exp2(1024) will misbehave
+    return [
+      0, // Returns 1 by definition
+      -128, // Returns subnormal value
+      kValue.f32.negative.min, // Closest to returning 0 as possible
+      ...biasedRange(kValue.f32.negative.max, -127, 100),
+      ...biasedRange(kValue.f32.positive.min, 127, 100),
+      ...linearRange(128, 1023, 10), // Overflows f32, but not f64
+    ].map(x => makeCase(x));
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -34,21 +54,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, exp2Interval);
-    };
-
-    // floor(log2(max f32 value)) = 127, so exp2(127) will be within range of a f32, but exp2(128) will not
-    // floor(ln(max f64 value)) = 1023, so exp2(1023) can be handled by the testing framework, but exp2(1024) will misbehave
-    const cases: Array<Case> = [
-      0, // Returns 1 by definition
-      -128, // Returns subnormal value
-      kValue.f32.negative.min, // Closest to returning 0 as possible
-      ...biasedRange(kValue.f32.negative.max, -127, 100),
-      ...biasedRange(kValue.f32.positive.min, 127, 100),
-      ...linearRange(128, 1023, 10), // Overflows f32, but not f64
-    ].map(x => makeCase(x));
-
+    const cases = await d.get('f32');
     await run(t, builtin('exp2'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
@@ -12,11 +12,36 @@ import { anyOf } from '../../../../../util/compare.js';
 import { f32, TypeF32, TypeVec, Vector } from '../../../../../util/conversion.js';
 import { faceForwardIntervals } from '../../../../../util/f32_interval.js';
 import { kVectorSparseTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('faceForward', {
+  f32_vec2: () => {
+    return kVectorSparseTestValues[2].flatMap(i =>
+      kVectorSparseTestValues[2].flatMap(j =>
+        kVectorSparseTestValues[2].map(k => makeCase(i, j, k))
+      )
+    );
+  },
+  f32_vec3: () => {
+    return kVectorSparseTestValues[3].flatMap(i =>
+      kVectorSparseTestValues[3].flatMap(j =>
+        kVectorSparseTestValues[3].map(k => makeCase(i, j, k))
+      )
+    );
+  },
+  f32_vec4: () => {
+    return kVectorSparseTestValues[4].flatMap(i =>
+      kVectorSparseTestValues[4].flatMap(j =>
+        kVectorSparseTestValues[4].map(k => makeCase(i, j, k))
+      )
+    );
+  },
+});
 
 /**
  * @returns a `faceForward` Case for a triplet of vectors of f32s input
@@ -53,12 +78,7 @@ g.test('f32_vec2')
   .desc(`f32 tests using vec2s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[2].flatMap(i =>
-      kVectorSparseTestValues[2].flatMap(j =>
-        kVectorSparseTestValues[2].map(k => makeCase(i, j, k))
-      )
-    );
-
+    const cases = await d.get('f32_vec2');
     await run(
       t,
       builtin('faceForward'),
@@ -74,12 +94,7 @@ g.test('f32_vec3')
   .desc(`f32 tests using vec3s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[3].flatMap(i =>
-      kVectorSparseTestValues[3].flatMap(j =>
-        kVectorSparseTestValues[3].map(k => makeCase(i, j, k))
-      )
-    );
-
+    const cases = await d.get('f32_vec3');
     await run(
       t,
       builtin('faceForward'),
@@ -95,12 +110,7 @@ g.test('f32_vec4')
   .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[4].flatMap(i =>
-      kVectorSparseTestValues[4].flatMap(j =>
-        kVectorSparseTestValues[4].map(k => makeCase(i, j, k))
-      )
-    );
-
+    const cases = await d.get('f32_vec4');
     await run(
       t,
       builtin('faceForward'),

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -12,11 +12,36 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { floorInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('floor', {
+  f32: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, floorInterval);
+    };
+
+    return [
+      // Small positive numbers
+      0.1,
+      0.9,
+      1.0,
+      1.1,
+      1.9,
+      // Small negative numbers
+      -0.1,
+      -0.9,
+      -1.0,
+      -1.1,
+      -1.9,
+      ...fullF32Range(),
+    ].map(x => makeCase(x));
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,26 +58,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, floorInterval);
-    };
-
-    const cases: Array<Case> = [
-      // Small positive numbers
-      0.1,
-      0.9,
-      1.0,
-      1.1,
-      1.9,
-      // Small negative numbers
-      -0.1,
-      -0.9,
-      -1.0,
-      -1.1,
-      -1.9,
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
-
+    const cases = await d.get('f32');
     await run(t, builtin('floor'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -13,11 +13,37 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { fractInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('fract', {
+  f32: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, fractInterval);
+    };
+
+    return [
+      0.5, // 0.5 -> 0.5
+      0.9, // ~0.9 -> ~0.9
+      1, // 1 -> 0
+      2, // 2 -> 0
+      1.11, // ~1.11 -> ~0.11
+      10.0001, // ~10.0001 -> ~0.0001
+      -0.1, // ~-0.1 -> ~0.9
+      -0.5, // -0.5 -> 0.5
+      -0.9, // ~-0.9 -> ~0.1
+      -1, // -1 -> 0
+      -2, // -2 -> 0
+      -1.11, // ~-1.11 -> ~0.89
+      -10.0001, // -10.0001 -> ~0.9999
+      ...fullF32Range(),
+    ].map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -34,28 +60,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, fractInterval);
-    };
-
-    const cases: Array<Case> = [
-      0.5, // 0.5 -> 0.5
-      0.9, // ~0.9 -> ~0.9
-      1, // 1 -> 0
-      2, // 2 -> 0
-      1.11, // ~1.11 -> ~0.11
-      10.0001, // ~10.0001 -> ~0.0001
-      -0.1, // ~-0.1 -> ~0.9
-      -0.5, // -0.5 -> 0.5
-      -0.9, // ~-0.9 -> ~0.1
-      -1, // -1 -> 0
-      -2, // -2 -> 0
-      -1.11, // ~-1.11 -> ~0.89
-      -10.0001, // -10.0001 -> ~0.9999
-      ...fullF32Range(),
-    ].map(makeCase);
-
-    // prettier-ignore
+    const cases = await d.get('f32');
     await run(t, builtin('fract'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -13,11 +13,27 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { inverseSqrtInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('inverseSqrt', {
+  f32: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, inverseSqrtInterval);
+    };
+
+    return [
+      // 0 < x <= 1 linearly spread
+      ...linearRange(kValue.f32.positive.min, 1, 100),
+      // 1 <= x < 2^32, biased towards 1
+      ...biasedRange(1, 2 ** 32, 1000),
+    ].map(x => makeCase(x));
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -34,17 +50,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, inverseSqrtInterval);
-    };
-
-    const cases: Array<Case> = [
-      // 0 < x <= 1 linearly spread
-      ...linearRange(kValue.f32.positive.min, 1, 100),
-      // 1 <= x < 2^32, biased towards 1
-      ...biasedRange(1, 2 ** 32, 1000),
-    ].map(x => makeCase(x));
-
+    const cases = await d.get('f32');
     await run(t, builtin('inverseSqrt'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -22,11 +22,33 @@ import {
   quantizeToF32,
   quantizeToI32,
 } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('ldexp', {
+  f32: () => {
+    const makeCase = (e1: number, e2: number): Case => {
+      // Due to the heterogeneous types of the params to ldexp (f32 & i32),
+      // makeBinaryToF32IntervalCase cannot be used here.
+      e1 = quantizeToF32(e1);
+      e2 = quantizeToI32(e2);
+      const expected = ldexpInterval(e1, e2);
+      return { input: [f32(e1), i32(e2)], expected };
+    };
+
+    const cases: Array<Case> = [];
+    fullF32Range().forEach(e1 => {
+      fullI32Range().forEach(e2 => {
+        cases.push(makeCase(e1, e2));
+      });
+    });
+    return cases;
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -46,21 +68,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (e1: number, e2: number): Case => {
-      // Due to the heterogeneous types of the params to ldexp (f32 & i32),
-      // makeBinaryToF32IntervalCase cannot be used here.
-      e1 = quantizeToF32(e1);
-      e2 = quantizeToI32(e2);
-      const expected = ldexpInterval(e1, e2);
-      return { input: [f32(e1), i32(e2)], expected };
-    };
-
-    const cases: Array<Case> = [];
-    fullF32Range().forEach(e1 => {
-      fullI32Range().forEach(e2 => {
-        cases.push(makeCase(e1, e2));
-      });
-    });
+    const cases = await d.get('f32');
     await run(t, builtin('ldexp'), [TypeF32, TypeI32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -12,6 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { lengthInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, kVectorTestValues } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
   Case,
@@ -23,6 +24,24 @@ import {
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('length', {
+  f32: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, lengthInterval);
+    };
+    return fullF32Range().map(makeCase);
+  },
+  f32_vec2: () => {
+    return kVectorTestValues[2].map(makeCaseVecF32);
+  },
+  f32_vec3: () => {
+    return kVectorTestValues[3].map(makeCaseVecF32);
+  },
+  f32_vec4: () => {
+    return kVectorTestValues[4].map(makeCaseVecF32);
+  },
+});
 
 /** @returns a `length` Case for a vector of f32s input */
 const makeCaseVecF32 = (x: number[]): Case => {
@@ -42,11 +61,7 @@ g.test('f32')
   .desc(`f32 tests`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, lengthInterval);
-    };
-    const cases: Case[] = fullF32Range().map(makeCase);
-
+    const cases = await d.get('f32');
     await run(t, builtin('length'), [TypeF32], TypeF32, t.params, cases);
   });
 
@@ -55,8 +70,7 @@ g.test('f32_vec2')
   .desc(`f32 tests using vec2s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[2].map(makeCaseVecF32);
-
+    const cases = await d.get('f32_vec2');
     await run(t, builtin('length'), [TypeVec(2, TypeF32)], TypeF32, t.params, cases);
   });
 
@@ -65,8 +79,7 @@ g.test('f32_vec3')
   .desc(`f32 tests using vec3s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[3].map(makeCaseVecF32);
-
+    const cases = await d.get('f32_vec3');
     await run(t, builtin('length'), [TypeVec(3, TypeF32)], TypeF32, t.params, cases);
   });
 
@@ -75,8 +88,7 @@ g.test('f32_vec4')
   .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[4].map(makeCaseVecF32);
-
+    const cases = await d.get('f32_vec4');
     await run(t, builtin('length'), [TypeVec(4, TypeF32)], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -13,11 +13,29 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { logInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('log', {
+  f32: () => {
+    // [1]: Need to decide what the ground-truth is.
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, logInterval);
+    };
+
+    return [
+      // log's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
+      ...linearRange(kValue.f32.positive.min, 0.5, 20),
+      ...linearRange(0.5, 2.0, 20),
+      ...biasedRange(2.0, 2 ** 32, 1000),
+      ...fullF32Range(),
+    ].map(x => makeCase(x));
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -40,19 +58,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    // [1]: Need to decide what the ground-truth is.
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, logInterval);
-    };
-
-    const cases: Array<Case> = [
-      // log's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
-      ...linearRange(kValue.f32.positive.min, 0.5, 20),
-      ...linearRange(0.5, 2.0, 20),
-      ...biasedRange(2.0, 2 ** 32, 1000),
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
-
+    const cases = await d.get('f32');
     await run(t, builtin('log'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -13,11 +13,29 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { log2Interval } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('log2', {
+  f32: () => {
+    // [1]: Need to decide what the ground-truth is.
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, log2Interval);
+    };
+
+    return [
+      // log2's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
+      ...linearRange(kValue.f32.positive.min, 0.5, 20),
+      ...linearRange(0.5, 2.0, 20),
+      ...biasedRange(2.0, 2 ** 32, 1000),
+      ...fullF32Range(),
+    ].map(x => makeCase(x));
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -40,19 +58,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    // [1]: Need to decide what the ground-truth is.
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, log2Interval);
-    };
-
-    const cases: Array<Case> = [
-      // log2's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
-      ...linearRange(kValue.f32.positive.min, 0.5, 20),
-      ...linearRange(0.5, 2.0, 20),
-      ...biasedRange(2.0, 2 ** 32, 1000),
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
-
+    const cases = await d.get('f32');
     await run(t, builtin('log2'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -21,11 +21,31 @@ import { kValue } from '../../../../../util/constants.js';
 import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
 import { minInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('min', {
+  f32: () => {
+    const makeCase = (x: number, y: number): Case => {
+      return makeBinaryToF32IntervalCase(x, y, minInterval);
+    };
+
+    const cases: Array<Case> = [];
+    const numeric_range = fullF32Range();
+    numeric_range.push(kValue.f32.infinity.positive, kValue.f32.infinity.negative);
+    numeric_range.forEach(lhs => {
+      numeric_range.forEach(rhs => {
+        cases.push(makeCase(lhs, rhs));
+      });
+    });
+
+    return cases;
+  },
+});
 
 /** Generate set of min test cases from list of interesting values */
 function generateTestCases(
@@ -98,19 +118,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number, y: number): Case => {
-      return makeBinaryToF32IntervalCase(x, y, minInterval);
-    };
-
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.push(kValue.f32.infinity.positive, kValue.f32.infinity.negative);
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs));
-      });
-    });
-
+    const cases = await d.get('f32');
     await run(t, builtin('min'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -11,11 +11,24 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { normalizeInterval } from '../../../../../util/f32_interval.js';
 import { kVectorTestValues } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeVectorToVectorIntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('normalize', {
+  f32_vec2: () => {
+    return kVectorTestValues[2].map(makeCaseVecF32);
+  },
+  f32_vec3: () => {
+    return kVectorTestValues[3].map(makeCaseVecF32);
+  },
+  f32_vec4: () => {
+    return kVectorTestValues[4].map(makeCaseVecF32);
+  },
+});
 
 /** @returns a `normalize` Case for a vector of f32s input */
 const makeCaseVecF32 = (x: number[]): Case => {
@@ -35,8 +48,7 @@ g.test('f32_vec2')
   .desc(`f32 tests using vec2s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[2].map(makeCaseVecF32);
-
+    const cases = await d.get('f32_vec2');
     await run(t, builtin('normalize'), [TypeVec(2, TypeF32)], TypeVec(2, TypeF32), t.params, cases);
   });
 
@@ -45,8 +57,7 @@ g.test('f32_vec3')
   .desc(`f32 tests using vec3s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[3].map(makeCaseVecF32);
-
+    const cases = await d.get('f32_vec3');
     await run(t, builtin('normalize'), [TypeVec(3, TypeF32)], TypeVec(3, TypeF32), t.params, cases);
   });
 
@@ -55,8 +66,7 @@ g.test('f32_vec4')
   .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorTestValues[4].map(makeCaseVecF32);
-
+    const cases = await d.get('f32_vec4');
     await run(t, builtin('normalize'), [TypeVec(4, TypeF32)], TypeVec(4, TypeF32), t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -12,11 +12,30 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { powInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('pow', {
+  f32: () => {
+    const makeCase = (x: number, y: number): Case => {
+      return makeBinaryToF32IntervalCase(x, y, powInterval);
+    };
+
+    const cases: Array<Case> = [];
+    const numeric_range = fullF32Range();
+    numeric_range.forEach(x => {
+      numeric_range.forEach(y => {
+        cases.push(makeCase(x, y));
+      });
+    });
+
+    return cases;
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,18 +52,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number, y: number): Case => {
-      return makeBinaryToF32IntervalCase(x, y, powInterval);
-    };
-
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(x => {
-      numeric_range.forEach(y => {
-        cases.push(makeCase(x, y));
-      });
-    });
-
+    const cases = await d.get('f32');
     await run(t, builtin('pow'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -14,19 +14,15 @@ import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { quantizeToF16Interval } from '../../../../../util/f32_interval.js';
 import { fullF16Range, fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('f32')
-  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(`f32 tests`)
-  .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
-  )
-  .fn(async t => {
+export const d = makeCaseCache('quantizeToF16', {
+  f32_const: () => {
     const makeCase = (x: number): Case => {
       return makeUnaryToF32IntervalCase(x, quantizeToF16Interval);
     };
@@ -42,11 +38,39 @@ g.test('f32')
       kValue.f16.positive.max,
     ].map(makeCase);
 
-    if (t.params.inputSource === 'const') {
-      cases.push(...fullF16Range().map(makeCase));
-    } else {
-      cases.push(...fullF32Range().map(makeCase));
-    }
+    cases.push(...fullF16Range().map(makeCase));
 
+    return cases;
+  },
+  f32_non_const: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, quantizeToF16Interval);
+    };
+
+    const cases = [
+      kValue.f16.negative.min,
+      kValue.f16.negative.max,
+      kValue.f16.subnormal.negative.min,
+      kValue.f16.subnormal.negative.max,
+      kValue.f16.subnormal.positive.min,
+      kValue.f16.subnormal.positive.max,
+      kValue.f16.positive.min,
+      kValue.f16.positive.max,
+    ].map(makeCase);
+
+    cases.push(...fullF32Range().map(makeCase));
+
+    return cases;
+  },
+});
+
+g.test('f32')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(`f32 tests`)
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(t.params.inputSource === 'const' ? 'f32_const' : 'f32_non_const');
     await run(t, builtin('quantizeToF16'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
@@ -13,11 +13,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { radiansInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('radians', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, radiansInterval);
+    };
+
+    return fullF32Range().map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -34,11 +45,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, radiansInterval);
-    };
-
-    const cases: Array<Case> = fullF32Range().map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('radians'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
@@ -12,6 +12,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { reflectInterval } from '../../../../../util/f32_interval.js';
 import { kVectorSparseTestValues } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
   Case,
@@ -22,6 +23,24 @@ import {
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('reflect', {
+  f32_vec2: () => {
+    return kVectorSparseTestValues[2].flatMap(i =>
+      kVectorSparseTestValues[2].map(j => makeCaseVecF32(i, j))
+    );
+  },
+  f32_vec3: () => {
+    return kVectorSparseTestValues[3].flatMap(i =>
+      kVectorSparseTestValues[3].map(j => makeCaseVecF32(i, j))
+    );
+  },
+  f32_vec4: () => {
+    return kVectorSparseTestValues[4].flatMap(i =>
+      kVectorSparseTestValues[4].map(j => makeCaseVecF32(i, j))
+    );
+  },
+});
 
 /** @returns a `reflect` Case for a pair of vectors of f32s input */
 const makeCaseVecF32 = (x: number[], y: number[]): Case => {
@@ -39,10 +58,7 @@ g.test('f32_vec2')
   .desc(`f32 tests using vec2s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[2].flatMap(i =>
-      kVectorSparseTestValues[2].map(j => makeCaseVecF32(i, j))
-    );
-
+    const cases = await d.get('f32_vec2');
     await run(
       t,
       builtin('reflect'),
@@ -58,10 +74,7 @@ g.test('f32_vec3')
   .desc(`f32 tests using vec3s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[3].flatMap(i =>
-      kVectorSparseTestValues[3].map(j => makeCaseVecF32(i, j))
-    );
-
+    const cases = await d.get('f32_vec3');
     await run(
       t,
       builtin('reflect'),
@@ -77,10 +90,7 @@ g.test('f32_vec4')
   .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[4].flatMap(i =>
-      kVectorSparseTestValues[4].map(j => makeCaseVecF32(i, j))
-    );
-
+    const cases = await d.get('f32_vec4');
     await run(
       t,
       builtin('reflect'),

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -15,11 +15,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { roundInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('round', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, roundInterval);
+    };
+
+    return fullF32Range().map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -36,11 +47,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, roundInterval);
-    };
-
-    const cases = fullF32Range().map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('round'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -12,11 +12,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { signInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('sign', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, signInterval);
+    };
+
+    return fullF32Range().map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,11 +44,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, signInterval);
-    };
-
-    const cases = fullF32Range().map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('sign'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -12,11 +12,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { sinhInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('sinh', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, sinhInterval);
+    };
+
+    return fullF32Range().map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,11 +44,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, sinhInterval);
-    };
-
-    const cases = fullF32Range().map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('sinh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -12,11 +12,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { sqrtInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('sqrt', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, sqrtInterval);
+    };
+
+    return fullF32Range().map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,11 +44,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, sqrtInterval);
-    };
-
-    const cases = fullF32Range().map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('sqrt'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -13,27 +13,15 @@ import { anyOf } from '../../../../../util/compare.js';
 import { f32, TypeF32 } from '../../../../../util/conversion.js';
 import { F32Interval, stepInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('abstract_float')
-  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(`abstract float tests`)
-  .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
-  )
-  .unimplemented();
-
-g.test('f32')
-  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
-  .desc(`f32 tests`)
-  .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
-  )
-  .fn(async t => {
+export const d = makeCaseCache('step', {
+  f32: () => {
     const zeroInterval = new F32Interval(0, 0);
     const oneInterval = new F32Interval(1, 1);
 
@@ -65,6 +53,26 @@ g.test('f32')
       });
     });
 
+    return cases;
+  },
+});
+
+g.test('abstract_float')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(`abstract float tests`)
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .unimplemented();
+
+g.test('f32')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(`f32 tests`)
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('f32');
     await run(t, builtin('step'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
@@ -12,11 +12,26 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { tanInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('tan', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, tanInterval);
+    };
+
+    return [
+      // Defined accuracy range
+      ...linearRange(-Math.PI, Math.PI, 100),
+      ...fullF32Range(),
+    ].map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,15 +48,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, tanInterval);
-    };
-
-    const cases: Array<Case> = [
-      // Defined accuracy range
-      ...linearRange(-Math.PI, Math.PI, 100),
-      ...fullF32Range(),
-    ].map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('tan'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
@@ -12,11 +12,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { tanhInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('tanh', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, tanhInterval);
+    };
+
+    return fullF32Range().map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,11 +44,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, tanhInterval);
-    };
-
-    const cases = fullF32Range().map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('tanh'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -13,11 +13,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { truncInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('trunc', {
+  f32: () => {
+    const makeCase = (n: number): Case => {
+      return makeUnaryToF32IntervalCase(n, truncInterval);
+    };
+
+    return fullF32Range().map(makeCase);
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -34,11 +45,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, truncInterval);
-    };
-
-    const cases = fullF32Range().map(makeCase);
+    const cases = await d.get('f32');
     await run(t, builtin('trunc'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
@@ -10,11 +10,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack2x16floatInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unpack2x16float', {
+  u32: () => {
+    const makeCase = (n: number): Case => {
+      return makeU32ToVectorIntervalCase(n, unpack2x16floatInterval);
+    };
+
+    return fullU32Range().map(makeCase);
+  },
+});
 
 g.test('unpack')
   .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
@@ -25,11 +36,6 @@ g.test('unpack')
   )
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack2x16floatInterval);
-    };
-
-    const cases: Array<Case> = fullU32Range().map(makeCase);
-
+    const cases = await d.get('u32');
     await run(t, builtin('unpack2x16float'), [TypeU32], TypeVec(2, TypeF32), t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
@@ -10,11 +10,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack2x16snormInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unpack2x16snorm', {
+  u32: () => {
+    const makeCase = (n: number): Case => {
+      return makeU32ToVectorIntervalCase(n, unpack2x16snormInterval);
+    };
+
+    return fullU32Range().map(makeCase);
+  },
+});
 
 g.test('unpack')
   .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
@@ -25,11 +36,6 @@ g.test('unpack')
   )
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack2x16snormInterval);
-    };
-
-    const cases: Array<Case> = fullU32Range().map(makeCase);
-
+    const cases = await d.get('u32');
     await run(t, builtin('unpack2x16snorm'), [TypeU32], TypeVec(2, TypeF32), t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -10,11 +10,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack2x16unormInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unpack2x16unorm', {
+  u32: () => {
+    const makeCase = (n: number): Case => {
+      return makeU32ToVectorIntervalCase(n, unpack2x16unormInterval);
+    };
+
+    return fullU32Range().map(makeCase);
+  },
+});
 
 g.test('unpack')
   .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
@@ -25,11 +36,6 @@ g.test('unpack')
   )
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack2x16unormInterval);
-    };
-
-    const cases: Array<Case> = fullU32Range().map(makeCase);
-
+    const cases = await d.get('u32');
     await run(t, builtin('unpack2x16unorm'), [TypeU32], TypeVec(2, TypeF32), t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
@@ -10,11 +10,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack4x8snormInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unpack4x8snorm', {
+  u32: () => {
+    const makeCase = (n: number): Case => {
+      return makeU32ToVectorIntervalCase(n, unpack4x8snormInterval);
+    };
+
+    return fullU32Range().map(makeCase);
+  },
+});
 
 g.test('unpack')
   .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
@@ -25,11 +36,6 @@ g.test('unpack')
   )
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack4x8snormInterval);
-    };
-
-    const cases: Array<Case> = fullU32Range().map(makeCase);
-
+    const cases = await d.get('u32');
     await run(t, builtin('unpack4x8snorm'), [TypeU32], TypeVec(4, TypeF32), t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
@@ -10,11 +10,22 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack4x8unormInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unpack4x8unorm', {
+  u32: () => {
+    const makeCase = (n: number): Case => {
+      return makeU32ToVectorIntervalCase(n, unpack4x8unormInterval);
+    };
+
+    return fullU32Range().map(makeCase);
+  },
+});
 
 g.test('unpack')
   .specURL('https://www.w3.org/TR/WGSL/#unpack-builtin-functions')
@@ -25,11 +36,6 @@ g.test('unpack')
   )
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack4x8unormInterval);
-    };
-
-    const cases: Array<Case> = fullU32Range().map(makeCase);
-
+    const cases = await d.get('u32');
     await run(t, builtin('unpack4x8unorm'), [TypeU32], TypeVec(4, TypeF32), t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/case_cache.ts
+++ b/src/webgpu/shader/execution/expression/case_cache.ts
@@ -1,0 +1,202 @@
+import { Cacheable, dataCache } from '../../../../common/framework/data_cache.js';
+import { SerializedComparator, deserializeComparator } from '../../../util/compare.js';
+import {
+  Scalar,
+  Vector,
+  serializeValue,
+  SerializedValue,
+  deserializeValue,
+} from '../../../util/conversion.js';
+import {
+  deserializeF32Interval,
+  F32Interval,
+  SerializedF32Interval,
+  serializeF32Interval,
+} from '../../../util/f32_interval.js';
+
+import { Case, CaseList, Expectation } from './expression.js';
+
+/**
+ * SerializedExpectationValue holds the serialized form of an Expectation when
+ * the Expectation is a Value
+ * This form can be safely encoded to JSON.
+ */
+type SerializedExpectationValue = {
+  kind: 'value';
+  value: SerializedValue;
+};
+
+/**
+ * SerializedExpectationValue holds the serialized form of an Expectation when
+ * the Expectation is an Interval
+ * This form can be safely encoded to JSON.
+ */
+type SerializedExpectationInterval = {
+  kind: 'interval';
+  value: SerializedF32Interval;
+};
+
+/**
+ * SerializedExpectationValue holds the serialized form of an Expectation when
+ * the Expectation is a list of Intervals
+ * This form can be safely encoded to JSON.
+ */
+type SerializedExpectationIntervals = {
+  kind: 'intervals';
+  value: SerializedF32Interval[];
+};
+
+/**
+ * SerializedExpectationValue holds the serialized form of an Expectation when
+ * the Expectation is a Comparator
+ * This form can be safely encoded to JSON.
+ */
+type SerializedExpectationComparator = {
+  kind: 'comparator';
+  value: SerializedComparator;
+};
+
+/**
+ * SerializedExpectation holds the serialized form of an Expectation.
+ * This form can be safely encoded to JSON.
+ */
+export type SerializedExpectation =
+  | SerializedExpectationValue
+  | SerializedExpectationInterval
+  | SerializedExpectationIntervals
+  | SerializedExpectationComparator;
+
+/** serializeExpectation() converts an Expectation to a SerializedExpectation */
+export function serializeExpectation(e: Expectation): SerializedExpectation {
+  if (e instanceof Scalar || e instanceof Vector) {
+    return { kind: 'value', value: serializeValue(e) };
+  }
+  if (e instanceof F32Interval) {
+    return { kind: 'interval', value: serializeF32Interval(e) };
+  }
+  if (e instanceof Array) {
+    return { kind: 'intervals', value: e.map(i => serializeF32Interval(i)) };
+  }
+  if (e instanceof Function) {
+    const comp = (e as unknown) as SerializedComparator;
+    if (comp.kind !== undefined && comp.data !== undefined) {
+      return { kind: 'comparator', value: { kind: comp.kind, data: comp.data } };
+    }
+    throw 'cannot serialize comparator';
+  }
+  throw 'cannot serialize expectation';
+}
+
+/** deserializeExpectation() converts a SerializedExpectation to a Expectation */
+export function deserializeExpectation(data: SerializedExpectation): Expectation {
+  switch (data.kind) {
+    case 'value':
+      return deserializeValue(data.value);
+    case 'interval':
+      return deserializeF32Interval(data.value);
+    case 'intervals':
+      return data.value.map(i => deserializeF32Interval(i));
+    case 'comparator':
+      return deserializeComparator(data.value);
+  }
+}
+
+/**
+ * SerializedCase holds the serialized form of a Case.
+ * This form can be safely encoded to JSON.
+ */
+export type SerializedCase = {
+  input: SerializedValue | SerializedValue[];
+  expected: SerializedExpectation;
+};
+
+/** serializeCase() converts an Case to a SerializedCase */
+export function serializeCase(c: Case): SerializedCase {
+  return {
+    input: c.input instanceof Array ? c.input.map(v => serializeValue(v)) : serializeValue(c.input),
+    expected: serializeExpectation(c.expected),
+  };
+}
+
+/** serializeCase() converts an SerializedCase to a Case */
+export function deserializeCase(data: SerializedCase): Case {
+  return {
+    input:
+      data.input instanceof Array
+        ? data.input.map(v => deserializeValue(v))
+        : deserializeValue(data.input),
+    expected: deserializeExpectation(data.expected),
+  };
+}
+
+/** CaseListBuilder is a function that builds a CaseList */
+export type CaseListBuilder = () => CaseList;
+
+/**
+ * CaseCache is a cache of CaseList.
+ * CaseCache implements the Cacheable interface, so the cases can be pre-built
+ * and stored in the data cache, reducing computation costs at CTS runtime.
+ */
+export class CaseCache implements Cacheable<Record<string, CaseList>> {
+  /**
+   * Constructor
+   * @param name the name of the cache. This must be globally unique.
+   * @param builders a Record of case-list name to case-list builder.
+   */
+  constructor(name: string, builders: Record<string, CaseListBuilder>) {
+    this.path = `webgpu/shader/execution/case-cache/${name}.json`;
+    this.builders = builders;
+  }
+
+  /** get() returns the list of cases with the given name */
+  public async get(name: string): Promise<CaseList> {
+    const data = await dataCache.fetch(this);
+    return data[name];
+  }
+
+  /**
+   * build() implements the Cacheable.build interface.
+   * @returns the data.
+   */
+  build(): Promise<Record<string, CaseList>> {
+    const built: Record<string, CaseList> = {};
+    for (const name in this.builders) {
+      const cases = this.builders[name]();
+      built[name] = cases;
+    }
+    return Promise.resolve(built);
+  }
+
+  /**
+   * serialize() implements the Cacheable.serialize interface.
+   * @returns the serialized data.
+   */
+  serialize(data: Record<string, CaseList>): string {
+    const serialized: Record<string, SerializedCase[]> = {};
+    for (const name in data) {
+      serialized[name] = data[name].map(c => serializeCase(c));
+    }
+    return JSON.stringify(serialized);
+  }
+
+  /**
+   * deserialize() implements the Cacheable.deserialize interface.
+   * @returns the deserialize data.
+   */
+  deserialize(serialized: string): Record<string, CaseList> {
+    const data = JSON.parse(serialized) as Record<string, SerializedCase[]>;
+    const casesByName: Record<string, CaseList> = {};
+    for (const name in data) {
+      const cases = data[name].map(caseData => deserializeCase(caseData));
+      casesByName[name] = cases;
+    }
+    return casesByName;
+  }
+
+  public readonly path: string;
+  private readonly builders: Record<string, CaseListBuilder>;
+}
+
+export function makeCaseCache(name: string, builders: Record<string, CaseListBuilder>): CaseCache {
+  return new CaseCache(name, builders);
+}

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -7,11 +7,24 @@ import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32 } from '../../../../util/conversion.js';
 import { negationInterval } from '../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../expression.js';
 
 import { unary } from './unary.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unary/f32_arithmetic', {
+  negation: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, negationInterval);
+    };
+
+    return fullF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }).map(x =>
+      makeCase(x)
+    );
+  },
+});
 
 g.test('negation')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
@@ -25,13 +38,6 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, negationInterval);
-    };
-
-    const cases = fullF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }).map(x =>
-      makeCase(x)
-    );
-
+    const cases = await d.get('negation');
     await run(t, unary('-'), [TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -295,7 +295,7 @@ export const kValue = {
     },
   },
 
-  // Limits of uint32
+  // Limits of u32
   u32: {
     min: 0,
     max: 4294967295,
@@ -346,6 +346,24 @@ export const kValue = {
       positive: hexToF32(kBit.f32.infinity.positive),
       negative: hexToF32(kBit.f32.infinity.negative),
     },
+  },
+
+  // Limits of i16
+  i16: {
+    positive: {
+      min: 0,
+      max: 32767,
+    },
+    negative: {
+      min: -32768,
+      max: 0,
+    },
+  },
+
+  // Limits of u16
+  u16: {
+    min: 0,
+    max: 65535,
   },
 
   // Limits of f16
@@ -511,5 +529,23 @@ export const kValue = {
     toMinus30: -Math.pow(2, -30),
     toMinus31: -Math.pow(2, -31),
     toMinus32: -Math.pow(2, -32),
+  },
+
+  // Limits of i8
+  i8: {
+    positive: {
+      min: 0,
+      max: 127,
+    },
+    negative: {
+      min: -128,
+      max: 0,
+    },
+  },
+
+  // Limits of u8
+  u8: {
+    min: 0,
+    max: 255,
   },
 } as const;

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -2,6 +2,7 @@ import { assert, unreachable } from '../../common/util/util.js';
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 
 import { kValue } from './constants.js';
+import { reinterpretF32AsU32, reinterpretU32AsF32 } from './conversion.js';
 import {
   cartesianProduct,
   correctlyRoundedF16,
@@ -97,6 +98,26 @@ export class F32Interval {
     }
     return this._any;
   }
+}
+
+/**
+ * SerializedF32Interval holds the serialized form of a F32Interval.
+ * This form can be safely encoded to JSON.
+ */
+export type SerializedF32Interval = { begin: number; end: number } | 'any';
+
+/** serializeF32Interval() converts a F32Interval to a SerializedF32Interval */
+export function serializeF32Interval(i: F32Interval): SerializedF32Interval {
+  return i === F32Interval.any()
+    ? 'any'
+    : { begin: reinterpretF32AsU32(i.begin), end: reinterpretF32AsU32(i.end) };
+}
+
+/** serializeF32Interval() converts a SerializedF32Interval to a F32Interval */
+export function deserializeF32Interval(data: SerializedF32Interval): F32Interval {
+  return data === 'any'
+    ? F32Interval.any()
+    : new F32Interval(reinterpretU32AsF32(data.begin), reinterpretU32AsF32(data.end));
 }
 
 /** @returns an interval containing the point or the original interval */

--- a/tools/gen_cache
+++ b/tools/gen_cache
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('../src/common/tools/setup-ts-in-node.js');
+require('../src/common/tools/gen_cache.ts');


### PR DESCRIPTION
Profiling has highlighted that the logic to build the floating-point shader expression test cases can often be more expensive than running the test.

This problem is compounded by the fact that the shader expression tests are often run with slight variations to the input source ('const', 'uniform', etc).

This change introduces a framework for caching the test cases. The `DataCache` is two level:
* A "L1" in-memory cache - backed by a `Map`.
* A "L2" file cache, which can be pre-generated with an "offline" tool.

This change introduces the new tool: `npm run gen_cache <dir> [suite...]`

The idea here is that CTS testing infrastructure can pre-generate the test cases, and then reuse this data between the concurrent shards.

With the shader expression tests updated to use the `CaseCache`, local macOS + chromium + `standalone` CTS testing has shown 2x+ speed improvement when running all the `webgpu:shader,execution,expression,*` tests.
These performance gains will likely be reduced with multi-process execution, as the number of cache-misses will scale with the number of instances.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
