### PR TITLE
Fix Buffer.mapState op tests

### DIFF
--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -471,13 +471,16 @@ g.test('mapAsync,mapState')
 
     // If buffer is already mapped test mapAsync on already mapped buffer
     if (buffer!.mapState === 'mapped') {
-      // mapAsync on already mapped buffer won't change the map state
-      const promise = buffer!.mapAsync(GPUMapMode.WRITE);
+      // mapAsync on already mapped buffer must be rejected with a validation error
+      // and the map state must keep 'mapped'
+      let promise: Promise<void>;
+      t.expectValidationError(() => {
+        promise = buffer!.mapAsync(GPUMapMode.WRITE);
+      }, true);
       t.expect(buffer!.mapState === 'mapped');
 
-      // mapAsync on already mapped buffer must reject and the map state must keep 'mapped'
       try {
-        await promise;
+        await promise!;
         t.fail('mapAsync on already mapped buffer must not succeed.');
       } catch {
         t.expect(buffer!.mapState === 'mapped');


### PR DESCRIPTION
Use `expectValidationError()` to catch a validation error caused by mapping on already mapped buffer.

Follow up PR against #2130 
Issue: #2124 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
