### PR TITLE
[wgsl] Add validation tests for `break` placement

### DIFF
--- a/src/webgpu/shader/validation/parse/break.spec.ts
+++ b/src/webgpu/shader/validation/parse/break.spec.ts
@@ -1,6 +1,7 @@
 export const description = `Validation tests for break`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
@@ -70,7 +71,7 @@ const kTests = {
 
 g.test('placement')
   .desc('Test that break placement is validated correctly')
-  .params(u => u.combine('stmt', Object.keys(kTests) as Array<keyof typeof kTests>))
+  .params(u => u.combine('stmt', keysOf(kTests)))
   .fn(t => {
     const code = `
 @vertex

--- a/src/webgpu/shader/validation/parse/break.spec.ts
+++ b/src/webgpu/shader/validation/parse/break.spec.ts
@@ -1,0 +1,83 @@
+export const description = `Validation tests for break`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kTests = {
+  loop_break: {
+    src: 'loop { break; }',
+    pass: true,
+  },
+  loop_if_break: {
+    src: 'loop { if true { break; } }',
+    pass: true,
+  },
+  continuing_break_if: {
+    src: 'loop { continuing { break if (true); } }',
+    pass: true,
+  },
+  while_break: {
+    src: 'while true { break; }',
+    pass: true,
+  },
+  while_if_break: {
+    src: 'while true { if true { break; } }',
+    pass: true,
+  },
+  for_break: {
+    src: 'for (;;) { break; }',
+    pass: true,
+  },
+  for_if_break: {
+    src: 'for (;;) { if true { break; } }',
+    pass: true,
+  },
+  switch_case_break: {
+    src: 'switch(1) { default: { break; } }',
+    pass: true,
+  },
+  switch_case_if_break: {
+    src: 'switch(1) { default: { if true { break; } } }',
+    pass: true,
+  },
+  break: {
+    src: 'break;',
+    pass: false,
+  },
+  return_break: {
+    src: 'return break;',
+    pass: false,
+  },
+  if_break: {
+    src: 'if true { break; }',
+    pass: false,
+  },
+  continuing_break: {
+    src: 'loop { continuing { break; } }',
+    pass: false,
+  },
+  continuing_if_break: {
+    src: 'loop { continuing { if (true) { break; } } }',
+    pass: false,
+  },
+  switch_break: {
+    src: 'switch(1) { break; }',
+    pass: false,
+  },
+};
+
+g.test('placement')
+  .desc('Test that break placement is validated correctly')
+  .params(u => u.combine('stmt', Object.keys(kTests) as Array<keyof typeof kTests>))
+  .fn(t => {
+    const code = `
+@vertex
+fn vtx() -> @builtin(position) vec4f {
+  ${kTests[t.params.stmt].src}
+  return vec4f(1);
+}
+    `;
+    t.expectCompileResult(kTests[t.params.stmt].pass, code);
+  });


### PR DESCRIPTION
This CL adds validation tests for the locations a `break` statement can appear.

Fixes #1671

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
