### PR TITLE
Remove class=reftest-wait from a -ref.html

### DIFF
--- a/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="reftest-wait">
+<html>
   <title>WebGPU canvas_image_rendering (ref)</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />


### PR DESCRIPTION
canvas_image_rendering-ref.html doesn't ever call takeScreenshot/Delayed so the `reftest-wait` class never gets removed and the ref never "completes" its rendering

```
18:33:42.269 14074 [1/1] wpt_internal/webgpu/web_platform/reftests/canvas_image_rendering.https.html failed unexpectedly (test reference timed out) 13.2295s
```

It's fortunate I went digging to understand `reftest-wait` in #2138 or this wouldn't have been obvious.

Issue: Followup to #2119 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
