### PR TITLE
Fix workgroup array size limit validation test

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -505,8 +505,8 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
               ${vec4Count <= 0 ? '' : 'var<workgroup> vec4_data: array<vec4<f32>, a>;'}
               ${mat4Count <= 0 ? '' : 'var<workgroup> mat4_data: array<mat4x4<f32>, b>;'}
               @compute @workgroup_size(1) fn main() {
-                ${vec4Count <= 0 ? '' : '_ = vec4_data;'}
-                ${vec4Count <= 0 ? '' : '_ = mat4_data;'}
+                ${vec4Count <= 0 ? '' : '_ = vec4_data[0];'}
+                ${mat4Count <= 0 ? '' : '_ = mat4_data[0];'}
               }`,
           }),
           entryPoint: 'main',


### PR DESCRIPTION
Arrays with pipeline-overridable element counts are not considered constructible and so cannot be assigned from. Instead just load a single element.

Also fix the selector expression for the matrix case.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
