### PR TITLE
Add a powerPreference option

### DIFF
--- a/docs/intro/developing.md
+++ b/docs/intro/developing.md
@@ -52,6 +52,8 @@ The following url parameters change how the harness runs:
 - `runnow=1` runs all matching tests on page load.
 - `debug=1` enables verbose debug logging from tests.
 - `worker=1` runs the tests on a Web Worker instead of the main thread.
+- `powerPreference=low-power` runs most tests passing `powerPreference: low-power` to `requestAdapter`
+- `powerPreference=high-performance` runs most tests passing `powerPreference: high-performance` to `requestAdapter`
 
 ## Editor
 

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -9,6 +9,7 @@ import { LiveTestCaseResult } from '../internal/logging/result.js';
 import { parseQuery } from '../internal/query/parseQuery.js';
 import { TestQueryLevel } from '../internal/query/query.js';
 import { TestTreeNode, TestSubtree, TestTreeLeaf, TestTree } from '../internal/tree.js';
+import { setDefaultRequestAdapterOptions } from '../util/navigator_gpu.js';
 import { assert, ErrorWithExtra, unreachable } from '../util/util.js';
 
 import { optionEnabled } from './helper/options.js';
@@ -45,6 +46,11 @@ let stopRequested = false;
 stopButtonElem.addEventListener('click', () => {
   stopRequested = true;
 });
+
+const powerPreference = new URLSearchParams(window.location.search).get('powerPreference');
+if (powerPreference) {
+  setDefaultRequestAdapterOptions({ powerPreference: powerPreference as GPUPowerPreference });
+}
 
 dataCache.setStore({
   load: async (path: string) => {
@@ -435,17 +441,15 @@ void (async () => {
 
   // Update the URL bar to match the exact current options.
   {
-    let url = window.location.protocol + '//' + window.location.host + window.location.pathname;
-    url +=
-      '?' +
-      new URLSearchParams([
-        ['runnow', runnow ? '1' : '0'],
-        ['worker', worker ? '1' : '0'],
-        ['debug', debug ? '1' : '0'],
-        ['unroll_const_eval_loops', unrollConstEvalLoops ? '1' : '0'],
-      ]).toString() +
-      '&' +
-      qs.map(q => 'q=' + q).join('&');
+    const params = {
+      runnow: runnow ? '1' : '0',
+      worker: worker ? '1' : '0',
+      debug: debug ? '1' : '0',
+      unroll_const_eval_loops: unrollConstEvalLoops ? '1' : '0',
+      ...(powerPreference && { powerPreference }),
+    };
+    let url = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+    url += `?${new URLSearchParams(params).toString()}&${qs.map(q => 'q=' + q).join('&')}`;
     window.history.replaceState(null, '', url);
   }
 

--- a/src/common/util/navigator_gpu.ts
+++ b/src/common/util/navigator_gpu.ts
@@ -32,6 +32,15 @@ export function setGPUProvider(provider: GPUProvider) {
 
 let impl: GPU | undefined = undefined;
 
+let defaultRequestAdapterOptions: GPURequestAdapterOptions | undefined;
+
+export function setDefaultRequestAdapterOptions(options: GPURequestAdapterOptions) {
+  if (impl) {
+    throw new Error('must call setDefaultRequestAdapterOptions before getGPU');
+  }
+  defaultRequestAdapterOptions = { ...options };
+}
+
 /**
  * Finds and returns the `navigator.gpu` object (or equivalent, for non-browser implementations).
  * Throws an exception if not found.
@@ -42,6 +51,24 @@ export function getGPU(): GPU {
   }
 
   impl = gpuProvider();
+
+  if (defaultRequestAdapterOptions) {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const oldFn = impl.requestAdapter;
+    impl.requestAdapter = function (
+      options?: GPURequestAdapterOptions
+    ): Promise<GPUAdapter | null> {
+      const promise = oldFn.call(this, { ...defaultRequestAdapterOptions, ...(options || {}) });
+      void promise.then(async adapter => {
+        if (adapter) {
+          const info = await adapter.requestAdapterInfo();
+          // eslint-disable-next-line no-console
+          console.log(info);
+        }
+      });
+      return promise;
+    };
+  }
 
   return impl;
 }


### PR DESCRIPTION
Not sure how to add this here's an attempt.

You can pass `powerPreference=low-power` or
`power-preference=high-performance` in the query string.




Issue: #2083

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
