### PR TITLE
operation,render_pipeline,sample_mask

### DIFF
--- a/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
@@ -1,16 +1,443 @@
 export const description = `
-TODO:
-- for sampleCount = { 1, 4 } and various combinations of:
-    - rasterization mask = { 0, 1, 2, 3, 15 }
-    - sample mask = { 0, 1, 2, 3, 15, 30 }
-    - fragment shader output mask (SV_Coverage) = { 0, 1, 2, 3, 15, 30 }
-- test that final sample mask is the logical AND of all the
-  relevant masks -- meaning that the samples not included in the final mask are discarded
-  for all the { color outputs, depth tests, stencil operations } on any attachments.
-- [choosing 30 = 2 + 4 + 8 + 16 because the 5th bit should be ignored]
+Tests that the final sample mask is the logical AND of all the relevant masks.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { assert, range } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
 
-export const g = makeTestGroup(GPUTest);
+const kColors = [
+  // Red
+  { R: 0xff, G: 0, B: 0, A: 0xff },
+  // Green
+  { R: 0, G: 0xff, B: 0, A: 0xff },
+  // Blue
+  { R: 0, G: 0, B: 0xff, A: 0xff },
+  // Yellow
+  { R: 0xff, G: 0xff, B: 0, A: 0xff },
+];
+
+const kEmptySample = { R: 0, G: 0, B: 0, A: 0 };
+
+// Format of the render target and resolve target
+const format = 'rgba8unorm';
+
+class F extends GPUTest {
+  async GetResolvedTargetTexture(
+    sampleCount: number,
+    rasterizationMask: number,
+    sampleMask: number,
+    fragmentShaderOutputMask: number
+  ): Promise<GPUTexture> {
+    // Create a 2x2 color texture to sample from
+    // texel 0 - Red
+    // texel 1 - Green
+    // texel 2 - Blue
+    // texel 3 - Yellow
+    const kSampleTextureSize = 2;
+    const imageData = new ImageData(
+      // prettier-ignore
+      new Uint8ClampedArray([
+        kColors[0].R, kColors[0].G, kColors[0].B, kColors[0].A,
+        kColors[1].R, kColors[1].G, kColors[1].B, kColors[1].A,
+        kColors[2].R, kColors[2].G, kColors[2].B, kColors[2].A,
+        kColors[3].R, kColors[3].G, kColors[3].B, kColors[3].A,
+      ]),
+      kSampleTextureSize,
+      kSampleTextureSize
+    );
+    const imageBitmap = await createImageBitmap(imageData);
+    const sampleTexture = this.device.createTexture({
+      size: [kSampleTextureSize, kSampleTextureSize, 1],
+      format: 'rgba8unorm',
+      usage:
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    this.device.queue.copyExternalImageToTexture(
+      { source: imageBitmap },
+      { texture: sampleTexture },
+      [imageBitmap.width, imageBitmap.height]
+    );
+
+    const sampler = this.device.createSampler({
+      magFilter: 'nearest',
+      minFilter: 'nearest',
+    });
+
+    const fragmentMaskUniformBuffer = this.device.createBuffer({
+      size: 4,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+    });
+    this.trackForCleanup(fragmentMaskUniformBuffer);
+    this.device.queue.writeBuffer(
+      fragmentMaskUniformBuffer,
+      0,
+      new Uint32Array([fragmentShaderOutputMask])
+    );
+
+    const pipeline = this.device.createRenderPipeline({
+      layout: 'auto',
+      vertex: {
+        module: this.device.createShaderModule({
+          code: `
+          struct VertexOutput {
+            @builtin(position) Position : vec4<f32>,
+            @location(0) @interpolate(perspective, sample) fragUV : vec2<f32>,
+          }
+          
+          @vertex
+          fn main(@builtin(vertex_index) VertexIndex : u32) -> VertexOutput {
+            var pos = array<vec2<f32>, 30>(
+                // full screen quad
+                vec2<f32>( 1.0,  1.0),
+                vec2<f32>( 1.0, -1.0),
+                vec2<f32>(-1.0, -1.0),
+                vec2<f32>( 1.0,  1.0),
+                vec2<f32>(-1.0, -1.0),
+                vec2<f32>(-1.0,  1.0),
+
+                // Sub quads are representing rasterization mask and
+                // are slightly scaled to avoid covering the pixel center
+
+                // top-left quad
+                vec2<f32>( -0.01, 1.0),
+                vec2<f32>( -0.01, 0.01),
+                vec2<f32>(-1.0, 0.01),
+                vec2<f32>( -0.01, 1.0),
+                vec2<f32>(-1.0, 0.01),
+                vec2<f32>(-1.0, 1.0),
+
+                // top-right quad
+                vec2<f32>(1.0, 1.0),
+                vec2<f32>(1.0, 0.01),
+                vec2<f32>(0.01, 0.01),
+                vec2<f32>(1.0, 1.0),
+                vec2<f32>(0.01, 0.01),
+                vec2<f32>(0.01, 1.0),
+
+                // bottom-left quad
+                vec2<f32>( -0.01,  -0.01),
+                vec2<f32>( -0.01, -1.0),
+                vec2<f32>(-1.0, -1.0),
+                vec2<f32>( -0.01,  -0.01),
+                vec2<f32>(-1.0, -1.0),
+                vec2<f32>(-1.0,  -0.01),
+
+                // bottom-right quad
+                vec2<f32>(1.0,  -0.01),
+                vec2<f32>(1.0, -1.0),
+                vec2<f32>(0.01, -1.0),
+                vec2<f32>(1.0,  -0.01),
+                vec2<f32>(0.01, -1.0),
+                vec2<f32>(0.01,  -0.01)
+              );
+          
+            var uv = array<vec2<f32>, 30>(
+                // full screen quad
+                vec2<f32>(1.0, 0.0),
+                vec2<f32>(1.0, 1.0),
+                vec2<f32>(0.0, 1.0),
+                vec2<f32>(1.0, 0.0),
+                vec2<f32>(0.0, 1.0),
+                vec2<f32>(0.0, 0.0),
+
+                // top-left quad (texel 0)
+                vec2<f32>(0.5, 0.0),
+                vec2<f32>(0.5, 0.5),
+                vec2<f32>(0.0, 0.5),
+                vec2<f32>(0.5, 0.0),
+                vec2<f32>(0.0, 0.5),
+                vec2<f32>(0.0, 0.0),
+
+                // top-right quad (texel 1)
+                vec2<f32>(1.0, 0.0),
+                vec2<f32>(1.0, 0.5),
+                vec2<f32>(0.5, 0.5),
+                vec2<f32>(1.0, 0.0),
+                vec2<f32>(0.5, 0.5),
+                vec2<f32>(0.5, 0.0),
+
+                // bottom-left quad (texel 2)
+                vec2<f32>(0.5, 0.5),
+                vec2<f32>(0.5, 1.0),
+                vec2<f32>(0.0, 1.0),
+                vec2<f32>(0.5, 0.5),
+                vec2<f32>(0.0, 1.0),
+                vec2<f32>(0.0, 0.5),
+
+                // bottom-right quad (texel 3)
+                vec2<f32>(1.0, 0.5),
+                vec2<f32>(1.0, 1.0),
+                vec2<f32>(0.5, 1.0),
+                vec2<f32>(1.0, 0.5),
+                vec2<f32>(0.5, 1.0),
+                vec2<f32>(0.5, 0.5)
+              );
+          
+            var output : VertexOutput;
+            output.Position = vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+            output.fragUV = uv[VertexIndex];
+            return output;
+          }`,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: this.device.createShaderModule({
+          code: `
+          @group(0) @binding(0) var mySampler: sampler;
+          @group(0) @binding(1) var myTexture: texture_2d<f32>;
+          @group(0) @binding(2) var<uniform> fragMask: u32;
+
+          struct FragmentOutput {
+            @builtin(sample_mask) mask : u32,
+            @location(0) color : vec4<f32>,
+          }
+          
+          @fragment
+          fn main(@location(0) @interpolate(perspective, sample) fragUV: vec2<f32>) -> FragmentOutput {
+            return FragmentOutput(fragMask, textureSample(myTexture, mySampler, fragUV));
+          }`,
+        }),
+        entryPoint: 'main',
+        targets: [{ format }],
+      },
+      primitive: { topology: 'triangle-list' },
+      multisample: {
+        count: sampleCount,
+        mask: sampleMask,
+        alphaToCoverageEnabled: false,
+      },
+    });
+
+    const uniformBindGroup = this.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: sampler,
+        },
+        {
+          binding: 1,
+          resource: sampleTexture.createView(),
+        },
+        {
+          binding: 2,
+          resource: {
+            buffer: fragmentMaskUniformBuffer,
+          },
+        },
+      ],
+    });
+
+    const kRenderTargetSize = 1;
+    const renderTargetTexture = this.device.createTexture({
+      format,
+      size: {
+        width: kRenderTargetSize,
+        height: kRenderTargetSize,
+        depthOrArrayLayers: 1,
+      },
+      sampleCount,
+      mipLevelCount: 1,
+      usage:
+        GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    const resolveTargetTexture =
+      sampleCount === 1
+        ? null
+        : this.device.createTexture({
+            format,
+            size: {
+              width: kRenderTargetSize,
+              height: kRenderTargetSize,
+              depthOrArrayLayers: 1,
+            },
+            sampleCount: 1,
+            mipLevelCount: 1,
+            usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+          });
+
+    const renderPassDescriptor: GPURenderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: renderTargetTexture.createView(),
+          resolveTarget: resolveTargetTexture?.createView(),
+
+          clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    };
+    const commandEncoder = this.device.createCommandEncoder();
+    const passEncoder = commandEncoder.beginRenderPass(renderPassDescriptor);
+    passEncoder.setPipeline(pipeline);
+    passEncoder.setBindGroup(0, uniformBindGroup);
+
+    if (rasterizationMask === 15) {
+      // draw full screen quad
+      passEncoder.draw(6);
+    } else {
+      if ((rasterizationMask & 1) !== 0) {
+        // draw top-left quad
+        passEncoder.draw(6, 1, 6);
+      }
+      if ((rasterizationMask & 2) !== 0) {
+        // draw top-right quad
+        passEncoder.draw(6, 1, 12);
+      }
+      if ((rasterizationMask & 4) !== 0) {
+        // draw bottom-left quad
+        passEncoder.draw(6, 1, 18);
+      }
+      if ((rasterizationMask & 8) !== 0) {
+        // draw bottom-right quad
+        passEncoder.draw(6, 1, 24);
+      }
+    }
+    passEncoder.end();
+    this.device.queue.submit([commandEncoder.finish()]);
+
+    const result = sampleCount === 1 ? renderTargetTexture : resolveTargetTexture;
+    assert(result !== null);
+    return result;
+  }
+
+  CheckSingleSampledResult(
+    texture: GPUTexture,
+    rasterizationMask: number,
+    sampleMask: number,
+    fragmentShaderOutputMask: number
+  ) {
+    let expected: typeof kColors[number] = kEmptySample;
+
+    if (
+      // rasterization needs to cover the center of the pixel
+      (rasterizationMask & 15) >= 15 &&
+      // There is only one sample
+      (fragmentShaderOutputMask & sampleMask & 1) !== 0
+    ) {
+      // When full screen quad is drawn, Texel 3 is sampled at the pixel center
+      expected = kColors[3];
+    }
+
+    this.expectSingleColor(texture, format, {
+      size: [1, 1, 1],
+      exp: {
+        R: expected.R / 0xff,
+        G: expected.G / 0xff,
+        B: expected.B / 0xff,
+        A: expected.A / 0xff,
+      },
+    });
+  }
+
+  CheckMultiSampledResult(
+    texture: GPUTexture,
+    sampleCount: number,
+    rasterizationMask: number,
+    sampleMask: number,
+    fragmentShaderOutputMask: number
+  ) {
+    const expected = {
+      R: 0,
+      G: 0,
+      B: 0,
+      A: 0,
+    };
+    range(4, (id: number) => {
+      const m = rasterizationMask & sampleMask & fragmentShaderOutputMask & (1 << id);
+      // WebGPU only support up to 4 samples, so samples after the first 4 should be ignored.
+      const s = (m & 0xf) === 0 ? kEmptySample : kColors[id % 4];
+      expected.R += s.R;
+      expected.G += s.G;
+      expected.B += s.B;
+      expected.A += s.A;
+    });
+
+    this.expectSinglePixelBetweenTwoValuesIn2DTexture(
+      texture,
+      format,
+      { x: 0, y: 0 },
+      {
+        exp: [
+          new Uint8Array([
+            Math.floor(expected.R / sampleCount),
+            Math.floor(expected.G / sampleCount),
+            Math.floor(expected.B / sampleCount),
+            Math.floor(expected.A / sampleCount),
+          ]),
+          new Uint8Array([
+            Math.ceil(expected.R / sampleCount),
+            Math.ceil(expected.G / sampleCount),
+            Math.ceil(expected.B / sampleCount),
+            Math.ceil(expected.A / sampleCount),
+          ]),
+        ],
+      }
+    );
+  }
+}
+
+export const g = makeTestGroup(F);
+
+g.test('final_output')
+  .desc(
+    `
+Tests that the final sample mask is the logical AND of all the relevant masks -- meaning that the samples
+not included in the final mask are discarded on any attachments including
+- color outputs
+TODO:
+- depth tests
+- stencil operations
+
+The test draws 0/1/1+ textured quads of which each sample in the standard 4-sample pattern results in a different color:
+- Sample 0, Texel 0, top-left: Red
+- Sample 1, Texel 1, top-left: Green
+- Sample 2, Texel 2, top-left: Blue
+- Sample 3, Texel 3, top-left: Yellow
+
+The test checks which sample is passed by looking at the final color of the 1x1 resolve target texture, to see if that matches
+what is expected given by the rasterization mask, sample mask, and fragment shader output mask.
+
+- for sampleCount = { 1, 4 } and various combinations of:
+    - rasterization mask = { 0, 1, 2, 3, 4, 5, 15 }
+    - sample mask = { 0, 1, 2, 3, 15, 30 }
+    - fragment shader output mask (SV_Coverage) = { 0, 1, 2, 3, 15, 30 }
+- [choosing 30 = 2 + 4 + 8 + 16 because the 5th bit should be ignored]
+`
+  )
+  .params(u =>
+    u
+      .combine('sampleCount', [1, 4] as const)
+      .beginSubcases()
+      .combine('rasterizationMask', [0, 1, 2, 3, 4, 5, 8, 15] as const)
+      .combine('sampleMask', [0, 1, 2, 3, 15, 30] as const)
+      .combine('fragmentShaderOutputMask', [0, 1, 2, 3, 15, 30] as const)
+  )
+  .fn(async t => {
+    const { sampleCount, rasterizationMask, sampleMask, fragmentShaderOutputMask } = t.params;
+
+    const texture = await t.GetResolvedTargetTexture(
+      sampleCount,
+      rasterizationMask,
+      sampleMask,
+      fragmentShaderOutputMask
+    );
+
+    if (sampleCount === 1) {
+      t.CheckSingleSampledResult(texture, rasterizationMask, sampleMask, fragmentShaderOutputMask);
+    } else {
+      assert(sampleCount === 4);
+      t.CheckMultiSampledResult(
+        texture,
+        sampleCount,
+        rasterizationMask,
+        sampleMask,
+        fragmentShaderOutputMask
+      );
+    }
+  });


### PR DESCRIPTION

Issue: #2146


Tests that the final sample mask is the logical AND of all the relevant masks

Test by drawing a fullscreen quad (for rasterization mask = 0xf) or small sub quads (one color quad) like this on a 1x1 render target texture.
![image](https://user-images.githubusercontent.com/5031596/211694115-8af3d2b6-1f3a-4090-b32e-407826ffec79.png)
(white dot roughly shows the standard sample point pattern)




Look at the color in the render target texture (sampleCount = 1) or resolve target texture (sampleCount = 4) to determine if it matches with the final sample masks output.

Passing on Windows Nvidia and Mac Intel.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
