### PR TITLE
Remove <link rel=match> from -ref.html

### DIFF
--- a/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
@@ -3,7 +3,6 @@
   <title>WebGPU canvas_image_rendering (ref)</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
-  <link rel="match" href="./ref/canvas_image_rendering-ref.html" />
   <img id="elem1" width="64" height="64" style="width: 99px; height: 99px;">
   <img id="elem2" width="64" height="64" style="width: 99px; height: 99px; image-rendering: pixelated;">
   <img id="elem3" width="64" height="64" style="width: 99px; height: 99px; image-rendering: crisp-edges">


### PR DESCRIPTION
The `<link rel=match>` is meant to be specified on the test file but I don't think it needs to be on the reference file.
https://web-platform-tests.org/writing-tests/reftests.html

This _might_ be causing WPT to treat the `-ref.html` file as a test on its own - I'm not sure if that's what's going on. Note the `-ref.html` file is "failing" on this Chromium roll attempt:
https://ci.chromium.org/ui/p/chromium/builders/try/dawn-linux-x64-deps-rel/31359/overview
Which is odd since it's not a test.

The test itself is also failing (with timeouts?) but I'm guessing that's a separate problem.

Issue: followup to #2119

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
