### PR TITLE
Add tests for u32 scalar-vector division

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -17,243 +17,207 @@ import {
 
 import { binary } from './binary.js';
 
+function u32_add(x: number, y: number): number | undefined {
+  return x + y;
+}
+
+function u32_subtract(x: number, y: number): number | undefined {
+  return x - y;
+}
+
+function u32_multiply(x: number, y: number): number | undefined {
+  return Math.imul(x, y);
+}
+
+function u32_divide_non_const(x: number, y: number): number | undefined {
+  if (y === 0) {
+    return x;
+  }
+  return x / y;
+}
+
+function u32_divide_const(x: number, y: number): number | undefined {
+  if (y === 0) {
+    return undefined;
+  }
+  return x / y;
+}
+
+function u32_remainder_non_const(x: number, y: number): number | undefined {
+  if (y === 0) {
+    return 0;
+  }
+  return x % y;
+}
+
+function u32_remainder_const(x: number, y: number): number | undefined {
+  if (y === 0) {
+    return undefined;
+  }
+  return x % y;
+}
+
 export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('binary/u32_arithmetic', {
   addition: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
-      return x + y;
-    });
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_add);
   },
   subtraction: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
-      return x - y;
-    });
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_subtract);
   },
   multiplication: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
-      return Math.imul(x, y);
-    });
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_multiply);
   },
   division_non_const: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
-      if (y === 0) {
-        return x;
-      }
-      return x / y;
-    });
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_divide_non_const);
   },
   division_const: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
-      if (y === 0) {
-        return undefined;
-      }
-      return x / y;
-    });
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_divide_const);
   },
   remainder_non_const: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
-      if (y === 0) {
-        return 0;
-      }
-      return x % y;
-    });
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_remainder_non_const);
   },
   remainder_const: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), (x, y) => {
-      if (y === 0) {
-        return undefined;
-      }
-      return x % y;
-    });
+    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_remainder_const);
   },
   addition_scalar_vector2: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
-      return x + y;
-    });
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), u32_add);
   },
   addition_scalar_vector3: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
-      return x + y;
-    });
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), u32_add);
   },
   addition_scalar_vector4: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
-      return x + y;
-    });
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), u32_add);
   },
   addition_vector2_scalar: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
-      return x + y;
-    });
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), u32_add);
   },
   addition_vector3_scalar: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
-      return x + y;
-    });
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), u32_add);
   },
   addition_vector4_scalar: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
-      return x + y;
-    });
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), u32_add);
   },
   subtraction_scalar_vector2: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
-      return x - y;
-    });
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), u32_subtract);
   },
   subtraction_scalar_vector3: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
-      return x - y;
-    });
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), u32_subtract);
   },
   subtraction_scalar_vector4: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
-      return x - y;
-    });
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), u32_subtract);
   },
   subtraction_vector2_scalar: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
-      return x - y;
-    });
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), u32_subtract);
   },
   subtraction_vector3_scalar: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
-      return x - y;
-    });
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), u32_subtract);
   },
   subtraction_vector4_scalar: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
-      return x - y;
-    });
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), u32_subtract);
   },
   multiplication_scalar_vector2: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
-      return Math.imul(x, y);
-    });
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), u32_multiply);
   },
   multiplication_scalar_vector3: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
-      return Math.imul(x, y);
-    });
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), u32_multiply);
   },
   multiplication_scalar_vector4: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
-      return Math.imul(x, y);
-    });
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), u32_multiply);
   },
   multiplication_vector2_scalar: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
-      return Math.imul(x, y);
-    });
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), u32_multiply);
   },
   multiplication_vector3_scalar: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
-      return Math.imul(x, y);
-    });
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), u32_multiply);
   },
   multiplication_vector4_scalar: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
-      return Math.imul(x, y);
-    });
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), u32_multiply);
   },
-
   division_scalar_vector2_non_const: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
-      if (y === 0) {
-        return x;
-      }
-      return x / y;
-    });
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(2),
+      u32_divide_non_const
+    );
   },
   division_scalar_vector3_non_const: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
-      if (y === 0) {
-        return x;
-      }
-      return x / y;
-    });
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(3),
+      u32_divide_non_const
+    );
   },
   division_scalar_vector4_non_const: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
-      if (y === 0) {
-        return x;
-      }
-      return x / y;
-    });
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(4),
+      u32_divide_non_const
+    );
   },
   division_vector2_scalar_non_const: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
