### PR TITLE
Add a ResizeObserve test

### DIFF
--- a/src/webgpu/web_platform/reftests/create-pattern-data-url.ts
+++ b/src/webgpu/web_platform/reftests/create-pattern-data-url.ts
@@ -1,0 +1,23 @@
+// creates a 4x4 pattern
+export default function createPatternDataURL() {
+  const patternSize = 4;
+  const ctx = document.createElement('canvas').getContext('2d')!;
+  ctx.canvas.width = patternSize;
+  ctx.canvas.height = patternSize;
+
+  const b = [0, 0, 0, 255];
+  const t = [0, 0, 0, 0];
+  const r = [255, 0, 0, 255];
+  const g = [0, 255, 0, 255];
+
+  const imageData = new ImageData(patternSize, patternSize);
+  // prettier-ignore
+  imageData.data.set([
+    b, t, t, r,
+    t, b, g, t,
+    t, r, b, t,
+    g, t, t, b,
+  ].flat());
+  ctx.putImageData(imageData, 0, 0);
+  return { patternSize, imageData, dataURL: ctx.canvas.toDataURL() };
+}

--- a/src/webgpu/web_platform/reftests/ref/resize_observer-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/resize_observer-ref.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+  <title>WebGPU ResizeObserver test (ref)</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <style>
+    .outer {
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+    }
+    .outer>* {
+      display: block;
+      height: 100px;
+    }
+  </style>
+  <body>
+    <div class="outer"></div>
+    <script type="module">
+  import createPatternDataURL from '../create-pattern-data-url.js';
+
+  const {patternSize, dataURL} = createPatternDataURL();
+
+  /**
+   * Set the pattern's size on this element so that it draws where
+   * 1 pixel in the pattern maps to 1 devicePixel.
+   */
+  function setPattern(elem) {
+    const oneDevicePixel = 1 / devicePixelRatio;
+    const patternPixels = oneDevicePixel * patternSize;
+    elem.style.backgroundImage = `url("${dataURL}")`;
+    elem.style.backgroundSize = `${patternPixels}px ${patternPixels}px`;
+  }
+
+  /*
+  This ref creates elements like this
+    <body>
+      <div class="outer">
+        <div></div>
+        <div></div>
+        <div></div>
+        ...
+      </div>
+    </body>
+  Where the outer div is a flexbox centering the child elements.
+  Each of the child elements is set to a different width in percent.
+  The devicePixelContentBox size of each child element is observed
+  with a ResizeObserver and when changed, a pattern is applied to
+  the element and the pattern's size set so each pixel in the pattern
+  will be one device pixel.
+  A similar process happens in the test HTML using canvases
+  and patterns generated using putImageData.
+  The test and this reference page should then match.
+  */
+
+  const outerElem = document.querySelector('.outer');
+
+  /**
+   * Set the pattern's size on this element so that it draws where
+   * 1 pixel in the pattern maps to 1 devicePixel.
+   */
+  function setPatterns(entries) {
+    for (const entry of entries) {
+      setPattern(entry.target)
+    }
+  }
+
+  const observer = new ResizeObserver(setPatterns);
+  for (let percentSize = 7; percentSize < 100; percentSize += 13) {
+    const innerElem = document.createElement('div');
+    innerElem.style.width = `${percentSize}%`;
+    observer.observe(innerElem, {box:"device-pixel-content-box"});
+    outerElem.appendChild(innerElem);
+  }
+    </script>
+  </body>
+ </html>

