### PR TITLE
Check that getBindGroupLayout returns unique JS objects.

### DIFF
--- a/src/webgpu/api/validation/getBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/getBindGroupLayout.spec.ts
@@ -3,6 +3,7 @@ export const description = `
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { assert } from '../../../common/util/util.js';
 
 import { ValidationTest } from './validation_test.js';
 
@@ -105,4 +106,96 @@ g.test('index_range,auto_layout')
     t.expectValidationError(() => {
       pipeline.getBindGroupLayout(index);
     }, shouldError);
+  });
+
+g.test('unique_js_object,auto_layout')
+  .desc(
+    `
+  Test that getBindGroupLayout returns a new JavaScript object for each call.
+  `
+  )
+  .fn(async t => {
+    const pipeline = t.device.createRenderPipeline({
+      layout: 'auto',
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+            @vertex
+            fn main()-> @builtin(position) vec4<f32> {
+              return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `
+            @group(0) @binding(0) var<uniform> binding: f32;
+            @fragment
+            fn main() -> @location(0) vec4<f32> {
+              _ = binding;
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+    });
+
+    const kIndex = 0;
+    const bgl1 = (pipeline.getBindGroupLayout(kIndex) as unknown) as Record<string, number>;
+    bgl1.extra = 42;
+    const bgl2 = (pipeline.getBindGroupLayout(kIndex) as unknown) as Record<string, number>;
+
+    assert(bgl1 !== bgl2, 'objects are not the same object');
+    assert(bgl2.extra === undefined, 'objects do not retain expando properties');
+  });
+
+g.test('unique_js_object,explicit_layout')
+  .desc(
+    `
+  Test that getBindGroupLayout returns a new JavaScript object for each call.
+  `
+  )
+  .fn(async t => {
+    const pipelineBindGroupLayouts = t.device.createBindGroupLayout({
+      entries: [],
+    });
+
+    const pipelineLayout = t.device.createPipelineLayout({
+      bindGroupLayouts: [pipelineBindGroupLayouts],
+    });
+
+    const pipeline = t.device.createRenderPipeline({
+      layout: pipelineLayout,
+      vertex: {
+        module: t.device.createShaderModule({
+          code: `
+            @vertex
+            fn main()-> @builtin(position) vec4<f32> {
+              return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: `
+            @fragment
+            fn main() -> @location(0) vec4<f32> {
+              return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+            }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+    });
+
+    const kIndex = 0;
+    const bgl1 = (pipeline.getBindGroupLayout(kIndex) as unknown) as Record<string, number>;
+    bgl1.extra = 42;
+    const bgl2 = (pipeline.getBindGroupLayout(kIndex) as unknown) as Record<string, number>;
+
+    assert(bgl1 !== bgl2, 'objects are not the same object');
+    assert(bgl2.extra === undefined, 'objects do not retain expando properties');
   });


### PR DESCRIPTION
Issue: #2019

Is this all that was needed? Is validation the correct place for it?

In the project tracker it says ["Open (has TODO)"](https://github.com/orgs/gpuweb/projects/3/views/1?filterQuery=is%3Aissue+-status%3AComplete%2CBlocked%2CStarted%2CPost-V1+getBindG). Where is that TODO?


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
