### PR TITLE
Add tests for i32 binary arithmetic operations

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
@@ -1,0 +1,156 @@
+export const description = `
+Execution Tests for the i32 arithmetic binary expression operations
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { kValue } from '../../../../util/constants.js';
+import { TypeI32 } from '../../../../util/conversion.js';
+import { fullI32Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
+import { allInputSources, generateBinaryToI32Cases, run } from '../expression.js';
+
+import { binary } from './binary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('binary/i32_arithmetic', {
+  addition: () => {
+    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), (x, y) => {
+      return x + y;
+    });
+  },
+  subtraction: () => {
+    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), (x, y) => {
+      return x - y;
+    });
+  },
+  multiplication: () => {
+    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), (x, y) => {
+      return Math.imul(x, y);
+    });
+  },
+  division_non_const: () => {
+    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), (x, y) => {
+      if (y === 0) {
+        return 0;
+      }
+      if (x === kValue.i32.negative.min && y === -1) {
+        return 0;
+      }
+      return x / y;
+    });
+  },
+  division_const: () => {
+    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      if (x === kValue.i32.negative.min && y === -1) {
+        return undefined;
+      }
+      return x / y;
+    });
+  },
+  remainder_non_const: () => {
+    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), (x, y) => {
+      if (y === 0) {
+        return 0;
+      }
+      if (x === kValue.i32.negative.min && y === -1) {
+        return 0;
+      }
+      return x % y;
+    });
+  },
+  remainder_const: () => {
+    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      if (x === kValue.i32.negative.min && y === -1) {
+        return undefined;
+      }
+      return x % y;
+    });
+  },
+});
+
+g.test('addition')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x + y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('addition');
+    await run(t, binary('+'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });
+
+g.test('subtraction')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x - y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('subtraction');
+    await run(t, binary('-'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });
+
+g.test('multiplication')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x * y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('multiplication');
+    await run(t, binary('*'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });
+
+g.test('division')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x / y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
+    );
+    await run(t, binary('/'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });
+
+g.test('remainder')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x % y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
+    );
+    await run(t, binary('%'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -13,6 +13,7 @@ import {
   VectorType,
   f32,
   u32,
+  i32,
 } from '../../../util/conversion.js';
 import {
   BinaryToInterval,
@@ -973,4 +974,32 @@ export function generateU32ToVectorCases(
   return params
     .map(e => makeU32ToVectorCase(e, filter, ...ops))
     .filter((c): c is Case => c !== undefined);
+}
+
+/**
+ * A function that performs a binary operation on x and y, and returns the expected
+ * result, or undefined if the operation is invalid for the given inputs.
+ */
+export interface BinaryToI32Op {
+  (x: number, y: number): number | undefined;
+}
+
+/**
+ * @returns an array of Cases for operations over a range of inputs
+ * @param param0s array of inputs to try for the first param
+ * @param param1s array of inputs to try for the second param
+ * @param op callback called on each pair of inputs to produce each case
+ */
+export function generateBinaryToI32Cases(
+  params0s: number[],
+  params1s: number[],
+  op: BinaryToI32Op
+) {
+  return cartesianProduct(params0s, params1s).reduce((cases, e) => {
+    const expected = op(e[0], e[1]);
+    if (expected !== undefined) {
+      cases.push({ input: [i32(e[0]), i32(e[1])], expected: i32(expected) });
+    }
+    return cases;
+  }, new Array<Case>());
 }


### PR DESCRIPTION
Issue: #1626 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
