### PR TITLE
Add tests for binary multiplication of scalars with vectors for u32

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -4,10 +4,16 @@ Execution Tests for the u32 arithmetic binary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { TypeU32 } from '../../../../util/conversion.js';
-import { fullU32Range } from '../../../../util/math.js';
+import { TypeU32, TypeVec } from '../../../../util/conversion.js';
+import { fullU32Range, sparseU32Range, vectorU32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, generateBinaryToU32Cases, run } from '../expression.js';
+import {
+  allInputSources,
+  generateBinaryToU32Cases,
+  generateU32VectorBinaryToVectorCases,
+  generateVectorU32BinaryToVectorCases,
+  run,
+} from '../expression.js';
 
 import { binary } from './binary.js';
 
@@ -61,10 +67,40 @@ export const d = makeCaseCache('binary/u32_arithmetic', {
       return x % y;
     });
   },
+  multiplication_scalar_vector2: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
+      return Math.imul(x, y);
+    });
+  },
+  multiplication_scalar_vector3: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
+      return Math.imul(x, y);
+    });
+  },
+  multiplication_scalar_vector4: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
+      return Math.imul(x, y);
+    });
+  },
+  multiplication_vector2_scalar: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
+      return Math.imul(x, y);
+    });
+  },
+  multiplication_vector3_scalar: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
+      return Math.imul(x, y);
+    });
+  },
+  multiplication_vector4_scalar: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
+      return Math.imul(x, y);
+    });
+  },
 });
 
 g.test('addition')
-  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
     `
 Expression: x + y
@@ -79,7 +115,7 @@ Expression: x + y
   });
 
 g.test('subtraction')
-  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
     `
 Expression: x - y
@@ -94,7 +130,7 @@ Expression: x - y
   });
 
 g.test('multiplication')
-  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
     `
 Expression: x * y
@@ -109,7 +145,7 @@ Expression: x * y
   });
 
 g.test('division')
-  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
     `
 Expression: x / y
@@ -126,7 +162,7 @@ Expression: x / y
   });
 
 g.test('remainder')
-  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
     `
 Expression: x % y
@@ -140,4 +176,38 @@ Expression: x % y
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
     await run(t, binary('%'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('multiplication_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x * y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_rhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_rhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const cases = await d.get(`multiplication_scalar_vector${vec_size}`);
+    await run(t, binary('*'), [TypeU32, vec_type], vec_type, t.params, cases);
+  });
+
+g.test('multiplication_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x * y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const cases = await d.get(`multiplication_vector${vec_size}_scalar`);
+    await run(t, binary('*'), [vec_type, TypeU32], vec_type, t.params, cases);
   });

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -12,6 +12,7 @@ import {
   kFloat16Format,
   kFloat32Format,
   Scalar,
+  u32,
 } from './conversion.js';
 
 /**
@@ -626,6 +627,55 @@ export function fullI32Range(
   ].map(Math.trunc);
 }
 
+/** Short list of u32 values of interest to test against */
+const kInterestingU32Values: number[] = [0, 1, kValue.u32.max / 2, kValue.u32.max];
+
+/** @returns minimal u32 values that cover the entire range of u32 behaviours
+ *
+ * This is used instead of fullU32Range when the number of test cases being
+ * generated is a super linear function of the length of u32 values which is
+ * leading to time outs.
+ */
+export function sparseU32Range(): number[] {
+  return kInterestingU32Values;
+}
+
+const kVectorU32Values = {
+  2: kInterestingU32Values.flatMap(f => [
+    [f, 1],
+    [1, f],
+  ]),
+  3: kInterestingU32Values.flatMap(f => [
+    [f, 1, 2],
+    [1, f, 2],
+    [1, 2, f],
+  ]),
+  4: kInterestingU32Values.flatMap(f => [
+    [f, 1, 2, 3],
+    [1, f, 2, 3],
+    [1, 2, f, 3],
+    [1, 2, 3, f],
+  ]),
+};
+
+/**
+ * Returns set of vectors, indexed by dimension containing interesting u32
+ * values.
+ *
+ * The tests do not do the simple option for coverage of computing the cartesian
+ * product of all of the interesting u32 values N times for vecN tests,
+ * because that creates a huge number of tests for vec3 and vec4, leading to
+ * time outs.
+ *
+ * Instead they insert the interesting u32 values into each location of the
+ * vector to get a spread of testing over the entire range. This reduces the
+ * number of cases being run substantially, but maintains coverage.
+ */
+export function vectorU32Range(dim: number): number[][] {
+  assert(dim === 2 || dim === 3 || dim === 4, 'vectorU32Range only accepts dimensions 2, 3, and 4');
+  return kVectorU32Values[dim];
+}
+
 /**
  * @returns an ascending sorted array of numbers spread over the entire range of 32-bit unsigned ints
  *
@@ -706,7 +756,7 @@ const kVectorF32Values = {
  * because that creates a huge number of tests for vec3 and vec4, leading to
  * time outs.
  *
- *  Instead they insert the interesting f32 values into each location of the
+ * Instead they insert the interesting f32 values into each location of the
  * vector to get a spread of testing over the entire range. This reduces the
  * number of cases being run substantially, but maintains coverage.
  */
@@ -788,6 +838,11 @@ export function quantizeToF32(num: number): number {
 /** @returns the closest 32-bit signed integer value to the input */
 export function quantizeToI32(num: number): number {
   return i32(num).value as number;
+}
+
+/** @returns the closest 32-bit signed integer value to the input */
+export function quantizeToU32(num: number): number {
+  return u32(num).value as number;
 }
 
 /** @returns whether the number is an integer and a power of two */


### PR DESCRIPTION
Issue: #1626 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
