### PR TITLE
Add flag to unroll const-eval loops

### DIFF
--- a/src/common/framework/test_config.ts
+++ b/src/common/framework/test_config.ts
@@ -2,10 +2,19 @@ export type TestConfig = {
   maxSubcasesInFlight: number;
   testHeartbeatCallback: () => void;
   noRaceWithRejectOnTimeout: boolean;
+
+  /**
+   * Controls the emission of loops in constant-evaluation shaders under
+   * 'webgpu:shader,execution,expression,*'
+   * FXC is extremely slow to compile shaders with loops unrolled, where as the
+   * MSL compiler is extremely slow to compile with loops rolled.
+   */
+  unrollConstEvalLoops: boolean;
 };
 
 export const globalTestConfig: TestConfig = {
   maxSubcasesInFlight: 500,
   testHeartbeatCallback: () => {},
   noRaceWithRejectOnTimeout: false,
+  unrollConstEvalLoops: false,
 };

--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -3,6 +3,7 @@
 import * as fs from 'fs';
 
 import { dataCache } from '../framework/data_cache.js';
+import { globalTestConfig } from '../framework/test_config.js';
 import { DefaultTestFileLoader } from '../internal/file_loader.js';
 import { prettyPrintLog } from '../internal/logging/log_message.js';
 import { Logger } from '../internal/logging/logger.js';
@@ -16,21 +17,21 @@ import { assert, unreachable } from '../util/util.js';
 import sys from './helper/sys.js';
 
 function usage(rc: number): never {
-  console.log('Usage:');
-  console.log(`  tools/run_${sys.type} [OPTIONS...] QUERIES...`);
-  console.log(`  tools/run_${sys.type} 'unittests:*' 'webgpu:buffers,*'`);
-  console.log('Options:');
-  console.log('  --colors             Enable ANSI colors in output.');
-  console.log('  --verbose            Print result/log of every test as it runs.');
-  console.log(
-    '  --list               Print all testcase names that match the given query and exit.'
-  );
-  console.log('  --debug              Include debug messages in logging.');
-  console.log('  --print-json         Print the complete result JSON in the output.');
-  console.log('  --expectations       Path to expectations file.');
-  console.log('  --gpu-provider       Path to node module that provides the GPU implementation.');
-  console.log('  --gpu-provider-flag  Flag to set on the gpu-provider as <flag>=<value>');
-  console.log('  --quiet              Suppress summary information in output');
+  console.log(`Usage:
+  tools/run_${sys.type} [OPTIONS...] QUERIES...
+  tools/run_${sys.type} 'unittests:*' 'webgpu:buffers,*'
+Options:
+  --colors                  Enable ANSI colors in output.
+  --verbose                 Print result/log of every test as it runs.
+  --list                    Print all testcase names that match the given query and exit.
+  --debug                   Include debug messages in logging.
+  --print-json              Print the complete result JSON in the output.
+  --expectations            Path to expectations file.
+  --gpu-provider            Path to node module that provides the GPU implementation.
+  --gpu-provider-flag       Flag to set on the gpu-provider as <flag>=<value>
+  --unroll-const-eval-loops Unrolls loops in constant-evaluation shader execution tests
+  --quiet                   Suppress summary information in output
+`);
   return sys.exit(rc);
 }
 
