### PR TITLE
Improve Buffer.mapAsync tests

### DIFF
--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -32,10 +32,10 @@ g.test('mapAsync')
     oomAndSizeParams //
       .beginSubcases()
       .combine('write', [false, true])
-      .combine('abortError', [false, true])
+      .combine('unmapBeforeResolve', [false, true])
   )
   .fn(async t => {
-    const { oom, write, size, abortError } = t.params;
+    const { oom, write, size, unmapBeforeResolve } = t.params;
 
     const buffer = t.expectGPUError(
       'out-of-memory',
@@ -55,7 +55,7 @@ g.test('mapAsync')
     }, oom);
 
     if (oom) {
-      if (abortError) {
+      if (unmapBeforeResolve) {
         // Should reject with abort error because buffer will be unmapped
         // before validation check finishes.
         t.shouldReject('AbortError', promise!);

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -32,9 +32,10 @@ g.test('mapAsync')
     oomAndSizeParams //
       .beginSubcases()
       .combine('write', [false, true])
+      .combine('abortError', [false, true])
   )
   .fn(async t => {
-    const { oom, write, size } = t.params;
+    const { oom, write, size, abortError } = t.params;
 
     const buffer = t.expectGPUError(
       'out-of-memory',
@@ -45,15 +46,27 @@ g.test('mapAsync')
         }),
       oom
     );
-    const promise = t.expectGPUError(
-      'validation', // Should be a validation error since the buffer is invalid.
-      () => buffer.mapAsync(write ? GPUMapMode.WRITE : GPUMapMode.READ),
-      oom
-    );
+
+    let promise: Promise<void>;
+    // Should be a validation error since the buffer is invalid.
+    // Unmap abort error shouldn't cause a validation error.
+    t.expectValidationError(() => {
+      promise = buffer.mapAsync(write ? GPUMapMode.WRITE : GPUMapMode.READ);
+    }, oom);
 
     if (oom) {
-      // Should also reject in addition to the validation error.
-      t.shouldReject('OperationError', promise);
+      if (abortError) {
+        // Should reject with abort error because buffer will be unmapped
+        // before validation check finishes.
+        t.shouldReject('AbortError', promise!);
+      } else {
+        // Should also reject in addition to the validation error.
+        t.shouldReject('OperationError', promise!);
+
+        // Wait for validation error before unmap to ensure validation check
+        // ends before unmap.
+        await promise!;
+      }
 
       // Should throw an OperationError because the buffer is not mapped.
       // Note: not a RangeError because the state of the buffer is checked first.
@@ -64,7 +77,7 @@ g.test('mapAsync')
       // Should't be a validation error even if the buffer failed to be mapped.
       buffer.unmap();
     } else {
-      await promise;
+      await promise!;
       const arraybuffer = buffer.getMappedRange();
       t.expect(arraybuffer.byteLength === size);
       buffer.unmap();

--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -65,7 +65,12 @@ g.test('mapAsync')
 
         // Wait for validation error before unmap to ensure validation check
         // ends before unmap.
-        await promise!;
+        try {
+          await promise!;
+          throw new Error('The promise should be rejected.');
+        } catch {
+          // Should cause an exception because the promise should be rejected.
+        }
       }
 
       // Should throw an OperationError because the buffer is not mapped.

--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -390,7 +390,12 @@ g.test('mapAsync,earlyRejection')
   });
 
 g.test('mapAsync,abort_over_invalid_error')
-  .desc('Test that unmap abort error should have precedence over validation error')
+  .desc(
+    `Test that unmap abort error should have precedence over validation error
+TODO
+  - Add other validation error test (eg. offset is not a multiple of 8)
+  `
+  )
   .paramsSubcasesOnly(u =>
     u.combine('mapMode', kMapModeOptions).combine('abortError', [true, false])
   )

--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -397,15 +397,15 @@ TODO
   `
   )
   .paramsSubcasesOnly(u =>
-    u.combine('mapMode', kMapModeOptions).combine('abortError', [true, false])
+    u.combine('mapMode', kMapModeOptions).combine('unmapBeforeResolve', [true, false])
   )
   .fn(async t => {
-    const { mapMode, abortError } = t.params;
+    const { mapMode, unmapBeforeResolve } = t.params;
     const bufferSize = 8;
     const buffer = t.createMappableBuffer(mapMode, bufferSize);
     await buffer.mapAsync(mapMode);
 
-    if (abortError) {
+    if (unmapBeforeResolve) {
       // unmap abort error should have precedence over validation error
       const pending = t.testMapAsyncCall(
         { validationError: true, earlyRejection: false, rejectName: 'AbortError' },


### PR DESCRIPTION
This PR improves `Buffer.mapAsync()` tests.

* Better error timing check.
* Test rejection with whether validation error.
* Follow the latest WebGPU API specification. Unmap abort error should have precedence over validation error.

This PR resolves

* https://github.com/gpuweb/cts/pull/2080#discussion_r1054967344
* https://dawn-review.googlesource.com/c/dawn/+/113607/comments/09b70269_59aa698e

Issue: #2009 <!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
