### PR TITLE
Unclutter the URL

### DIFF
--- a/docs/intro/developing.md
+++ b/docs/intro/developing.md
@@ -52,8 +52,8 @@ The following url parameters change how the harness runs:
 - `runnow=1` runs all matching tests on page load.
 - `debug=1` enables verbose debug logging from tests.
 - `worker=1` runs the tests on a Web Worker instead of the main thread.
-- `powerPreference=low-power` runs most tests passing `powerPreference: low-power` to `requestAdapter`
-- `powerPreference=high-performance` runs most tests passing `powerPreference: high-performance` to `requestAdapter`
+- `power_preference=low-power` runs most tests passing `powerPreference: low-power` to `requestAdapter`
+- `power_preference=high-performance` runs most tests passing `powerPreference: high-performance` to `requestAdapter`
 
 ## Editor
 

--- a/src/common/runtime/helper/options.ts
+++ b/src/common/runtime/helper/options.ts
@@ -13,3 +13,10 @@ export function optionEnabled(
   const val = searchParams.get(opt);
   return val !== null && val !== '0';
 }
+
+export function optionString(
+  opt: string,
+  searchParams: URLSearchParams = getWindowURL().searchParams
+): string {
+  return searchParams.get(opt) || '';
+}

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -12,7 +12,7 @@ import { TestTreeNode, TestSubtree, TestTreeLeaf, TestTree } from '../internal/t
 import { setDefaultRequestAdapterOptions } from '../util/navigator_gpu.js';
 import { assert, ErrorWithExtra, unreachable } from '../util/util.js';
 
