### PR TITLE
Add HTML5 DOCTYPE to all reftests

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_clear.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_clear.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_clear</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_complex_bgra8unorm_copy</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_complex_bgra8unorm_draw</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_copy.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_complex_rgba16float_copy</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_draw.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_complex_rgba16float_draw</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_store.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_store.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_complex_rgba16float_store</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_copy.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_complex_rgba8unorm_copy</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_draw.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_complex_rgba8unorm_draw</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_store.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_store.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_complex_rgba8unorm_store</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_bgra8unorm_opaque</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_bgra8unorm_opaque</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_bgra8unorm_premultiplied</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_bgra8unorm_premultiplied</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_rgba16float_opaque</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_rgba16float_opaque</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_rgba16float_premultiplied</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_rgba16float_premultiplied</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_rgba8unorm_opaque</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_rgba8unorm_opaque</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_rgba8unorm_premultiplied</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_composite_alpha_rgba8unorm_premultiplied</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_image_rendering.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_image_rendering.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_image_rendering</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.https.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_back_buffer_different_size</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/ref/canvas_clear-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_clear-ref.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <title>WebGPU canvas_clear (ref)</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/ref/canvas_complex-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_complex-ref.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <title>WebGPU canvas_complex (ref)</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/ref/canvas_composite_alpha_opaque-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_composite_alpha_opaque-ref.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <title>WebGPU canvas_composite_alpha_premultiplied (ref)</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/ref/canvas_composite_alpha_premultiplied-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_composite_alpha_premultiplied-ref.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <title>WebGPU canvas_composite_alpha_premultiplied (ref)</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html class="reftest-wait">
   <title>WebGPU canvas_image_rendering (ref)</title>
   <meta charset="utf-8" />

--- a/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_size_different_with_back_buffer_size-ref.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <title>WebGPU canvas_back_buffer_different_size (ref)</title>
   <meta charset="utf-8" />


### PR DESCRIPTION
This puts the pages in HTML5 mode instead of "quirks mode". Found by this (perhaps new) Chromium presubmit check:

`HTML file "third_party/blink/web_tests/wpt_internal/webgpu/web_platform/reftests/canvas_image_rendering.https.html" does not start with . If you really intend to test in quirks mode, add "quirk" to the name of your test.`
on this roll CL:
https://chromium-review.googlesource.com/c/chromium/src/+/4143990

I can't easily test this, so I'll let it test itself on the autoroller.

Issue: None

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] ~Tests are properly located in the test tree.~
- [x] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [x] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [x] ~Helpers and types promote readability and maintainability.~

When landing this PR, be sure to make any necessary issue status updates.
