### PR TITLE
Update `align` parsing tests.

### DIFF
--- a/src/webgpu/shader/validation/parse/align.spec.ts
+++ b/src/webgpu/shader/validation/parse/align.spec.ts
@@ -1,55 +1,137 @@
 export const description = `Validation tests for @align`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
 
-const kValidAlign = new Set([
-  '',
-  '@align(1)',
-  '@align(4)',
-  '@align(4i)',
-  '@align(4u)',
-  '@align(0x4)',
-  '@align(4,)',
-  '@align(u_val)',
-  '@align(i_val)',
-  '@align(i_val + 4 - 6)',
-  '@align(1073741824)',
-  '@\talign\t(4)',
-  '@/^comment^/align/^comment^/(4)',
-]);
-const kInvalidAlign = new Set([
-  '@malign(4)',
-  '@align()',
-  '@align 4)',
-  '@align(4',
-  '@align(4, 2)',
-  '@align(4,)',
-  '@align(3)', // Not a power of 2
-  '@align(f_val)',
-  '@align(1.0)',
-  '@align(4f)',
-  '@align(4h)',
-  '@align',
-  '@align(0)',
-  '@align(-4)',
-  '@align(2147483646)', // Not a power of 2
-  '@align(2147483648)', // Larger then max i32
-]);
+const kTests = {
+  blank: {
+    src: '',
+    pass: true,
+  },
+  one: {
+    src: '@align(1)',
+    pass: true,
+  },
+  four_a: {
+    src: '@align(4)',
+    pass: true,
+  },
+  four_i: {
+    src: '@align(4i)',
+    pass: true,
+  },
+  four_u: {
+    src: '@align(4u)',
+    pass: true,
+  },
+  four_hex: {
+    src: '@align(0x4)',
+    pass: true,
+  },
+  trailing_comma: {
+    src: '@align(4,)',
+    pass: true,
+  },
+  const_u: {
+    src: '@align(u_val)',
+    pass: true,
+  },
+  const_i: {
+    src: '@align(i_val)',
+    pass: true,
+  },
+  const_expr: {
+    src: '@align(i_val + 4 - 6)',
+    pass: true,
+  },
+  large: {
+    src: '@align(1073741824)',
+    pass: true,
+  },
+  tabs: {
+    src: '@\talign\t(4)',
+    pass: true,
+  },
+  comment: {
+    src: '@/*comment*/align/*comment*/(4)',
+    pass: true,
+  },
+  misspelling: {
+    src: '@malign(4)',
+    pass: false,
+  },
+  empty: {
+    src: '@align()',
+    pass: false,
+  },
+  missing_left_paren: {
+    src: '@align 4)',
+    pass: false,
+  },
+  missing_right_paren: {
+    src: '@align(4',
+    pass: false,
+  },
+  multiple_values: {
+    src: '@align(4, 2)',
+    pass: false,
+  },
+  non_power_two: {
+    src: '@align(3)',
+    pass: false,
+  },
+  const_f: {
+    src: '@align(f_val)',
+    pass: false,
+  },
+  one_f: {
+    src: '@align(1.0)',
+    pass: false,
+  },
+  four_f: {
+    src: '@align(4f)',
+    pass: false,
+  },
+  four_h: {
+    src: '@align(4h)',
+    pass: false,
+  },
+  no_params: {
+    src: '@align',
+    pass: false,
+  },
+  zero_a: {
+    src: '@align(0)',
+    pass: false,
+  },
+  negative: {
+    src: '@align(-4)',
+    pass: false,
+  },
+  large_no_power_two: {
+    src: '@align(2147483646)',
+    pass: false,
+  },
+  larger_than_max_i32: {
+    src: '@align(2147483648)',
+    pass: false,
+  },
+};
 
-g.test('align_parsing')
+g.test('parsing')
   .desc(`Test that @align is parsed correctly.`)
-  .params(u => u.combine('align', new Set([...kValidAlign, ...kInvalidAlign])))
+  .params(u => u.combine('align', keysOf(kTests)))
   .fn(t => {
-    const v = t.params.align.replace(/\^/g, '*');
+    const src = kTests[t.params.align].src;
     const code = `
 const i_val: i32 = 4;
 const u_val: u32 = 4;
 const f_val: f32 = 4.2;
 struct B {
-  ${v} a: i32,
+  ${src} a: i32,
 }
 
 @group(0) @binding(0)
@@ -59,18 +141,14 @@ var<uniform> uniform_buffer: B;
 fn main() -> @location(0) vec4<f32> {
   return vec4<f32>(.4, .2, .3, .1);
 }`;
-    t.expectCompileResult(kValidAlign.has(t.params.align), code);
+    t.expectCompileResult(kTests[t.params.align].pass, code);
   });
 
-g.test('align_required_alignment')
+g.test('required_alignment')
   .desc('Test that the align with an invalid size is an error')
   .params(u =>
     u
       .combine('address_space', ['storage', 'uniform'])
-      // These test a few cases:
-      //  * 1 -- Invalid, alignment smaller then all the required alignments
-      //  * alignment -- Valid, the required alignment
-      //  * 32 -- Valid, an alignment larger then the required alignment.
       .combine('align', [1, 2, 'alignment', 32])
       .combine('type', [
         { name: 'i32', storage: 4, uniform: 4 },
@@ -165,16 +243,12 @@ g.test('align_required_alignment')
       return vec4<f32>(.4, .2, .3, .1);
     }`;
 
+    // An array of `vec2` in uniform will not validate because, while the alignment on the array
+    // itself is fine, the `vec2` element inside the array will have the wrong alignment. Uniform
+    // requires that inner vec2 to have an align 16 which can only be done by specifying `vec4`
+    // instead.
     const fails =
-      // An alignment of 1 is never valid as it is smaller then all required alignments.
-      t.params.align === 1 ||
-      // Except for f16, 2 should also fail as being too small.
-      (t.params.align === 2 && t.params.type.name !== 'f16') ||
-      // An array of `vec2` in uniform will not validate because, while the alignment on the array
-      // itself is fine, the `vec2` element inside the array will have the wrong alignment. Uniform
-      // requires that inner vec2 to have an align 16 which can only be done by specifying `vec4`
-      // instead.
-      (t.params.address_space === 'uniform' && t.params.type.name.startsWith('array<vec2'));
+      t.params.address_space === 'uniform' && t.params.type.name.startsWith('array<vec2');
 
     t.expectCompileResult(!fails, code);
   });


### PR DESCRIPTION
This CL updates the align parsing tests to not use code snippets in the URL. The required_alignment tests are updated to allow alignments smaller then the required object alignment.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
