### PR TITLE
Remove class=reftest-wait from reftests

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_clear.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_clear.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_clear</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_copy.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_complex_bgra8unorm_copy</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_bgra8unorm_draw.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_complex_bgra8unorm_draw</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_copy.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_complex_rgba16float_copy</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_draw.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_complex_rgba16float_draw</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_store.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba16float_store.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_complex_rgba16float_store</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_copy.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_complex_rgba8unorm_copy</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_draw.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_complex_rgba8unorm_draw</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_store.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_complex_rgba8unorm_store.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_complex_rgba8unorm_store</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_copy.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_bgra8unorm_opaque</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_opaque_draw.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_bgra8unorm_opaque</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_bgra8unorm_premultiplied</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_bgra8unorm_premultiplied</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_copy.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_rgba16float_opaque</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_opaque_draw.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_rgba16float_opaque</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_rgba16float_premultiplied</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_rgba16float_premultiplied</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_copy.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_rgba8unorm_opaque</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_opaque_draw.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_rgba8unorm_opaque</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_rgba8unorm_premultiplied</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_composite_alpha_rgba8unorm_premultiplied</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_image_rendering.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_image_rendering.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_image_rendering</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_size_different_with_back_buffer_size.https.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_back_buffer_different_size</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />

--- a/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_image_rendering (ref)</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />


### PR DESCRIPTION
As far as I can tell this shouldn't be necessary. Without this, the page snapshot is supposed to occur after the 'load' event fires, which is fine for us (that should be after `<script type=module>`s are loaded).
https://web-platform-tests.org/writing-tests/reftests.html#controlling-when-comparison-occurs

Will verify when it rolls into Chromium (will hold off on landing this until we've successfully rolled the other new reftest, #2119, and have understood why it was failing to roll)

Issue: None

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
