### PR TITLE
Adjust fuzzy value on canvas_colorspace_rgba16float ref test

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
@@ -14,7 +14,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU rgba16float canvas with colorSpace set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_colorspace-ref.html" />
-  <meta name=fuzzy content="maxDifference=1;totalPixels=0">
+  <meta name=fuzzy content="maxDifference=0-1;totalPixels=0">
   <script type="module">
     import { runColorSpaceTest } from './canvas_colorspace.html.js';
     runColorSpaceTest('rgba16float');

--- a/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
@@ -14,7 +14,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU rgba16float canvas with colorSpace set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_colorspace-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-1;totalPixels=0">
+  <meta name=fuzzy content="maxDifference=1;totalPixels=8192">
   <script type="module">
     import { runColorSpaceTest } from './canvas_colorspace.html.js';
     runColorSpaceTest('rgba16float');


### PR DESCRIPTION
Seems like according to https://web-platform-tests.org/writing-tests/reftests.html#fuzzy-matching specifying range of `0-1` should make it work since the results of the test are only off by 1. I think that specifying `1` only is expecting an error of at most 1/255 = 0?