### PR TITLE
Expect DataCloneError when transferring a detached mapped ArrayBuffer

### DIFF
--- a/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_ArrayBuffer.spec.ts
@@ -83,6 +83,7 @@ g.test('postMessage')
 
     buf.unmap();
     t.expect(ab1.byteLength === 0, 'after unmap, ab1 should be detached');
-    // Still can't transfer after detaching
-    t.shouldThrow('TypeError', () => mc.port1.postMessage(ab1, [ab1]));
+
+    // Transferring an already-detached ArrayBuffer is a DataCloneError.
+    t.shouldThrow('DataCloneError', () => mc.port1.postMessage(ab1, [ab1]));
   });


### PR DESCRIPTION
StructuredSerializeWithTransfer first checks whether the ArrayBuffer is detached before attempting DetachArrayBuffer. On failure, it throws DataCloneError, so we should expect that instead of TypeError.

https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