-      if (y === 0) {
-        return x;
-      }
-      return x / y;
-    });
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(2),
+      sparseU32Range(),
+      u32_divide_non_const
+    );
   },
   division_vector3_scalar_non_const: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
-      if (y === 0) {
-        return x;
-      }
-      return x / y;
-    });
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(3),
+      sparseU32Range(),
+      u32_divide_non_const
+    );
   },
   division_vector4_scalar_non_const: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
-      if (y === 0) {
-        return x;
-      }
-      return x / y;
-    });
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(4),
+      sparseU32Range(),
+      u32_divide_non_const
+    );
   },
-
   division_scalar_vector2_const: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
-      if (y === 0) {
-        return undefined;
-      }
-      return x / y;
-    });
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(2),
+      u32_divide_const
+    );
   },
   division_scalar_vector3_const: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
-      if (y === 0) {
-        return undefined;
-      }
-      return x / y;
-    });
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(3),
+      u32_divide_const
+    );
   },
   division_scalar_vector4_const: () => {
-    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
-      if (y === 0) {
-        return undefined;
-      }
-      return x / y;
-    });
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(4),
+      u32_divide_const
+    );
   },
   division_vector2_scalar_const: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
-      if (y === 0) {
-        return undefined;
-      }
-      return x / y;
-    });
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(2),
+      sparseU32Range(),
+      u32_divide_const
+    );
   },
   division_vector3_scalar_const: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
-      if (y === 0) {
-        return undefined;
-      }
-      return x / y;
-    });
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(3),
+      sparseU32Range(),
+      u32_divide_const
+    );
   },
   division_vector4_scalar_const: () => {
-    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
-      if (y === 0) {
-        return undefined;
-      }
-      return x / y;
-    });
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(4),
+      sparseU32Range(),
+      u32_divide_const
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -157,6 +157,104 @@ export const d = makeCaseCache('binary/u32_arithmetic', {
       return Math.imul(x, y);
     });
   },
+
+  division_scalar_vector2_non_const: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
+      if (y === 0) {
+        return x;
+      }
+      return x / y;
+    });
+  },
+  division_scalar_vector3_non_const: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
+      if (y === 0) {
+        return x;
+      }
+      return x / y;
+    });
+  },
+  division_scalar_vector4_non_const: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
+      if (y === 0) {
+        return x;
+      }
+      return x / y;
+    });
+  },
+  division_vector2_scalar_non_const: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
+      if (y === 0) {
+        return x;
+      }
+      return x / y;
+    });
+  },
+  division_vector3_scalar_non_const: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
+      if (y === 0) {
+        return x;
+      }
+      return x / y;
+    });
+  },
+  division_vector4_scalar_non_const: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
+      if (y === 0) {
+        return x;
+      }
+      return x / y;
+    });
+  },
+
+  division_scalar_vector2_const: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      return x / y;
+    });
+  },
+  division_scalar_vector3_const: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(3), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      return x / y;
+    });
+  },
+  division_scalar_vector4_const: () => {
+    return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(4), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      return x / y;
+    });
+  },
+  division_vector2_scalar_const: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(2), sparseU32Range(), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      return x / y;
+    });
+  },
+  division_vector3_scalar_const: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(3), sparseU32Range(), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      return x / y;
+    });
+  },
+  division_vector4_scalar_const: () => {
+    return generateVectorU32BinaryToVectorCases(vectorU32Range(4), sparseU32Range(), (x, y) => {
+      if (y === 0) {
+        return undefined;
+      }
+      return x / y;
+    });
+  },
 });
 
 g.test('addition')
@@ -338,4 +436,40 @@ Expression: x * y
     const vec_type = TypeVec(vec_size, TypeU32);
     const cases = await d.get(`multiplication_vector${vec_size}_scalar`);
     await run(t, binary('*'), [vec_type, TypeU32], vec_type, t.params, cases);
+  });
+
+g.test('division_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x / y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_rhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_rhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
+    const cases = await d.get(`division_scalar_vector${vec_size}_${source}`);
+    await run(t, binary('/'), [TypeU32, vec_type], vec_type, t.params, cases);
+  });
+
+g.test('division_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x / y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
+    const cases = await d.get(`division_vector${vec_size}_scalar_${source}`);
+    await run(t, binary('/'), [vec_type, TypeU32], vec_type, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -1036,7 +1036,11 @@ export function generateBinaryToI32Cases(
   }, new Array<Case>());
 }
 
