### PR TITLE
expect command encoder validation error to be at beginRenderPass/beginComputePass time

### DIFF
--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -17,7 +17,9 @@ class F extends ValidationTest {
     this.expectValidationError(() => {
       pass.end();
     }, !success);
-    encoder.finish();
+    this.expectValidationError(() => {
+      encoder.finish();
+    }, !success);
   }
 }
 

--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -10,9 +10,14 @@ class F extends ValidationTest {
   tryComputePass(success: boolean, descriptor: GPUComputePassDescriptor): void {
     const encoder = this.device.createCommandEncoder();
 
+    let pass: GPUComputePassEncoder;
     this.expectValidationError(() => {
-      encoder.beginComputePass(descriptor);
+      pass = encoder.beginComputePass(descriptor);
     }, !success);
+    this.expectValidationError(() => {
+      pass.end();
+    }, !success);
+    encoder.finish();
   }
 }
 

--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -9,11 +9,9 @@ import { ValidationTest } from '../validation_test.js';
 class F extends ValidationTest {
   tryComputePass(success: boolean, descriptor: GPUComputePassDescriptor): void {
     const encoder = this.device.createCommandEncoder();
-    const computePass = encoder.beginComputePass(descriptor);
-    computePass.end();
 
     this.expectValidationError(() => {
-      encoder.finish();
+      encoder.beginComputePass(descriptor);
     }, !success);
   }
 }

--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -14,9 +14,7 @@ class F extends ValidationTest {
     this.expectValidationError(() => {
       pass = encoder.beginComputePass(descriptor);
     }, !success);
-    this.expectValidationError(() => {
-      pass.end();
-    }, !success);
+    pass.end();
     this.expectValidationError(() => {
       encoder.finish();
     }, !success);

--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -14,7 +14,9 @@ class F extends ValidationTest {
     this.expectValidationError(() => {
       pass = encoder.beginComputePass(descriptor);
     }, !success);
-    pass.end();
+    this.expectValidationError(() => {
+      pass.end();
+    }, false);
     this.expectValidationError(() => {
       encoder.finish();
     }, !success);

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -82,28 +82,28 @@ g.test('color_attachments,device_mismatch')
       ? t.getDeviceMismatchedRenderTexture()
       : t.getRenderTexture();
 
-    const encoder = t.createEncoder('non-pass');
-    const pass = encoder.encoder.beginRenderPass({
-      colorAttachments: [
-        {
-          view: view0Texture.createView(),
-          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
-          loadOp: 'clear',
-          storeOp: 'store',
-          resolveTarget: target0Texture.createView(),
-        },
-        {
-          view: view1Texture.createView(),
-          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
-          loadOp: 'clear',
-          storeOp: 'store',
-          resolveTarget: target1Texture.createView(),
-        },
-      ],
-    });
-    pass.end();
-
-    encoder.validateFinish(!mismatched);
+    t.expectValidationError(() => {
+      const encoder = t.createEncoder('non-pass');
+      const pass = encoder.encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: view0Texture.createView(),
+            clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+            loadOp: 'clear',
+            storeOp: 'store',
+            resolveTarget: target0Texture.createView(),
+          },
+          {
+            view: view1Texture.createView(),
+            clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+            loadOp: 'clear',
+            storeOp: 'store',
+            resolveTarget: target1Texture.createView(),
+          },
+        ],
+      });
+      pass.end();
+    }, mismatched);
   });
 
 g.test('depth_stencil_attachment,device_mismatch')
@@ -127,22 +127,22 @@ g.test('depth_stencil_attachment,device_mismatch')
       ? t.getDeviceMismatchedTexture(descriptor)
       : t.device.createTexture(descriptor);
 
-    const encoder = t.createEncoder('non-pass');
-    const pass = encoder.encoder.beginRenderPass({
-      colorAttachments: [],
-      depthStencilAttachment: {
-        view: depthStencilTexture.createView(),
-        depthClearValue: 0,
-        depthLoadOp: 'clear',
-        depthStoreOp: 'store',
-        stencilClearValue: 0,
-        stencilLoadOp: 'clear',
-        stencilStoreOp: 'store',
-      },
-    });
-    pass.end();
-
-    encoder.validateFinish(!mismatched);
+    t.expectValidationError(() => {
+      const encoder = t.createEncoder('non-pass');
+      const pass = encoder.encoder.beginRenderPass({
+        colorAttachments: [],
+        depthStencilAttachment: {
+          view: depthStencilTexture.createView(),
+          depthClearValue: 0,
+          depthLoadOp: 'clear',
+          depthStoreOp: 'store',
+          stencilClearValue: 0,
+          stencilLoadOp: 'clear',
+          stencilStoreOp: 'store',
+        },
+      });
+      pass.end();
+    }, mismatched);
   });
 
 g.test('occlusion_query_set,device_mismatch')
