### PR TITLE
Add earlyRejection parameter to testMapAsyncCall()

### DIFF
--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -12,6 +12,7 @@ import { ValidationTest } from '../validation_test.js';
 class F extends ValidationTest {
   async testMapAsyncCall(
     success: boolean,
+    earlyRejection: boolean,
     rejectName: string | null,
     buffer: GPUBuffer,
     mode: GPUMapModeFlags,
@@ -26,12 +27,26 @@ class F extends ValidationTest {
       this.expectValidationError(() => {
         p = buffer.mapAsync(mode, offset, size);
       });
+      let caught = false;
+      let rejectedEarly = false;
+      // First microtask
+      p!.catch(() => {
+        caught = true;
+      });
+      // Second microtask.
+      // The first microtask should be called before the second and
+      // third ones for early rejection.
+      queueMicrotask(() => {
+        rejectedEarly = caught;
+      });
       try {
+        // Third microtask
         await p!;
         assert(rejectName === null, 'mapAsync unexpectedly passed');
       } catch (ex) {
         assert(ex instanceof Error, 'mapAsync rejected with non-error');
         assert(rejectName === ex.name, `mapAsync rejected unexpectedly with: ${ex}`);
+        assert(earlyRejection === rejectedEarly, 'mapAsync rejected at an unexpected timing');
       }
     }
   }
@@ -102,7 +117,7 @@ g.test('mapAsync,usage')
     });
 
     const success = usage === validUsage;
-    await t.testMapAsyncCall(success, 'OperationError', buffer, mapMode);
+    await t.testMapAsyncCall(success, false, 'OperationError', buffer, mapMode);
   });
 
 g.test('mapAsync,invalidBuffer')
@@ -111,7 +126,7 @@ g.test('mapAsync,invalidBuffer')
   .fn(async t => {
     const { mapMode } = t.params;
     const buffer = t.getErrorBuffer();
-    await t.testMapAsyncCall(false, 'OperationError', buffer, mapMode);
+    await t.testMapAsyncCall(false, false, 'OperationError', buffer, mapMode);
   });
 
 g.test('mapAsync,state,destroyed')
@@ -121,7 +136,7 @@ g.test('mapAsync,state,destroyed')
     const { mapMode } = t.params;
     const buffer = t.createMappableBuffer(mapMode, 16);
     buffer.destroy();
-    await t.testMapAsyncCall(false, 'OperationError', buffer, mapMode);
+    await t.testMapAsyncCall(false, false, 'OperationError', buffer, mapMode);
   });
 
 g.test('mapAsync,state,mappedAtCreation')
@@ -141,10 +156,10 @@ g.test('mapAsync,state,mappedAtCreation')
       usage: validUsage,
       mappedAtCreation: true,
     });
-    await t.testMapAsyncCall(false, 'OperationError', buffer, mapMode);
+    await t.testMapAsyncCall(false, false, 'OperationError', buffer, mapMode);
 
     buffer.unmap();
-    await t.testMapAsyncCall(true, null, buffer, mapMode);
+    await t.testMapAsyncCall(true, false, null, buffer, mapMode);
   });
 
 g.test('mapAsync,state,mapped')
@@ -157,11 +172,11 @@ g.test('mapAsync,state,mapped')
     const { mapMode } = t.params;
 
     const buffer = t.createMappableBuffer(mapMode, 16);
-    await t.testMapAsyncCall(true, null, buffer, mapMode);
-    await t.testMapAsyncCall(false, 'OperationError', buffer, mapMode);
+    await t.testMapAsyncCall(true, false, null, buffer, mapMode);
+    await t.testMapAsyncCall(false, false, 'OperationError', buffer, mapMode);
 
     buffer.unmap();
-    await t.testMapAsyncCall(true, null, buffer, mapMode);
+    await t.testMapAsyncCall(true, false, null, buffer, mapMode);
   });
 
 g.test('mapAsync,state,mappingPending')
@@ -188,7 +203,7 @@ g.test('mapAsync,state,mappingPending')
 
     // Unmap the first mapping. It should now be possible to successfully call mapAsync
     buffer.unmap();
