### PR TITLE
webgpu/shader/validation: Add static_assert tests

### DIFF
--- a/src/webgpu/shader/validation/parse/static_assert.spec.ts
+++ b/src/webgpu/shader/validation/parse/static_assert.spec.ts
@@ -1,0 +1,37 @@
+export const description = `Parser validation tests for static_assert`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kCases = {
+  no_parentheses: { code: `static_assert true;`, pass: true },
+  left_parenthesis_only: { code: `static_assert(true;`, pass: false },
+  right_parenthesis_only: { code: `static_assert true);`, pass: false },
+  both_parentheses: { code: `static_assert(true);`, pass: true },
+  condition_on_newline: {
+    code: `static_assert
+true;`,
+    pass: true,
+  },
+  multiline_with_parentheses: {
+    code: `static_assert
+(
+  true
+);`,
+    pass: true,
+  },
+  invalid_expression: { code: `static_assert(1!2);`, pass: false },
+  no_condition_no_parentheses: { code: `static_assert;`, pass: false },
+  no_condition_with_parentheses: { code: `static_assert();`, pass: false },
+  not_a_boolean: { code: `static_assert 42;`, pass: false },
+};
+
+g.test('parse')
+  .desc(`Tests that the static_assert statement parses correctly.`)
+  .params(u => u.combine('case', Object.keys(kCases) as Array<keyof typeof kCases>).beginSubcases())
+  .fn(t => {
+    const c = kCases[t.params.case];
+    t.expectCompileResult(c.pass, c.code);
+  });

--- a/src/webgpu/shader/validation/static_assert/static_assert.spec.ts
+++ b/src/webgpu/shader/validation/static_assert/static_assert.spec.ts
@@ -1,0 +1,70 @@
+export const description = `Validation tests for static_assert`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+/**
+ * Builds a static_assert() statement, which checks that @p expr is equal to @p expect_true.
+ * @param expect_true true if @p expr should evaluate to true
+ * @param expr the constant expression
+ * @param scope module-scope or function-scope constant expression
+ * @returns the WGSL code
+ */
+function buildStaticAssert(expect_true: boolean, expr: string, scope: 'module' | 'function') {
+  const stmt = expect_true ? `static_assert ${expr};` : `static_assert !(${expr});`;
+  return scope === 'module' ? stmt : `fn f() { ${stmt} }`;
+}
+
+const kConditionCases = {
+  true_literal: `true`,
+  not_false: `!false`,
+  const_eq_literal_int: `one == 1`,
+  const_eq_literal_float: `one == 1.0`,
+  binary_op_eq_const: `one+1 == two`,
+  any: `any(vec3(false, true, false))`,
+  min_max: `min(three, max(two, one)) == 2`,
+};
+
+g.test('constant_expression')
+  .desc(`Test that static_assert validates the condition expression.`)
+  .params(u =>
+    u
+      .combine('case', Object.keys(kConditionCases) as Array<keyof typeof kConditionCases>)
+      .combine('scope', ['module', 'function'] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    const constants = `
+const one = 1;
+const two = 2;
+const three = 2;
+`;
+    const expr = kConditionCases[t.params.case];
+    t.expectCompileResult(true, constants + buildStaticAssert(true, expr, t.params.scope));
+    t.expectCompileResult(false, constants + buildStaticAssert(false, expr, t.params.scope));
+  });
+
+g.test('evaluation_stage')
+  .desc(`Test that the static_assert expression must be a constant expression.`)
+  .params(u =>
+    u
+      .combine('scope', ['module', 'function'] as const)
+      .combine('stage', ['constant', 'override', 'runtime'] as const)
+      .beginSubcases()
+  )
+  .fn(t => {
+    const staticAssert = buildStaticAssert(true, 'value', t.params.scope);
+    switch (t.params.stage) {
+      case 'constant':
+        t.expectCompileResult(true, `const value = true;\n${staticAssert}`);
+        break;
+      case 'override':
+        t.expectCompileResult(false, `override value = true;\n${staticAssert}`);
+        break;
+      case 'runtime':
+        t.expectCompileResult(false, `var<private> value = true;\n${staticAssert}`);
+        break;
+    }
+  });


### PR DESCRIPTION
Fixes: #1686

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
