### PR TITLE
op: Implement 'depth_test_fail' test in depth.spec.ts

### DIFF
--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -238,12 +238,57 @@ g.test('depth_write_disabled')
     } as const;
 
     const testStates = [
-      // Draw a base triangle with depth write enabled.
+      // Draw a base point with depth write enabled.
       { state: baseState, color: kBaseColor, depth: 1.0 },
-      // Draw a second triangle without depth write enabled.
+      // Draw a second point without depth write enabled.
       { state: depthWriteState, color: kRedStencilColor, depth: 0.0 },
-      // Draw a third triangle which should occlude the second even though it is behind it.
+      // Draw a third point which should occlude the second even though it is behind it.
       { state: checkState, color: kGreenStencilColor, depth: lastDepth },
+    ];
+
+    t.runDepthStateTest(testStates, _expectedColor);
+  });
+
+g.test('depth_test_fail')
+  .desc(
+    `
+  Test that render results on depth test failure cases with 'less' depthCompare operation and
+  depthWriteEnabled is true.
+  `
+  )
+  .params(u =>
+    u //
+      .combineWithParams([
+        { secondDepth: 1.0, lastDepth: 2.0, _expectedColor: kBaseColor }, // fail -> fail.
+        { secondDepth: 0.0, lastDepth: 2.0, _expectedColor: kRedStencilColor }, // pass -> fail.
+        { secondDepth: 2.0, lastDepth: 0.9, _expectedColor: kGreenStencilColor }, // fail -> pass.
+      ] as const)
+  )
+  .fn(async t => {
+    const { secondDepth, lastDepth, _expectedColor } = t.params;
+
+    const depthSpencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
+
+    const baseState = {
+      format: depthSpencilFormat,
+      depthWriteEnabled: true,
+      depthCompare: 'always',
+      stencilReadMask: 0xff,
+      stencilWriteMask: 0xff,
+    } as const;
+
+    const depthTestState = {
+      format: depthSpencilFormat,
+      depthWriteEnabled: true,
+      depthCompare: 'less',
+      stencilReadMask: 0xff,
+      stencilWriteMask: 0xff,
+    } as const;
+
+    const testStates = [
+      { state: baseState, color: kBaseColor, depth: 1.0 },
+      { state: depthTestState, color: kRedStencilColor, depth: secondDepth },
+      { state: depthTestState, color: kGreenStencilColor, depth: lastDepth },
     ];
 
     t.runDepthStateTest(testStates, _expectedColor);

--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -389,7 +389,7 @@ g.test('stencil_passOp_operation')
     t.checkStencilOperation(passOp, initialStencil, referenceStencil, expectedStencil);
   });
 
-g.test('stencil_fail_operation')
+g.test('stencil_test_fail')
   .desc(
     `
   Test that the stencil operation is executed on stencil fail. Triangle with stencil reference 2


### PR DESCRIPTION
This PR adds a new test to check if render results are correct on depth test failure with 'less' depthCompare operation.

Additionally, this PR renames the' stencil_fail_operation' test to 'stencil_test_fail', and fixes wrong comments in the 'depth_write_disabled' test.

Issue: #2023

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
