### PR TITLE
Add test case about copying HTMLVideoElement to texture

### DIFF
--- a/src/webgpu/web_platform/copyToTexture/video.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/video.spec.ts
@@ -6,7 +6,6 @@ copyToTexture with HTMLVideoElement (and other video-type sources?).
 - TODO: enhance with more cases with crop, rotation, etc.
 
 TODO: consider whether external_texture and copyToTexture video tests should be in the same file
-TODO: plan
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
@@ -37,7 +36,6 @@ It creates HTMLVideoElement with videos under Resource folder.
   The tests covers:
   - Video comes from different color spaces.
   - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
-  - TODO: Compare whole contents instead of single pixels
   - TODO: partial copy tests should be added
   - TODO: all valid dstColorFormat tests should be added.
   - TODO: dst color space tests need to be added

--- a/src/webgpu/web_platform/copyToTexture/video.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/video.spec.ts
@@ -10,6 +10,92 @@ TODO: plan
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { GPUTest } from '../../gpu_test.js';
+import { GPUTest, TextureTestMixin } from '../../gpu_test.js';
+import {
+  startPlayingAndWaitForVideo,
+  getVideoElement,
+  kVideoExpectations,
+} from '../../web_platform/util.js';
 
-export const g = makeTestGroup(GPUTest);
+const kFormat = 'rgba8unorm';
+
+export const g = makeTestGroup(TextureTestMixin(GPUTest));
+
+g.test('copy_from_video_element')
+  .desc(
+    `
+Test HTMLVideoElement can be copied to WebGPU texture correctly.
+
+It creates HTMLVideoElement with videos under Resource folder.
+
+  Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
+  of dst texture, and read the contents out to compare with the ImageBitmap contents.
+
+  If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
+  is flipped.
+
+  The tests covers:
+  - Video comes from different color spaces.
+  - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
+  - TODO: Compare whole contents instead of single pixels
+  - TODO: partial copy tests should be added
+  - TODO: all valid dstColorFormat tests should be added.
+  - TODO: dst color space tests need to be added
+`
+  )
+  .params(u =>
+    u //
+      .combineWithParams(kVideoExpectations)
+      .combine('srcDoFlipYDuringCopy', [true, false])
+  )
+  .fn(async t => {
+    const { videoName, srcDoFlipYDuringCopy } = t.params;
+
+    const videoElement = getVideoElement(t, videoName);
+
+    await startPlayingAndWaitForVideo(videoElement, () => {
+      const width = videoElement.videoWidth;
+      const height = videoElement.videoHeight;
+      const dstTexture = t.device.createTexture({
+        format: kFormat,
+        size: { width, height, depthOrArrayLayers: 1 },
+        usage:
+          GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+      });
+
+      t.queue.copyExternalImageToTexture(
+        { source: videoElement, origin: { x: 0, y: 0 }, flipY: srcDoFlipYDuringCopy },
+        {
+          texture: dstTexture,
+          origin: { x: 0, y: 0 },
+          colorSpace: 'srgb',
+          premultipliedAlpha: true,
+        },
+        { width, height, depthOrArrayLayers: 1 }
+      );
+
+      if (srcDoFlipYDuringCopy) {
+        t.expectSinglePixelComparisonsAreOkInTexture({ texture: dstTexture }, [
+          // Top-left should be blue.
+          { coord: { x: width * 0.25, y: height * 0.25 }, exp: t.params._blueExpectation },
+          // Top-right should be green.
+          { coord: { x: width * 0.75, y: height * 0.25 }, exp: t.params._greenExpectation },
+          // Bottom-left should be yellow.
+          { coord: { x: width * 0.25, y: height * 0.75 }, exp: t.params._yellowExpectation },
+          // Bottom-right should be red.
+          { coord: { x: width * 0.75, y: height * 0.75 }, exp: t.params._redExpectation },
+        ]);
+      } else {
+        t.expectSinglePixelComparisonsAreOkInTexture({ texture: dstTexture }, [
+          // Top-left should be yellow.
+          { coord: { x: width * 0.25, y: height * 0.25 }, exp: t.params._yellowExpectation },
+          // Top-right should be red.
+          { coord: { x: width * 0.75, y: height * 0.25 }, exp: t.params._redExpectation },
+          // Bottom-left should be blue.
+          { coord: { x: width * 0.25, y: height * 0.75 }, exp: t.params._blueExpectation },
+          // Bottom-right should be green.
+          { coord: { x: width * 0.75, y: height * 0.75 }, exp: t.params._greenExpectation },
+        ]);
+      }
+    });
+  });

