### PR TITLE
Throw RangeError when creating a very large mappedAtCreation buffer

### DIFF
--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -72,14 +72,11 @@ g.test('mapAsync')
     }
   });
 
-g.test('mappedAtCreation,full_getMappedRange')
+g.test('mappedAtCreation')
   .desc(
-    `Test creating a very large buffer mappedAtCreation buffer should produce
-an out-of-memory error if allocation fails.
-  - Because the buffer can be immediately mapped, getMappedRange throws an OperationError only
-    because such a large ArrayBuffer cannot be created.
-  - unmap() should not throw.
-  `
+    `Test creating a very large buffer mappedAtCreation buffer should throw a RangeError only
+     because such a large ArrayBuffer cannot be created when we initialize an active buffer mapping.
+`
   )
   .params(
     oomAndSizeParams //
@@ -89,59 +86,18 @@ an out-of-memory error if allocation fails.
   .fn(async t => {
     const { oom, usage, size } = t.params;
 
-    const buffer = t.expectGPUError(
-      'out-of-memory',
-      () => t.device.createBuffer({ mappedAtCreation: true, size, usage }),
-      oom
-    );
+    const f = () => t.device.createBuffer({ mappedAtCreation: true, size, usage });
 
-    const f = () => buffer.getMappedRange();
-
-    let mapping: ArrayBuffer | undefined = undefined;
     if (oom) {
       // getMappedRange is normally valid on OOM buffers, but this one fails because the
       // (default) range is too large to create the returned ArrayBuffer.
       t.shouldThrow('RangeError', f);
     } else {
-      mapping = f();
+      const buffer = f();
+      const mapping = buffer.getMappedRange();
+      buffer.unmap();
+      if (mapping !== undefined) {
+        t.expect(mapping.byteLength === 0, 'Mapping should be detached');
+      }
     }
-
-    // Should be valid because buffer is mapped, regardless of OOM.
-    buffer.unmap();
-    if (mapping !== undefined) {
-      t.expect(mapping.byteLength === 0, 'Mapping should be detached');
-    }
-  });
-
-g.test('mappedAtCreation,smaller_getMappedRange')
-  .desc(
-    `Test creating a very large mappedAtCreation buffer should produce
-an out-of-memory error if allocation fails.
-  - Because the buffer can be immediately mapped, getMappedRange does not throw an OperationError. Calling it on a small range of the buffer successfully returns an ArrayBuffer.
-  - unmap() should detach the ArrayBuffer.
-  `
-  )
-  .params(
-    oomAndSizeParams //
-      .beginSubcases()
-      .combine('usage', kBufferUsages)
-  )
-  .fn(async t => {
-    const { oom, usage, size } = t.params;
-
-    const buffer = t.expectGPUError(
-      'out-of-memory',
-      () => t.device.createBuffer({ mappedAtCreation: true, size, usage }),
-      oom
-    );
-
-    // Note: It is always valid to get mapped ranges of a GPUBuffer that is mapped at creation,
-    // even if it is invalid, because the Content timeline might not know it is invalid.
-    // Should be valid because mappedAtCreation was set, regardless of OOM.
-    const mapping = buffer.getMappedRange(0, 16);
-    t.expect(mapping.byteLength === 16);
-
-    // Should be valid because buffer is mapped, regardless of OOM.
-    buffer.unmap();
-    t.expect(mapping.byteLength === 0, 'Mapping should be detached');
   });

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -75,7 +75,7 @@ g.test('mapAsync')
 g.test('mappedAtCreation')
   .desc(
     `Test creating a very large buffer mappedAtCreation buffer should throw a RangeError only
-     because such a large ArrayBuffer cannot be created when we initialize an active buffer mapping.
+     because such a large allocation cannot be created when we initialize an active buffer mapping.
 `
   )
   .params(

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -95,9 +95,8 @@ g.test('mappedAtCreation')
     } else {
       const buffer = f();
       const mapping = buffer.getMappedRange();
+      t.expect(mapping.byteLength === size, 'Mapping should be successful');
       buffer.unmap();
-      if (mapping !== undefined) {
-        t.expect(mapping.byteLength === 0, 'Mapping should be detached');
-      }
+      t.expect(mapping.byteLength === 0, 'Mapping should be detached');
     }
   });


### PR DESCRIPTION
According to latest WebGPU SPEC, when calling CreateBuffer() to create a very large mappedAtCreation buffer, a RangeError will be thrown as an active buffer mapping cannot be initialized. This patch updates all the tests about OOM when creating mappedAtCreation buffer to match the latest WebGPU SPEC.




Fixed: #2016

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
