### PR TITLE
op: Implement 'depth_disabled' test in depth.spec.ts

### DIFF
--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -154,7 +154,28 @@ g.test('depth_bias')
   )
   .unimplemented();
 
-g.test('depth_disabled').desc(`Tests render results with depth test disabled`).unimplemented();
+g.test('depth_disabled')
+  .desc('Tests render results with depth test disabled.')
+  .fn(async t => {
+    const depthSpencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
+    const state = { format: depthSpencilFormat };
+
+    const testStates = [
+      { state, color: kBaseColor, depth: 0.0 },
+      { state, color: kRedStencilColor, depth: 0.5 },
+      { state, color: kGreenStencilColor, depth: 1.0 },
+    ];
+
+    // Test that for all combinations and ensure the last triangle drawn is the one visible
+    // regardless of depth testing.
+    for (let last = 0; last < 3; ++last) {
+      const i = (last + 1) % 3;
+      const j = (last + 2) % 3;
+
+      t.runDepthStateTest([testStates[i], testStates[j], testStates[last]], testStates[last].color);
+      t.runDepthStateTest([testStates[j], testStates[i], testStates[last]], testStates[last].color);
+    }
+  });
 
 g.test('depth_write_disabled')
   .desc(


### PR DESCRIPTION
This PR adds a new test to check if rendering works correctly with depth testing disabled.

Issue: #2023


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
