### PR TITLE
Add some progress

### DIFF
--- a/standalone/index.html
+++ b/standalone/index.html
@@ -38,6 +38,24 @@
       #info {
         font-family: monospace;
       }
+      #progress {
+        position: fixed;
+        display: flex;
+        width: 100%;
+        left: 0;
+        top: 0;
+        background-color: #000;
+        color: #fff;
+        align-items: center;
+      }
+      #progress .progress-test-name {
+        flex: 1 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        direction: rtl;
+        white-space: nowrap;
+      }
       #resultsJSON {
         font-family: monospace;
         width: 100%;
@@ -276,6 +294,7 @@
 
     <div id="info"></div>
     <div id="resultsVis"></div>
+    <div id="progress" style="display: none;"><button type="button">stop</button><div class="progress-test-name"></div></div>
 
     <p>
       <input type="button" id="copyResultsJSON" value="Copy results as JSON">


### PR DESCRIPTION
This is a first attempt at providing some progress, at least something that shows that things are running. Often I click play and I can't tell.

I'm happy to make any changes. I didn't see an easy total of number of tests about to run to show a progress bar. It seems like that might be a big refactor as it's just calling `runSubTest` and there's no info except that captured in closures?

Issue: 2099

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