@@ -80,6 +81,8 @@ for (let i = 0; i < sys.args.length; ++i) {
       gpuProviderFlags.push(sys.args[++i]);
     } else if (a === '--quiet') {
       quiet = true;
+    } else if (a === '--unroll-const-eval-loops') {
+      globalTestConfig.unrollConstEvalLoops = true;
     } else {
       console.log('unrecognized flag: ', a);
       usage(1);

--- a/src/common/runtime/server.ts
+++ b/src/common/runtime/server.ts
@@ -5,6 +5,7 @@ import * as http from 'http';
 import { AddressInfo } from 'net';
 
 import { dataCache } from '../framework/data_cache.js';
+import { globalTestConfig } from '../framework/test_config.js';
 import { DefaultTestFileLoader } from '../internal/file_loader.js';
 import { prettyPrintLog } from '../internal/logging/log_message.js';
 import { Logger } from '../internal/logging/logger.js';
@@ -18,21 +19,24 @@ import { setGPUProvider } from '../util/navigator_gpu.js';
 import sys from './helper/sys.js';
 
 function usage(rc: number): never {
-  console.log('Usage:');
-  console.log(`  tools/run_${sys.type} [OPTIONS...]`);
-  console.log('Options:');
-  console.log('  --colors             Enable ANSI colors in output.');
-  console.log('  --coverage           Add coverage data to each result.');
-  console.log('  --data               Path to the data cache directory.');
-  console.log('  --verbose            Print result/log of every test as it runs.');
-  console.log('  --gpu-provider       Path to node module that provides the GPU implementation.');
-  console.log('  --gpu-provider-flag  Flag to set on the gpu-provider as <flag>=<value>');
-  console.log(``);
-  console.log(`Provides an HTTP server used for running tests via an HTTP RPC interface`);
-  console.log(`To run a test, perform an HTTP GET or POST at the URL:`);
-  console.log(`  http://localhost:port/run?<test-name>`);
-  console.log(`To shutdown the server perform an HTTP GET or POST at the URL:`);
-  console.log(`  http://localhost:port/terminate`);
+  console.log(`Usage:
+  tools/run_${sys.type} [OPTIONS...]
+Options:
+  --colors                  Enable ANSI colors in output.
+  --coverage                Add coverage data to each result.
+  --data                    Path to the data cache directory.
+  --verbose                 Print result/log of every test as it runs.
+  --gpu-provider            Path to node module that provides the GPU implementation.
+  --gpu-provider-flag       Flag to set on the gpu-provider as <flag>=<value>
+  --unroll-const-eval-loops Unrolls loops in constant-evaluation shader execution tests
+  --u                       Flag to set on the gpu-provider as <flag>=<value>
+
+Provides an HTTP server used for running tests via an HTTP RPC interface
+To run a test, perform an HTTP GET or POST at the URL:
+  http://localhost:port/run?<test-name>
+To shutdown the server perform an HTTP GET or POST at the URL:
+  http://localhost:port/terminate
+`);
   return sys.exit(rc);
 }
 
@@ -89,6 +93,8 @@ for (let i = 0; i < sys.args.length; ++i) {
       gpuProviderModule = require(modulePath);
     } else if (a === '--gpu-provider-flag') {
       gpuProviderFlags.push(sys.args[++i]);
+    } else if (a === '--unroll-const-eval-loops') {
+      globalTestConfig.unrollConstEvalLoops = true;
     } else if (a === '--help') {
       usage(1);
     } else if (a === '--verbose') {

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -2,6 +2,7 @@
 
 import { dataCache } from '../framework/data_cache.js';
 import { setBaseResourcePath } from '../framework/resources.js';
+import { globalTestConfig } from '../framework/test_config.js';
 import { DefaultTestFileLoader } from '../internal/file_loader.js';
 import { Logger } from '../internal/logging/logger.js';
 import { LiveTestCaseResult } from '../internal/logging/result.js';
@@ -22,6 +23,9 @@ let haveSomeResults = false;
 
 const runnow = optionEnabled('runnow');
 const debug = optionEnabled('debug');
+const unrollConstEvalLoops = optionEnabled('unroll_const_eval_loops');
+
+globalTestConfig.unrollConstEvalLoops = unrollConstEvalLoops;
 
 Logger.globalDebugMode = debug;
 const logger = new Logger();
@@ -438,6 +442,7 @@ void (async () => {
         ['runnow', runnow ? '1' : '0'],
         ['worker', worker ? '1' : '0'],
         ['debug', debug ? '1' : '0'],
+        ['unroll_const_eval_loops', unrollConstEvalLoops ? '1' : '0'],
       ]).toString() +
       '&' +
       qs.map(q => 'q=' + q).join('&');

--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -1,5 +1,6 @@
 // Implements the wpt-embedded test runner (see also: wpt/cts.https.html).
 
+import { globalTestConfig } from '../framework/test_config.js';
 import { DefaultTestFileLoader } from '../internal/file_loader.js';
 import { prettyPrintLog } from '../internal/logging/log_message.js';
 import { Logger } from '../internal/logging/logger.js';
@@ -32,6 +33,8 @@ setup({
 void (async () => {
   const workerEnabled = optionEnabled('worker');
   const worker = workerEnabled ? new TestWorker(false) : undefined;
+
+  globalTestConfig.unrollConstEvalLoops = optionEnabled('unroll_const_eval_loops');
 
   const failOnWarnings =
     typeof shouldWebGPUCTSFailOnWarnings !== 'undefined' && (await shouldWebGPUCTSFailOnWarnings);

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -348,6 +348,12 @@ struct Output {
         return `${toStorage(returnType, expressionBuilder(args))}`;
       });
 
+      const wgslBody = globalTestConfig.unrollConstEvalLoops
+        ? wgslValues.map((_, i) => `outputs[${i}].value = values[${i}];`).join('\n  ')
+        : `for (var i = 0u; i < ${cases.length}; i++) {
+    outputs[i].value = values[i];
+  }`;
+
       // the full WGSL shader source
       const source = `
 ${wgslOutputs}
@@ -358,9 +364,7 @@ const values = array<${wgslStorageType}, ${cases.length}>(
 
 @compute @workgroup_size(1)
 fn main() {
-  for (var i = 0u; i < ${cases.length}; i++) {
-    outputs[i].value = values[i];
-  }
+  ${wgslBody}
 }
 `;
 


### PR DESCRIPTION
FXC is extremely slow to compile a number of individual assignments to a storage buffer.

MSL is extremely slow to compile a for loop reading from a constant array.

Add a flag to customize the behavior, so we can optimize CTS runs for the given platform.

Note: Exercising different code paths based on platform is far from ideal, however: • This is on a flag, so the runner can opt into this or not. • The unrolling only applies to const-eval tests, which primarily exist to check that constant evaluation produces the correct answer. Whether assignments are done via a loop or not should not change this behaviour.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