--- a/src/webgpu/web_platform/copyToTexture/video.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/video.spec.ts
@@ -3,9 +3,6 @@ copyToTexture with HTMLVideoElement (and other video-type sources?).
 
 - videos with various encodings/formats (webm vp8, webm vp9, ogg theora, mp4), color spaces
   (bt.601, bt.709, bt.2020)
-- TODO: enhance with more cases with crop, rotation, etc.
-
-TODO: consider whether external_texture and copyToTexture video tests should be in the same file
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -14,80 +14,13 @@ import {
   startPlayingAndWaitForVideo,
   getVideoFrameFromVideoElement,
   getVideoElement,
+  kVideoExpectations,
+  kVideoRotationExpectations,
 } from '../../web_platform/util.js';
 
 const kHeight = 16;
 const kWidth = 16;
 const kFormat = 'rgba8unorm';
-
-// The process to calculate these expected pixel values can be found:
-// https://github.com/gpuweb/cts/pull/2242#issuecomment-1430382811
-const kBt601Red = new Uint8Array([248, 36, 0, 255]);
-const kBt601Green = new Uint8Array([64, 252, 0, 255]);
-const kBt601Blue = new Uint8Array([26, 35, 255, 255]);
-const kBt601Yellow = new Uint8Array([254, 253, 0, 255]);
-
-const kVideoExpectations = [
-  {
-    videoName: 'four-colors-vp8-bt601.webm',
-    _redExpectation: kBt601Red,
-    _greenExpectation: kBt601Green,
-    _blueExpectation: kBt601Blue,
-    _yellowExpectation: kBt601Yellow,
-  },
-  {
-    videoName: 'four-colors-theora-bt601.ogv',
-    _redExpectation: kBt601Red,
-    _greenExpectation: kBt601Green,
-    _blueExpectation: kBt601Blue,
-    _yellowExpectation: kBt601Yellow,
-  },
-  {
-    videoName: 'four-colors-h264-bt601.mp4',
-    _redExpectation: kBt601Red,
-    _greenExpectation: kBt601Green,
-    _blueExpectation: kBt601Blue,
-    _yellowExpectation: kBt601Yellow,
-  },
-  {
-    videoName: 'four-colors-vp9-bt601.webm',
-    _redExpectation: kBt601Red,
-    _greenExpectation: kBt601Green,
-    _blueExpectation: kBt601Blue,
-    _yellowExpectation: kBt601Yellow,
-  },
-  {
-    videoName: 'four-colors-vp9-bt709.webm',
-    _redExpectation: new Uint8Array([255, 0, 0, 255]),
-    _greenExpectation: new Uint8Array([0, 255, 0, 255]),
-    _blueExpectation: new Uint8Array([0, 0, 255, 255]),
-    _yellowExpectation: new Uint8Array([255, 255, 0, 255]),
-  },
-] as const;
-
-const kVideoRotationExpectations = [
-  {
-    videoName: 'four-colors-h264-bt601-rotate-90.mp4',
-    _topLeftExpectation: kBt601Red,
-    _topRightExpectation: kBt601Green,
-    _bottomLeftExpectation: kBt601Yellow,
-    _bottomRightExpectation: kBt601Blue,
-  },
-  {
-    videoName: 'four-colors-h264-bt601-rotate-180.mp4',
-    _topLeftExpectation: kBt601Green,
-    _topRightExpectation: kBt601Blue,
-    _bottomLeftExpectation: kBt601Red,
-    _bottomRightExpectation: kBt601Yellow,
-  },
-  {
-    videoName: 'four-colors-h264-bt601-rotate-270.mp4',
-    _topLeftExpectation: kBt601Blue,
-    _topRightExpectation: kBt601Yellow,
-    _bottomLeftExpectation: kBt601Green,
-    _bottomRightExpectation: kBt601Red,
-  },
-] as const;
 
 export const g = makeTestGroup(TextureTestMixin(GPUTest));
 

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -33,10 +33,29 @@ export type VideoName = keyof typeof kVideoInfo;
 // Source video color space affects expected values.
 // The process to calculate these expected pixel values can be found:
 // https://github.com/gpuweb/cts/pull/2242#issuecomment-1430382811
