### PR TITLE
Convert remaining dispatch() to dispatchWorkgroups()

### DIFF
--- a/src/stress/adapter/device_allocation.spec.ts
+++ b/src/stress/adapter/device_allocation.spec.ts
@@ -78,7 +78,7 @@ async function createDeviceAndComputeCommands(adapter: GPUAdapter) {
       const pass = encoder.beginComputePass();
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindgroup);
-      pass.dispatch(
+      pass.dispatchWorkgroups(
         kLimitInfo.maxComputeWorkgroupSizeX.default,
         kLimitInfo.maxComputeWorkgroupSizeY.default
       );

--- a/src/stress/compute/compute_pass.spec.ts
+++ b/src/stress/compute/compute_pass.spec.ts
@@ -43,7 +43,7 @@ GPUComputePipeline.`
       const pass = encoder.beginComputePass();
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
-      pass.dispatch(kNumElements);
+      pass.dispatchWorkgroups(kNumElements);
       pass.end();
       t.device.queue.submit([encoder.finish()]);
     }
@@ -86,7 +86,7 @@ GPUComputePipeline.`
       const pass = encoder.beginComputePass();
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
-      pass.dispatch(1);
+      pass.dispatchWorkgroups(1);
       pass.end();
       t.device.queue.submit([encoder.finish()]);
     }
@@ -140,7 +140,7 @@ groups.`
         ],
       });
       pass.setBindGroup(0, bindGroup);
-      pass.dispatch(kNumElements);
+      pass.dispatchWorkgroups(kNumElements);
     }
     pass.end();
     t.device.queue.submit([encoder.finish()]);
@@ -185,7 +185,7 @@ g.test('many_dispatches')
     });
     pass.setBindGroup(0, bindGroup);
     for (let i = 0; i < kNumIterations; ++i) {
-      pass.dispatch(kNumElements);
+      pass.dispatchWorkgroups(kNumElements);
     }
     pass.end();
     t.device.queue.submit([encoder.finish()]);
@@ -231,7 +231,7 @@ g.test('huge_dispatches')
       const pass = encoder.beginComputePass();
       pass.setBindGroup(0, bindGroup);
       pass.setPipeline(pipeline);
-      pass.dispatch(kDimensions[0], kDimensions[1], kDimensions[2]);
+      pass.dispatchWorkgroups(kDimensions[0], kDimensions[1], kDimensions[2]);
       pass.end();
       t.device.queue.submit([encoder.finish()]);
       await t.device.queue.onSubmittedWorkDone();

--- a/src/stress/queue/submit.spec.ts
+++ b/src/stress/queue/submit.spec.ts
@@ -44,7 +44,7 @@ results verified at the end of the test.`
       const pass = encoder.beginComputePass();
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
-      pass.dispatch(kNumElements);
+      pass.dispatchWorkgroups(kNumElements);
       pass.end();
     }
     t.device.queue.submit([encoder.finish()]);
@@ -90,7 +90,7 @@ submit() call.`
       const pass = encoder.beginComputePass();
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
-      pass.dispatch(kNumElements);
+      pass.dispatchWorkgroups(kNumElements);
       pass.end();
       buffers.push(encoder.finish());
     }

--- a/src/stress/render/vertex_buffers.spec.ts
+++ b/src/stress/render/vertex_buffers.spec.ts
@@ -45,7 +45,7 @@ function createHugeVertexBuffer(t: GPUTest, size: number) {
   const pass = encoder.beginComputePass();
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, bindGroup);
-  pass.dispatch(size);
+  pass.dispatchWorkgroups(size);
   pass.end();
 
   const vertexBuffer = t.device.createBuffer({

--- a/src/stress/shaders/entry_points.spec.ts
+++ b/src/stress/shaders/entry_points.spec.ts
@@ -69,7 +69,7 @@ a shader, in which case this would become a validation test instead.`
       const pass = encoder.beginComputePass();
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, bindGroup);
-      pass.dispatch(1);
+      pass.dispatchWorkgroups(1);
       pass.end();
     });
 

--- a/src/stress/shaders/non_halting.spec.ts
+++ b/src/stress/shaders/non_halting.spec.ts
@@ -43,7 +43,7 @@ device loss.`
       entries: [{ binding: 0, resource: { buffer } }],
     });
     pass.setBindGroup(0, bindGroup);
-    pass.dispatch(1);
+    pass.dispatchWorkgroups(1);
     pass.end();
     t.device.queue.submit([encoder.finish()]);
     await t.device.lost;

--- a/src/stress/shaders/slow.spec.ts
+++ b/src/stress/shaders/slow.spec.ts
@@ -40,7 +40,7 @@ g.test('compute')
       entries: [{ binding: 0, resource: { buffer } }],
     });
     pass.setBindGroup(0, bindGroup);
-    pass.dispatch(kDispatchSize);
+    pass.dispatchWorkgroups(kDispatchSize);
     pass.end();
     t.device.queue.submit([encoder.finish()]);
     t.expectGPUBufferValuesEqual(buffer, new Uint32Array(new Array(kDispatchSize).fill(1000000)));

--- a/src/webgpu/api/operation/adapter/requestAdapter.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestAdapter.spec.ts
@@ -74,7 +74,7 @@ async function testAdapter(adapter: GPUAdapter | null) {
   const pass = encoder.beginComputePass();
   pass.setPipeline(pipeline);
   pass.setBindGroup(0, bindGroup);
-  pass.dispatch(kNumElements);
+  pass.dispatchWorkgroups(kNumElements);
   pass.end();
 
   encoder.copyBufferToBuffer(buffer, 0, resultBuffer, 0, kBufferSize);


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
