### PR TITLE
Fix u32 and i32 non-const divide by 0 expecting lhs (not 0)

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
@@ -33,10 +33,10 @@ export const d = makeCaseCache('binary/i32_arithmetic', {
   division_non_const: () => {
     return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), (x, y) => {
       if (y === 0) {
-        return 0;
+        return x;
       }
       if (x === kValue.i32.negative.min && y === -1) {
-        return 0;
+        return x;
       }
       return x / y;
     });

--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -32,7 +32,7 @@ export const d = makeCaseCache('binary/i32_arithmetic', {
   division_non_const: () => {
     return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
       if (y === 0) {
-        return 0;
+        return x;
       }
       return x / y;
     });


### PR DESCRIPTION
Issue: #1626 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