-export interface BinaryToU32Op {
+/**
+ * A function that performs a binary operation on x and y, and returns the expected
+ * result.
+ */
+export interface BinaryOp {
   (x: number, y: number): number | undefined;
 }
 
@@ -1046,11 +1050,7 @@ export interface BinaryToU32Op {
  * @param param1s array of inputs to try for the second param
  * @param op callback called on each pair of inputs to produce each case
  */
-export function generateBinaryToU32Cases(
-  params0s: number[],
-  params1s: number[],
-  op: BinaryToU32Op
-) {
+export function generateBinaryToU32Cases(params0s: number[], params1s: number[], op: BinaryOp) {
   return cartesianProduct(params0s, params1s).reduce((cases, e) => {
     const expected = op(e[0], e[1]);
     if (expected !== undefined) {
@@ -1061,26 +1061,25 @@ export function generateBinaryToU32Cases(
 }
 
 /**
- * A function that performs a binary operation on x and y, and returns the expected
- * result.
- */
-export interface BinaryOp {
-  (x: number, y: number): number;
-}
-
-/**
  * @returns a Case for the input params with op applied
  * @param scalar scalar param
  * @param vector vector param (2, 3, or 4 elements)
  * @param op the op to apply to scalar and vector
  */
-function makeU32VectorBinaryToVectorCase(scalar: number, vector: number[], op: BinaryOp): Case {
+function makeU32VectorBinaryToVectorCase(
+  scalar: number,
+  vector: number[],
+  op: BinaryOp
+): Case | undefined {
   scalar = quantizeToU32(scalar);
   vector = vector.map(quantizeToU32);
-  const result = new Vector(vector.map(v => u32(op(scalar, v))));
+  const result = vector.map(v => op(scalar, v));
+  if (result.includes(undefined)) {
+    return undefined;
+  }
   return {
     input: [u32(scalar), new Vector(vector.map(u32))],
-    expected: result,
+    expected: new Vector((result as number[]).map(u32)),
   };
 }
 
@@ -1095,11 +1094,16 @@ export function generateU32VectorBinaryToVectorCases(
   vectors: number[][],
   op: BinaryOp
 ): Case[] {
-  return scalars.flatMap(s => {
-    return vectors.map(v => {
-      return makeU32VectorBinaryToVectorCase(s, v, op);
+  const cases = new Array<Case>();
+  scalars.forEach(s => {
+    vectors.forEach(v => {
+      const c = makeU32VectorBinaryToVectorCase(s, v, op);
+      if (c !== undefined) {
+        cases.push(c);
+      }
     });
   });
+  return cases;
 }
 
 /**
@@ -1108,13 +1112,20 @@ export function generateU32VectorBinaryToVectorCases(
  * @param scalar scalar param
  * @param op the op to apply to vector and scalar
  */
-function makeVectorU32BinaryToVectorCase(vector: number[], scalar: number, op: BinaryOp): Case {
+function makeVectorU32BinaryToVectorCase(
+  vector: number[],
+  scalar: number,
+  op: BinaryOp
+): Case | undefined {
   vector = vector.map(quantizeToU32);
   scalar = quantizeToU32(scalar);
-  const result = new Vector(vector.map(v => u32(op(v, scalar))));
+  const result = vector.map(v => op(v, scalar));
+  if (result.includes(undefined)) {
+    return undefined;
+  }
   return {
     input: [new Vector(vector.map(u32)), u32(scalar)],
-    expected: result,
+    expected: new Vector((result as number[]).map(u32)),
   };
 }
 
@@ -1129,9 +1140,14 @@ export function generateVectorU32BinaryToVectorCases(
   scalars: number[],
   op: BinaryOp
 ): Case[] {
-  return scalars.flatMap(s => {
-    return vectors.map(v => {
-      return makeVectorU32BinaryToVectorCase(v, s, op);
+  const cases = new Array<Case>();
+  scalars.forEach(s => {
+    vectors.forEach(v => {
+      const c = makeVectorU32BinaryToVectorCase(v, s, op);
+      if (c !== undefined) {
+        cases.push(c);
+      }
     });
   });
+  return cases;
 }


### PR DESCRIPTION
Issue: #1626 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
