### PR TITLE
Upgrade gpuweb/types to 0.1.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "0.1.25",
+        "@webgpu/types": "0.1.27",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1261,13 +1261,10 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.25.tgz",
-      "integrity": "sha512-XTlMU1fEbVqIwuQAqlA0w8lJepW4KqeGmUxwWioVL0aoVgut0PE4ex+ixQWM74JKAyRfvS9+0lp+dFMfx5KZvw==",
-      "dev": true,
-      "dependencies": {
-        "typescript": "^4.6.4"
-      }
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-9oZDgM+/vhyPDM3twL1KQSs0fLbXvbxrStWi/+tvXnas7pQuQNaNBpge8wNcEUtbLMoORQYDc6hPFCSQKqpNAw==",
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -9877,13 +9874,10 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.25.tgz",
-      "integrity": "sha512-XTlMU1fEbVqIwuQAqlA0w8lJepW4KqeGmUxwWioVL0aoVgut0PE4ex+ixQWM74JKAyRfvS9+0lp+dFMfx5KZvw==",
-      "dev": true,
-      "requires": {
-        "typescript": "^4.6.4"
-      }
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-9oZDgM+/vhyPDM3twL1KQSs0fLbXvbxrStWi/+tvXnas7pQuQNaNBpge8wNcEUtbLMoORQYDc6hPFCSQKqpNAw==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "0.1.25",
+    "@webgpu/types": "0.1.27",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -1086,6 +1086,7 @@ export const kDrawIndexedIndirectParametersSize = 5;
 export const kFeatureNameInfo: {
   readonly [k in GPUFeatureName]: {};
 } = /* prettier-ignore */ {
+  'bgra8unorm-storage': {},
   'depth-clip-control': {},
   'depth32float-stencil8': {},
   'texture-compression-bc': {},

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -16,6 +16,7 @@ import {
   startPlayingAndWaitForVideo,
   getVideoColorSpaceInit,
   getVideoFrameFromVideoElement,
+  waitForNextFrame,
 } from '../../web_platform/util.js';
 
 const kHeight = 16;
@@ -310,6 +311,15 @@ TODO: Make this test work without requestVideoFrameCallback support (in waitForN
         t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), true);
       }
     });
+    if (sourceType === 'VideoElement') {
+      // Update new video frame.
+      await waitForNextFrame(videoElement, () => {
+        // VideoFrame is updated. GPUExternalTexture imported from HTMLVideoElement should be expired.
+        // Using the GPUExternalTexture should result in an error.
+        const commandBuffer = useExternalTexture();
+        t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), true);
+      });
+    }
   });
 
 g.test('importExternalTexture,compute')

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -16,7 +16,6 @@ import {
   startPlayingAndWaitForVideo,
   getVideoColorSpaceInit,
   getVideoFrameFromVideoElement,
-  waitForNextFrame,
 } from '../../web_platform/util.js';
 
 const kHeight = 16;
@@ -304,26 +303,13 @@ TODO: Make this test work without requestVideoFrameCallback support (in waitForN
 
       const commandBuffer = useExternalTexture();
       t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), false);
-      t.expect(!externalTexture.expired);
 
       if (sourceType === 'VideoFrame') {
         (source as VideoFrame).close();
         const commandBuffer = useExternalTexture();
         t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), true);
-        t.expect(externalTexture.expired);
       }
     });
-
-    if (sourceType === 'VideoElement') {
-      // Update new video frame.
-      await waitForNextFrame(videoElement, () => {
-        // VideoFrame is updated. GPUExternalTexture imported from HTMLVideoElement should be expired.
-        // Using the GPUExternalTexture should result in an error.
-        const commandBuffer = useExternalTexture();
-        t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), true);
-        t.expect(externalTexture.expired);
-      });
-    }
   });
 
 g.test('importExternalTexture,compute')


### PR DESCRIPTION
This PR upgrade gpuweb/types to 0.1.27 and fix issues:
- GPUExternalTexture.expired has been removed. Modify related cts
- Adding new feature name 'bgra8unorm-storage'




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
