### PR TITLE
Clear pages between pages.

### DIFF
--- a/src/common/tools/run_wpt_ref_tests.ts
+++ b/src/common/tools/run_wpt_ref_tests.ts
@@ -215,11 +215,25 @@ function exists(filename: string) {
   }
 }
 
+async function waitForPageRender(page: Page) {
+  await page.evaluate(() => {
+    return new Promise(resolve => requestAnimationFrame(resolve));
+  });
+}
+
 // returns true if the page timed out.
 async function runPage(page: Page, url: string, refWait: boolean) {
   console.log('  loading:', url);
+  // we need to load about:blank to force the browser to re-render
+  // else the previous page may still be visible if the page we are loading fails
+  await page.goto('about:blank');
+  await page.waitForLoadState('domcontentloaded');
+  await waitForPageRender(page);
+
   await page.goto(url);
   await page.waitForLoadState('domcontentloaded');
+  await waitForPageRender(page);
+
   if (refWait) {
     await page.waitForFunction(() => wptRefTestPageReady());
     const timeout = await page.evaluate(() => wptRefTestGetTimeout());


### PR DESCRIPTION
The ref test runner could potentially take a screenshot of the previous page if the new page didn't render anything. So, load `about:blank` and wait for it to render.




Issue: None

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
