### PR TITLE
Update to use `keysOf` helper.

### DIFF
--- a/src/webgpu/shader/validation/const_assert/const_assert.spec.ts
+++ b/src/webgpu/shader/validation/const_assert/const_assert.spec.ts
@@ -1,6 +1,7 @@
 export const description = `Validation tests for const_assert`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
@@ -31,7 +32,7 @@ g.test('constant_expression')
   .desc(`Test that const_assert validates the condition expression.`)
   .params(u =>
     u
-      .combine('case', Object.keys(kConditionCases) as Array<keyof typeof kConditionCases>)
+      .combine('case', keysOf(kConditionCases))
       .combine('scope', ['module', 'function'] as const)
       .beginSubcases()
   )

--- a/src/webgpu/shader/validation/parse/attribute.spec.ts
+++ b/src/webgpu/shader/validation/parse/attribute.spec.ts
@@ -1,6 +1,7 @@
 export const description = `Validation tests for attributes`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
@@ -35,9 +36,7 @@ const kAllowedUsages = {
 g.test('expressions')
   .desc(`Tests attributes which allow expressions`)
   .params(u =>
-    u
-      .combine('value', Object.keys(kPossibleValues) as Array<keyof typeof kPossibleValues>)
-      .combine('attribute', Object.keys(kAllowedUsages) as Array<keyof typeof kAllowedUsages>)
+    u.combine('value', keysOf(kPossibleValues)).combine('attribute', keysOf(kAllowedUsages))
   )
   .fn(t => {
     const attributes = {

--- a/src/webgpu/shader/validation/parse/const_assert.spec.ts
+++ b/src/webgpu/shader/validation/parse/const_assert.spec.ts
@@ -1,6 +1,7 @@
 export const description = `Parser validation tests for const_assert`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
@@ -30,7 +31,7 @@ true;`,
 
 g.test('parse')
   .desc(`Tests that the const_assert statement parses correctly.`)
-  .params(u => u.combine('case', Object.keys(kCases) as Array<keyof typeof kCases>).beginSubcases())
+  .params(u => u.combine('case', keysOf(kCases)))
   .fn(t => {
     const c = kCases[t.params.case];
     t.expectCompileResult(c.pass, c.code);


### PR DESCRIPTION
Remove `keyof typeof` usage in favour of the `keysOf` helper method.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
