### PR TITLE
op: Add 'index_format,setIndexBuffer_before_setPipeline' test in index_format.spec.ts

### DIFF
--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -274,6 +274,66 @@ g.test('index_format,change_pipeline_after_setIndexBuffer')
     t.expectGPUBufferValuesEqual(result, expectedTextureValues);
   });
 
+g.test('index_format,setIndexBuffer_before_setPipeline')
+  .desc('Test that setting the index buffer before the pipeline works correctly.')
+  .params(u => u.combine('setIndexBufferBeforeSetPipeline', [false, true]))
+  .fn(t => {
+    const indexOffset = 12;
+    const indexCount = 7;
+    const expectedShape = kBottomLeftTriangle;
+
+    const indexFormat = 'uint32';
+
+    const indices: number[] = [1, 2, 0, 0, 0, 0, 0, 1, 3, 0];
+    const indexBuffer = t.CreateIndexBuffer(indices, indexFormat);
+
+    const kPrimitiveTopology = 'triangle-strip';
+    const pipeline = t.MakeRenderPipeline(kPrimitiveTopology, indexFormat);
+
+    const colorAttachment = t.device.createTexture({
+      format: kTextureFormat,
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const result = t.device.createBuffer({
+      size: byteLength,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: colorAttachment.createView(),
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+
+    if (t.params.setIndexBufferBeforeSetPipeline) {
+      pass.setIndexBuffer(indexBuffer, indexFormat, indexOffset);
+      pass.setPipeline(pipeline);
+    } else {
+      pass.setPipeline(pipeline);
+      pass.setIndexBuffer(indexBuffer, indexFormat, indexOffset);
+    }
+
+    pass.drawIndexed(indexCount);
+    pass.end();
+    encoder.copyTextureToBuffer(
+      { texture: colorAttachment },
+      { buffer: result, bytesPerRow, rowsPerImage },
+      [kWidth, kHeight]
+    );
+    t.device.queue.submit([encoder.finish()]);
+
+    const expectedTextureValues = t.CreateExpectedUint8Array(expectedShape);
+    t.expectGPUBufferValuesEqual(result, expectedTextureValues);
+  });
+
 g.test('index_format,setIndexBuffer_different_formats')
   .desc(
     `


### PR DESCRIPTION
This PR implements 'index_format,setIndexBuffer_before_setPipeline' test in index_formats.spec.ts to ensure that setting the index buffer before the pipeline works correctly.

Issue: #1968

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
