### PR TITLE
webgpu/shader/validation: Add resource binding tests

### DIFF
--- a/src/webgpu/shader/validation/resource_interface/bindings.spec.ts
+++ b/src/webgpu/shader/validation/resource_interface/bindings.spec.ts
@@ -1,0 +1,118 @@
+export const description = `Validation tests for resource interface bindings`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import {
+  declareEntrypoint,
+  kResourceEmitters,
+  kResourceKindsA,
+  kResourceKindsB,
+  ResourceDeclarationEmitter,
+} from './util.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('single_entry_point')
+  .desc(
+    `Test that two different resource variables in a shader must not have the same group and binding values, when considered as a pair.`
+  )
+  .params(u =>
+    u
+      .combine('stage', ['vertex', 'fragment', 'compute'] as const)
+      .combine('a_kind', kResourceKindsA)
+      .combine('b_kind', kResourceKindsB)
+      .combine('a_group', [0, 3] as const)
+      .combine('b_group', [0, 3] as const)
+      .combine('a_binding', [0, 3] as const)
+      .combine('b_binding', [0, 3] as const)
+      .combine('usage', ['direct', 'transitive'] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    const resourceA = kResourceEmitters.get(t.params.a_kind) as ResourceDeclarationEmitter;
+    const resourceB = kResourceEmitters.get(t.params.b_kind) as ResourceDeclarationEmitter;
+    const resources = `
+${resourceA('resource_a', t.params.a_group, t.params.a_binding)}
+${resourceB('resource_b', t.params.b_group, t.params.b_binding)}
+`;
+    const expect =
+      t.params.a_group !== t.params.b_group || t.params.a_binding !== t.params.b_binding;
+
+    if (t.params.usage === 'direct') {
+      const code = `
+${resources}
+${declareEntrypoint('main', t.params.stage, '_ = resource_a; _ = resource_b;')}
+`;
+      t.expectCompileResult(expect, code);
+    } else {
+      const code = `
+${resources}
+fn use_a() { _ = resource_a; }
+fn use_b() { _ = resource_b; }
+${declareEntrypoint('main', t.params.stage, 'use_a(); use_b();')}
+`;
+      t.expectCompileResult(expect, code);
+    }
+  });
+
+g.test('different_entry_points')
+  .desc(
+    `Test that resources may use the same binding points if exclusively accessed by different entry points.`
+  )
+  .params(u =>
+    u
+      .combine('a_stage', ['vertex', 'fragment', 'compute'] as const)
+      .combine('b_stage', ['vertex', 'fragment', 'compute'] as const)
+      .combine('a_kind', kResourceKindsA)
+      .combine('b_kind', kResourceKindsB)
+      .combine('usage', ['direct', 'transitive'] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    const resourceA = kResourceEmitters.get(t.params.a_kind) as ResourceDeclarationEmitter;
+    const resourceB = kResourceEmitters.get(t.params.b_kind) as ResourceDeclarationEmitter;
+    const resources = `
+${resourceA('resource_a', /* group */ 0, /* binding */ 0)}
+${resourceB('resource_b', /* group */ 0, /* binding */ 0)}
+`;
+    const expect = true; // Binding reuse between different entry points is fine.
+
+    if (t.params.usage === 'direct') {
+      const code = `
+${resources}
+${declareEntrypoint('main_a', t.params.a_stage, '_ = resource_a;')}
+${declareEntrypoint('main_b', t.params.b_stage, '_ = resource_b;')}
+`;
+      t.expectCompileResult(expect, code);
+    } else {
+      const code = `
+${resources}
+fn use_a() { _ = resource_a; }
+fn use_b() { _ = resource_b; }
+${declareEntrypoint('main_a', t.params.a_stage, 'use_a();')}
+${declareEntrypoint('main_b', t.params.b_stage, 'use_b();')}
+`;
+      t.expectCompileResult(expect, code);
+    }
+  });
+
+g.test('binding_attributes')
+  .desc(`Test that both @group and @binding attributes must both be declared.`)
+  .params(u =>
+    u
+      .combine('stage', ['vertex', 'fragment', 'compute'] as const)
+      .combine('has_group', [true, false] as const)
+      .combine('has_binding', [true, false] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    const emitter = kResourceEmitters.get('uniform') as ResourceDeclarationEmitter;
+    const code = emitter(
+      'R',
+      t.params.has_group ? 0 : undefined,
+      t.params.has_binding ? 0 : undefined
+    );
+    const expect = t.params.has_group && t.params.has_binding;
+    t.expectCompileResult(expect, code);
+  });

