### PR TITLE
Implement rg11b10ufloat-renderable validation test

### DIFF
--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -16,10 +16,20 @@ sampleCount > 1, iff rg11b10ufloat-renderable feature is enabled.
 Note, the createTexture tests cover these validation cases where this feature is not enabled.
 `
   )
-  .params(u =>
-    u.combine('usage', [0, GPUConst.TextureUsage.RENDER_ATTACHMENT]).combine('sampleCount', [1, 4])
-  )
-  .unimplemented();
+  .params(u => u.combine('sampleCount', [1, 4]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('rg11b10ufloat-renderable');
+  })
+  .fn(async t => {
+    const { sampleCount } = t.params;
+    const descriptor = {
+      size: [1, 1, 1],
+      format: 'rg11b10ufloat' as const,
+      sampleCount,
+      usage: GPUConst.TextureUsage.RENDER_ATTACHMENT,
+    };
+    t.device.createTexture(descriptor);
+  });
 
 g.test('begin_render_pass')
   .desc(
@@ -28,7 +38,28 @@ Test that it is valid to begin render pass with rg11b10ufloat texture format
 iff rg11b10ufloat-renderable feature is enabled.
 `
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('rg11b10ufloat-renderable');
+  })
+  .fn(async t => {
+    const texture = t.device.createTexture({
+      size: [1, 1, 1],
+      format: 'rg11b10ufloat',
+      sampleCount: 1,
+      usage: GPUConst.TextureUsage.RENDER_ATTACHMENT,
+    });
+    const encoder = t.device.createCommandEncoder();
+    encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: texture.createView(),
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+  });
 
 g.test('begin_render_bundle_encoder')
   .desc(
@@ -37,7 +68,14 @@ Test that it is valid to begin render bundle encoder with rg11b10ufloat texture
 format iff rg11b10ufloat-renderable feature is enabled.
 `
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('rg11b10ufloat-renderable');
+  })
+  .fn(async t => {
+    t.device.createRenderBundleEncoder({
+      colorFormats: ['rg11b10ufloat'],
+    });
+  });
 
 g.test('create_render_pipeline')
   .desc(
@@ -46,4 +84,25 @@ Test that it is valid to create render pipeline with rg11b10ufloat texture forma
 in descriptor.fragment.targets iff rg11b10ufloat-renderable feature is enabled.
 `
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('rg11b10ufloat-renderable');
+  })
+  .fn(async t => {
+    t.device.createRenderPipeline({
+      layout: 'auto',
+      vertex: {
+        module: t.device.createShaderModule({
+          code: t.getNoOpShaderCode('VERTEX'),
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: t.getNoOpShaderCode('FRAGMENT'),
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rg11b10ufloat', writeMask: 0 }],
+      },
+      primitive: { topology: 'triangle-list' },
+    });
+  });


### PR DESCRIPTION


Issue: #1874 
Plan: #1937

This PR adds rg11b10ufloat-renderable validation test implementation.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
