### PR TITLE
Add test for u32 scalar-vector remainder

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -219,6 +219,90 @@ export const d = makeCaseCache('binary/u32_arithmetic', {
       u32_divide_const
     );
   },
+  remainder_scalar_vector2_non_const: () => {
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(2),
+      u32_remainder_non_const
+    );
+  },
+  remainder_scalar_vector3_non_const: () => {
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(3),
+      u32_remainder_non_const
+    );
+  },
+  remainder_scalar_vector4_non_const: () => {
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(4),
+      u32_remainder_non_const
+    );
+  },
+  remainder_vector2_scalar_non_const: () => {
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(2),
+      sparseU32Range(),
+      u32_remainder_non_const
+    );
+  },
+  remainder_vector3_scalar_non_const: () => {
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(3),
+      sparseU32Range(),
+      u32_remainder_non_const
+    );
+  },
+  remainder_vector4_scalar_non_const: () => {
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(4),
+      sparseU32Range(),
+      u32_remainder_non_const
+    );
+  },
+  remainder_scalar_vector2_const: () => {
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(2),
+      u32_remainder_const
+    );
+  },
+  remainder_scalar_vector3_const: () => {
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(3),
+      u32_remainder_const
+    );
+  },
+  remainder_scalar_vector4_const: () => {
+    return generateU32VectorBinaryToVectorCases(
+      sparseU32Range(),
+      vectorU32Range(4),
+      u32_remainder_const
+    );
+  },
+  remainder_vector2_scalar_const: () => {
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(2),
+      sparseU32Range(),
+      u32_remainder_const
+    );
+  },
+  remainder_vector3_scalar_const: () => {
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(3),
+      sparseU32Range(),
+      u32_remainder_const
+    );
+  },
+  remainder_vector4_scalar_const: () => {
+    return generateVectorU32BinaryToVectorCases(
+      vectorU32Range(4),
+      sparseU32Range(),
+      u32_remainder_const
+    );
+  },
 });
 
 g.test('addition')
@@ -436,4 +520,40 @@ Expression: x / y
     const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
     const cases = await d.get(`division_vector${vec_size}_scalar_${source}`);
     await run(t, binary('/'), [vec_type, TypeU32], vec_type, t.params, cases);
+  });
+
+g.test('remainder_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x % y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_rhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_rhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
+    const cases = await d.get(`remainder_scalar_vector${vec_size}_${source}`);
+    await run(t, binary('%'), [TypeU32, vec_type], vec_type, t.params, cases);
+  });
+
+g.test('remainder_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x % y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
+    const cases = await d.get(`remainder_vector${vec_size}_scalar_${source}`);
+    await run(t, binary('%'), [vec_type, TypeU32], vec_type, t.params, cases);
   });


### PR DESCRIPTION
Issue: #1626

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
