### PR TITLE
Fix a few spelling errors

### DIFF
--- a/src/common/runtime/server.ts
+++ b/src/common/runtime/server.ts
@@ -100,7 +100,7 @@ for (let i = 0; i < sys.args.length; ++i) {
     } else if (a === '--verbose') {
       verbose = true;
     } else {
-      console.log(`unrecognised flag: ${a}`);
+      console.log(`unrecognized flag: ${a}`);
     }
   }
 }

--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -17,7 +17,7 @@ export const g = makeTestGroup(Fixture);
 g.test('default')
   .desc(
     `
-    Test requesting the device with a variation of default paramters.
+    Test requesting the device with a variation of default parameters.
     - No features listed in default device
     - Default limits`
   )

--- a/src/webgpu/api/operation/memory_sync/buffer/multiple_buffers.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/multiple_buffers.spec.ts
@@ -2,7 +2,7 @@ export const description = `
 Memory Synchronization Tests for multiple buffers: read before write, read after write, and write after write.
 
 - Create multiple src buffers and initialize it to 0, wait on the fence to ensure the data is initialized.
-Write Op: write a value (say 1) into the src buffer via render pass, copmute pass, copy, write buffer, etc.
+Write Op: write a value (say 1) into the src buffer via render pass, compute pass, copy, write buffer, etc.
 Read Op: read the value from the src buffer and write it to dst buffer via render pass (vertex, index, indirect input, uniform, storage), compute pass, copy etc.
 Wait on another fence, then call expectContents to verify the dst buffer value.
   - x= write op: {storage buffer in {compute, render, render-via-bundle}, t2b copy dst, b2b copy dst, writeBuffer}

--- a/src/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.ts
@@ -2,7 +2,7 @@ export const description = `
 Memory Synchronization Tests for Buffer: read before write, read after write, and write after write.
 
 - Create a src buffer and initialize it to 0, wait on the fence to ensure the data is initialized.
-Write Op: write a value (say 1) into the src buffer via render pass, copmute pass, copy, write buffer, etc.
+Write Op: write a value (say 1) into the src buffer via render pass, compute pass, copy, write buffer, etc.
 Read Op: read the value from the src buffer and write it to dst buffer via render pass (vertex, index, indirect input, uniform, storage), compute pass, copy etc.
 Wait on another fence, then call expectContents to verify the dst buffer value.
   - x= write op: {storage buffer in {compute, render, render-via-bundle}, t2b copy dst, b2b copy dst, writeBuffer}
@@ -164,7 +164,7 @@ g.test('ww')
     t.verifyData(buffer, 2);
   });
 
-// Cases with loose render result guarentees.
+// Cases with loose render result guarantees.
 
 g.test('two_draws_in_the_same_render_pass')
   .desc(

--- a/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
@@ -194,7 +194,7 @@ g.test('offset_alignment')
   });
 
 g.test('overflow')
-  .desc(`Test that clears which may cause arthimetic overflows are invalid.`)
+  .desc(`Test that clears which may cause arithmetic overflows are invalid.`)
   .paramsSubcasesOnly([
     { offset: 0, size: kMaxSafeMultipleOf8 },
     { offset: 16, size: kMaxSafeMultipleOf8 },

--- a/src/webgpu/api/validation/error_scope.spec.ts
+++ b/src/webgpu/api/validation/error_scope.spec.ts
@@ -240,7 +240,7 @@ Tests that sibling error scopes need to be balanced.
     }
 
     {
-      // Trying to pop an additional non-exisiting scope should reject.
+      // Trying to pop an additional non-existing scope should reject.
       const promise = t.device.popErrorScope();
       t.shouldReject('OperationError', promise);
     }
@@ -276,7 +276,7 @@ Tests that nested error scopes need to be balanced.
     t.expect(errors.every(e => e === null));
 
     {
-      // Trying to pop an additional non-exisiting scope should reject.
+      // Trying to pop an additional non-existing scope should reject.
       const promise = t.device.popErrorScope();
       t.shouldReject('OperationError', promise);
     }

--- a/src/webgpu/api/validation/shader_module/entry_point.spec.ts
+++ b/src/webgpu/api/validation/shader_module/entry_point.spec.ts
@@ -11,7 +11,7 @@ The entryPoint assigned in descriptor include:
 
 TODO:
 - Test unicode normalization (gpuweb/gpuweb#1160)
-- Fine-tune test cases to reduce number by removing trivially similiar cases
+- Fine-tune test cases to reduce number by removing trivially similar cases
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -325,7 +325,7 @@ g.test('createBindGroup')
   .desc(
     `
 Tests creating bind group on destroyed device. Tests valid combinations of:
-  - Various binded resource types
+  - Various bound resource types
   - Various valid binding entries
   - Maximum set of visibility for each binding entry
   `

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1074,7 +1074,7 @@ export function TextureTestMixin<F extends FixtureClass<GPUTest>>(
         const coordKey = JSON.stringify(coord);
         coords.push(coord);
 
-        // Compute the minimum sub-rect that enconpasses all the pixel comparisons. The
+        // Compute the minimum sub-rect that encompasses all the pixel comparisons. The
         // `lowerCorner` will become the origin, and the `upperCorner` will be used to compute the
         // size.
         lowerCorner[0] = Math.min(lowerCorner[0], coord.x);


### PR DESCRIPTION


Issue: #None
<hr>


**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
