### PR TITLE
val,render_pipeline,depth_stencil_state,depth_write,frag_depth

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -11,6 +11,7 @@ import {
   kCompareFunctions,
   kStencilOperations,
 } from '../../../capability_info.js';
+import { getFragmentShaderCodeWithOutput } from '../../../util/shader.js';
 
 import { CreateRenderPipelineValidationTest } from './common.js';
 
@@ -83,6 +84,35 @@ g.test('depth_write')
       depthStencil: { format, depthWriteEnabled },
     });
     t.doCreateRenderPipelineTest(isAsync, !depthWriteEnabled || info.depth, descriptor);
+  });
+
+g.test('depth_write,frag_depth')
+  .desc(`Depth aspect must be contained in the format if frag_depth is written in fragment stage.`)
+  .params(u =>
+    u.combine('isAsync', [false, true]).combine('format', [undefined, ...kDepthStencilFormats])
+  )
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    if (format !== undefined) {
+      const info = kTextureFormatInfo[format];
+      t.selectDeviceOrSkipTestCase(info.feature);
+    }
+  })
+  .fn(async t => {
+    const { isAsync, format } = t.params;
+
+    const descriptor = t.getDescriptor({
+      // Keep one color target so that the pipeline is still valid with no depth stencil target.
+      targets: [{ format: 'rgba8unorm' }],
+      depthStencil: format ? { format, depthWriteEnabled: true } : undefined,
+      fragmentShaderCode: getFragmentShaderCodeWithOutput(
+        [{ values: [1, 1, 1, 1], plainType: 'f32', componentCount: 4 }],
+        { value: 0.5 }
+      ),
+    });
+
+    const hasDepth = format ? kTextureFormatInfo[format].depth : false;
+    t.doCreateRenderPipelineTest(isAsync, hasDepth, descriptor);
   });
 
 g.test('stencil_test')

--- a/src/webgpu/util/shader.ts
+++ b/src/webgpu/util/shader.ts
@@ -75,7 +75,11 @@ export function getPlainTypeInfo(sampleType: GPUTextureSampleType): keyof typeof
  *     return Outputs(vec4<f32>(1.0, 0.0, 1.0, 1.0), vec4<u32>(1, 2));
  * }
  * ```
+ *
+ * If fragDepth is given there will be an extra @builtin(frag_depth) output with the specified value assigned.
+ *
  * @param outputs the shader outputs for each location attribute
+ * @param fragDepth the shader outputs frag_depth value (optional)
  * @returns the fragment shader string
  */
 export function getFragmentShaderCodeWithOutput(
@@ -83,9 +87,16 @@ export function getFragmentShaderCodeWithOutput(
     values: readonly number[];
     plainType: 'i32' | 'u32' | 'f32';
     componentCount: number;
-  } | null)[]
+  } | null)[],
+  fragDepth: { value: number } | null = null
 ): string {
   if (outputs.length === 0) {
+    if (fragDepth) {
+      return `
+        @fragment fn main() -> @builtin(frag_depth) f32 {
+          return ${fragDepth.value.toFixed(kPlainTypeInfo['f32'].fractionDigits)};
+        }`;
+    }
     return `
         @fragment fn main() {
         }`;
@@ -93,6 +104,11 @@ export function getFragmentShaderCodeWithOutput(
 
   const resultStrings = [] as string[];
   let outputStructString = '';
+
+  if (fragDepth) {
+    resultStrings.push(`${fragDepth.value.toFixed(kPlainTypeInfo['f32'].fractionDigits)}`);
+    outputStructString += `@builtin(frag_depth) depth_out: f32,\n`;
+  }
 
   for (let i = 0; i < outputs.length; i++) {
     const o = outputs[i];


### PR DESCRIPTION


Issue: [#3728](https://github.com/gpuweb/gpuweb/issues/3728)

Validation fix for chrome: https://dawn-review.googlesource.com/c/dawn/+/116859

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
