### PR TITLE
op: Implement stencil_fail_operation test in stencil.spec.ts

### DIFF
--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -9,7 +9,13 @@ import { TexelView } from '../../../util/texture/texel_view.js';
 import { textureContentIsOKByT2B } from '../../../util/texture/texture_ok.js';
 
 const kBaseColor = new Float32Array([1.0, 1.0, 1.0, 1.0]);
-const kStencilColor = new Float32Array([0.0, 0.0, 0.0, 1.0]);
+const kRedStencilColor = new Float32Array([1.0, 0.0, 0.0, 1.0]);
+const kGreenStencilColor = new Float32Array([0.0, 1.0, 0.0, 1.0]);
+
+type TestStates = {
+  state: GPUDepthStencilState;
+  color: Float32Array;
+};
 
 class StencilTest extends GPUTest {
   checkStencilCompareFunction(
@@ -47,12 +53,13 @@ class StencilTest extends GPUTest {
       stencilBack: stencilState,
     } as const;
 
-    this.runStencilStateTest(baseState, state, stencilRefValue, expectedColor);
+    const testParams = [{ state, color: kGreenStencilColor }];
+    this.runStencilStateTest(baseState, testParams, stencilRefValue, expectedColor);
   }
 
   runStencilStateTest(
     baseState: GPUDepthStencilState,
-    state: GPUDepthStencilState,
+    testStates: TestStates[],
     stencilRefValue: number,
     expectedColor: Float32Array
   ) {
@@ -106,14 +113,14 @@ class StencilTest extends GPUTest {
     }
 
     // Draw a triangle with the given stencil reference and the comparison function.
-    // The color will be kStencilColor if the stencil test passes, and kBaseColor if not.
-    {
-      const testPipeline = this.createRenderPipelineForTest(state);
+    // The color will be kGreenStencilColor if the stencil test passes, and kBaseColor if not.
+    for (const test of testStates) {
+      const testPipeline = this.createRenderPipelineForTest(test.state);
       pass.setPipeline(testPipeline);
       pass.setStencilReference(stencilRefValue);
       pass.setBindGroup(
         0,
-        this.createBindGroupForTest(testPipeline.getBindGroupLayout(0), kStencilColor)
+        this.createBindGroupForTest(testPipeline.getBindGroupLayout(0), test.color)
       );
       pass.draw(1);
     }
@@ -200,33 +207,115 @@ g.test('stencil_compare_func')
   .params(u =>
     u //
       .combineWithParams([
-        { stencilCompare: 'always', stencilRefValue: 0, _expectedColor: kStencilColor },
-        { stencilCompare: 'always', stencilRefValue: 1, _expectedColor: kStencilColor },
-        { stencilCompare: 'always', stencilRefValue: 2, _expectedColor: kStencilColor },
+        { stencilCompare: 'always', stencilRefValue: 0, _expectedColor: kGreenStencilColor },
+        { stencilCompare: 'always', stencilRefValue: 1, _expectedColor: kGreenStencilColor },
+        { stencilCompare: 'always', stencilRefValue: 2, _expectedColor: kGreenStencilColor },
         { stencilCompare: 'equal', stencilRefValue: 0, _expectedColor: kBaseColor },
-        { stencilCompare: 'equal', stencilRefValue: 1, _expectedColor: kStencilColor },
+        { stencilCompare: 'equal', stencilRefValue: 1, _expectedColor: kGreenStencilColor },
         { stencilCompare: 'equal', stencilRefValue: 2, _expectedColor: kBaseColor },
         { stencilCompare: 'greater', stencilRefValue: 0, _expectedColor: kBaseColor },
         { stencilCompare: 'greater', stencilRefValue: 1, _expectedColor: kBaseColor },
-        { stencilCompare: 'greater', stencilRefValue: 2, _expectedColor: kStencilColor },
+        { stencilCompare: 'greater', stencilRefValue: 2, _expectedColor: kGreenStencilColor },
         { stencilCompare: 'greater-equal', stencilRefValue: 0, _expectedColor: kBaseColor },
-        { stencilCompare: 'greater-equal', stencilRefValue: 1, _expectedColor: kStencilColor },
-        { stencilCompare: 'greater-equal', stencilRefValue: 2, _expectedColor: kStencilColor },
-        { stencilCompare: 'less', stencilRefValue: 0, _expectedColor: kStencilColor },
+        { stencilCompare: 'greater-equal', stencilRefValue: 1, _expectedColor: kGreenStencilColor },
+        { stencilCompare: 'greater-equal', stencilRefValue: 2, _expectedColor: kGreenStencilColor },
+        { stencilCompare: 'less', stencilRefValue: 0, _expectedColor: kGreenStencilColor },
         { stencilCompare: 'less', stencilRefValue: 1, _expectedColor: kBaseColor },
         { stencilCompare: 'less', stencilRefValue: 2, _expectedColor: kBaseColor },
-        { stencilCompare: 'less-equal', stencilRefValue: 0, _expectedColor: kStencilColor },
-        { stencilCompare: 'less-equal', stencilRefValue: 1, _expectedColor: kStencilColor },
+        { stencilCompare: 'less-equal', stencilRefValue: 0, _expectedColor: kGreenStencilColor },
+        { stencilCompare: 'less-equal', stencilRefValue: 1, _expectedColor: kGreenStencilColor },
         { stencilCompare: 'less-equal', stencilRefValue: 2, _expectedColor: kBaseColor },
         { stencilCompare: 'never', stencilRefValue: 0, _expectedColor: kBaseColor },
         { stencilCompare: 'never', stencilRefValue: 1, _expectedColor: kBaseColor },
         { stencilCompare: 'never', stencilRefValue: 2, _expectedColor: kBaseColor },
-        { stencilCompare: 'not-equal', stencilRefValue: 0, _expectedColor: kStencilColor },
+        { stencilCompare: 'not-equal', stencilRefValue: 0, _expectedColor: kGreenStencilColor },
         { stencilCompare: 'not-equal', stencilRefValue: 1, _expectedColor: kBaseColor },
-        { stencilCompare: 'not-equal', stencilRefValue: 2, _expectedColor: kStencilColor },
+        { stencilCompare: 'not-equal', stencilRefValue: 2, _expectedColor: kGreenStencilColor },
       ] as const)
   )
   .fn(async t => {
     const { stencilCompare, stencilRefValue, _expectedColor } = t.params;
     t.checkStencilCompareFunction(stencilCompare, stencilRefValue, _expectedColor);
+  });
+
+g.test('stencil_fail_operation')
+  .desc(
+    `
+  Test that the stencil operation is executed on stencil fail. Triangle with stencil reference 2
+  fails the 'less' comparison function because the base stencil reference is 1.
+    - If the fail operation is 'keep', it keeps the base color.
+    - If the fail operation is 'replace', it replaces the base color with the last stencil color.
+
+  TODO: Need to test the other stencil operations?
+  `
+  )
+  .params(u =>
+    u //
+      .combineWithParams([
+        { operation: 'keep', _expectedColor: kBaseColor },
+        { operation: 'replace', _expectedColor: kGreenStencilColor },
+      ] as const)
+  )
+  .fn(async t => {
+    const { operation, _expectedColor } = t.params;
+
+    const depthSpencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
+
+    const baseStencilState = {
+      compare: 'always',
+      failOp: 'keep',
+      passOp: 'replace',
+    } as const;
+
+    const failedStencilState = {
+      compare: 'less',
+      failOp: operation,
+      passOp: 'keep',
+    } as const;
+
+    const stencilState = {
+      compare: 'equal',
+      failOp: 'keep',
+      passOp: 'keep',
+    } as const;
+
+    const baseState = {
+      format: depthSpencilFormat,
+      depthWriteEnabled: false,
+      depthCompare: 'always',
+      stencilFront: baseStencilState,
+      stencilBack: baseStencilState,
+      stencilReadMask: 0xff,
+      stencilWriteMask: 0xff,
+    } as const;
+
+    const failState = {
+      format: depthSpencilFormat,
+      depthWriteEnabled: false,
+      depthCompare: 'always',
+      stencilFront: failedStencilState,
+      stencilBack: failedStencilState,
+      stencilReadMask: 0xff,
+      stencilWriteMask: 0xff,
+    } as const;
+
+    const passState = {
+      format: depthSpencilFormat,
+      depthWriteEnabled: false,
+      depthCompare: 'always',
+      stencilFront: stencilState,
+      stencilBack: stencilState,
+      stencilReadMask: 0xff,
+      stencilWriteMask: 0xff,
+    } as const;
+
+    const testStates = [
+      // Always fails because the ref (2) is less than the initial stencil contents (1).
+      // Therefore red is never drawn, and the stencil contents may be updated according to
+      // `operation`.
+      { state: failState, color: kRedStencilColor },
+      // Passes iff the ref (2) equals the current stencil contents (1 or 2).
+      { state: passState, color: kGreenStencilColor },
+    ];
+    t.runStencilStateTest(baseState, testStates, 2, _expectedColor);
   });


### PR DESCRIPTION
This PR adds a new test to check if the fail stencil operations work correctly. The test only checks 'keep' and 'replace' operations for now.

Issue: #2023

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
