### PR TITLE
Avoid writable storage buffer binding aliasing

### DIFF
--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -231,6 +231,11 @@ referenced by that bind group is "used" in the usage scope. `
         ) {
           return false;
         }
+
+        // Avoid writable storage buffer bindings aliasing.
+        if (t.usage0 === 'storage' && t.usage1 === 'storage') {
+          return false;
+        }
         return true;
       })
       .combine('hasOverlap', [true, false])
@@ -557,6 +562,11 @@ layout visibilities.`
         }
         // As usage1 is accessible in the draw call, the draw call cannot be before usage1.
         if (t.drawBeforeUsage1 && t.usage1AccessibleInDraw) {
+          return false;
+        }
+
+        // Avoid writable storage buffer bindings aliasing.
+        if (t.usage0 === 'storage' && t.usage1 === 'storage') {
           return false;
         }
         return true;

--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -188,7 +188,11 @@ g.test('subresources,buffer_usage_in_one_compute_pass_with_one_dispatch')
 Test that when one buffer is used in one compute pass encoder, its list of internal usages within
 one usage scope can only be a compatible usage list. According to WebGPU SPEC, within one dispatch,
 for each bind group slot that is used by the current GPUComputePipeline's layout, every subresource
-referenced by that bind group is "used" in the usage scope. `
+referenced by that bind group is "used" in the usage scope.
+
+For both usage === storage, there is writable buffer binding aliasing so we skip this case and will
+have tests covered (https://github.com/gpuweb/cts/issues/2232)
+`
   )
   .params(u =>
     u
@@ -531,7 +535,11 @@ g.test('subresources,buffer_usage_in_one_render_pass_with_one_draw')
 Test that when one buffer is used in one render pass encoder where there is one draw call, its list
 of internal usages within one usage scope (all the commands in the whole render pass) can only be a
 compatible usage list. The usage scope rules are not related to the buffer offset or the bind group
-layout visibilities.`
+layout visibilities.
+
+For both usage === storage, there is writable buffer binding aliasing so we skip this case and will
+have tests covered (https://github.com/gpuweb/cts/issues/2232)
+`
   )
   .params(u =>
     u


### PR DESCRIPTION

Issue: https://github.com/gpuweb/cts/issues/2232

Found during Chromium implementation. Reflecting the latest spec changes.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
