### PR TITLE
Remove infinities from all f32 test inputs

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_logical.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { anyOf } from '../../../../util/compare.js';
 import { bool, f32, Scalar, TypeBool, TypeF32 } from '../../../../util/conversion.js';
-import { flushSubnormalScalarF32, vectorTestValues } from '../../../../util/math.js';
+import { flushSubnormalScalarF32, vectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, Case, run } from '../expression.js';
 
@@ -46,7 +46,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) === (rhs.value as number);
     };
 
-    return vectorTestValues(2, false).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -55,7 +55,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) === (rhs.value as number);
     };
 
-    return vectorTestValues(2, true).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -64,7 +64,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) !== (rhs.value as number);
     };
 
-    return vectorTestValues(2, false).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -73,7 +73,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) !== (rhs.value as number);
     };
 
-    return vectorTestValues(2, true).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -82,7 +82,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) < (rhs.value as number);
     };
 
-    return vectorTestValues(2, false).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -91,7 +91,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) < (rhs.value as number);
     };
 
-    return vectorTestValues(2, true).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -100,7 +100,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) <= (rhs.value as number);
     };
 
-    return vectorTestValues(2, false).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -109,7 +109,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) <= (rhs.value as number);
     };
 
-    return vectorTestValues(2, true).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -118,7 +118,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) > (rhs.value as number);
     };
 
-    return vectorTestValues(2, false).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -127,7 +127,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) > (rhs.value as number);
     };
 
-    return vectorTestValues(2, true).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -136,7 +136,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) >= (rhs.value as number);
     };
 
