### PR TITLE
Add limit tests for maxTextureDimension1/2/3D

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -1,0 +1,284 @@
+import { Fixture } from '../../../../../common/framework/fixture.js';
+import { kUnitCaseParamsBuilder } from '../../../../../common/framework/params_builder.js';
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../../common/util/data_tables.js';
+import { getGPU } from '../../../../../common/util/navigator_gpu.js';
+import { assert } from '../../../../../common/util/util.js';
+import { kLimitInfo } from '../../../../capability_info.js';
+
+type GPUSupportedLimit = keyof GPUSupportedLimits;
+
+export const TestValue = {
+  atLimit: true,
+  overLimit: true,
+};
+
+export const kTestValueKeys = keysOf(TestValue);
+
+export function getTestValue(limit: number, testValue: keyof typeof TestValue) {
+  switch (testValue) {
+    case 'atLimit':
+      return limit;
+    case 'overLimit':
+      return limit + 1;
+  }
+}
+
+export const LimitValueTest = {
+  atDefault: true,
+  underDefault: true,
+  atMaximum: true,
+  overMaximum: true,
+};
+export const kLimitValueTestKeys = keysOf(LimitValueTest);
+
+function getLimitValue(
+  defaultLimit: number,
+  maximumLimit: number,
+  limitValueTest: keyof typeof LimitValueTest
+) {
+  switch (limitValueTest) {
+    case 'atDefault':
+      return defaultLimit;
+    case 'underDefault':
+      return defaultLimit - 1;
+    case 'atMaximum':
+      return maximumLimit;
+    case 'overMaximum':
+      return maximumLimit + 1;
+  }
+}
+
+export type DeviceAndLimits = {
+  device: GPUDevice;
+  defaultLimit: number;
+  maximumLimit: number;
+  requestedLimit: number;
+  actualLimit: number;
+};
+
+export type LimitTestInputs = DeviceAndLimits & {
+  testValueName: keyof typeof TestValue;
+  testValue: number;
+  shouldError: boolean;
+};
+
+/**
+ * Adds the default parameters to a limit test
+ */
+export const kLimitBaseParams = kUnitCaseParamsBuilder
+  .combine('limitTest', kLimitValueTestKeys)
+  .beginSubcases()
+  .combine('testValueName', kTestValueKeys);
+
+export class LimitTestsImpl extends Fixture {
+  _device: GPUDevice | undefined = undefined;
+  limit: GPUSupportedLimit = '' as GPUSupportedLimit;
+
+  get device(): GPUDevice {
+    assert(
+      this._device !== undefined,
+      'device is only valid in testDeviceWithRequestedLimits callback'
+    );
+    return this._device;
+  }
+
+  async requestDeviceWithLimits(
+    limitValueTest: keyof typeof LimitValueTest,
+    adapter: GPUAdapter,
+    requiredLimits: Record<string, number>
+  ) {
+    switch (limitValueTest) {
+      case 'overMaximum':
+        this.shouldReject('OperationError', adapter.requestDevice({ requiredLimits }));
+        return undefined;
+      default:
+        return await adapter.requestDevice({ requiredLimits });
+    }
+  }
+
+  /**
+   * Gets a device with the adapter a requested limit and checks that that limit
+   * is correct or that the device failed to create if the requested limit is
+   * beyond the maximum supported by the device.
+   */
+  async _getDeviceWithRequestedLimit(
+    limitValueTest: keyof typeof LimitValueTest
+  ): Promise<DeviceAndLimits | undefined> {
+    const limit = this.limit;
+    const gpu = getGPU();
+    const adapter = await gpu.requestAdapter();
+    assert(!!adapter);
+
+    const defaultLimit = (kLimitInfo as Record<string, { default: number }>)[limit].default;
+    const maximumLimit = adapter.limits[limit] as number;
+    assert(!Number.isNaN(defaultLimit));
+    assert(!Number.isNaN(maximumLimit));
+
+    const requestedLimit = getLimitValue(defaultLimit, maximumLimit, limitValueTest);
+
+    const requiredLimits: Record<string, number> = {};
+    requiredLimits[limit] = requestedLimit;
+
+    const device = await this.requestDeviceWithLimits(limitValueTest, adapter, requiredLimits);
+    const actualLimit = (device ? device.limits[limit] : 0) as number;
+
+    switch (limitValueTest) {
+      case 'atDefault':
+        this.expect(!!device);
+        this.expect(actualLimit === defaultLimit);
+        break;
+      case 'underDefault':
+        this.expect(!!device);
+        this.expect(actualLimit === defaultLimit);
+        break;
+      case 'atMaximum':
+        this.expect(!!device);
+        this.expect(actualLimit === maximumLimit);
+        break;
+      case 'overMaximum':
+        this.expect(!device);
+        break;
+    }
+
+    return device ? { device, defaultLimit, maximumLimit, requestedLimit, actualLimit } : undefined;
+  }
+
+  /**
+   * Creates a device with the requested limits.
+   * If the limit of over the maximum we expect an exception
+   * If the device is created then we call a test function, checking
+   * that the function does not leak any GPU errors.
+   */
+  async testDeviceWithRequestedLimits(
+    limitTest: keyof typeof LimitValueTest,
+    testValueName: keyof typeof TestValue,
+    fn: (inputs: LimitTestInputs) => void | Promise<void>
+  ) {
+    assert(!this._device);
+
+    const deviceAndLimits = await this._getDeviceWithRequestedLimit(limitTest);
+    // If we request over the limit requestDevice will throw
+    if (!deviceAndLimits) {
+      return;
+    }
+
+    const { device, actualLimit } = deviceAndLimits;
+    this._device = device;
+    const testValue = getTestValue(actualLimit, testValueName);
+    const shouldError = testValueName === 'overLimit';
+
+    device.pushErrorScope('internal');
+    device.pushErrorScope('out-of-memory');
+    device.pushErrorScope('validation');
+
+    await fn({ ...deviceAndLimits, testValueName, testValue, shouldError });
+
+    const validationError = await device.popErrorScope();
+    const outOfMemoryError = await device.popErrorScope();
+    const internalError = await device.popErrorScope();
+
+    this.expect(!validationError, validationError?.message || '');
+    this.expect(!outOfMemoryError, outOfMemoryError?.message || '');
+    this.expect(!internalError, internalError?.message || '');
+
+    device.destroy();
+    this._device = undefined;
+  }
+
+  /**
+   * Calls a function that expects a GPU error if shouldError is true
+   */
+  // MAINTENANCE_TODO: Remove this duplicated code with GPUTest if possible
+  async expectGPUError<R>(
+    filter: GPUErrorFilter,
+    fn: () => R,
+    shouldError: boolean = true,
+    msg = ''
+  ): Promise<R> {
+    const { device } = this;
+
+    device.pushErrorScope(filter);
+    const returnValue = fn();
+    if (returnValue instanceof Promise) {
+      await returnValue;
+    }
+
+    const error = await device.popErrorScope();
+    this.expect(
+      !!error === shouldError,
+      `${error?.message || 'no error when one was expected'}: ${msg}`
+    );
+
+    return returnValue;
+  }
+
+  /**
+   * Calls a function that expects a validation error if shouldError is true
+   */
+  async expectValidationError<R>(fn: () => R, shouldError: boolean = true, msg = ''): Promise<R> {
+    return this.expectGPUError('validation', fn, shouldError, msg);
+  }
+
+  /**
+   * Calls a function that expects to not generate a validation error
+   */
+  async expectNoValidationError<R>(fn: () => R, msg = ''): Promise<R> {
+    return this.expectGPUError('validation', fn, false, msg);
+  }
+
+  /**
+   * Calls a function that might expect a validation error.
+   * if shouldError is true then expect a validation error,
+   * if shouldError is false then ignore out-of-memory errors.
+   */
+  async testForValidationErrorWithPossibleOutOfMemoryError<R>(
+    fn: () => R,
+    shouldError: boolean = true,
+    msg = ''
+  ): Promise<R> {
+    const { device } = this;
+
+    if (!shouldError) {
+      device.pushErrorScope('out-of-memory');
+      const result = fn();
+      await device.popErrorScope();
+      return result;
+    }
+
+    // Validation should fail before out-of-memory so there is no need to check
+    // for out-of-memory here.
+    device.pushErrorScope('validation');
+    const returnValue = fn();
+    const validationError = await device.popErrorScope();
+
+    this.expect(
+      !!validationError,
+      `${validationError?.message || 'no error when one was expected'}: ${msg}`
+    );
+
+    return returnValue;
+  }
+}
+
+/**
+ * Makes a new LimitTest class so that the tests have access to `limit`
+ */
+function makeLimitTestFixture(limit: GPUSupportedLimit): typeof LimitTestsImpl {
+  class LimitTests extends LimitTestsImpl {
+    limit = limit;
+  }
+
+  return LimitTests;
+}
+
+/**
+ * This is to avoid repeating yourself (D.R.Y.) as I ran into that issue multiple times
+ * writing these tests where I'd copy a test, need to rename a limit in 3-4 places,
+ * forget one place, and then spend 20-30 minutes wondering why the test was failing.
+ */
+export function makeLimitTestGroup(limit: GPUSupportedLimit) {
+  const description = `API Validation Tests for ${limit}.`;
+  const g = makeTestGroup(makeLimitTestFixture(limit));
+  return { g, description, limit };
+}

