### PR TITLE
Add a canvas image-rendering wpt ref test

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_image_rendering.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_image_rendering.html.ts
@@ -1,0 +1,79 @@
+import { runRefTest } from './gpu_ref_test.js';
+
+runRefTest(async t => {
+  const device = t.device;
+  const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
+
+  const module = device.createShaderModule({
+    code: `
+      @vertex fn vs(
+        @builtin(vertex_index) VertexIndex : u32
+      ) -> @builtin(position) vec4<f32> {
+        var pos = array<vec2<f32>, 3>(
+        vec2(-1.0, 3.0),
+        vec2(-1.0,-1.0),
+        vec2( 3.0,-1.0)
+        );
+
+        return vec4(pos[VertexIndex], 0.0, 1.0);
+      }
+
+      @fragment fn fs(
+         @builtin(position) Pos : vec4<f32>
+      ) -> @location(0) vec4<f32> {
+        let black = vec4f(0, 0, 0, 1);
+        let white = vec4f(1, 1, 1, 1);
+        let iPos = vec4u(Pos);
+        let check = (iPos.x + iPos.y) & 1;
+        return mix(black, white, f32(check));
+      }
+    `,
+  });
+
+  const pipeline = device.createRenderPipeline({
+    layout: 'auto',
+    vertex: {
+      module,
+      entryPoint: 'vs',
+    },
+    fragment: {
+      module,
+      entryPoint: 'fs',
+      targets: [{ format: presentationFormat }],
+    },
+  });
+
+  function draw(selector: string, alphaMode: GPUCanvasAlphaMode) {
+    const canvas = document.querySelector(selector) as HTMLCanvasElement;
+    const context = canvas.getContext('webgpu') as GPUCanvasContext;
+    context.configure({
+      device,
+      format: presentationFormat,
+      alphaMode,
+    });
+
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: context.getCurrentTexture().createView(),
+          clearValue: [0.0, 0.0, 0.0, 0.0],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.setPipeline(pipeline);
+    pass.draw(3);
+    pass.end();
+
+    device.queue.submit([encoder.finish()]);
+  }
+
+  draw('#elem1', 'premultiplied');
+  draw('#elem2', 'premultiplied');
+  draw('#elem3', 'premultiplied');
+  draw('#elem4', 'opaque');
+  draw('#elem5', 'opaque');
+  draw('#elem6', 'opaque');
+});

--- a/src/webgpu/web_platform/reftests/canvas_image_rendering.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_image_rendering.https.html
@@ -1,0 +1,15 @@
+<html class="reftest-wait">
+  <title>WebGPU canvas_image_rendering</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta name="assert" content="WebGPU canvas with image-rendering set should be rendered correctly" />
+  <link rel="match" href="./ref/canvas_image_rendering-ref.html" />
+  <canvas id="elem1" width="64" height="64" style="width: 99px; height: 99px;"></canvas>
+  <canvas id="elem2" width="64" height="64" style="width: 99px; height: 99px; image-rendering: pixelated;"></canvas>
+  <canvas id="elem3" width="64" height="64" style="width: 99px; height: 99px; image-rendering: crisp-edges"></canvas>
+  <canvas id="elem4" width="64" height="64" style="width: 99px; height: 99px;"></canvas>
+  <canvas id="elem5" width="64" height="64" style="width: 99px; height: 99px; image-rendering: pixelated;"></canvas>
+  <canvas id="elem6" width="64" height="64" style="width: 99px; height: 99px; image-rendering: crisp-edges"></canvas>
+  <script src="/common/reftest-wait.js"></script>
+  <script type="module" src="canvas_image_rendering.html.js"></script>
+</html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
@@ -1,0 +1,16 @@
+<html class="reftest-wait">
+  <title>WebGPU canvas_image_rendering (ref)</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <link rel="match" href="./ref/canvas_image_rendering-ref.html" />
+  <img id="elem1" width="64" height="64" style="width: 99px; height: 99px;">
+  <img id="elem2" width="64" height="64" style="width: 99px; height: 99px; image-rendering: pixelated;">
+  <img id="elem3" width="64" height="64" style="width: 99px; height: 99px; image-rendering: crisp-edges">
+  <img id="elem4" width="64" height="64" style="width: 99px; height: 99px;">
+  <img id="elem5" width="64" height="64" style="width: 99px; height: 99px; image-rendering: pixelated;">
+  <img id="elem6" width="64" height="64" style="width: 99px; height: 99px; image-rendering: crisp-edges">
+  <script>
+    const dataURL = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAKdJREFUeF7t28kJwDAQA0Cp/6I3hJAqNK/kazDr2atJ7u7S9v3Z+76nnz18m7oBboAYIAZMRv//1fMKcAAHkCAJLuYAXoEv8ZMLcAAHcAAHcAAHjBZEOeBSDuAADuAADuAADtjrCqsIqQh98xAkSIIkSIIkSIIkSIKrYzJ6gyRIgiRIgiRIgiRIgiRoZ2hwYcp8gKqwSVF9AXuD9gbtDdobXGWw7nCbB5+MQQlHipKKAAAAAElFTkSuQmCC';
+    document.querySelectorAll('img').forEach(img => img.src = dataURL);
+  </script>
+</html>


### PR DESCRIPTION
Note: the test currently fails in Chrome.

Issue: #1116 and #1115 (not sure what the difference between those are)

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
