### PR TITLE
Update kMaxQueryCount to 4096

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -15,7 +15,7 @@ import { ImageCopyType } from './util/texture/layout.js';
 // Queries
 
 /** Maximum number of queries in GPUQuerySet, by spec. */
-export const kMaxQueryCount = 8192;
+export const kMaxQueryCount = 4096;
 /** Per-GPUQueryType info. */
 export type QueryTypeInfo = {
   /** Optional feature required to use this GPUQueryType. */


### PR DESCRIPTION
This number has been reduced from 8192 in the WebGPU spec.




Issue: None

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
