### PR TITLE
Implement the division param restrictions in atan2

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1767,9 +1767,15 @@ g.test('atan2Interval')
       { input: [kValue.f32.subnormal.positive.max, 1], expected: kAny },
       { input: [kValue.f32.subnormal.negative.min, 1], expected: kAny },
 
-      // atan(y/x) ~ 0, test that ULP applied to result, not the intermediate atan(y/x) value
+      // When atan(y/x) ~ 0, test that ULP applied to result of atan2, not the intermediate atan(y/x) value
       {input: [hexToF32(0x80800000), hexToF32(0xbf800000)], expected: [minusNULP(kValue.f32.negative.pi.whole, 4096), plusNULP(kValue.f32.negative.pi.whole, 4096)] },
       {input: [hexToF32(0x00800000), hexToF32(0xbf800000)], expected: [minusNULP(kValue.f32.positive.pi.whole, 4096), plusNULP(kValue.f32.positive.pi.whole, 4096)] },
+
+      // Very large |x| values should cause kAny to be returned, due to the restrictions on division
+      { input: [1, kValue.f32.positive.max], expected: kAny },
+      { input: [1, kValue.f32.positive.nearest_max], expected: kAny },
+      { input: [1, kValue.f32.negative.min], expected: kAny },
+      { input: [1, kValue.f32.negative.nearest_min], expected: kAny },
     ]
   )
   .fn(t => {


### PR DESCRIPTION
Since atan2Interval is no longer using divisionInterval, it needs to implement the same restrictions on inputs.

Issue #2142

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
