### PR TITLE
Test GPUCanvasContext.configure colorSpace

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_colorspace.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace.html.ts
@@ -1,0 +1,82 @@
+import { kUnitCaseParamsBuilder } from '../../../common/framework/params_builder.js';
+import { Float16Array } from '../../../external/petamoriken/float16/float16.js';
+import { kCanvasAlphaModes, kCanvasColorSpaces } from '../../capability_info.js';
+
+import { runRefTest } from './gpu_ref_test.js';
+
+function bgra8UnormFromRgba8Unorm(rgba8Unorm: Uint8Array) {
+  const bgra8Unorm = rgba8Unorm.slice();
+  for (let i = 0; i < bgra8Unorm.length; i += 4) {
+    [bgra8Unorm[i], bgra8Unorm[i + 2]] = [bgra8Unorm[i + 2], bgra8Unorm[i]];
+  }
+  return bgra8Unorm;
+}
+
+function rgba16floatFromRgba8unorm(rgba8Unorm: Uint8Array) {
+  const rgba16Float = new Float16Array(rgba8Unorm.length);
+  for (let i = 0; i < rgba8Unorm.length; ++i) {
+    rgba16Float[i] = rgba8Unorm[i] / 255;
+  }
+  return rgba16Float;
+}
+
+export function runColorSpaceTest(format: GPUTextureFormat) {
+  runRefTest(async t => {
+    const device = t.device;
+
+    // prettier-ignore
+    const kRGBA8UnormData = new Uint8Array([
+      0, 255, 0, 255,
+      117, 251, 7, 255,
+      170, 35, 209, 255,
+      80, 150, 200, 255,
+    ]);
+    const kBGRA8UnormData = bgra8UnormFromRgba8Unorm(kRGBA8UnormData);
+    const kRGBA16FloatData = rgba16floatFromRgba8unorm(kRGBA8UnormData);
+    const width = kRGBA8UnormData.length / 4;
+
+    const testData: { [id: string]: Uint8Array | Float16Array } = {
+      rgba8unorm: kRGBA8UnormData,
+      bgra8unorm: kBGRA8UnormData,
+      rgba16float: kRGBA16FloatData,
+    };
+
+    function createCanvas(
+      alphaMode: GPUCanvasAlphaMode,
+      format: GPUTextureFormat,
+      colorSpace: PredefinedColorSpace
+    ) {
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = 1;
+      const context = canvas.getContext('webgpu') as GPUCanvasContext;
+      context.configure({
+        device,
+        format,
+        usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+        alphaMode,
+        colorSpace,
+      });
+
+      const textureData = testData[format];
+      const texture = context.getCurrentTexture();
+      device.queue.writeTexture(
+        { texture },
+        textureData.buffer,
+        {
+          bytesPerRow: textureData.byteLength,
+        },
+        { width: 4, height: 1 }
+      );
+      document.body.appendChild(canvas);
+    }
+
+    const u = kUnitCaseParamsBuilder
+      .combine('alphaMode', kCanvasAlphaModes)
+      .combine('colorSpace', kCanvasColorSpaces);
+
+    for (const { alphaMode, colorSpace } of u) {
+      createCanvas(alphaMode, format, colorSpace);
+    }
+  });
+}

--- a/src/webgpu/web_platform/reftests/canvas_colorspace_bgra8unorm.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_bgra8unorm.https.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <title>WebGPU canvas_colorspace_bgra8unorm</title>
+  <meta charset="utf-8" />
+  <style>
+    canvas {
+      width: 128px;
+      height: 128px;
+      margin-right: 5px;
+      image-rendering: pixelated;
+      image-rendering: crisp-edges;
+    }
+  </style>
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta name="assert" content="WebGPU bgra8norm canvas with colorSpace set should be rendered correctly" />
+  <link rel="match" href="./ref/canvas_colorspace-ref.html" />
+  <script type="module">
+    import { runColorSpaceTest } from './canvas_colorspace.html.js';
+    runColorSpaceTest('bgra8unorm');
+  </script>
+  <body></body>
+</html>

