### PR TITLE
op: Implement 'depth_bias_24bit_format' test in depth_bias.spec.ts

### DIFF
--- a/src/webgpu/api/operation/rendering/depth_bias.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_bias.spec.ts
@@ -343,8 +343,12 @@ g.test('depth_bias')
 g.test('depth_bias_24bit_format')
   .desc(
     `
-  Tests that a square with different depth bias values like 'positive', 'negative', 'infinity',
+  Tests that a square with different depth bias values like 'positive', 'negative',
   'slope', 'clamp', etc. is drawn as expected with 24 bit depth format.
+
+  TODO: Enhance these tests by reading back the depth (emulating the copy using texture sampling)
+  and checking the result directly, like the non-24-bit depth tests, instead of just relying on
+  whether the depth test passes or fails.
   `
   )
   .params(u =>

--- a/src/webgpu/api/operation/rendering/depth_bias.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_bias.spec.ts
@@ -353,6 +353,7 @@ g.test('depth_bias_24bit_format')
   )
   .params(u =>
     u //
+      .combine('format', ['depth24plus', 'depth24plus-stencil8'] as const)
       .combineWithParams([
         {
           quadAngle: QuadAngle.Flat,
@@ -378,5 +379,6 @@ g.test('depth_bias_24bit_format')
       ] as const)
   )
   .fn(async t => {
-    t.runDepthBiasTestFor24BitFormat('depth24plus-stencil8', t.params);
+    const { format } = t.params;
+    t.runDepthBiasTestFor24BitFormat(format, t.params);
   });


### PR DESCRIPTION
This PR adds a new test to ensure that 24bit depth texture also draws a square with different depth bias values.

Issue: #2023

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
