### PR TITLE
Replace usage of vector inputs with fullF32Range for arithmetic tests

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -12,7 +12,7 @@ import {
   remainderInterval,
   subtractionInterval,
 } from '../../../../util/f32_interval.js';
-import { vectorTestValues } from '../../../../util/math.js';
+import { fullF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../expression.js';
 
@@ -26,8 +26,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
     };
 
-    return vectorTestValues(2, false).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
   addition_const: () => {
@@ -35,8 +37,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
     };
 
-    return vectorTestValues(2, true).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
   subtraction_non_const: () => {
@@ -44,8 +48,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
     };
 
-    return vectorTestValues(2, false).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
   subtraction_const: () => {
@@ -53,8 +59,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
     };
 
-    return vectorTestValues(2, true).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
   multiplication_non_const: () => {
@@ -62,8 +70,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
     };
 
-    return vectorTestValues(2, false).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
   multiplication_const: () => {
@@ -71,8 +81,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
     };
 
-    return vectorTestValues(2, true).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
   division_non_const: () => {
@@ -80,8 +92,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
     };
 
-    return vectorTestValues(2, false).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
   division_const: () => {
@@ -89,8 +103,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
     };
 
-    return vectorTestValues(2, true).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
   remainder_non_const: () => {
@@ -98,8 +114,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
     };
 
-    return vectorTestValues(2, false).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
   remainder_const: () => {
@@ -107,8 +125,10 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
     };
 
-    return vectorTestValues(2, true).map(v => {
-      return makeCase(v[0], v[1]);
+    return fullF32Range().flatMap(x => {
+      return fullF32Range().map(y => {
+        return makeCase(x, y);
+      });
     });
   },
 });


### PR DESCRIPTION
During one of the refactorings of this code, the vectorTestValues were substituted in for fullF32Range when generating the inputs. This is not desired, so I am reverting this behavioural change.

There are more broken const-eval tests on some backends due to this change, though const-eval was failing on these backends already. This will be resolved in a pending change I have for filtering out bad const-eval inputs, https://github.com/gpuweb/cts/pull/2045.

I am sending up this patch early, so that coverage of division can be restored for investigating potential issues with the atan2 tests.

Issue #2020

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
