### PR TITLE
Only try to generate errors for testable error filters

### DIFF
--- a/src/webgpu/api/validation/error_scope.spec.ts
+++ b/src/webgpu/api/validation/error_scope.spec.ts
@@ -11,7 +11,7 @@ import { Fixture } from '../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { getGPU } from '../../../common/util/navigator_gpu.js';
 import { assert, raceWithRejectOnTimeout } from '../../../common/util/util.js';
-import { kErrorScopeFilters } from '../../capability_info.js';
+import { kErrorScopeFilters, kGeneratableErrorScopeFilters } from '../../capability_info.js';
 import { kMaxUnsignedLongLongValue } from '../../constants.js';
 
 class ErrorScopeTests extends Fixture {
@@ -107,7 +107,7 @@ Tests that error scopes catches their expected errors, firing an uncaptured erro
     `
   )
   .params(u =>
-    u.combine('errorType', kErrorScopeFilters).combine('errorFilter', kErrorScopeFilters)
+    u.combine('errorType', kGeneratableErrorScopeFilters).combine('errorFilter', kErrorScopeFilters)
   )
   .fn(async t => {
     const { errorType, errorFilter } = t.params;
@@ -151,7 +151,9 @@ Tests that an error bubbles to the correct parent scope.
     `
   )
   .params(u =>
-    u.combine('errorFilter', kErrorScopeFilters).combine('stackDepth', [1, 10, 100, 1000])
+    u
+      .combine('errorFilter', kGeneratableErrorScopeFilters)
+      .combine('stackDepth', [1, 10, 100, 1000])
   )
   .fn(async t => {
     const { errorFilter, stackDepth } = t.params;
@@ -189,7 +191,9 @@ Tests that an error does not bubbles to parent scopes when local scope matches.
     `
   )
   .params(u =>
-    u.combine('errorFilter', kErrorScopeFilters).combine('stackDepth', [1, 10, 100, 1000, 100000])
+    u
+      .combine('errorFilter', kGeneratableErrorScopeFilters)
+      .combine('stackDepth', [1, 10, 100, 1000, 100000])
   )
   .fn(async t => {
     const { errorFilter, stackDepth } = t.params;

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -75,8 +75,9 @@ export const kErrorScopeFilterInfo: {
   'validation':    {},
   'internal':      {},
 };
-/** List of all GPUTextureAspect values. */
+/** List of all GPUErrorFilter values. */
 export const kErrorScopeFilters = keysOf(kErrorScopeFilterInfo);
+export const kGeneratableErrorScopeFilters = kErrorScopeFilters.filter(e => e !== 'internal');
 
 // Textures
 


### PR DESCRIPTION
The "internal" error filter is not testable in a portable manner so tests that try to generate "internal" errors are not possible.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
