### PR TITLE
op: Add infinity bias slope scale params to 'depth_bias' test

### DIFF
--- a/src/webgpu/api/operation/rendering/depth_bias.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_bias.spec.ts
@@ -5,6 +5,7 @@ Tests render results with different depth bias values like 'positive', 'negative
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { unreachable } from '../../../../common/util/util.js';
+import { kValue } from '../../../../webgpu/util/constants.js';
 import {
   DepthStencilFormat,
   EncodableTextureFormat,
@@ -297,6 +298,20 @@ g.test('depth_bias')
           biasSlopeScale: 0,
           biasClamp: -0.125,
           _expectedDepth: 0.125,
+        },
+        {
+          quadAngle: QuadAngle.TiltedX,
+          bias: 0,
+          biasSlopeScale: kValue.f32.infinity.positive,
+          biasClamp: 0,
+          _expectedDepth: 1.0,
+        },
+        {
+          quadAngle: QuadAngle.TiltedX,
+          bias: 0,
+          biasSlopeScale: kValue.f32.infinity.negative,
+          biasClamp: 0,
+          _expectedDepth: 0.0,
         },
         {
           quadAngle: QuadAngle.TiltedX,


### PR DESCRIPTION
This PR adds more parameterizations to 'depth_bias' test for the infinity bias slope scale.

Issue: #2023

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
