### PR TITLE
Add subrect copy tests for copyToTexture

### DIFF
--- a/src/webgpu/util/copy_to_texture.ts
+++ b/src/webgpu/util/copy_to_texture.ts
@@ -1,10 +1,59 @@
 import { assert, memcpy } from '../../common/util/util.js';
 import { RegularTextureFormat } from '../capability_info.js';
 import { GPUTest } from '../gpu_test.js';
+import { reifyExtent3D, reifyOrigin3D } from '../util/unions.js';
 
 import { makeInPlaceColorConversion } from './color_space_conversion.js';
 import { TexelView } from './texture/texel_view.js';
 import { TexelCompareOptions, textureContentIsOKByT2B } from './texture/texture_ok.js';
+
+/**
+ * Predefined copy sub rect meta infos.
+ */
+export const kCopySubrectInfo = [
+  {
+    srcOrigin: { x: 2, y: 2 },
+    dstOrigin: { x: 0, y: 0, z: 0 },
+    srcSize: { width: 16, height: 16 },
+    dstSize: { width: 4, height: 4 },
+    copyExtent: { width: 4, height: 4, depthOrArrayLayers: 1 },
+  },
+  {
+    srcOrigin: { x: 10, y: 2 },
+    dstOrigin: { x: 0, y: 0, z: 0 },
+    srcSize: { width: 16, height: 16 },
+    dstSize: { width: 4, height: 4 },
+    copyExtent: { width: 4, height: 4, depthOrArrayLayers: 1 },
+  },
+  {
+    srcOrigin: { x: 2, y: 10 },
+    dstOrigin: { x: 0, y: 0, z: 0 },
+    srcSize: { width: 16, height: 16 },
+    dstSize: { width: 4, height: 4 },
+    copyExtent: { width: 4, height: 4, depthOrArrayLayers: 1 },
+  },
+  {
+    srcOrigin: { x: 10, y: 10 },
+    dstOrigin: { x: 0, y: 0, z: 0 },
+    srcSize: { width: 16, height: 16 },
+    dstSize: { width: 4, height: 4 },
+    copyExtent: { width: 4, height: 4, depthOrArrayLayers: 1 },
+  },
+  {
+    srcOrigin: { x: 2, y: 2 },
+    dstOrigin: { x: 2, y: 2, z: 0 },
+    srcSize: { width: 16, height: 16 },
+    dstSize: { width: 16, height: 16 },
+    copyExtent: { width: 4, height: 4, depthOrArrayLayers: 1 },
+  },
+  {
+    srcOrigin: { x: 10, y: 2 },
+    dstOrigin: { x: 2, y: 2, z: 0 },
+    srcSize: { width: 16, height: 16 },
+    dstSize: { width: 16, height: 16 },
+    copyExtent: { width: 4, height: 4, depthOrArrayLayers: 1 },
+  },
+] as const;
 
 export class CopyToTextureUtils extends GPUTest {
   doFlipY(
@@ -32,34 +81,82 @@ export class CopyToTextureUtils extends GPUTest {
     return dstPixels;
   }
 
-  getExpectedPixels(
-    sourcePixels: Uint8ClampedArray,
-    width: number,
-    height: number,
-    format: RegularTextureFormat,
-    isFlipY: boolean,
+  getExpectedDstPixelsFromSrcPixels({
+    srcPixels,
+    srcOrigin,
+    srcSize,
+    dstOrigin,
+    dstSize,
+    subRectSize,
+    format,
+    flipSrcBeforeCopy,
+    srcDoFlipYDuringCopy,
+    conversion,
+  }: {
+    srcPixels: Uint8ClampedArray;
+    srcOrigin: GPUOrigin2D;
+    srcSize: GPUExtent3D;
+    dstOrigin: GPUOrigin3D;
+    dstSize: GPUExtent3D;
+    subRectSize: GPUExtent3D;
+    format: RegularTextureFormat;
+    flipSrcBeforeCopy: boolean;
+    srcDoFlipYDuringCopy: boolean;
     conversion: {
       srcPremultiplied: boolean;
       dstPremultiplied: boolean;
       srcColorSpace?: PredefinedColorSpace;
       dstColorSpace?: PredefinedColorSpace;
-    }
-  ): TexelView {
+    };
+  }): TexelView {
     const applyConversion = makeInPlaceColorConversion(conversion);
+
+    const reifySrcOrigin = reifyOrigin3D(srcOrigin);
+    const reifySrcSize = reifyExtent3D(srcSize);
+    const reifyDstOrigin = reifyOrigin3D(dstOrigin);
+    const reifyDstSize = reifyExtent3D(dstSize);
+    const reifySubRectSize = reifyExtent3D(subRectSize);
 
     const divide = 255.0;
     return TexelView.fromTexelsAsColors(
       format,
       coords => {
-        assert(coords.x < width && coords.y < height && coords.z === 0, 'out of bounds');
-        const y = isFlipY ? height - coords.y - 1 : coords.y;
-        const pixelPos = y * width + coords.x;
+        assert(
+          reifyDstOrigin.x + reifySubRectSize.width <= reifyDstSize.width &&
+            reifyDstOrigin.y + reifySubRectSize.height <= reifyDstSize.height,
+          'subrect is out of bounds'
+        );
+        assert(
+          coords.x >= reifyDstOrigin.x &&
+            coords.y >= reifyDstOrigin.y &&
+            coords.x < reifyDstOrigin.x + reifySubRectSize.width &&
+            coords.y < reifyDstOrigin.y + reifySubRectSize.height &&
+            coords.z === 0,
+          'out of bounds'
+        );
+        // Map dst coords to get candidate src pixel position in y.
+        let src_y = coords.y - reifyDstOrigin.y + reifySrcOrigin.y;
+
+        // If srcDoFlipYDuringCopy is true, a flipY op has been applied to src during copy.
+        // WebGPU spec requires origin option relative to the top-left corner of the source image, increasing downward consistently.
+        // https://www.w3.org/TR/webgpu/#dom-gpuimagecopyexternalimage-flipy
+        // Flip only happens in copy rect contents and src origin always top-left.
+        // Get candidate src pixel position in y by mirroring in copy sub rect.
+        if (srcDoFlipYDuringCopy)
+          src_y = reifySubRectSize.height - (src_y - reifySrcOrigin.y) - 1 + reifySrcOrigin.y;
+
+        // Test might generate flipped source based on srcPixels, e.g. Create ImageBitmap based on srcPixels but set orientation to 'flipY'
+        // Get candidate src pixel position in y by mirroring in source.
+        if (flipSrcBeforeCopy) src_y = reifySrcSize.height - src_y - 1;
+
+        const pixelPos =
+          src_y * reifySrcSize.width + (coords.x - reifyDstOrigin.x) + reifySrcOrigin.x;
 
         const rgba = {
-          R: sourcePixels[pixelPos * 4] / divide,
-          G: sourcePixels[pixelPos * 4 + 1] / divide,
-          B: sourcePixels[pixelPos * 4 + 2] / divide,
-          A: sourcePixels[pixelPos * 4 + 3] / divide,
+          R: srcPixels[pixelPos * 4] / divide,
+          G: srcPixels[pixelPos * 4 + 1] / divide,
+          B: srcPixels[pixelPos * 4 + 2] / divide,
+          A: srcPixels[pixelPos * 4 + 3] / divide,
         };
         applyConversion(rgba);
         return rgba;
@@ -83,7 +180,7 @@ export class CopyToTextureUtils extends GPUTest {
 
     const resultPromise = textureContentIsOKByT2B(
       this,
-      { texture: dstTextureCopyView.texture },
+      { texture: dstTextureCopyView.texture, origin: dstTextureCopyView.origin },
       copySize,
       { expTexelView },
       texelCompareOptions

--- a/src/webgpu/util/texture/texel_view.ts
+++ b/src/webgpu/util/texture/texel_view.ts
@@ -73,9 +73,9 @@ export class TexelView {
         coords.x >= origin.x &&
           coords.y >= origin.y &&
           coords.z >= origin.z &&
-          coords.x < size.width &&
-          coords.y < size.height &&
-          coords.z < size.depthOrArrayLayers,
+          coords.x < origin.x + size.width &&
+          coords.y < origin.y + size.height &&
+          coords.z < origin.z + size.depthOrArrayLayers,
         'coordinate out of bounds'
       );
 

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -16,7 +16,7 @@ import {
   kValidTextureFormatsForCopyE2T,
   EncodableTextureFormat,
 } from '../../capability_info.js';
-import { CopyToTextureUtils } from '../../util/copy_to_texture.js';
+import { CopyToTextureUtils, kCopySubrectInfo } from '../../util/copy_to_texture.js';
 import { PerTexelComponent } from '../../util/texture/texel_data.js';
 import { TexelView } from '../../util/texture/texel_view.js';
 
@@ -94,13 +94,10 @@ g.test('from_ImageData')
   is flipped.
 
   The tests covers:
-  - Valid canvas type
-  - Source WebGPU Canvas lives in the same GPUDevice or different GPUDevice as test
   - Valid dstColorFormat of copyExternalImageToTexture()
   - Valid source image alphaMode
   - Valid dest alphaMode
   - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
-  - TODO(#913): color space tests need to be added
 
   And the expected results are all passed.
   `
@@ -159,14 +156,21 @@ g.test('from_ImageData')
     });
 
     const expFormat = kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat;
-    const expectFlipped = srcDoFlipYDuringCopy !== (orientation === 'flipY');
-    const texelViewExpected = makeTestColorsTexelView({
-      testColors,
+    const flipSrcBeforeCopy = orientation === 'flipY';
+    const texelViewExpected = t.getExpectedDstPixelsFromSrcPixels({
+      srcPixels: imageData.data,
+      srcOrigin: [0, 0],
+      srcSize: [width, height],
+      dstOrigin: [0, 0],
+      dstSize: [width, height],
+      subRectSize: [width, height],
       format: expFormat,
-      width,
-      height,
-      flipY: expectFlipped,
-      premultiplied: dstPremultiplied,
+      flipSrcBeforeCopy,
+      srcDoFlipYDuringCopy,
+      conversion: {
+        srcPremultiplied: false,
+        dstPremultiplied,
+      },
     });
 
     t.doTestAndCheckResult(
@@ -204,13 +208,11 @@ g.test('from_canvas')
   is flipped.
 
   The tests covers:
-  - Valid canvas type
-  - Source WebGPU Canvas lives in the same GPUDevice or different GPUDevice as test
+  - Valid 2D canvas
   - Valid dstColorFormat of copyExternalImageToTexture()
   - Valid source image alphaMode
   - Valid dest alphaMode
   - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
-  - TODO(#913): color space tests need to be added
 
   And the expected results are all passed.
   `
@@ -295,14 +297,21 @@ g.test('from_canvas')
     });
 
     const expFormat = kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat;
-    const expectFlipped = srcDoFlipYDuringCopy !== (orientation === 'flipY');
-    const texelViewExpected = makeTestColorsTexelView({
-      testColors: kTestColorsOpaque,
+    const flipSrcBeforeCopy = orientation === 'flipY';
+    const texelViewExpected = t.getExpectedDstPixelsFromSrcPixels({
+      srcPixels: imageData.data,
+      srcOrigin: [0, 0],
+      srcSize: [width, height],
+      dstOrigin: [0, 0],
+      dstSize: [width, height],
+      subRectSize: [width, height],
       format: expFormat,
-      width,
-      height,
-      flipY: expectFlipped,
-      premultiplied: dstPremultiplied,
+      flipSrcBeforeCopy,
+      srcDoFlipYDuringCopy,
+      conversion: {
+        srcPremultiplied: false,
+        dstPremultiplied,
+      },
     });
 
     t.doTestAndCheckResult(
@@ -315,6 +324,255 @@ g.test('from_canvas')
       },
       texelViewExpected,
       { width, height, depthOrArrayLayers: 1 },
+      // 1.0 and 0.6 are representable precisely by all formats except rgb10a2unorm, but
+      // allow diffs of 1ULP since that's the generally-appropriate threshold.
+      { maxDiffULPsForFloatFormat: 1, maxDiffULPsForNormFormat: 1 }
+    );
+  });
+
+g.test('copy_subrect_from_ImageData')
+  .desc(
+    `
+  Test ImageBitmap generated from ImageData can be copied to WebGPU
+  texture correctly. These imageBitmaps are highly possible living in CPU back resource.
+
+  It generates pixels in ImageData one by one based on a color list:
+  [Red, Green, Blue, Black, White].
+
+  Then call copyExternalImageToTexture() to do a subrect copy, based on a predefined copy
+  rect info list, to the 0 mipLevel of dst texture, and read the contents out to compare
+  with the ImageBitmap contents.
+
+  Do premultiply alpha during copy if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
+  is set to 'true' and do unpremultiply alpha if it is set to 'false'.
+
+  If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
+  is flipped, and origin is top-left consistantly.
+
+  The tests covers:
+  - Source WebGPU Canvas lives in the same GPUDevice or different GPUDevice as test
+  - Valid dstColorFormat of copyExternalImageToTexture()
+  - Valid source image alphaMode
+  - Valid dest alphaMode
+  - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
+  - Valid subrect copies.
+
+  And the expected results are all passed.
+  `
+  )
+  .params(u =>
+    u
+      .combine('alpha', ['none', 'premultiply'] as const)
+      .combine('orientation', ['none', 'flipY'] as const)
+      .combine('srcDoFlipYDuringCopy', [true, false])
+      .combine('dstPremultiplied', [true, false])
+      .beginSubcases()
+      .combine('copySubRectInfo', kCopySubrectInfo)
+  )
+  .fn(async t => {
+    const {
+      copySubRectInfo,
+      alpha,
+      orientation,
+      dstPremultiplied,
+      srcDoFlipYDuringCopy,
+    } = t.params;
+
+    const testColors = kTestColorsAll;
+    const { srcOrigin, dstOrigin, srcSize, dstSize, copyExtent } = copySubRectInfo;
+    const kColorFormat = 'rgba8unorm';
+
+    // Generate correct expected values
+    const texelViewSource = makeTestColorsTexelView({
+      testColors,
+      format: kColorFormat, // ImageData is always in rgba8unorm format.
+      width: srcSize.width,
+      height: srcSize.height,
+      flipY: false,
+      premultiplied: false,
+    });
+    const imageData = new ImageData(srcSize.width, srcSize.height);
+    texelViewSource.writeTextureData(imageData.data, {
+      bytesPerRow: srcSize.width * 4,
+      rowsPerImage: srcSize.height,
+      subrectOrigin: [0, 0],
+      subrectSize: srcSize,
+    });
+
+    const imageBitmap = await createImageBitmap(imageData, {
+      premultiplyAlpha: alpha,
+      imageOrientation: orientation,
+    });
+
+    const dst = t.device.createTexture({
+      size: dstSize,
+      format: kColorFormat,
+      usage:
+        GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const flipSrcBeforeCopy = orientation === 'flipY';
+    const texelViewExpected = t.getExpectedDstPixelsFromSrcPixels({
+      srcPixels: imageData.data,
+      srcOrigin,
+      srcSize,
+      dstOrigin,
+      dstSize,
+      subRectSize: copyExtent,
+      format: kColorFormat,
+      flipSrcBeforeCopy,
+      srcDoFlipYDuringCopy,
+      conversion: {
+        srcPremultiplied: false,
+        dstPremultiplied,
+      },
+    });
+
+    t.doTestAndCheckResult(
+      { source: imageBitmap, origin: srcOrigin, flipY: srcDoFlipYDuringCopy },
+      {
+        texture: dst,
+        origin: dstOrigin,
+        colorSpace: 'srgb',
+        premultipliedAlpha: dstPremultiplied,
+      },
+      texelViewExpected,
+      copyExtent,
+      // 1.0 and 0.6 are representable precisely by all formats except rgb10a2unorm, but
+      // allow diffs of 1ULP since that's the generally-appropriate threshold.
+      { maxDiffULPsForFloatFormat: 1, maxDiffULPsForNormFormat: 1 }
+    );
+  });
+
+g.test('copy_subrect_from_2D_Canvas')
+  .desc(
+    `
+  Test ImageBitmap generated from canvas/offscreenCanvas can be copied to WebGPU
+  texture correctly. These imageBitmaps are highly possible living in GPU back resource.
+
+  It generates pixels in ImageData one by one based on a color list:
+  [Red, Green, Blue, Black, White].
+
+  Then call copyExternalImageToTexture() to do a subrect copy, based on a predefined copy
+  rect info list, to the 0 mipLevel of dst texture, and read the contents out to compare
+  with the ImageBitmap contents.
+
+  Do premultiply alpha during copy if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
+  is set to 'true' and do unpremultiply alpha if it is set to 'false'.
+
+  If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
+  is flipped, and origin is top-left consistantly.
+
+  The tests covers:
+  - Source WebGPU Canvas lives in the same GPUDevice or different GPUDevice as test
+  - Valid dstColorFormat of copyExternalImageToTexture()
+  - Valid source image alphaMode
+  - Valid dest alphaMode
+  - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
+  - Valid subrect copies.
+
+  And the expected results are all passed.
+  `
+  )
+  .params(u =>
+    u
+      .combine('orientation', ['none', 'flipY'] as const)
+      .combine('srcDoFlipYDuringCopy', [true, false])
+      .combine('dstPremultiplied', [true, false])
+      .beginSubcases()
+      .combine('copySubRectInfo', kCopySubrectInfo)
+  )
+  .fn(async t => {
+    const { copySubRectInfo, orientation, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
+
+    const { srcOrigin, dstOrigin, srcSize, dstSize, copyExtent } = copySubRectInfo;
+    const kColorFormat = 'rgba8unorm';
+
+    // CTS sometimes runs on worker threads, where document is not available.
+    // In this case, OffscreenCanvas can be used instead of <canvas>.
+    // But some browsers don't support OffscreenCanvas, and some don't
+    // support '2d' contexts on OffscreenCanvas.
+    // In this situation, the case will be skipped.
+    let imageCanvas;
+    if (typeof document !== 'undefined') {
+      imageCanvas = document.createElement('canvas');
+      imageCanvas.width = srcSize.width;
+      imageCanvas.height = srcSize.height;
+    } else if (typeof OffscreenCanvas === 'undefined') {
+      t.skip('OffscreenCanvas is not supported');
+      return;
+    } else {
+      imageCanvas = new OffscreenCanvas(srcSize.width, srcSize.height);
+    }
+    const imageCanvasContext = imageCanvas.getContext('2d');
+    if (imageCanvasContext === null) {
+      t.skip('OffscreenCanvas "2d" context not available');
+      return;
+    }
+
+    // Generate non-transparent pixel data to avoid canvas
+    // different opt behaviour on putImageData()
+    // from browsers.
+    const texelViewSource = makeTestColorsTexelView({
+      testColors: kTestColorsOpaque,
+      format: 'rgba8unorm', // ImageData is always in rgba8unorm format.
+      width: srcSize.width,
+      height: srcSize.height,
+      flipY: false,
+      premultiplied: false,
+    });
+    // Generate correct expected values
+    const imageData = new ImageData(srcSize.width, srcSize.height);
+    texelViewSource.writeTextureData(imageData.data, {
+      bytesPerRow: srcSize.width * 4,
+      rowsPerImage: srcSize.height,
+      subrectOrigin: [0, 0],
+      subrectSize: srcSize,
+    });
+
+    // Use putImageData to prevent color space conversion.
+    imageCanvasContext.putImageData(imageData, 0, 0);
+
+    // MAINTENANCE_TODO: Workaround for @types/offscreencanvas missing an overload of
+    // `createImageBitmap` that takes `ImageBitmapOptions`.
+    const imageBitmap = await createImageBitmap(imageCanvas as HTMLCanvasElement, {
+      premultiplyAlpha: 'premultiply',
+      imageOrientation: orientation,
+    });
+
+    const dst = t.device.createTexture({
+      size: dstSize,
+      format: kColorFormat,
+      usage:
+        GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const texelViewExpected = t.getExpectedDstPixelsFromSrcPixels({
+      srcPixels: imageData.data,
+      srcOrigin,
+      srcSize,
+      dstOrigin,
+      dstSize,
+      subRectSize: copyExtent,
+      format: kColorFormat,
+      flipSrcBeforeCopy: false,
+      srcDoFlipYDuringCopy,
+      conversion: {
+        srcPremultiplied: false,
+        dstPremultiplied,
+      },
+    });
+
+    t.doTestAndCheckResult(
+      { source: imageBitmap, origin: srcOrigin, flipY: srcDoFlipYDuringCopy },
+      {
+        texture: dst,
+        origin: dstOrigin,
+        colorSpace: 'srgb',
+        premultipliedAlpha: dstPremultiplied,
+      },
+      texelViewExpected,
+      copyExtent,
       // 1.0 and 0.6 are representable precisely by all formats except rgb10a2unorm, but
       // allow diffs of 1ULP since that's the generally-appropriate threshold.
       { maxDiffULPsForFloatFormat: 1, maxDiffULPsForNormFormat: 1 }

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -547,6 +547,7 @@ g.test('copy_subrect_from_2D_Canvas')
         GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
+    const flipSrcBeforeCopy = orientation === 'flipY';
     const texelViewExpected = t.getExpectedDstPixelsFromSrcPixels({
       srcPixels: imageData.data,
       srcOrigin,
@@ -555,7 +556,7 @@ g.test('copy_subrect_from_2D_Canvas')
       dstSize,
       subRectSize: copyExtent,
       format: kColorFormat,
-      flipSrcBeforeCopy: false,
+      flipSrcBeforeCopy,
       srcDoFlipYDuringCopy,
       conversion: {
         srcPremultiplied: false,

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -419,17 +419,21 @@ class F extends CopyToTextureUtils {
 
     // For 2d canvas, get expected pixels with getImageData(), which returns unpremultiplied
     // values.
-    const expectedDestinationImage = this.getExpectedPixels(
-      expectedSourceImage,
-      p.width,
-      p.height,
-      expFormat,
-      p.srcDoFlipYDuringCopy,
-      {
+    const expectedDestinationImage = this.getExpectedDstPixelsFromSrcPixels({
+      srcPixels: expectedSourceImage,
+      srcOrigin: [0, 0],
+      srcSize: [p.width, p.height],
+      dstOrigin: [0, 0],
+      dstSize: [p.width, p.height],
+      subRectSize: [p.width, p.height],
+      format: expFormat,
+      flipSrcBeforeCopy: false,
+      srcDoFlipYDuringCopy: p.srcDoFlipYDuringCopy,
+      conversion: {
         srcPremultiplied: p.srcPremultiplied,
         dstPremultiplied: p.dstPremultiplied,
-      }
-    );
+      },
+    });
 
     this.doTestAndCheckResult(
       { source, origin: { x: 0, y: 0 }, flipY: p.srcDoFlipYDuringCopy },
@@ -715,20 +719,24 @@ g.test('color_space_conversion')
         GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
-    const expectedDestinationImage = t.getExpectedPixels(
-      expectedSourceData,
-      width,
-      height,
+    const expectedDestinationImage = t.getExpectedDstPixelsFromSrcPixels({
+      srcPixels: expectedSourceData,
+      srcOrigin: [0, 0],
+      srcSize: [width, height],
+      dstOrigin: [0, 0],
+      dstSize: [width, height],
+      subRectSize: [width, height],
       // copyExternalImageToTexture does not perform gamma-encoding into `-srgb` formats.
-      kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat,
+      format: kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat,
+      flipSrcBeforeCopy: false,
       srcDoFlipYDuringCopy,
-      {
+      conversion: {
         srcPremultiplied: false,
         dstPremultiplied,
         srcColorSpace,
         dstColorSpace,
-      }
-    );
+      },
+    });
 
     const texelCompareOptions: TexelCompareOptions = {
       maxFractionalDiff: 0,


### PR DESCRIPTION
This PR added subrect copy tests for copyToTexture to cover subrect copies of copyEI2T.

The PR also fixed possible flipY issues in previous cts.

Issue: #2079




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
