### PR TITLE
Implement generate*Cases functions and use them

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../expression.js';
+import { allInputSources, generateBinaryToF32IntervalCases, run } from '../expression.js';
 
 import { binary } from './binary.js';
 
@@ -22,114 +22,34 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('binary/f32_arithmetic', {
   addition_non_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), additionInterval);
   },
   addition_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, additionInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), additionInterval);
   },
   subtraction_non_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), subtractionInterval);
   },
   subtraction_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, subtractionInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), subtractionInterval);
   },
   multiplication_non_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), multiplicationInterval);
   },
   multiplication_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, multiplicationInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), multiplicationInterval);
   },
   division_non_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), divisionInterval);
   },
   division_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, divisionInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), divisionInterval);
   },
   remainder_non_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), remainderInterval);
   },
   remainder_const: () => {
-    const makeCase = (lhs: number, rhs: number): Case => {
-      return makeBinaryToF32IntervalCase(lhs, rhs, remainderInterval);
-    };
-
-    return fullF32Range().flatMap(x => {
-      return fullF32Range().map(y => {
-        return makeCase(x, y);
-      });
-    });
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), remainderInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -22,7 +22,7 @@ import { i32Bits, TypeF32, TypeI32, TypeU32, u32Bits } from '../../../../../util
 import { absInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -30,18 +30,10 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('abs', {
   f32_non_const: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, absInterval);
-    };
-
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), absInterval);
   },
   f32_const: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, absInterval);
-    };
-
-    return fullF32Range().map(x => makeCase(x));
+    return generateUnaryToF32IntervalCases(fullF32Range(), absInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { acosInterval } from '../../../../../util/f32_interval.js';
 import { sourceFilteredF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,24 +21,22 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('acos', {
   f32_const: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, acosInterval);
-    };
-
-    return [
-      ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
-      ...sourceFilteredF32Range('const', -1, 1),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
+        ...sourceFilteredF32Range('const', -1, 1),
+      ],
+      acosInterval
+    );
   },
   f32_non_const: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, acosInterval);
-    };
-
-    return [
-      ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
-      ...sourceFilteredF32Range('storage', -1, 1),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        ...linearRange(-1, 1, 100), // acos is defined on [-1, 1]
+        ...sourceFilteredF32Range('const', -1, 1),
+      ],
+      acosInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -17,7 +17,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { acoshIntervals } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -25,14 +25,13 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('acosh', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, ...acoshIntervals);
-    };
-
-    return [
-      ...biasedRange(1, 2, 100), // x near 1 can be problematic to implement
-      ...fullF32Range(),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        ...biasedRange(1, 2, 100), // x near 1 can be problematic to implement
+        ...fullF32Range(),
+      ],
+      ...acoshIntervals
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { asinInterval } from '../../../../../util/f32_interval.js';
 import { sourceFilteredF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,24 +21,22 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('asin', {
   f32_const: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, asinInterval);
-    };
-
-    return [
-      ...linearRange(-1, 1, 100), // asin is defined on [-1, 1]
-      ...sourceFilteredF32Range('const', -1, 1),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        ...linearRange(-1, 1, 100), // asin is defined on [-1, 1]
+        ...sourceFilteredF32Range('const', -1, 1),
+      ],
+      asinInterval
+    );
   },
   f32_non_const: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, asinInterval);
-    };
-
-    return [
-      ...linearRange(-1, 1, 100), // asin is defined on [-1, 1]
-      ...sourceFilteredF32Range('storage', -1, 1),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        ...linearRange(-1, 1, 100), // asin is defined on [-1, 1]
+        ...sourceFilteredF32Range('storage', -1, 1),
+      ],
+      asinInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
@@ -16,7 +16,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { asinhInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -24,11 +24,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('asinh', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, asinhInterval);
-    };
-
-    return [...fullF32Range()].map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), asinhInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { atanInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,40 +22,38 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('atan', {
   f32_non_const: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, atanInterval);
-    };
+    return generateUnaryToF32IntervalCases(
+      [
+        // Known values
+        -Math.sqrt(3),
+        -1,
+        -1 / Math.sqrt(3),
+        0,
+        1,
+        1 / Math.sqrt(3),
+        Math.sqrt(3),
 
-    return [
-      // Known values
-      -Math.sqrt(3),
-      -1,
-      -1 / Math.sqrt(3),
-      0,
-      1,
-      1 / Math.sqrt(3),
-      Math.sqrt(3),
-
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
+        ...fullF32Range(),
+      ],
+      atanInterval
+    );
   },
   f32_const: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, atanInterval);
