### PR TITLE
add maxXXXPerShaderStage limit tests

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -219,6 +219,41 @@ export function mapLazy<T, R>(xs: Iterable<T>, f: (x: T) => R): Iterable<R> {
   };
 }
 
+const ReorderOrders = {
+  forward: true,
+  backward: true,
+  shiftByHalf: true,
+};
+export type ReorderOrder = keyof typeof ReorderOrders;
+export const kReorderOrderKeys = keysOf(ReorderOrders);
+
+/**
+ * Creates a new array from the given array with the first half
+ * swapped with the last half.
+ */
+export function shiftByHalf<R>(arr: R[]): R[] {
+  const len = arr.length;
+  const half = (len / 2) | 0;
+  const firstHalf = arr.splice(0, half);
+  return [...arr, ...firstHalf];
+}
+
+/**
+ * Creates a reordered array from the input array based on the Order
+ */
+export function reorder<R>(order: ReorderOrder, arr: R[]): R[] {
+  switch (order) {
+    case 'forward':
+      return arr.slice();
+    case 'backward':
+      return arr.slice().reverse();
+    case 'shiftByHalf': {
+      // should this be pseudo random?
+      return shiftByHalf(arr);
+    }
+  }
+}
+
 const TypedArrayBufferViewInstances = [
   new Uint8Array(),
   new Uint8ClampedArray(),

--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -2,7 +2,7 @@ import { kUnitCaseParamsBuilder } from '../../../../../common/framework/params_b
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../../common/util/data_tables.js';
 import { getGPU } from '../../../../../common/util/navigator_gpu.js';
-import { assert } from '../../../../../common/util/util.js';
+import { assert, range, reorder, ReorderOrder } from '../../../../../common/util/util.js';
 import { kLimitInfo } from '../../../../capability_info.js';
 import { GPUTestBase } from '../../../../gpu_test.js';
 
@@ -10,25 +10,19 @@ type GPUSupportedLimit = keyof GPUSupportedLimits;
 
 const CreatePipelineTypes = {
   createRenderPipeline: true,
+  createRenderPipelineWithFragmentStage: true,
   createComputePipeline: true,
 };
 export type CreatePipelineType = keyof typeof CreatePipelineTypes;
-
-export const kCreatePipelineTypes = [
-  'createRenderPipeline',
-  'createComputePipeline',
-] as CreatePipelineType[];
+export const kCreatePipelineTypes = keysOf(CreatePipelineTypes);
 
 const CreatePipelineAsyncTypes = {
   createRenderPipelineAsync: true,
+  createRenderPipelineAsyncWithFragmentStage: true,
   createComputePipelineAsync: true,
 };
 export type CreatePipelineAsyncType = keyof typeof CreatePipelineAsyncTypes;
-
-export const kCreatePipelineAsyncTypes = [
-  'createRenderPipelineAsync',
-  'createComputePipelineAsync',
-] as CreatePipelineAsyncType[];
+export const kCreatePipelineAsyncTypes = keysOf(CreatePipelineAsyncTypes);
 
 const RenderEncoderTypes = {
   render: true,
@@ -44,6 +38,197 @@ const EncoderTypes = {
 };
 export type EncoderType = keyof typeof EncoderTypes;
 export const kEncoderTypes = keysOf(EncoderTypes);
+
+const BindGroupTests = {
+  sameGroup: true,
+  differentGroups: true,
+};
+export type BindGroupTest = keyof typeof BindGroupTests;
+export const kBindGroupTests = keysOf(BindGroupTests);
+
+const BindingCombinations = {
+  vertex: true,
+  fragment: true,
+  vertexAndFragmentWithPossibleVertexStageOverflow: true,
+  vertexAndFragmentWithPossibleFragmentStageOverflow: true,
+  compute: true,
+};
+export type BindingCombination = keyof typeof BindingCombinations;
+export const kBindingCombinations = keysOf(BindingCombinations);
+
+export function getPipelineTypeForBindingCombination(bindingCombination: BindingCombination) {
+  switch (bindingCombination) {
+    case 'vertex':
+      return 'createRenderPipeline';
+    case 'fragment':
+    case 'vertexAndFragmentWithPossibleVertexStageOverflow':
+    case 'vertexAndFragmentWithPossibleFragmentStageOverflow':
+      return 'createRenderPipelineWithFragmentStage';
+    case 'compute':
+      return 'createComputePipeline';
+  }
+}
+
+export function getPipelineAsyncTypeForBindingCombination(bindingCombination: BindingCombination) {
+  switch (bindingCombination) {
+    case 'vertex':
+      return 'createRenderPipelineAsync';
+    case 'fragment':
+    case 'vertexAndFragmentWithPossibleVertexStageOverflow':
+    case 'vertexAndFragmentWithPossibleFragmentStageOverflow':
+      return 'createRenderPipelineAsyncWithFragmentStage';
+    case 'compute':
+      return 'createComputePipelineAsync';
+  }
+}
+
+function getBindGroupIndex(bindGroupTest: BindGroupTest, i: number) {
+  switch (bindGroupTest) {
+    case 'sameGroup':
+      return 0;
+    case 'differentGroups':
+      return i % 3;
+  }
+}
+
+function getWGSLBindings(
+  order: ReorderOrder,
+  bindGroupTest: BindGroupTest,
+  storageDefinitionWGSLSnippetFn: (i: number, j: number) => string,
+  numBindings: number,
+  id: number
+) {
+  return reorder(
+    order,
+    range(
+      numBindings,
+      i =>
+        `@group(${getBindGroupIndex(
+          bindGroupTest,
+          i
+        )}) @binding(${i}) ${storageDefinitionWGSLSnippetFn(i, id)};`
+    )
+  ).join('\n');
+}
+
+export function getPerStageWGSLForBindingCombinationImpl(
+  bindingCombination: BindingCombination,
+  order: ReorderOrder,
+  bindGroupTest: BindGroupTest,
+  storageDefinitionWGSLSnippetFn: (i: number, j: number) => string,
+  bodyFn: (numBindings: number, set: number) => string,
+  numBindings: number,
+  extraWGSL = ''
+) {
+  switch (bindingCombination) {
+    case 'vertex':
+      return `
+        ${extraWGSL}
+        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 0)}
+        @vertex fn mainVS() -> @builtin(position) vec4f {
+          ${bodyFn(numBindings, 0)}
+          return vec4f(0);
+        }
+      `;
+    case 'fragment':
+      return `
+        ${extraWGSL}
+        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 0)}
+        @vertex fn mainVS() -> @builtin(position) vec4f {
+          return vec4f(0);
+        }
+        @fragment fn mainFS() -> @location(0) vec4f {
+          ${bodyFn(numBindings, 0)}
+          return vec4f(0);
+        }
+      `;
+    case 'vertexAndFragmentWithPossibleVertexStageOverflow': {
+      return `
+        ${extraWGSL}
+        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 0)}
+        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings - 1, 1)}
+        @vertex fn mainVS() -> @builtin(position) vec4f {
+          ${bodyFn(numBindings, 0)}
+          return vec4f(0);
+        }
+        @fragment fn mainFS() -> @location(0) vec4f {
+          ${bodyFn(numBindings - 1, 1)}
+          return vec4f(0);
+        }
+      `;
+    }
+    case 'vertexAndFragmentWithPossibleFragmentStageOverflow': {
+      return `
+        ${extraWGSL}
+        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings - 1, 0)}
+        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 1)}
+        @vertex fn mainVS() -> @builtin(position) vec4f {
+          ${bodyFn(numBindings - 1, 0)}
+          return vec4f(0);
+        }
+        @fragment fn mainFS() -> @location(0) vec4f {
+          ${bodyFn(numBindings, 1)}
+          return vec4f(0);
+        }
+      `;
+    }
+    case 'compute':
+      return `
+        ${extraWGSL}
+        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 0)}
+        @group(3) @binding(0) var<storage, read_write> d: f32;
+        @compute @workgroup_size(1) fn main() {
+          ${bodyFn(numBindings, 0)}
+        }
+      `;
+      break;
+  }
+}
+
+export function getPerStageWGSLForBindingCombination(
+  bindingCombination: BindingCombination,
+  order: ReorderOrder,
+  bindGroupTest: BindGroupTest,
+  storageDefinitionWGSLSnippetFn: (i: number, j: number) => string,
+  usageWGSLSnippetFn: (i: number, j: number) => string,
+  numBindings: number,
+  extraWGSL = ''
+) {
+  return getPerStageWGSLForBindingCombinationImpl(
+    bindingCombination,
+    order,
+    bindGroupTest,
+    storageDefinitionWGSLSnippetFn,
+    (numBindings: number, set: number) =>
+      `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n')}`,
+    numBindings,
+    extraWGSL
+  );
+}
+
+export function getPerStageWGSLForBindingCombinationStorageTextures(
+  bindingCombination: BindingCombination,
+  order: ReorderOrder,
+  bindGroupTest: BindGroupTest,
+  storageDefinitionWGSLSnippetFn: (i: number, j: number) => string,
+  usageWGSLSnippetFn: (i: number, j: number) => string,
+  numBindings: number,
+  extraWGSL = ''
+) {
+  return getPerStageWGSLForBindingCombinationImpl(
+    bindingCombination,
+    order,
+    bindGroupTest,
+    storageDefinitionWGSLSnippetFn,
+    (numBindings: number, set: number) => {
+      return bindingCombination === 'compute'
+        ? `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n')};`
+        : `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n')}; return vec4f(0);`;
+    },
+    numBindings,
+    extraWGSL
+  );
+}
 
 export const TestValues = {
   atLimit: true,
@@ -388,17 +573,27 @@ export class LimitTestsImpl extends GPUTestBase {
       case 'createRenderPipelineAsync':
         return `
           @group(${groupIndex}) @binding(0) var<uniform> v: f32;
-          @vertex fn main() -> @builtin(position) vec4f {
+          @vertex fn mainVS() -> @builtin(position) vec4f {
             return vec4f(v);
+          }
+        `;
+      case 'createRenderPipelineWithFragmentStage':
+      case 'createRenderPipelineAsyncWithFragmentStage':
+        return `
+          @group(${groupIndex}) @binding(0) var<uniform> v: f32;
+          @vertex fn mainVS() -> @builtin(position) vec4f {
+            return vec4f(v);
+          }
+          @fragment fn mainFS() -> @location(0) vec4f {
+            return vec4f(1);
           }
         `;
       case 'createComputePipeline':
       case 'createComputePipelineAsync':
         return `
-          @group(0) @binding(0) var<storage, read_write> d: f32;
           @group(${groupIndex}) @binding(0) var<uniform> v: f32;
           @compute @workgroup_size(1) fn main() {
-            d = v;
+            _ = v;
           }
         `;
         break;
@@ -414,17 +609,27 @@ export class LimitTestsImpl extends GPUTestBase {
       case 'createRenderPipelineAsync':
         return `
           @group(0) @binding(${bindingIndex}) var<uniform> v: f32;
-          @vertex fn main() -> @builtin(position) vec4f {
+          @vertex fn mainVS() -> @builtin(position) vec4f {
             return vec4f(v);
+          }
+        `;
+      case 'createRenderPipelineWithFragmentStage':
+      case 'createRenderPipelineAsyncWithFragmentStage':
+        return `
+          @group(0) @binding(${bindingIndex}) var<uniform> v: f32;
+          @vertex fn mainVS() -> @builtin(position) vec4f {
+            return vec4f(v);
+          }
+          @fragment fn mainFS() -> @location(0) vec4f {
+            return vec4f(1);
           }
         `;
       case 'createComputePipeline':
       case 'createComputePipelineAsync':
         return `
-          @group(0) @binding(0) var<storage, read_write> d: f32;
           @group(0) @binding(${bindingIndex}) var<uniform> v: f32;
           @compute @workgroup_size(1) fn main() {
-            d = v;
+            _ = v;
           }
         `;
         break;
@@ -440,7 +645,21 @@ export class LimitTestsImpl extends GPUTestBase {
           layout: 'auto',
           vertex: {
             module,
-            entryPoint: 'main',
+            entryPoint: 'mainVS',
+          },
+        });
+        break;
+      case 'createRenderPipelineWithFragmentStage':
+        return device.createRenderPipeline({
+          layout: 'auto',
+          vertex: {
+            module,
+            entryPoint: 'mainVS',
+          },
+          fragment: {
+            module,
+            entryPoint: 'mainFS',
+            targets: [{ format: 'rgba8unorm' }],
           },
         });
         break;
@@ -465,7 +684,20 @@ export class LimitTestsImpl extends GPUTestBase {
           layout: 'auto',
           vertex: {
             module,
-            entryPoint: 'main',
+            entryPoint: 'mainVS',
+          },
+        });
+      case 'createRenderPipelineAsyncWithFragmentStage':
+        return device.createRenderPipelineAsync({
+          layout: 'auto',
+          vertex: {
+            module,
+            entryPoint: 'mainVS',
+          },
+          fragment: {
+            module,
+            entryPoint: 'mainFS',
+            targets: [{ format: 'rgba8unorm' }],
           },
         });
       case 'createComputePipelineAsync':
@@ -487,16 +719,20 @@ export class LimitTestsImpl extends GPUTestBase {
 
     switch (encoderType) {
       case 'render': {
-        const buffer = device.createBuffer({
-          size: 16,
-          usage: GPUBufferUsage.UNIFORM,
-        });
+        const buffer = this.trackForCleanup(
+          device.createBuffer({
+            size: 16,
+            usage: GPUBufferUsage.UNIFORM,
+          })
+        );
 
-        const texture = device.createTexture({
-          size: [1, 1],
-          format: 'rgba8unorm',
-          usage: GPUTextureUsage.RENDER_ATTACHMENT,
-        });
+        const texture = this.trackForCleanup(
+          device.createTexture({
+            size: [1, 1],
+            format: 'rgba8unorm',
+            usage: GPUTextureUsage.RENDER_ATTACHMENT,
+          })
+        );
 
         const layout = device.createBindGroupLayout({
           entries: [
@@ -538,19 +774,17 @@ export class LimitTestsImpl extends GPUTestBase {
           test() {
             encoder.finish();
           },
-          cleanup() {
-            buffer.destroy();
-            texture.destroy();
-          },
         };
         break;
       }
 
       case 'renderBundle': {
-        const buffer = device.createBuffer({
-          size: 16,
-          usage: GPUBufferUsage.UNIFORM,
-        });
+        const buffer = this.trackForCleanup(
+          device.createBuffer({
+            size: 16,
+            usage: GPUBufferUsage.UNIFORM,
+          })
+        );
 
         const layout = device.createBindGroupLayout({
           entries: [
@@ -583,9 +817,6 @@ export class LimitTestsImpl extends GPUTestBase {
           test() {
             mixin.finish();
           },
-          cleanup() {
-            buffer.destroy();
-          },
         };
         break;
       }
@@ -602,13 +833,11 @@ export class LimitTestsImpl extends GPUTestBase {
     shouldError: boolean,
     msg = ''
   ) {
-    const { mixin, prep, test, cleanup } = this._getGPURenderCommandsMixin(encoderType);
+    const { mixin, prep, test } = this._getGPURenderCommandsMixin(encoderType);
     fn({ mixin });
     prep();
 
     await this.expectValidationError(test, shouldError, msg);
-
-    cleanup();
   }
 
   /**
@@ -619,10 +848,12 @@ export class LimitTestsImpl extends GPUTestBase {
 
     switch (encoderType) {
       case 'compute': {
-        const buffer = device.createBuffer({
-          size: 16,
-          usage: GPUBufferUsage.UNIFORM,
-        });
+        const buffer = this.trackForCleanup(
+          device.createBuffer({
+            size: 16,
+            usage: GPUBufferUsage.UNIFORM,
+          })
+        );
 
         const layout = device.createBindGroupLayout({
           entries: [
@@ -655,9 +886,6 @@ export class LimitTestsImpl extends GPUTestBase {
           test() {
             encoder.finish();
           },
-          cleanup() {
-            buffer.destroy();
-          },
         };
         break;
       }
@@ -678,13 +906,11 @@ export class LimitTestsImpl extends GPUTestBase {
     shouldError: boolean,
     msg = ''
   ) {
-    const { mixin, bindGroup, prep, test, cleanup } = this._getGPUBindingCommandsMixin(encoderType);
+    const { mixin, bindGroup, prep, test } = this._getGPUBindingCommandsMixin(encoderType);
     fn({ mixin, bindGroup });
     prep();
 
     await this.expectValidationError(test, shouldError, msg);
-
-    cleanup();
   }
 }
 

--- a/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
@@ -1,0 +1,187 @@
+import {
+  range,
+  reorder,
+  kReorderOrderKeys,
+  ReorderOrder,
+} from '../../../../../common/util/util.js';
+import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
+
+import {
+  kLimitBaseParams,
+  makeLimitTestGroup,
+  kBindGroupTests,
+  kBindingCombinations,
+  getPipelineTypeForBindingCombination,
+  getPipelineAsyncTypeForBindingCombination,
+  getPerStageWGSLForBindingCombination,
+} from './limit_utils.js';
+
+const limit = 'maxSampledTexturesPerShaderStage';
+export const { g, description } = makeLimitTestGroup(limit);
+
+function createBindGroupLayout(
+  device: GPUDevice,
+  visibility: number,
+  order: ReorderOrder,
+  numBindings: number
+) {
+  return device.createBindGroupLayout({
+    entries: reorder(
+      order,
+      range(numBindings, i => ({
+        binding: i,
+        visibility,
+        texture: {},
+      }))
+    ),
+  });
+}
+
+g.test('createBindGroupLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createBindGroupLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', kShaderStageCombinationsWithStage)
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        await t.expectValidationError(
+          () => createBindGroupLayout(device, visibility, order, testValue),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('createPipelineLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createPipelineLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', kShaderStageCombinationsWithStage)
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const kNumGroups = 3;
+        const bindGroupLayouts = range(kNumGroups, i => {
+          const minInGroup = Math.floor(testValue / kNumGroups);
+          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          return createBindGroupLayout(device, visibility, order, numInGroup);
+        });
+        await t.expectValidationError(
+          () => device.createPipelineLayout({ bindGroupLayouts }),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('createPipeline,at_over')
+  .desc(
+    `
+  Test using createRenderPipeline and createComputePipeline at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', kBindingCombinations)
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombination(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var u${j}_${i}: texture_2d<f32>`,
+          (i, j) => `_ = textureLoad(u${j}_${i}, vec2u(0), 0);`,
+          testValue
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.expectValidationError(
+          () => {
+            t.createPipeline(pipelineType, module);
+          },
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });
+
+g.test('createPipelineAsync,at_over')
+  .desc(
+    `
+  Test using createRenderPipelineAsync and createComputePipelineAsync at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', kBindingCombinations)
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombination(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var u${j}_${i}: texture_2d<f32>`,
+          (i, j) => `_ = textureLoad(u${j}_${i}, vec2u(0), 0);`,
+          testValue
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.shouldRejectConditionally(
+          'OperationError',
+          t.createPipelineAsync(pipelineType, module),
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
@@ -1,0 +1,189 @@
+import {
+  range,
+  reorder,
+  kReorderOrderKeys,
+  ReorderOrder,
+} from '../../../../../common/util/util.js';
+import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
+
+import {
+  kLimitBaseParams,
+  makeLimitTestGroup,
+  kBindGroupTests,
+  kBindingCombinations,
+  getPipelineTypeForBindingCombination,
+  getPipelineAsyncTypeForBindingCombination,
+  getPerStageWGSLForBindingCombination,
+} from './limit_utils.js';
+
+const limit = 'maxSamplersPerShaderStage';
+export const { g, description } = makeLimitTestGroup(limit);
+
+function createBindGroupLayout(
+  device: GPUDevice,
+  visibility: number,
+  order: ReorderOrder,
+  numBindings: number
+) {
+  return device.createBindGroupLayout({
+    entries: reorder(
+      order,
+      range(numBindings, i => ({
+        binding: i,
+        visibility,
+        sampler: {},
+      }))
+    ),
+  });
+}
+
+g.test('createBindGroupLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createBindGroupLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', kShaderStageCombinationsWithStage)
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        await t.expectValidationError(
+          () => createBindGroupLayout(device, visibility, order, testValue),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('createPipelineLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createPipelineLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', kShaderStageCombinationsWithStage)
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const kNumGroups = 3;
+        const bindGroupLayouts = range(kNumGroups, i => {
+          const minInGroup = Math.floor(testValue / kNumGroups);
+          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          return createBindGroupLayout(device, visibility, order, numInGroup);
+        });
+        await t.expectValidationError(
+          () => device.createPipelineLayout({ bindGroupLayouts }),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('createPipeline,at_over')
+  .desc(
+    `
+  Test using createRenderPipeline and createComputePipeline at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', kBindingCombinations)
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombination(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var u${j}_${i}: sampler`,
+          (i, j) => `_ = textureGather(0, tex, u${j}_${i}, vec2f(0));`,
+          testValue,
+          '@group(3) @binding(1) var tex: texture_2d<f32>;'
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.expectValidationError(
+          () => {
+            t.createPipeline(pipelineType, module);
+          },
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });
+
+g.test('createPipelineAsync,at_over')
+  .desc(
+    `
+  Test using createRenderPipelineAsync and createComputePipelineAsync at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', kBindingCombinations)
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombination(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var u${j}_${i}: sampler`,
+          (i, j) => `_ = textureGather(0, tex, u${j}_${i}, vec2f(0));`,
+          testValue,
+          '@group(3) @binding(1) var tex: texture_2d<f32>;'
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.shouldRejectConditionally(
+          'OperationError',
+          t.createPipelineAsync(pipelineType, module),
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
@@ -1,0 +1,217 @@
+import {
+  range,
+  reorder,
+  kReorderOrderKeys,
+  ReorderOrder,
+} from '../../../../../common/util/util.js';
+import { GPUConst } from '../../../../constants.js';
+
+import {
+  kLimitBaseParams,
+  makeLimitTestGroup,
+  kBindGroupTests,
+  kBindingCombinations,
+  getPipelineTypeForBindingCombination,
+  getPipelineAsyncTypeForBindingCombination,
+  getPerStageWGSLForBindingCombination,
+} from './limit_utils.js';
+
+const limit = 'maxStorageBuffersPerShaderStage';
+export const { g, description } = makeLimitTestGroup(limit);
+
+function createBindGroupLayout(
+  device: GPUDevice,
+  visibility: number,
+  type: GPUBufferBindingType,
+  order: ReorderOrder,
+  numBindings: number
+) {
+  return device.createBindGroupLayout({
+    entries: reorder(
+      order,
+      range(numBindings, i => ({
+        binding: i,
+        visibility,
+        buffer: { type },
+      }))
+    ),
+  });
+}
+
+g.test('createBindGroupLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createBindGroupLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', [
+        GPUConst.ShaderStage.VERTEX,
+        GPUConst.ShaderStage.FRAGMENT,
+        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
+        GPUConst.ShaderStage.COMPUTE,
+        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.COMPUTE,
+        GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
+        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
+      ])
+      .combine('type', ['storage', 'read-only-storage'] as GPUBufferBindingType[])
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order, type } = t.params;
+
+    if (visibility & GPUConst.ShaderStage.VERTEX && type === 'storage') {
+      // vertex stage does not support storage buffers
+      return;
+    }
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        await t.expectValidationError(() => {
+          createBindGroupLayout(device, visibility, type, order, testValue);
+        }, shouldError);
+      }
+    );
+  });
+
+g.test('createPipelineLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createPipelineLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', [
+        GPUConst.ShaderStage.VERTEX,
+        GPUConst.ShaderStage.FRAGMENT,
+        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
+        GPUConst.ShaderStage.COMPUTE,
+        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.COMPUTE,
+        GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
+        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
+      ])
+      .combine('type', ['storage', 'read-only-storage'] as GPUBufferBindingType[])
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order, type } = t.params;
+
+    if (visibility & GPUConst.ShaderStage.VERTEX && type === 'storage') {
+      // vertex stage does not support storage buffers
+      return;
+    }
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const kNumGroups = 3;
+        const bindGroupLayouts = range(kNumGroups, i => {
+          const minInGroup = Math.floor(testValue / kNumGroups);
+          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          return createBindGroupLayout(device, visibility, type, order, numInGroup);
+        });
+        await t.expectValidationError(
+          () => device.createPipelineLayout({ bindGroupLayouts }),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('createPipeline,at_over')
+  .desc(
+    `
+  Test using createRenderPipeline and createComputePipeline at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', kBindingCombinations)
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombination(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var<storage> u${j}_${i}: f32`,
+          (i, j) => `_ = u${j}_${i};`,
+          testValue
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.expectValidationError(
+          () => {
+            t.createPipeline(pipelineType, module);
+          },
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });
+
+g.test('createPipelineAsync,at_over')
+  .desc(
+    `
+  Test using createRenderPipelineAsync and createComputePipelineAsync at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', kBindingCombinations)
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombination(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var<storage> u${j}_${i}: f32`,
+          (i, j) => `_ = u${j}_${i};`,
+          testValue
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.shouldRejectConditionally(
+          'OperationError',
+          t.createPipelineAsync(pipelineType, module),
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
@@ -1,0 +1,195 @@
+import {
+  range,
+  reorder,
+  ReorderOrder,
+  kReorderOrderKeys,
+} from '../../../../../common/util/util.js';
+import { GPUConst } from '../../../../constants.js';
+
+import {
+  kLimitBaseParams,
+  makeLimitTestGroup,
+  kBindGroupTests,
+  getPipelineTypeForBindingCombination,
+  getPipelineAsyncTypeForBindingCombination,
+  getPerStageWGSLForBindingCombinationStorageTextures,
+  BindingCombination,
+} from './limit_utils.js';
+
+const limit = 'maxStorageTexturesPerShaderStage';
+export const { g, description } = makeLimitTestGroup(limit);
+
+function createBindGroupLayout(
+  device: GPUDevice,
+  visibility: number,
+  order: ReorderOrder,
+  numBindings: number
+) {
+  return device.createBindGroupLayout({
+    entries: reorder(
+      order,
+      range(numBindings, i => ({
+        binding: i,
+        visibility,
+        storageTexture: { format: 'rgba8unorm' },
+      }))
+    ),
+  });
+}
+
+g.test('createBindGroupLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createBindGroupLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', [
+        GPUConst.ShaderStage.FRAGMENT,
+        GPUConst.ShaderStage.COMPUTE,
+        GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
+      ])
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        await t.expectValidationError(
+          () => createBindGroupLayout(device, visibility, order, testValue),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('createPipelineLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createPipelineLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', [
+        GPUConst.ShaderStage.FRAGMENT,
+        GPUConst.ShaderStage.COMPUTE,
+        GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
+      ])
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const kNumGroups = 3;
+        const bindGroupLayouts = range(kNumGroups, i => {
+          const minInGroup = Math.floor(testValue / kNumGroups);
+          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          return createBindGroupLayout(device, visibility, order, numInGroup);
+        });
+        await t.expectValidationError(
+          () => device.createPipelineLayout({ bindGroupLayouts }),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('createPipeline,at_over')
+  .desc(
+    `
+  Test using createRenderPipeline and createComputePipeline at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', ['fragment', 'compute'] as BindingCombination[])
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombinationStorageTextures(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var u${j}_${i}: texture_storage_2d<rgba8unorm, write>`,
+          (i, j) => `textureStore(u${j}_${i}, vec2u(0), vec4f(1));`,
+          testValue
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.expectValidationError(
+          () => {
+            t.createPipeline(pipelineType, module);
+          },
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });
+
+g.test('createPipelineAsync,at_over')
+  .desc(
+    `
+  Test using createRenderPipelineAsync and createComputePipelineAsync at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', ['fragment', 'compute'] as BindingCombination[])
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombinationStorageTextures(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var u${j}_${i}: texture_storage_2d<rgba8unorm, write>`,
+          (i, j) => `textureStore(u${j}_${i}, vec2u(0), vec4f(1));`,
+          testValue
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.shouldRejectConditionally(
+          'OperationError',
+          t.createPipelineAsync(pipelineType, module),
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
@@ -1,0 +1,187 @@
+import {
+  range,
+  reorder,
+  kReorderOrderKeys,
+  ReorderOrder,
+} from '../../../../../common/util/util.js';
+import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
+
+import {
+  kLimitBaseParams,
+  makeLimitTestGroup,
+  kBindGroupTests,
+  kBindingCombinations,
+  getPipelineTypeForBindingCombination,
+  getPipelineAsyncTypeForBindingCombination,
+  getPerStageWGSLForBindingCombination,
+} from './limit_utils.js';
+
+const limit = 'maxUniformBuffersPerShaderStage';
+export const { g, description } = makeLimitTestGroup(limit);
+
+function createBindGroupLayout(
+  device: GPUDevice,
+  visibility: number,
+  order: ReorderOrder,
+  numBindings: number
+) {
+  return device.createBindGroupLayout({
+    entries: reorder(
+      order,
+      range(numBindings, i => ({
+        binding: i,
+        visibility,
+        buffer: {},
+      }))
+    ),
+  });
+}
+
+g.test('createBindGroupLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createBindGroupLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', kShaderStageCombinationsWithStage)
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        await t.expectValidationError(
+          () => createBindGroupLayout(device, visibility, order, testValue),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('createPipelineLayout,at_over')
+  .desc(
+    `
+  Test using at and over ${limit} limit in createPipelineLayout
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('visibility', kShaderStageCombinationsWithStage)
+      .combine('order', kReorderOrderKeys)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility, order } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const kNumGroups = 3;
+        const bindGroupLayouts = range(kNumGroups, i => {
+          const minInGroup = Math.floor(testValue / kNumGroups);
+          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          return createBindGroupLayout(device, visibility, order, numInGroup);
+        });
+        await t.expectValidationError(
+          () => device.createPipelineLayout({ bindGroupLayouts }),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('createPipeline,at_over')
+  .desc(
+    `
+  Test using createRenderPipeline and createComputePipeline at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', kBindingCombinations)
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombination(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var<uniform> u${j}_${i}: f32`,
+          (i, j) => `_ = u${j}_${i};`,
+          testValue
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.expectValidationError(
+          () => {
+            t.createPipeline(pipelineType, module);
+          },
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });
+
+g.test('createPipelineAsync,at_over')
+  .desc(
+    `
+  Test using createRenderPipelineAsync and createComputePipelineAsync at and over ${limit} limit
+  
+  Note: We also test order to make sure the implementation isn't just looking
+  at just the last entry.
+  `
+  )
+  .params(
+    kLimitBaseParams
+      .combine('bindingCombination', kBindingCombinations)
+      .combine('order', kReorderOrderKeys)
+      .combine('bindGroupTest', kBindGroupTests)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
+    const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
+
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const code = getPerStageWGSLForBindingCombination(
+          bindingCombination,
+          order,
+          bindGroupTest,
+          (i, j) => `var<uniform> u${j}_${i}: f32`,
+          (i, j) => `_ = u${j}_${i};`,
+          testValue
+        );
+        const module = device.createShaderModule({ code });
+
+        await t.shouldRejectConditionally(
+          'OperationError',
+          t.createPipelineAsync(pipelineType, module),
+          shouldError,
+          `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
+        );
+      }
+    );
+  });

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -973,6 +973,15 @@ export const kShaderStages: readonly GPUShaderStageFlags[] = [
 ];
 /** List of all possible combinations of GPUShaderStage values. */
 export const kShaderStageCombinations: readonly GPUShaderStageFlags[] = [0, 1, 2, 3, 4, 5, 6, 7];
+export const kShaderStageCombinationsWithStage: readonly GPUShaderStageFlags[] = [
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+];
 
 /**
  * List of all possible texture sampleCount values.


### PR DESCRIPTION

Issue: #2195 

random comment: Seems like I should be able to use `GPUShaderStage.FRAGMENT` instead of `GPUConst.ShaderStage.FRAGMENT`. Does something need to be updated?

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
