### PR TITLE
[wgsl] Add validation of `discard` placement.

### DIFF
--- a/src/webgpu/shader/validation/parse/discard.spec.ts
+++ b/src/webgpu/shader/validation/parse/discard.spec.ts
@@ -1,0 +1,65 @@
+export const description = `Validation tests for discard`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('placement')
+  .desc('Test that discard usage is validated')
+  .params(u =>
+    u.combine('place', ['compute', 'vertex', 'fragment', 'module', 'subfrag', 'subvert', 'subcomp'])
+  )
+  .fn(t => {
+    const pos: { [key: string]: string } = {
+      module: '',
+      subvert: '',
+      subfrag: '',
+      subcomp: '',
+      vertex: '',
+      fragment: '',
+      compute: '',
+    };
+
+    pos[t.params.place] = 'discard;';
+
+    const code = `
+${pos.module}
+
+fn subvert() {
+  ${pos.subvert}
+}
+
+@vertex
+fn vtx() -> @builtin(position) vec4f {
+  ${pos.vertex}
+  subvert();
+  return vec4f(1);
+}
+
+fn subfrag() {
+  ${pos.subfrag}
+}
+
+@fragment
+fn frag() -> @location(0) vec4f {
+  ${pos.fragment}
+  subfrag();
+  return vec4f(1);
+}
+
+fn subcomp() {
+  ${pos.subcomp}
+}
+
+@compute
+@workgroup_size(1)
+fn comp() {
+  ${pos.compute}
+  subcomp();
+}
+`;
+
+    const pass = ['fragment', 'subfrag'].includes(t.params.place);
+    t.expectCompileResult(pass, code);
+  });


### PR DESCRIPTION
This CL adds validation of the placement of a `discard` command inside a WGSL shader.

Issue #1683

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
