### PR TITLE
Implement `modf` f32 tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -73,6 +73,8 @@ import {
   unpack2x16unormInterval,
   unpack4x8snormInterval,
   unpack4x8unormInterval,
+  modfInterval,
+  toF32Interval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -3314,3 +3316,58 @@ interface RefractCase {
       );
     });
 }
+
+interface ModfCase {
+  input: number;
+  fract: IntervalBounds;
+  whole: IntervalBounds;
+}
+
+g.test('modfInterval')
+  .paramsSubcasesOnly<ModfCase>(
+    // When performing modf(x), where x is an integer value, the acceptance intervals are somewhat unintuitive.
+    // Specifically the acceptance intervals will be something like { fract: [0, 1], whole: [x-1, x] } instead of just
+    // { fract: [0], whole: [x] }.
+    // This is because the accuracy calculations for `%`, which is used for calculating the results of modf, has
+    // trunc(y/x) in it, which introduces 2.5 ULP of error before the truncate. So when near the integer boundary, this
+    // can cause the value being truncated to be slightly above or below the 'true' integer value, which causes an
+    // observable difference to the result. This then propagates through create the wide than expected acceptance
+    // intervals.
+    // prettier-ignore
+    [
+      // Normals
+      { input: 0, fract: [0], whole: [0] },
+      { input: 1, fract: [0, 1], whole: [0, 1] },
+      { input: -1, fract: [-1, 0], whole: [-1, 0] },
+      { input: 0.5, fract: [0.5], whole: [0] },
+      { input: -0.5, fract: [-0.5], whole: [0] },
+      { input: 2.5, fract: [0.5], whole: [2] },
+      { input: -2.5, fract: [-0.5], whole: [-2] },
+      { input: 10.0, fract: [0, 1], whole: [9, 10] },
+      { input: -10.0, fract: [-1, 0], whole: [-10, -9] },
+
+      // Subnormals
+      { input: kValue.f32.subnormal.negative.min, fract: [kValue.f32.subnormal.negative.min, 0], whole: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
+      { input: kValue.f32.subnormal.negative.max, fract: [kValue.f32.subnormal.negative.max, 0], whole: [kValue.f32.subnormal.negative.max, kValue.f32.subnormal.positive.min] },
+      { input: kValue.f32.subnormal.positive.min, fract: [0, kValue.f32.subnormal.positive.min], whole: [kValue.f32.subnormal.negative.max, kValue.f32.subnormal.positive.min] },
+      { input: kValue.f32.subnormal.positive.max, fract: [0, kValue.f32.subnormal.positive.max], whole: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
+
+      // Boundaries
+      { input: kValue.f32.negative.min, fract: kAny, whole: kAny },
+      { input: kValue.f32.negative.max, fract: [kValue.f32.negative.max], whole: [0] },
+      { input: kValue.f32.positive.min, fract: [kValue.f32.positive.min], whole: [0] },
+      { input: kValue.f32.positive.max, fract: kAny, whole: kAny },
+    ]
+  )
+  .fn(t => {
+    const expected = {
+      fract: toF32Interval(t.params.fract),
+      whole: toF32Interval(t.params.whole),
+    };
+
+    const got = modfInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `modfInterval([${t.params.input}) returned { fract: [${got.fract}], whole: [${got.whole}] }. Expected { fract: [${expected.fract}], whole: [${expected.whole}] }`
+    );
+  });

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -3325,38 +3325,30 @@ interface ModfCase {
 
 g.test('modfInterval')
   .paramsSubcasesOnly<ModfCase>(
-    // When performing modf(x), where x is an integer value, the acceptance intervals are somewhat unintuitive.
-    // Specifically the acceptance intervals will be something like { fract: [0, 1], whole: [x-1, x] } instead of just
-    // { fract: [0], whole: [x] }.
-    // This is because the accuracy calculations for `%`, which is used for calculating the results of modf, has
-    // trunc(y/x) in it, which introduces 2.5 ULP of error before the truncate. So when near the integer boundary, this
-    // can cause the value being truncated to be slightly above or below the 'true' integer value, which causes an
-    // observable difference to the result. This then propagates through create the wide than expected acceptance
-    // intervals.
     // prettier-ignore
     [
       // Normals
       { input: 0, fract: [0], whole: [0] },
-      { input: 1, fract: [0, 1], whole: [0, 1] },
-      { input: -1, fract: [-1, 0], whole: [-1, 0] },
+      { input: 1, fract: [0], whole: [1] },
+      { input: -1, fract: [0], whole: [-1] },
       { input: 0.5, fract: [0.5], whole: [0] },
       { input: -0.5, fract: [-0.5], whole: [0] },
       { input: 2.5, fract: [0.5], whole: [2] },
       { input: -2.5, fract: [-0.5], whole: [-2] },
-      { input: 10.0, fract: [0, 1], whole: [9, 10] },
-      { input: -10.0, fract: [-1, 0], whole: [-10, -9] },
+      { input: 10.0, fract: [0], whole: [10] },
+      { input: -10.0, fract: [0], whole: [-10] },
 
       // Subnormals
-      { input: kValue.f32.subnormal.negative.min, fract: [kValue.f32.subnormal.negative.min, 0], whole: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
-      { input: kValue.f32.subnormal.negative.max, fract: [kValue.f32.subnormal.negative.max, 0], whole: [kValue.f32.subnormal.negative.max, kValue.f32.subnormal.positive.min] },
-      { input: kValue.f32.subnormal.positive.min, fract: [0, kValue.f32.subnormal.positive.min], whole: [kValue.f32.subnormal.negative.max, kValue.f32.subnormal.positive.min] },
-      { input: kValue.f32.subnormal.positive.max, fract: [0, kValue.f32.subnormal.positive.max], whole: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
+      { input: kValue.f32.subnormal.negative.min, fract: [kValue.f32.subnormal.negative.min, 0], whole: [0] },
+      { input: kValue.f32.subnormal.negative.max, fract: [kValue.f32.subnormal.negative.max, 0], whole: [0] },
+      { input: kValue.f32.subnormal.positive.min, fract: [0, kValue.f32.subnormal.positive.min], whole: [0] },
+      { input: kValue.f32.subnormal.positive.max, fract: [0, kValue.f32.subnormal.positive.max], whole: [0] },
 
       // Boundaries
-      { input: kValue.f32.negative.min, fract: kAny, whole: kAny },
+      { input: kValue.f32.negative.min, fract: [0], whole: [kValue.f32.negative.min] },
       { input: kValue.f32.negative.max, fract: [kValue.f32.negative.max], whole: [0] },
       { input: kValue.f32.positive.min, fract: [kValue.f32.positive.min], whole: [0] },
-      { input: kValue.f32.positive.max, fract: kAny, whole: kAny },
+      { input: kValue.f32.positive.max, fract: [0], whole: [kValue.f32.positive.max] },
     ]
   )
   .fn(t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -97,7 +97,7 @@ g.test('f32_fract')
     `
 T is f32
 
-struct __modf_result {
+struct __modf_result_f32 {
   fract : f32, // fractional part
   whole : f32  // whole part
 }
@@ -115,7 +115,7 @@ g.test('f32_whole')
     `
 T is f32
 
-struct __modf_result {
+struct __modf_result_f32 {
   fract : f32, // fractional part
   whole : f32  // whole part
 }
@@ -133,7 +133,7 @@ g.test('f32_vec2_fract')
     `
 T is vec2<f32>
 
-struct __modf_result_vec2 {
+struct __modf_result_vec2_f32 {
   fract : vec2<f32>, // fractional part
   whole : vec2<f32>  // whole part
 }
@@ -151,7 +151,7 @@ g.test('f32_vec2_whole')
     `
 T is vec2<f32>
 
-struct __modf_result_vec2 {
+struct __modf_result_vec2_f32 {
   fract : vec2<f32>, // fractional part
   whole : vec2<f32>  // whole part
 }
@@ -169,7 +169,7 @@ g.test('f32_vec3_fract')
     `
 T is vec3<f32>
 
-struct __modf_result_vec3 {
+struct __modf_result_vec3_f32 {
   fract : vec3<f32>, // fractional part
   whole : vec3<f32>  // whole part
 }
@@ -187,7 +187,7 @@ g.test('f32_vec3_whole')
     `
 T is vec3<f32>
 
-struct __modf_result_vec3 {
+struct __modf_result_vec3_f32 {
   fract : vec3<f32>, // fractional part
   whole : vec3<f32>  // whole part
 }
@@ -205,7 +205,7 @@ g.test('f32_vec4_fract')
     `
 T is vec4<f32>
 
-struct __modf_result_vec4 {
+struct __modf_result_vec4_f32 {
   fract : vec4<f32>, // fractional part
   whole : vec4<f32>  // whole part
 }
@@ -223,7 +223,7 @@ g.test('f32_vec4_whole')
     `
 T is vec4<f32>
 
-struct __modf_result_vec4 {
+struct __modf_result_vec4_f32 {
   fract : vec4<f32>, // fractional part
   whole : vec4<f32>  // whole part
 }

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -18,11 +18,80 @@ Returns the result_struct for the given type.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { f32, toVector, TypeF32, TypeVec } from '../../../../../util/conversion.js';
+import { modfInterval } from '../../../../../util/f32_interval.js';
+import { fullF32Range, quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache.js';
+import { allInputSources, Case, ExpressionBuilder, run } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('scalar_f32')
+/* @returns an ExpressionBuilder that evaluates modf and returns .whole from the result structure */
+function wholeBuilder(): ExpressionBuilder {
+  return value => `modf(${value}).whole`;
+}
+
+/* @returns an ExpressionBuilder that evaluates modf and returns .fract from the result structure */
+function fractBuilder(): ExpressionBuilder {
+  return value => `modf(${value}).fract`;
+}
+
+/* @returns a fract Case for a given vector input */
+function makeVectorCaseFract(v: number[]): Case {
+  v = v.map(quantizeToF32);
+  const fs = v.map(e => {
+    return modfInterval(e).fract;
+  });
+
+  return { input: toVector(v, f32), expected: fs };
+}
+
+/* @returns a fract Case for a given vector input */
+function makeVectorCaseWhole(v: number[]): Case {
+  v = v.map(quantizeToF32);
+  const ws = v.map(e => {
+    return modfInterval(e).whole;
+  });
+
+  return { input: toVector(v, f32), expected: ws };
+}
+
+export const d = makeCaseCache('modf', {
+  f32_fract: () => {
+    const makeCase = (n: number): Case => {
+      n = quantizeToF32(n);
+      return { input: f32(n), expected: modfInterval(n).fract };
+    };
+    return fullF32Range().map(makeCase);
+  },
+  f32_whole: () => {
+    const makeCase = (n: number): Case => {
+      n = quantizeToF32(n);
+      return { input: f32(n), expected: modfInterval(n).whole };
+    };
+    return fullF32Range().map(makeCase);
+  },
+  f32_vec2_fract: () => {
+    return vectorTestValues(2, true).map(makeVectorCaseFract);
+  },
+  f32_vec2_whole: () => {
+    return vectorTestValues(2, true).map(makeVectorCaseWhole);
+  },
+  f32_vec3_fract: () => {
+    return vectorTestValues(3, true).map(makeVectorCaseFract);
+  },
+  f32_vec3_whole: () => {
+    return vectorTestValues(3, true).map(makeVectorCaseWhole);
+  },
+  f32_vec4_fract: () => {
+    return vectorTestValues(4, true).map(makeVectorCaseFract);
+  },
+  f32_vec4_whole: () => {
+    return vectorTestValues(4, true).map(makeVectorCaseWhole);
+  },
+});
+
+g.test('f32_fract')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
@@ -35,9 +104,138 @@ struct __modf_result {
 `
   )
   .params(u => u.combine('inputSource', allInputSources))
-  .unimplemented();
+  .fn(async t => {
+    const cases = await d.get('f32_fract');
+    await run(t, fractBuilder(), [TypeF32], TypeF32, t.params, cases);
+  });
 
-g.test('scalar_f16')
+g.test('f32_whole')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is f32
+
+struct __modf_result {
+  fract : f32, // fractional part
+  whole : f32  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_whole');
+    await run(t, wholeBuilder(), [TypeF32], TypeF32, t.params, cases);
+  });
+
+g.test('f32_vec2_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec2<f32>
+
+struct __modf_result_vec2 {
+  fract : vec2<f32>, // fractional part
+  whole : vec2<f32>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec2_fract');
+    await run(t, fractBuilder(), [TypeVec(2, TypeF32)], TypeVec(2, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec2_whole')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec2<f32>
+
+struct __modf_result_vec2 {
+  fract : vec2<f32>, // fractional part
+  whole : vec2<f32>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec2_whole');
+    await run(t, wholeBuilder(), [TypeVec(2, TypeF32)], TypeVec(2, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec3_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec3<f32>
+
+struct __modf_result_vec3 {
+  fract : vec3<f32>, // fractional part
+  whole : vec3<f32>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec3_fract');
+    await run(t, fractBuilder(), [TypeVec(3, TypeF32)], TypeVec(3, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec3_whole')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec3<f32>
+
+struct __modf_result_vec3 {
+  fract : vec3<f32>, // fractional part
+  whole : vec3<f32>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec3_whole');
+    await run(t, wholeBuilder(), [TypeVec(3, TypeF32)], TypeVec(3, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec4_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec4<f32>
+
+struct __modf_result_vec4 {
+  fract : vec4<f32>, // fractional part
+  whole : vec4<f32>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec4_fract');
+    await run(t, fractBuilder(), [TypeVec(4, TypeF32)], TypeVec(4, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec4_whole')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec4<f32>
+
+struct __modf_result_vec4 {
+  fract : vec4<f32>, // fractional part
+  whole : vec4<f32>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec4_whole');
+    await run(t, wholeBuilder(), [TypeVec(4, TypeF32)], TypeVec(4, TypeF32), t.params, cases);
+  });
+
+g.test('f16_fract')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
@@ -52,32 +250,107 @@ struct __modf_result_f16 {
   .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
-g.test('vector_f32')
+g.test('f16_whole')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is vecN<f32>
+T is f16
 
-struct __modf_result_vecN {
-  fract : vecN<f32>, // fractional part
-  whole : vecN<f32>  // whole part
+struct __modf_result_f16 {
+  fract : f16, // fractional part
+  whole : f16  // whole part
 }
 `
   )
-  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
-g.test('vector_f16')
+g.test('f16_vec2_fract')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-T is vecN<f16>
+T is vec2<f16>
 
-struct __modf_result_vecN_f16 {
-  fract : vecN<f16>, // fractional part
-  whole : vecN<f16>  // whole part
+struct __modf_result_vec2_f16 {
+  fract : vec2<f16>, // fractional part
+  whole : vec2<f16>  // whole part
 }
 `
   )
-  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
+  .params(u => u.combine('inputSource', allInputSources))
+  .unimplemented();
+
+g.test('f16_vec2_whole')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec2<f16>
+
+struct __modf_result_vec2_f16 {
+  fract : vec2<f16>, // fractional part
+  whole : vec2<f16>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .unimplemented();
+
+g.test('f16_vec3_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec3<f16>
+
+struct __modf_result_vec3_f16 {
+  fract : vec3<f16>, // fractional part
+  whole : vec3<f16>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .unimplemented();
+
+g.test('f16_vec3_whole')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec3<f16>
+
+struct __modf_result_vec3_f16 {
+  fract : vec3<f16>, // fractional part
+  whole : vec3<f16>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .unimplemented();
+
+g.test('f16_vec4_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec4<f16>
+
+struct __modf_result_vec4_f16 {
+  fract : vec4<f16>, // fractional part
+  whole : vec4<f16>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .unimplemented();
+
+g.test('f16_vec4_whole')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec4<f16>
+
+struct __modf_result_vec4_f16 {
+  fract : vec4<f16>, // fractional part
+  whole : vec4<f16>  // whole part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -970,6 +970,24 @@ export function vec4(x: Scalar, y: Scalar, z: Scalar, w: Scalar) {
   return new Vector([x, y, z, w]);
 }
 
+/**
+ * Helper for constructing Vectors from arrays of numbers
+ *
+ * @param v array of numbers to be converted, must contain 2, 3 or 4 elements
+ * @param op function to convert from number to Scalar, e.g. 'f32`
+ */
+export function toVector(v: number[], op: (n: number) => Scalar): Vector {
+  switch (v.length) {
+    case 2:
+      return vec2(op(v[0]), op(v[1]));
+    case 3:
+      return vec3(op(v[0]), op(v[1]), op(v[2]));
+    case 4:
+      return vec4(op(v[0]), op(v[1]), op(v[2]), op(v[3]));
+  }
+  unreachable(`input to 'toVector' must contain 2, 3, or 4 elements`);
+}
+
 /** Value is a Scalar or Vector value. */
 export type Value = Scalar | Vector;
 

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -130,7 +130,7 @@ export function deserializeF32Interval(data: SerializedF32Interval): F32Interval
 }
 
 /** @returns an interval containing the point or the original interval */
-function toF32Interval(n: number | IntervalBounds | F32Interval): F32Interval {
+export function toF32Interval(n: number | IntervalBounds | F32Interval): F32Interval {
   if (n instanceof F32Interval) {
     return n;
   }
@@ -1632,6 +1632,13 @@ export function mixPreciseInterval(x: number, y: number, z: number): F32Interval
     toF32Interval(z),
     MixPreciseIntervalOp
   );
+}
+
+/** Calculate an acceptance interval of modf(x) */
+export function modfInterval(n: number): { fract: F32Interval; whole: F32Interval } {
+  const fract = remainderInterval(n, 1.0);
+  const whole = subtractionInterval(n, fract);
+  return { fract, whole };
 }
 
 const MultiplicationInnerOp = {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1636,8 +1636,8 @@ export function mixPreciseInterval(x: number, y: number, z: number): F32Interval
 
 /** Calculate an acceptance interval of modf(x) */
 export function modfInterval(n: number): { fract: F32Interval; whole: F32Interval } {
-  const fract = remainderInterval(n, 1.0);
-  const whole = subtractionInterval(n, fract);
+  const fract = correctlyRoundedInterval(n % 1.0);
+  const whole = correctlyRoundedInterval(n - (n % 1.0));
   return { fract, whole };
 }
 

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1,4 +1,4 @@
-import { assert } from '../../common/util/util.js';
+import { assert, unreachable } from '../../common/util/util.js';
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 
 import { kBit, kValue } from './constants.js';
@@ -732,7 +732,7 @@ export function vectorTestValues(dimension: number, finite_only: boolean): numbe
         [-1.0, -2.0, -3.0, f],
       ]);
   }
-  return [[]];
+  unreachable(`vectorTestValues is only defined for dim 2, 3, and 4`);
 }
 
 /**


### PR DESCRIPTION
This also introduces a helper (toVector) for the common operation of converting number[] -> Vector, and exposes toF32Interval to avoid having to invoke `new F32Interval` directly.

Follow on patches will propegate these code improvements to other tests.

Fixes #1228, #1226

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