--- a/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <title>WebGPU canvas_colorspace_rgba16float</title>
+  <meta charset="utf-8" />
+  <style>
+    canvas {
+      width: 128px;
+      height: 128px;
+      margin-right: 5px;
+      image-rendering: pixelated;
+      image-rendering: crisp-edges;
+    }
+  </style>
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta name="assert" content="WebGPU rgba16float canvas with colorSpace set should be rendered correctly" />
+  <link rel="match" href="./ref/canvas_colorspace-ref.html" />
+  <script type="module">
+    import { runColorSpaceTest } from './canvas_colorspace.html.js';
+    runColorSpaceTest('rgba16float');
+  </script>
+  <body></body>
+</html>

--- a/src/webgpu/web_platform/reftests/canvas_colorspace_rgba8unorm.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_rgba8unorm.https.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+  <title>WebGPU canvas_colorspace_rgba8unorm</title>
+  <meta charset="utf-8" />
+  <style>
+    canvas {
+      width: 128px;
+      height: 128px;
+      margin-right: 5px;
+      image-rendering: pixelated;
+      image-rendering: crisp-edges;
+    }
+  </style>
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <meta name="assert" content="WebGPU rgba8unorm canvas with colorSpace set should be rendered correctly" />
+  <link rel="match" href="./ref/canvas_colorspace-ref.html" />
+  <script type="module">
+    import { runColorSpaceTest } from './canvas_colorspace.html.js';
+    runColorSpaceTest('rgba8unorm');
+  </script>
+  <body></body>
+</html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_colorspace-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_colorspace-ref.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <title>WebGPU canvas_colorspace (ref)</title>
+  <meta charset="utf-8" />
+  <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
+  <style>
+    canvas {
+      width: 128px;
+      height: 128px;
+      margin-right: 5px;
+      image-rendering: pixelated;
+      image-rendering: crisp-edges;
+    }
+  </style>
+  <body></body>
+  <script type="module" src="canvas_colorspace-ref.html.js"></script>
+</html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_colorspace-ref.html.ts
+++ b/src/webgpu/web_platform/reftests/ref/canvas_colorspace-ref.html.ts
@@ -1,0 +1,36 @@
+import { kUnitCaseParamsBuilder } from '../../../../common/framework/params_builder.js';
+import { kCanvasAlphaModes, kCanvasColorSpaces } from '../../../capability_info.js';
+
+// prettier-ignore
+const kRGBAData = new Uint8Array([
+  0, 255, 0, 255,
+  117, 251, 7, 255,
+  170, 35, 209, 255,
+  80, 150, 200, 255,
+]);
+const width = kRGBAData.length / 4;
+
+function createCanvas(colorSpace: PredefinedColorSpace) {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = 1;
+  const context = canvas.getContext('2d', {
+    colorSpace,
+  }) as CanvasRenderingContext2D;
+
+  const imgData = context.getImageData(0, 0, width, 1);
+  imgData.data.set(kRGBAData);
+  context.putImageData(imgData, 0, 0);
+
+  document.body.appendChild(canvas);
+}
+
+const u = kUnitCaseParamsBuilder
+  .combine('alphaMode', kCanvasAlphaModes)
+  .combine('colorSpace', kCanvasColorSpaces);
+
+// Generate reference canvases for all combinations from the test.
+// We only need colorSpace to generate the correct reference.
+for (const { colorSpace } of u) {
+  createCanvas(colorSpace);
+}


### PR DESCRIPTION
Note: Unless I'm not understanding, everything except srgb->srgb is broken, even display-p3->display-p3

Here's something that shows results doing the same with canvas 2d
https://jsgist.org/?src=5b8a3a2e438b1850c02c77f19b25ffb1

Issue: #918

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
