### PR TITLE
Remove infinity cases from const eval ranges

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -12,7 +12,7 @@ import {
   remainderInterval,
   subtractionInterval,
 } from '../../../../util/f32_interval.js';
-import { kVectorTestValues } from '../../../../util/math.js';
+import { vectorTestValues } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../expression.js';
 
@@ -21,48 +21,93 @@ import { binary } from './binary.js';
 export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('binary/f32_arithmetic', {
-  addition: () => {
+  addition_non_const: () => {
     const makeCase = (lhs: number, rhs: number): Case => {
       return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
       return makeCase(v[0], v[1]);
     });
   },
-  subtraction: () => {
+  addition_const: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
+    };
+
+    return vectorTestValues(2, true).map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+  subtraction_non_const: () => {
     const makeCase = (lhs: number, rhs: number): Case => {
       return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
       return makeCase(v[0], v[1]);
     });
   },
-  multiplication: () => {
+  subtraction_const: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
+    };
+
+    return vectorTestValues(2, true).map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+  multiplication_non_const: () => {
     const makeCase = (lhs: number, rhs: number): Case => {
       return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
       return makeCase(v[0], v[1]);
     });
   },
-  division: () => {
+  multiplication_const: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
+    };
+
+    return vectorTestValues(2, true).map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+  division_non_const: () => {
     const makeCase = (lhs: number, rhs: number): Case => {
       return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
       return makeCase(v[0], v[1]);
     });
   },
-  remainder: () => {
+  division_const: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
+    };
+
+    return vectorTestValues(2, true).map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+  remainder_non_const: () => {
     const makeCase = (lhs: number, rhs: number): Case => {
       return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
+      return makeCase(v[0], v[1]);
+    });
+  },
+  remainder_const: () => {
+    const makeCase = (lhs: number, rhs: number): Case => {
+      return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
+    };
+
+    return vectorTestValues(2, true).map(v => {
       return makeCase(v[0], v[1]);
     });
   },
@@ -80,7 +125,9 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('addition');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'addition_const' : 'addition_non_const'
+    );
     await run(t, binary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -96,7 +143,9 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('subtraction');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'subtraction_const' : 'subtraction_non_const'
+    );
     await run(t, binary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -112,7 +161,9 @@ Accuracy: Correctly rounded
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('multiplication');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'multiplication_const' : 'multiplication_non_const'
+    );
     await run(t, binary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -128,7 +179,9 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('division');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
+    );
     await run(t, binary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -144,6 +197,8 @@ Accuracy: Derived from x - y * trunc(x/y)
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('remainder');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
+    );
     await run(t, binary('%'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { anyOf } from '../../../../util/compare.js';
 import { bool, f32, Scalar, TypeBool, TypeF32 } from '../../../../util/conversion.js';
-import { flushSubnormalScalarF32, kVectorTestValues } from '../../../../util/math.js';
+import { flushSubnormalScalarF32, vectorTestValues } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, Case, run } from '../expression.js';
 
@@ -41,57 +41,111 @@ function makeCase(
 }
 
 export const d = makeCaseCache('binary/f32_logical', {
-  equals: () => {
+  equals_non_const: () => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
       return (lhs.value as number) === (rhs.value as number);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
-  not_equals: () => {
+  equals_const: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) === (rhs.value as number);
+    };
+
+    return vectorTestValues(2, true).map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  not_equals_non_const: () => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
       return (lhs.value as number) !== (rhs.value as number);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
-  less_than: () => {
+  not_equals_const: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) !== (rhs.value as number);
+    };
+
+    return vectorTestValues(2, true).map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  less_than_non_const: () => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
       return (lhs.value as number) < (rhs.value as number);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
-  less_equals: () => {
+  less_than_const: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) < (rhs.value as number);
+    };
+
+    return vectorTestValues(2, true).map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  less_equals_non_const: () => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
       return (lhs.value as number) <= (rhs.value as number);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
-  greater_than: () => {
+  less_equals_const: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) <= (rhs.value as number);
+    };
+
+    return vectorTestValues(2, true).map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  greater_than_non_const: () => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
       return (lhs.value as number) > (rhs.value as number);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
-  greater_equals: () => {
+  greater_than_const: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) > (rhs.value as number);
+    };
+
+    return vectorTestValues(2, true).map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  greater_equals_non_const: () => {
     const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
       return (lhs.value as number) >= (rhs.value as number);
     };
 