-const kBt601Red = new Uint8Array([248, 36, 0, 255]);
-const kBt601Green = new Uint8Array([64, 252, 0, 255]);
-const kBt601Blue = new Uint8Array([26, 35, 255, 255]);
-const kBt601Yellow = new Uint8Array([254, 253, 0, 255]);
+// and https://github.com/gpuweb/cts/pull/2242#issuecomment-1463273434
+const kBt601PixelValue = {
+  red: new Float32Array([0.972945567233341, 0.141794376683341, -0.0209589916711088, 1.0]),
+  green: new Float32Array([0.248234279433399, 0.984810378661784, -0.0564701319494314, 1.0]),
+  blue: new Float32Array([0.10159735826538, 0.135451122863674, 1.00262982899724, 1.0]),
+  yellow: new Float32Array([0.995470750775951, 0.992742114518355, -0.0774291236205402, 1.0]),
+};
+
+function convertToUnorm8(expectation: Float32Array): Uint8Array {
+  const unorm8 = new Uint8ClampedArray(expectation.length);
+
+  for (let i = 0; i < expectation.length; ++i) {
+    unorm8[i] = Math.round(expectation[i] * 255.0);
+  }
+
+  return new Uint8Array(unorm8.buffer);
+}
+
+// kVideoExpectations uses unorm8 results
+const kBt601Red = convertToUnorm8(kBt601PixelValue.red);
+const kBt601Green = convertToUnorm8(kBt601PixelValue.green);
+const kBt601Blue = convertToUnorm8(kBt601PixelValue.blue);
+const kBt601Yellow = convertToUnorm8(kBt601PixelValue.yellow);
 
 export const kVideoExpectations = [
   {

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -29,6 +29,77 @@ export const kVideoInfo = /* prettier-ignore */ makeTable(
 } as const);
 export type VideoName = keyof typeof kVideoInfo;
 
+// Expectation values about converting video contents to sRGB color space.
+// Source video color space affects expected values.
+// The process to calculate these expected pixel values can be found:
+// https://github.com/gpuweb/cts/pull/2242#issuecomment-1430382811
+const kBt601Red = new Uint8Array([248, 36, 0, 255]);
+const kBt601Green = new Uint8Array([64, 252, 0, 255]);
+const kBt601Blue = new Uint8Array([26, 35, 255, 255]);
+const kBt601Yellow = new Uint8Array([254, 253, 0, 255]);
+
+export const kVideoExpectations = [
+  {
+    videoName: 'four-colors-vp8-bt601.webm',
+    _redExpectation: kBt601Red,
+    _greenExpectation: kBt601Green,
+    _blueExpectation: kBt601Blue,
+    _yellowExpectation: kBt601Yellow,
+  },
+  {
+    videoName: 'four-colors-theora-bt601.ogv',
+    _redExpectation: kBt601Red,
+    _greenExpectation: kBt601Green,
+    _blueExpectation: kBt601Blue,
+    _yellowExpectation: kBt601Yellow,
+  },
+  {
+    videoName: 'four-colors-h264-bt601.mp4',
+    _redExpectation: kBt601Red,
+    _greenExpectation: kBt601Green,
+    _blueExpectation: kBt601Blue,
+    _yellowExpectation: kBt601Yellow,
+  },
+  {
+    videoName: 'four-colors-vp9-bt601.webm',
+    _redExpectation: kBt601Red,
+    _greenExpectation: kBt601Green,
+    _blueExpectation: kBt601Blue,
+    _yellowExpectation: kBt601Yellow,
+  },
+  {
+    videoName: 'four-colors-vp9-bt709.webm',
+    _redExpectation: new Uint8Array([255, 0, 0, 255]),
+    _greenExpectation: new Uint8Array([0, 255, 0, 255]),
+    _blueExpectation: new Uint8Array([0, 0, 255, 255]),
+    _yellowExpectation: new Uint8Array([255, 255, 0, 255]),
+  },
+] as const;
+
+export const kVideoRotationExpectations = [
+  {
+    videoName: 'four-colors-h264-bt601-rotate-90.mp4',
+    _topLeftExpectation: kBt601Red,
+    _topRightExpectation: kBt601Green,
+    _bottomLeftExpectation: kBt601Yellow,
+    _bottomRightExpectation: kBt601Blue,
+  },
+  {
+    videoName: 'four-colors-h264-bt601-rotate-180.mp4',
+    _topLeftExpectation: kBt601Green,
+    _topRightExpectation: kBt601Blue,
+    _bottomLeftExpectation: kBt601Red,
+    _bottomRightExpectation: kBt601Yellow,
+  },
+  {
+    videoName: 'four-colors-h264-bt601-rotate-270.mp4',
+    _topLeftExpectation: kBt601Blue,
+    _topRightExpectation: kBt601Yellow,
+    _bottomLeftExpectation: kBt601Green,
+    _bottomRightExpectation: kBt601Red,
+  },
+] as const;
+
 /**
  * Starts playing a video and waits for it to be consumable.
  * Returns a promise which resolves after `callback` (which may be async) completes.


### PR DESCRIPTION
This PR add a base test about copying HTMLVideoElement to texture. It also moves some helper functions from web_platfrom/external_texture/video.spec.ts to web_platform/util.ts for reusing.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
