### PR TITLE
op: Add more parameters to 'color_write_mask,channel_work' test

### DIFF
--- a/src/webgpu/api/operation/rendering/color_target_state.spec.ts
+++ b/src/webgpu/api/operation/rendering/color_target_state.spec.ts
@@ -622,54 +622,62 @@ g.test('blend_constant,not_inherited')
     t.expectOK(result);
   });
 
+const kColorWriteCombinations: readonly GPUColorWriteFlags[] = [
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+];
+
 g.test('color_write_mask,channel_work')
-  .desc(`Test that the color write mask works alone or with multiple channels.`)
+  .desc(
+    `
+  Test that the color write mask works with the zero channel, a single channel, multiple channels,
+  and all channels.
+  `
+  )
   .params(u =>
-    u
-      .combine('mask1', [
-        GPUConst.ColorWrite.RED,
-        GPUConst.ColorWrite.GREEN,
-        GPUConst.ColorWrite.BLUE,
-        GPUConst.ColorWrite.ALPHA,
-      ])
-      .combine('mask2', [
-        GPUConst.ColorWrite.RED,
-        GPUConst.ColorWrite.GREEN,
-        GPUConst.ColorWrite.BLUE,
-        GPUConst.ColorWrite.ALPHA,
-      ])
+    u //
+      .combine('mask', kColorWriteCombinations)
   )
   .fn(async t => {
-    const { mask1, mask2 } = t.params;
+    const { mask } = t.params;
 
     const format = 'rgba8unorm';
     const kSize = 1;
-    const masks = [mask1, mask2];
 
     let r = 0,
       g = 0,
       b = 0,
       a = 0;
-    for (let i = 0; i < 2; i++) {
-      switch (masks[i]) {
-        case GPUColorWrite.RED:
-          r = 1;
-          break;
-        case GPUColorWrite.GREEN:
-          g = 1;
-          break;
-        case GPUColorWrite.BLUE:
-          b = 1;
-          break;
-        case GPUColorWrite.ALPHA:
-          a = 1;
-          break;
-      }
+    if (mask & GPUConst.ColorWrite.RED) {
+      r = 1;
+    }
+    if (mask & GPUConst.ColorWrite.GREEN) {
+      g = 1;
+    }
+    if (mask & GPUConst.ColorWrite.BLUE) {
+      b = 1;
+    }
+    if (mask & GPUConst.ColorWrite.ALPHA) {
+      a = 1;
     }
 
     const testPipeline = t.createRenderPipelineForTest({
       format,
-      writeMask: masks[0] | masks[1],
+      writeMask: mask,
     });
 
     const renderTarget = t.device.createTexture({


### PR DESCRIPTION
This PR adds the zero channel and all channel cases to the parameters.

Issue: #1835

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
