### PR TITLE
Test beginComputePass/RenderPass after encoder.finish() in call_after_successful_finish

### DIFF
--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -111,31 +111,41 @@ g.test('call_after_successful_finish')
     const pass = passType === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder);
     pass.end();
 
-    const callFn = () => {
-      switch (callCmd) {
-        case 'beginComputePass':
-          encoder.beginComputePass();
-          break;
-        case 'beginRenderPass':
-          t.beginRenderPass(encoder);
-          break;
-        case 'insertDebugMarker':
-          encoder.insertDebugMarker('');
-          break;
-        default:
-          unreachable();
-      }
-    };
-
     if (IsEncoderFinished) {
       encoder.finish();
-      t.expectValidationError(() => {
-        callFn();
-      }, IsEncoderFinished);
-    } else {
-      t.expectValidationError(() => {
-        callFn();
-      }, IsEncoderFinished);
+    }
+
+    switch (callCmd) {
+      case 'beginComputePass':
+        {
+          let pass: GPUComputePassEncoder;
+          t.expectValidationError(() => {
+            pass = encoder.beginComputePass();
+          }, IsEncoderFinished);
+          t.expectValidationError(() => {
+            pass.end();
+          }, IsEncoderFinished);
+        }
+        break;
+      case 'beginRenderPass':
+        {
+          let pass: GPURenderPassEncoder;
+          t.expectValidationError(() => {
+            pass = t.beginRenderPass(encoder);
+          }, IsEncoderFinished);
+          t.expectValidationError(() => {
+            pass.end();
+          }, IsEncoderFinished);
+        }
+        break;
+      case 'insertDebugMarker':
+        t.expectValidationError(() => {
+          encoder.insertDebugMarker('');
+        }, IsEncoderFinished);
+        break;
+    }
+
+    if (!IsEncoderFinished) {
       encoder.finish();
     }
   });

--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -96,11 +96,12 @@ g.test('pass_end_invalid_order')
 
 g.test('call_after_successful_finish')
   .desc(`Test that encoding command after a successful finish generates a validation error.`)
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
+      .combine('callCmd', ['beginComputePass', 'beginRenderPass', 'copyBufferToBuffer'])
+      .beginSubcases()
       .combine('passType', ['compute', 'render'])
       .combine('IsEncoderFinished', [false, true])
-      .combine('callCmd', ['beginComputePass', 'beginRenderPass', 'copyBufferToBuffer'])
   )
   .fn(async t => {
     const { passType, IsEncoderFinished, callCmd } = t.params;

--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -98,7 +98,7 @@ g.test('call_after_successful_finish')
   .desc(`Test that encoding command after a successful finish generates a validation error.`)
   .params(u =>
     u
-      .combine('callCmd', ['beginComputePass', 'beginRenderPass', 'copyBufferToBuffer'])
+      .combine('callCmd', ['beginComputePass', 'beginRenderPass', 'insertDebugMarker'])
       .beginSubcases()
       .combine('passType', ['compute', 'render'])
       .combine('IsEncoderFinished', [false, true])
@@ -111,16 +111,6 @@ g.test('call_after_successful_finish')
     const pass = passType === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder);
     pass.end();
 
-    const srcBuffer = t.device.createBuffer({
-      size: 1024,
-      usage: GPUBufferUsage.COPY_SRC,
-    });
-
-    const dstBuffer = t.device.createBuffer({
-      size: 1024,
-      usage: GPUBufferUsage.COPY_DST,
-    });
-
     const callFn = () => {
       switch (callCmd) {
         case 'beginComputePass':
@@ -129,8 +119,8 @@ g.test('call_after_successful_finish')
         case 'beginRenderPass':
           t.beginRenderPass(encoder);
           break;
-        case 'copyBufferToBuffer':
-          encoder.copyBufferToBuffer(srcBuffer, 0, dstBuffer, 0, 0);
+        case 'insertDebugMarker':
+          encoder.insertDebugMarker('');
           break;
         default:
           unreachable();


### PR DESCRIPTION





Issue: #1914

Latest spec says beginComputePass/RenderPass generate validation error when `encoder.state` is ended. Add calling cmd of beginComputePass/RenderPass to the existing `call_after_successful_finish` test which used to only call `copyBufferToBuffer`

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
