### PR TITLE
Reduce the number of test cases generated for atan2

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -9,9 +9,10 @@ Returns the arc tangent of e1 over e2. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { atan2Interval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { linearRange, sparseF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
 
@@ -25,7 +26,12 @@ export const d = makeCaseCache('atan2', {
       return makeBinaryToF32IntervalCase(y, x, atan2Interval);
     };
 
-    const numeric_range = fullF32Range();
+    // Using sparse, since there a N^2 cases being generated, but including extra values around 0, since that is where
+    // there is a discontinuity that implementations tend to behave badly at.
+    const numeric_range = [
+      ...sparseF32Range(true),
+      ...linearRange(kValue.f32.negative.max, kValue.f32.positive.min, 10),
+    ];
     const cases: Array<Case> = [];
     numeric_range.forEach(y => {
       numeric_range.forEach(x => {


### PR DESCRIPTION
Since atan2 takes in two parameters, N^2 cases will be generated in the CTS. For some systems atan2 is relatively expensive to run, so it causes test timeouts when attempting to run the CTS.

This changes reduces the number of tests being run, by using sparse f32 values + values around 0, where atan2 implementations tend to misbehave.

This reduces the run time of these tests by 50% on my local machine.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
