### PR TITLE
Add test for u32 binary arithmetic operations

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -1,0 +1,143 @@
+export const description = `
+Execution Tests for the u32 arithmetic binary expression operations
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { TypeU32 } from '../../../../util/conversion.js';
+import { fullU32Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
+import { allInputSources, generateBinaryToU32Cases, run } from '../expression.js';
+
+import { binary } from './binary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('binary/i32_arithmetic', {
+  addition: () => {
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
+      return x + y;
+    });
+  },
+  subtraction: () => {
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
+      return x - y;
+    });
+  },
+  multiplication: () => {
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
+      return Math.imul(x, y);
+    });
+  },
+  division_non_const: () => {
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
+      if (y === 0) {
+        return 0;
+      }
+      return x / y;
+    });
+  },
+  division_const: () => {
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      return x / y;
+    });
+  },
+  remainder_non_const: () => {
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
+      if (y === 0) {
+        return 0;
+      }
+      return x % y;
+    });
+  },
+  remainder_const: () => {
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      return x % y;
+    });
+  },
+});
+
+g.test('addition')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x + y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('addition');
+    await run(t, binary('+'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('subtraction')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x - y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('subtraction');
+    await run(t, binary('-'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('multiplication')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x * y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('multiplication');
+    await run(t, binary('*'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('division')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x / y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
+    );
+    await run(t, binary('/'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('remainder')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x % y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
+    );
+    await run(t, binary('%'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -1035,3 +1035,27 @@ export function generateBinaryToI32Cases(
     return cases;
   }, new Array<Case>());
 }
+
+export interface BinaryToU32Op {
+  (x: number, y: number): number | undefined;
+}
+
+/**
+ * @returns an array of Cases for operations over a range of inputs
+ * @param param0s array of inputs to try for the first param
+ * @param param1s array of inputs to try for the second param
+ * @param op callback called on each pair of inputs to produce each case
+ */
+export function generateBinaryToU32Cases(
+  params0s: number[],
+  params1s: number[],
+  op: BinaryToU32Op
+) {
+  return cartesianProduct(params0s, params1s).reduce((cases, e) => {
+    const expected = op(e[0], e[1]);
+    if (expected !== undefined) {
+      cases.push({ input: [u32(e[0]), u32(e[1])], expected: u32(expected) });
+    }
+    return cases;
+  }, new Array<Case>());
+}


### PR DESCRIPTION
Issue: #1626 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
