### PR TITLE
Buffer.mapAsync pending map error shouldn't be a validation error

### DIFF
--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -186,8 +186,9 @@ g.test('mapAsync,state,mapped')
 
 g.test('mapAsync,state,mappingPending')
   .desc(
-    `Test that mapAsync is an error when called on a buffer that is being mapped,
-    but succeeds after the previous mapping request is cancelled.`
+    `Test that mapAsync is rejected when called on a buffer that is being mapped,
+    but succeeds after the previous mapping request is cancelled.
+    TODO: Replace shouldReject with testMapAsyncCall to check error timing`
   )
   .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
@@ -199,12 +200,10 @@ g.test('mapAsync,state,mappingPending')
     // the mapping promise with an AbortError.
     t.shouldReject('AbortError', buffer.mapAsync(mapMode));
 
-    // Do the test of mapAsync while [[state]] is mapping pending. It has to be synchronous so
-    // that we can unmap the previous mapping in the same stack frame and check this one doesn't
-    // get canceled, but instead is treated as a real error.
-    t.expectValidationError(() => {
-      t.shouldReject('OperationError', buffer.mapAsync(mapMode));
-    });
+    // Do the test of mapAsync while [[pending_map]] is non-null. It has to be synchronous so
+    // that we can unmap the previous mapping in the same stack frame and testing this one doesn't
+    // get canceled, but instead is rejected.
+    t.shouldReject('OperationError', buffer.mapAsync(mapMode));
 
     // Unmap the first mapping. It should now be possible to successfully call mapAsync
     buffer.unmap();
@@ -537,17 +536,18 @@ Test for various cases of being destroyed: at creation, after a mapAsync call or
   });
 
 g.test('getMappedRange,state,mappingPending')
-  .desc('Test that it is invalid to call getMappedRange in the mappingPending state.')
+  .desc(
+    `Test that it is invalid to call getMappedRange in the mappingPending state.
+         TODO: Replace shouldReject with testMapAsyncCall to check error timing`
+  )
   .paramsSubcasesOnly(u => u.combine('mapMode', kMapModeOptions))
   .fn(async t => {
     const { mapMode } = t.params;
     const buffer = t.createMappableBuffer(mapMode, 16);
 
     /* noawait */ const mapping0 = buffer.mapAsync(mapMode);
-    t.expectValidationError(() => {
-      // seconding mapping should be rejected
-      t.shouldReject('OperationError', buffer.mapAsync(mapMode));
-    });
+    // seconding mapping should be rejected
+    t.shouldReject('OperationError', buffer.mapAsync(mapMode));
 
     // invalid in mappingPending state
     t.testGetMappedRangeCall(false, buffer);


### PR DESCRIPTION
From: https://github.com/gpuweb/cts/issues/2009#issuecomment-1350608028

The current `Buffer.mapAsync` pending map error (mapAsync request on non-null [[pending_map]] error) tests expect a validation error but it doesn't produce a validation error in the WebGPU spec.

Issue: #2009

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
