### PR TITLE
Add a few more constant/override tests

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -274,6 +274,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         { constants: {}, _success: true },
         { constants: { c0: 0 }, _success: true },
         { constants: { c0: 0, c1: 1 }, _success: true },
+        { constants: { 'c0\0': 0 }, _success: false },
         { constants: { c9: 0 }, _success: false },
         { constants: { 1: 0 }, _success: true },
         { constants: { c3: 0 }, _success: false }, // pipeline constant id is specified for c3
@@ -281,6 +282,8 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         { constants: { 1000: 0 }, _success: true },
         { constants: { 9999: 0 }, _success: false },
         { constants: { 1000: 0, c2: 0 }, _success: false },
+        { constants: { 数: 0 }, _success: true },
+        { constants: { séquençage: 0 }, _success: true }, // test unicode normalization
       ] as { constants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(t => {
@@ -293,14 +296,16 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
           code: `
             override c0: bool = true;      // type: bool
             override c1: u32 = 0u;          // default override
+            override 数: u32 = 0u;          // non-ASCII
+            override sequencage: u32 = 0u;  // unicode normalization
             @id(1000) override c2: u32 = 10u;  // default
             @id(1) override c3: u32 = 11u;     // default
             @compute @workgroup_size(1) fn main () {
               // make sure the overridable constants are not optimized out
               _ = u32(c0);
               _ = u32(c1);
-              _ = u32(c2);
-              _ = u32(c3);
+              _ = u32(c2 + sequencage);
+              _ = u32(c3 + 数);
             }`,
         }),
         entryPoint: 'main',

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -22,12 +22,15 @@ Tests calling createRenderPipeline(Async) validation for overridable constants i
         { vertexConstants: {}, _success: true },
         { vertexConstants: { x: 1, y: 1 }, _success: true },
         { vertexConstants: { x: 1, y: 1, 1: 1, 1000: 1 }, _success: true },
+        { vertexConstants: { 'x\0': 1, y: 1 }, _success: false },
         { vertexConstants: { xxx: 1 }, _success: false },
         { vertexConstants: { 1: 1 }, _success: true },
         { vertexConstants: { 2: 1 }, _success: false },
         { vertexConstants: { z: 1 }, _success: false }, // pipeline constant id is specified for z
         { vertexConstants: { w: 1 }, _success: false }, // pipeline constant id is specified for w
         { vertexConstants: { 1: 1, z: 1 }, _success: false }, // pipeline constant id is specified for z
+        { vertexConstants: { 数: 1 }, _success: true }, // test non-ASCII
+        { vertexConstants: { séquençage: 0 }, _success: true }, // test unicode normalization
       ] as { vertexConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(t => {
@@ -40,10 +43,12 @@ Tests calling createRenderPipeline(Async) validation for overridable constants i
           code: `
             override x: f32 = 0.0;
             override y: f32 = 0.0;
+            override 数: f32 = 0.0;
+            override sequencage: f32 = 0.0;
             @id(1) override z: f32 = 0.0;
             @id(1000) override w: f32 = 1.0;
             @vertex fn main() -> @builtin(position) vec4<f32> {
-              return vec4<f32>(x, y, z, w);
+              return vec4<f32>(x, y, z, w + 数 + sequencage);
             }`,
         }),
         entryPoint: 'main',
@@ -74,12 +79,15 @@ Tests calling createRenderPipeline(Async) validation for overridable constants i
         { fragmentConstants: {}, _success: true },
         { fragmentConstants: { r: 1, g: 1 }, _success: true },
         { fragmentConstants: { r: 1, g: 1, 1: 1, 1000: 1 }, _success: true },
+        { fragmentConstants: { 'r\0': 1 }, _success: false },
         { fragmentConstants: { xxx: 1 }, _success: false },
         { fragmentConstants: { 1: 1 }, _success: true },
         { fragmentConstants: { 2: 1 }, _success: false },
         { fragmentConstants: { b: 1 }, _success: false }, // pipeline constant id is specified for b
         { fragmentConstants: { a: 1 }, _success: false }, // pipeline constant id is specified for a
         { fragmentConstants: { 1: 1, b: 1 }, _success: false }, // pipeline constant id is specified for b
+        { fragmentConstants: { 数: 1 }, _success: true }, // test non-ASCII
+        { fragmentConstants: { séquençage: 0 }, _success: true }, // test unicode normalization
       ] as { fragmentConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(t => {
@@ -89,11 +97,13 @@ Tests calling createRenderPipeline(Async) validation for overridable constants i
       fragmentShaderCode: `
         override r: f32 = 0.0;
         override g: f32 = 0.0;
+        override 数: f32 = 0.0;
+        override sequencage: f32 = 0.0;
         @id(1) override b: f32 = 0.0;
         @id(1000) override a: f32 = 0.0;
         @fragment fn main()
             -> @location(0) vec4<f32> {
-            return vec4<f32>(r, g, b, a);
+            return vec4<f32>(r, g, b, a + 数 + sequencage);
         }`,
       fragmentConstants,
     });


### PR DESCRIPTION
Test that `id\0` does not match `id`
Test that non-ASCII is ok
Test that unicode ids that are different but normalize to the same id match

the `\0` tests fail in Chrome


Issue: none

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
