### PR TITLE
[wgsl] Alignment attribute tests.

### DIFF
--- a/src/webgpu/shader/validation/parse/align.spec.ts
+++ b/src/webgpu/shader/validation/parse/align.spec.ts
@@ -179,44 +179,72 @@ g.test('align_required_alignment')
     t.expectCompileResult(!fails, code);
   });
 
-g.test('align_non_struct')
-  .desc('Test that alignment is only allowed on struct members')
+g.test('placement')
+  .desc('Tests the locations @align is allowed to appear')
   .params(u =>
-    u.combine('scope', ['private', 'function']).combine('with_align', [true, false]).beginSubcases()
+    u
+      .combine('scope', [
+        'private-var',
+        'storage-var',
+        'struct-member',
+        'fn-decl',
+        'fn-param',
+        'fn-var',
+        'fn-return',
+        'while-stmt',
+        undefined,
+      ] as const)
+      .combine('attribute', [
+        {
+          'private-var': false,
+          'storage-var': false,
+          'struct-member': true,
+          'fn-decl': false,
+          'fn-param': false,
+          'fn-var': false,
+          'fn-return': false,
+          'while-stmt': false,
+        },
+      ])
+      .beginSubcases()
   )
   .fn(t => {
-    let code = `struct A {
-      a: i32,
-    }
+    const scope = t.params.scope;
+
+    const attr = '@align(32)';
+    const code = `
+      ${scope === 'private-var' ? attr : ''}
+      var<private> priv_var : i32;
+
+      ${scope === 'storage-var' ? attr : ''}
+      @group(0) @binding(0)
+      var<storage> stor_var : i32;
+
+      struct A {
+        ${scope === 'struct-member' ? attr : ''}
+        a : i32,
+      }
+
+      @vertex
+      ${scope === 'fn-decl' ? attr : ''}
+      fn f(
+        ${scope === 'fn-param' ? attr : ''}
+        @location(0) b : i32,
+      ) -> ${scope === 'fn-return' ? attr : ''} @builtin(position) vec4f {
+        ${scope === 'fn-var' ? attr : ''}
+        var<function> func_v : i32;
+
+        ${scope === 'while-stmt' ? attr : ''}
+        while false {}
+
+        return vec4(1, 1, 1, 1);
+      }
     `;
 
-    let val = '';
-    if (t.params.with_align === true) {
-      val += '@align(128) ';
-    }
-    val += `var<${t.params.scope}> b : A;
-    `;
-
-    if (t.params.scope === 'private') {
-      code += val;
-    }
-
-    code += `
-      @fragment
-      fn main() -> @location(0) vec4<f32> {
-    `;
-
-    if (t.params.scope === 'function') {
-      code += val;
-    }
-
-    code += `
-        return vec4<f32>(.4, .2, .3, .1);
-      }`;
-    t.expectCompileResult(!t.params.with_align, code);
+    t.expectCompileResult(scope === undefined || t.params.attribute[scope], code);
   });
 
-g.test('align_multi')
+g.test('multi_align')
   .desc('Tests that align multiple times is an error')
   .params(u => u.combine('multi', [true, false]))
   .fn(t => {


### PR DESCRIPTION
This CL adds test for alignment attribute used outside as struct and multiple alignment attributes applied to an item.

Fixes #1432

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