-    return vectorTestValues(2, false).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },
@@ -145,7 +145,7 @@ export const d = makeCaseCache('binary/f32_logical', {
       return (lhs.value as number) >= (rhs.value as number);
     };
 
-    return vectorTestValues(2, true).map(v => {
+    return vectorF32Range(2).map(v => {
       return makeCase(v[0], v[1], truthFunc);
     });
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -34,9 +34,7 @@ export const d = makeCaseCache('abs', {
       return makeUnaryToF32IntervalCase(x, absInterval);
     };
 
-    return [Number.NEGATIVE_INFINITY, ...fullF32Range(), Number.POSITIVE_INFINITY].map(x =>
-      makeCase(x)
-    );
+    return fullF32Range().map(makeCase);
   },
   f32_const: () => {
     const makeCase = (x: number): Case => {

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -28,7 +28,6 @@ export const d = makeCaseCache('atan', {
 
     return [
       // Known values
-      Number.NEGATIVE_INFINITY,
       -Math.sqrt(3),
       -1,
       -1 / Math.sqrt(3),
@@ -36,7 +35,6 @@ export const d = makeCaseCache('atan', {
       1,
       1 / Math.sqrt(3),
       Math.sqrt(3),
-      Number.POSITIVE_INFINITY,
 
       ...fullF32Range(),
     ].map(x => makeCase(x));

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -29,7 +29,7 @@ export const d = makeCaseCache('atan2', {
     // Using sparse, since there a N^2 cases being generated, but including extra values around 0, since that is where
     // there is a discontinuity that implementations tend to behave badly at.
     const numeric_range = [
-      ...sparseF32Range(true),
+      ...sparseF32Range(),
       ...linearRange(kValue.f32.negative.max, kValue.f32.positive.min, 10),
     ];
     const cases: Array<Case> = [];

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -72,7 +72,7 @@ export const d = makeCaseCache('clamp', {
     };
 
     // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range(false);
+    const values = sparseF32Range();
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {
@@ -91,7 +91,7 @@ export const d = makeCaseCache('clamp', {
     };
 
     // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range(true);
+    const values = sparseF32Range();
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -10,7 +10,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { crossInterval } from '../../../../../util/f32_interval.js';
-import { vectorTestValues } from '../../../../../util/math.js';
+import { vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
@@ -29,8 +29,8 @@ export const d = makeCaseCache('cross', {
       return makeVectorPairToVectorIntervalCase(x, y, crossInterval);
     };
 
-    return vectorTestValues(3, false).flatMap(i => {
-      return vectorTestValues(3, false).map(j => {
+    return vectorF32Range(3).flatMap(i => {
+      return vectorF32Range(3).map(j => {
         return makeCase(i, j);
       });
     });

--- a/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
@@ -12,7 +12,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { distanceInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, kVectorSparseTestValues } from '../../../../../util/math.js';
+import { fullF32Range, sparseVectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
@@ -34,18 +34,18 @@ export const d = makeCaseCache('distance', {
     return fullF32Range().flatMap(i => fullF32Range().map(j => makeCase(i, j)));
   },
   f32_vec2: () => {
-    return kVectorSparseTestValues[2].flatMap(i =>
-      kVectorSparseTestValues[2].map(j => makeCaseVecF32(i, j))
+    return sparseVectorF32Range(2).flatMap(i =>
+      sparseVectorF32Range(2).map(j => makeCaseVecF32(i, j))
     );
   },
   f32_vec3: () => {
-    return kVectorSparseTestValues[3].flatMap(i =>
-      kVectorSparseTestValues[3].map(j => makeCaseVecF32(i, j))
+    return sparseVectorF32Range(3).flatMap(i =>
+      sparseVectorF32Range(3).map(j => makeCaseVecF32(i, j))
     );
   },
   f32_vec4: () => {
-    return kVectorSparseTestValues[4].flatMap(i =>
-      kVectorSparseTestValues[4].map(j => makeCaseVecF32(i, j))
+    return sparseVectorF32Range(4).flatMap(i =>
+      sparseVectorF32Range(4).map(j => makeCaseVecF32(i, j))
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { dotInterval } from '../../../../../util/f32_interval.js';
-import { vectorTestValues } from '../../../../../util/math.js';
+import { vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeVectorPairToF32IntervalCase, run } from '../../expression.js';
 
@@ -25,8 +25,8 @@ export const d = makeCaseCache('dot', {
       return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
-    return vectorTestValues(2, false).flatMap(i => {
-      return vectorTestValues(2, false).map(j => {
+    return vectorF32Range(2).flatMap(i => {
+      return vectorF32Range(2).map(j => {
         return makeCase(i, j);
       });
     });
@@ -36,8 +36,8 @@ export const d = makeCaseCache('dot', {
       return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
-    return vectorTestValues(3, false).flatMap(i => {
-      return vectorTestValues(3, false).map(j => {
+    return vectorF32Range(3).flatMap(i => {
+      return vectorF32Range(3).map(j => {
         return makeCase(i, j);
       });
     });
@@ -47,8 +47,8 @@ export const d = makeCaseCache('dot', {
       return makeVectorPairToF32IntervalCase(x, y, dotInterval);
     };
 
-    return vectorTestValues(4, false).flatMap(i => {
-      return vectorTestValues(4, false).map(j => {
+    return vectorF32Range(4).flatMap(i => {
+      return vectorF32Range(4).map(j => {
         return makeCase(i, j);
       });
     });

--- a/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
@@ -11,7 +11,7 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf } from '../../../../../util/compare.js';
 import { f32, TypeF32, TypeVec, Vector } from '../../../../../util/conversion.js';
 import { faceForwardIntervals } from '../../../../../util/f32_interval.js';
-import { kVectorSparseTestValues, quantizeToF32 } from '../../../../../util/math.js';
+import { quantizeToF32, sparseVectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
@@ -21,24 +21,18 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('faceForward', {
   f32_vec2: () => {
-    return kVectorSparseTestValues[2].flatMap(i =>
-      kVectorSparseTestValues[2].flatMap(j =>
-        kVectorSparseTestValues[2].map(k => makeCase(i, j, k))
-      )
+    return sparseVectorF32Range(2).flatMap(i =>
+      sparseVectorF32Range(2).flatMap(j => sparseVectorF32Range(2).map(k => makeCase(i, j, k)))
     );
   },
   f32_vec3: () => {
-    return kVectorSparseTestValues[3].flatMap(i =>
-      kVectorSparseTestValues[3].flatMap(j =>
-        kVectorSparseTestValues[3].map(k => makeCase(i, j, k))
-      )
+    return sparseVectorF32Range(3).flatMap(i =>
+      sparseVectorF32Range(3).flatMap(j => sparseVectorF32Range(3).map(k => makeCase(i, j, k)))
     );
   },
   f32_vec4: () => {
-    return kVectorSparseTestValues[4].flatMap(i =>
-      kVectorSparseTestValues[4].flatMap(j =>
-        kVectorSparseTestValues[4].map(k => makeCase(i, j, k))
-      )
+    return sparseVectorF32Range(4).flatMap(i =>
+      sparseVectorF32Range(4).flatMap(j => sparseVectorF32Range(4).map(k => makeCase(i, j, k)))
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
@@ -34,7 +34,7 @@ g.test('f32')
   )
   .fn(async t => {
     // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range(t.params.inputSource === 'const');
+    const values = sparseF32Range();
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { lengthInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, vectorTestValues } from '../../../../../util/math.js';
+import { fullF32Range, vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
@@ -33,13 +33,13 @@ export const d = makeCaseCache('length', {
     return fullF32Range().map(makeCase);
   },
   f32_vec2: () => {
-    return vectorTestValues(2, false).map(makeCaseVecF32);
+    return vectorF32Range(2).map(makeCaseVecF32);
   },
   f32_vec3: () => {
-    return vectorTestValues(3, false).map(makeCaseVecF32);
+    return vectorF32Range(3).map(makeCaseVecF32);
   },
   f32_vec4: () => {
-    return vectorTestValues(4, false).map(makeCaseVecF32);
+    return vectorF32Range(4).map(makeCaseVecF32);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -18,7 +18,6 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { kValue } from '../../../../../util/constants.js';
 import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
 import { maxInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
@@ -51,7 +50,6 @@ export const d = makeCaseCache('max', {
 
     const cases: Array<Case> = [];
     const numeric_range = fullF32Range();
-    numeric_range.push(kValue.f32.infinity.positive, kValue.f32.infinity.negative);
     numeric_range.forEach(lhs => {
       numeric_range.forEach(rhs => {
         cases.push(makeCase(lhs, rhs));

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -17,7 +17,6 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { kValue } from '../../../../../util/constants.js';
 import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
 import { minInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
@@ -36,7 +35,6 @@ export const d = makeCaseCache('min', {
 
     const cases: Array<Case> = [];
     const numeric_range = fullF32Range();
-    numeric_range.push(kValue.f32.infinity.positive, kValue.f32.infinity.negative);
     numeric_range.forEach(lhs => {
       numeric_range.forEach(rhs => {
         cases.push(makeCase(lhs, rhs));

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -32,7 +32,7 @@ export const d = makeCaseCache('mix', {
       return makeTernaryToF32IntervalCase(x, y, z, ...mixIntervals);
     };
 
-    const values = sparseF32Range(false);
+    const values = sparseF32Range();
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -20,7 +20,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { f32, toVector, TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { modfInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
+import { fullF32Range, quantizeToF32, vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, ExpressionBuilder, run } from '../../expression.js';
 
@@ -72,22 +72,22 @@ export const d = makeCaseCache('modf', {
     return fullF32Range().map(makeCase);
   },
   f32_vec2_fract: () => {
-    return vectorTestValues(2, true).map(makeVectorCaseFract);
+    return vectorF32Range(2).map(makeVectorCaseFract);
   },
   f32_vec2_whole: () => {
-    return vectorTestValues(2, true).map(makeVectorCaseWhole);
+    return vectorF32Range(2).map(makeVectorCaseWhole);
   },
   f32_vec3_fract: () => {
-    return vectorTestValues(3, true).map(makeVectorCaseFract);
+    return vectorF32Range(3).map(makeVectorCaseFract);
   },
   f32_vec3_whole: () => {
-    return vectorTestValues(3, true).map(makeVectorCaseWhole);
+    return vectorF32Range(3).map(makeVectorCaseWhole);
   },
   f32_vec4_fract: () => {
-    return vectorTestValues(4, true).map(makeVectorCaseFract);
+    return vectorF32Range(4).map(makeVectorCaseFract);
   },
   f32_vec4_whole: () => {
-    return vectorTestValues(4, true).map(makeVectorCaseWhole);
+    return vectorF32Range(4).map(makeVectorCaseWhole);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -10,7 +10,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { normalizeInterval } from '../../../../../util/f32_interval.js';
-import { vectorTestValues } from '../../../../../util/math.js';
+import { vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, makeVectorToVectorIntervalCase, run } from '../../expression.js';
 
@@ -20,13 +20,13 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('normalize', {
   f32_vec2: () => {
-    return vectorTestValues(2, false).map(makeCaseVecF32);
+    return vectorF32Range(2).map(makeCaseVecF32);
   },
   f32_vec3: () => {
-    return vectorTestValues(3, false).map(makeCaseVecF32);
+    return vectorF32Range(3).map(makeCaseVecF32);
   },
   f32_vec4: () => {
-    return vectorTestValues(4, false).map(makeCaseVecF32);
+    return vectorF32Range(4).map(makeCaseVecF32);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
+import { quantizeToF32, vectorF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -61,7 +61,7 @@ g.test('pack')
       return { input: [vec2(f32(x), f32(y))], expected: anyOf(...results.map(cmp)) };
     };
 
-    const cases: Array<Case> = vectorTestValues(2, t.params.inputSource === 'const').map(v => {
+    const cases: Array<Case> = vectorF32Range(2).map(v => {
       return makeCase(...(v as [number, number]));
     });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16snorm.spec.ts
@@ -17,7 +17,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
+import { quantizeToF32, vectorF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -44,7 +44,7 @@ g.test('pack')
       return n / kValue.f32.positive.max;
     };
 
-    const cases: Array<Case> = vectorTestValues(2, t.params.inputSource === 'const').flatMap(v => {
+    const cases: Array<Case> = vectorF32Range(2).flatMap(v => {
       return [
         makeCase(...(v as [number, number])),
         makeCase(...(v.map(normalizeF32) as [number, number])),

--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16unorm.spec.ts
@@ -17,7 +17,7 @@ import {
   u32,
   vec2,
 } from '../../../../../util/conversion.js';
-import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
+import { quantizeToF32, vectorF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -44,7 +44,7 @@ g.test('pack')
       return n > 0 ? n / kValue.f32.positive.max : n / kValue.f32.negative.min;
     };
 
-    const cases: Array<Case> = vectorTestValues(2, t.params.inputSource === 'const').flatMap(v => {
+    const cases: Array<Case> = vectorF32Range(2).flatMap(v => {
       return [
         makeCase(...(v as [number, number])),
         makeCase(...(v.map(normalizeF32) as [number, number])),

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8snorm.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec4,
 } from '../../../../../util/conversion.js';
-import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
+import { quantizeToF32, vectorF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -49,7 +49,7 @@ g.test('pack')
       return n / kValue.f32.positive.max;
     };
 
-    const cases: Array<Case> = vectorTestValues(4, t.params.inputSource === 'const').flatMap(v => {
+    const cases: Array<Case> = vectorF32Range(4).flatMap(v => {
       return [
         makeCase(v as [number, number, number, number]),
         makeCase(v.map(normalizeF32) as [number, number, number, number]),

--- a/src/webgpu/shader/execution/expression/call/builtin/pack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack4x8unorm.spec.ts
@@ -18,7 +18,7 @@ import {
   u32,
   vec4,
 } from '../../../../../util/conversion.js';
-import { quantizeToF32, vectorTestValues } from '../../../../../util/math.js';
+import { quantizeToF32, vectorF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -49,7 +49,7 @@ g.test('pack')
       return n > 0 ? n / kValue.f32.positive.max : n / kValue.f32.negative.min;
     };
 
-    const cases: Array<Case> = vectorTestValues(4, t.params.inputSource === 'const').flatMap(v => {
+    const cases: Array<Case> = vectorF32Range(4).flatMap(v => {
       return [
         makeCase(v as [number, number, number, number]),
         makeCase(v.map(normalizeF32) as [number, number, number, number]),

--- a/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { reflectInterval } from '../../../../../util/f32_interval.js';
-import { kVectorSparseTestValues } from '../../../../../util/math.js';
+import { sparseVectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
@@ -26,18 +26,18 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('reflect', {
   f32_vec2: () => {
-    return kVectorSparseTestValues[2].flatMap(i =>
-      kVectorSparseTestValues[2].map(j => makeCaseVecF32(i, j))
+    return sparseVectorF32Range(2).flatMap(i =>
+      sparseVectorF32Range(2).map(j => makeCaseVecF32(i, j))
     );
   },
   f32_vec3: () => {
-    return kVectorSparseTestValues[3].flatMap(i =>
-      kVectorSparseTestValues[3].map(j => makeCaseVecF32(i, j))
+    return sparseVectorF32Range(3).flatMap(i =>
+      sparseVectorF32Range(3).map(j => makeCaseVecF32(i, j))
     );
   },
   f32_vec4: () => {
-    return kVectorSparseTestValues[4].flatMap(i =>
-      kVectorSparseTestValues[4].map(j => makeCaseVecF32(i, j))
+    return sparseVectorF32Range(4).flatMap(i =>
+      sparseVectorF32Range(4).map(j => makeCaseVecF32(i, j))
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
@@ -14,11 +14,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { f32, TypeF32, TypeVec, Vector } from '../../../../../util/conversion.js';
 import { refractInterval } from '../../../../../util/f32_interval.js';
-import {
-  kVectorSparseTestValues,
-  quantizeToF32,
-  sparseF32Range,
-} from '../../../../../util/math.js';
+import { sparseVectorF32Range, quantizeToF32, sparseF32Range } from '../../../../../util/math.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -52,9 +48,9 @@ g.test('f32_vec2')
   .desc(`f32 tests using vec2s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[2].flatMap(i => {
-      return kVectorSparseTestValues[2].flatMap(j => {
-        return sparseF32Range(t.params.inputSource === 'const').map(k => {
+    const cases: Case[] = sparseVectorF32Range(2).flatMap(i => {
+      return sparseVectorF32Range(2).flatMap(j => {
+        return sparseF32Range().map(k => {
           return makeCaseF32(i, j, k);
         });
       });
@@ -75,9 +71,9 @@ g.test('f32_vec3')
   .desc(`f32 tests using vec3s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[3].flatMap(i => {
-      return kVectorSparseTestValues[3].flatMap(j => {
-        return sparseF32Range(t.params.inputSource === 'const').map(k => {
+    const cases: Case[] = sparseVectorF32Range(3).flatMap(i => {
+      return sparseVectorF32Range(3).flatMap(j => {
+        return sparseF32Range().map(k => {
           return makeCaseF32(i, j, k);
         });
       });
@@ -98,9 +94,9 @@ g.test('f32_vec4')
   .desc(`f32 tests using vec4s`)
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases: Case[] = kVectorSparseTestValues[4].flatMap(i => {
-      return kVectorSparseTestValues[4].flatMap(j => {
-        return sparseF32Range(t.params.inputSource === 'const').map(k => {
+    const cases: Case[] = sparseVectorF32Range(4).flatMap(i => {
+      return sparseVectorF32Range(4).flatMap(j => {
+        return sparseF32Range().map(k => {
           return makeCaseF32(i, j, k);
         });
       });

--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -28,7 +28,7 @@ export const d = makeCaseCache('smoothstep', {
     };
 
     // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range(false);
+    const values = sparseF32Range();
     const cases: Array<Case> = [];
     values.forEach(x => {
       values.forEach(y => {

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1,4 +1,4 @@
-import { assert, unreachable } from '../../common/util/util.js';
+import { assert } from '../../common/util/util.js';
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 
 import { kBit, kValue } from './constants.js';
@@ -639,25 +639,6 @@ export function fullU32Range(count: number = 50): Array<number> {
 
 /** Short list of f32 values of interest to test against */
 const kInterestingF32Values: number[] = [
-  Number.NEGATIVE_INFINITY,
-  kValue.f32.negative.min,
-  -10.0,
-  -1.0,
-  kValue.f32.negative.max,
-  kValue.f32.subnormal.negative.min,
-  kValue.f32.subnormal.negative.max,
-  0.0,
-  kValue.f32.subnormal.positive.min,
-  kValue.f32.subnormal.positive.max,
-  kValue.f32.positive.min,
-  1.0,
-  10.0,
-  kValue.f32.positive.max,
-  Number.POSITIVE_INFINITY,
-];
-
-/** Short list of finite-only f32 values of interest to test against */
-const kInterestingF32ValuesFinite: number[] = [
   kValue.f32.negative.min,
   -10.0,
   -1.0,
@@ -685,73 +666,63 @@ const kInterestingF32ValuesFinite: number[] = [
  * specific values of interest. If there are known values of interest they
  * should be appended to this list in the test generation code.
  */
-export function sparseF32Range(finite_only: boolean): Array<number> {
-  return finite_only ? kInterestingF32ValuesFinite : kInterestingF32Values;
+export function sparseF32Range(): number[] {
+  return kInterestingF32Values;
 }
 
+const kVectorF32Values = {
+  2: kInterestingF32Values.flatMap(f => [
+    [f, 1.0],
+    [1.0, f],
+    [f, -1.0],
+    [-1.0, f],
+  ]),
+  3: kInterestingF32Values.flatMap(f => [
+    [f, 1.0, 2.0],
+    [1.0, f, 2.0],
+    [1.0, 2.0, f],
+    [f, -1.0, -2.0],
+    [-1.0, f, -2.0],
+    [-1.0, -2.0, f],
+  ]),
+  4: kInterestingF32Values.flatMap(f => [
+    [f, 1.0, 2.0, 3.0],
+    [1.0, f, 2.0, 3.0],
+    [1.0, 2.0, f, 3.0],
+    [1.0, 2.0, 3.0, f],
+    [f, -1.0, -2.0, -3.0],
+    [-1.0, f, -2.0, -3.0],
+    [-1.0, -2.0, f, -3.0],
+    [-1.0, -2.0, -3.0, f],
+  ]),
+};
+
 /**
- * Returns set of vectors, indexed by dimension and filtered by source type,
- * that contain interesting float values.
- *
+ * Returns set of vectors, indexed by dimension containing interesting float
+ * values.
  *
  * The tests do not do the simple option for coverage of computing the cartesian
  * product of all of the interesting float values N times for vecN tests,
  * because that creates a huge number of tests for vec3 and vec4, leading to
  * time outs.
- * Instead they insert the interesting f32 values into each location of the
+ *
+ *  Instead they insert the interesting f32 values into each location of the
  * vector to get a spread of testing over the entire range. This reduces the
  * number of cases being run substantially, but maintains coverage.
  */
-export function vectorTestValues(dimension: number, finite_only: boolean): number[][] {
-  switch (dimension) {
-    case 2:
-      return sparseF32Range(finite_only).flatMap(f => [
-        [f, 1.0],
-        [1.0, f],
-        [f, -1.0],
-        [-1.0, f],
-      ]);
-    case 3:
-      return sparseF32Range(finite_only).flatMap(f => [
-        [f, 1.0, 2.0],
-        [1.0, f, 2.0],
-        [1.0, 2.0, f],
-        [f, -1.0, -2.0],
-        [-1.0, f, -2.0],
-        [-1.0, -2.0, f],
-      ]);
-    case 4:
-      return sparseF32Range(finite_only).flatMap(f => [
-        [f, 1.0, 2.0, 3.0],
-        [1.0, f, 2.0, 3.0],
-        [1.0, 2.0, f, 3.0],
-        [1.0, 2.0, 3.0, f],
-        [f, -1.0, -2.0, -3.0],
-        [-1.0, f, -2.0, -3.0],
-        [-1.0, -2.0, f, -3.0],
-        [-1.0, -2.0, -3.0, f],
-      ]);
-  }
-  unreachable(`vectorTestValues is only defined for dim 2, 3, and 4`);
+export function vectorF32Range(dim: number): number[][] {
+  assert(dim === 2 || dim === 3 || dim === 4, 'vectorF32Range only accepts dimensions 2, 3, and 4');
+  return kVectorF32Values[dim];
 }
 
-/**
- * Minimal set of vectors, indexed by dimension, that contain interesting float
- * values.
- *
- * This is an even more stripped down version of `vectorTestValues` for when
- * pairs of vectors are being tested.
- * All of the interesting floats from sparseF32 are guaranteed to be tested, but
- * not in every position.
- */
-export const kVectorSparseTestValues = {
-  2: sparseF32Range(false).map((f, idx) => [idx % 2 === 0 ? f : idx, idx % 2 === 1 ? f : -idx]),
-  3: sparseF32Range(false).map((f, idx) => [
+const kSparseVectorF32Values = {
+  2: sparseF32Range().map((f, idx) => [idx % 2 === 0 ? f : idx, idx % 2 === 1 ? f : -idx]),
+  3: sparseF32Range().map((f, idx) => [
     idx % 3 === 0 ? f : idx,
     idx % 3 === 1 ? f : -idx,
     idx % 3 === 2 ? f : idx,
   ]),
-  4: sparseF32Range(false).map((f, idx) => [
+  4: sparseF32Range().map((f, idx) => [
     idx % 4 === 0 ? f : idx,
     idx % 4 === 1 ? f : -idx,
     idx % 4 === 2 ? f : idx,
@@ -759,6 +730,22 @@ export const kVectorSparseTestValues = {
   ]),
 };
 
+/**
+ * Minimal set of vectors, indexed by dimension, that contain interesting float
+ * values.
+ *
+ * This is an even more stripped down version of `vectorF32Range` for when
+ * pairs of vectors are being tested.
+ * All of the interesting floats from sparseF32 are guaranteed to be tested, but
+ * not in every position.
+ */
+export function sparseVectorF32Range(dim: number): number[][] {
+  assert(
+    dim === 2 || dim === 3 || dim === 4,
+    'sparseVectorF32Range only accepts dimensions 2, 3, and 4'
+  );
+  return kSparseVectorF32Values[dim];
+}
 /**
  * @returns the result matrix in Array<Array<number>> type.
  *


### PR DESCRIPTION
This will reduce testing failures due infinities being past into const-eval tests, which cannot be represented.

Some const-eval tests still fail due to intermediate calculation values not being representable in f32. Filtering inputs to prevent this will be done in a future patch.

This patch does not remove the `1/0` trick used in Scalars to attempt to output infinity. That will be removed in a future patch.

Issue #2020

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
