### PR TITLE
add maxBufferSize limit test

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxBufferSize.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBufferSize.spec.ts
@@ -1,0 +1,28 @@
+import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+
+const limit = 'maxBufferSize';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createBuffer,at_over')
+  .desc(`Test using at and over ${limit} limit`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        await t.testForValidationErrorWithPossibleOutOfMemoryError(
+          () => {
+            const buffer = device.createBuffer({
+              usage: GPUBufferUsage.VERTEX,
+              size: testValue,
+            });
+            buffer.destroy();
+          },
+          shouldError,
+          `size: ${testValue}, limit: ${actualLimit}`
+        );
+      }
+    );
+  });


### PR DESCRIPTION
Note: this fails on Chrome. It fails where it asks for one more than the default limit (but not 1 more than the max limit).

Issue: #2195

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
