### PR TITLE
Adds val,buffer,create,limit tests

### DIFF
--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -8,6 +8,7 @@ import {
   kAllBufferUsageBits,
   kBufferSizeAlignment,
   kBufferUsages,
+  kLimitInfo,
 } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import { kMaxSafeMultipleOf8 } from '../../../util/math.js';
@@ -43,9 +44,26 @@ g.test('size')
     );
   });
 
+g.test('limit')
+  .desc('Test buffer size is validated against maxBufferSize.')
+  .params(u =>
+    u
+      .beginSubcases()
+      .combine('size', [
+        kLimitInfo.maxBufferSize.default - 1,
+        kLimitInfo.maxBufferSize.default,
+        kLimitInfo.maxBufferSize.default + 1,
+      ])
+  )
+  .fn(t => {
+    const { size } = t.params;
+    const isValid = size <= kLimitInfo.maxBufferSize.default;
+    const usage = BufferUsage.COPY_SRC;
+    t.expectGPUError('validation', () => t.device.createBuffer({ size, usage }), !isValid);
+  });
+
 const kInvalidUsage = 0x8000;
 assert((kInvalidUsage & kAllBufferUsageBits) === 0);
-
 g.test('usage')
   .desc('Test combinations of zero to two usage flags are validated to be valid.')
   .params(u =>

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -1050,6 +1050,7 @@ export const kLimitInfo = /* prettier-ignore */ makeTable(
   'minStorageBufferOffsetAlignment':           ['alignment',       256,                          ],
 
   'maxVertexBuffers':                          [           ,         8,                          ],
+  'maxBufferSize':                             [           , 268435456, kMaxUnsignedLongLongValue],
   'maxVertexAttributes':                       [           ,        16,                          ],
   'maxVertexBufferArrayStride':                [           ,      2048,                          ],
   'maxInterStageShaderComponents':             [           ,        60,                          ],


### PR DESCRIPTION
Note that currently in Chrome, the validation error is not actually triggered, rather it is hidden behind a deprecated warning for now.

Issue: #2191

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.
