### PR TITLE
If subcase can't be added to .message, use .stack

### DIFF
--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -539,8 +539,14 @@ class RunCaseSpecific implements RunCase {
                           try {
                             arg.message = subcasePrefix + '\n' + arg.message;
                           } catch {
-                            // Silence exception if the property isn't settable
-                            // (e.g. arg.message on DOMException).
+                            // If that fails (e.g. on DOMException), try to put it in the stack:
+                            let stack = subcasePrefix;
+                            if (arg.stack) stack += '\n' + arg.stack;
+                            try {
+                              arg.stack = stack;
+                            } catch {
+                              // If that fails too, just silence it.
+                            }
                           }
                         }
                       }


### PR DESCRIPTION
Fallback so we have subcase logging for DOMException which doesn't allow setting .message.

Tested manually using `demo:subcases:DOMException,subcases:`

Issue: #2103, see also #2102

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