-import { optionEnabled } from './helper/options.js';
+import { optionEnabled, optionString } from './helper/options.js';
 import { TestWorker } from './helper/test_worker.js';
 
 window.onbeforeunload = () => {
@@ -22,10 +22,76 @@ window.onbeforeunload = () => {
 
 let haveSomeResults = false;
 
-const runnow = optionEnabled('runnow');
-const debug = optionEnabled('debug');
-const unrollConstEvalLoops = optionEnabled('unroll_const_eval_loops');
+// The possible options for the tests.
+interface StandaloneOptions {
+  runnow: boolean;
+  worker: boolean;
+  debug: boolean;
+  unrollConstEvalLoops: boolean;
+  powerPreference: string;
+}
 
+// Extra per option info.
+interface StandaloneOptionInfo {
+  description: string;
+  parser?: (key: string) => boolean | string;
+  selectValueDescriptions?: { value: string; description: string }[];
+}
+
+// Type for info for every option. This definition means adding an option
+// will generate a compile time error if not extra info is provided.
+type StandaloneOptionsInfos = Record<keyof StandaloneOptions, StandaloneOptionInfo>;
+
+const optionsInfo: StandaloneOptionsInfos = {
+  runnow: { description: 'run immediately on load' },
+  worker: { description: 'run in a worker' },
+  debug: { description: 'show more info' },
+  unrollConstEvalLoops: { description: 'unroll const eval loops in WGSL' },
+  powerPreference: {
+    description: 'set default powerPreference for some tests',
+    parser: optionString,
+    selectValueDescriptions: [
+      { value: '', description: 'default' },
+      { value: 'low-power', description: 'low-power' },
+      { value: 'high-performance', description: 'high-performance' },
+    ],
+  },
+};
+
+/**
+ * Converts camel case to snake case.
+ * Examples:
+ *    fooBar -> foo_bar
+ *    parseHTMLFile -> parse_html_file
+ */
+function camelCaseToSnakeCase(id: string) {
+  return id
+    .replace(/(.)([A-Z][a-z]+)/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+/**
+ * Creates a StandaloneOptions from the current URL search parameters.
+ */
+function getOptionsInfoFromSearchParameters(
+  optionsInfos: StandaloneOptionsInfos
+): StandaloneOptions {
+  const optionValues: Record<string, boolean | string> = {};
+  for (const [optionName, info] of Object.entries(optionsInfos)) {
+    const parser = info.parser || optionEnabled;
+    optionValues[optionName] = parser(camelCaseToSnakeCase(optionName));
+  }
+  return (optionValues as unknown) as StandaloneOptions;
+}
+
+// This is just a cast in one place.
+function optionsToRecord(options: StandaloneOptions) {
+  return (options as unknown) as Record<string, boolean | string>;
+}
+
+const options = getOptionsInfoFromSearchParameters(optionsInfo);
+const { runnow, debug, unrollConstEvalLoops, powerPreference } = options;
 globalTestConfig.unrollConstEvalLoops = unrollConstEvalLoops;
 
 Logger.globalDebugMode = debug;
@@ -33,7 +99,7 @@ const logger = new Logger();
 
 setBaseResourcePath('../out/resources');
 
-const worker = optionEnabled('worker') ? new TestWorker(debug) : undefined;
+const worker = options.worker ? new TestWorker(debug) : undefined;
 
 const autoCloseOnPass = document.getElementById('autoCloseOnPass') as HTMLInputElement;
 const resultsVis = document.getElementById('resultsVis')!;
@@ -47,7 +113,6 @@ stopButtonElem.addEventListener('click', () => {
   stopRequested = true;
 });
 
-const powerPreference = new URLSearchParams(window.location.search).get('powerPreference');
 if (powerPreference) {
   setDefaultRequestAdapterOptions({ powerPreference: powerPreference as GPUPowerPreference });
 }
@@ -430,6 +495,41 @@ function makeTreeNodeHeaderHTML(
 // Collapse s:f:t:* or s:f:t:c by default.
 let lastQueryLevelToExpand: TestQueryLevel = 2;
 
+type ParamValue = string | undefined | null | boolean | string[];
+
+/**
+ * Takes an array of string, ParamValue and returns an array of pairs
+ * of [key, value] where value is a string. Converts boolean to '0' or '1'.
+ */
+function keyValueToPairs([k, v]: [string, ParamValue]): [string, string][] {
+  const key = camelCaseToSnakeCase(k);
+  if (typeof v === 'boolean') {
+    return [[key, v ? '1' : '0']];
+  } else if (Array.isArray(v)) {
+    return v.map(v => [key, v]);
+  } else {
+    return [[key, v!.toString()]];
+  }
+}
+
+/**
+ * Converts key value pairs to a search string.
+ * Keys will appear in order in the search string.
+ * Values can be undefined, null, boolean, string, or string[]
+ * If the value is falsy the key will not appear in the search string.
+ * If the value is an array the key will appear multiple times.
+ *
+ * @param params Some object with key value pairs.
+ * @returns a search string.
+ */
+function prepareParams(params: Record<string, ParamValue>): string {
+  const pairsArrays = Object.entries(params)
+    .filter(([, v]) => !!v)
+    .map(keyValueToPairs);
+  const pairs = pairsArrays.flat();
+  return new URLSearchParams(pairs).toString();
+}
+
 void (async () => {
   const loader = new DefaultTestFileLoader();
 
@@ -440,18 +540,58 @@ void (async () => {
   }
 
   // Update the URL bar to match the exact current options.
-  {
-    const params = {
-      runnow: runnow ? '1' : '0',
-      worker: worker ? '1' : '0',
-      debug: debug ? '1' : '0',
-      unroll_const_eval_loops: unrollConstEvalLoops ? '1' : '0',
-      ...(powerPreference && { powerPreference }),
+  const updateURLWithCurrentOptions = () => {
+    const search = prepareParams(optionsToRecord(options));
+    let url = `${window.location.origin}${window.location.pathname}`;
+    // Add in q separately to avoid escaping punctuation marks.
+    url += `?${search}${search ? '&' : ''}${qs.map(q => 'q=' + q).join('&')}`;
+    window.history.replaceState(null, '', url.toString());
+  };
+  updateURLWithCurrentOptions();
+
+  const addOptionsToPage = (options: StandaloneOptions, optionsInfos: StandaloneOptionsInfos) => {
+    const optionsElem = $('table#options>tbody')[0];
+    const optionValues = optionsToRecord(options);
+
+    const createCheckbox = (optionName: string) => {
+      return $(`<input>`)
+        .attr('type', 'checkbox')
+        .prop('checked', optionValues[optionName] as boolean)
+        .on('change', function () {
+          optionValues[optionName] = (this as HTMLInputElement).checked;
+          updateURLWithCurrentOptions();
+        });
     };
-    let url = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
-    url += `?${new URLSearchParams(params).toString()}&${qs.map(q => 'q=' + q).join('&')}`;
-    window.history.replaceState(null, '', url);
-  }
+
+    const createSelect = (optionName: string, info: StandaloneOptionInfo) => {
+      const select = $('<select>').on('change', function () {
+        optionValues[optionName] = (this as HTMLInputElement).value;
+        updateURLWithCurrentOptions();
+      });
+      const currentValue = optionValues[optionName];
+      for (const { value, description } of info.selectValueDescriptions!) {
+        $('<option>')
+          .text(description)
+          .val(value)
+          .prop('selected', value === currentValue)
+          .appendTo(select);
+      }
+      return select;
+    };
+
+    for (const [optionName, info] of Object.entries(optionsInfos)) {
+      const input =
+        typeof optionValues[optionName] === 'boolean'
+          ? createCheckbox(optionName)
+          : createSelect(optionName, info);
+      $('<tr>')
+        .append($('<td>').append(input))
+        .append($('<td>').text(camelCaseToSnakeCase(optionName)))
+        .append($('<td>').text(info.description))
+        .appendTo(optionsElem);
+    }
+  };
+  addOptionsToPage(options, optionsInfo);
 
   assert(qs.length === 1, 'currently, there must be exactly one ?q=');
   const rootQuery = parseQuery(qs[0]);

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -23,6 +23,7 @@
         --fg-color: #000;
         --bg-color: #fff;
         --border-color: #888;
+        --emphasis-fg-color: #F00;
 
         --results-fg-color: gray;
         --node-description-fg-color: #gray;
@@ -52,6 +53,7 @@
           --fg-color: #fff;
           --bg-color: #000;
           --border-color: #888;
+          --emphasis-fg-color: #F44;
 
           --results-fg-color: #aaa;
           --node-description-fg-color: #aaa;
@@ -98,6 +100,34 @@
       .logo {
         height: 1.2em;
         float: left;
+      }
+      .important {
+        font-weight: bold;
+        color: var(--emphasis-fg-color);
+      }
+      #options label {
+        display: flex;
+      }
+      table#options {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      #options td {
+        border: 1px solid var(--subtree-border-color);
+        width: 1px; /* to make the columns as small as possible */
+      }
+      #options tr:hover {
+        background: var(--node-hover-bg-color);
+      }
+      #options td:nth-child(1) {
+          text-align: right;
+      }
+      #options td:nth-child(2),
+      #options td:nth-child(3) {
+          padding-left: 0.5em;
+      }
+      #options td:nth-child(3) {
+          width: 100%; /* to make the last column use the space */
       }
       #info {
         font-family: monospace;
@@ -367,6 +397,14 @@
   </head>
   <body>
     <h1><img class="logo" src="webgpu-logo-notext.svg">WebGPU Conformance Test Suite</h1>
+    <details>
+      <summary>options (requires reload!)</summary>
+      <table id="options">
+        <tbody></tbody>
+      </table>
+      <p class="important">Note: The options above only set the url parameters. 
+         You must reload the page for the options to take affect.</p>
+    </details>
     <p>
       <input type=button id=expandall value="Expand All (slow!)">
       <label><input type=checkbox id=autoCloseOnPass> Auto-close each subtree when it passes</label>


### PR DESCRIPTION
The URL is getting long as new options are added. It's common to want to edit the q parameter but as more options are added this gets harder as it get pushed off the to the right.

So, only show options that are non-falsy.

I wasn't sure this was ok. I kind of assumed you wanted to see all the options. But, as more get added, it's getting too verbose. The docs should show the available options.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] ~Tests are properly located in the test tree.~
- [x] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [x] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
