### PR TITLE
operation,rendering,blending nits

### DIFF
--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -21,22 +21,11 @@ import { TexelView } from '../../../util/texture/texel_view.js';
 import { textureContentIsOKByT2B } from '../../../util/texture/texture_ok.js';
 
 class BlendingTest extends GPUTest {
-  createRenderPipelineForTest(
-    colorTargetState: GPUColorTargetState,
-    blendComponent: GPUBlendComponent | undefined
-  ): GPURenderPipeline {
+  createRenderPipelineForTest(colorTargetState: GPUColorTargetState): GPURenderPipeline {
     return this.device.createRenderPipeline({
       layout: 'auto',
       fragment: {
-        targets: [
-          {
-            format: colorTargetState.format,
-            blend: {
-              color: blendComponent ?? {},
-              alpha: blendComponent ?? {},
-            },
-          },
-        ],
+        targets: [colorTargetState],
         module: this.device.createShaderModule({
           code: `
             struct Params {
@@ -444,15 +433,15 @@ g.test('default_blend_constant,initial_blend_constant')
     const kWhiteColorData = new Float32Array([255, 255, 255, 255]);
     const kBlackColorData = new Float32Array([0, 0, 0, 0]);
 
-    const basePipeline = t.createRenderPipelineForTest({ format }, undefined);
-    const testPipeline = t.createRenderPipelineForTest(
-      { format },
-      {
-        srcFactor: 'constant',
-        dstFactor: 'one',
-        operation: 'add',
-      }
-    );
+    const basePipeline = t.createRenderPipelineForTest({
+      format,
+      blend: { color: {}, alpha: {} },
+    });
+    const blendComponent = { srcFactor: 'constant', dstFactor: 'one', operation: 'add' } as const;
+    const testPipeline = t.createRenderPipelineForTest({
+      format,
+      blend: { color: blendComponent, alpha: blendComponent },
+    });
 
     const renderTarget = t.device.createTexture({
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
@@ -487,7 +476,7 @@ g.test('default_blend_constant,initial_blend_constant')
     renderPass.end();
     t.device.queue.submit([commandEncoder.finish()]);
 
-    // Check that the initial blend color is black(0,0,0,0) after setting testPipeline which has
+    // Check that the initial blend constant is black(0,0,0,0) after setting testPipeline which has
     // a white color buffer data.
     const expColor = { R: 0, G: 0, B: 0, A: 0 };
     const expTexelView = TexelView.fromTexelsAsColors(format, coords => expColor);

--- a/src/webgpu/api/operation/rendering/blending.spec.ts
+++ b/src/webgpu/api/operation/rendering/blending.spec.ts
@@ -431,12 +431,7 @@ g.test('default_blend_constant,initial_blend_constant')
     const format = 'rgba8unorm';
     const kSize = 1;
     const kWhiteColorData = new Float32Array([255, 255, 255, 255]);
-    const kBlackColorData = new Float32Array([0, 0, 0, 0]);
 
-    const basePipeline = t.createRenderPipelineForTest({
-      format,
-      blend: { color: {}, alpha: {} },
-    });
     const blendComponent = { srcFactor: 'constant', dstFactor: 'one', operation: 'add' } as const;
     const testPipeline = t.createRenderPipelineForTest({
       format,
@@ -459,11 +454,6 @@ g.test('default_blend_constant,initial_blend_constant')
         },
       ],
     });
-    renderPass.setPipeline(basePipeline);
-    renderPass.setBindGroup(
-      0,
-      t.createBindGroupForTest(basePipeline.getBindGroupLayout(0), kBlackColorData)
-    );
     renderPass.setPipeline(testPipeline);
     renderPass.setBindGroup(
       0,


### PR DESCRIPTION

Issue: #1980

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] ~Tests are properly located in the test tree.~
- [ ] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
