### PR TITLE
Add more states to canvas composite ref tests.

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha.html.ts
@@ -2,9 +2,6 @@ import { assert, unreachable } from '../../../common/util/util.js';
 
 import { runRefTest } from './gpu_ref_test.js';
 
-// <canvas> element from html page
-declare const cvs: HTMLCanvasElement;
-
 type WriteCanvasMethod = 'draw' | 'copy';
 
 export function run(
@@ -13,64 +10,15 @@ export function run(
   writeCanvasMethod: WriteCanvasMethod
 ) {
   runRefTest(async t => {
-    const ctx = cvs.getContext('webgpu');
-    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
-
-    switch (format) {
-      case 'bgra8unorm':
-      case 'bgra8unorm-srgb':
-      case 'rgba8unorm':
-      case 'rgba8unorm-srgb':
-      case 'rgba16float':
-        break;
-      default:
-        unreachable();
-    }
-
-    let usage = 0;
-    switch (writeCanvasMethod) {
-      case 'draw':
-        usage = GPUTextureUsage.RENDER_ATTACHMENT;
-        break;
-      case 'copy':
-        usage = GPUTextureUsage.COPY_DST;
-        break;
-    }
-    ctx.configure({
-      device: t.device,
-      format,
-      usage,
-      alphaMode,
-    });
-
-    // The blending behavior here is to mimic 2d context blending behavior
-    // of drawing rects in order
-    // https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_srcover
-    const kBlendStateSourceOver = {
-      color: {
-        srcFactor: 'src-alpha',
-        dstFactor: 'one-minus-src-alpha',
-        operation: 'add',
-      },
-      alpha: {
-        srcFactor: 'one',
-        dstFactor: 'one-minus-src-alpha',
-        operation: 'add',
-      },
-    } as const;
-
-    const pipeline = t.device.createRenderPipeline({
-      layout: 'auto',
-      vertex: {
-        module: t.device.createShaderModule({
-          code: `
+    const module = t.device.createShaderModule({
+      code: `
 struct VertexOutput {
 @builtin(position) Position : vec4<f32>,
 @location(0) fragColor : vec4<f32>,
 }
 
 @vertex
-fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
+fn mainVS(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
 var pos = array<vec2<f32>, 6>(
     vec2<f32>( 0.75,  0.75),
     vec2<f32>( 0.75, -0.75),
@@ -98,81 +46,132 @@ output.Position = vec4<f32>(pos[VertexIndex % 6u] + offset[VertexIndex / 6u], 0.
 output.fragColor = color[VertexIndex / 6u];
 return output;
 }
-        `,
-        }),
-        entryPoint: 'main',
-      },
-      fragment: {
-        module: t.device.createShaderModule({
-          code: `
+
 @fragment
-fn main(@location(0) fragColor: vec4<f32>) -> @location(0) vec4<f32> {
+fn mainFS(@location(0) fragColor: vec4<f32>) -> @location(0) vec4<f32> {
 return fragColor;
 }
-        `,
-        }),
-        entryPoint: 'main',
-        targets: [
-          {
-            format,
-            blend: { premultiplied: kBlendStateSourceOver, opaque: undefined }[alphaMode],
-          },
-        ],
-      },
-      primitive: {
-        topology: 'triangle-list',
-      },
+      `,
     });
 
-    let renderTarget: GPUTexture;
-    switch (writeCanvasMethod) {
-      case 'draw':
-        renderTarget = ctx.getCurrentTexture();
-        break;
-      case 'copy':
-        renderTarget = t.device.createTexture({
-          size: [ctx.canvas.width, ctx.canvas.height],
-          format,
-          usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-        });
-        break;
-    }
-    const renderPassDescriptor: GPURenderPassDescriptor = {
-      colorAttachments: [
-        {
-          view: renderTarget.createView(),
-          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
-          loadOp: 'clear',
-          storeOp: 'store',
+    document.querySelectorAll('canvas').forEach(canvas => {
+      const ctx = canvas.getContext('webgpu');
+      assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
+
+      switch (format) {
+        case 'bgra8unorm':
+        case 'bgra8unorm-srgb':
+        case 'rgba8unorm':
+        case 'rgba8unorm-srgb':
+        case 'rgba16float':
+          break;
+        default:
+          unreachable();
+      }
+
+      let usage = 0;
+      switch (writeCanvasMethod) {
+        case 'draw':
+          usage = GPUTextureUsage.RENDER_ATTACHMENT;
+          break;
+        case 'copy':
+          usage = GPUTextureUsage.COPY_DST;
+          break;
+      }
+      ctx.configure({
+        device: t.device,
+        format,
+        usage,
+        alphaMode,
+      });
+
+      // The blending behavior here is to mimic 2d context blending behavior
+      // of drawing rects in order
+      // https://drafts.fxtf.org/compositing/#porterduffcompositingoperators_srcover
+      const kBlendStateSourceOver = {
+        color: {
+          srcFactor: 'src-alpha',
+          dstFactor: 'one-minus-src-alpha',
+          operation: 'add',
         },
-      ],
-    };
+        alpha: {
+          srcFactor: 'one',
+          dstFactor: 'one-minus-src-alpha',
+          operation: 'add',
+        },
+      } as const;
 
-    const commandEncoder = t.device.createCommandEncoder();
-    const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
-    passEncoder.setPipeline(pipeline);
-    passEncoder.draw(6, 1, 0, 0);
-    passEncoder.draw(6, 1, 6, 0);
-    passEncoder.draw(6, 1, 12, 0);
-    passEncoder.draw(6, 1, 18, 0);
-    passEncoder.end();
+      const pipeline = t.device.createRenderPipeline({
+        layout: 'auto',
+        vertex: {
+          module,
+          entryPoint: 'mainVS',
+        },
+        fragment: {
+          module,
+          entryPoint: 'mainFS',
+          targets: [
+            {
+              format,
+              blend: { premultiplied: kBlendStateSourceOver, opaque: undefined }[alphaMode],
+            },
+          ],
+        },
+        primitive: {
+          topology: 'triangle-list',
+        },
+      });
 
-    switch (writeCanvasMethod) {
-      case 'draw':
-        break;
-      case 'copy':
-        commandEncoder.copyTextureToTexture(
+      let renderTarget: GPUTexture;
+      switch (writeCanvasMethod) {
+        case 'draw':
+          renderTarget = ctx.getCurrentTexture();
+          break;
+        case 'copy':
+          renderTarget = t.device.createTexture({
+            size: [ctx.canvas.width, ctx.canvas.height],
+            format,
+            usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+          });
+          break;
+      }
+      const renderPassDescriptor: GPURenderPassDescriptor = {
+        colorAttachments: [
           {
-            texture: renderTarget,
+            view: renderTarget.createView(),
+            clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+            loadOp: 'clear',
+            storeOp: 'store',
           },
-          {
-            texture: ctx.getCurrentTexture(),
-          },
-          [ctx.canvas.width, ctx.canvas.height]
-        );
-        break;
-    }
+        ],
+      };
 
-    t.device.queue.submit([commandEncoder.finish()]);
+      const commandEncoder = t.device.createCommandEncoder();
+      const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+      passEncoder.setPipeline(pipeline);
+      passEncoder.draw(6, 1, 0, 0);
+      passEncoder.draw(6, 1, 6, 0);
+      passEncoder.draw(6, 1, 12, 0);
+      passEncoder.draw(6, 1, 18, 0);
+      passEncoder.end();
+
+      switch (writeCanvasMethod) {
+        case 'draw':
+          break;
+        case 'copy':
+          commandEncoder.copyTextureToTexture(
+            {
+              texture: renderTarget,
+            },
+            {
+              texture: ctx.getCurrentTexture(),
+            },
+            [ctx.canvas.width, ctx.canvas.height]
+          );
+          break;
+      }
+
+      t.device.queue.submit([commandEncoder.finish()]);
+    });
   });
 }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
@@ -10,11 +10,12 @@
   <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('bgra8unorm', 'opaque', 'copy');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
@@ -10,11 +10,12 @@
   <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('bgra8unorm', 'opaque', 'draw');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
@@ -11,11 +11,12 @@
   <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('bgra8unorm', 'premultiplied', 'copy');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
@@ -11,11 +11,12 @@
   <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('bgra8unorm', 'premultiplied', 'draw');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html
@@ -10,11 +10,12 @@
   <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('rgba16float', 'opaque', 'copy');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html
@@ -10,11 +10,12 @@
   <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('rgba16float', 'opaque', 'draw');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
@@ -11,11 +11,12 @@
   <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('rgba16float', 'premultiplied', 'copy');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
@@ -11,11 +11,12 @@
   <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('rgba16float', 'premultiplied', 'draw');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html
@@ -10,11 +10,12 @@
   <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('rgba8unorm', 'opaque', 'copy');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html
@@ -10,11 +10,12 @@
   <link rel="match" href="./ref/canvas_composite_alpha_opaque-ref.html" />
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('rgba8unorm', 'opaque', 'draw');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
@@ -11,11 +11,12 @@
   <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('rgba8unorm', 'premultiplied', 'copy');
   </script>

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
@@ -11,11 +11,12 @@
   <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script src="/common/reftest-wait.js"></script>
   <script type="module">
-    cvs.style.imageRendering = 'pixelated';
     import { run } from './canvas_composite_alpha.html.js';
     run('rgba8unorm', 'premultiplied', 'draw');
   </script>

--- a/src/webgpu/web_platform/reftests/ref/canvas_composite_alpha_opaque-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_composite_alpha_opaque-ref.html
@@ -5,18 +5,22 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script>
-    const ctx = cvs.getContext('2d');
-    ctx.globalAlpha = 1.0;
-    ctx.fillStyle = '#660000';
-    ctx.fillRect(0, 0, 15, 15);
-    ctx.fillStyle = '#006600';
-    ctx.fillRect(5, 0, 15, 15);
-    ctx.fillStyle = '#000066';
-    ctx.fillRect(0, 5, 15, 20);
-    ctx.fillStyle = '#666600';
-    ctx.fillRect(5, 5, 20, 20);
+    document.querySelectorAll('canvas').forEach(canvas => {
+      const ctx = canvas.getContext('2d');
+      ctx.globalAlpha = 1.0;
+      ctx.fillStyle = '#660000';
+      ctx.fillRect(0, 0, 15, 15);
+      ctx.fillStyle = '#006600';
+      ctx.fillRect(5, 0, 15, 15);
+      ctx.fillStyle = '#000066';
+      ctx.fillRect(0, 5, 15, 20);
+      ctx.fillStyle = '#666600';
+      ctx.fillRect(5, 5, 20, 20);
+    });
   </script>
 </html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_composite_alpha_premultiplied-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_composite_alpha_premultiplied-ref.html
@@ -5,18 +5,22 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <style>
     body { background-color: #F0E68C; }
+    #c-canvas { background-color: #8CF0E6; }
   </style>
-  <canvas id="cvs" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-body" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
+  <canvas id="c-canvas" width="20" height="20" style="width: 20px; height: 20px;"></canvas>
   <script>
-    const ctx = cvs.getContext('2d');
-    ctx.globalAlpha = 0.5;
-    ctx.fillStyle = '#660000';
-    ctx.fillRect(0, 0, 15, 15);
-    ctx.fillStyle = '#006600';
-    ctx.fillRect(5, 0, 15, 15);
-    ctx.fillStyle = '#000066';
-    ctx.fillRect(0, 5, 15, 20);
-    ctx.fillStyle = '#666600';
-    ctx.fillRect(5, 5, 20, 20);
+    document.querySelectorAll('canvas').forEach(canvas => {
+      const ctx = canvas.getContext('2d');
+      ctx.globalAlpha = 0.5;
+      ctx.fillStyle = '#660000';
+      ctx.fillRect(0, 0, 15, 15);
+      ctx.fillStyle = '#006600';
+      ctx.fillRect(5, 0, 15, 15);
+      ctx.fillStyle = '#000066';
+      ctx.fillRect(0, 5, 15, 20);
+      ctx.fillStyle = '#666600';
+      ctx.fillRect(5, 5, 20, 20);
+    });
   </script>
 </html>


### PR DESCRIPTION
There are bugs related to setting the CSS background color of a canvas vs setting the background color of the body so I added a couple of test cases.

The 3 cases are now

1. A canvas on top of a colored body with imageRendering set at runtime by javascript

2. A canvas on top of a colored body with imageRendering set via CSS canvas rule

3. A canvas with background color set in CSS with imageRendering set via CSS canvas rule


This test fails in Chrome though AFAICT it was already failing

Issue: #2132

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
