### PR TITLE
Remove attempting to emit infinities in WGSL

### DIFF
--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -721,20 +721,6 @@ export class Scalar {
         case 'bool':
           return `${this.value}`;
       }
-    } else if (this.value === Number.POSITIVE_INFINITY) {
-      switch (this.type.kind) {
-        case 'f32':
-          return `(1.f/0.f)`;
-        case 'f16':
-          return `(1.h/0.h)`;
-      }
-    } else if (this.value === Number.NEGATIVE_INFINITY) {
-      switch (this.type.kind) {
-        case 'f32':
-          return `(-1.f/0.f)`;
-        case 'f16':
-          return `(-1.h/0.h)`;
-      }
     }
     throw new Error(
       `scalar of value ${this.value} and type ${this.type} has no WGSL representation`


### PR DESCRIPTION
This removes from the Scalar wgsl emission function attempting to emit infinities into shaders using the 1/0 trick, since that no longer works.

Tests are still able to store infinities in Scalars for comparison purposes and printing out to logs, just shader emission has been removed.

Attempting to write out an infinity via Scalar will now cause an error to be thrown in the test runner.

Previous patches have removed test cases that would be broken by this, local testing has shown no impact on test output.

Fixes #2020

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
