### PR TITLE
Add a few more debug markers

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/debug.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/debug.spec.ts
@@ -9,6 +9,8 @@ Test Coverage:
       - An error must be generated for non matching counts.
     - Test calling pushDebugGroup with empty and non-empty strings.
     - Test inserting a debug marker with empty and non-empty strings.
+    - Test strings with \0 in them.
+    - Test non-ASCII strings.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
@@ -41,7 +43,7 @@ g.test('debug_group')
     u //
       .combine('encoderType', kEncoderTypes)
       .beginSubcases()
-      .combine('label', ['', 'group'])
+      .combine('label', ['', 'group', 'null\0in\0group\0label', '\0null at beginning', '🌞👆'])
   )
   .fn(t => {
     const { encoder, validateFinishAndSubmit } = t.createEncoder(t.params.encoderType);
@@ -55,7 +57,7 @@ g.test('debug_marker')
     u //
       .combine('encoderType', kEncoderTypes)
       .beginSubcases()
-      .combine('label', ['', 'marker'])
+      .combine('label', ['', 'marker', 'null\0in\0marker', '\0null at beginning', '🌞👆'])
   )
   .fn(t => {
     const { encoder, validateFinishAndSubmit } = t.createEncoder(t.params.encoderType);


### PR DESCRIPTION
There's nothing to test but it's good to know the implementation doesn't crash with unusual labels.




Issue: none

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
