### PR TITLE
op: Implement 'stencil_basic' test

### DIFF
--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -191,6 +191,46 @@ class StencilTest extends GPUTest {
 
 export const g = makeTestGroup(StencilTest);
 
+g.test('stencil_basic')
+  .desc('Tests that the basic stencil state works as expected.')
+  .fn(async t => {
+    const depthSpencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
+
+    const baseStencilState = {
+      compare: 'always',
+      failOp: 'keep',
+      passOp: 'keep',
+    } as const;
+
+    const stencilState = {
+      compare: 'always',
+      failOp: 'keep',
+      passOp: 'keep',
+    } as const;
+
+    const baseState = {
+      format: depthSpencilFormat,
+      depthWriteEnabled: false,
+      depthCompare: 'always',
+      stencilFront: baseStencilState,
+      stencilBack: baseStencilState,
+      stencilReadMask: 0xff,
+      stencilWriteMask: 0xff,
+    } as const;
+
+    const state = {
+      format: depthSpencilFormat,
+      depthWriteEnabled: false,
+      depthCompare: 'always',
+      stencilFront: stencilState,
+      stencilBack: stencilState,
+      stencilReadMask: 0xff,
+      stencilWriteMask: 0xff,
+    } as const;
+
+    t.runStencilStateTest(baseState, state, 0, kStencilColor);
+  });
+
 g.test('stencil_compare_func')
   .desc(
     `


### PR DESCRIPTION
This PR adds a new test to check if the basic stencil state work correctly.

Issue: #2023


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
