### PR TITLE
Fix wrong _errorLine in operation/shader_module/compilation_info.spec.ts

### DIFF
--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -53,7 +53,7 @@ const kInvalidShaderSources = [
   {
     valid: false,
     name: 'carriage-return',
-    _errorLine: 4,
+    _errorLine: 5,
     _code:
       `
       @vertex fn main() -> @builtin(position) vec4<f32> {` +


### PR DESCRIPTION
This patch fixes the wrong value of _errorLine of the shader named 'carriage-return' in kInvalidShaderSources. The correct error line should be 5:
line 1: \n
line 2: @vertex fn main() -> @builtin(position) vec4<f32> {\r\n
line 3: \n
line 4: // Expected Error: unknown function 'unknown'
line 5: return unknown(0.0, 0.0, 0.0, 1.0);




Fixed: #2087

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
