### PR TITLE
Make objectEquals(NaN, NaN) return true

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -167,9 +167,15 @@ export function sortObjectByKey(v: { [k: string]: unknown }): { [k: string]: unk
 
 /**
  * Determines whether two JS values are equal, recursing into objects and arrays.
+ * NaN is treated specially, such that `objectEquals(NaN, NaN)`.
  */
 export function objectEquals(x: unknown, y: unknown): boolean {
-  if (typeof x !== 'object' || typeof y !== 'object') return x === y;
+  if (typeof x !== 'object' || typeof y !== 'object') {
+    if (typeof x === 'number' && typeof y === 'number' && Number.isNaN(x) && Number.isNaN(y)) {
+      return true;
+    }
+    return x === y;
+  }
   if (x === null || y === null) return x === y;
   if (x.constructor !== y.constructor) return false;
   if (x instanceof Function) return x === y;


### PR DESCRIPTION
This makes urls like the following work, instead of throwing "Error: Query ... does not match any cases".
https://gpuweb.github.io/cts/standalone/?q=webgpu:api,validation,compute_pipeline:overrides,value,type_error:isAsync=true;constants={%22cf%22:%22_nan_%22}

Hopefully this doesn't have any unintended fallout. I don't expect it to, but there are a few tests using it, so we'll watch for that.

Issue: https://crbug.com/1406620

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] ~Tests are properly located in the test tree.~
- [x] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [x] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
