### PR TITLE
[wgsl] Tests `@const` is not allowed to be used as an attribute.

### DIFF
--- a/src/webgpu/shader/validation/parse/const.spec.ts
+++ b/src/webgpu/shader/validation/parse/const.spec.ts
@@ -1,0 +1,57 @@
+export const description = `Validation tests for @const`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('placement')
+  .desc('Tests @const is not allowed to appear')
+  .params(u =>
+    u.combine('scope', [
+      'private-var',
+      'storage-var',
+      'struct-member',
+      'fn-decl',
+      'fn-param',
+      'fn-var',
+      'fn-return',
+      'while-stmt',
+      undefined,
+    ] as const)
+  )
+  .fn(t => {
+    const scope = t.params.scope;
+
+    const attr = '@const';
+    const code = `
+      ${scope === 'private-var' ? attr : ''}
+      var<private> priv_var : i32;
+
+      ${scope === 'storage-var' ? attr : ''}
+      @group(0) @binding(0)
+      var<storage> stor_var : i32;
+
+      struct A {
+        ${scope === 'struct-member' ? attr : ''}
+        a : i32,
+      }
+
+      @vertex
+      ${scope === 'fn-decl' ? attr : ''}
+      fn f(
+        ${scope === 'fn-param' ? attr : ''}
+        @location(0) b : i32,
+      ) -> ${scope === 'fn-return' ? attr : ''} @builtin(position) vec4f {
+        ${scope === 'fn-var' ? attr : ''}
+        var<function> func_v : i32;
+
+        ${scope === 'while-stmt' ? attr : ''}
+        while false {}
+
+        return vec4(1, 1, 1, 1);
+      }
+    `;
+
+    t.expectCompileResult(scope === undefined, code);
+  });


### PR DESCRIPTION
This CL adds a test that using the `@const` attribute will result in a compilation error.

Fixes #1438

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