-    return kVectorTestValues[2].map(v => {
+    return vectorTestValues(2, false).map(v => {
+      return makeCase(v[0], v[1], truthFunc);
+    });
+  },
+  greater_equals_const: () => {
+    const truthFunc = (lhs: Scalar, rhs: Scalar): boolean => {
+      return (lhs.value as number) >= (rhs.value as number);
+    };
+
+    return vectorTestValues(2, true).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -109,7 +163,9 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('equals');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'equals_const' : 'equals_non_const'
+    );
     await run(t, binary('=='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -125,7 +181,9 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('not_equals');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'not_equals_const' : 'not_equals_non_const'
+    );
     await run(t, binary('!='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -141,7 +199,9 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('less_than');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'less_than_const' : 'less_than_non_const'
+    );
     await run(t, binary('<'), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -157,7 +217,9 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('less_equals');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'less_equals_const' : 'less_equals_non_const'
+    );
     await run(t, binary('<='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -173,7 +235,9 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('greater_than');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'greater_than_const' : 'greater_than_non_const'
+    );
     await run(t, binary('>'), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });
 
@@ -189,6 +253,8 @@ Accuracy: Correct result
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('greater_equals');
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'greater_equals_const' : 'greater_equals_non_const'
+    );
     await run(t, binary('>='), [TypeF32, TypeF32], TypeBool, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -29,7 +29,7 @@ import { builtin } from './builtin.js';
 export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('abs', {
-  f32: () => {
+  f32_non_const: () => {
     const makeCase = (x: number): Case => {
       return makeUnaryToF32IntervalCase(x, absInterval);
     };
@@ -37,6 +37,13 @@ export const d = makeCaseCache('abs', {
     return [Number.NEGATIVE_INFINITY, ...fullF32Range(), Number.POSITIVE_INFINITY].map(x =>
       makeCase(x)
     );
+  },
+  f32_const: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, absInterval);
+    };
+
+    return fullF32Range().map(x => makeCase(x));
   },
 });
 
@@ -160,7 +167,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('f32');
+    const cases = await d.get(t.params.inputSource === 'const' ? 'f32_const' : 'f32_non_const');
     await run(t, builtin('abs'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -21,7 +21,7 @@ import { builtin } from './builtin.js';
 export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('atan', {
-  f32: () => {
+  f32_non_const: () => {
     const makeCase = (x: number): Case => {
       return makeUnaryToF32IntervalCase(x, atanInterval);
     };
@@ -37,6 +37,24 @@ export const d = makeCaseCache('atan', {
       1 / Math.sqrt(3),
       Math.sqrt(3),
       Number.POSITIVE_INFINITY,
+
+      ...fullF32Range(),
+    ].map(x => makeCase(x));
+  },
+  f32_const: () => {
+    const makeCase = (x: number): Case => {
+      return makeUnaryToF32IntervalCase(x, atanInterval);
+    };
+
+    return [
+      // Known values
+      -Math.sqrt(3),
+      -1,
+      -1 / Math.sqrt(3),
+      0,
+      1,
+      1 / Math.sqrt(3),
+      Math.sqrt(3),
 
       ...fullF32Range(),
     ].map(x => makeCase(x));
@@ -64,7 +82,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('f32');
+    const cases = await d.get(t.params.inputSource === 'const' ? 'f32_const' : 'f32_non_const');
     await run(t, builtin('atan'), [TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -66,13 +66,32 @@ export const d = makeCaseCache('clamp', {
 
     return generateIntegerTestCases(test_values);
   },
-  f32: () => {
+  f32_non_const: () => {
     const makeCase = (x: number, y: number, z: number): Case => {
       return makeTernaryToF32IntervalCase(x, y, z, ...clampIntervals);
     };
 
     // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range();
+    const values = sparseF32Range(false);
+    const cases: Array<Case> = [];
+    values.forEach(x => {
+      values.forEach(y => {
+        values.forEach(z => {
+          cases.push(makeCase(x, y, z));
+        });
+      });
+    });
+
+    return cases;
+  },
+
+  f32_const: () => {
+    const makeCase = (x: number, y: number, z: number): Case => {
+      return makeTernaryToF32IntervalCase(x, y, z, ...clampIntervals);
+    };
+
+    // Using sparseF32Range since this will generate N^3 test cases
+    const values = sparseF32Range(true);
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {
@@ -159,7 +178,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('f32');
+    const cases = await d.get(t.params.inputSource === 'const' ? 'f32_const' : 'f32_non_const');
     await run(t, builtin('clamp'), [TypeF32, TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -10,7 +10,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { crossInterval } from '../../../../../util/f32_interval.js';
-import { kVectorTestValues } from '../../../../../util/math.js';
+import { vectorTestValues } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
@@ -29,8 +29,8 @@ export const d = makeCaseCache('cross', {
       return makeVectorPairToVectorIntervalCase(x, y, crossInterval);
     };
 
-    return kVectorTestValues[3].flatMap(i => {
-      return kVectorTestValues[3].map(j => {
+    return vectorTestValues(3, false).flatMap(i => {
+      return vectorTestValues(3, false).map(j => {
         return makeCase(i, j);
       });
     });

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { dotInterval } from '../../../../../util/f32_interval.js';
-import { kVectorTestValues } from '../../../../../util/math.js';
+import { vectorTestValues } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeVectorPairToF32IntervalCase, run } from '../../expression.js';
 
@@ -25,8 +25,8 @@ export const d = makeCaseCache('dot', {
       return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
-    return kVectorTestValues[2].flatMap(i => {
-      return kVectorTestValues[2].map(j => {
+    return vectorTestValues(2, false).flatMap(i => {
+      return vectorTestValues(2, false).map(j => {
         return makeCase(i, j);
       });
     });
@@ -36,8 +36,8 @@ export const d = makeCaseCache('dot', {
       return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
-    return kVectorTestValues[3].flatMap(i => {
-      return kVectorTestValues[3].map(j => {
+    return vectorTestValues(3, false).flatMap(i => {
+      return vectorTestValues(3, false).map(j => {
         return makeCase(i, j);
       });
     });
@@ -47,8 +47,8 @@ export const d = makeCaseCache('dot', {
       return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
-    return kVectorTestValues[4].flatMap(i => {
-      return kVectorTestValues[4].map(j => {
+    return vectorTestValues(4, false).flatMap(i => {
+      return vectorTestValues(4, false).map(j => {
         return makeCase(i, j);
       });
     });

--- a/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range();
+    const values = sparseF32Range(t.params.inputSource === 'const');
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { lengthInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, kVectorTestValues } from '../../../../../util/math.js';
+import { fullF32Range, vectorTestValues } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
@@ -33,13 +33,13 @@ export const d = makeCaseCache('length', {
     return fullF32Range().map(makeCase);
   },
   f32_vec2: () => {
-    return kVectorTestValues[2].map(makeCaseVecF32);
+    return vectorTestValues(2, false).map(makeCaseVecF32);
   },
   f32_vec3: () => {
-    return kVectorTestValues[3].map(makeCaseVecF32);
+    return vectorTestValues(3, false).map(makeCaseVecF32);
   },
   f32_vec4: () => {
-    return kVectorTestValues[4].map(makeCaseVecF32);
+    return vectorTestValues(4, false).map(makeCaseVecF32);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -32,7 +32,7 @@ export const d = makeCaseCache('mix', {
       return makeTernaryToF32IntervalCase(x, y, z, ...mixIntervals);
     };
 
-    const values = sparseF32Range();
+    const values = sparseF32Range(false);
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {

--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -10,7 +10,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { normalizeInterval } from '../../../../../util/f32_interval.js';
-import { kVectorTestValues } from '../../../../../util/math.js';
+import { vectorTestValues } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeVectorToVectorIntervalCase, run } from '../../expression.js';
 
@@ -20,13 +20,13 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('normalize', {
   f32_vec2: () => {
-    return kVectorTestValues[2].map(makeCaseVecF32);
+    return vectorTestValues(2, false).map(makeCaseVecF32);
   },
   f32_vec3: () => {
-    return kVectorTestValues[3].map(makeCaseVecF32);
+    return vectorTestValues(3, false).map(makeCaseVecF32);
   },
   f32_vec4: () => {
-    return kVectorTestValues[4].map(makeCaseVecF32);
+    return vectorTestValues(4, false).map(makeCaseVecF32);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -61,7 +61,7 @@ g.test('pack')
       return { input: [vec2(f32(x), f32(y))], expected: anyOf(...results.map(cmp)) };
     };
 
-    const cases: Array<Case> = kVectorTestValues[2].map(v => {
+    const cases: Array<Case> = vectorTestValues(2, t.params.inputSource === 'const').map(v => {
       return makeCase(...(v as [number, number]));
     });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
@@ -17,7 +17,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -44,7 +44,7 @@ g.test('pack')
       return n / kValue.f32.positive.max;
     };
 
-    const cases: Array<Case> = kVectorTestValues[2].flatMap(v => {
+    const cases: Array<Case> = vectorTestValues(2, t.params.inputSource === 'const').flatMap(v => {
       return [
         makeCase(...(v as [number, number])),
         makeCase(...(v.map(normalizeF32) as [number, number])),

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
@@ -17,7 +17,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -44,7 +44,7 @@ g.test('pack')
       return n > 0 ? n / kValue.f32.positive.max : n / kValue.f32.negative.min;
     };
 
-    const cases: Array<Case> = kVectorTestValues[2].flatMap(v => {
+    const cases: Array<Case> = vectorTestValues(2, t.params.inputSource === 'const').flatMap(v => {
       return [
         makeCase(...(v as [number, number])),
         makeCase(...(v.map(normalizeF32) as [number, number])),

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec4,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -49,7 +49,7 @@ g.test('pack')
       return n / kValue.f32.positive.max;
     };
 
-    const cases: Array<Case> = kVectorTestValues[4].flatMap(v => {
+    const cases: Array<Case> = vectorTestValues(4, t.params.inputSource === 'const').flatMap(v => {
       return [
         makeCase(v as [number, number, number, number]),
         makeCase(v.map(normalizeF32) as [number, number, number, number]),

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8unorm.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec4,
 } from '../../../../../util/conversion.js';
-import { kVectorTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -49,7 +49,7 @@ g.test('pack')
       return n > 0 ? n / kValue.f32.positive.max : n / kValue.f32.negative.min;
     };
 
-    const cases: Array<Case> = kVectorTestValues[4].flatMap(v => {
+    const cases: Array<Case> = vectorTestValues(4, t.params.inputSource === 'const').flatMap(v => {
       return [
         makeCase(v as [number, number, number, number]),
         makeCase(v.map(normalizeF32) as [number, number, number, number]),

--- a/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
@@ -54,7 +54,7 @@ g.test('f32_vec2')
   .fn(async t => {
     const cases: Case[] = kVectorSparseTestValues[2].flatMap(i => {
       return kVectorSparseTestValues[2].flatMap(j => {
-        return sparseF32Range().map(k => {
+        return sparseF32Range(t.params.inputSource === 'const').map(k => {
           return makeCaseF32(i, j, k);
         });
       });
@@ -77,7 +77,7 @@ g.test('f32_vec3')
   .fn(async t => {
     const cases: Case[] = kVectorSparseTestValues[3].flatMap(i => {
       return kVectorSparseTestValues[3].flatMap(j => {
-        return sparseF32Range().map(k => {
+        return sparseF32Range(t.params.inputSource === 'const').map(k => {
           return makeCaseF32(i, j, k);
         });
       });
@@ -100,7 +100,7 @@ g.test('f32_vec4')
   .fn(async t => {
     const cases: Case[] = kVectorSparseTestValues[4].flatMap(i => {
       return kVectorSparseTestValues[4].flatMap(j => {
-        return sparseF32Range().map(k => {
+        return sparseF32Range(t.params.inputSource === 'const').map(k => {
           return makeCaseF32(i, j, k);
         });
       });

--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -28,7 +28,7 @@ export const d = makeCaseCache('smoothstep', {
     };
 
     // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range();
+    const values = sparseF32Range(false);
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -656,6 +656,23 @@ const kInterestingF32Values: number[] = [
   Number.POSITIVE_INFINITY,
 ];
 
+/** Short list of finite-only f32 values of interest to test against */
+const kInterestingF32ValuesFinite: number[] = [
+  kValue.f32.negative.min,
+  -10.0,
+  -1.0,
+  kValue.f32.negative.max,
+  kValue.f32.subnormal.negative.min,
+  kValue.f32.subnormal.negative.max,
+  0.0,
+  kValue.f32.subnormal.positive.min,
+  kValue.f32.subnormal.positive.max,
+  kValue.f32.positive.min,
+  1.0,
+  10.0,
+  kValue.f32.positive.max,
+];
+
 /** @returns minimal f32 values that cover the entire range of f32 behaviours
  *
  * Has specially selected values that cover edge cases, normals, and subnormals.
@@ -668,12 +685,14 @@ const kInterestingF32Values: number[] = [
  * specific values of interest. If there are known values of interest they
  * should be appended to this list in the test generation code.
  */
-export function sparseF32Range(): Array<number> {
-  return kInterestingF32Values;
+export function sparseF32Range(finite_only: boolean): Array<number> {
+  return finite_only ? kInterestingF32ValuesFinite : kInterestingF32Values;
 }
 
 /**
- * Set of vectors, indexed by dimension, that contain interesting float values
+ * Returns set of vectors, indexed by dimension and filtered by source type,
+ * that contain interesting float values.
+ *
  *
  * The tests do not do the simple option for coverage of computing the cartesian
  * product of all of the interesting float values N times for vecN tests,
@@ -683,50 +702,56 @@ export function sparseF32Range(): Array<number> {
  * vector to get a spread of testing over the entire range. This reduces the
  * number of cases being run substantially, but maintains coverage.
  */
-export const kVectorTestValues = {
-  2: sparseF32Range().flatMap(f => [
-    [f, 1.0],
-    [1.0, f],
-    [f, -1.0],
-    [-1.0, f],
-  ]),
-  3: sparseF32Range().flatMap(f => [
-    [f, 1.0, 2.0],
-    [1.0, f, 2.0],
-    [1.0, 2.0, f],
-    [f, -1.0, -2.0],
-    [-1.0, f, -2.0],
-    [-1.0, -2.0, f],
-  ]),
-  4: sparseF32Range().flatMap(f => [
-    [f, 1.0, 2.0, 3.0],
-    [1.0, f, 2.0, 3.0],
-    [1.0, 2.0, f, 3.0],
-    [1.0, 2.0, 3.0, f],
-    [f, -1.0, -2.0, -3.0],
-    [-1.0, f, -2.0, -3.0],
-    [-1.0, -2.0, f, -3.0],
-    [-1.0, -2.0, -3.0, f],
-  ]),
-};
+export function vectorTestValues(dimension: number, finite_only: boolean): number[][] {
+  switch (dimension) {
+    case 2:
+      return sparseF32Range(finite_only).flatMap(f => [
+        [f, 1.0],
+        [1.0, f],
+        [f, -1.0],
+        [-1.0, f],
+      ]);
+    case 3:
+      return sparseF32Range(finite_only).flatMap(f => [
+        [f, 1.0, 2.0],
+        [1.0, f, 2.0],
+        [1.0, 2.0, f],
+        [f, -1.0, -2.0],
+        [-1.0, f, -2.0],
+        [-1.0, -2.0, f],
+      ]);
+    case 4:
+      return sparseF32Range(finite_only).flatMap(f => [
+        [f, 1.0, 2.0, 3.0],
+        [1.0, f, 2.0, 3.0],
+        [1.0, 2.0, f, 3.0],
+        [1.0, 2.0, 3.0, f],
+        [f, -1.0, -2.0, -3.0],
+        [-1.0, f, -2.0, -3.0],
+        [-1.0, -2.0, f, -3.0],
+        [-1.0, -2.0, -3.0, f],
+      ]);
+  }
+  return [[]];
+}
 
 /**
  * Minimal set of vectors, indexed by dimension, that contain interesting float
  * values.
  *
- * This is an even more stripped down version of `kVectorTestValues` for when
+ * This is an even more stripped down version of `vectorTestValues` for when
  * pairs of vectors are being tested.
  * All of the interesting floats from sparseF32 are guaranteed to be tested, but
  * not in every position.
  */
 export const kVectorSparseTestValues = {
-  2: sparseF32Range().map((f, idx) => [idx % 2 === 0 ? f : idx, idx % 2 === 1 ? f : -idx]),
-  3: sparseF32Range().map((f, idx) => [
+  2: sparseF32Range(false).map((f, idx) => [idx % 2 === 0 ? f : idx, idx % 2 === 1 ? f : -idx]),
+  3: sparseF32Range(false).map((f, idx) => [
     idx % 3 === 0 ? f : idx,
     idx % 3 === 1 ? f : -idx,
     idx % 3 === 2 ? f : idx,
   ]),
-  4: sparseF32Range().map((f, idx) => [
+  4: sparseF32Range(false).map((f, idx) => [
     idx % 4 === 0 ? f : idx,
     idx % 4 === 1 ? f : -idx,
     idx % 4 === 2 ? f : idx,


### PR DESCRIPTION
The spec no longer allows for infinity values in const eval expressions (formerly, it wasn't allowed for abstracts, but was allowed for concretes).

Issue: #1989

