### PR TITLE
Make canvas_colorspace_rgba16float ref test more fuzzy

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
@@ -14,6 +14,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU rgba16float canvas with colorSpace set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_colorspace-ref.html" />
+  <meta name=fuzzy content="maxDifference=1;totalPixels=0">
   <script type="module">
     import { runColorSpaceTest } from './canvas_colorspace.html.js';
     runColorSpaceTest('rgba16float');


### PR DESCRIPTION


Issue: #918 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
