### PR TITLE
Test buffer.mapAsync() early rejection

### DIFF
--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -280,6 +280,39 @@ g.test('mapAsync,offsetAndSizeOOB')
     await t.testMapAsyncCall(success, 'OperationError', buffer, mapMode, offset, size);
   });
 
+g.test('mapAsync,earlyRejection')
+  .desc("Test that mapAsync fails immediately if it's pending map.")
+  .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions).combine('offset2', [0, 8]))
+  .fn(async t => {
+    const { mapMode, offset2 } = t.params;
+
+    const bufferSize = 16;
+    const mapSize = 8;
+    const offset1 = 0;
+
+    const buffer = t.createMappableBuffer(mapMode, bufferSize);
+
+    const p1 = buffer.mapAsync(mapMode, offset1, mapSize); // succeeds
+    let success = false;
+    {
+      let caught = false;
+      // should be already rejected
+      const p2 = buffer.mapAsync(mapMode, offset2, mapSize);
+      // queues a microtask catching the rejection
+      p2.catch(() => {
+        caught = true;
+      });
+      // queues a second microtask to capture the state immediately after the catch.
+      // Test fails if p2 isn't rejected before the second microtask is fired or
+      // p1 is resolved.
+      queueMicrotask(() => {
+        success = caught;
+      });
+    }
+    await p1; // ensure the original map still succeeds
+    assert(success);
+  });
+
 g.test('getMappedRange,state,mapped')
   .desc('Test that it is valid to call getMappedRange in the mapped state')
   .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))


### PR DESCRIPTION
With this WebGPU spec change https://github.com/gpuweb/gpuweb/pull/3348 `buffer.mapAsync()` rejects immediately if it is pending map. This commit adds a test to check it.

The test is based on https://bugs.chromium.org/p/chromium/issues/detail?id=1355994#c3 that @kainino0x suggested.


Issue: #2009 <!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