@@ -163,8 +163,9 @@ g.test('occlusion_query_set,device_mismatch')
     });
     t.trackForCleanup(occlusionQuerySet);
 
-    const encoder = t.createEncoder('render pass', { occlusionQuerySet });
-    encoder.validateFinish(!mismatched);
+    t.expectValidationError(() => {
+      t.createEncoder('render pass', { occlusionQuerySet });
+    }, mismatched);
   });
 
 g.test('timestamp_query_set,device_mismatch')
@@ -195,17 +196,17 @@ g.test('timestamp_query_set,device_mismatch')
     });
 
     const encoder = t.createEncoder('non-pass');
-    const pass = encoder.encoder.beginRenderPass({
-      colorAttachments: [
-        {
-          view: colorTexture.createView(),
-          loadOp: 'load',
-          storeOp: 'store',
-        },
-      ],
-      timestampWrites: [timestampWrite],
-    });
-    pass.end();
-
-    encoder.validateFinish(!mismatched);
+    t.expectValidationError(() => {
+      const pass = encoder.encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: colorTexture.createView(),
+            loadOp: 'load',
+            storeOp: 'store',
+          },
+        ],
+        timestampWrites: [timestampWrite],
+      });
+      pass.end();
+    }, mismatched);
   });

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -82,27 +82,32 @@ g.test('color_attachments,device_mismatch')
       ? t.getDeviceMismatchedRenderTexture()
       : t.getRenderTexture();
 
+    const view0TextureView = view0Texture.createView();
+    const target0TextureView = target0Texture.createView();
+
+    const view1TextureView = view1Texture.createView();
+    const target1TextureView = target1Texture.createView();
+
+    const encoder = t.createEncoder('non-pass');
     t.expectValidationError(() => {
-      const encoder = t.createEncoder('non-pass');
-      const pass = encoder.encoder.beginRenderPass({
+      encoder.encoder.beginRenderPass({
         colorAttachments: [
           {
-            view: view0Texture.createView(),
+            view: view0TextureView,
             clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
             loadOp: 'clear',
             storeOp: 'store',
-            resolveTarget: target0Texture.createView(),
+            resolveTarget: target0TextureView,
           },
           {
-            view: view1Texture.createView(),
+            view: view1TextureView,
             clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
             loadOp: 'clear',
             storeOp: 'store',
-            resolveTarget: target1Texture.createView(),
+            resolveTarget: target1TextureView,
           },
         ],
       });
-      pass.end();
     }, mismatched);
   });
 
@@ -126,13 +131,14 @@ g.test('depth_stencil_attachment,device_mismatch')
     const depthStencilTexture = mismatched
       ? t.getDeviceMismatchedTexture(descriptor)
       : t.device.createTexture(descriptor);
+    const depthStencilTextureView = depthStencilTexture.createView();
 
+    const encoder = t.createEncoder('non-pass');
     t.expectValidationError(() => {
-      const encoder = t.createEncoder('non-pass');
-      const pass = encoder.encoder.beginRenderPass({
+      encoder.encoder.beginRenderPass({
         colorAttachments: [],
         depthStencilAttachment: {
-          view: depthStencilTexture.createView(),
+          view: depthStencilTextureView,
           depthClearValue: 0,
           depthLoadOp: 'clear',
           depthStoreOp: 'store',
@@ -141,7 +147,6 @@ g.test('depth_stencil_attachment,device_mismatch')
           stencilStoreOp: 'store',
         },
       });
-      pass.end();
     }, mismatched);
   });
 
@@ -163,8 +168,25 @@ g.test('occlusion_query_set,device_mismatch')
     });
     t.trackForCleanup(occlusionQuerySet);
 
+    const colorTexture = t.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    const colorTextureView = colorTexture.createView();
+
+    const encoder = t.createEncoder('non-pass');
     t.expectValidationError(() => {
-      t.createEncoder('render pass', { occlusionQuerySet });
+      encoder.encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: colorTextureView,
+            loadOp: 'load',
+            storeOp: 'store',
+          },
+        ],
+        occlusionQuerySet,
+      });
     }, mismatched);
   });
 
@@ -194,19 +216,19 @@ g.test('timestamp_query_set,device_mismatch')
       size: { width: 4, height: 4, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.RENDER_ATTACHMENT,
     });
+    const colorTextureView = colorTexture.createView();
 
     const encoder = t.createEncoder('non-pass');
     t.expectValidationError(() => {
-      const pass = encoder.encoder.beginRenderPass({
+      encoder.encoder.beginRenderPass({
         colorAttachments: [
           {
-            view: colorTexture.createView(),
+            view: colorTextureView,
             loadOp: 'load',
             storeOp: 'store',
           },
         ],
         timestampWrites: [timestampWrite],
       });
-      pass.end();
     }, mismatched);
   });

