### PR TITLE
Test all stencil formats, and address some nits in depth_bias/stencil tests

### DIFF
--- a/src/webgpu/api/operation/rendering/depth_bias.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_bias.spec.ts
@@ -155,13 +155,13 @@ class DepthBiasTest extends GPUTest {
       bias,
       biasSlopeScale,
       biasClamp,
-      expectedDepth,
+      _expectedDepth,
     }: {
       quadAngle: QuadAngle;
       bias: number;
       biasSlopeScale: number;
       biasClamp: number;
-      expectedDepth: number;
+      _expectedDepth: number;
     }
   ) {
     const { renderTarget, depthTexture } = this.runDepthBiasTestInternal(depthFormat, {
@@ -172,7 +172,7 @@ class DepthBiasTest extends GPUTest {
       initialDepth: 0,
     });
 
-    const expColor = { Depth: expectedDepth };
+    const expColor = { Depth: _expectedDepth };
     const expTexelView = TexelView.fromTexelsAsColors(depthFormat, coords => expColor);
 
     const result = textureContentIsOKByT2B(
@@ -194,13 +194,13 @@ class DepthBiasTest extends GPUTest {
       bias,
       biasSlopeScale,
       biasClamp,
-      expectedColor,
+      _expectedColor,
     }: {
       quadAngle: QuadAngle;
       bias: number;
       biasSlopeScale: number;
       biasClamp: number;
-      expectedColor: Float32Array;
+      _expectedColor: Float32Array;
     }
   ) {
     const { renderTarget, depthTexture } = this.runDepthBiasTestInternal(depthFormat, {
@@ -213,10 +213,10 @@ class DepthBiasTest extends GPUTest {
 
     const renderTargetFormat = 'rgba8unorm';
     const expColor = {
-      R: expectedColor[0],
-      G: expectedColor[1],
-      B: expectedColor[2],
-      A: expectedColor[3],
+      R: _expectedColor[0],
+      G: _expectedColor[1],
+      B: _expectedColor[2],
+      A: _expectedColor[3],
     };
     const expTexelView = TexelView.fromTexelsAsColors(renderTargetFormat, coords => expColor);
 
@@ -276,63 +276,63 @@ g.test('depth_bias')
           bias: kPointTwoFiveBiasForPointTwoFiveZOnFloat,
           biasSlopeScale: 0,
           biasClamp: 0,
-          expectedDepth: 0.5,
+          _expectedDepth: 0.5,
         },
         {
           quadAngle: QuadAngle.Flat,
           bias: kPointTwoFiveBiasForPointTwoFiveZOnFloat,
           biasSlopeScale: 0,
           biasClamp: 0.125,
-          expectedDepth: 0.375,
+          _expectedDepth: 0.375,
         },
         {
           quadAngle: QuadAngle.Flat,
           bias: -kPointTwoFiveBiasForPointTwoFiveZOnFloat,
           biasSlopeScale: 0,
           biasClamp: 0.125,
-          expectedDepth: 0,
+          _expectedDepth: 0,
         },
         {
           quadAngle: QuadAngle.Flat,
           bias: -kPointTwoFiveBiasForPointTwoFiveZOnFloat,
           biasSlopeScale: 0,
           biasClamp: -0.125,
-          expectedDepth: 0.125,
+          _expectedDepth: 0.125,
         },
         {
           quadAngle: QuadAngle.TiltedX,
           bias: 0,
           biasSlopeScale: 0,
           biasClamp: 0,
-          expectedDepth: 0.25,
+          _expectedDepth: 0.25,
         },
         {
           quadAngle: QuadAngle.TiltedX,
           bias: 0,
           biasSlopeScale: 1,
           biasClamp: 0,
-          expectedDepth: 0.75,
+          _expectedDepth: 0.75,
         },
         {
           quadAngle: QuadAngle.TiltedX,
           bias: 0,
           biasSlopeScale: -0.5,
           biasClamp: 0,
-          expectedDepth: 0,
+          _expectedDepth: 0,
         },
         {
           quadAngle: QuadAngle.TiltedX,
           bias: 0,
           biasSlopeScale: kValue.f32.infinity.positive,
           biasClamp: 0,
-          expectedDepth: 1,
+          _expectedDepth: 1,
         },
         {
           quadAngle: QuadAngle.TiltedX,
           bias: 0,
           biasSlopeScale: kValue.f32.infinity.negative,
           biasClamp: 0,
-          expectedDepth: 0,
+          _expectedDepth: 0,
         },
       ] as const)
   )
@@ -360,21 +360,21 @@ g.test('depth_bias_24bit_format')
           bias: 0.25 * (1 << 25),
           biasSlopeScale: 0,
           biasClamp: 0,
-          expectedColor: new Float32Array([1.0, 0.0, 0.0, 1.0]),
+          _expectedColor: new Float32Array([1.0, 0.0, 0.0, 1.0]),
         },
         {
           quadAngle: QuadAngle.TiltedX,
           bias: 0.25 * (1 << 25),
           biasSlopeScale: 1,
           biasClamp: 0,
-          expectedColor: new Float32Array([1.0, 0.0, 0.0, 1.0]),
+          _expectedColor: new Float32Array([1.0, 0.0, 0.0, 1.0]),
         },
         {
           quadAngle: QuadAngle.Flat,
           bias: 0.25 * (1 << 25),
           biasSlopeScale: 0,
           biasClamp: 0.1,
-          expectedColor: new Float32Array([0.0, 0.0, 0.0, 0.0]),
+          _expectedColor: new Float32Array([0.0, 0.0, 0.0, 0.0]),
         },
       ] as const)
   )

