### PR TITLE
Remove usage of Case Cache in `pack2x16float`

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pack2x16float.spec.ts
@@ -19,16 +19,18 @@ import {
   vec2,
 } from '../../../../../util/conversion.js';
 import { cartesianProduct, fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
-import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
-// unpack2x16float has somewhat unusual behaviour, specifically around how it is
+// pack2x16float has somewhat unusual behaviour, specifically around how it is
 // supposed to behave when values go OOB and when they are considered to have
 // gone OOB, so has its own bespoke implementation.
+//
+// The use of a custom Comparator prevents easy serialization in the case cache,
+// https://github.com/gpuweb/cts/issues/2077
 
 /**
  * @returns a custom comparator for a possible result from pack2x16float
@@ -51,7 +53,7 @@ function cmp(expectation: number | undefined): Comparator {
 }
 
 /**
- * @returns a Case for `unpack2x16float`
+ * @returns a Case for `pack2x16float`
  * @param param0 first param for the case
  * @param param1 second param for the case
  * @param filter_undefined should inputs that cause an undefined expectation be
@@ -70,7 +72,7 @@ function makeCase(param0: number, param1: number, filter_undefined: boolean): Ca
 }
 
 /**
- * @returns an array of Cases for `unpack2x16float`
+ * @returns an array of Cases for `pack2x16float`
  * @param param0s array of inputs to try for the first param
  * @param param1s array of inputs to try for the second param
  * @param filter_undefined should inputs that cause an undefined expectation be
@@ -82,15 +84,6 @@ function generateCases(param0s: number[], param1s: number[], filter_undefined: b
     .filter((c): c is Case => c !== undefined);
 }
 
-export const d = makeCaseCache('unpack2x16float', {
-  f32_const: () => {
-    return generateCases(fullF32Range(), fullF32Range(), true);
-  },
-  f32_non_const: () => {
-    return generateCases(fullF32Range(), fullF32Range(), false);
-  },
-});
-
 g.test('pack')
   .specURL('https://www.w3.org/TR/WGSL/#pack-builtin-functions')
   .desc(
@@ -100,6 +93,9 @@ g.test('pack')
   )
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
-    const cases = await d.get(t.params.inputSource === 'const' ? 'f32_const' : 'f32_non_const');
+    const cases =
+      t.params.inputSource === 'const'
+        ? generateCases(fullF32Range(), fullF32Range(), true)
+        : generateCases(fullF32Range(), fullF32Range(), false);
     await run(t, builtin('pack2x16float'), [TypeVec(2, TypeF32)], TypeU32, t.params, cases);
   });


### PR DESCRIPTION
This first fixes the duplicate cache error that is being seen, because of sloppy copypasta, and also fixes the hidden issue that the custom comparator cannot be serialized.

Issue #2077

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
