### PR TITLE
Test you can not create 1d, 2d-array, and 3d multisampled textures

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -389,6 +389,31 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
     }, !success);
   });
 
+g.test('sample_count,1d_2d_array_3d')
+  .desc(`Test that you can not create 1d, 2d_array, and 3d multisampled textures`)
+  .params(u =>
+    u.combineWithParams([
+      { dimension: '2d', size: [4, 4, 1], shouldError: false },
+      { dimension: '1d', size: [4, 1, 1], shouldError: true },
+      { dimension: '2d', size: [4, 4, 4], shouldError: true },
+      { dimension: '2d', size: [4, 4, 6], shouldError: true },
+      { dimension: '3d', size: [4, 4, 4], shouldError: true },
+    ] as const)
+  )
+  .fn(async t => {
+    const { dimension, size, shouldError } = t.params;
+
+    t.expectValidationError(() => {
+      t.device.createTexture({
+        size,
+        dimension,
+        sampleCount: 4,
+        format: 'rgba8unorm',
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT,
+      });
+    }, shouldError);
+  });
+
 g.test('texture_size,default_value_and_smallest_size,uncompressed_format')
   .desc(
     `Test default values for height and depthOrArrayLayers for every dimension type and every uncompressed format.


### PR DESCRIPTION
Issue: #1078

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
