### PR TITLE
Replace calls to `F32Interval` constructor with `toF32Interval`

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -406,8 +406,8 @@ g.test('span')
     ]
   )
   .fn(t => {
-    const intervals = t.params.intervals.map(x => new F32Interval(...x));
-    const expected = new F32Interval(...t.params.expected);
+    const intervals = t.params.intervals.map(toF32Interval);
+    const expected = toF32Interval(t.params.expected);
 
     const got = F32Interval.span(...intervals);
     t.expect(
@@ -464,7 +464,7 @@ g.test('correctlyRoundedInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = correctlyRoundedInterval(t.params.value);
     t.expect(
@@ -538,7 +538,7 @@ g.test('absoluteErrorInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = absoluteErrorInterval(t.params.value, t.params.error);
     t.expect(
@@ -612,7 +612,7 @@ g.test('ulpInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = ulpInterval(t.params.value, t.params.num_ulp);
     t.expect(
@@ -659,7 +659,7 @@ g.test('absInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = absInterval(t.params.input);
     t.expect(
@@ -688,7 +688,7 @@ g.test('acosInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = acosInterval(t.params.input);
     t.expect(
@@ -715,7 +715,7 @@ g.test('acoshAlternativeInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = acoshAlternativeInterval(t.params.input);
     t.expect(
@@ -742,7 +742,7 @@ g.test('acoshPrimaryInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = acoshPrimaryInterval(t.params.input);
     t.expect(
@@ -771,7 +771,7 @@ g.test('asinInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = asinInterval(t.params.input);
     t.expect(
@@ -796,7 +796,7 @@ g.test('asinhInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = asinhInterval(t.params.input);
     t.expect(
@@ -826,7 +826,7 @@ g.test('atanInterval')
     };
 
     t.params.expected = applyError(t.params.expected, error);
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = atanInterval(t.params.input);
     t.expect(
@@ -853,7 +853,7 @@ g.test('atanhInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = atanhInterval(t.params.input);
     t.expect(
@@ -896,7 +896,7 @@ g.test('ceilInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = ceilInterval(t.params.input);
     t.expect(
@@ -930,7 +930,7 @@ g.test('cosInterval')
     };
 
     t.params.expected = applyError(t.params.expected, error);
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = cosInterval(t.params.input);
     t.expect(
@@ -955,7 +955,7 @@ g.test('coshInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = coshInterval(t.params.input);
     t.expect(
@@ -988,7 +988,7 @@ g.test('degreesInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = degreesInterval(t.params.input);
     t.expect(
@@ -1014,7 +1014,7 @@ g.test('expInterval')
     };
 
     t.params.expected = applyError(t.params.expected, error);
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = expInterval(t.params.input);
     t.expect(
@@ -1040,7 +1040,7 @@ g.test('exp2Interval')
     };
 
     t.params.expected = applyError(t.params.expected, error);
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = exp2Interval(t.params.input);
     t.expect(
@@ -1083,7 +1083,7 @@ g.test('floorInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = floorInterval(t.params.input);
     t.expect(
@@ -1116,7 +1116,7 @@ g.test('fractInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = fractInterval(t.params.input);
     t.expect(
@@ -1144,7 +1144,7 @@ g.test('inverseSqrtInterval')
     };
 
     t.params.expected = applyError(t.params.expected, error);
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = inverseSqrtInterval(t.params.input);
     t.expect(
@@ -1185,7 +1185,7 @@ g.test('lengthIntervalScalar')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = lengthInterval(t.params.input);
     t.expect(
@@ -1214,7 +1214,7 @@ g.test('logInterval')
     };
 
     t.params.expected = applyError(t.params.expected, error);
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = logInterval(t.params.input);
     t.expect(
@@ -1243,7 +1243,7 @@ g.test('log2Interval')
     };
 
     t.params.expected = applyError(t.params.expected, error);
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = log2Interval(t.params.input);
     t.expect(
@@ -1280,7 +1280,7 @@ g.test('negationInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = negationInterval(t.params.input);
     t.expect(
@@ -1315,7 +1315,7 @@ g.test('quantizeToF16Interval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = quantizeToF16Interval(t.params.input);
     t.expect(
@@ -1346,7 +1346,7 @@ g.test('radiansInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = radiansInterval(t.params.input);
     t.expect(
@@ -1393,7 +1393,7 @@ g.test('roundInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = roundInterval(t.params.input);
     t.expect(
@@ -1432,7 +1432,7 @@ g.test('saturateInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = saturateInterval(t.params.input);
     t.expect(
@@ -1465,7 +1465,7 @@ g.test('signInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = signInterval(t.params.input);
     t.expect(
@@ -1497,7 +1497,7 @@ g.test('sinInterval')
     };
 
     t.params.expected = applyError(t.params.expected, error);
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = sinInterval(t.params.input);
     t.expect(
@@ -1522,7 +1522,7 @@ g.test('sinhInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = sinhInterval(t.params.input);
     t.expect(
@@ -1547,7 +1547,7 @@ g.test('sqrtInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = sqrtInterval(t.params.input);
     t.expect(
@@ -1581,7 +1581,7 @@ g.test('tanInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = tanInterval(t.params.input);
     t.expect(
@@ -1606,7 +1606,7 @@ g.test('tanhInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = tanhInterval(t.params.input);
     t.expect(
@@ -1647,7 +1647,7 @@ g.test('truncInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = truncInterval(t.params.input);
     t.expect(
@@ -1711,7 +1711,7 @@ g.test('additionInterval')
   )
   .fn(t => {
     const [x, y] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = additionInterval(x, y);
     t.expect(
@@ -1766,7 +1766,7 @@ g.test('atan2Interval')
   )
   .fn(t => {
     const [y, x] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = atan2Interval(y, x);
     t.expect(
@@ -1817,7 +1817,7 @@ g.test('distanceIntervalScalar')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = distanceInterval(...t.params.input);
     t.expect(
@@ -1869,7 +1869,7 @@ g.test('divisionInterval')
 
     const [x, y] = t.params.input;
     t.params.expected = applyError(t.params.expected, error);
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = divisionInterval(x, y);
     t.expect(
@@ -1918,7 +1918,7 @@ g.test('ldexpInterval')
   )
   .fn(t => {
     const [x, y] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = ldexpInterval(x, y);
     t.expect(
@@ -1975,7 +1975,7 @@ g.test('maxInterval')
   )
   .fn(t => {
     const [x, y] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = maxInterval(x, y);
     t.expect(
@@ -2032,7 +2032,7 @@ g.test('minInterval')
   )
   .fn(t => {
     const [x, y] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = minInterval(x, y);
     t.expect(
@@ -2095,7 +2095,7 @@ g.test('multiplicationInterval')
   )
   .fn(t => {
     const [x, y] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = multiplicationInterval(x, y);
     t.expect(
@@ -2146,7 +2146,7 @@ g.test('remainderInterval')
   )
   .fn(t => {
     const [x, y] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = remainderInterval(x, y);
     t.expect(
@@ -2179,7 +2179,7 @@ g.test('powInterval')
   )
   .fn(t => {
     const [x, y] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = powInterval(x, y);
     t.expect(
@@ -2256,7 +2256,7 @@ g.test('stepInterval')
   )
   .fn(t => {
     const [edge, x] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = stepInterval(edge, x);
     t.expect(
@@ -2313,7 +2313,7 @@ g.test('subtractionInterval')
   )
   .fn(t => {
     const [x, y] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = subtractionInterval(x, y);
     t.expect(
@@ -2369,7 +2369,7 @@ g.test('clampMedianInterval')
   )
   .fn(t => {
     const [x, y, z] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = clampMedianInterval(x, y, z);
     t.expect(
@@ -2420,7 +2420,7 @@ g.test('clampMinMaxInterval')
   )
   .fn(t => {
     const [x, y, z] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = clampMinMaxInterval(x, y, z);
     t.expect(
@@ -2470,7 +2470,7 @@ g.test('fmaInterval')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = fmaInterval(...t.params.input);
     t.expect(
@@ -2548,7 +2548,7 @@ g.test('mixImpreciseInterval')
   )
   .fn(t => {
     const [x, y, z] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = mixImpreciseInterval(x, y, z);
     t.expect(
@@ -2626,7 +2626,7 @@ g.test('mixPreciseInterval')
   )
   .fn(t => {
     const [x, y, z] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = mixPreciseInterval(x, y, z);
     t.expect(
@@ -2680,7 +2680,7 @@ g.test('smoothStepInterval')
   )
   .fn(t => {
     const [low, high, x] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = smoothStepInterval(low, high, x);
     t.expect(
@@ -2930,7 +2930,7 @@ g.test('lengthIntervalVector')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = lengthInterval(t.params.input);
     t.expect(
@@ -2998,7 +2998,7 @@ g.test('distanceIntervalVector')
     ]
   )
   .fn(t => {
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = distanceInterval(...t.params.input);
     t.expect(
@@ -3041,7 +3041,7 @@ g.test('dotInterval')
   )
   .fn(t => {
     const [x, y] = t.params.input;
-    const expected = new F32Interval(...t.params.expected);
+    const expected = toF32Interval(t.params.expected);
 
     const got = dotInterval(x, y);
     t.expect(
@@ -3083,7 +3083,7 @@ g.test('normalizeInterval')
   )
   .fn(t => {
     const x = t.params.input;
-    const expected = t.params.expected.map(e => new F32Interval(...e));
+    const expected = t.params.expected.map(toF32Interval);
 
     const got = normalizeInterval(x);
     t.expect(

--- a/src/unittests/serialization.spec.ts
+++ b/src/unittests/serialization.spec.ts
@@ -27,8 +27,8 @@ import {
 } from '../webgpu/util/conversion.js';
 import {
   deserializeF32Interval,
-  F32Interval,
   serializeF32Interval,
+  toF32Interval,
 } from '../webgpu/util/f32_interval.js';
 
 import { UnitTest } from './unit_test.js';
@@ -142,28 +142,28 @@ g.test('value').fn(t => {
 
 g.test('f32_interval').fn(t => {
   for (const interval of [
-    new F32Interval(0),
-    new F32Interval(-0),
-    new F32Interval(1),
-    new F32Interval(-1),
-    new F32Interval(0.5),
-    new F32Interval(-0.5),
-    new F32Interval(kValue.f32.positive.max),
-    new F32Interval(kValue.f32.positive.min),
-    new F32Interval(kValue.f32.subnormal.positive.max),
-    new F32Interval(kValue.f32.subnormal.positive.min),
-    new F32Interval(kValue.f32.subnormal.negative.max),
-    new F32Interval(kValue.f32.subnormal.negative.min),
-    new F32Interval(kValue.f32.infinity.positive),
-    new F32Interval(kValue.f32.infinity.negative),
+    toF32Interval(0),
+    toF32Interval(-0),
+    toF32Interval(1),
+    toF32Interval(-1),
+    toF32Interval(0.5),
+    toF32Interval(-0.5),
+    toF32Interval(kValue.f32.positive.max),
+    toF32Interval(kValue.f32.positive.min),
+    toF32Interval(kValue.f32.subnormal.positive.max),
+    toF32Interval(kValue.f32.subnormal.positive.min),
+    toF32Interval(kValue.f32.subnormal.negative.max),
+    toF32Interval(kValue.f32.subnormal.negative.min),
+    toF32Interval(kValue.f32.infinity.positive),
+    toF32Interval(kValue.f32.infinity.negative),
 
-    new F32Interval(-0, 0),
-    new F32Interval(-1, 1),
-    new F32Interval(-0.5, 0.5),
-    new F32Interval(kValue.f32.positive.min, kValue.f32.positive.max),
-    new F32Interval(kValue.f32.subnormal.positive.min, kValue.f32.subnormal.positive.max),
-    new F32Interval(kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max),
-    new F32Interval(kValue.f32.infinity.negative, kValue.f32.infinity.positive),
+    toF32Interval([-0, 0]),
+    toF32Interval([-1, 1]),
+    toF32Interval([-0.5, 0.5]),
+    toF32Interval([kValue.f32.positive.min, kValue.f32.positive.max]),
+    toF32Interval([kValue.f32.subnormal.positive.min, kValue.f32.subnormal.positive.max]),
+    toF32Interval([kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max]),
+    toF32Interval([kValue.f32.infinity.negative, kValue.f32.infinity.positive]),
   ]) {
     const serialized = serializeF32Interval(interval);
     const deserialized = deserializeF32Interval(serialized);
@@ -180,10 +180,10 @@ g.test('expression_expectation').fn(t => {
     f32(123),
     vec2(f32(1), f32(2)),
     // Interval
-    new F32Interval(-0.5, 0.5),
-    new F32Interval(kValue.f32.positive.min, kValue.f32.positive.max),
+    toF32Interval([-0.5, 0.5]),
+    toF32Interval([kValue.f32.positive.min, kValue.f32.positive.max]),
     // Intervals
-    [new F32Interval(-8.0, 0.5), new F32Interval(2.0, 4.0)],
+    [toF32Interval([-8.0, 0.5]), toF32Interval([2.0, 4.0])],
   ]) {
     const serialized = serializeExpectation(expectation);
     const deserialized = deserializeExpectation(serialized);

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf } from '../../../../../util/compare.js';
 import { f32, TypeF32 } from '../../../../../util/conversion.js';
-import { F32Interval, stepInterval } from '../../../../../util/f32_interval.js';
+import { stepInterval, toF32Interval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
@@ -22,8 +22,8 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('step', {
   f32: () => {
-    const zeroInterval = new F32Interval(0, 0);
-    const oneInterval = new F32Interval(1, 1);
+    const zeroInterval = toF32Interval(0);
+    const oneInterval = toF32Interval(1);
 
     // stepInterval's return value isn't always interpreted as an acceptance
     // interval, so makeBinaryToF32IntervalCase cannot be used here.

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -31,6 +31,8 @@ export class F32Interval {
 
   /** Constructor
    *
+   * `toF32Interval` is the preferred way to create F32Intervals
+   *
    * @param bounds either a pair of numbers indicating the beginning then the
    *               end of the interval, or a single element array indicating the
    *               interval is a point
@@ -126,7 +128,7 @@ export function serializeF32Interval(i: F32Interval): SerializedF32Interval {
 export function deserializeF32Interval(data: SerializedF32Interval): F32Interval {
   return data === 'any'
     ? F32Interval.any()
-    : new F32Interval(reinterpretU32AsF32(data.begin), reinterpretU32AsF32(data.end));
+    : toF32Interval([reinterpretU32AsF32(data.begin), reinterpretU32AsF32(data.end)]);
 }
 
 /** @returns an interval containing the point or the original interval */
@@ -143,16 +145,16 @@ export function toF32Interval(n: number | IntervalBounds | F32Interval): F32Inte
 }
 
 /** F32Interval of [-π, π] */
-const kNegPiToPiInterval = new F32Interval(
+const kNegPiToPiInterval = toF32Interval([
   kValue.f32.negative.pi.whole,
-  kValue.f32.positive.pi.whole
-);
+  kValue.f32.positive.pi.whole,
+]);
 
 /** F32Interval of values greater than 0 and less than or equal to f32 max */
-const kGreaterThanZeroInterval = new F32Interval(
+const kGreaterThanZeroInterval = toF32Interval([
   kValue.f32.subnormal.positive.min,
-  kValue.f32.positive.max
-);
+  kValue.f32.positive.max,
+]);
 
 /** Representation of a vec2/3/4 of floating point intervals as an array of F32Intervals */
 type F32Vector =
@@ -943,7 +945,7 @@ function AbsoluteErrorIntervalOp(error_range: number): PointToIntervalOp {
   if (isFiniteF32(error_range)) {
     op.impl = (n: number) => {
       assert(!Number.isNaN(n), `absolute error not defined for NaN`);
-      return new F32Interval(n - error_range, n + error_range);
+      return toF32Interval([n - error_range, n + error_range]);
     };
   }
 
@@ -972,10 +974,10 @@ function ULPIntervalOp(numULP: number): PointToIntervalOp {
       const begin = n - numULP * ulp;
       const end = n + numULP * ulp;
 
-      return new F32Interval(
+      return toF32Interval([
         Math.min(begin, flushSubnormalNumberF32(begin)),
-        Math.max(end, flushSubnormalNumberF32(end))
-      );
+        Math.max(end, flushSubnormalNumberF32(end)),
+      ]);
     };
   }
 
@@ -1322,8 +1324,8 @@ export function distanceInterval(x: number | number[], y: number | number[]): F3
 const DivisionIntervalOp: BinaryToIntervalOp = {
   impl: limitBinaryToIntervalDomain(
     {
-      x: new F32Interval(kValue.f32.negative.min, kValue.f32.positive.max),
-      y: [new F32Interval(-(2 ** 126), -(2 ** -126)), new F32Interval(2 ** -126, 2 ** 126)],
+      x: toF32Interval([kValue.f32.negative.min, kValue.f32.positive.max]),
+      y: [toF32Interval([-(2 ** 126), -(2 ** -126)]), toF32Interval([2 ** -126, 2 ** 126])],
     },
     (x: number, y: number): F32Interval => {
       if (y === 0) {
@@ -1491,8 +1493,8 @@ const LdexpIntervalOp: BinaryToIntervalOp = {
     // Implementing SPIR-V's more restrictive domain until
     // https://github.com/gpuweb/gpuweb/issues/3134 is resolved
     {
-      x: new F32Interval(kValue.f32.negative.min, kValue.f32.positive.max),
-      y: [new F32Interval(-126, 128)],
+      x: toF32Interval([kValue.f32.negative.min, kValue.f32.positive.max]),
+      y: [toF32Interval([-126, 128])],
     },
     (e1: number, e2: number): F32Interval => {
       // Though the spec says the result of ldexp(e1, e2) = e1 * 2 ^ e2, the


### PR DESCRIPTION
Fixes #2027

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
