### PR TITLE
Add tests for u32 scalar-vector addition and subtraction

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -67,6 +67,66 @@ export const d = makeCaseCache('binary/u32_arithmetic', {
       return x % y;
     });
   },
+  addition_scalar_vector2: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
+      return x + y;
+    });
+  },
+  addition_scalar_vector3: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
+      return x + y;
+    });
+  },
+  addition_scalar_vector4: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
+      return x + y;
+    });
+  },
+  addition_vector2_scalar: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
+      return x + y;
+    });
+  },
+  addition_vector3_scalar: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
+      return x + y;
+    });
+  },
+  addition_vector4_scalar: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
+      return x + y;
+    });
+  },
+  subtraction_scalar_vector2: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
+      return x - y;
+    });
+  },
+  subtraction_scalar_vector3: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
+      return x - y;
+    });
+  },
+  subtraction_scalar_vector4: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
+      return x - y;
+    });
+  },
+  subtraction_vector2_scalar: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
+      return x - y;
+    });
+  },
+  subtraction_vector3_scalar: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
+      return x - y;
+    });
+  },
+  subtraction_vector4_scalar: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
+      return x - y;
+    });
+  },
   multiplication_scalar_vector2: () => {
     return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
       return Math.imul(x, y);
@@ -176,6 +236,74 @@ Expression: x % y
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
     await run(t, binary('%'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('addition_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x + y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_rhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_rhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const cases = await d.get(`addition_scalar_vector${vec_size}`);
+    await run(t, binary('+'), [TypeU32, vec_type], vec_type, t.params, cases);
+  });
+
+g.test('addition_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x + y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const cases = await d.get(`addition_vector${vec_size}_scalar`);
+    await run(t, binary('+'), [vec_type, TypeU32], vec_type, t.params, cases);
+  });
+
+g.test('subtraction_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x - y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_rhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_rhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const cases = await d.get(`subtraction_scalar_vector${vec_size}`);
+    await run(t, binary('-'), [TypeU32, vec_type], vec_type, t.params, cases);
+  });
+
+g.test('subtraction_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x - y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const cases = await d.get(`subtraction_vector${vec_size}_scalar`);
+    await run(t, binary('-'), [vec_type, TypeU32], vec_type, t.params, cases);
   });
 
 g.test('multiplication_scalar_vector')


### PR DESCRIPTION
Issue: #1626 

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
