### PR TITLE
Add more tests for end twice

### DIFF
--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -186,7 +186,7 @@ g.test('pass_end_twice,basic')
       .combine('passType', ['compute', 'render'])
       // Simply end twice, the parent encoder is open at that time. If the second pass end is in the middle of another pass, the parent encoder is locked. It should generate a validation error in either situation.
       .combine('endTwice', [false, true])
-      .combine('secondEndInAnotherPass', [false, true])
+      .combine('secondEndInAnotherPass', [false, 'compute', 'render'])
       .filter(p => p.endTwice || !p.secondEndInAnotherPass)
   )
   .fn(t => {
@@ -202,7 +202,9 @@ g.test('pass_end_twice,basic')
 
     if (secondEndInAnotherPass) {
       const pass1 =
-        passType === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder, view);
+        secondEndInAnotherPass === 'compute'
+          ? encoder.beginComputePass()
+          : t.beginRenderPass(encoder, view);
 
       t.expectValidationError(() => {
         pass.end();

--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -177,15 +177,20 @@ g.test('pass_end_none')
     }, endCount === 0);
   });
 
-g.test('pass_end_twice')
-  .desc('Test that ending a {compute,render} pass twice generates a validation error.')
+g.test('pass_end_twice,basic')
+  .desc(
+    'Test that ending a {compute,render} pass twice generates a validation error. The parent encoder (command encoder) can be either locked or open.'
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('passType', ['compute', 'render'])
+      // Simply end twice, the parent encoder is open at that time. If the second pass end is in the middle of another pass, the parent encoder is locked. It should generate a validation error in either situation.
       .combine('endTwice', [false, true])
+      .combine('secondEndInAnotherPass', [false, true])
+      .filter(p => p.endTwice || !p.secondEndInAnotherPass)
   )
   .fn(t => {
-    const { passType, endTwice } = t.params;
+    const { passType, endTwice, secondEndInAnotherPass } = t.params;
 
     const view = t.createAttachmentTextureView();
     const encoder = t.device.createCommandEncoder();
@@ -194,11 +199,50 @@ g.test('pass_end_twice')
       passType === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder, view);
 
     pass.end();
+
+    if (secondEndInAnotherPass) {
+      const pass1 =
+        passType === 'compute' ? encoder.beginComputePass() : t.beginRenderPass(encoder, view);
+
+      t.expectValidationError(() => {
+        pass.end();
+      });
+
+      pass1.end();
+    } else {
+      if (endTwice) {
+        t.expectValidationError(() => {
+          pass.end();
+        });
+      }
+    }
+
+    encoder.finish();
+  });
+
+g.test('pass_end_twice,render_pass_invalid')
+  .desc(
+    'Test that ending a render pass twice generates a validation error even if the pass is invalid.'
+  )
+  .paramsSubcasesOnly(u => u.combine('endTwice', [false, true]))
+  .fn(t => {
+    const { endTwice } = t.params;
+
+    const encoder = t.device.createCommandEncoder();
+    // Pass encoder creation will fail because both color and depth/stencil attachments are empty.
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [],
+    });
+
+    pass.end();
+
     if (endTwice) {
       t.expectValidationError(() => {
         pass.end();
       });
     }
 
-    encoder.finish();
+    t.expectValidationError(() => {
+      encoder.finish();
+    });
   });


### PR DESCRIPTION
The existing end twice tests covers pass end twice when its parent encoder is open and the pass encoder is valid.

This change adds more tests to cover situations below:
  - the parent encoder is locked (pass end twice in the middle of another pass)
  - the pass encoder is invalid and we end the pass twice

It should generate validation error immediately when pass end twice in the situations above.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
