### PR TITLE
Fix package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "0.1.22",
+        "@webgpu/types": "0.1.25",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1261,10 +1261,13 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.22.tgz",
-      "integrity": "sha512-RrohwhHOIlczHX8q10AHYaegfeFIgQBLhHj4IKFWv8wb29annYz8jbl2citFiA1XbRnAU1ZozEvRJCiZZu4fkA==",
-      "dev": true
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-XTlMU1fEbVqIwuQAqlA0w8lJepW4KqeGmUxwWioVL0aoVgut0PE4ex+ixQWM74JKAyRfvS9+0lp+dFMfx5KZvw==",
+      "dev": true,
+      "dependencies": {
+        "typescript": "^4.6.4"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -9874,10 +9877,13 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.22.tgz",
-      "integrity": "sha512-RrohwhHOIlczHX8q10AHYaegfeFIgQBLhHj4IKFWv8wb29annYz8jbl2citFiA1XbRnAU1ZozEvRJCiZZu4fkA==",
-      "dev": true
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-XTlMU1fEbVqIwuQAqlA0w8lJepW4KqeGmUxwWioVL0aoVgut0PE4ex+ixQWM74JKAyRfvS9+0lp+dFMfx5KZvw==",
+      "dev": true,
+      "requires": {
+        "typescript": "^4.6.4"
+      }
     },
     "abbrev": {
       "version": "1.1.1",


### PR DESCRIPTION
After editing package.json you need to run `npm i` and check in the changes to package-lock.json otherwise `npm ci` complains the 2 are not in sync




Issue: #none

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
