### PR TITLE
Handle inputs that are arrays in `cartesianProduct`

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -875,21 +875,42 @@ g.test('f16LimitsEquivalency')
     );
   });
 
-interface cartesianProductCase {
-  inputs: number[][];
-  result: number[][];
+interface cartesianProductCase<T> {
+  inputs: T[][];
+  result: T[][];
 }
 
-g.test('cartesianProduct')
-  .paramsSimple<cartesianProductCase>(
+g.test('cartesianProductNumber')
+  .paramsSimple<cartesianProductCase<number>>(
     // prettier-ignore
     [
       { inputs: [[0], [1]], result: [[0, 1]] },
-      { inputs: [[0, 1], [2]], result: [[0, 2], [1, 2]] },
-      { inputs: [[0], [1, 2]], result: [[0, 1], [0, 2]] },
-      { inputs: [[0, 1], [2, 3]], result: [[0,2], [1, 2], [0, 3], [1, 3]] },
-      { inputs: [[0, 1, 2], [3, 4, 5]], result: [[0, 3], [1, 3], [2, 3], [0, 4], [1, 4], [2, 4], [0, 5], [1, 5], [2, 5]] },
-      { inputs: [[0, 1], [2, 3], [4, 5]], result: [[0, 2, 4], [1, 2, 4], [0, 3, 4], [1, 3, 4], [0, 2, 5], [1, 2, 5], [0, 3, 5], [1, 3, 5]] },
+      { inputs: [[0, 1], [2]], result: [[0, 2],
+                                        [1, 2]] },
+      { inputs: [[0], [1, 2]], result: [[0, 1],
+                                        [0, 2]] },
+      { inputs: [[0, 1], [2, 3]], result: [[0,2],
+                                           [1, 2],
+                                           [0, 3],
+                                           [1, 3]] },
+      { inputs: [[0, 1, 2], [3, 4, 5]], result: [[0, 3],
+                                                 [1, 3],
+                                                 [2, 3],
+                                                 [0, 4],
+                                                 [1, 4],
+                                                 [2, 4],
+                                                 [0, 5],
+                                                 [1, 5],
+                                                 [2, 5]] },
+      { inputs: [[0, 1], [2, 3], [4, 5]], result: [[0, 2, 4],
+                                                   [1, 2, 4],
+                                                   [0, 3, 4],
+                                                   [1, 3, 4],
+                                                   [0, 2, 5],
+                                                   [1, 2, 5],
+                                                   [0, 3, 5],
+                                                   [1, 3, 5]] },
+
   ]
   )
   .fn(test => {
@@ -899,8 +920,45 @@ g.test('cartesianProduct')
 
     test.expect(
       objectEquals(got, expect),
-      `cartesianProduct([${inputs.map(i => '[' + i.toString() + ']')}]) returned [${got.map(
-        g => '[' + g.toString() + ']'
-      )}]. Expected ${expect.map(e => '[' + e.toString() + ']')}`
+      `cartesianProduct(${JSON.stringify(inputs)}) returned ${JSON.stringify(
+        got
+      )}. Expected ${JSON.stringify(expect)} `
+    );
+  });
+
+g.test('cartesianProductArray')
+  .paramsSimple<cartesianProductCase<number[]>>(
+    // prettier-ignore
+    [
+      { inputs: [[[0, 1], [2, 3]], [[4, 5], [6, 7]]], result: [[[0, 1], [4, 5]],
+                                                               [[2, 3], [4, 5]],
+                                                               [[0, 1], [6, 7]],
+                                                               [[2, 3], [6, 7]]]},
+      { inputs: [[[0, 1], [2, 3]], [[4, 5], [6, 7]], [[8, 9]]], result: [[[0, 1], [4, 5], [8, 9]],
+                                                                         [[2, 3], [4, 5], [8, 9]],
+                                                                         [[0, 1], [6, 7], [8, 9]],
+                                                                         [[2, 3], [6, 7], [8, 9]]]},
+      { inputs: [[[0, 1, 2], [3, 4, 5], [6, 7, 8]], [[2, 1, 0], [5, 4, 3], [8, 7, 6]]], result:  [[[0, 1, 2], [2, 1, 0]],
+                                                                                                  [[3, 4, 5], [2, 1, 0]],
+                                                                                                  [[6, 7, 8], [2, 1, 0]],
+                                                                                                  [[0, 1, 2], [5, 4, 3]],
+                                                                                                  [[3, 4, 5], [5, 4, 3]],
+                                                                                                  [[6, 7, 8], [5, 4, 3]],
+                                                                                                  [[0, 1, 2], [8, 7, 6]],
+                                                                                                  [[3, 4, 5], [8, 7, 6]],
+                                                                                                  [[6, 7, 8], [8, 7, 6]]]}
+
+    ]
+  )
+  .fn(test => {
+    const inputs = test.params.inputs;
+    const got = cartesianProduct(...inputs);
+    const expect = test.params.result;
+
+    test.expect(
+      objectEquals(got, expect),
+      `cartesianProduct(${JSON.stringify(inputs)}) returned ${JSON.stringify(
+        got
+      )}. Expected ${JSON.stringify(expect)} `
     );
   });

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -858,10 +858,10 @@ export function hexToF64(h32: number, l32: number): number {
  */
 function cartesianProductImpl<T>(elements: T[], intermediate: T[][]): T[][] {
   const result: T[][] = [];
-  elements.forEach(e => {
+  elements.forEach((e: T) => {
     if (intermediate.length > 0) {
-      intermediate.forEach(a => {
-        result.push(a.concat(e));
+      intermediate.forEach((i: T[]) => {
+        result.push([...i, e]);
       });
     } else {
       result.push([e]);
@@ -882,7 +882,7 @@ function cartesianProductImpl<T>(elements: T[], intermediate: T[][]): T[][] {
  */
 export function cartesianProduct<T>(...inputs: T[][]): T[][] {
   let result: T[][] = [];
-  inputs.forEach(i => {
+  inputs.forEach((i: T[]) => {
     result = cartesianProductImpl<T>(i, result);
   });
 


### PR DESCRIPTION
The existing use of concat will add each element of the input array to the result, instead of adding the entire array as a single element. Using spread fixes this issue.

Fixes #2030

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
