### PR TITLE
Put subcase in the stack instead of the message

### DIFF
--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -536,8 +536,10 @@ class RunCaseSpecific implements RunCase {
                       // Prepend the subcase name to all error messages.
                       for (const arg of args) {
                         if (arg instanceof Error) {
+                          let stack = subcasePrefix;
+                          if (arg.stack) stack += '\n' + arg.stack;
                           try {
-                            arg.message = subcasePrefix + '\n' + arg.message;
+                            arg.stack = stack;
                           } catch {
                             // Silence exception if the property isn't settable
                             // (e.g. arg.message on DOMException).


### PR DESCRIPTION
`DOMException.stack` is settable, while `.message` isn't. Guessing there are no errors where `message` is settable and `stack` isn't, so this seems like a better place to put custom info. (It's kind of "stack"ish anyway.)

Question is, will this be surfaced in the places we want to see it? I don't know what context prompted the original PR, and whether it prints the message or the stack.

Issue: See also #2102

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] ~Tests are properly located in the test tree.~
- [x] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [x] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
