### PR TITLE
Add transferControlToOffscreen cases to colorSpace ref test

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_colorspace.html.ts
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace.html.ts
@@ -20,10 +20,33 @@ function rgba16floatFromRgba8unorm(rgba8Unorm: Uint8Array) {
   return rgba16Float;
 }
 
-export function runColorSpaceTest(format: GPUTextureFormat) {
-  runRefTest(t => {
-    const device = t.device;
+type Transferable = {
+  canvas: HTMLCanvasElement | OffscreenCanvas;
+  textureData: ArrayBuffer;
+  format: GPUTextureFormat;
+  colorSpace: PredefinedColorSpace;
+  alphaMode: GPUCanvasAlphaMode;
+};
 
+function render(
+  device: GPUDevice,
+  { canvas, format, alphaMode, colorSpace, textureData }: Transferable
+) {
+  const context = canvas.getContext('webgpu') as GPUCanvasContext;
+  context.configure({
+    device,
+    format,
+    usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+    alphaMode,
+    colorSpace,
+  });
+
+  const texture = context.getCurrentTexture();
+  device.queue.writeTexture({ texture }, textureData, {}, { width: 4, height: 1 });
+}
+
+export function runColorSpaceTest(format: GPUTextureFormat) {
+  runRefTest(async t => {
     // prettier-ignore
     const kRGBA8UnormData = new Uint8Array([
       0, 255, 0, 255,
@@ -40,8 +63,10 @@ export function runColorSpaceTest(format: GPUTextureFormat) {
       bgra8unorm: kBGRA8UnormData,
       rgba16float: kRGBA16FloatData,
     };
+    const textureData = testData[format].buffer;
 
-    function createCanvas(
+    async function createCanvas(
+      creation: string,
       alphaMode: GPUCanvasAlphaMode,
       format: GPUTextureFormat,
       colorSpace: PredefinedColorSpace
@@ -49,34 +74,64 @@ export function runColorSpaceTest(format: GPUTextureFormat) {
       const canvas = document.createElement('canvas');
       canvas.width = width;
       canvas.height = 1;
-      const context = canvas.getContext('webgpu') as GPUCanvasContext;
-      context.configure({
-        device,
-        format,
-        usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-        alphaMode,
-        colorSpace,
-      });
-
-      const textureData = testData[format];
-      const texture = context.getCurrentTexture();
-      device.queue.writeTexture(
-        { texture },
-        textureData.buffer,
-        {
-          bytesPerRow: textureData.byteLength,
-        },
-        { width: 4, height: 1 }
-      );
       document.body.appendChild(canvas);
+
+      switch (creation) {
+        case 'canvas':
+          render(t.device, { canvas, format, alphaMode, colorSpace, textureData });
+          break;
+
+        case 'transferControlToOffscreen': {
+          const offscreenCanvas = canvas.transferControlToOffscreen();
+          render(t.device, { canvas: offscreenCanvas, format, alphaMode, colorSpace, textureData });
+          break;
+        }
+
+        case 'transferControlToOffscreenWorker': {
+          const offscreenCanvas = canvas.transferControlToOffscreen();
+          const source = `
+          ${render.toString()}
+
+          onmessage = async (event) => {
+            try {
+              const adapter = await navigator.gpu.requestAdapter();
+              const device = await adapter.requestDevice();
+              render(device, event.data);
+              postMessage(true);
+            } catch (e) {
+              postMessage(false);
+            }
+          };
+          `;
+          const blob = new Blob([source], { type: 'application/javascript' });
+          const url = URL.createObjectURL(blob);
+          const worker = new Worker(url);
+          let resolve: (success: boolean) => void;
+          const promise = new Promise(_resolve => (resolve = _resolve));
+          worker.onmessage = event => {
+            resolve(event.data);
+          };
+          worker.postMessage(
+            { canvas: offscreenCanvas, format, alphaMode, colorSpace, textureData },
+            [offscreenCanvas]
+          );
+          await promise;
+          break;
+        }
+      }
     }
 
     const u = kUnitCaseParamsBuilder
       .combine('alphaMode', kCanvasAlphaModes)
-      .combine('colorSpace', kCanvasColorSpaces);
+      .combine('colorSpace', kCanvasColorSpaces)
+      .combine('creation', [
+        'canvas',
+        'transferControlToOffscreen',
+        'transferControlToOffscreenWorker',
+      ]);
 
-    for (const { alphaMode, colorSpace } of u) {
-      createCanvas(alphaMode, format, colorSpace);
+    for (const { alphaMode, colorSpace, creation } of u) {
+      await createCanvas(creation, alphaMode, format, colorSpace);
     }
   });
 }

--- a/src/webgpu/web_platform/reftests/ref/canvas_colorspace-ref.html.ts
+++ b/src/webgpu/web_platform/reftests/ref/canvas_colorspace-ref.html.ts
@@ -27,7 +27,12 @@ function createCanvas(colorSpace: PredefinedColorSpace) {
 
 const u = kUnitCaseParamsBuilder
   .combine('alphaMode', kCanvasAlphaModes)
-  .combine('colorSpace', kCanvasColorSpaces);
+  .combine('colorSpace', kCanvasColorSpaces)
+  .combine('creation', [
+    'canvas',
+    'transferControlToOffscreen',
+    'transferControlToOffscreenWorker',
+  ]);
 
 // Generate reference canvases for all combinations from the test.
 // We only need colorSpace to generate the correct reference.


### PR DESCRIPTION
I'm not sure it makes sense to have them be separate ref test. In fact it's possible we should add transferControlToOffscreen to the image_rendering test and the compositing test, the alpha test, etc...

As it is, all the `transferControlToOffscreen` are not rendered with the correct image-rendering which is why tests fail.


Issue: #941

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
