### PR TITLE
[wgsl] Validate expressions passed to attributes.

### DIFF
--- a/src/webgpu/shader/validation/parse/attribute.spec.ts
+++ b/src/webgpu/shader/validation/parse/attribute.spec.ts
@@ -13,6 +13,15 @@ const kPossibleValues = {
   const_func: 'min(4, 8)',
   const: 'a_const',
 };
+const kAttributeUsage = {
+  align: '@align($val)',
+  binding: '@binding($val) @group(0)',
+  group: '@binding(1) @group($val)',
+  id: '@id($val)',
+  location: '@location($val)',
+  size: '@size($val)',
+  workgroup_size: '@workgroup_size($val, $val, $val)',
+};
 const kAllowedUsages = {
   align: ['val', 'expr', 'const', 'const_func'],
   binding: ['val', 'expr', 'const', 'const_func'],
@@ -31,29 +40,18 @@ g.test('expressions')
       .combine('attribute', Object.keys(kAllowedUsages) as Array<keyof typeof kAllowedUsages>)
   )
   .fn(t => {
-    let align = '';
-    let b_and_g = '@binding(0) @group(0)';
-    let id = '@id(2)';
-    let loc = '@location(0)';
-    let size = '';
-    let wg_size = '@workgroup_size(1)';
+    const attributes = {
+      align: '',
+      binding: '@binding(0) @group(0)',
+      group: '@binding(1) @group(1)',
+      id: '@id(2)',
+      location: '@location(0)',
+      size: '',
+      workgroup_size: '@workgroup_size(1)',
+    };
 
     const val = kPossibleValues[t.params.value];
-    if (t.params.attribute === 'align') {
-      align = `@align(${val})`;
-    } else if (t.params.attribute === 'binding') {
-      b_and_g = `@binding(${val}) @group(0)`;
-    } else if (t.params.attribute === 'group') {
-      b_and_g = `@binding(0) @group(${val})`;
-    } else if (t.params.attribute === 'id') {
-      id = `@id(${val})`;
-    } else if (t.params.attribute === 'location') {
-      loc = `@location(${val})`;
-    } else if (t.params.attribute === 'size') {
-      size = `@size(${val})`;
-    } else if (t.params.attribute === 'workgroup_size') {
-      wg_size = `@workgroup_size(${val}, ${val}, ${val})`;
-    }
+    attributes[t.params.attribute] = kAttributeUsage[t.params.attribute].replace(/(\$val)/g, val);
 
     const code = `
 fn a_func() -> i32 {
@@ -63,22 +61,25 @@ fn a_func() -> i32 {
 const a_const = -2 + 10;
 override a_override: i32 = 2;
 
-${id} override my_id: i32 = 4;
+${attributes.id} override my_id: i32 = 4;
 
 struct B {
-  ${align} ${size} a: i32,
+  ${attributes.align} ${attributes.size} a: i32,
 }
 
-${b_and_g}
-var<uniform> uniform_buffer: B;
+${attributes.binding}
+var<uniform> uniform_buffer_1: B;
+
+${attributes.group}
+var<uniform> uniform_buffer_2: B;
 
 @fragment
-fn main() -> ${loc} vec4<f32> {
+fn main() -> ${attributes.location} vec4<f32> {
   return vec4<f32>(.4, .2, .3, .1);
 }
 
 @compute
-${wg_size}
+${attributes.workgroup_size}
 fn compute_main() {}
 `;
 

--- a/src/webgpu/shader/validation/parse/attribute.spec.ts
+++ b/src/webgpu/shader/validation/parse/attribute.spec.ts
@@ -1,0 +1,87 @@
+export const description = `Validation tests for attributes`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kPossibleValues = {
+  val: '32',
+  expr: '30 + 2',
+  override: 'a_override',
+  user_func: 'a_func()',
+  const_func: 'min(4, 8)',
+  const: 'a_const',
+};
+const kAllowedUsages = {
+  align: ['val', 'expr', 'const', 'const_func'],
+  binding: ['val', 'expr', 'const', 'const_func'],
+  group: ['val', 'expr', 'const', 'const_func'],
+  id: ['val', 'expr', 'const', 'const_func'],
+  location: ['val', 'expr', 'const', 'const_func'],
+  size: ['val', 'expr', 'const', 'const_func'],
+  workgroup_size: ['val', 'expr', 'const', 'const_func', 'override'],
+};
+
+g.test('expressions')
+  .desc(`Tests attributes which allow expressions`)
+  .params(u =>
+    u
+      .combine('value', Object.keys(kPossibleValues) as Array<keyof typeof kPossibleValues>)
+      .combine('attribute', Object.keys(kAllowedUsages) as Array<keyof typeof kAllowedUsages>)
+  )
+  .fn(t => {
+    let align = '';
+    let b_and_g = '@binding(0) @group(0)';
+    let id = '@id(2)';
+    let loc = '@location(0)';
+    let size = '';
+    let wg_size = '@workgroup_size(1)';
+
+    const val = kPossibleValues[t.params.value];
+    if (t.params.attribute === 'align') {
+      align = `@align(${val})`;
+    } else if (t.params.attribute === 'binding') {
+      b_and_g = `@binding(${val}) @group(0)`;
+    } else if (t.params.attribute === 'group') {
+      b_and_g = `@binding(0) @group(${val})`;
+    } else if (t.params.attribute === 'id') {
+      id = `@id(${val})`;
+    } else if (t.params.attribute === 'location') {
+      loc = `@location(${val})`;
+    } else if (t.params.attribute === 'size') {
+      size = `@size(${val})`;
+    } else if (t.params.attribute === 'workgroup_size') {
+      wg_size = `@workgroup_size(${val}, ${val}, ${val})`;
+    }
+
+    const code = `
+fn a_func() -> i32 {
+    return 4;
+}
+
+const a_const = -2 + 10;
+override a_override: i32 = 2;
+
+${id} override my_id: i32 = 4;
+
+struct B {
+  ${align} ${size} a: i32,
+}
+
+${b_and_g}
+var<uniform> uniform_buffer: B;
+
+@fragment
+fn main() -> ${loc} vec4<f32> {
+  return vec4<f32>(.4, .2, .3, .1);
+}
+
+@compute
+${wg_size}
+fn compute_main() {}
+`;
+
+    const pass = kAllowedUsages[t.params.attribute].includes(t.params.value);
+    t.expectCompileResult(pass, code);
+  });


### PR DESCRIPTION
For the attributes which accept a value, as opposed to a context dependant name, this CL validates the acceptance of const-expressions and override-expressions where appropriate.

Fixes: #1716

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