--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -204,7 +204,20 @@ g.test('non_pass_commands')
           break;
         case 'beginRenderPass':
           {
-            encoder.beginRenderPass({ colorAttachments: [] });
+            const colorTexture = t.device.createTexture({
+              format: 'rgba8unorm',
+              size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+              usage: GPUTextureUsage.RENDER_ATTACHMENT,
+            });
+            encoder.beginRenderPass({
+              colorAttachments: [
+                {
+                  view: colorTexture.createView(),
+                  loadOp: 'load',
+                  storeOp: 'store',
+                },
+              ],
+            });
           }
           break;
         case 'clearBuffer':

--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -185,6 +185,12 @@ g.test('non_pass_commands')
       format: textureFormat,
       usage: GPUTextureUsage.COPY_DST,
     });
+    const colorTexture = t.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    const colorTextureView = colorTexture.createView();
 
     const querySet = t.device.createQuerySet({
       type: command === 'writeTimestamp' ? 'timestamp' : 'occlusion',
@@ -204,15 +210,10 @@ g.test('non_pass_commands')
           break;
         case 'beginRenderPass':
           {
-            const colorTexture = t.device.createTexture({
-              format: 'rgba8unorm',
-              size: { width: 4, height: 4, depthOrArrayLayers: 1 },
-              usage: GPUTextureUsage.RENDER_ATTACHMENT,
-            });
             encoder.beginRenderPass({
               colorAttachments: [
                 {
-                  view: colorTexture.createView(),
+                  view: colorTextureView,
                   loadOp: 'load',
                   storeOp: 'store',
                 },

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -34,10 +34,12 @@ Tests that set occlusion query set with all types in render pass descriptor:
     const type = t.params.type;
     const querySet = type === undefined ? undefined : createQuerySetWithType(t, type, 1);
 
-    const encoder = t.createEncoder('render pass', { occlusionQuerySet: querySet });
-    encoder.encoder.beginOcclusionQuery(0);
-    encoder.encoder.endOcclusionQuery();
-    encoder.validateFinish(type === 'occlusion');
+    t.expectValidationError(() => {
+      const encoder = t.createEncoder('render pass', { occlusionQuerySet: querySet });
+      encoder.encoder.beginOcclusionQuery(0);
+      encoder.encoder.endOcclusionQuery();
+      encoder.validateFinish(type === 'occlusion');
+    }, type === 'timestamp');
   });
 
 g.test('occlusion_query,invalid_query_set')
@@ -50,10 +52,9 @@ Tests that begin occlusion query with a invalid query set that failed during cre
   .fn(t => {
     const occlusionQuerySet = t.createQuerySetWithState(t.params.querySetState);
 
-    const encoder = t.createEncoder('render pass', { occlusionQuerySet });
-    encoder.encoder.beginOcclusionQuery(0);
-    encoder.encoder.endOcclusionQuery();
-    encoder.validateFinishAndSubmitGivenState(t.params.querySetState);
+    t.expectValidationError(() => {
+      t.createEncoder('render pass', { occlusionQuerySet });
+    }, t.params.querySetState === 'invalid');
   });
 
 g.test('occlusion_query,query_index')

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -52,8 +52,25 @@ Tests that begin occlusion query with a invalid query set that failed during cre
   .fn(t => {
     const occlusionQuerySet = t.createQuerySetWithState(t.params.querySetState);
 
+    const colorTexture = t.device.createTexture({
+      format: 'rgba8unorm',
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    const colorTextureView = colorTexture.createView();
+
+    const encoder = t.createEncoder('non-pass');
     t.expectValidationError(() => {
-      t.createEncoder('render pass', { occlusionQuerySet });
+      encoder.encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: colorTextureView,
+            loadOp: 'load',
+            storeOp: 'store',
+          },
+        ],
+        occlusionQuerySet,
+      });
     }, t.params.querySetState === 'invalid');
   });
 

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -76,13 +76,21 @@ class F extends ValidationTest {
     };
   }
 
+  // tryRenderPass2(success: boolean, descriptor: GPURenderPassDescriptor): void {
+  //   const commandEncoder = this.device.createCommandEncoder();
+  //   const renderPass = commandEncoder.beginRenderPass(descriptor);
+  //   renderPass.end();
+
+  //   this.expectValidationError(() => {
+  //     commandEncoder.finish();
+  //   }, !success);
+  // }
+
   tryRenderPass(success: boolean, descriptor: GPURenderPassDescriptor): void {
     const commandEncoder = this.device.createCommandEncoder();
-    const renderPass = commandEncoder.beginRenderPass(descriptor);
-    renderPass.end();
 
     this.expectValidationError(() => {
-      commandEncoder.finish();
+      commandEncoder.beginRenderPass(descriptor);
     }, !success);
   }
 }

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -83,7 +83,9 @@ class F extends ValidationTest {
     this.expectValidationError(() => {
       pass = commandEncoder.beginRenderPass(descriptor);
     }, !success);
-    pass.end();
+    this.expectValidationError(() => {
+      pass.end();
+    }, false);
     this.expectValidationError(() => {
       commandEncoder.finish();
     }, !success);

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -76,22 +76,17 @@ class F extends ValidationTest {
     };
   }
 
