### PR TITLE
Convert `dot` to calculating permutations for vec3 and vec4

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -3045,6 +3045,9 @@ g.test('dotInterval')
       { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kAny },
       { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kAny },
       { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kAny },
+
+      // https://github.com/gpuweb/cts/issues/2155
+      { input: [[kValue.f32.positive.max, 1.0, 2.0, 3.0], [-1.0, kValue.f32.positive.max, -2.0, -3.0]], expected: [-13, 0] },
     ]
   )
   .fn(t => {

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../webgpu/util/conversion.js';
 import {
   biasedRange,
+  calculatePermutations,
   cartesianProduct,
   correctlyRoundedF32,
   FlushMode,
@@ -958,6 +959,62 @@ g.test('cartesianProductArray')
     test.expect(
       objectEquals(got, expect),
       `cartesianProduct(${JSON.stringify(inputs)}) returned ${JSON.stringify(
+        got
+      )}. Expected ${JSON.stringify(expect)} `
+    );
+  });
+
+interface calculatePermutationsCase<T> {
+  input: T[];
+  result: T[][];
+}
+
+g.test('calculatePermutations')
+  .paramsSimple<calculatePermutationsCase<number>>(
+    // prettier-ignore
+    [
+      { input: [0, 1], result: [[0, 1],
+                                [1, 0]] },
+      { input: [0, 1, 2], result: [[0, 1, 2],
+                                   [0, 2, 1],
+                                   [1, 0, 2],
+                                   [1, 2, 0],
+                                   [2, 0, 1],
+                                   [2, 1, 0]] },
+        { input: [0, 1, 2, 3], result: [[0, 1, 2, 3],
+                                        [0, 1, 3, 2],
+                                        [0, 2, 1, 3],
+                                        [0, 2, 3, 1],
+                                        [0, 3, 1, 2],
+                                        [0, 3, 2, 1],
+                                        [1, 0, 2, 3],
+                                        [1, 0, 3, 2],
+                                        [1, 2, 0, 3],
+                                        [1, 2, 3, 0],
+                                        [1, 3, 0, 2],
+                                        [1, 3, 2, 0],
+                                        [2, 0, 1, 3],
+                                        [2, 0, 3, 1],
+                                        [2, 1, 0, 3],
+                                        [2, 1, 3, 0],
+                                        [2, 3, 0, 1],
+                                        [2, 3, 1, 0],
+                                        [3, 0, 1, 2],
+                                        [3, 0, 2, 1],
+                                        [3, 1, 0, 2],
+                                        [3, 1, 2, 0],
+                                        [3, 2, 0, 1],
+                                        [3, 2, 1, 0]] },
+    ]
+  )
+  .fn(test => {
+    const input = test.params.input;
+    const got = calculatePermutations(input);
+    const expect = test.params.result;
+
+    test.expect(
+      objectEquals(got, expect),
+      `calculatePermutations(${JSON.stringify(input)}) returned ${JSON.stringify(
         got
       )}. Expected ${JSON.stringify(expect)} `
     );

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -4,14 +4,13 @@ Execution tests for the 'dot' builtin function
 T is AbstractInt, AbstractFloat, i32, u32, f32, or f16
 @const fn dot(e1: vecN<T>,e2: vecN<T>) -> T
 Returns the dot product of e1 and e2.
-
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { dotInterval } from '../../../../../util/f32_interval.js';
-import { vectorF32Range } from '../../../../../util/math.js';
+import { sparseVectorF32Range, vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, generateVectorPairToF32IntervalCases, run } from '../../expression.js';
 
@@ -19,6 +18,8 @@ import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
+// vec3 and vec4 require calculating all possible permutations, so their runtime is much longer per test, so only using
+// sparse vectors for them
 export const d = makeCaseCache('dot', {
   f32_vec2_const: () => {
     return generateVectorPairToF32IntervalCases(
@@ -38,32 +39,32 @@ export const d = makeCaseCache('dot', {
   },
   f32_vec3_const: () => {
     return generateVectorPairToF32IntervalCases(
-      vectorF32Range(3),
-      vectorF32Range(3),
+      sparseVectorF32Range(3),
+      sparseVectorF32Range(3),
       'f32-only',
       dotInterval
     );
   },
   f32_vec3_non_const: () => {
     return generateVectorPairToF32IntervalCases(
-      vectorF32Range(3),
-      vectorF32Range(3),
+      sparseVectorF32Range(3),
+      sparseVectorF32Range(3),
       'unfiltered',
       dotInterval
     );
   },
   f32_vec4_const: () => {
     return generateVectorPairToF32IntervalCases(
-      vectorF32Range(4),
-      vectorF32Range(4),
+      sparseVectorF32Range(4),
+      sparseVectorF32Range(4),
       'f32-only',
       dotInterval
     );
   },
   f32_vec4_non_const: () => {
     return generateVectorPairToF32IntervalCases(
-      vectorF32Range(4),
-      vectorF32Range(4),
+      sparseVectorF32Range(4),
+      sparseVectorF32Range(4),
       'unfiltered',
       dotInterval
     );

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -4,6 +4,7 @@ import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 import { kValue } from './constants.js';
 import { reinterpretF32AsU32, reinterpretU32AsF32 } from './conversion.js';
 import {
+  calculatePermutations,
   cartesianProduct,
   correctlyRoundedF16,
   correctlyRoundedF32,
@@ -1350,38 +1351,25 @@ export function divisionInterval(x: number | F32Interval, y: number | F32Interva
 
 const DotIntervalOp: VectorPairToIntervalOp = {
   impl: (x: number[], y: number[]): F32Interval => {
-    assert(x.length === y.length, 'params to DotIntervalOp.impl need to be of the same length');
-    const positives: F32Interval[] = [];
-    const negatives: F32Interval[] = [];
-
     // dot(x, y) = sum of x[i] * y[i]
-    // Bucketing the multiplications in to positives & negatives, since though the result of summing them is not
-    // dependent on order, the error in the result interval is.
-    // The ordering with the maximum widest acceptance interval will be the one causing the largest magnitude
-    // intermediate result of the additions, which will either be from adding all of the positive terms together or all
-    // of the negative terms.
-    x.forEach((_, i) => {
-      if (x[i] * y[i] < 0) {
-        negatives.push(multiplicationInterval(x[i], y[i]));
-      } else {
-        positives.push(multiplicationInterval(x[i], y[i]));
-      }
-    });
+    const multiplications = runBinaryToIntervalOpComponentWise(
+      toF32Vector(x),
+      toF32Vector(y),
+      MultiplicationIntervalOp
+    );
 
-    if (positives.length !== 0 && negatives.length !== 0) {
-      return additionInterval(
-        positives.reduce((prev, cur) => additionInterval(prev, cur)),
-        negatives.reduce((prev, cur) => additionInterval(prev, cur))
-      );
-    } else {
-      if (positives.length !== 0) {
-        return positives.reduce((prev, cur) => additionInterval(prev, cur));
-      }
-      if (negatives.length !== 0) {
-        return negatives.reduce((prev, cur) => additionInterval(prev, cur));
-      }
-      unreachable(`Both 'positives' and 'negatives' buckets are empty in DotIntervalOp.impl`);
+    // vec2 doesn't require permutations, since a + b = b + a for floats
+    if (multiplications.length === 2) {
+      return additionInterval(multiplications[0], multiplications[1]);
     }
+
+    // The spec does not state the ordering of summation, so all of the permutations are calculated and their results
+    // spanned, since addition of more then two floats is not transitive, i.e. a + b + c is not guaranteed to equal
+    // b + a + c
+    const permutations: F32Interval[][] = calculatePermutations(multiplications);
+    return F32Interval.span(
+      ...permutations.map(p => p.reduce((prev, cur) => additionInterval(prev, cur)))
+    );
   },
 };
 

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -875,3 +875,35 @@ export function cartesianProduct<T>(...inputs: T[][]): T[][] {
 
   return result;
 }
+
+/** @returns all of the permutations of an array
+ *
+ * Recursively calculates all of the permutations, does not cull duplicate
+ * entries.
+ *
+ * @param input the array to get permutations of
+ */
+export function calculatePermutations<T>(input: T[]): T[][] {
+  if (input.length === 0) {
+    return [];
+  }
+
+  if (input.length === 1) {
+    return [input];
+  }
+
+  if (input.length === 2) {
+    return [input, [input[1], input[0]]];
+  }
+
+  const result: T[][] = [];
+  input.forEach((head, idx) => {
+    const tail = input.slice(0, idx).concat(input.slice(idx + 1));
+    const permutations = calculatePermutations(tail);
+    permutations.forEach(p => {
+      result.push([head, ...p]);
+    });
+  });
+
+  return result;
+}


### PR DESCRIPTION
Fixes #2155

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
