### PR TITLE
Expect a TypeError when transferring a mapped ArrayBuffer

### DIFF
--- a/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
@@ -83,8 +83,6 @@ g.test('postMessage')
 
     buf.unmap();
     t.expect(ab1.byteLength === 0, 'after unmap, ab1 should be detached');
-    if (transfer) {
-      // Still can't transfer after detaching
-      t.shouldThrow('TypeError', () => mc.port1.postMessage(ab1, [ab1]));
-    }
+    // Still can't transfer after detaching
+    t.shouldThrow('TypeError', () => mc.port1.postMessage(ab1, [ab1]));
   });


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
