### PR TITLE
Add Buffer.mapState test

### DIFF
--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -386,20 +386,20 @@ g.test('mappedAtCreation,mapState')
     }, validationError);
 
     // mapState must be "mapped" regardless of validation error
-    assert(buffer!.mapState === 'mapped');
+    t.expect(buffer!.mapState === 'mapped');
 
     // getMappedRange must not change the map state
     buffer!.getMappedRange(...range);
-    assert(buffer!.mapState === 'mapped');
+    t.expect(buffer!.mapState === 'mapped');
 
     if (afterUnmap) {
       buffer!.unmap();
-      assert(buffer!.mapState === 'unmapped');
+      t.expect(buffer!.mapState === 'unmapped');
     }
 
     if (afterDestroy) {
       buffer!.destroy();
-      assert(buffer!.mapState === 'unmapped');
+      t.expect(buffer!.mapState === 'unmapped');
     }
   });
 
@@ -437,32 +437,32 @@ g.test('mapAsync,mapState')
       });
     }, bufferCreationValidationError);
 
-    assert(buffer!.mapState === 'unmapped');
+    t.expect(buffer!.mapState === 'unmapped');
 
     {
       const promise = buffer!.mapAsync(mapAsyncValidationError ? 0 : GPUMapMode.WRITE);
-      assert(buffer!.mapState === 'pending');
+      t.expect(buffer!.mapState === 'pending');
 
       try {
         if (beforeUnmap) {
           buffer!.unmap();
-          assert(buffer!.mapState === 'unmapped');
+          t.expect(buffer!.mapState === 'unmapped');
         }
         if (beforeDestroy) {
           buffer!.destroy();
-          assert(buffer!.mapState === 'unmapped');
+          t.expect(buffer!.mapState === 'unmapped');
         }
 
         await promise;
-        assert(buffer!.mapState === 'mapped');
+        t.expect(buffer!.mapState === 'mapped');
 
         // getMappedRange must not change the map state
         buffer!.getMappedRange(...range);
-        assert(buffer!.mapState === 'mapped');
+        t.expect(buffer!.mapState === 'mapped');
       } catch {
         // unmapped before resolve, destroyed before resolve, or mapAsync validation error
         // will end up with rejection and 'unmapped'
-        assert(buffer!.mapState === 'unmapped');
+        t.expect(buffer!.mapState === 'unmapped');
       }
     }
 
@@ -470,24 +470,24 @@ g.test('mapAsync,mapState')
     if (buffer!.mapState === 'mapped') {
       // mapAsync on already mapped buffer won't change the map state
       const promise = buffer!.mapAsync(GPUMapMode.WRITE);
-      assert(buffer!.mapState === 'mapped');
+      t.expect(buffer!.mapState === 'mapped');
 
       // mapAsync on already mapped buffer must reject and the map state must keep 'mapped'
       try {
         await promise;
-        throw new Error('mapAsync on already mapped buffer must not succeed.');
+        t.fail('mapAsync on already mapped buffer must not succeed.');
       } catch {
-        assert(buffer!.mapState === 'mapped');
+        t.expect(buffer!.mapState === 'mapped');
       }
     }
 
     if (afterUnmap) {
       buffer!.unmap();
-      assert(buffer!.mapState === 'unmapped');
+      t.expect(buffer!.mapState === 'unmapped');
     }
 
     if (afterDestroy) {
       buffer!.destroy();
-      assert(buffer!.mapState === 'unmapped');
+      t.expect(buffer!.mapState === 'unmapped');
     }
   });

--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -370,11 +370,11 @@ g.test('mappedAtCreation,mapState')
       .combine('validationError', [false, true])
       .combine('afterUnmap', [false, true])
       .combine('afterDestroy', [false, true])
-      .beginSubcases()
-      .combineWithParams(kSubcases)
   )
   .fn(async t => {
-    const { size, range, validationError, afterUnmap, afterDestroy } = t.params;
+    const { validationError, afterUnmap, afterDestroy } = t.params;
+    const size = 8;
+    const range = [0, 8];
 
     let buffer: GPUBuffer;
     t.expectValidationError(() => {
@@ -413,13 +413,9 @@ g.test('mapAsync,mapState')
       .combine('beforeDestroy', [false, true])
       .combine('afterUnmap', [false, true])
       .combine('afterDestroy', [false, true])
-      .beginSubcases()
-      .combineWithParams(kSubcases)
   )
   .fn(async t => {
     const {
-      size,
-      range,
       bufferCreationValidationError,
       mapAsyncValidationError,
       beforeUnmap,
@@ -427,6 +423,8 @@ g.test('mapAsync,mapState')
       afterUnmap,
       afterDestroy,
     } = t.params;
+    const size = 8;
+    const range = [0, 8];
 
     let buffer: GPUBuffer;
     t.expectValidationError(() => {

--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -440,7 +440,10 @@ g.test('mapAsync,mapState')
     t.expect(buffer!.mapState === 'unmapped');
 
     {
-      const promise = buffer!.mapAsync(mapAsyncValidationError ? 0 : GPUMapMode.WRITE);
+      let promise: Promise<void>;
+      t.expectValidationError(() => {
+        promise = buffer!.mapAsync(mapAsyncValidationError ? 0 : GPUMapMode.WRITE);
+      }, bufferCreationValidationError || mapAsyncValidationError);
       t.expect(buffer!.mapState === 'pending');
 
       try {
@@ -453,7 +456,7 @@ g.test('mapAsync,mapState')
           t.expect(buffer!.mapState === 'unmapped');
         }
 
-        await promise;
+        await promise!;
         t.expect(buffer!.mapState === 'mapped');
 
         // getMappedRange must not change the map state


### PR DESCRIPTION
Issue: #2124

This PR adds `Buffer.mapState` test.

https://github.com/gpuweb/gpuweb/pull/3014

I made new tests for `Buffer.mapState` rather than inserting `Buffer.mapState` check in the existing tests because I thought it can be simpler and cleaner. Please let me know if inserting in the existing tests is better.

And also please let me know if you have any simplification or better test coverage ideas.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
