### PR TITLE
shader/expression: Reduce 'const' shader size

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -165,7 +165,7 @@ export async function run(
   const casesPerBatch = (function () {
     switch (cfg.inputSource) {
       case 'const':
-        return 64; // Arbitrary limit, to ensure shaders aren't too large
+        return 32; // Arbitrary limit, to ensure shaders aren't too large
       case 'uniform':
         return Math.floor(
           t.device.limits.maxUniformBufferBindingSize / (parameterTypes.length * kValueStride)


### PR DESCRIPTION
Smaller shaders will take less time to compile, and heartbeats between the batches should result in fewer timeouts.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