-    await t.testMapAsyncCall(true, null, buffer, mapMode);
+    await t.testMapAsyncCall(true, false, null, buffer, mapMode);
   });
 
 g.test('mapAsync,sizeUnspecifiedOOB')
@@ -219,7 +234,7 @@ g.test('mapAsync,sizeUnspecifiedOOB')
     const buffer = t.createMappableBuffer(mapMode, bufferSize);
 
     const success = offset <= bufferSize;
-    await t.testMapAsyncCall(success, 'OperationError', buffer, mapMode, offset);
+    await t.testMapAsyncCall(success, false, 'OperationError', buffer, mapMode, offset);
   });
 
 g.test('mapAsync,offsetAndSizeAlignment')
@@ -235,7 +250,7 @@ g.test('mapAsync,offsetAndSizeAlignment')
     const buffer = t.createMappableBuffer(mapMode, 16);
 
     const success = offset % kOffsetAlignment === 0 && size % kSizeAlignment === 0;
-    await t.testMapAsyncCall(success, 'OperationError', buffer, mapMode, offset, size);
+    await t.testMapAsyncCall(success, false, 'OperationError', buffer, mapMode, offset, size);
   });
 
 g.test('mapAsync,offsetAndSizeOOB')
@@ -277,7 +292,7 @@ g.test('mapAsync,offsetAndSizeOOB')
     const buffer = t.createMappableBuffer(mapMode, bufferSize);
 
     const success = offset + size <= bufferSize;
-    await t.testMapAsyncCall(success, 'OperationError', buffer, mapMode, offset, size);
+    await t.testMapAsyncCall(success, false, 'OperationError', buffer, mapMode, offset, size);
   });
 
 g.test('mapAsync,earlyRejection')
@@ -291,26 +306,9 @@ g.test('mapAsync,earlyRejection')
     const offset1 = 0;
 
     const buffer = t.createMappableBuffer(mapMode, bufferSize);
-
     const p1 = buffer.mapAsync(mapMode, offset1, mapSize); // succeeds
-    let success = false;
-    {
-      let caught = false;
-      // should be already rejected
-      const p2 = buffer.mapAsync(mapMode, offset2, mapSize);
-      // queues a microtask catching the rejection
-      p2.catch(() => {
-        caught = true;
-      });
-      // queues a second microtask to capture the state immediately after the catch.
-      // Test fails if p2 isn't rejected before the second microtask is fired or
-      // p1 is resolved.
-      queueMicrotask(() => {
-        success = caught;
-      });
-    }
+    await t.testMapAsyncCall(false, true, 'OperationError', buffer, mapMode, offset2, mapSize);
     await p1; // ensure the original map still succeeds
-    assert(success);
   });
 
 g.test('getMappedRange,state,mapped')
@@ -405,7 +403,7 @@ g.test('getMappedRange,state,mappedAgain')
     await buffer.mapAsync(mapMode);
 
     // call mapAsync again on already mapped buffer should fail
-    await t.testMapAsyncCall(false, 'OperationError', buffer, mapMode);
+    await t.testMapAsyncCall(false, false, 'OperationError', buffer, mapMode);
 
     // getMapppedRange should still success
     t.testGetMappedRangeCall(true, buffer);

--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -29,18 +29,18 @@ class F extends ValidationTest {
       });
       let caught = false;
       let rejectedEarly = false;
-      // First microtask
+      // If mapAsync rejected early, microtask A will run before B.
+      // If not, B will run before A.
       p!.catch(() => {
+        // Microtask A
         caught = true;
       });
-      // Second microtask.
-      // The first microtask should be called before the second and
-      // third ones for early rejection.
       queueMicrotask(() => {
+        // Microtask B
         rejectedEarly = caught;
       });
       try {
-        // Third microtask
+        // This await will always complete after microtasks A and B are both done.
         await p!;
         assert(rejectName === null, 'mapAsync unexpectedly passed');
       } catch (ex) {


### PR DESCRIPTION
From: https://github.com/gpuweb/cts/issues/2009#issuecomment-1329945474

It allows to validate the immediate rejection and non-immediate rejection. For example, `mapAsync()` should immediately reject on buffers being pending map while it should not immediately reject on already mapped buffers. The change allows to check them.

Issue: #2009 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
