### PR TITLE
runtime: Add server '/load' RPC

### DIFF
--- a/src/common/runtime/server.ts
+++ b/src/common/runtime/server.ts
@@ -144,18 +144,7 @@ if (verbose) {
 (async () => {
   Logger.globalDebugMode = verbose;
   const log = new Logger();
-  const testcases = allWebGPUTestcases();
-
-  async function allWebGPUTestcases() {
-    const webgpuQuery = parseQuery('webgpu:*');
-    const loader = new DefaultTestFileLoader();
-    const map = new Map<string, TestTreeLeaf>();
-    for (const testcase of await loader.loadCases(webgpuQuery)) {
-      const name = testcase.query.toString();
-      map.set(name, testcase);
-    }
-    return map;
-  }
+  const testcases = new Map<string, TestTreeLeaf>();
 
   async function runTestcase(
     testcase: TestTreeLeaf,
@@ -174,13 +163,28 @@ if (verbose) {
         return;
       }
 
+      const loadCasesPrefix = '/load?';
       const runPrefix = '/run?';
       const terminatePrefix = '/terminate';
 
-      if (request.url.startsWith(runPrefix)) {
+      if (request.url.startsWith(loadCasesPrefix)) {
+        const query = request.url.substr(loadCasesPrefix.length);
+        try {
+          const webgpuQuery = parseQuery(query);
+          const loader = new DefaultTestFileLoader();
+          for (const testcase of await loader.loadCases(webgpuQuery)) {
+            testcases.set(testcase.query.toString(), testcase);
+          }
+          response.statusCode = 200;
+          response.end();
+        } catch (err) {
+          response.statusCode = 500;
+          response.end(`load failed with error: ${err}\n${(err as Error).stack}`);
+        }
+      } else if (request.url.startsWith(runPrefix)) {
         const name = request.url.substr(runPrefix.length);
         try {
-          const testcase = (await testcases).get(name);
+          const testcase = testcases.get(name);
           if (testcase) {
             if (codeCoverage !== undefined) {
               codeCoverage.begin();


### PR DESCRIPTION
Instead of loading *all* the test cases, on first case, make the loading of the test cases explicit.

This can dramatically reduce the latency of small test runs.

Note: this currently only affects the `dawn/node` test runner, which requires the corresponding change: https://dawn-review.googlesource.com/c/dawn/+/117200