--- a/src/webgpu/shader/validation/resource_interface/util.ts
+++ b/src/webgpu/shader/validation/resource_interface/util.ts
@@ -1,0 +1,91 @@
+/**
+ * ResourceDeclarationEmitter is a function that emits the WGSL declaring a resource variable with
+ * the given group, binding and name.
+ */
+export type ResourceDeclarationEmitter = (name: string, group?: number, binding?: number) => string;
+
+/** Helper function for emitting a resource declaration's group and binding attributes */
+function groupAndBinding(group?: number, binding?: number): string {
+  return (
+    `${group !== undefined ? `@group(${group})` : '/* no group */'} ` +
+    `${binding !== undefined ? `@binding(${binding})` : '/* no binding */'}`
+  );
+}
+
+/** Helper function for emitting a resource declaration for the given type */
+function basicEmitter(type: string): ResourceDeclarationEmitter {
+  return (name: string, group?: number, binding?: number) =>
+    `${groupAndBinding(group, binding)} var ${name} : ${type};\n`;
+}
+
+/** Map of resource declaration name, to an emitter. */
+export const kResourceEmitters = new Map<string, ResourceDeclarationEmitter>([
+  ['texture_1d', basicEmitter('texture_1d<i32>')],
+  ['texture_2d', basicEmitter('texture_2d<i32>')],
+  ['texture_2d_array', basicEmitter('texture_2d_array<f32>')],
+  ['texture_3d', basicEmitter('texture_3d<i32>')],
+  ['texture_cube', basicEmitter('texture_cube<u32>')],
+  ['texture_cube_array', basicEmitter('texture_cube_array<u32>')],
+  ['texture_multisampled_2d', basicEmitter('texture_multisampled_2d<i32>')],
+  ['texture_external', basicEmitter('texture_external')],
+  ['texture_storage_1d', basicEmitter('texture_storage_1d<rgba8unorm, write>')],
+  ['texture_storage_2d', basicEmitter('texture_storage_2d<rgba8sint, write>')],
+  ['texture_storage_2d_array', basicEmitter('texture_storage_2d_array<r32uint, write>')],
+  ['texture_storage_3d', basicEmitter('texture_storage_3d<rg32uint, write>')],
+  ['texture_depth_2d', basicEmitter('texture_depth_2d')],
+  ['texture_depth_2d_array', basicEmitter('texture_depth_2d_array')],
+  ['texture_depth_cube', basicEmitter('texture_depth_cube')],
+  ['texture_depth_cube_array', basicEmitter('texture_depth_cube_array')],
+  ['texture_depth_multisampled_2d', basicEmitter('texture_depth_multisampled_2d')],
+  ['sampler', basicEmitter('sampler')],
+  ['sampler_comparison', basicEmitter('sampler_comparison')],
+  [
+    'uniform',
+    (name: string, group?: number, binding?: number) =>
+      `${groupAndBinding(group, binding)} var<uniform> ${name} : array<vec4<f32>, 16>;\n`,
+  ],
+  [
+    'storage',
+    (name: string, group?: number, binding?: number) =>
+      `${groupAndBinding(group, binding)} var<storage> ${name} : array<vec4<f32>, 16>;\n`,
+  ],
+]);
+
+/** A small selection of resource declaration names, which can be used in test permutations */
+export const kResourceKindsA = ['storage', 'texture_2d', 'texture_external', 'uniform'];
+
+/** A small selection of resource declaration names, which can be used in test permutations */
+export const kResourceKindsB = ['texture_3d', 'texture_storage_1d', 'uniform'];
+
+/** An enumerator of shader stages */
+export type ShaderStage = 'vertex' | 'fragment' | 'compute';
+
+/**
+ * declareEntrypoint emits the WGSL to declare an entry point with the given name, stage and body.
+ * The generated function will have an appropriate return type and return statement, so that @p body
+ * does not have to change between stage.
+ * @param name the entry point function name
+ * @param stage the entry point stage
+ * @param body the body of the function (excluding any automatically suffixed return statements)
+ * @returns the WGSL string for the entry point
+ */
+export function declareEntrypoint(name: string, stage: ShaderStage, body: string): string {
+  switch (stage) {
+    case 'vertex':
+      return `@vertex
+fn ${name}() -> @builtin(position) vec4f {
+  ${body}
+  return vec4f();
+}`;
+    case 'fragment':
+      return `@fragment
+fn ${name}() {
+  ${body}
+}`;
+    case 'compute':
+      return `@compute @workgroup_size(1)
+fn ${name}() {
+  ${body}
+}`;
+  }
+}


### PR DESCRIPTION
Fixes: #1707

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
