### PR TITLE
Fix const-eval failures for ldexp

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -14,9 +14,11 @@ Returns e1 * 2^e2. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
+import { kValue } from '../../../../../util/constants.js';
 import { f32, i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
 import { ldexpInterval } from '../../../../../util/f32_interval.js';
 import {
+  biasedRange,
   fullF32Range,
   fullI32Range,
   quantizeToF32,
@@ -29,21 +31,33 @@ import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
-export const d = makeCaseCache('ldexp', {
-  f32: () => {
-    const makeCase = (e1: number, e2: number): Case => {
-      // Due to the heterogeneous types of the params to ldexp (f32 & i32),
-      // makeBinaryToF32IntervalCase cannot be used here.
-      e1 = quantizeToF32(e1);
-      e2 = quantizeToI32(e2);
-      const expected = ldexpInterval(e1, e2);
-      return { input: [f32(e1), i32(e2)], expected };
-    };
+const makeCase = (e1: number, e2: number): Case => {
+  // Due to the heterogeneous types of the params to ldexp (f32 & i32),
+  // makeBinaryToF32IntervalCase cannot be used here.
+  e1 = quantizeToF32(e1);
+  e2 = quantizeToI32(e2);
+  const expected = ldexpInterval(e1, e2);
+  return { input: [f32(e1), i32(e2)], expected };
+};
 
+export const d = makeCaseCache('ldexp', {
+  f32_non_const: () => {
     const cases: Array<Case> = [];
     fullF32Range().forEach(e1 => {
       fullI32Range().forEach(e2 => {
         cases.push(makeCase(e1, e2));
+      });
+    });
+    return cases;
+  },
+  f32_const: () => {
+    const cases: Array<Case> = [];
+    fullF32Range().forEach(e1 => {
+      biasedRange(-128, 128, 10).forEach(e2 => {
+        const val = e1 * Math.pow(2, e2);
+        if (val >= kValue.f32.negative.min && val <= kValue.f32.positive.max) {
+          cases.push(makeCase(e1, e2));
+        }
       });
     });
     return cases;
@@ -68,7 +82,7 @@ g.test('f32')
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('f32');
+    const cases = await d.get(t.params.inputSource === 'const' ? 'f32_const' : 'f32_non_const');
     await run(t, builtin('ldexp'), [TypeF32, TypeI32], TypeF32, t.params, cases);
   });
 


### PR DESCRIPTION
The exponent (2nd arg) cannot be larger than `128` for `f32`. Filter out values that would result in a value that does not fit in a `f32`.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