--- a/src/webgpu/api/operation/rendering/depth_bias.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_bias.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-Tests render results with different depth bias values like 'positive', 'negative', 'infinity',
+Tests render results with different depth bias values like 'positive', 'negative',
 'slope', 'clamp', etc.
 `;
 
@@ -11,7 +11,6 @@ import {
   kTextureFormatInfo,
 } from '../../../capability_info.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { kValue } from '../../../util/constants.js';
 import { TexelView } from '../../../util/texture/texel_view.js';
 import { textureContentIsOKByT2B } from '../../../util/texture/texture_ok.js';
 
@@ -264,7 +263,7 @@ export const g = makeTestGroup(DepthBiasTest);
 g.test('depth_bias')
   .desc(
     `
-  Tests that a square with different depth bias values like 'positive', 'negative', 'infinity',
+  Tests that a square with different depth bias values like 'positive', 'negative',
   'slope', 'clamp', etc. is drawn as expected.
   `
   )
@@ -317,20 +316,6 @@ g.test('depth_bias')
           quadAngle: QuadAngle.TiltedX,
           bias: 0,
           biasSlopeScale: -0.5,
-          biasClamp: 0,
-          _expectedDepth: 0,
-        },
-        {
-          quadAngle: QuadAngle.TiltedX,
-          bias: 0,
-          biasSlopeScale: kValue.f32.infinity.positive,
-          biasClamp: 0,
-          _expectedDepth: 1,
-        },
-        {
-          quadAngle: QuadAngle.TiltedX,
-          bias: 0,
-          biasSlopeScale: kValue.f32.infinity.negative,
           biasClamp: 0,
           _expectedDepth: 0,
         },

--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -30,7 +30,7 @@ class StencilTest extends GPUTest {
     depthStencilFormat: DepthStencilFormat,
     testStencilState: GPUStencilFaceState,
     initialStencil: number,
-    expectedStencil: number,
+    _expectedStencil: number,
     depthCompare: GPUCompareFunction = 'always'
   ) {
     const kReferenceStencil = 3;
@@ -75,7 +75,7 @@ class StencilTest extends GPUTest {
       // Draw the base triangle with stencil reference 1. This clears the stencil buffer to 1.
       { state: baseState, color: kBaseColor, stencil: initialStencil },
       { state: testState, color: kRedStencilColor, stencil: kReferenceStencil },
-      { state: testState2, color: kGreenStencilColor, stencil: expectedStencil },
+      { state: testState2, color: kGreenStencilColor, stencil: _expectedStencil },
     ];
     this.runStencilStateTest(depthStencilFormat, testStates, kGreenStencilColor);
   }
@@ -333,25 +333,25 @@ g.test('stencil_passOp_operation')
     u //
       .combine('format', kStencilFormats)
       .combineWithParams([
-        { passOp: 'keep', initialStencil: 1, expectedStencil: 1 },
-        { passOp: 'zero', initialStencil: 1, expectedStencil: 0 },
-        { passOp: 'replace', initialStencil: 1, expectedStencil: 3 },
-        { passOp: 'invert', initialStencil: 0xf0, expectedStencil: 0x0f },
-        { passOp: 'increment-clamp', initialStencil: 1, expectedStencil: 2 },
-        { passOp: 'increment-clamp', initialStencil: 0xff, expectedStencil: 0xff },
-        { passOp: 'increment-wrap', initialStencil: 1, expectedStencil: 2 },
-        { passOp: 'increment-wrap', initialStencil: 0xff, expectedStencil: 0 },
-        { passOp: 'decrement-clamp', initialStencil: 1, expectedStencil: 0 },
-        { passOp: 'decrement-clamp', initialStencil: 0, expectedStencil: 0 },
-        { passOp: 'decrement-wrap', initialStencil: 1, expectedStencil: 0 },
-        { passOp: 'decrement-wrap', initialStencil: 0, expectedStencil: 0xff },
+        { passOp: 'keep', initialStencil: 1, _expectedStencil: 1 },
+        { passOp: 'zero', initialStencil: 1, _expectedStencil: 0 },
+        { passOp: 'replace', initialStencil: 1, _expectedStencil: 3 },
+        { passOp: 'invert', initialStencil: 0xf0, _expectedStencil: 0x0f },
+        { passOp: 'increment-clamp', initialStencil: 1, _expectedStencil: 2 },
+        { passOp: 'increment-clamp', initialStencil: 0xff, _expectedStencil: 0xff },
+        { passOp: 'increment-wrap', initialStencil: 1, _expectedStencil: 2 },
+        { passOp: 'increment-wrap', initialStencil: 0xff, _expectedStencil: 0 },
+        { passOp: 'decrement-clamp', initialStencil: 1, _expectedStencil: 0 },
+        { passOp: 'decrement-clamp', initialStencil: 0, _expectedStencil: 0 },
+        { passOp: 'decrement-wrap', initialStencil: 1, _expectedStencil: 0 },
+        { passOp: 'decrement-wrap', initialStencil: 0, _expectedStencil: 0xff },
       ] as const)
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
-    const { format, passOp, initialStencil, expectedStencil } = t.params;
+    const { format, passOp, initialStencil, _expectedStencil } = t.params;
 
     const stencilState = {
       compare: 'always',
@@ -359,7 +359,7 @@ g.test('stencil_passOp_operation')
       passOp,
     } as const;
 
-    t.checkStencilOperation(format, stencilState, initialStencil, expectedStencil);
+    t.checkStencilOperation(format, stencilState, initialStencil, _expectedStencil);
   });
 
 g.test('stencil_failOp_operation')
@@ -377,26 +377,26 @@ g.test('stencil_failOp_operation')
     u //
       .combine('format', kStencilFormats)
       .combineWithParams([
-        { failOp: 'keep', initialStencil: 1, expectedStencil: 1 },
-        { failOp: 'zero', initialStencil: 1, expectedStencil: 0 },
-        { failOp: 'replace', initialStencil: 1, expectedStencil: 3 },
-        { failOp: 'invert', initialStencil: 0xf0, expectedStencil: 0x0f },
-        { failOp: 'increment-clamp', initialStencil: 1, expectedStencil: 2 },
-        { failOp: 'increment-clamp', initialStencil: 0xff, expectedStencil: 0xff },
-        { failOp: 'increment-wrap', initialStencil: 1, expectedStencil: 2 },
-        { failOp: 'increment-wrap', initialStencil: 0xff, expectedStencil: 0 },
-        { failOp: 'decrement-clamp', initialStencil: 1, expectedStencil: 0 },
-        { failOp: 'decrement-clamp', initialStencil: 0, expectedStencil: 0 },
-        { failOp: 'decrement-wrap', initialStencil: 2, expectedStencil: 1 },
-        { failOp: 'decrement-wrap', initialStencil: 1, expectedStencil: 0 },
-        { failOp: 'decrement-wrap', initialStencil: 0, expectedStencil: 0xff },
+        { failOp: 'keep', initialStencil: 1, _expectedStencil: 1 },
+        { failOp: 'zero', initialStencil: 1, _expectedStencil: 0 },
+        { failOp: 'replace', initialStencil: 1, _expectedStencil: 3 },
+        { failOp: 'invert', initialStencil: 0xf0, _expectedStencil: 0x0f },
+        { failOp: 'increment-clamp', initialStencil: 1, _expectedStencil: 2 },
+        { failOp: 'increment-clamp', initialStencil: 0xff, _expectedStencil: 0xff },
+        { failOp: 'increment-wrap', initialStencil: 1, _expectedStencil: 2 },
+        { failOp: 'increment-wrap', initialStencil: 0xff, _expectedStencil: 0 },
+        { failOp: 'decrement-clamp', initialStencil: 1, _expectedStencil: 0 },
+        { failOp: 'decrement-clamp', initialStencil: 0, _expectedStencil: 0 },
+        { failOp: 'decrement-wrap', initialStencil: 2, _expectedStencil: 1 },
+        { failOp: 'decrement-wrap', initialStencil: 1, _expectedStencil: 0 },
+        { failOp: 'decrement-wrap', initialStencil: 0, _expectedStencil: 0xff },
       ] as const)
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
-    const { format, failOp, initialStencil, expectedStencil } = t.params;
+    const { format, failOp, initialStencil, _expectedStencil } = t.params;
 
     const stencilState = {
       compare: 'never',
@@ -407,7 +407,7 @@ g.test('stencil_failOp_operation')
     // Draw the base triangle with stencil reference 1. This clears the stencil buffer to 1.
     // Always fails because the comparison never passes. Therefore red is never drawn, and the
     // stencil contents may be updated according to `operation`.
-    t.checkStencilOperation(format, stencilState, initialStencil, expectedStencil);
+    t.checkStencilOperation(format, stencilState, initialStencil, _expectedStencil);
   });
 
 g.test('stencil_depthFailOp_operation')
@@ -431,26 +431,26 @@ g.test('stencil_depthFailOp_operation')
         })
       )
       .combineWithParams([
-        { depthFailOp: 'keep', initialStencil: 1, expectedStencil: 1 },
-        { depthFailOp: 'zero', initialStencil: 1, expectedStencil: 0 },
-        { depthFailOp: 'replace', initialStencil: 1, expectedStencil: 3 },
-        { depthFailOp: 'invert', initialStencil: 0xf0, expectedStencil: 0x0f },
-        { depthFailOp: 'increment-clamp', initialStencil: 1, expectedStencil: 2 },
-        { depthFailOp: 'increment-clamp', initialStencil: 0xff, expectedStencil: 0xff },
-        { depthFailOp: 'increment-wrap', initialStencil: 1, expectedStencil: 2 },
-        { depthFailOp: 'increment-wrap', initialStencil: 0xff, expectedStencil: 0 },
-        { depthFailOp: 'decrement-clamp', initialStencil: 1, expectedStencil: 0 },
-        { depthFailOp: 'decrement-clamp', initialStencil: 0, expectedStencil: 0 },
-        { depthFailOp: 'decrement-wrap', initialStencil: 2, expectedStencil: 1 },
-        { depthFailOp: 'decrement-wrap', initialStencil: 1, expectedStencil: 0 },
-        { depthFailOp: 'decrement-wrap', initialStencil: 0, expectedStencil: 0xff },
+        { depthFailOp: 'keep', initialStencil: 1, _expectedStencil: 1 },
+        { depthFailOp: 'zero', initialStencil: 1, _expectedStencil: 0 },
+        { depthFailOp: 'replace', initialStencil: 1, _expectedStencil: 3 },
+        { depthFailOp: 'invert', initialStencil: 0xf0, _expectedStencil: 0x0f },
+        { depthFailOp: 'increment-clamp', initialStencil: 1, _expectedStencil: 2 },
+        { depthFailOp: 'increment-clamp', initialStencil: 0xff, _expectedStencil: 0xff },
+        { depthFailOp: 'increment-wrap', initialStencil: 1, _expectedStencil: 2 },
+        { depthFailOp: 'increment-wrap', initialStencil: 0xff, _expectedStencil: 0 },
+        { depthFailOp: 'decrement-clamp', initialStencil: 1, _expectedStencil: 0 },
+        { depthFailOp: 'decrement-clamp', initialStencil: 0, _expectedStencil: 0 },
+        { depthFailOp: 'decrement-wrap', initialStencil: 2, _expectedStencil: 1 },
+        { depthFailOp: 'decrement-wrap', initialStencil: 1, _expectedStencil: 0 },
+        { depthFailOp: 'decrement-wrap', initialStencil: 0, _expectedStencil: 0xff },
       ] as const)
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
-    const { format, depthFailOp, initialStencil, expectedStencil } = t.params;
+    const { format, depthFailOp, initialStencil, _expectedStencil } = t.params;
 
     const stencilState = {
       compare: 'always',
@@ -461,7 +461,7 @@ g.test('stencil_depthFailOp_operation')
 
     // Call checkStencilOperation function with enabling the depthTest to test that the depthFailOp
     // stencil operation works as expected.
-    t.checkStencilOperation(format, stencilState, initialStencil, expectedStencil, 'never');
+    t.checkStencilOperation(format, stencilState, initialStencil, _expectedStencil, 'never');
   });
 
 g.test('stencil_read_write_mask')

--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -467,7 +467,7 @@ g.test('stencil_read_write_mask')
   .fn(async t => {
     const { maskType, stencilRefValue, _expectedColor } = t.params;
 
-    const depthSpencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
+    const depthStencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
 
     const baseStencilState = {
       compare: 'always',
@@ -482,7 +482,7 @@ g.test('stencil_read_write_mask')
     } as const;
 
     const baseState = {
-      format: depthSpencilFormat,
+      format: depthStencilFormat,
       depthWriteEnabled: false,
       depthCompare: 'always',
       stencilFront: baseStencilState,
@@ -492,7 +492,7 @@ g.test('stencil_read_write_mask')
     } as const;
 
     const testState = {
-      format: depthSpencilFormat,
+      format: depthStencilFormat,
       depthWriteEnabled: false,
       depthCompare: 'always',
       stencilFront: stencilState,
@@ -513,7 +513,7 @@ g.test('stencil_read_write_mask')
 g.test('stencil_reference_initialized')
   .desc('Test that stencil reference is initialized as zero for new render pass.')
   .fn(async t => {
-    const depthSpencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
+    const depthStencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
 
     const baseStencilState = {
       compare: 'always',
@@ -526,13 +526,13 @@ g.test('stencil_reference_initialized')
     } as const;
 
     const baseState = {
-      format: depthSpencilFormat,
+      format: depthStencilFormat,
       stencilFront: baseStencilState,
       stencilBack: baseStencilState,
     } as const;
 
     const testState = {
-      format: depthSpencilFormat,
+      format: depthStencilFormat,
       stencilFront: testStencilState,
       stencilBack: testStencilState,
     } as const;


### PR DESCRIPTION
**Commits may be reviewed separately for easier reading**

Issue: #2023

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
