### PR TITLE
textureSampleLevel(texture_external) -> textureSampleBaseClampToEdge()

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -20,7 +20,7 @@ fn textureSampleLevel(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, level: 
 fn textureSampleLevel(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, level: f32, offset: vec2<i32>) -> vec4<f32>
 
 Parameters:
- * t  The sampled, depth, or external texture to sample.
+ * t  The sampled or depth texture to sample.
  * s  The sampler type.
  * coords The texture coordinates used for sampling.
  * level
@@ -55,7 +55,7 @@ fn textureSampleLevel(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, a
 fn textureSampleLevel(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: C, level: f32, offset: vec2<i32>) -> vec4<f32>
 
 Parameters:
- * t  The sampled, depth, or external texture to sample.
+ * t  The sampled or depth texture to sample.
  * s  The sampler type.
  * coords The texture coordinates used for sampling.
  * array_index The 0-based texture array index to sample.
@@ -93,7 +93,7 @@ fn textureSampleLevel(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, level: 
 fn textureSampleLevel(t: texture_cube<f32>, s: sampler, coords: vec3<f32>, level: f32) -> vec4<f32>
 
 Parameters:
- * t  The sampled, depth, or external texture to sample.
+ * t  The sampled or depth texture to sample.
  * s  The sampler type.
  * coords The texture coordinates used for sampling.
  * level
@@ -129,7 +129,7 @@ C is i32 or u32
 fn textureSampleLevel(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: C, level: f32) -> vec4<f32>
 
 Parameters:
- * t  The sampled, depth, or external texture to sample.
+ * t  The sampled or depth texture to sample.
  * s  The sampler type.
  * coords The texture coordinates used for sampling.
  * array_index The 0-based texture array index to sample.
@@ -168,7 +168,7 @@ fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level:
 fn textureSampleLevel(t: texture_depth_2d, s: sampler, coords: vec2<f32>, level: C, offset: vec2<i32>) -> f32
 
 Parameters:
- * t  The sampled, depth, or external texture to sample.
+ * t  The sampled or depth texture to sample.
  * s  The sampler type.
  * coords The texture coordinates used for sampling.
  * level
@@ -205,7 +205,7 @@ fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, 
 fn textureSampleLevel(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: C, level: C, offset: vec2<i32>) -> f32
 
 Parameters:
- * t  The sampled, depth, or external texture to sample.
+ * t  The sampled or depth texture to sample.
  * s  The sampler type.
  * array_index The 0-based texture array index to sample.
  * coords The texture coordinates used for sampling.
@@ -244,7 +244,7 @@ fn textureSampleLevel(t: texture_depth_cube, s: sampler, coords: vec3<f32>, leve
 fn textureSampleLevel(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: C, level: C) -> f32
 
 Parameters:
- * t  The sampled, depth, or external texture to sample.
+ * t  The sampled or depth texture to sample.
  * s  The sampler type.
  * coords The texture coordinates used for sampling.
  * level
@@ -270,24 +270,5 @@ Parameters:
       .combine('coords', generateCoordBoundaries(3))
       /* array_index not param'd as out-of-bounds is implementation specific */
       .combine('level', [undefined, 0, 1, 'textureNumLevels', 'textureNumLevels+1'] as const)
-  )
-  .unimplemented();
-
-g.test('external')
-  .specURL('https://www.w3.org/TR/WGSL/#texturesamplelevel')
-  .desc(
-    `
-fn textureSampleLevel(t: texture_external, s: sampler, coords: vec2<f32>) -> vec4<f32>
-
-Parameters:
- * t  The sampled, depth, or external texture to sample.
- * s  The sampler type.
- * coords The texture coordinates used for sampling.
-`
-  )
-  .paramsSubcasesOnly(u =>
-    u
-      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'])
-      .combine('coords', generateCoordBoundaries(2))
   )
   .unimplemented();

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -101,7 +101,7 @@ function createExternalTextureSamplingTestPipeline(t: GPUTest): GPURenderPipelin
 
         @fragment fn main(@builtin(position) FragCoord : vec4<f32>)
                                  -> @location(0) vec4<f32> {
-            return textureSampleLevel(t, s, FragCoord.xy / vec2<f32>(16.0, 16.0));
+            return textureSampleBaseClampToEdge(t, s, FragCoord.xy / vec2<f32>(16.0, 16.0));
         }
         `,
       }),


### PR DESCRIPTION


The `textureSampleLevel(texture_external)` overload has been replaced with `textureSampleBaseClampToEdge(texture_external)`

See https://github.com/gpuweb/gpuweb/pull/3403

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
