### PR TITLE
Test destroying an invalid queryset and an invalid texture

### DIFF
--- a/src/webgpu/api/validation/query_set/destroy.spec.ts
+++ b/src/webgpu/api/validation/query_set/destroy.spec.ts
@@ -13,3 +13,21 @@ g.test('twice').fn(t => {
   qset.destroy();
   qset.destroy();
 });
+
+g.test('invalid_queryset')
+  .desc('Test that invalid querysets may be destroyed without generating validation errors.')
+  .fn(async t => {
+    t.device.pushErrorScope('validation');
+
+    const invalidQuerySet = t.device.createQuerySet({
+      type: 'occlusion',
+      count: 4097, // 4096 is the limit
+    });
+
+    // Expect error because it's invalid.
+    const error = await t.device.popErrorScope();
+    t.expect(!!error);
+
+    // This line should not generate an error
+    invalidQuerySet.destroy();
+  });

--- a/src/webgpu/api/validation/texture/destroy.spec.ts
+++ b/src/webgpu/api/validation/texture/destroy.spec.ts
@@ -23,6 +23,25 @@ g.test('twice')
     texture.destroy();
   });
 
+g.test('invalid_texture')
+  .desc('Test that invalid textures may be destroyed without generating validation errors.')
+  .fn(async t => {
+    t.device.pushErrorScope('validation');
+
+    const invalidTexture = t.device.createTexture({
+      size: [t.device.limits.maxTextureDimension2D + 1, 1, 1],
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING,
+    });
+
+    // Expect error because it's invalid.
+    const error = await t.device.popErrorScope();
+    t.expect(!!error);
+
+    // This line should not generate an error
+    invalidTexture.destroy();
+  });
+
 g.test('submit_a_destroyed_texture_as_attachment')
   .desc(
     `


### PR DESCRIPTION
According to the spec these should not generate errors
Note: Buffer is already tested


Chrome fails both of these tests.

Issue: #2222

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
