### PR TITLE
Add val:*_pipeline,overrides,value,type_error/validation_error

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -478,6 +478,10 @@ TODO(#2060): test with last_f64_castable.
         { constants: { cf16: kValue.f16.negative.first_f64_not_castable }, _success: false },
         { constants: { cf16: kValue.f16.positive.max }, _success: true },
         { constants: { cf16: kValue.f16.positive.first_f64_not_castable }, _success: false },
+        { constants: { cf16: kValue.f32.negative.min }, _success: false },
+        { constants: { cf16: kValue.f32.positive.max }, _success: false },
+        { constants: { cf16: kValue.f32.negative.first_f64_not_castable }, _success: false },
+        { constants: { cf16: kValue.f32.positive.first_f64_not_castable }, _success: false },
       ] as const)
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -467,7 +467,8 @@ g.test('overrides,value,validation_error,f16')
     `
 Tests calling createComputePipeline(Async) validation for unrepresentable f16 constant values in compute stage.
 
-TODO(#2060): test with last_f64_castable.
+TODO(#2060): Tighten the cases around the valid/invalid boundary once we have WGSL spec
+clarity on whether values like f16.positive.last_f64_castable would be valid. See issue.
 `
   )
   .params(u =>

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -3,6 +3,7 @@ This test dedicatedly tests validation of pipeline overridable constants of crea
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { kValue } from '../../../util/constants.js';
 
 import { CreateRenderPipelineValidationTest } from './common.js';
 
@@ -11,7 +12,7 @@ export const g = makeTestGroup(CreateRenderPipelineValidationTest);
 g.test('identifier,vertex')
   .desc(
     `
-Tests calling createComputePipeline(Async) validation for overridable constants identifiers in vertex state.
+Tests calling createRenderPipeline(Async) validation for overridable constants identifiers in vertex state.
 `
   )
   .params(u =>
@@ -63,7 +64,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
 g.test('identifier,fragment')
   .desc(
     `
-Tests calling createComputePipeline(Async) validation for overridable constants identifiers in fragment state.
+Tests calling createRenderPipeline(Async) validation for overridable constants identifiers in fragment state.
 `
   )
   .params(u =>
@@ -103,7 +104,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
 g.test('uninitialized,vertex')
   .desc(
     `
-Tests calling createComputePipeline(Async) validation for uninitialized overridable constants in vertex state.
+Tests calling createRenderPipeline(Async) validation for uninitialized overridable constants in vertex state.
 `
   )
   .params(u =>
@@ -150,7 +151,7 @@ Tests calling createComputePipeline(Async) validation for uninitialized overrida
 g.test('uninitialized,fragment')
   .desc(
     `
-Tests calling createComputePipeline(Async) validation for uninitialized overridable constants in fragment state.
+Tests calling createRenderPipeline(Async) validation for uninitialized overridable constants in fragment state.
 `
   )
   .params(u =>
@@ -175,6 +176,203 @@ Tests calling createComputePipeline(Async) validation for uninitialized overrida
         @fragment fn main()
             -> @location(0) vec4<f32> {
             return vec4<f32>(r, g, b, a);
+        }
+          `,
+      fragmentConstants,
+    });
+
+    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+  });
+
+g.test('value,type_error,vertex')
+  .desc(
+    `
+Tests calling createRenderPipeline(Async) validation for invalid constant values like inf, NaN will results in TypeError.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { vertexConstants: { cf: 1 }, _success: true }, // control
+        { vertexConstants: { cf: NaN }, _success: false },
+        { vertexConstants: { cf: Number.POSITIVE_INFINITY }, _success: false },
+        { vertexConstants: { cf: Number.NEGATIVE_INFINITY }, _success: false },
+      ] as { vertexConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
+  )
+  .fn(async t => {
+    const { isAsync, vertexConstants, _success } = t.params;
+
+    t.doCreateRenderPipelineTest(
+      isAsync,
+      _success,
+      {
+        layout: 'auto',
+        vertex: {
+          module: t.device.createShaderModule({
+            code: `
+            override cf: f32 = 0.0;
+            @vertex fn main() -> @builtin(position) vec4<f32> {
+              _ = cf;
+              return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+            }`,
+          }),
+          entryPoint: 'main',
+          constants: vertexConstants,
+        },
+        fragment: {
+          module: t.device.createShaderModule({
+            code: `@fragment fn main() -> @location(0) vec4<f32> {
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+            }`,
+          }),
+          entryPoint: 'main',
+          targets: [{ format: 'rgba8unorm' }],
+        },
+      },
+      'TypeError'
+    );
+  });
+
+g.test('value,type_error,fragment')
+  .desc(
+    `
+Tests calling createRenderPipeline(Async) validation for invalid constant values like inf, NaN will results in TypeError.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { fragmentConstants: { cf: 1 }, _success: true }, // control
+        { fragmentConstants: { cf: NaN }, _success: false },
+        { fragmentConstants: { cf: Number.POSITIVE_INFINITY }, _success: false },
+        { fragmentConstants: { cf: Number.NEGATIVE_INFINITY }, _success: false },
+      ] as { fragmentConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
+  )
+  .fn(async t => {
+    const { isAsync, fragmentConstants, _success } = t.params;
+
+    const descriptor = t.getDescriptor({
+      fragmentShaderCode: `
+        override cf: f32 = 0.0;
+        @fragment fn main()
+            -> @location(0) vec4<f32> {
+            _ = cf;
+            return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+        }
+          `,
+      fragmentConstants,
+    });
+
+    t.doCreateRenderPipelineTest(isAsync, _success, descriptor, 'TypeError');
+  });
+
+g.test('value,validation_error,vertex')
+  .desc(
+    `
+Tests calling createRenderPipeline(Async) validation for unrepresentable constant values in vertex stage.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { vertexConstants: { cu: kValue.u32.min }, _success: true },
+        { vertexConstants: { cu: kValue.u32.min - 1 }, _success: false },
+        { vertexConstants: { cu: kValue.u32.max }, _success: true },
+        { vertexConstants: { cu: kValue.u32.max + 1 }, _success: false },
+        { vertexConstants: { ci: kValue.i32.negative.min }, _success: true },
+        { vertexConstants: { ci: kValue.i32.negative.min - 1 }, _success: false },
+        { vertexConstants: { ci: kValue.i32.positive.max }, _success: true },
+        { vertexConstants: { ci: kValue.i32.positive.max + 1 }, _success: false },
+        { vertexConstants: { cf: kValue.f32.negative.min }, _success: true },
+        { vertexConstants: { cf: -Number.MAX_VALUE }, _success: false },
+        { vertexConstants: { cf: kValue.f32.positive.max }, _success: true },
+        { vertexConstants: { cf: Number.MAX_VALUE }, _success: false },
+        // Conversion to boolean can't fail
+        { vertexConstants: { cb: Number.MAX_VALUE }, _success: true },
+        { vertexConstants: { cb: kValue.i32.negative.min - 1 }, _success: true },
+      ] as { vertexConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
+  )
+  .fn(async t => {
+    const { isAsync, vertexConstants, _success } = t.params;
+
+    t.doCreateRenderPipelineTest(isAsync, _success, {
+      layout: 'auto',
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+          override cb: bool = false;
+          override cu: u32 = 0u;
+          override ci: i32 = 0;
+          override cf: f32 = 0.0;
+            @vertex fn main() -> @builtin(position) vec4<f32> {
+              _ = cb;
+              _ = cu;
+              _ = ci;
+              _ = cf;
+              return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+        constants: vertexConstants,
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `@fragment fn main() -> @location(0) vec4<f32> {
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+    });
+  });
+
+g.test('value,validation_error,fragment')
+  .desc(
+    `
+Tests calling createRenderPipeline(Async) validation for unrepresentable constant values in fragment stage.
+`
+  )
+  .params(u =>
+    u //
+      .combine('isAsync', [true, false])
+      .combineWithParams([
+        { fragmentConstants: { cu: kValue.u32.min }, _success: true },
+        { fragmentConstants: { cu: kValue.u32.min - 1 }, _success: false },
+        { fragmentConstants: { cu: kValue.u32.max }, _success: true },
+        { fragmentConstants: { cu: kValue.u32.max + 1 }, _success: false },
+        { fragmentConstants: { ci: kValue.i32.negative.min }, _success: true },
+        { fragmentConstants: { ci: kValue.i32.negative.min - 1 }, _success: false },
+        { fragmentConstants: { ci: kValue.i32.positive.max }, _success: true },
+        { fragmentConstants: { ci: kValue.i32.positive.max + 1 }, _success: false },
+        { fragmentConstants: { cf: kValue.f32.negative.min }, _success: true },
+        { fragmentConstants: { cf: -Number.MAX_VALUE }, _success: false },
+        { fragmentConstants: { cf: kValue.f32.positive.max }, _success: true },
+        { fragmentConstants: { cf: Number.MAX_VALUE }, _success: false },
+        // Conversion to boolean can't fail
+        { fragmentConstants: { cb: Number.MAX_VALUE }, _success: true },
+        { fragmentConstants: { cb: kValue.i32.negative.min - 1 }, _success: true },
+      ] as { fragmentConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
+  )
+  .fn(async t => {
+    const { isAsync, fragmentConstants, _success } = t.params;
+
+    const descriptor = t.getDescriptor({
+      fragmentShaderCode: `
+        override cb: bool = false;
+        override cu: u32 = 0u;
+        override ci: i32 = 0;
+        override cf: f32 = 0.0;
+        @fragment fn main()
+            -> @location(0) vec4<f32> {
+            _ = cb;
+            _ = cu;
+            _ = ci;
+            _ = cf;
+            return vec4<f32>(1.0, 1.0, 1.0, 1.0);
         }
           `,
       fragmentConstants,

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -390,7 +390,8 @@ g.test('value,validation_error,f16,vertex')
     `
 Tests calling createRenderPipeline(Async) validation for unrepresentable f16 constant values in vertex stage.
 
-TODO(#2060): test with last_f64_castable.
+TODO(#2060): Tighten the cases around the valid/invalid boundary once we have WGSL spec
+clarity on whether values like f16.positive.last_f64_castable would be valid. See issue.
 `
   )
   .params(u =>
@@ -446,7 +447,8 @@ g.test('value,validation_error,f16,fragment')
     `
 Tests calling createRenderPipeline(Async) validation for unrepresentable f16 constant values in fragment stage.
 
-TODO(#2060): test with last_f64_castable.
+TODO(#2060): Tighten the cases around the valid/invalid boundary once we have WGSL spec
+clarity on whether values like f16.positive.last_f64_castable would be valid. See issue.
 `
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -401,6 +401,10 @@ TODO(#2060): test with last_f64_castable.
         { vertexConstants: { cf16: kValue.f16.negative.first_f64_not_castable }, _success: false },
         { vertexConstants: { cf16: kValue.f16.positive.max }, _success: true },
         { vertexConstants: { cf16: kValue.f16.positive.first_f64_not_castable }, _success: false },
+        { vertexConstants: { cf16: kValue.f32.negative.min }, _success: false },
+        { vertexConstants: { cf16: kValue.f32.positive.max }, _success: false },
+        { vertexConstants: { cf16: kValue.f32.negative.first_f64_not_castable }, _success: false },
+        { vertexConstants: { cf16: kValue.f32.positive.first_f64_not_castable }, _success: false },
       ] as const)
   )
   .beforeAllSubcases(t => {
@@ -460,6 +464,16 @@ TODO(#2060): test with last_f64_castable.
         { fragmentConstants: { cf16: kValue.f16.positive.max }, _success: true },
         {
           fragmentConstants: { cf16: kValue.f16.positive.first_f64_not_castable },
+          _success: false,
+        },
+        { fragmentConstants: { cf16: kValue.f32.negative.min }, _success: false },
+        { fragmentConstants: { cf16: kValue.f32.positive.max }, _success: false },
+        {
+          fragmentConstants: { cf16: kValue.f32.negative.first_f64_not_castable },
+          _success: false,
+        },
+        {
+          fragmentConstants: { cf16: kValue.f32.positive.first_f64_not_castable },
           _success: false,
         },
       ] as const)

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -398,18 +398,25 @@ export class ValidationTest extends GPUTest {
   doCreateRenderPipelineTest(
     isAsync: boolean,
     _success: boolean,
-    descriptor: GPURenderPipelineDescriptor
+    descriptor: GPURenderPipelineDescriptor,
+    errorTypeName: 'OperationError' | 'TypeError' = 'OperationError'
   ) {
     if (isAsync) {
       if (_success) {
         this.shouldResolve(this.device.createRenderPipelineAsync(descriptor));
       } else {
-        this.shouldReject('OperationError', this.device.createRenderPipelineAsync(descriptor));
+        this.shouldReject(errorTypeName, this.device.createRenderPipelineAsync(descriptor));
       }
     } else {
-      this.expectValidationError(() => {
-        this.device.createRenderPipeline(descriptor);
-      }, !_success);
+      if (errorTypeName === 'OperationError') {
+        this.expectValidationError(() => {
+          this.device.createRenderPipeline(descriptor);
+        }, !_success);
+      } else {
+        this.shouldThrow(_success ? false : errorTypeName, () => {
+          this.device.createRenderPipeline(descriptor);
+        });
+      }
     }
   }
 
@@ -417,18 +424,25 @@ export class ValidationTest extends GPUTest {
   doCreateComputePipelineTest(
     isAsync: boolean,
     _success: boolean,
-    descriptor: GPUComputePipelineDescriptor
+    descriptor: GPUComputePipelineDescriptor,
+    errorTypeName: 'OperationError' | 'TypeError' = 'OperationError'
   ) {
     if (isAsync) {
       if (_success) {
         this.shouldResolve(this.device.createComputePipelineAsync(descriptor));
       } else {
-        this.shouldReject('OperationError', this.device.createComputePipelineAsync(descriptor));
+        this.shouldReject(errorTypeName, this.device.createComputePipelineAsync(descriptor));
       }
     } else {
-      this.expectValidationError(() => {
-        this.device.createComputePipeline(descriptor);
-      }, !_success);
+      if (errorTypeName === 'OperationError') {
+        this.expectValidationError(() => {
+          this.device.createComputePipeline(descriptor);
+        }, !_success);
+      } else {
+        this.shouldThrow(_success ? false : errorTypeName, () => {
+          this.device.createComputePipeline(descriptor);
+        });
+      }
     }
   }
 }

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -400,18 +400,18 @@ export const kValue = {
       min: hexToF16(kBit.f16.positive.min),
       max: hexToF16(kBit.f16.positive.max),
       zero: hexToF16(kBit.f16.positive.zero),
-      first_f64_not_castable: hexToF16(kBit.f16.positive.max) / 2 + 2 ** 127, // mid point of 2**128 and largest f16
+      first_f64_not_castable: hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16, // mid point of 2**16 and largest f16
       last_f64_castable: hexToF64(
-        f64ToHex(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 127) - BigInt(1)
+        f64ToHex(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
       ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     negative: {
       max: hexToF16(kBit.f16.negative.max),
       min: hexToF16(kBit.f16.negative.min),
       zero: hexToF16(kBit.f16.negative.zero),
-      first_f64_not_castable: -(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 127), // mid point of -2**128 and largest f16
+      first_f64_not_castable: -(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16), // mid point of -2**16 and largest f16
       last_f64_castable: -hexToF64(
-        f64ToHex(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 127) - BigInt(1)
+        f64ToHex(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
       ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     subnormal: {

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -263,6 +263,26 @@ export const kBit = {
 } as const;
 
 /**
+ * Converts a 64-bit hex value to a 64-bit float value
+ *
+ * Using a locally defined function here to avoid compile time dependency
+ * issues.
+ * */
+function hexToF64(hex: bigint): number {
+  return new Float64Array(new BigInt64Array([hex]).buffer)[0];
+}
+
+/**
+ * Converts a 64-bit float value to a 64-bit hex value
+ *
+ * Using a locally defined function here to avoid compile time dependency
+ * issues.
+ * */
+function f64ToHex(number: number): bigint {
+  return new BigUint64Array(new Float64Array([number]).buffer)[0];
+}
+
+/**
  * Converts a 32-bit hex value to a 32-bit float value
  *
  * Using a locally defined function here to avoid compile time dependency
@@ -317,6 +337,10 @@ export const kValue = {
         sixth: hexToF32(kBit.f32.positive.pi.sixth),
       },
       e: hexToF32(kBit.f32.positive.e),
+      first_f64_not_castable: hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127, // mid point of 2**128 and largest f32
+      last_f64_castable: hexToF64(
+        f64ToHex(hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
+      ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     negative: {
       max: hexToF32(kBit.f32.negative.max),
@@ -331,6 +355,10 @@ export const kValue = {
         quarter: hexToF32(kBit.f32.negative.pi.quarter),
         sixth: hexToF32(kBit.f32.negative.pi.sixth),
       },
+      first_f64_not_castable: -(hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127), // mid point of -2**128 and largest f32
+      last_f64_castable: -hexToF64(
+        f64ToHex(hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
+      ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     subnormal: {
       positive: {
@@ -372,11 +400,19 @@ export const kValue = {
       min: hexToF16(kBit.f16.positive.min),
       max: hexToF16(kBit.f16.positive.max),
       zero: hexToF16(kBit.f16.positive.zero),
+      first_f64_not_castable: hexToF16(kBit.f16.positive.max) / 2 + 2 ** 127, // mid point of 2**128 and largest f16
+      last_f64_castable: hexToF64(
+        f64ToHex(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 127) - BigInt(1)
+      ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     negative: {
       max: hexToF16(kBit.f16.negative.max),
       min: hexToF16(kBit.f16.negative.min),
       zero: hexToF16(kBit.f16.negative.zero),
+      first_f64_not_castable: -(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 127), // mid point of -2**128 and largest f16
+      last_f64_castable: -hexToF64(
+        f64ToHex(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 127) - BigInt(1)
+      ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     subnormal: {
       positive: {


### PR DESCRIPTION

Issue: #2060

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) (Pass with https://dawn-review.googlesource.com/c/dawn/+/112920 which is about to land; f16 is not fully implemented and is skipped;)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
