### PR TITLE
Add wpt ref test docs

### DIFF
--- a/docs/intro/developing.md
+++ b/docs/intro/developing.md
@@ -55,6 +55,13 @@ The following url parameters change how the harness runs:
 - `powerPreference=low-power` runs most tests passing `powerPreference: low-power` to `requestAdapter`
 - `powerPreference=high-performance` runs most tests passing `powerPreference: high-performance` to `requestAdapter`
 
+### Web Platform Tests (wpt) - Ref Tests
+
+You can execute individual web platform reftests at
+
+ - `http://localhost:8080/out/webgpu/web_platform/reftests/canvas_clear.https.html`
+ - `http://localhost:8080/out/webgpu/web_platform/reftests/ref/canvas_clear-ref.html`
+
 ## Editor
 
 Since this project is written in TypeScript, it integrates best with
@@ -63,7 +70,7 @@ This is optional, but highly recommended: it automatically adds `import` lines a
 provides robust completions, cross-references, renames, error highlighting,
 deprecation highlighting, and type/JSDoc popups.
 
-Open the `cts.code-workspace` workspace file to load settings convienient for this project.
+Open the `cts.code-workspace` workspace file to load settings convenient for this project.
 You can make local configuration changes in `.vscode/`, which is untracked by Git.
 
 ## Pull Requests

--- a/docs/intro/developing.md
+++ b/docs/intro/developing.md
@@ -57,7 +57,9 @@ The following url parameters change how the harness runs:
 
 ### Web Platform Tests (wpt) - Ref Tests
 
-You can execute individual web platform reftests at
+Running ref tests is not possible with this repository alone. It depends on WPT test harness support.
+
+You can however inspect the actual and reference pages for web platform reftests in the standalone runner by navigating to them. For example, by loading:
 
  - `http://localhost:8080/out/webgpu/web_platform/reftests/canvas_clear.https.html`
  - `http://localhost:8080/out/webgpu/web_platform/reftests/ref/canvas_clear-ref.html`


### PR DESCRIPTION
Add some docs for how to run wpt ref tests.

If there are instructions for actually running them as tests, that would be great! I'm guessing at the moment that's a per-browser thing. It made me wonder if we could/should make cts extension that exposes a screen capture API. A harness could run each test in an iframe and capture to compare.

Also, if there are instructions for running the non-ref WPT tests I'm happy to add them

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