-    };
+    return generateUnaryToF32IntervalCases(
+      [
+        // Known values
+        -Math.sqrt(3),
+        -1,
+        -1 / Math.sqrt(3),
+        0,
+        1,
+        1 / Math.sqrt(3),
+        Math.sqrt(3),
 
-    return [
-      // Known values
-      -Math.sqrt(3),
-      -1,
-      -1 / Math.sqrt(3),
-      0,
-      1,
-      1 / Math.sqrt(3),
-      Math.sqrt(3),
-
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
+        ...fullF32Range(),
+      ],
+      atanInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { atan2Interval } from '../../../../../util/f32_interval.js';
 import { linearRange, sparseF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateBinaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,24 +22,13 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('atan2', {
   f32: () => {
-    const makeCase = (y: number, x: number): Case => {
-      return makeBinaryToF32IntervalCase(y, x, atan2Interval);
-    };
-
     // Using sparse, since there a N^2 cases being generated, but including extra values around 0, since that is where
     // there is a discontinuity that implementations tend to behave badly at.
     const numeric_range = [
       ...sparseF32Range(),
       ...linearRange(kValue.f32.negative.max, kValue.f32.positive.min, 10),
     ];
-    const cases: Array<Case> = [];
-    numeric_range.forEach(y => {
-      numeric_range.forEach(x => {
-        cases.push(makeCase(y, x));
-      });
-    });
-
-    return cases;
+    return generateBinaryToF32IntervalCases(numeric_range, numeric_range, atan2Interval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -17,7 +17,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { atanhInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, sourceFilteredF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -25,40 +25,35 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('atanh', {
   f32_const: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, atanhInterval);
-    };
-
-    return [
-      ...biasedRange(kValue.f32.negative.less_than_one, -0.9, 20), // discontinuity at x = -1
-      ...biasedRange(kValue.f32.positive.less_than_one, 0.9, 20), // discontinuity at x = 1
-      ...sourceFilteredF32Range(
-        'const',
-        kValue.f32.negative.less_than_one,
-        kValue.f32.positive.less_than_one
-      ),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        ...biasedRange(kValue.f32.negative.less_than_one, -0.9, 20), // discontinuity at x = -1
+        ...biasedRange(kValue.f32.positive.less_than_one, 0.9, 20), // discontinuity at x = 1
+        ...sourceFilteredF32Range(
+          'const',
+          kValue.f32.negative.less_than_one,
+          kValue.f32.positive.less_than_one
+        ),
+      ],
+      atanhInterval
+    );
   },
   f32_non_const: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, atanhInterval);
-    };
-
-    const cases = [
-      ...biasedRange(kValue.f32.negative.less_than_one, -0.9, 20), // discontinuity at x = -1
-      ...biasedRange(kValue.f32.positive.less_than_one, 0.9, 20), // discontinuity at x = 1
-      ...sourceFilteredF32Range(
-        'storage',
-        kValue.f32.negative.less_than_one,
-        kValue.f32.positive.less_than_one
-      ),
-    ].map(makeCase);
-
-    // Handle the edge case of -1 and 1 when not doing const-eval
-    const edgeCases = [-1, 1].map(makeCase);
-    cases.push(...edgeCases);
-
-    return cases;
+    return generateUnaryToF32IntervalCases(
+      [
+        ...biasedRange(kValue.f32.negative.less_than_one, -0.9, 20), // discontinuity at x = -1
+        ...biasedRange(kValue.f32.positive.less_than_one, 0.9, 20), // discontinuity at x = 1
+        ...sourceFilteredF32Range(
+          'storage',
+          kValue.f32.negative.less_than_one,
+          kValue.f32.positive.less_than_one
+        ),
+        // Handle the edge case of -1 and 1 when not doing const-eval
+        -1,
+        1,
+      ],
+      atanhInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { ceilInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,25 +22,24 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('ceil', {
   f32: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, ceilInterval);
-    };
-
-    return [
-      // Small positive numbers
-      0.1,
-      0.9,
-      1.0,
-      1.1,
-      1.9,
-      // Small negative numbers
-      -0.1,
-      -0.9,
-      -1.0,
-      -1.1,
-      -1.9,
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
+    return generateUnaryToF32IntervalCases(
+      [
+        // Small positive numbers
+        0.1,
+        0.9,
+        1.0,
+        1.1,
+        1.9,
+        // Small negative numbers
+        -0.1,
+        -0.9,
+        -1.0,
+        -1.1,
+        -1.9,
+        ...fullF32Range(),
+      ],
+      ceilInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -29,7 +29,7 @@ import {
 import { clampIntervals } from '../../../../../util/f32_interval.js';
 import { sparseF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeTernaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, generateTernaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -67,41 +67,20 @@ export const d = makeCaseCache('clamp', {
     return generateIntegerTestCases(test_values);
   },
   f32_non_const: () => {
-    const makeCase = (x: number, y: number, z: number): Case => {
-      return makeTernaryToF32IntervalCase(x, y, z, ...clampIntervals);
-    };
-
-    // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range();
-    const cases: Array<Case> = [];
-    values.forEach(x => {
-      values.forEach(y => {
-        values.forEach(z => {
-          cases.push(makeCase(x, y, z));
-        });
-      });
-    });
-
-    return cases;
+    return generateTernaryToF32IntervalCases(
+      sparseF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
+      ...clampIntervals
+    );
   },
-
   f32_const: () => {
-    const makeCase = (x: number, y: number, z: number): Case => {
-      return makeTernaryToF32IntervalCase(x, y, z, ...clampIntervals);
-    };
-
-    // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range();
-    const cases: Array<Case> = [];
-    values.forEach(x => {
-      values.forEach(y => {
-        values.forEach(z => {
-          cases.push(makeCase(x, y, z));
-        });
-      });
-    });
-
-    return cases;
+    return generateTernaryToF32IntervalCases(
+      sparseF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
+      ...clampIntervals
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { cosInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,16 +22,14 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('cos', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, cosInterval);
-    };
-
-    return [
-      // Well defined accuracy range
-      ...linearRange(-Math.PI, Math.PI, 1000),
-
-      ...fullF32Range(),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        // Well defined accuracy range
+        ...linearRange(-Math.PI, Math.PI, 1000),
+        ...fullF32Range(),
+      ],
+      cosInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { coshInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,11 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('cosh', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, coshInterval);
-    };
-
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), coshInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -12,12 +12,7 @@ import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { crossInterval } from '../../../../../util/f32_interval.js';
 import { vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import {
-  allInputSources,
-  Case,
-  makeVectorPairToVectorIntervalCase,
-  run,
-} from '../../expression.js';
+import { allInputSources, generateVectorPairToVectorCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -25,15 +20,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('cross', {
   f32: () => {
-    const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairToVectorIntervalCase(x, y, crossInterval);
-    };
-
-    return vectorF32Range(3).flatMap(i => {
-      return vectorF32Range(3).map(j => {
-        return makeCase(i, j);
-      });
-    });
+    return generateVectorPairToVectorCases(vectorF32Range(3), vectorF32Range(3), crossInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { degreesInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,10 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('degrees', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, degreesInterval);
-    };
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), degreesInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
@@ -16,9 +16,8 @@ import { fullF32Range, sparseVectorF32Range } from '../../../../../util/math.js'
 import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
-  Case,
-  makeBinaryToF32IntervalCase,
-  makeVectorPairToF32IntervalCase,
+  generateBinaryToF32IntervalCases,
+  generateVectorPairToF32IntervalCases,
   run,
 } from '../../expression.js';
 
@@ -28,32 +27,30 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('distance', {
   f32: () => {
-    const makeCase = (x: number, y: number): Case => {
-      return makeBinaryToF32IntervalCase(x, y, distanceInterval);
-    };
-    return fullF32Range().flatMap(i => fullF32Range().map(j => makeCase(i, j)));
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), distanceInterval);
   },
   f32_vec2: () => {
-    return sparseVectorF32Range(2).flatMap(i =>
-      sparseVectorF32Range(2).map(j => makeCaseVecF32(i, j))
+    return generateVectorPairToF32IntervalCases(
+      sparseVectorF32Range(2),
+      sparseVectorF32Range(2),
+      distanceInterval
     );
   },
   f32_vec3: () => {
-    return sparseVectorF32Range(3).flatMap(i =>
-      sparseVectorF32Range(3).map(j => makeCaseVecF32(i, j))
+    return generateVectorPairToF32IntervalCases(
+      sparseVectorF32Range(3),
+      sparseVectorF32Range(3),
+      distanceInterval
     );
   },
   f32_vec4: () => {
-    return sparseVectorF32Range(4).flatMap(i =>
-      sparseVectorF32Range(4).map(j => makeCaseVecF32(i, j))
+    return generateVectorPairToF32IntervalCases(
+      sparseVectorF32Range(4),
+      sparseVectorF32Range(4),
+      distanceInterval
     );
   },
 });
-
-/** @returns a `distance` Case for a pair of vectors of f32s input */
-const makeCaseVecF32 = (x: number[], y: number[]): Case => {
-  return makeVectorPairToF32IntervalCase(x, y, distanceInterval);
-};
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { dotInterval } from '../../../../../util/f32_interval.js';
 import { vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeVectorPairToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateVectorPairToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,37 +21,13 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('dot', {
   f32_vec2: () => {
-    const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
-    };
-
-    return vectorF32Range(2).flatMap(i => {
-      return vectorF32Range(2).map(j => {
-        return makeCase(i, j);
-      });
-    });
+    return generateVectorPairToF32IntervalCases(vectorF32Range(2), vectorF32Range(2), dotInterval);
   },
   f32_vec3: () => {
-    const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
-    };
-
-    return vectorF32Range(3).flatMap(i => {
-      return vectorF32Range(3).map(j => {
-        return makeCase(i, j);
-      });
-    });
+    return generateVectorPairToF32IntervalCases(vectorF32Range(3), vectorF32Range(3), dotInterval);
   },
   f32_vec4: () => {
-    const makeCase = (x: number[], y: number[]): Case => {
-      return makeVectorPairToF32IntervalCase(x, y, dotInterval);
-    };
-
-    return vectorF32Range(4).flatMap(i => {
-      return vectorF32Range(4).map(j => {
-        return makeCase(i, j);
-      });
-    });
+    return generateVectorPairToF32IntervalCases(vectorF32Range(4), vectorF32Range(4), dotInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { expInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,20 +22,19 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('exp', {
   f32: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, expInterval);
-    };
-
     // floor(ln(max f32 value)) = 88, so exp(88) will be within range of a f32, but exp(89) will not
     // floor(ln(max f64 value)) = 709, so exp(709) can be handled by the testing framework, but exp(710) will misbehave
-    return [
-      0, // Returns 1 by definition
-      -89, // Returns subnormal value
-      kValue.f32.negative.min, // Closest to returning 0 as possible
-      ...biasedRange(kValue.f32.negative.max, -88, 100),
-      ...biasedRange(kValue.f32.positive.min, 88, 100),
-      ...linearRange(89, 709, 10), // Overflows f32, but not f64
-    ].map(x => makeCase(x));
+    return generateUnaryToF32IntervalCases(
+      [
+        0, // Returns 1 by definition
+        -89, // Returns subnormal value
+        kValue.f32.negative.min, // Closest to returning 0 as possible
+        ...biasedRange(kValue.f32.negative.max, -88, 100),
+        ...biasedRange(kValue.f32.positive.min, 88, 100),
+        ...linearRange(89, 709, 10), // Overflows f32, but not f64
+      ],
+      expInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { exp2Interval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,20 +22,19 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('exp2', {
   f32: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, exp2Interval);
-    };
-
     // floor(log2(max f32 value)) = 127, so exp2(127) will be within range of a f32, but exp2(128) will not
     // floor(ln(max f64 value)) = 1023, so exp2(1023) can be handled by the testing framework, but exp2(1024) will misbehave
-    return [
-      0, // Returns 1 by definition
-      -128, // Returns subnormal value
-      kValue.f32.negative.min, // Closest to returning 0 as possible
-      ...biasedRange(kValue.f32.negative.max, -127, 100),
-      ...biasedRange(kValue.f32.positive.min, 127, 100),
-      ...linearRange(128, 1023, 10), // Overflows f32, but not f64
-    ].map(x => makeCase(x));
+    return generateUnaryToF32IntervalCases(
+      [
+        0, // Returns 1 by definition
+        -128, // Returns subnormal value
+        kValue.f32.negative.min, // Closest to returning 0 as possible
+        ...biasedRange(kValue.f32.negative.max, -127, 100),
+        ...biasedRange(kValue.f32.positive.min, 127, 100),
+        ...linearRange(128, 1023, 10), // Overflows f32, but not f64
+      ],
+      exp2Interval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { floorInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,25 +21,24 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('floor', {
   f32: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, floorInterval);
-    };
-
-    return [
-      // Small positive numbers
-      0.1,
-      0.9,
-      1.0,
-      1.1,
-      1.9,
-      // Small negative numbers
-      -0.1,
-      -0.9,
-      -1.0,
-      -1.1,
-      -1.9,
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
+    return generateUnaryToF32IntervalCases(
+      [
+        // Small positive numbers
+        0.1,
+        0.9,
+        1.0,
+        1.1,
+        1.9,
+        // Small negative numbers
+        -0.1,
+        -0.9,
+        -1.0,
+        -1.1,
+        -1.9,
+        ...fullF32Range(),
+      ],
+      floorInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
@@ -12,11 +12,23 @@ import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
 import { fmaInterval } from '../../../../../util/f32_interval.js';
 import { sparseF32Range } from '../../../../../util/math.js';
-import { allInputSources, Case, makeTernaryToF32IntervalCase, run } from '../../expression.js';
+import { makeCaseCache } from '../../case_cache.js';
+import { allInputSources, generateTernaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('fma', {
+  f32: () => {
+    return generateTernaryToF32IntervalCases(
+      sparseF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
+      fmaInterval
+    );
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -33,17 +45,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range();
-    const cases: Array<Case> = [];
-    values.forEach(x => {
-      values.forEach(y => {
-        values.forEach(z => {
-          cases.push(makeTernaryToF32IntervalCase(x, y, z, fmaInterval));
-        });
-      });
-    });
-
+    const cases = await d.get('f32');
     await run(t, builtin('fma'), [TypeF32, TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { fractInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,26 +22,25 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('fract', {
   f32: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, fractInterval);
-    };
-
-    return [
-      0.5, // 0.5 -> 0.5
-      0.9, // ~0.9 -> ~0.9
-      1, // 1 -> 0
-      2, // 2 -> 0
-      1.11, // ~1.11 -> ~0.11
-      10.0001, // ~10.0001 -> ~0.0001
-      -0.1, // ~-0.1 -> ~0.9
-      -0.5, // -0.5 -> 0.5
-      -0.9, // ~-0.9 -> ~0.1
-      -1, // -1 -> 0
-      -2, // -2 -> 0
-      -1.11, // ~-1.11 -> ~0.89
-      -10.0001, // -10.0001 -> ~0.9999
-      ...fullF32Range(),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        0.5, // 0.5 -> 0.5
+        0.9, // ~0.9 -> ~0.9
+        1, // 1 -> 0
+        2, // 2 -> 0
+        1.11, // ~1.11 -> ~0.11
+        10.0001, // ~10.0001 -> ~0.0001
+        -0.1, // ~-0.1 -> ~0.9
+        -0.5, // -0.5 -> 0.5
+        -0.9, // ~-0.9 -> ~0.1
+        -1, // -1 -> 0
+        -2, // -2 -> 0
+        -1.11, // ~-1.11 -> ~0.89
+        -10.0001, // -10.0001 -> ~0.9999
+        ...fullF32Range(),
+      ],
+      fractInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { inverseSqrtInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,16 +22,15 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('inverseSqrt', {
   f32: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, inverseSqrtInterval);
-    };
-
-    return [
-      // 0 < x <= 1 linearly spread
-      ...linearRange(kValue.f32.positive.min, 1, 100),
-      // 1 <= x < 2^32, biased towards 1
-      ...biasedRange(1, 2 ** 32, 1000),
-    ].map(x => makeCase(x));
+    return generateUnaryToF32IntervalCases(
+      [
+        // 0 < x <= 1 linearly spread
+        ...linearRange(kValue.f32.positive.min, 1, 100),
+        // 1 <= x < 2^32, biased towards 1
+        ...biasedRange(1, 2 ** 32, 1000),
+      ],
+      inverseSqrtInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -15,9 +15,8 @@ import { fullF32Range, vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
-  Case,
-  makeUnaryToF32IntervalCase,
-  makeVectorToF32IntervalCase,
+  generateUnaryToF32IntervalCases,
+  generateVectorToF32IntervalCases,
   run,
 } from '../../expression.js';
 
@@ -27,26 +26,18 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('length', {
   f32: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, lengthInterval);
-    };
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), lengthInterval);
   },
   f32_vec2: () => {
-    return vectorF32Range(2).map(makeCaseVecF32);
+    return generateVectorToF32IntervalCases(vectorF32Range(2), lengthInterval);
   },
   f32_vec3: () => {
-    return vectorF32Range(3).map(makeCaseVecF32);
+    return generateVectorToF32IntervalCases(vectorF32Range(3), lengthInterval);
   },
   f32_vec4: () => {
-    return vectorF32Range(4).map(makeCaseVecF32);
+    return generateVectorToF32IntervalCases(vectorF32Range(4), lengthInterval);
   },
 });
-
-/** @returns a `length` Case for a vector of f32s input */
-const makeCaseVecF32 = (x: number[]): Case => {
-  return makeVectorToF32IntervalCase(x, lengthInterval);
-};
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#numeric-builtin-functions')

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { logInterval } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,18 +22,16 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('log', {
   f32: () => {
-    // [1]: Need to decide what the ground-truth is.
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, logInterval);
-    };
-
-    return [
-      // log's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
-      ...linearRange(kValue.f32.positive.min, 0.5, 20),
-      ...linearRange(0.5, 2.0, 20),
-      ...biasedRange(2.0, 2 ** 32, 1000),
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
+    return generateUnaryToF32IntervalCases(
+      [
+        // log's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
+        ...linearRange(kValue.f32.positive.min, 0.5, 20),
+        ...linearRange(0.5, 2.0, 20),
+        ...biasedRange(2.0, 2 ** 32, 1000),
+        ...fullF32Range(),
+      ],
+      logInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { log2Interval } from '../../../../../util/f32_interval.js';
 import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,18 +22,16 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('log2', {
   f32: () => {
-    // [1]: Need to decide what the ground-truth is.
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, log2Interval);
-    };
-
-    return [
-      // log2's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
-      ...linearRange(kValue.f32.positive.min, 0.5, 20),
-      ...linearRange(0.5, 2.0, 20),
-      ...biasedRange(2.0, 2 ** 32, 1000),
-      ...fullF32Range(),
-    ].map(x => makeCase(x));
+    return generateUnaryToF32IntervalCases(
+      [
+        // log2's accuracy is defined in three regions { [0, 0.5), [0.5, 2.0], (2.0, +∞] }
+        ...linearRange(kValue.f32.positive.min, 0.5, 20),
+        ...linearRange(0.5, 2.0, 20),
+        ...biasedRange(2.0, 2 ** 32, 1000),
+        ...fullF32Range(),
+      ],
+      log2Interval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -22,7 +22,7 @@ import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/convers
 import { maxInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, generateBinaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -44,19 +44,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('max', {
   f32: () => {
-    const makeCase = (x: number, y: number): Case => {
-      return makeBinaryToF32IntervalCase(x, y, maxInterval);
-    };
-
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs));
-      });
-    });
-
-    return cases;
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), maxInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -21,7 +21,7 @@ import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/convers
 import { minInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, Case, generateBinaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -29,19 +29,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('min', {
   f32: () => {
-    const makeCase = (x: number, y: number): Case => {
-      return makeBinaryToF32IntervalCase(x, y, minInterval);
-    };
-
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(lhs => {
-      numeric_range.forEach(rhs => {
-        cases.push(makeCase(lhs, rhs));
-      });
-    });
-
-    return cases;
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), minInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -20,7 +20,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { mixIntervals } from '../../../../../util/f32_interval.js';
 import { sparseF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeTernaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateTernaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -28,21 +28,12 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('mix', {
   f32: () => {
-    const makeCase = (x: number, y: number, z: number): Case => {
-      return makeTernaryToF32IntervalCase(x, y, z, ...mixIntervals);
-    };
-
-    const values = sparseF32Range();
-    const cases: Array<Case> = [];
-    values.forEach(x => {
-      values.forEach(y => {
-        values.forEach(z => {
-          cases.push(makeCase(x, y, z));
-        });
-      });
-    });
-
-    return cases;
+    return generateTernaryToF32IntervalCases(
+      sparseF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
+      ...mixIntervals
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -12,7 +12,7 @@ import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { normalizeInterval } from '../../../../../util/f32_interval.js';
 import { vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeVectorToVectorIntervalCase, run } from '../../expression.js';
+import { allInputSources, generateVectorToVectorCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -20,20 +20,15 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('normalize', {
   f32_vec2: () => {
-    return vectorF32Range(2).map(makeCaseVecF32);
+    return generateVectorToVectorCases(vectorF32Range(2), normalizeInterval);
   },
   f32_vec3: () => {
-    return vectorF32Range(3).map(makeCaseVecF32);
+    return generateVectorToVectorCases(vectorF32Range(3), normalizeInterval);
   },
   f32_vec4: () => {
-    return vectorF32Range(4).map(makeCaseVecF32);
+    return generateVectorToVectorCases(vectorF32Range(4), normalizeInterval);
   },
 });
-
-/** @returns a `normalize` Case for a vector of f32s input */
-const makeCaseVecF32 = (x: number[]): Case => {
-  return makeVectorToVectorIntervalCase(x, normalizeInterval);
-};
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { powInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeBinaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateBinaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,19 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('pow', {
   f32: () => {
-    const makeCase = (x: number, y: number): Case => {
-      return makeBinaryToF32IntervalCase(x, y, powInterval);
-    };
-
-    const cases: Array<Case> = [];
-    const numeric_range = fullF32Range();
-    numeric_range.forEach(x => {
-      numeric_range.forEach(y => {
-        cases.push(makeCase(x, y));
-      });
-    });
-
-    return cases;
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), powInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -15,7 +15,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { quantizeToF16Interval } from '../../../../../util/f32_interval.js';
 import { fullF16Range, fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,44 +23,36 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('quantizeToF16', {
   f32_const: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, quantizeToF16Interval);
-    };
-
-    const cases = [
-      kValue.f16.negative.min,
-      kValue.f16.negative.max,
-      kValue.f16.subnormal.negative.min,
-      kValue.f16.subnormal.negative.max,
-      kValue.f16.subnormal.positive.min,
-      kValue.f16.subnormal.positive.max,
-      kValue.f16.positive.min,
-      kValue.f16.positive.max,
-    ].map(makeCase);
-
-    cases.push(...fullF16Range().map(makeCase));
-
-    return cases;
+    return generateUnaryToF32IntervalCases(
+      [
+        kValue.f16.negative.min,
+        kValue.f16.negative.max,
+        kValue.f16.subnormal.negative.min,
+        kValue.f16.subnormal.negative.max,
+        kValue.f16.subnormal.positive.min,
+        kValue.f16.subnormal.positive.max,
+        kValue.f16.positive.min,
+        kValue.f16.positive.max,
+        ...fullF16Range(),
+      ],
+      quantizeToF16Interval
+    );
   },
   f32_non_const: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, quantizeToF16Interval);
-    };
-
-    const cases = [
-      kValue.f16.negative.min,
-      kValue.f16.negative.max,
-      kValue.f16.subnormal.negative.min,
-      kValue.f16.subnormal.negative.max,
-      kValue.f16.subnormal.positive.min,
-      kValue.f16.subnormal.positive.max,
-      kValue.f16.positive.min,
-      kValue.f16.positive.max,
-    ].map(makeCase);
-
-    cases.push(...fullF32Range().map(makeCase));
-
-    return cases;
+    return generateUnaryToF32IntervalCases(
+      [
+        kValue.f16.negative.min,
+        kValue.f16.negative.max,
+        kValue.f16.subnormal.negative.min,
+        kValue.f16.subnormal.negative.max,
+        kValue.f16.subnormal.positive.min,
+        kValue.f16.subnormal.positive.max,
+        kValue.f16.positive.min,
+        kValue.f16.positive.max,
+        ...fullF32Range(),
+      ],
+      quantizeToF16Interval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { radiansInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,11 +22,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('radians', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, radiansInterval);
-    };
-
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), radiansInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
@@ -13,12 +13,7 @@ import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { reflectInterval } from '../../../../../util/f32_interval.js';
 import { sparseVectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import {
-  allInputSources,
-  Case,
-  makeVectorPairToVectorIntervalCase,
-  run,
-} from '../../expression.js';
+import { allInputSources, generateVectorPairToVectorCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -26,26 +21,27 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('reflect', {
   f32_vec2: () => {
-    return sparseVectorF32Range(2).flatMap(i =>
-      sparseVectorF32Range(2).map(j => makeCaseVecF32(i, j))
+    return generateVectorPairToVectorCases(
+      sparseVectorF32Range(2),
+      sparseVectorF32Range(2),
+      reflectInterval
     );
   },
   f32_vec3: () => {
-    return sparseVectorF32Range(3).flatMap(i =>
-      sparseVectorF32Range(3).map(j => makeCaseVecF32(i, j))
+    return generateVectorPairToVectorCases(
+      sparseVectorF32Range(3),
+      sparseVectorF32Range(3),
+      reflectInterval
     );
   },
   f32_vec4: () => {
-    return sparseVectorF32Range(4).flatMap(i =>
-      sparseVectorF32Range(4).map(j => makeCaseVecF32(i, j))
+    return generateVectorPairToVectorCases(
+      sparseVectorF32Range(4),
+      sparseVectorF32Range(4),
+      reflectInterval
     );
   },
 });
-
-/** @returns a `reflect` Case for a pair of vectors of f32s input */
-const makeCaseVecF32 = (x: number[], y: number[]): Case => {
-  return makeVectorPairToVectorIntervalCase(x, y, reflectInterval);
-};
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -16,7 +16,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { roundInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -24,11 +24,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('round', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, roundInterval);
-    };
-
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), roundInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { saturateInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,16 +21,14 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('saturate', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, saturateInterval);
-    };
-
-    return [
-      // Non-clamped values
-      ...linearRange(0.0, 1.0, 100),
-
-      ...fullF32Range(),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        // Non-clamped values
+        ...linearRange(0.0, 1.0, 100),
+        ...fullF32Range(),
+      ],
+      saturateInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { signInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,11 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sign', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, signInterval);
-    };
-
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), signInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { sinInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,16 +21,15 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sin', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, sinInterval);
-    };
+    return generateUnaryToF32IntervalCases(
+      [
+        // Well defined accuracy range
+        ...linearRange(-Math.PI, Math.PI, 1000),
 
-    return [
-      // Well defined accuracy range
-      ...linearRange(-Math.PI, Math.PI, 1000),
-
-      ...fullF32Range(),
-    ].map(makeCase);
+        ...fullF32Range(),
+      ],
+      sinInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { sinhInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,11 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sinh', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, sinhInterval);
-    };
-
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), sinhInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -15,7 +15,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { smoothStepInterval } from '../../../../../util/f32_interval.js';
 import { sparseF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeTernaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateTernaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,22 +23,12 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('smoothstep', {
   f32: () => {
-    const makeCase = (x: number, y: number, z: number): Case => {
-      return makeTernaryToF32IntervalCase(x, y, z, smoothStepInterval);
-    };
-
-    // Using sparseF32Range since this will generate N^3 test cases
-    const values = sparseF32Range();
-    const cases: Array<Case> = [];
-    values.forEach(x => {
-      values.forEach(y => {
-        values.forEach(z => {
-          cases.push(makeCase(x, y, z));
-        });
-      });
-    });
-
-    return cases;
+    return generateTernaryToF32IntervalCases(
+      sparseF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
+      smoothStepInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { sqrtInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,11 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sqrt', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, sqrtInterval);
-    };
-
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), sqrtInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { tanInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,15 +21,14 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('tan', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, tanInterval);
-    };
-
-    return [
-      // Defined accuracy range
-      ...linearRange(-Math.PI, Math.PI, 100),
-      ...fullF32Range(),
-    ].map(makeCase);
+    return generateUnaryToF32IntervalCases(
+      [
+        // Defined accuracy range
+        ...linearRange(-Math.PI, Math.PI, 100),
+        ...fullF32Range(),
+      ],
+      tanInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
@@ -13,7 +13,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { tanhInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,11 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('tanh', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, tanhInterval);
-    };
-
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), tanhInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -14,7 +14,7 @@ import { TypeF32 } from '../../../../../util/conversion.js';
 import { truncInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,11 +22,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('trunc', {
   f32: () => {
-    const makeCase = (n: number): Case => {
-      return makeUnaryToF32IntervalCase(n, truncInterval);
-    };
-
-    return fullF32Range().map(makeCase);
+    return generateUnaryToF32IntervalCases(fullF32Range(), truncInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
@@ -11,7 +11,7 @@ import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack2x16floatInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
+import { allInputSources, generateU32ToVectorCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -19,11 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack2x16float', {
   u32: () => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack2x16floatInterval);
-    };
-
-    return fullU32Range().map(makeCase);
+    return generateU32ToVectorCases(fullU32Range(), unpack2x16floatInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
@@ -11,7 +11,7 @@ import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack2x16snormInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
+import { allInputSources, generateU32ToVectorCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -19,11 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack2x16snorm', {
   u32: () => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack2x16snormInterval);
-    };
-
-    return fullU32Range().map(makeCase);
+    return generateU32ToVectorCases(fullU32Range(), unpack2x16snormInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -11,7 +11,7 @@ import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack2x16unormInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
+import { allInputSources, generateU32ToVectorCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -19,11 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack2x16unorm', {
   u32: () => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack2x16unormInterval);
-    };
-
-    return fullU32Range().map(makeCase);
+    return generateU32ToVectorCases(fullU32Range(), unpack2x16unormInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
@@ -11,7 +11,7 @@ import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack4x8snormInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
+import { allInputSources, generateU32ToVectorCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -19,11 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack4x8snorm', {
   u32: () => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack4x8snormInterval);
-    };
-
-    return fullU32Range().map(makeCase);
+    return generateU32ToVectorCases(fullU32Range(), unpack4x8snormInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
@@ -11,7 +11,7 @@ import { TypeF32, TypeU32, TypeVec } from '../../../../../util/conversion.js';
 import { unpack4x8unormInterval } from '../../../../../util/f32_interval.js';
 import { fullU32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, makeU32ToVectorIntervalCase, run } from '../../expression.js';
+import { allInputSources, generateU32ToVectorCases, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -19,11 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack4x8unorm', {
   u32: () => {
-    const makeCase = (n: number): Case => {
-      return makeU32ToVectorIntervalCase(n, unpack4x8unormInterval);
-    };
-
-    return fullU32Range().map(makeCase);
+    return generateU32ToVectorCases(fullU32Range(), unpack4x8unormInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -25,7 +25,7 @@ import {
   VectorToInterval,
   VectorToVector,
 } from '../../../util/f32_interval.js';
-import { quantizeToF32 } from '../../../util/math.js';
+import { cartesianProduct, quantizeToF32 } from '../../../util/math.js';
 
 export type Expectation = Value | F32Interval | F32Interval[] | Comparator;
 
@@ -563,12 +563,12 @@ function packScalarsToVector(
 }
 
 /**
- * Generates a Case for the param and unary interval generator provided.
+ * Builds a Case for the param and unary interval generator provided.
  * The Case will use use an interval comparator for matching results.
  * @param param the param to pass into the unary operation
  * @param ops callbacks that implement generating an acceptance interval for a unary operation
  */
-export function makeUnaryToF32IntervalCase(param: number, ...ops: PointToInterval[]): Case {
+function makeUnaryToF32IntervalCase(param: number, ...ops: PointToInterval[]): Case {
   param = quantizeToF32(param);
 
   const intervals = ops.map(o => o(param));
@@ -576,13 +576,25 @@ export function makeUnaryToF32IntervalCase(param: number, ...ops: PointToInterva
 }
 
 /**
- * Generates a Case for the params and binary interval generator provided.
+ *  @returns an array of Cases for a given operation over a range of inputs
+ *  @param params array of inputs to try
+ *  @param ops accuracy interval generators to use in the tests
+ **/
+export function generateUnaryToF32IntervalCases(
+  params: number[],
+  ...ops: PointToInterval[]
+): Case[] {
+  return params.map(e => makeUnaryToF32IntervalCase(e, ...ops));
+}
+
+/**
+ * Builds a Case for the params and binary interval generator provided.
  * The Case will use use an interval comparator for matching results.
  * @param param0 the first param or left hand side to pass into the binary operation
  * @param param1 the second param or rhs hand side to pass into the binary operation
  * @param ops callbacks that implement generating an acceptance interval for a binary operation
  */
-export function makeBinaryToF32IntervalCase(
+function makeBinaryToF32IntervalCase(
   param0: number,
   param1: number,
   ...ops: BinaryToInterval[]
@@ -595,7 +607,23 @@ export function makeBinaryToF32IntervalCase(
 }
 
 /**
- * Generates a Case for the params and ternary interval generator provided.
+ *  @returns an array of Cases for a given operation over a range of inputs
+ *  @param param0s array of inputs to try for the first param
+ *  @param param1s array of inputs to try for the second param
+ *  @param ops accuracy interval generators to use in the tests
+ **/
+export function generateBinaryToF32IntervalCases(
+  param0s: number[],
+  param1s: number[],
+  ...ops: BinaryToInterval[]
+): Case[] {
+  return cartesianProduct(param0s, param1s).map(e =>
+    makeBinaryToF32IntervalCase(e[0], e[1], ...ops)
+  );
+}
+
+/**
+ * Builds a Case for the params and ternary interval generator provided.
  * The Case will use use an interval comparator for matching results.
  * @param param0 the first param to pass into the ternary operation
  * @param param1 the second param to pass into the ternary operation
@@ -603,7 +631,7 @@ export function makeBinaryToF32IntervalCase(
  * @param ops callbacks that implement generating an acceptance interval for a
  *           ternary operation.
  */
-export function makeTernaryToF32IntervalCase(
+function makeTernaryToF32IntervalCase(
   param0: number,
   param1: number,
   param2: number,
@@ -621,12 +649,30 @@ export function makeTernaryToF32IntervalCase(
 }
 
 /**
- * Generates a Case for the param and vector interval generator provided.
+ *  @returns an array of Cases for a given operation over a range of inputs
+ *  @param param0s array of inputs to try for the first param
+ *  @param param1s array of inputs to try for the second param
+ *  @param param2s array of inputs to try for the second param
+ *  @param ops accuracy interval generators to use in the tests
+ **/
+export function generateTernaryToF32IntervalCases(
+  param0s: number[],
+  param1s: number[],
+  param2s: number[],
+  ...ops: TernaryToInterval[]
+): Case[] {
+  return cartesianProduct(param0s, param1s, param2s).map(e =>
+    makeTernaryToF32IntervalCase(e[0], e[1], e[2], ...ops)
+  );
+}
+
+/**
+ * Builds a Case for the param and vector interval generator provided.
  * @param param the param to pass into the operation
  * @param ops callbacks that implement generating an acceptance interval for a
  *            vector.
  */
-export function makeVectorToF32IntervalCase(param: number[], ...ops: VectorToInterval[]): Case {
+function makeVectorToF32IntervalCase(param: number[], ...ops: VectorToInterval[]): Case {
   param = param.map(quantizeToF32);
   const param_f32 = param.map(f32);
 
@@ -638,13 +684,25 @@ export function makeVectorToF32IntervalCase(param: number[], ...ops: VectorToInt
 }
 
 /**
- * Generates a Case for the params and vector pair interval generator provided.
+ *  @returns an array of Cases for a given operation over a range of inputs
+ *  @param params array of inputs to try
+ *  @param ops accuracy interval generators to use in the tests
+ **/
+export function generateVectorToF32IntervalCases(
+  params: number[][],
+  ...ops: VectorToInterval[]
+): Case[] {
+  return params.map(e => makeVectorToF32IntervalCase(e, ...ops));
+}
+
+/**
+ * Builds a Case for the params and vector pair interval generator provided.
  * @param param0 the first param to pass into the operation
  * @param param1 the second param to pass into the operation
  * @param ops callbacks that implement generating an acceptance interval for a
  *            pair of vectors.
  */
-export function makeVectorPairToF32IntervalCase(
+function makeVectorPairToF32IntervalCase(
   param0: number[],
   param1: number[],
   ...ops: VectorPairToInterval[]
@@ -662,12 +720,28 @@ export function makeVectorPairToF32IntervalCase(
 }
 
 /**
- * Generates a Case for the param and vector of intervals generator provided.
+ *  @returns an array of Cases for a given operation over a range of inputs
+ *  @param param0s array of inputs to try for the first input
+ *  @param param1s array of inputs to try for the second input
+ *  @param ops accuracy interval generators to use in the tests
+ **/
+export function generateVectorPairToF32IntervalCases(
+  param0s: number[][],
+  param1s: number[][],
+  ...ops: VectorPairToInterval[]
+): Case[] {
+  return cartesianProduct(param0s, param1s).map(e =>
+    makeVectorPairToF32IntervalCase(e[0], e[1], ...ops)
+  );
+}
+
+/**
+ * Builds a Case for the param and vector of intervals generator provided.
  * @param param the param to pass into the operation
  * @param ops callbacks that implement generating an vector of acceptance
  *            intervals for a vector.
  */
-export function makeVectorToVectorIntervalCase(param: number[], ...ops: VectorToVector[]): Case {
+function makeVectorToVectorCase(param: number[], ...ops: VectorToVector[]): Case {
   param = param.map(quantizeToF32);
   const param_f32 = param.map(f32);
 
@@ -679,13 +753,22 @@ export function makeVectorToVectorIntervalCase(param: number[], ...ops: VectorTo
 }
 
 /**
- * Generates a Case for the params and vector of intervals generator provided.
+ *  @returns an array of Cases for a given operation over a range of inputs
+ *  @param params array of inputs to try
+ *  @param ops accuracy interval generators to use in the tests
+ **/
+export function generateVectorToVectorCases(params: number[][], ...ops: VectorToVector[]): Case[] {
+  return params.map(e => makeVectorToVectorCase(e, ...ops));
+}
+
+/**
+ * Builds a Case for the params and vector of intervals generator provided.
  * @param param0 the first param to pass into the operation
  * @param param1 the second param to pass into the operation
  * @param ops callbacks that implement generating an vector of acceptance
  *            intervals for a pair of vectors.
  */
-export function makeVectorPairToVectorIntervalCase(
+function makeVectorPairToVectorCase(
   param0: number[],
   param1: number[],
   ...ops: VectorPairToVector[]
@@ -703,13 +786,29 @@ export function makeVectorPairToVectorIntervalCase(
 }
 
 /**
- * Generates a Case for the param and vector of intervals generator provided.
+ *  @returns an array of Cases for a given operation over a range of inputs
+ *  @param param0s array of inputs to try for the first input
+ *  @param param1s array of inputs to try for the second input
+ *  @param ops accuracy interval generators to use in the tests
+ **/
+export function generateVectorPairToVectorCases(
+  param0s: number[][],
+  param1s: number[][],
+  ...ops: VectorPairToVector[]
+): Case[] {
+  return cartesianProduct(param0s, param1s).map(e =>
+    makeVectorPairToVectorCase(e[0], e[1], ...ops)
+  );
+}
+
+/**
+ * Builds a Case for the param and vector of intervals generator provided.
  * The input is treated as an unsigned int.
  * @param param the param to pass into the operation
  * @param ops callbacks that implement generating an vector of acceptance
  *            intervals for a vector.
  */
-export function makeU32ToVectorIntervalCase(param: number, ...ops: PointToVector[]): Case {
+function makeU32ToVectorCase(param: number, ...ops: PointToVector[]): Case {
   param = Math.trunc(param);
   const param_u32 = u32(param);
 
@@ -718,4 +817,13 @@ export function makeU32ToVectorIntervalCase(param: number, ...ops: PointToVector
     input: param_u32,
     expected: anyOf(...vectors),
   };
+}
+
+/**
+ *  @returns an array of Cases for a given operation over a range of inputs
+ *  @param params array of inputs to try
+ *  @param ops accuracy interval generators to use in the tests
+ **/
+export function generateU32ToVectorCases(params: number[], ...ops: PointToVector[]): Case[] {
+  return params.map(e => makeU32ToVectorCase(e, ...ops));
 }

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -563,10 +563,10 @@ function packScalarsToVector(
 }
 
 /**
- * Builds a Case for the param and unary interval generator provided.
+ * @returns a Case for the param and unary interval generator provided
  * The Case will use use an interval comparator for matching results.
- * @param param the param to pass into the unary operation
- * @param ops callbacks that implement generating an acceptance interval for a unary operation
+ * @param param the param to pass in
+ * @param ops callbacks that implement generating an acceptance interval for an unary operation
  */
 function makeUnaryToF32IntervalCase(param: number, ...ops: PointToInterval[]): Case {
   param = quantizeToF32(param);
@@ -576,10 +576,11 @@ function makeUnaryToF32IntervalCase(param: number, ...ops: PointToInterval[]): C
 }
 
 /**
- *  @returns an array of Cases for a given operation over a range of inputs
- *  @param params array of inputs to try
- *  @param ops accuracy interval generators to use in the tests
- **/
+ * @returns an array of Cases for operations over a range of inputs
+ * @param params array of inputs to try
+ * @param ops callbacks that implement generating an acceptance interval for an
+ *            unary operation
+ */
 export function generateUnaryToF32IntervalCases(
   params: number[],
   ...ops: PointToInterval[]
@@ -588,11 +589,12 @@ export function generateUnaryToF32IntervalCases(
 }
 
 /**
- * Builds a Case for the params and binary interval generator provided.
+ * @returns a Case for the params and binary interval generator provided
  * The Case will use use an interval comparator for matching results.
- * @param param0 the first param or left hand side to pass into the binary operation
- * @param param1 the second param or rhs hand side to pass into the binary operation
- * @param ops callbacks that implement generating an acceptance interval for a binary operation
+ * @param param0 the first param or left hand side to pass in
+ * @param param1 the second param or rhs hand side to pass in
+ * @param ops callbacks that implement generating an acceptance interval for a
+ *            binary operation
  */
 function makeBinaryToF32IntervalCase(
   param0: number,
@@ -607,11 +609,12 @@ function makeBinaryToF32IntervalCase(
 }
 
 /**
- *  @returns an array of Cases for a given operation over a range of inputs
- *  @param param0s array of inputs to try for the first param
- *  @param param1s array of inputs to try for the second param
- *  @param ops accuracy interval generators to use in the tests
- **/
+ * @returns an array of Cases for operations over a range of inputs
+ * @param param0s array of inputs to try for the first param
+ * @param param1s array of inputs to try for the second param
+ * @param ops callbacks that implement generating an acceptance interval for a
+ *            binary operation
+ */
 export function generateBinaryToF32IntervalCases(
   param0s: number[],
   param1s: number[],
@@ -623,13 +626,13 @@ export function generateBinaryToF32IntervalCases(
 }
 
 /**
- * Builds a Case for the params and ternary interval generator provided.
+ * @returns a Case for the params and ternary interval generator provided
  * The Case will use use an interval comparator for matching results.
- * @param param0 the first param to pass into the ternary operation
- * @param param1 the second param to pass into the ternary operation
- * @param param2 the third param to pass into the ternary operation
+ * @param param0 the first param to pass in
+ * @param param1 the second param to pass in
+ * @param param2 the third param to pass in
  * @param ops callbacks that implement generating an acceptance interval for a
- *           ternary operation.
+ *            ternary operation.
  */
 function makeTernaryToF32IntervalCase(
   param0: number,
@@ -649,12 +652,13 @@ function makeTernaryToF32IntervalCase(
 }
 
 /**
- *  @returns an array of Cases for a given operation over a range of inputs
- *  @param param0s array of inputs to try for the first param
- *  @param param1s array of inputs to try for the second param
- *  @param param2s array of inputs to try for the second param
- *  @param ops accuracy interval generators to use in the tests
- **/
+ * @returns an array of Cases for operations over a range of inputs
+ * @param param0s array of inputs to try for the first param
+ * @param param1s array of inputs to try for the second param
+ * @param param2s array of inputs to try for the third param
+ * @param ops callbacks that implement generating an acceptance interval for a
+ *            ternary operation.
+ */
 export function generateTernaryToF32IntervalCases(
   param0s: number[],
   param1s: number[],
@@ -667,8 +671,8 @@ export function generateTernaryToF32IntervalCases(
 }
 
 /**
- * Builds a Case for the param and vector interval generator provided.
- * @param param the param to pass into the operation
+ * @returns a Case for the param and vector interval generator provided
+ * @param param the param to pass in
  * @param ops callbacks that implement generating an acceptance interval for a
  *            vector.
  */
@@ -684,9 +688,10 @@ function makeVectorToF32IntervalCase(param: number[], ...ops: VectorToInterval[]
 }
 
 /**
- *  @returns an array of Cases for a given operation over a range of inputs
- *  @param params array of inputs to try
- *  @param ops accuracy interval generators to use in the tests
+ * @returns an array of Cases for operations over a range of inputs
+ * @param params array of inputs to try
+ * @param ops callbacks that implement generating an acceptance interval for a
+ *            vector.
  **/
 export function generateVectorToF32IntervalCases(
   params: number[][],
@@ -696,9 +701,9 @@ export function generateVectorToF32IntervalCases(
 }
 
 /**
- * Builds a Case for the params and vector pair interval generator provided.
- * @param param0 the first param to pass into the operation
- * @param param1 the second param to pass into the operation
+ * @returns a Case for the params and vector pair interval generator provided
+ * @param param0 the first param to pass in
+ * @param param1 the second param to pass in
  * @param ops callbacks that implement generating an acceptance interval for a
  *            pair of vectors.
  */
@@ -720,11 +725,12 @@ function makeVectorPairToF32IntervalCase(
 }
 
 /**
- *  @returns an array of Cases for a given operation over a range of inputs
- *  @param param0s array of inputs to try for the first input
- *  @param param1s array of inputs to try for the second input
- *  @param ops accuracy interval generators to use in the tests
- **/
+ * @returns an array of Cases for operations over a range of inputs
+ * @param param0s array of inputs to try for the first input
+ * @param param1s array of inputs to try for the second input
+ * @param ops callbacks that implement generating an acceptance interval for a
+ *            pair of vectors.
+ */
 export function generateVectorPairToF32IntervalCases(
   param0s: number[][],
   param1s: number[][],
@@ -736,8 +742,8 @@ export function generateVectorPairToF32IntervalCases(
 }
 
 /**
- * Builds a Case for the param and vector of intervals generator provided.
- * @param param the param to pass into the operation
+ * @returns a Case for the param and vector of intervals generator provided
+ * @param param the param to pass in
  * @param ops callbacks that implement generating an vector of acceptance
  *            intervals for a vector.
  */
@@ -753,18 +759,19 @@ function makeVectorToVectorCase(param: number[], ...ops: VectorToVector[]): Case
 }
 
 /**
- *  @returns an array of Cases for a given operation over a range of inputs
- *  @param params array of inputs to try
- *  @param ops accuracy interval generators to use in the tests
- **/
+ * @returns an array of Cases for operations over a range of inputs
+ * @param params array of inputs to try
+ * @param ops callbacks that implement generating an vector of acceptance
+ *            intervals for a vector.
+ */
 export function generateVectorToVectorCases(params: number[][], ...ops: VectorToVector[]): Case[] {
   return params.map(e => makeVectorToVectorCase(e, ...ops));
 }
 
 /**
- * Builds a Case for the params and vector of intervals generator provided.
- * @param param0 the first param to pass into the operation
- * @param param1 the second param to pass into the operation
+ * @returns a Case for the params and vector of intervals generator provided
+ * @param param0 the first param to pass in
+ * @param param1 the second param to pass in
  * @param ops callbacks that implement generating an vector of acceptance
  *            intervals for a pair of vectors.
  */
@@ -786,11 +793,12 @@ function makeVectorPairToVectorCase(
 }
 
 /**
- *  @returns an array of Cases for a given operation over a range of inputs
- *  @param param0s array of inputs to try for the first input
- *  @param param1s array of inputs to try for the second input
- *  @param ops accuracy interval generators to use in the tests
- **/
+ * @returns an array of Cases for operations over a range of inputs
+ * @param param0s array of inputs to try for the first input
+ * @param param1s array of inputs to try for the second input
+ * @param ops callbacks that implement generating an vector of acceptance
+ *            intervals for a pair of vectors.
+ */
 export function generateVectorPairToVectorCases(
   param0s: number[][],
   param1s: number[][],
@@ -802,11 +810,11 @@ export function generateVectorPairToVectorCases(
 }
 
 /**
- * Builds a Case for the param and vector of intervals generator provided.
+ * @returns a Case for the param and vector of intervals generator provided
  * The input is treated as an unsigned int.
- * @param param the param to pass into the operation
- * @param ops callbacks that implement generating an vector of acceptance
- *            intervals for a vector.
+ * @param param the param to pass in
+ * @param ops callbacks that implement generating an acceptance
+ *            interval for an unsigned int.
  */
 function makeU32ToVectorCase(param: number, ...ops: PointToVector[]): Case {
   param = Math.trunc(param);
@@ -820,10 +828,11 @@ function makeU32ToVectorCase(param: number, ...ops: PointToVector[]): Case {
 }
 
 /**
- *  @returns an array of Cases for a given operation over a range of inputs
- *  @param params array of inputs to try
- *  @param ops accuracy interval generators to use in the tests
- **/
+ * @returns an array of Cases for operations over a range of inputs
+ * @param params array of inputs to try
+ * @param ops callbacks that implement generating an acceptance
+ *            interval for an unsigned int.
+ */
 export function generateU32ToVectorCases(params: number[], ...ops: PointToVector[]): Case[] {
   return params.map(e => makeU32ToVectorCase(e, ...ops));
 }

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -8,7 +8,7 @@ import { TypeF32 } from '../../../../util/conversion.js';
 import { negationInterval } from '../../../../util/f32_interval.js';
 import { fullF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, Case, makeUnaryToF32IntervalCase, run } from '../expression.js';
+import { allInputSources, generateUnaryToF32IntervalCases, run } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -16,12 +16,9 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unary/f32_arithmetic', {
   negation: () => {
-    const makeCase = (x: number): Case => {
-      return makeUnaryToF32IntervalCase(x, negationInterval);
-    };
-
-    return fullF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }).map(x =>
-      makeCase(x)
+    return generateUnaryToF32IntervalCases(
+      fullF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }),
+      negationInterval
     );
   },
 });


### PR DESCRIPTION
This replaces the various patterns used throughout the numeric tests to create an array of input tuples and then maps them to make*Case to a common pattern that uses `cartesianProduct` for calculating the tuples.

This reduces duplication of code and will allow for easier future work on filtering cases for const/non-const by having a single point where the filtering needs to occur.

This patch does not change the results of the tests, it is just a refactoring.

Issue #2058

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
