### PR TITLE
Maximize the acceptance interval size for `dot`

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -3012,31 +3012,39 @@ g.test('dotInterval')
     // prettier-ignore
     [
       // vec2
-      {input: [[1.0, 0.0], [1.0, 0.0]], expected: [1.0] },
-      {input: [[0.0, 1.0], [0.0, 1.0]], expected: [1.0] },
-      {input: [[1.0, 1.0], [1.0, 1.0]], expected: [2.0] },
-      {input: [[-1.0, -1.0], [-1.0, -1.0]], expected: [2.0] },
-      {input: [[-1.0, 1.0], [1.0, -1.0]], expected: [-2.0] },
-      {input: [[0.1, 0.0], [1.0, 0.0]], expected: [hexToF64(0x3fb99999, 0x80000000), hexToF64(0x3fb99999, 0xa0000000)]},  // ~0.1
+      { input: [[1.0, 0.0], [1.0, 0.0]], expected: [1.0] },
+      { input: [[0.0, 1.0], [0.0, 1.0]], expected: [1.0] },
+      { input: [[1.0, 1.0], [1.0, 1.0]], expected: [2.0] },
+      { input: [[-1.0, -1.0], [-1.0, -1.0]], expected: [2.0] },
+      { input: [[-1.0, 1.0], [1.0, -1.0]], expected: [-2.0] },
+      { input: [[0.1, 0.0], [1.0, 0.0]], expected: [hexToF64(0x3fb99999, 0x80000000), hexToF64(0x3fb99999, 0xa0000000)]},  // ~0.1
 
       // vec3
-      {input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [1.0] },
-      {input: [[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]], expected: [1.0] },
-      {input: [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]], expected: [1.0] },
-      {input: [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], expected: [3.0] },
-      {input: [[-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]], expected: [3.0] },
-      {input: [[1.0, -1.0, -1.0], [-1.0, 1.0, -1.0]], expected: [-1.0] },
-      {input: [[0.1, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [hexToF64(0x3fb99999, 0x80000000), hexToF64(0x3fb99999, 0xa0000000)]},  // ~0.1
+      { input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [1.0] },
+      { input: [[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]], expected: [1.0] },
+      { input: [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]], expected: [1.0] },
+      { input: [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]], expected: [3.0] },
+      { input: [[-1.0, -1.0, -1.0], [-1.0, -1.0, -1.0]], expected: [3.0] },
+      { input: [[1.0, -1.0, -1.0], [-1.0, 1.0, -1.0]], expected: [-1.0] },
+      { input: [[0.1, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [hexToF64(0x3fb99999, 0x80000000), hexToF64(0x3fb99999, 0xa0000000)]},  // ~0.1
 
       // vec4
-      {input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [1.0] },
-      {input: [[0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], expected: [1.0] },
-      {input: [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0]], expected: [1.0] },
-      {input: [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]], expected: [1.0] },
-      {input: [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]], expected: [4.0] },
-      {input: [[-1.0, -1.0, -1.0, -1.0], [-1.0, -1.0, -1.0, -1.0]], expected: [4.0] },
-      {input: [[-1.0, 1.0, -1.0, 1.0], [1.0, -1.0, 1.0, -1.0]], expected: [-4.0] },
-      {input: [[0.1, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb99999, 0x80000000), hexToF64(0x3fb99999, 0xa0000000)]},  // ~0.1
+      { input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [1.0] },
+      { input: [[0.0, 1.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], expected: [1.0] },
+      { input: [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0]], expected: [1.0] },
+      { input: [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]], expected: [1.0] },
+      { input: [[1.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]], expected: [4.0] },
+      { input: [[-1.0, -1.0, -1.0, -1.0], [-1.0, -1.0, -1.0, -1.0]], expected: [4.0] },
+      { input: [[-1.0, 1.0, -1.0, 1.0], [1.0, -1.0, 1.0, -1.0]], expected: [-4.0] },
+      { input: [[0.1, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb99999, 0x80000000), hexToF64(0x3fb99999, 0xa0000000)]},  // ~0.1
+
+      // Test that going out of bounds in the intermediate calculations is caught correctly.
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kAny },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kAny },
+      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kAny },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kAny },
+      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kAny },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kAny },
     ]
   )
   .fn(t => {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1350,13 +1350,38 @@ export function divisionInterval(x: number | F32Interval, y: number | F32Interva
 
 const DotIntervalOp: VectorPairToIntervalOp = {
   impl: (x: number[], y: number[]): F32Interval => {
+    assert(x.length === y.length, 'params to DotIntervalOp.impl need to be of the same length');
+    const positives: F32Interval[] = [];
+    const negatives: F32Interval[] = [];
+
     // dot(x, y) = sum of x[i] * y[i]
-    const multiplications = runBinaryToIntervalOpComponentWise(
-      toF32Vector(x),
-      toF32Vector(y),
-      MultiplicationIntervalOp
-    );
-    return multiplications.reduce((previous, current) => additionInterval(previous, current));
+    // Bucketing the multiplications in to positives & negatives, since though the result of summing them is not
+    // dependent on order, the error in the result interval is.
+    // The ordering with the maximum widest acceptance interval will be the one causing the largest magnitude
+    // intermediate result of the additions, which will either be from adding all of the positive terms together or all
+    // of the negative terms.
+    x.forEach((_, i) => {
+      if (x[i] * y[i] < 0) {
+        negatives.push(multiplicationInterval(x[i], y[i]));
+      } else {
+        positives.push(multiplicationInterval(x[i], y[i]));
+      }
+    });
+
+    if (positives.length !== 0 && negatives.length !== 0) {
+      return additionInterval(
+        positives.reduce((prev, cur) => additionInterval(prev, cur)),
+        negatives.reduce((prev, cur) => additionInterval(prev, cur))
+      );
+    } else {
+      if (positives.length !== 0) {
+        return positives.reduce((prev, cur) => additionInterval(prev, cur));
+      }
+      if (negatives.length !== 0) {
+        return negatives.reduce((prev, cur) => additionInterval(prev, cur));
+      }
+      unreachable(`Both 'positives' and 'negatives' buckets are empty in DotIntervalOp.impl`);
+    }
   },
 };
 


### PR DESCRIPTION
`dot` currently calculates the interval size by summing the multipltications in element order, but the spec does not require a specific operation ordering. The error in the calculation is dependent on the specific ordering.

The new implementation sums all of the negative and positive terms together seperately from each other, since the largest intermediate value, thus error, will occur from one of these two intermediate results. This avoids needing to calculate all of the permutations of the addition ordering to discover the largest acceptance interval.

Issue #2134

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
