### PR TITLE
op: Implement 'stencil_reference_initialized' test in stencil.spec.ts

### DIFF
--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -15,7 +15,7 @@ const kGreenStencilColor = new Float32Array([0.0, 1.0, 0.0, 1.0]);
 type TestStates = {
   state: GPUDepthStencilState;
   color: Float32Array;
-  stencil: number;
+  stencil: number | undefined;
 };
 
 class StencilTest extends GPUTest {
@@ -121,7 +121,11 @@ class StencilTest extends GPUTest {
     this.runStencilStateTest(testStates, expectedColor);
   }
 
-  runStencilStateTest(testStates: TestStates[], expectedColor: Float32Array) {
+  runStencilStateTest(
+    testStates: TestStates[],
+    expectedColor: Float32Array,
+    isSingleEncoderMultiplePass: boolean = false
+  ) {
     const renderTargetFormat = 'rgba8unorm';
     const renderTarget = this.device.createTexture({
       format: renderTargetFormat,
@@ -147,7 +151,7 @@ class StencilTest extends GPUTest {
     };
 
     const encoder = this.device.createCommandEncoder();
-    const pass = encoder.beginRenderPass({
+    let pass = encoder.beginRenderPass({
       colorAttachments: [
         {
           view: renderTarget.createView(),
@@ -158,20 +162,44 @@ class StencilTest extends GPUTest {
       depthStencilAttachment,
     });
 
+    if (isSingleEncoderMultiplePass) {
+      pass.end();
+    }
+
     // Draw a triangle with the given stencil reference and the comparison function.
     // The color will be kGreenStencilColor if the stencil test passes, and kBaseColor if not.
     for (const test of testStates) {
+      if (isSingleEncoderMultiplePass) {
+        pass = encoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view: renderTarget.createView(),
+              storeOp: 'store',
+              loadOp: 'load',
+            },
+          ],
+          depthStencilAttachment,
+        });
+      }
       const testPipeline = this.createRenderPipelineForTest(test.state);
       pass.setPipeline(testPipeline);
-      pass.setStencilReference(test.stencil);
+      if (test.stencil !== undefined) {
+        pass.setStencilReference(test.stencil);
+      }
       pass.setBindGroup(
         0,
         this.createBindGroupForTest(testPipeline.getBindGroupLayout(0), test.color)
       );
       pass.draw(1);
+
+      if (isSingleEncoderMultiplePass) {
+        pass.end();
+      }
     }
 
-    pass.end();
+    if (!isSingleEncoderMultiplePass) {
+      pass.end();
+    }
     this.device.queue.submit([encoder.finish()]);
 
     const expColor = {
@@ -517,4 +545,43 @@ g.test('stencil_read_write_mask')
     ];
 
     t.runStencilStateTest(testStates, _expectedColor);
+  });
+
+g.test('stencil_reference_initialized')
+  .desc('Test that stencil reference is initialized as zero for new render pass.')
+  .fn(async t => {
+    const depthSpencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
+
+    const baseStencilState = {
+      compare: 'always',
+      passOp: 'replace',
+    } as const;
+
+    const testStencilState = {
+      compare: 'equal',
+      passOp: 'keep',
+    } as const;
+
+    const baseState = {
+      format: depthSpencilFormat,
+      stencilFront: baseStencilState,
+      stencilBack: baseStencilState,
+    } as const;
+
+    const testState = {
+      format: depthSpencilFormat,
+      stencilFront: testStencilState,
+      stencilBack: testStencilState,
+    } as const;
+
+    // First pass sets the stencil to 0x1, the second pass sets the stencil to its default
+    // value, and the third pass tests if the stencil is zero.
+    const testStates = [
+      { state: baseState, color: kBaseColor, stencil: 0x1 },
+      { state: baseState, color: kRedStencilColor, stencil: undefined },
+      { state: testState, color: kGreenStencilColor, stencil: 0x0 },
+    ];
+
+    // The third draw should pass the stencil test since the second pass set it to default zero.
+    t.runStencilStateTest(testStates, kGreenStencilColor, true);
   });


### PR DESCRIPTION
This PR adds a new test to check if the stencil reference is initialized as zero for new render pass.

Issue: #2023


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
