### PR TITLE
op,render_pipeline,sample_mask depth stencil multisampled tests

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -21,6 +21,7 @@ import {
   checkElementsFloat16Between,
 } from './util/check_contents.js';
 import { CommandBufferMaker, EncoderType } from './util/command_buffer_maker.js';
+import { ScalarType } from './util/conversion.js';
 import { DevicePool, DeviceProvider, UncanonicalizedDeviceDescriptor } from './util/device_pool.js';
 import { align, roundDown } from './util/math.js';
 import { makeTextureWithContents } from './util/texture.js';
@@ -682,6 +683,110 @@ export class GPUTest extends Fixture<GPUTestSubcaseBatchState> {
         checkElementsBetweenFn: checkElementsFloat16Between,
       }
     );
+  }
+
+  /**
+   * Emulate a texture to buffer copy by using a compute shader
+   * to load texture value of a single pixel and write to a storage buffer.
+   * For sample count == 1, the buffer contains only one value of the sample.
+   * For sample count > 1, the buffer contains (N = 2 ** sampleCount) values sorted
+   * in the order of their sample index [0, 2 ** sampleCount - 1]
+   *
+   * This can be useful when the texture to buffer copy is not available to the texture format
+   * e.g. (depth24plus)
+   *
+   * MAINTENANCE_TODO: extend to read multiple pixels with given origin and size.
+   *
+   * @returns storage buffer containing the copied value from the texture.
+   */
+  copySinglePixelTextureToBufferUsingComputePass(
+    type: ScalarType,
+    numElements: number,
+    textureView: GPUTextureView,
+    sampleCount: number
+  ): GPUBuffer {
+    const textureLoadCode =
+      numElements === 1
+        ? `dst.data[sampleIndex] = textureLoad(src, coord, sampleIndex).x;`
+        : `let o = sampleIndex * ${numElements};
+      let v = textureLoad(src, coord, sampleIndex);
+      dst.data[o] = v.r;
+      dst.data[o + 1] = v.g;
+      dst.data[o + 2] = v.b;
+      dst.data[o + 3] = v.a;
+      `;
+    const computePipeline = this.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: this.device.createShaderModule({
+          code:
+            sampleCount === 1
+              ? `
+            struct Buffer {
+              data: array<${type.toString()}>,
+            };
+
+            @group(0) @binding(0) var src: texture_2d<${type.toString()}>;
+            @group(0) @binding(1) var<storage, read_write> dst : Buffer;
+
+            @compute @workgroup_size(1) fn main() {
+              var coord = vec2<i32>(0, 0);
+              let sampleIndex = 0;
+              ${textureLoadCode}
+            }
+            `
+              : `
+            struct Buffer {
+              data: array<${type.toString()}>,
+            };
+
+            @group(0) @binding(0) var src: texture_multisampled_2d<${type.toString()}>;
+            @group(0) @binding(1) var<storage, read_write> dst : Buffer;
+
+            @compute @workgroup_size(1) fn main() {
+              var coord = vec2<i32>(0, 0);
+              for (var sampleIndex = 0; sampleIndex < ${sampleCount};
+                sampleIndex = sampleIndex + 1) {
+                ${textureLoadCode}
+              }
+            }
+          `,
+        }),
+        entryPoint: 'main',
+      },
+    });
+
+    const storageBuffer = this.device.createBuffer({
+      size: sampleCount * type.getSize() * numElements,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+    });
+    this.trackForCleanup(storageBuffer);
+
+    const uniformBindGroup = this.device.createBindGroup({
+      layout: computePipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: textureView,
+        },
+        {
+          binding: 1,
+          resource: {
+            buffer: storageBuffer,
+          },
+        },
+      ],
+    });
+
+    const encoder = this.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(computePipeline);
+    pass.setBindGroup(0, uniformBindGroup);
+    pass.dispatchWorkgroups(1);
+    pass.end();
+    this.device.queue.submit([encoder.finish()]);
+
+    return storageBuffer;
   }
 
   /**

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -536,12 +536,12 @@ export type ScalarKind =
 /** ScalarType describes the type of WGSL Scalar. */
 export class ScalarType {
   readonly kind: ScalarKind; // The named type
-  readonly size: number; // In bytes
+  readonly _size: number; // In bytes
   readonly read: (buf: Uint8Array, offset: number) => Scalar; // reads a scalar from a buffer
 
   constructor(kind: ScalarKind, size: number, read: (buf: Uint8Array, offset: number) => Scalar) {
     this.kind = kind;
-    this.size = size;
+    this._size = size;
     this.read = read;
   }
 
@@ -549,8 +549,8 @@ export class ScalarType {
     return this.kind;
   }
 
-  public getSize(): number {
-    return this.size;
+  public get size(): number {
+    return this._size;
   }
 }
 
@@ -581,7 +581,7 @@ export class VectorType {
     return `vec${this.width}<${this.elementType}>`;
   }
 
-  public getSize(): number {
+  public get size(): number {
     return this.elementType.size * this.width;
   }
 }

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -548,6 +548,10 @@ export class ScalarType {
   public toString(): string {
     return this.kind;
   }
+
+  public getSize(): number {
+    return this.size;
+  }
 }
 
 /** ScalarType describes the type of WGSL Vector. */
@@ -575,6 +579,10 @@ export class VectorType {
 
   public toString(): string {
     return `vec${this.width}<${this.elementType}>`;
+  }
+
+  public getSize(): number {
+    return this.elementType.size * this.width;
   }
 }
 


### PR DESCRIPTION
Issue: https://github.com/gpuweb/cts/issues/2146

Add depth and stencil tests to op,render_pipeline,sample_mask

Check is performed by using a compute shader to `textureLoad` each sample from the depth/stencil texture and write to a buffer and then compare the result.

I think we can integrate the functionality of `checking multisampled color/depth/stencil` into the texture_ok helper in a later pull request to:
- have a first review to align
- later dealing with different formats (sample type 'f32' ULP, 'u32'; aspect: depth only, stencil only;)
- avoid conflicting too much with current helper function refactoring

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
