### PR TITLE
Also test depthWriteEnabled:true in depth_write_disabled

### DIFF
--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -159,18 +159,23 @@ g.test('depth_disabled').desc(`Tests render results with depth test disabled`).u
 g.test('depth_write_disabled')
   .desc(
     `
-  Test that disabling depth writes works and leaves the depth buffer unchanged.
+  Test that depthWriteEnabled behaves as expected.
+  If enabled, a depth value of 0.0 is written.
+  If disabled, it's not written, so it keeps the previous value of 1.0.
+  Use a depthCompare: 'equal' check at the end to check the value.
   `
   )
   .params(u =>
     u //
       .combineWithParams([
-        { lastDepth: 0.0, _expectedColor: kRedStencilColor },
-        { lastDepth: 1.0, _expectedColor: kGreenStencilColor },
+        { depthWriteEnabled: false, lastDepth: 0.0, _expectedColor: kRedStencilColor },
+        { depthWriteEnabled: true, lastDepth: 0.0, _expectedColor: kGreenStencilColor },
+        { depthWriteEnabled: false, lastDepth: 1.0, _expectedColor: kGreenStencilColor },
+        { depthWriteEnabled: true, lastDepth: 1.0, _expectedColor: kRedStencilColor },
       ])
   )
   .fn(async t => {
-    const { lastDepth, _expectedColor } = t.params;
+    const { depthWriteEnabled, lastDepth, _expectedColor } = t.params;
 
     const depthSpencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
 
@@ -193,7 +198,7 @@ g.test('depth_write_disabled')
 
     const depthWriteState = {
       format: depthSpencilFormat,
-      depthWriteEnabled: false,
+      depthWriteEnabled,
       depthCompare: 'always',
       stencilFront: stencilState,
       stencilBack: stencilState,


### PR DESCRIPTION
This is probably a unnecessary but it helps ensure the test code is correct. And it runs very fast so it's fine.

Issue: #2023 #2024

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