--- a/src/webgpu/web_platform/reftests/resize_observer.html.ts
+++ b/src/webgpu/web_platform/reftests/resize_observer.html.ts
@@ -1,0 +1,141 @@
+import createPatternDataURL from './create-pattern-data-url.js';
+import { runRefTest } from './gpu_ref_test.js';
+
+runRefTest(async t => {
+  const { patternSize, imageData: patternImageData } = createPatternDataURL();
+
+  const device = t.device;
+  const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
+
+  const module = device.createShaderModule({
+    code: `
+      @vertex fn vs(
+        @builtin(vertex_index) VertexIndex : u32
+      ) -> @builtin(position) vec4<f32> {
+        var pos = array<vec2<f32>, 3>(
+        vec2(-1.0, 3.0),
+        vec2(-1.0,-1.0),
+        vec2( 3.0,-1.0)
+        );
+
+        return vec4(pos[VertexIndex], 0.0, 1.0);
+      }
+
+      @group(0) @binding(0) var pattern: texture_2d<f32>;
+
+      @fragment fn fs(
+         @builtin(position) Pos : vec4<f32>
+      ) -> @location(0) vec4<f32> {
+        let patternSize = textureDimensions(pattern, 0);
+        let uPos = vec2u(Pos.xy) % patternSize;
+        return textureLoad(pattern, uPos, 0);
+      }
+    `,
+  });
+
+  const pipeline = device.createRenderPipeline({
+    layout: 'auto',
+    vertex: {
+      module,
+      entryPoint: 'vs',
+    },
+    fragment: {
+      module,
+      entryPoint: 'fs',
+      targets: [{ format: presentationFormat }],
+    },
+  });
+
+  const tex = device.createTexture({
+    size: [patternSize, patternSize, 1],
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+  });
+  device.queue.writeTexture(
+    { texture: tex },
+    patternImageData.data,
+    { bytesPerRow: patternSize * 4, rowsPerImage: 4 },
+    { width: patternSize, height: patternSize }
+  );
+
+  const bindGroup = device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [{ binding: 0, resource: tex.createView() }],
+  });
+
+  function setCanvasPattern(
+    canvas: HTMLCanvasElement,
+    devicePixelWidth: number,
+    devicePixelHeight: number
+  ) {
+    canvas.width = devicePixelWidth;
+    canvas.height = devicePixelHeight;
+    const context = canvas.getContext('webgpu') as GPUCanvasContext;
+    context.configure({
+      device,
+      format: presentationFormat,
+      alphaMode: 'premultiplied',
+    });
+
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: context.getCurrentTexture().createView(),
+          clearValue: [0.0, 0.0, 0.0, 0.0],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(3);
+    pass.end();
+
+    device.queue.submit([encoder.finish()]);
+  }
+
+  /*
+  This test creates elements like this
+    <body>
+      <div class="outer">
+        <canvas></canvas>
+        <canvas></canvas>
+        <canvas></canvas>
+        ...
+      </div>
+    </body>
+  Where the outer div is a flexbox centering the child canvases.
+  Each of the child canvases is set to a different width in percent.
+  The size of each canvas in device pixels is queried with ResizeObserver
+  and then each canvases' resolution is set to that size so that there should
+  be one pixel in each canvas for each device pixel.
+  Each canvas is filled with a pattern using putImageData.
+  In the reference the canvas elements are replaced with divs.
+  For the divs the same pattern is applied with CSS and its size
+  adjusted so the pattern should appear with one pixel in the pattern
+  corresponding to 1 device pixel.
+  The reference and this page should then match.
+  */
+
+  const outerElem = document.querySelector('.outer')!;
+
+  function setPatternsUsingSizeInfo(entries: ResizeObserverEntry[]) {
+    for (const entry of entries) {
+      setCanvasPattern(
+        entry.target as HTMLCanvasElement,
+        entry.devicePixelContentBoxSize[0].inlineSize,
+        entry.devicePixelContentBoxSize[0].blockSize
+      );
+    }
+  }
+
+  const observer = new ResizeObserver(setPatternsUsingSizeInfo);
+  for (let percentSize = 7; percentSize < 100; percentSize += 13) {
+    const canvasElem = document.createElement('canvas');
+    canvasElem.style.width = `${percentSize}%`;
+    observer.observe(canvasElem, { box: 'device-pixel-content-box' });
+    outerElem.appendChild(canvasElem);
+  }
+});

--- a/src/webgpu/web_platform/reftests/resize_observer.https.html
+++ b/src/webgpu/web_platform/reftests/resize_observer.https.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <title>WebGPU resize_observer</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta name="assert" content="WebGPU canvases should return the correct ResizeObserver values" />
+  <link rel="match" href="./ref/resize_observer-ref.html" />
+  <style>
+    .outer {
+      display: flex;
+      align-items: center;
+      flex-direction: column;
+    }
+    .outer>* {
+      display: block;
+      height: 100px;
+    }
+  </style>
+  <body>
+    <div class="outer"></div>
+    <script type="module" src="resize_observer.html.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This is a test I submitted to the Web Platform Tests but changed to use WebGPU instead of canvas 2d.

It works by creating a bunch of divs(ref) or canvas(test) and setting them to be various percent sizes.

For the divs it sets their background-image pattern so that 1 pixel in the pattern is one device pixel. This is easy since it's just patterSize / devicePixelRatio

For the canvas it uses ResizeObserver and given the size it receives it fulls each canvas with a 1 canvs pixel to 1 device pixel pattern.

The 2 pages should match. If ResizeObserver is bad they won't.

The pattern used is 4x4 which gives more chances for things to be off of alignment than a 2x2.


Issue: #1115

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
