### PR TITLE
Add validation tests for unary not and binary and/or

### DIFF
--- a/src/webgpu/shader/validation/parse/binary_ops.spec.ts
+++ b/src/webgpu/shader/validation/parse/binary_ops.spec.ts
@@ -1,0 +1,89 @@
+export const description = `Validation tests for binary ops`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kTests = {
+  and_bool_literal_bool_literal: {
+    src: `let a = true & true;`,
+    pass: true,
+  },
+  and_bool_expr_bool_expr: {
+    src: `let a = (1 == 2) & (3 == 4);`,
+    pass: true,
+  },
+  and_bool_literal_bool_expr: {
+    src: `let a = true & (1 == 2);`,
+    pass: true,
+  },
+  and_bool_expr_bool_literal: {
+    src: `let a = (1 == 2) & true;`,
+    pass: true,
+  },
+  and_bool_literal_int_literal: {
+    src: `let a = true & 1;`,
+    pass: false,
+  },
+  and_int_literal_bool_literal: {
+    src: `let a = 1 & true;`,
+    pass: false,
+  },
+  and_bool_expr_int_literal: {
+    src: `let a = (1 == 2) & 1;`,
+    pass: false,
+  },
+  and_int_literal_bool_expr: {
+    src: `let a = 1 & (1 == 2);`,
+    pass: false,
+  },
+
+  or_bool_literal_bool_literal: {
+    src: `let a = true | true;`,
+    pass: true,
+  },
+  or_bool_expr_bool_expr: {
+    src: `let a = (1 == 2) | (3 == 4);`,
+    pass: true,
+  },
+  or_bool_literal_bool_expr: {
+    src: `let a = true | (1 == 2);`,
+    pass: true,
+  },
+  or_bool_expr_bool_literal: {
+    src: `let a = (1 == 2) | true;`,
+    pass: true,
+  },
+  or_bool_literal_int_literal: {
+    src: `let a = true | 1;`,
+    pass: false,
+  },
+  or_int_literal_bool_literal: {
+    src: `let a = 1 | true;`,
+    pass: false,
+  },
+  or_bool_expr_int_literal: {
+    src: `let a = (1 == 2) | 1;`,
+    pass: false,
+  },
+  or_int_literal_bool_expr: {
+    src: `let a = 1 | (1 == 2);`,
+    pass: false,
+  },
+};
+
+g.test('all')
+  .desc('Test that binary operators are validated correctly')
+  .params(u => u.combine('stmt', keysOf(kTests)))
+  .fn(t => {
+    const code = `
+@vertex
+fn vtx() -> @builtin(position) vec4f {
+  ${kTests[t.params.stmt].src}
+  return vec4f(1);
+}
+    `;
+    t.expectCompileResult(kTests[t.params.stmt].pass, code);
+  });

--- a/src/webgpu/shader/validation/parse/unary_ops.spec.ts
+++ b/src/webgpu/shader/validation/parse/unary_ops.spec.ts
@@ -1,0 +1,48 @@
+export const description = `Validation tests for unary ops`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kTests = {
+  not_bool_literal: {
+    src: 'let a = !true;',
+    pass: true,
+  },
+  not_bool_expr: {
+    src: `let a = !(1 == 2);`,
+    pass: true,
+  },
+  not_not_bool_literal: {
+    src: 'let a = !!true;',
+    pass: true,
+  },
+  not_not_bool_expr: {
+    src: `let a = !!(1 == 2);`,
+    pass: true,
+  },
+  not_int_literal: {
+    src: `let a = !42;`,
+    pass: false,
+  },
+  not_int_expr: {
+    src: `let a = !(40 + 2);`,
+    pass: false,
+  },
+};
+
+g.test('all')
+  .desc('Test that unary operators are validated correctly')
+  .params(u => u.combine('stmt', keysOf(kTests)))
+  .fn(t => {
+    const code = `
+@vertex
+fn vtx() -> @builtin(position) vec4f {
+  ${kTests[t.params.stmt].src}
+  return vec4f(1);
+}
+    `;
+    t.expectCompileResult(kTests[t.params.stmt].pass, code);
+  });


### PR DESCRIPTION
Issue: #1623 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