-  // tryRenderPass2(success: boolean, descriptor: GPURenderPassDescriptor): void {
-  //   const commandEncoder = this.device.createCommandEncoder();
-  //   const renderPass = commandEncoder.beginRenderPass(descriptor);
-  //   renderPass.end();
-
-  //   this.expectValidationError(() => {
-  //     commandEncoder.finish();
-  //   }, !success);
-  // }
-
   tryRenderPass(success: boolean, descriptor: GPURenderPassDescriptor): void {
     const commandEncoder = this.device.createCommandEncoder();
 
+    let pass: GPURenderPassEncoder;
     this.expectValidationError(() => {
-      commandEncoder.beginRenderPass(descriptor);
+      pass = commandEncoder.beginRenderPass(descriptor);
     }, !success);
+    this.expectValidationError(() => {
+      pass.end();
+    }, !success);
+    commandEncoder.finish();
   }
 }
 

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -86,7 +86,9 @@ class F extends ValidationTest {
     this.expectValidationError(() => {
       pass.end();
     }, !success);
-    commandEncoder.finish();
+    this.expectValidationError(() => {
+      commandEncoder.finish();
+    }, !success);
   }
 }
 

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -83,9 +83,7 @@ class F extends ValidationTest {
     this.expectValidationError(() => {
       pass = commandEncoder.beginRenderPass(descriptor);
     }, !success);
-    this.expectValidationError(() => {
-      pass.end();
-    }, !success);
+    pass.end();
     this.expectValidationError(() => {
       commandEncoder.finish();
     }, !success);

--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -180,13 +180,11 @@ Test various validation behaviors when a resolveTarget is provided.
         }
       }
       const encoder = t.device.createCommandEncoder();
-      const pass = encoder.beginRenderPass({
-        colorAttachments: renderPassColorAttachmentDescriptors,
-      });
-      pass.end();
 
       t.expectValidationError(() => {
-        encoder.finish();
+        encoder.beginRenderPass({
+          colorAttachments: renderPassColorAttachmentDescriptors,
+        });
       }, !_valid);
     }
   });

--- a/src/webgpu/api/validation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/validation/render_pass/storeOp.spec.ts
@@ -55,21 +55,19 @@ g.test('store_op_and_read_only')
     const depthAttachmentView = depthAttachment.createView();
 
     const encoder = t.device.createCommandEncoder();
-    const pass = encoder.beginRenderPass({
-      colorAttachments: [],
-      depthStencilAttachment: {
-        view: depthAttachmentView,
-        depthLoadOp: 'load',
-        depthStoreOp,
-        depthReadOnly,
-        stencilLoadOp: 'load',
-        stencilStoreOp,
-        stencilReadOnly,
-      },
-    });
-    pass.end();
 
     t.expectValidationError(() => {
-      encoder.finish();
+      encoder.beginRenderPass({
+        colorAttachments: [],
+        depthStencilAttachment: {
+          view: depthAttachmentView,
+          depthLoadOp: 'load',
+          depthStoreOp,
+          depthReadOnly,
+          stencilLoadOp: 'load',
+          stencilStoreOp,
+          stencilReadOnly,
+        },
+      });
     }, !_valid);
   });

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -186,6 +186,10 @@ g.test('subresources,set_bind_group_on_same_index_depth_stencil_texture')
         view: depthStencilTexture.createView(),
         depthReadOnly: depthStencilReadOnly,
         stencilReadOnly: depthStencilReadOnly,
+        depthLoadOp: depthStencilReadOnly ? undefined : 'load',
+        depthStoreOp: depthStencilReadOnly ? undefined : 'store',
+        stencilLoadOp: depthStencilReadOnly ? undefined : 'load',
+        stencilStoreOp: depthStencilReadOnly ? undefined : 'store',
       },
     });
     renderPassEncoder.setBindGroup(0, conflictedToNonReadOnlyAttachmentBindGroup);


### PR DESCRIPTION



Issue: https://crbug.com/dawn/1602

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
