### PR TITLE
[wgsl] Add placement tests for @builtin.

### DIFF
--- a/src/webgpu/shader/validation/parse/builtin.spec.ts
+++ b/src/webgpu/shader/validation/parse/builtin.spec.ts
@@ -73,3 +73,72 @@ fn main() -> ${src} vec4<f32> {
 }`;
     t.expectCompileResult(kTests[t.params.builtin].pass, code);
   });
+
+g.test('placement')
+  .desc('Tests the locations @builtin is allowed to appear')
+  .params(u =>
+    u
+      .combine('scope', [
+        // The fn-param and fn-ret are part of the shader_io/builtins tests
+        'private-var',
+        'storage-var',
+        'struct-member',
+        'non-ep-param',
+        'non-ep-ret',
+        'fn-decl',
+        'fn-var',
+        'while-stmt',
+        undefined,
+      ] as const)
+      .combine('attribute', [
+        {
+          'private-var': false,
+          'storage-var': false,
+          'struct-member': true,
+          'non-ep-param': false,
+          'non-ep-ret': false,
+          'fn-decl': false,
+          'fn-var': false,
+          'fn-return': false,
+          'while-stmt': false,
+        },
+      ])
+      .beginSubcases()
+  )
+  .fn(t => {
+    const scope = t.params.scope;
+
+    const attr = '@builtin(vertex_index)';
+    const code = `
+      ${scope === 'private-var' ? attr : ''}
+      var<private> priv_var : u32;
+
+      ${scope === 'storage-var' ? attr : ''}
+      @group(0) @binding(0)
+      var<storage> stor_var : u32;
+
+      struct A {
+        ${scope === 'struct-member' ? attr : ''}
+        a : u32,
+      }
+
+      fn v(${scope === 'non-ep-param' ? attr : ''} i : u32) ->
+            ${scope === 'non-ep-ret' ? attr : ''} u32 { return 1; }
+
+      @vertex
+      ${scope === 'fn-decl' ? attr : ''}
+      fn f(
+        @location(0) b : u32,
+      ) -> @builtin(position) vec4f {
+        ${scope === 'fn-var' ? attr : ''}
+        var<function> func_v : u32;
+
+        ${scope === 'while-stmt' ? attr : ''}
+        while false {}
+
+        return vec4(1, 1, 1, 1);
+      }
+    `;
+
+    t.expectCompileResult(scope === undefined || t.params.attribute[scope], code);
+  });


### PR DESCRIPTION
This CL adds tests to validate where a `@builtin` attribute is accepted.

Fixes #1435

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