--- a/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension1D.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension1D.spec.ts
@@ -1,0 +1,34 @@
+import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+
+const limit = 'maxTextureDimension1D';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createTexture,at_over')
+  .desc(`Test using at and over ${limit} limit`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        await t.testForValidationErrorWithPossibleOutOfMemoryError(() => {
+          const texture = device.createTexture({
+            size: [testValue, 1, 1],
+            format: 'rgba8unorm',
+            dimension: '1d',
+            usage: GPUTextureUsage.TEXTURE_BINDING,
+          });
+
+          // MAINTENANCE_TODO: Remove this 'if' once the bug in chrome is fixed
+          // This 'if' is only here because of a bug in Chrome
+          // that generates an error calling destroy on an invalid texture.
+          // This doesn't affect the test but the 'if' should be removed
+          // once the Chrome bug is fixed.
+          if (!shouldError) {
+            texture.destroy();
+          }
+        }, shouldError);
+      }
+    );
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension2D.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension2D.spec.ts
@@ -1,0 +1,133 @@
+import { getGPU } from '../../../../../common/util/navigator_gpu.js';
+import { kAllCanvasTypes, createCanvas } from '../../../../util/create_elements.js';
+
+import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+
+const limit = 'maxTextureDimension2D';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createTexture,at_over')
+  .desc(`Test using at and over ${limit} limit`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, shouldError, testValue, actualLimit }) => {
+        for (let dimensionIndex = 0; dimensionIndex < 2; ++dimensionIndex) {
+          const size = [1, 1, 1];
+          size[dimensionIndex] = testValue;
+
+          await t.testForValidationErrorWithPossibleOutOfMemoryError(
+            () => {
+              const texture = device.createTexture({
+                size,
+                format: 'rgba8unorm',
+                usage: GPUTextureUsage.TEXTURE_BINDING,
+              });
+
+              // MAINTENANCE_TODO: Remove this 'if' once the bug in chrome is fixed
+              // This 'if' is only here because of a bug in Chrome
+              // that generates an error calling destroy on an invalid texture.
+              // This doesn't affect the test but the 'if' should be removed
+              // once the Chrome bug is fixed.
+              if (!shouldError) {
+                texture.destroy();
+              }
+            },
+            shouldError,
+            `size: ${size}, actualLimit: ${actualLimit}`
+          );
+        }
+      }
+    );
+  });
+
+g.test('configure,at_over')
+  .desc(`Test using at and over ${limit} limit`)
+  .params(kLimitBaseParams.combine('canvasType', kAllCanvasTypes))
+  .fn(async t => {
+    const { limitTest, testValueName, canvasType } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, shouldError, testValue, actualLimit }) => {
+        for (let dimensionIndex = 0; dimensionIndex < 2; ++dimensionIndex) {
+          const size = [1, 1];
+          size[dimensionIndex] = testValue;
+
+          // This should not fail, even if the size is too large but it might fail
+          // if we're in a worker and HTMLCanvasElement does not exist.
+          const canvas = createCanvas(t, canvasType, size[0], size[1])!;
+          if (canvas) {
+            const context = canvas.getContext('webgpu') as GPUCanvasContext;
+            t.expect(!!context, 'should not fail to create context even if size is too large');
+
+            await t.testForValidationErrorWithPossibleOutOfMemoryError(
+              () => {
+                context.configure({
+                  device,
+                  format: getGPU().getPreferredCanvasFormat(),
+                });
+              },
+              shouldError,
+              `size: ${size}, actualLimit: ${actualLimit}`
+            );
+          }
+        }
+      }
+    );
+  });
+
+g.test('getCurrentTexture,at_over')
+  .desc(`Test using at and over ${limit} limit`)
+  .params(kLimitBaseParams.combine('canvasType', kAllCanvasTypes))
+  .fn(async t => {
+    const { limitTest, testValueName, canvasType } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, shouldError, testValue, actualLimit }) => {
+        for (let dimensionIndex = 0; dimensionIndex < 2; ++dimensionIndex) {
+          const size = [1, 1];
+          size[dimensionIndex] = testValue;
+
+          // Start with a small size so configure will succeed.
+          // This should not fail, even if the size is too large but it might fail
+          // if we're in a worker and HTMLCanvasElement does not exist.
+          const canvas = createCanvas(t, canvasType, 1, 1)!;
+          if (canvas) {
+            const context = canvas.getContext('webgpu') as GPUCanvasContext;
+            t.expect(!!context, 'should not fail to create context even if size is too large');
+
+            context.configure({
+              device,
+              format: getGPU().getPreferredCanvasFormat(),
+            });
+
+            if (canvas) {
+              await t.testForValidationErrorWithPossibleOutOfMemoryError(
+                () => {
+                  canvas.width = size[0];
+                  canvas.height = size[1];
+                  const texture = context.getCurrentTexture();
+
+                  // MAINTENANCE_TODO: Remove this 'if' once the bug in chrome is fixed
+                  // This 'if' is only here because of a bug in Chrome
+                  // that generates an error calling destroy on an invalid texture.
+                  // This doesn't affect the test but the 'if' should be removed
+                  // once the Chrome bug is fixed.
+                  if (!shouldError) {
+                    texture.destroy();
+                  }
+                },
+                shouldError,
+                `size: ${size}, actualLimit: ${actualLimit}`
+              );
+            }
+          }
+        }
+      }
+    );
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension3D.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension3D.spec.ts
@@ -1,0 +1,39 @@
+import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+
+const limit = 'maxTextureDimension3D';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createTexture,at_over')
+  .desc(`Test using at and over ${limit} limit`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, shouldError, testValue }) => {
+        for (let dimensionIndex = 0; dimensionIndex < 3; ++dimensionIndex) {
+          const size = [2, 2, 2];
+          size[dimensionIndex] = testValue;
+
+          await t.testForValidationErrorWithPossibleOutOfMemoryError(() => {
+            const texture = device.createTexture({
+              size,
+              format: 'rgba8unorm',
+              dimension: '3d',
+              usage: GPUTextureUsage.TEXTURE_BINDING,
+            });
+
+            // MAINTENANCE_TODO: Remove this 'if' once the bug in chrome is fixed
+            // This 'if' is only here because of a bug in Chrome
+            // that generates an error calling destroy on an invalid texture.
+            // This doesn't affect the test but the 'if' should be removed
+            // once the Chrome bug is fixed.
+            if (!shouldError) {
+              texture.destroy();
+            }
+          }, shouldError);
+        }
+      }
+    );
+  });

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -1032,6 +1032,7 @@ export const kLimitInfo = /* prettier-ignore */ makeTable(
   'maxTextureArrayLayers':                     [           ,       256,                          ],
 
   'maxBindGroups':                             [           ,         4,                          ],
+  'maxBindingsPerBindGroup':                   [           ,       640,                          ],
   'maxDynamicUniformBuffersPerPipelineLayout': [           ,         8,                          ],
   'maxDynamicStorageBuffersPerPipelineLayout': [           ,         4,                          ],
   'maxSampledTexturesPerShaderStage':          [           ,        16,                          ],


### PR DESCRIPTION
I have 11 limit tests written so far but it seemed best to do a few at a time.

note: I'd have liked to use `import.meta` but I go an error that we're using old style JavaScript the node cts runner. I didn't look into updating that but it's probably a good idea.

As it is now the files are W.E.T. instead of D.R.Y. because the limit, for example `maxTextureDimension2D` is written twice. Once in the filename and again in the test. Using `import.meta` it was only written one.

Issue: #2195

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
