### PR TITLE
Fix silencing of DOMExceptions

### DIFF
--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -536,7 +536,12 @@ class RunCaseSpecific implements RunCase {
                       // Prepend the subcase name to all error messages.
                       for (const arg of args) {
                         if (arg instanceof Error) {
-                          arg.message = subcasePrefix + '\n' + arg.message;
+                          try {
+                            arg.message = subcasePrefix + '\n' + arg.message;
+                          } catch {
+                            // Silence exception if the property isn't settable
+                            // (e.g. arg.message on DOMException).
+                          }
                         }
                       }
 

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -8,7 +8,7 @@ import { LiveTestCaseResult } from '../internal/logging/result.js';
 import { parseQuery } from '../internal/query/parseQuery.js';
 import { TestQueryLevel } from '../internal/query/query.js';
 import { TestTreeNode, TestSubtree, TestTreeLeaf, TestTree } from '../internal/tree.js';
-import { assert, ErrorWithExtra } from '../util/util.js';
+import { assert, ErrorWithExtra, unreachable } from '../util/util.js';
 
 import { optionEnabled } from './helper/options.js';
 import { TestWorker } from './helper/test_worker.js';
@@ -144,6 +144,8 @@ function makeCaseHTML(t: TestTreeLeaf): VisualizedSubtree {
       case 'warn':
         result.warn++;
         break;
+      default:
+        unreachable();
     }
 
     if (updateRenderedResult) updateRenderedResult();

--- a/src/demo/subcases.spec.ts
+++ b/src/demo/subcases.spec.ts
@@ -1,0 +1,38 @@
+export const description = 'Tests with subcases';
+
+import { makeTestGroup } from '../common/framework/test_group.js';
+import { UnitTest } from '../unittests/unit_test.js';
+
+export const g = makeTestGroup(UnitTest);
+
+g.test('pass_warn_fail')
+  .params(u =>
+    u
+      .combine('x', [1, 2, 3]) //
+      .beginSubcases()
+      .combine('y', [1, 2, 3])
+  )
+  .fn(t => {
+    const { x, y } = t.params;
+    if (x + y > 5) {
+      t.fail();
+    } else if (x + y > 4) {
+      t.warn();
+    }
+  });
+
+g.test('DOMException,cases')
+  .params(u => u.combine('fail', [false, true]))
+  .fn(t => {
+    if (t.params.fail) {
+      throw new DOMException('Message!', 'Name!');
+    }
+  });
+
+g.test('DOMException,subcases')
+  .paramsSubcasesOnly(u => u.combine('fail', [false, true]))
+  .fn(t => {
+    if (t.params.fail) {
+      throw new DOMException('Message!', 'Name!');
+    }
+  });

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -261,6 +261,37 @@ g.test('subcases').fn(async t0 => {
   t0.expect(Array.from(result.values()).every(v => v.status === 'pass'));
 });
 
+g.test('exceptions')
+  .params(u =>
+    u
+      .combine('useSubcases', [false, true]) //
+      .combine('useDOMException', [false, true])
+  )
+  .fn(async t0 => {
+    const { useSubcases, useDOMException } = t0.params;
+    const g = makeTestGroupForUnitTesting(UnitTest);
+
+    const b1 = g.test('a');
+    let b2;
+    if (useSubcases) {
+      b2 = b1.paramsSubcasesOnly(u => u);
+    } else {
+      b2 = b1.params(u => u);
+    }
+    b2.fn(t => {
+      if (useDOMException) {
+        throw new DOMException('Message!', 'Name!');
+      } else {
+        throw new Error('Message!');
+      }
+    });
+
+    const result = await t0.run(g);
+    const values = Array.from(result.values());
+    t0.expect(values.length === 1);
+    t0.expect(values[0].status === 'fail');
+  });
+
 g.test('throws').fn(async t0 => {
   const g = makeTestGroupForUnitTesting(UnitTest);
 


### PR DESCRIPTION
Quick fix, but I'll put up a suggested cleanup (just need Austin's review to make sure that will work).

The bug was that `rec.threw()` would never be called for `DOMException`s, causing the test to erroneously pass.

Issue: Regressed in #2086, found in #2101

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] ~Tests are properly located in the test tree.~
- [x] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [x] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
