### PR TITLE
Added sourcmaps to webgpu:api,operation,shader_module,compilation_info

### DIFF
--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -3,6 +3,7 @@ ShaderModule CompilationInfo tests.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { assert } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
 
@@ -67,22 +68,67 @@ const kInvalidShaderSources = [
 
 const kAllShaderSources = [...kValidShaderSources, ...kInvalidShaderSources];
 
+// This is the source the sourcemap refers to.
+const kOriginalSource = new Array(20)
+  .fill(0)
+  .map((_, i) => `original line ${i}`)
+  .join('\n');
+
+const kSourceMaps: { [name: string]: undefined | object } = {
+  none: undefined,
+  empty: {},
+  // A valid source map. It maps `unknown` on lines 4 and line 5 to
+  // `wasUnknown` from lines 20, 21 respectively
+  valid: {
+    version: 3,
+    sources: ['myCode'],
+    sourcesContent: [kOriginalSource],
+    names: ['myMain', 'wasUnknown'],
+    mappings: ';kBAYkCA,OACd;SAElB;gBAKOC;gBACAA',
+  },
+  // not a valid sourcemap
+  invalid: {
+    version: -123,
+    notAnything: {},
+  },
+  // The correct format but this data is for lines 11,12 even
+  // though the source only has 5 or 6 lines
+  nonMatching: {
+    version: 3,
+    sources: ['myCode'],
+    sourcesContent: [kOriginalSource],
+    names: ['myMain'],
+    mappings: ';;;;;;;;;;kBAYkCA,OACd;SAElB',
+  },
+};
+const kSourceMapsKeys = keysOf(kSourceMaps);
+
 g.test('compilationInfo_returns')
   .desc(
     `
     Test that compilationInfo() can be called on any ShaderModule.
+
+    Note: sourcemaps are not used in the WebGPU API. We are only testing that
+    browser that happen to use them don't fail or crash if the sourcemap is
+    bad or invalid.
+
     - Test for both valid and invalid shader modules.
     - Test for shader modules containing only ASCII and those containing unicode characters.
     - Test that the compilation info for valid shader modules contains no errors.
     - Test that the compilation info for invalid shader modules contains at least one error.`
   )
-  .paramsSimple(kAllShaderSources)
+  .params(u =>
+    u.combineWithParams(kAllShaderSources).beginSubcases().combine('sourceMapName', kSourceMapsKeys)
+  )
   .fn(async t => {
-    const { _code, valid } = t.params;
+    const { _code, valid, sourceMapName } = t.params;
 
     const shaderModule = t.expectGPUError(
       'validation',
-      () => t.device.createShaderModule({ code: _code }),
+      () => {
+        const sourceMap = kSourceMaps[sourceMapName];
+        return t.device.createShaderModule({ code: _code, ...(sourceMap && { sourceMap }) });
+      },
       !valid
     );
 
@@ -113,16 +159,27 @@ g.test('line_number_and_position')
     `
     Test that line numbers reported by compilationInfo either point at an appropriate line and
     position or at 0:0, indicating an unknown position.
+
+    Note: sourcemaps are not used in the WebGPU API. We are only testing that
+    browser that happen to use them don't fail or crash if the sourcemap is
+    bad or invalid.
+
     - Test for invalid shader modules containing containing at least one error.
     - Test for shader modules containing only ASCII and those containing unicode characters.`
   )
-  .paramsSimple(kInvalidShaderSources)
+  .params(u =>
+    u
+      .combineWithParams(kInvalidShaderSources)
+      .beginSubcases()
+      .combine('sourceMapName', kSourceMapsKeys)
+  )
   .fn(async t => {
-    const { _code, _errorLine } = t.params;
+    const { _code, _errorLine, sourceMapName } = t.params;
 
-    const shaderModule = t.expectGPUError('validation', () =>
-      t.device.createShaderModule({ code: _code })
-    );
+    const shaderModule = t.expectGPUError('validation', () => {
+      const sourceMap = kSourceMaps[sourceMapName];
+      return t.device.createShaderModule({ code: _code, ...(sourceMap && { sourceMap }) });
+    });
 
     const info = await shaderModule.compilationInfo();
 
@@ -155,16 +212,26 @@ g.test('line_number_and_position')
 g.test('offset_and_length')
   .desc(
     `Test that message offsets and lengths are valid and align with any reported lineNum and linePos.
+
+     Note: sourcemaps are not used in the WebGPU API. We are only testing that
+     browser that happen to use them don't fail or crash if the sourcemap is
+     bad or invalid.
+
     - Test for valid and invalid shader modules.
     - Test for shader modules containing only ASCII and those containing unicode characters.`
   )
-  .paramsSimple(kAllShaderSources)
+  .params(u =>
+    u.combineWithParams(kAllShaderSources).beginSubcases().combine('sourceMapName', kSourceMapsKeys)
+  )
   .fn(async t => {
-    const { _code, valid } = t.params;
+    const { _code, valid, sourceMapName } = t.params;
 
     const shaderModule = t.expectGPUError(
       'validation',
-      () => t.device.createShaderModule({ code: _code }),
+      () => {
+        const sourceMap = kSourceMaps[sourceMapName];
+        return t.device.createShaderModule({ code: _code, ...(sourceMap && { sourceMap }) });
+      },
       !valid
     );
 


### PR DESCRIPTION
This seemed like the appropriate place to add them as it was already checking for correct line numbers and offsets

Issue: #2209

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
