### PR TITLE
Remove tests of end pass twice in encoder_state.spec.ts

### DIFF
--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -52,8 +52,6 @@ g.test('pass_end_invalid_order')
     `
   Test that beginning a {compute,render} pass before ending the previous {compute,render} pass
   causes an error.
-
-  TODO: Update this test according to https://github.com/gpuweb/gpuweb/issues/2464
   `
   )
   .params(u =>
@@ -63,6 +61,8 @@ g.test('pass_end_invalid_order')
       .beginSubcases()
       .combine('firstPassEnd', [true, false])
       .combine('endPasses', [[], [0], [1], [0, 1], [1, 0]])
+      // Don't end the first pass multiple times (that generates a validation error but doesn't invalidate the encoder)
+      .unless(p => p.firstPassEnd && p.endPasses.includes(0))
   )
   .fn(t => {
     const { pass0Type, pass1Type, firstPassEnd, endPasses } = t.params;


### PR DESCRIPTION
End pass twice leads to validation error immediately. The validation error must be reported before finish(). And finish() might be valid. So, the tests are incorrect according to latest WebGPU spec.

See the discussion for end pass twice at this issue: https://github.com/gpuweb/gpuweb/issues/2464

And end pass twice related tests have already been covered in other test file. So this change simply removes corresponding tests in encoder_state.




Issue: #1914

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
