### PR TITLE
Adds explicit check that mapAsync rejects when buffer is destroyed.

### DIFF
--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -120,6 +120,11 @@ g.test('mapAsync,state,destroyed')
   .fn(async t => {
     const { mapMode } = t.params;
     const buffer = t.createMappableBuffer(mapMode, 16);
+
+    // Start mapping the buffer, we are going to destroy it before it resolves so it will reject
+    // the mapping promise with an AbortError.
+    t.shouldReject('AbortError', buffer.mapAsync(mapMode));
+
     buffer.destroy();
     await t.testMapAsyncCall(false, 'OperationError', buffer, mapMode);
   });


### PR DESCRIPTION
Issue: #929

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
