### PR TITLE
Test colorSpace in readback tests

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -267,7 +267,22 @@ export const kRenderableColorTextureFormats = kRegularTextureFormats.filter(
 export const kCanvasTextureFormats = ['bgra8unorm', 'rgba8unorm', 'rgba16float'] as const;
 
 // The alpha mode for canvas context.
-export const kCanvasAlphaModes = ['opaque', 'premultiplied'] as const;
+export const kCanvasAlphaModesInfo: {
+  readonly [k in GPUCanvasAlphaMode]: {};
+} = /* prettier-ignore */ {
+  'opaque': {},
+  'premultiplied': {},
+};
+export const kCanvasAlphaModes = keysOf(kCanvasAlphaModesInfo);
+
+// The color spaces for canvas context
+export const kCanvasColorSpacesInfo: {
+  readonly [k in PredefinedColorSpace]: {};
+} = /* prettier-ignore */ {
+  'srgb': {},
+  'display-p3': {},
+};
+export const kCanvasColorSpaces = keysOf(kCanvasColorSpacesInfo);
 
 /** Per-GPUTextureFormat info. */
 // Exists just for documentation. Otherwise could be inferred by `makeTable`.

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -1,12 +1,25 @@
 export const description = `
 Tests for readback from WebGPU Canvas.
 
+This includes testing that colorSpace makes it through from the WebGPU canvas
+to the form of copy (toDataURL, toBlob, ImageBitmap, drawImage)
+
+The color space support is tested by drawing the readback form of the WebGPU
+canvas into a 2D canvas of a different color space via drawImage (A). Another
+2D canvas is created with the same source data and color space as the WebGPU
+canvas and also drawn into another 2D canvas of a different color space (B).
+The contents of A and B should match.
+
 TODO: implement all canvas types, see TODO on kCanvasTypes.
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { assert, raceWithRejectOnTimeout, unreachable } from '../../../common/util/util.js';
-import { kCanvasAlphaModes, kCanvasTextureFormats } from '../../capability_info.js';
+import {
+  kCanvasAlphaModes,
+  kCanvasColorSpaces,
+  kCanvasTextureFormats,
+} from '../../capability_info.js';
 import { GPUTest } from '../../gpu_test.js';
 import { checkElementsEqual } from '../../util/check_contents.js';
 import {
@@ -48,10 +61,11 @@ const expect = {
   ]),
 };
 
-async function initCanvasContent<T extends CanvasType>(
+async function initWebGPUCanvasContent<T extends CanvasType>(
   t: GPUTest,
   format: GPUTextureFormat,
   alphaMode: GPUCanvasAlphaMode,
+  colorSpace: PredefinedColorSpace,
   canvasType: T
 ) {
   const canvas = createCanvas(t, canvasType, 2, 2);
@@ -63,6 +77,7 @@ async function initCanvasContent<T extends CanvasType>(
     format,
     usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     alphaMode,
+    colorSpace,
   });
 
   const canvasTexture = ctx.getCurrentTexture();
@@ -96,17 +111,68 @@ async function initCanvasContent<T extends CanvasType>(
   t.device.queue.submit([encoder.finish()]);
   tempTexture.destroy();
 
-  await t.device.queue.onSubmittedWorkDone();
-
   return canvas;
 }
 
-function checkImageResult(t: GPUTest, image: CanvasImageSource, expect: Uint8ClampedArray) {
+function drawImageSourceIntoCanvas(
+  t: GPUTest,
+  image: CanvasImageSource,
+  colorSpace: PredefinedColorSpace
+) {
   const canvas: HTMLCanvasElement = createOnscreenCanvas(t, 2, 2);
-  const ctx = canvas.getContext('2d');
+  const ctx = canvas.getContext('2d', { colorSpace });
   assert(ctx !== null);
   ctx.drawImage(image, 0, 0);
+  return ctx;
+}
+
+function checkImageResultWithSameColorSpaceCanvas(
+  t: GPUTest,
+  image: CanvasImageSource,
+  sourceColorSpace: PredefinedColorSpace,
+  expect: Uint8ClampedArray
+) {
+  const ctx = drawImageSourceIntoCanvas(t, image, sourceColorSpace);
   readPixelsFrom2DCanvasAndCompare(t, ctx, expect);
+}
+
+function checkImageResultWithDifferentColorSpaceCanvas(
+  t: GPUTest,
+  image: CanvasImageSource,
+  sourceColorSpace: PredefinedColorSpace,
+  sourceData: Uint8ClampedArray
+) {
+  const destinationColorSpace = sourceColorSpace === 'srgb' ? 'display-p3' : 'srgb';
+
+  // draw the WebGPU derived data into a canvas
+  const fromWebGPUCtx = drawImageSourceIntoCanvas(t, image, destinationColorSpace);
+
+  // create a 2D canvas with the same source data in the same color space as the WebGPU
+  // canvas
+  const source2DCanvas: HTMLCanvasElement = createOnscreenCanvas(t, 2, 2);
+  const source2DCtx = source2DCanvas.getContext('2d', { colorSpace: sourceColorSpace });
+  assert(source2DCtx !== null);
+  const imgData = source2DCtx.getImageData(0, 0, 2, 2);
+  imgData.data.set(sourceData);
+  source2DCtx.putImageData(imgData, 0, 0);
+
+  // draw the source 2D canvas into another 2D canvas with the destination color space and
+  // then pull out the data. This result should be the same as the WebGPU derived data
+  // written to a 2D canvas of the same destination color space.
+  const from2DCtx = drawImageSourceIntoCanvas(t, source2DCanvas, destinationColorSpace);
+  const expect = from2DCtx.getImageData(0, 0, 2, 2).data;
+
+  readPixelsFrom2DCanvasAndCompare(t, fromWebGPUCtx, expect);
+}
+
+function checkImageResult(
+  t: GPUTest,
+  image: CanvasImageSource,
+  sourceColorSpace: PredefinedColorSpace,
+  expect: Uint8ClampedArray
+) {
+  checkImageResultWithSameColorSpaceCanvas(t, image, sourceColorSpace, expect);
+  checkImageResultWithDifferentColorSpaceCanvas(t, image, sourceColorSpace, expect);
 }
 
 function readPixelsFrom2DCanvasAndCompare(
@@ -125,6 +191,7 @@ g.test('onscreenCanvas,snapshot')
     Ensure snapshot of canvas with WebGPU context is correct with
     - various WebGPU canvas texture formats
     - WebGPU canvas alpha mode = {"opaque", "premultiplied"}
+    - colorSpace = {"srgb", "display-p3"}
     - snapshot methods = {convertToBlob, transferToImageBitmap, createImageBitmap}
 
     TODO: Snapshot canvas to jpeg, webp and other mime type and
@@ -135,10 +202,17 @@ g.test('onscreenCanvas,snapshot')
     u //
       .combine('format', kCanvasTextureFormats)
       .combine('alphaMode', kCanvasAlphaModes)
+      .combine('colorSpace', kCanvasColorSpaces)
       .combine('snapshotType', ['toDataURL', 'toBlob', 'imageBitmap'])
   )
   .fn(async t => {
-    const canvas = await initCanvasContent(t, t.params.format, t.params.alphaMode, 'onscreen');
+    const canvas = await initWebGPUCanvasContent(
+      t,
+      t.params.format,
+      t.params.alphaMode,
+      t.params.colorSpace,
+      'onscreen'
+    );
 
     let snapshot: HTMLImageElement | ImageBitmap;
     switch (t.params.snapshotType) {
@@ -170,7 +244,7 @@ g.test('onscreenCanvas,snapshot')
         unreachable();
     }
 
-    checkImageResult(t, snapshot, expect[t.params.alphaMode]);
+    checkImageResult(t, snapshot, t.params.colorSpace, expect[t.params.alphaMode]);
   });
 
 g.test('offscreenCanvas,snapshot')
@@ -179,6 +253,7 @@ g.test('offscreenCanvas,snapshot')
     Ensure snapshot of offscreenCanvas with WebGPU context is correct with
     - various WebGPU canvas texture formats
     - WebGPU canvas alpha mode = {"opaque", "premultiplied"}
+    - colorSpace = {"srgb", "display-p3"}
     - snapshot methods = {convertToBlob, transferToImageBitmap, createImageBitmap}
 
     TODO: Snapshot offscreenCanvas to jpeg, webp and other mime type and
@@ -189,13 +264,15 @@ g.test('offscreenCanvas,snapshot')
     u //
       .combine('format', kCanvasTextureFormats)
       .combine('alphaMode', kCanvasAlphaModes)
+      .combine('colorSpace', kCanvasColorSpaces)
       .combine('snapshotType', ['convertToBlob', 'transferToImageBitmap', 'imageBitmap'])
   )
   .fn(async t => {
-    const offscreenCanvas = await initCanvasContent(
+    const offscreenCanvas = await initWebGPUCanvasContent(
       t,
       t.params.format,
       t.params.alphaMode,
+      t.params.colorSpace,
       'offscreen'
     );
 
@@ -230,7 +307,7 @@ g.test('offscreenCanvas,snapshot')
         unreachable();
     }
 
-    checkImageResult(t, snapshot, expect[t.params.alphaMode]);
+    checkImageResult(t, snapshot, t.params.colorSpace, expect[t.params.alphaMode]);
   });
 
 g.test('onscreenCanvas,uploadToWebGL')
@@ -251,7 +328,7 @@ g.test('onscreenCanvas,uploadToWebGL')
   )
   .fn(async t => {
     const { format, webgl, upload } = t.params;
-    const canvas = await initCanvasContent(t, format, t.params.alphaMode, 'onscreen');
+    const canvas = await initWebGPUCanvasContent(t, format, t.params.alphaMode, 'srgb', 'onscreen');
 
     const expectCanvas: HTMLCanvasElement = createOnscreenCanvas(t, canvas.width, canvas.height);
     const gl = expectCanvas.getContext(webgl) as WebGLRenderingContext | WebGL2RenderingContext;
@@ -303,6 +380,7 @@ g.test('drawTo2DCanvas')
     Ensure draw WebGPU context canvas to 2d context canvas/offscreenCanvas is correct with
     - various WebGPU canvas texture formats
     - WebGPU canvas alpha mode = {"opaque", "premultiplied"}
+    - colorSpace = {"srgb", "display-p3"}
     - WebGPU canvas type = {"onscreen", "offscreen"}
     - 2d canvas type = {"onscreen", "offscreen"}
     `
@@ -311,16 +389,23 @@ g.test('drawTo2DCanvas')
     u //
       .combine('format', kCanvasTextureFormats)
       .combine('alphaMode', kCanvasAlphaModes)
+      .combine('colorSpace', kCanvasColorSpaces)
       .combine('webgpuCanvasType', kAllCanvasTypes)
       .combine('canvas2DType', kAllCanvasTypes)
   )
   .fn(async t => {
-    const { format, webgpuCanvasType, alphaMode, canvas2DType } = t.params;
+    const { format, webgpuCanvasType, alphaMode, colorSpace, canvas2DType } = t.params;
 
-    const canvas = await initCanvasContent(t, format, alphaMode, webgpuCanvasType);
+    const canvas = await initWebGPUCanvasContent(
+      t,
+      format,
+      alphaMode,
+      colorSpace,
+      webgpuCanvasType
+    );
 
     const expectCanvas = createCanvas(t, canvas2DType, canvas.width, canvas.height);
-    const ctx = expectCanvas.getContext('2d');
+    const ctx = expectCanvas.getContext('2d') as CanvasRenderingContext2D;
     if (ctx === null) {
       t.skip(canvas2DType + ' canvas cannot get 2d context');
       return;


### PR DESCRIPTION
Issue: #918 ?

On MacOS all the `rgba8unorm` tests fail on Chrome. Further, chrome crashes

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
