### PR TITLE
Add f32 matrix addition tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -12,7 +12,7 @@ import {
   acoshAlternativeInterval,
   acoshPrimaryInterval,
   additionInterval,
-  additionMatrixPairInterval,
+  additionMatrixInterval,
   asinInterval,
   asinhInterval,
   atanInterval,
@@ -3570,7 +3570,7 @@ interface MatrixPairCase {
   expected: IntervalBounds[][] | number[][];
 }
 
-g.test('additionMatrixMatrixInterval')
+g.test('additionMatrixInterval')
   .paramsSubcasesOnly<MatrixPairCase>([
     // Only testing that different shapes of matrices are handled correctly, to
     // reduce test duplication. This function uses AdditionIntervalOp for
@@ -3753,10 +3753,10 @@ g.test('additionMatrixMatrixInterval')
     const y = t.params.input[1];
     const expected = toF32Matrix(t.params.expected);
 
-    const got = additionMatrixPairInterval(x, y);
+    const got = additionMatrixInterval(x, y);
     t.expect(
       objectEquals(expected, got),
-      `additionMatrixMatrixInterval([${JSON.stringify(x)}], [${JSON.stringify(
+      `additionMatrixInterval([${JSON.stringify(x)}], [${JSON.stringify(
         y
       )}]) returned '[${JSON.stringify(got)}]'. Expected '[${JSON.stringify(expected)}]'`
     );

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -12,6 +12,7 @@ import {
   acoshAlternativeInterval,
   acoshPrimaryInterval,
   additionInterval,
+  additionMatrixPairInterval,
   asinInterval,
   asinhInterval,
   atanInterval,
@@ -3561,5 +3562,202 @@ g.test('transposeInterval')
       `transposeInterval([${JSON.stringify(input)}]) returned '[${JSON.stringify(
         got
       )}]'. Expected '[${JSON.stringify(expected)}]'`
+    );
+  });
+
+interface MatrixPairCase {
+  input: [number[][], number[][]];
+  expected: IntervalBounds[][] | number[][];
+}
+
+g.test('additionMatrixMatrixInterval')
+  .paramsSubcasesOnly<MatrixPairCase>([
+    // Only testing that different shapes of matrices are handled correctly, to
+    // reduce test duplication. This function uses AdditionIntervalOp for
+    // calculating intervals, so depending on additionInterval's testing to
+    // make sure that things like subnormals are handled as expected.
+    {
+      input: [
+        [
+          [1, 2],
+          [3, 4],
+        ],
+        [
+          [10, 20],
+          [30, 40],
+        ],
+      ],
+      expected: [
+        [11, 22],
+        [33, 44],
+      ],
+    },
+    {
+      input: [
+        [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+        ],
+        [
+          [10, 20],
+          [30, 40],
+          [50, 60],
+        ],
+      ],
+      expected: [
+        [11, 22],
+        [33, 44],
+        [55, 66],
+      ],
+    },
+    {
+      input: [
+        [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+          [7, 8],
+        ],
+        [
+          [10, 20],
+          [30, 40],
+          [50, 60],
+          [70, 80],
+        ],
+      ],
+      expected: [
+        [11, 22],
+        [33, 44],
+        [55, 66],
+        [77, 88],
+      ],
+    },
+    {
+      input: [
+        [
+          [1, 2, 3],
+          [4, 5, 6],
+        ],
+        [
+          [10, 20, 30],
+          [40, 50, 60],
+        ],
+      ],
+      expected: [
+        [11, 22, 33],
+        [44, 55, 66],
+      ],
+    },
+    {
+      input: [
+        [
+          [1, 2, 3],
+          [4, 5, 6],
+          [7, 8, 9],
+        ],
+        [
+          [10, 20, 30],
+          [40, 50, 60],
+          [70, 80, 90],
+        ],
+      ],
+      expected: [
+        [11, 22, 33],
+        [44, 55, 66],
+        [77, 88, 99],
+      ],
+    },
+    {
+      input: [
+        [
+          [1, 2, 3],
+          [4, 5, 6],
+          [7, 8, 9],
+          [10, 11, 12],
+        ],
+        [
+          [10, 20, 30],
+          [40, 50, 60],
+          [70, 80, 90],
+          [1000, 1100, 1200],
+        ],
+      ],
+      expected: [
+        [11, 22, 33],
+        [44, 55, 66],
+        [77, 88, 99],
+        [1010, 1111, 1212],
+      ],
+    },
+    {
+      input: [
+        [
+          [1, 2, 3, 4],
+          [5, 6, 7, 8],
+        ],
+        [
+          [10, 20, 30, 40],
+          [50, 60, 70, 80],
+        ],
+      ],
+      expected: [
+        [11, 22, 33, 44],
+        [55, 66, 77, 88],
+      ],
+    },
+    {
+      input: [
+        [
+          [1, 2, 3, 4],
+          [5, 6, 7, 8],
+          [9, 10, 11, 12],
+        ],
+        [
+          [10, 20, 30, 40],
+          [50, 60, 70, 80],
+          [90, 1000, 1100, 1200],
+        ],
+      ],
+      expected: [
+        [11, 22, 33, 44],
+        [55, 66, 77, 88],
+        [99, 1010, 1111, 1212],
+      ],
+    },
+    {
+      input: [
+        [
+          [1, 2, 3, 4],
+          [5, 6, 7, 8],
+          [9, 10, 11, 12],
+          [13, 14, 15, 16],
+        ],
+        [
+          [10, 20, 30, 40],
+          [50, 60, 70, 80],
+          [90, 1000, 1100, 1200],
+          [1300, 1400, 1500, 1600],
+        ],
+      ],
+      expected: [
+        [11, 22, 33, 44],
+        [55, 66, 77, 88],
+        [99, 1010, 1111, 1212],
+        [1313, 1414, 1515, 1616],
+      ],
+    },
+  ])
+  .fn(t => {
+    const x = t.params.input[0];
+    const y = t.params.input[1];
+    const expected = toF32Matrix(t.params.expected);
+
+    const got = additionMatrixPairInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `additionMatrixMatrixInterval([${JSON.stringify(x)}], [${JSON.stringify(
+        y
+      )}]) returned '[${JSON.stringify(got)}]'. Expected '[${JSON.stringify(expected)}]'`
     );
   });

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -3572,10 +3572,11 @@ interface MatrixPairCase {
 
 g.test('additionMatrixInterval')
   .paramsSubcasesOnly<MatrixPairCase>([
-    // Only testing that different shapes of matrices are handled correctly, to
-    // reduce test duplication. This function uses AdditionIntervalOp for
-    // calculating intervals, so depending on additionInterval's testing to
-    // make sure that things like subnormals are handled as expected.
+    // Only testing that different shapes of matrices are handled correctly
+    // here, to reduce test duplication.
+    // additionMatrixInterval uses AdditionIntervalOp for calculating intervals,
+    // so the testing for additionInterval covers the actual interval
+    // calculations.
     {
       input: [
         [

--- a/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-Execution Tests for the matrix arithmetic binary expression operations
+Execution Tests for the f32 matrix arithmetic binary expression operations
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
@@ -14,7 +14,7 @@ import { binary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
 
-export const d = makeCaseCache('binary/matrix_arithmetic', {
+export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
   addition_2x2_const: () => {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 2),

--- a/src/webgpu/shader/execution/expression/binary/matrix_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/matrix_arithmetic.spec.ts
@@ -1,0 +1,194 @@
+export const description = `
+Execution Tests for the matrix arithmetic binary expression operations
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { TypeF32, TypeMat } from '../../../../util/conversion.js';
+import { additionMatrixPairInterval } from '../../../../util/f32_interval.js';
+import { sparseMatrixF32Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
+import { allInputSources, generateMatrixPairToMatrixCases, run } from '../expression.js';
+
+import { binary } from './binary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('binary/matrix_arithmetic', {
+  addition_2x2_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 2),
+      sparseMatrixF32Range(2, 2),
+      'f32-only',
+      additionMatrixPairInterval
+    );
+  },
+  addition_2x2_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 2),
+      sparseMatrixF32Range(2, 2),
+      'unfiltered',
+      additionMatrixPairInterval
+    );
+  },
+  addition_2x3_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 3),
+      sparseMatrixF32Range(2, 3),
+      'f32-only',
+      additionMatrixPairInterval
+    );
+  },
+  addition_2x3_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 3),
+      sparseMatrixF32Range(2, 3),
+      'unfiltered',
+      additionMatrixPairInterval
+    );
+  },
+  addition_2x4_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 4),
+      sparseMatrixF32Range(2, 4),
+      'f32-only',
+      additionMatrixPairInterval
+    );
+  },
+  addition_2x4_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 4),
+      sparseMatrixF32Range(2, 4),
+      'unfiltered',
+      additionMatrixPairInterval
+    );
+  },
+  addition_3x2_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 2),
+      sparseMatrixF32Range(3, 2),
+      'f32-only',
+      additionMatrixPairInterval
+    );
+  },
+  addition_3x2_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 2),
+      sparseMatrixF32Range(3, 2),
+      'unfiltered',
+      additionMatrixPairInterval
+    );
+  },
+  addition_3x3_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 3),
+      sparseMatrixF32Range(3, 3),
+      'f32-only',
+      additionMatrixPairInterval
+    );
+  },
+  addition_3x3_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 3),
+      sparseMatrixF32Range(3, 3),
+      'unfiltered',
+      additionMatrixPairInterval
+    );
+  },
+  addition_3x4_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 4),
+      sparseMatrixF32Range(3, 4),
+      'f32-only',
+      additionMatrixPairInterval
+    );
+  },
+  addition_3x4_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 4),
+      sparseMatrixF32Range(3, 4),
+      'unfiltered',
+      additionMatrixPairInterval
+    );
+  },
+  addition_4x2_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 2),
+      sparseMatrixF32Range(4, 2),
+      'f32-only',
+      additionMatrixPairInterval
+    );
+  },
+  addition_4x2_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 2),
+      sparseMatrixF32Range(4, 2),
+      'unfiltered',
+      additionMatrixPairInterval
+    );
+  },
+  addition_4x3_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 3),
+      sparseMatrixF32Range(4, 3),
+      'f32-only',
+      additionMatrixPairInterval
+    );
+  },
+  addition_4x3_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 3),
+      sparseMatrixF32Range(4, 3),
+      'unfiltered',
+      additionMatrixPairInterval
+    );
+  },
+  addition_4x4_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 4),
+      sparseMatrixF32Range(4, 4),
+      'f32-only',
+      additionMatrixPairInterval
+    );
+  },
+  addition_4x4_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 4),
+      sparseMatrixF32Range(4, 4),
+      'unfiltered',
+      additionMatrixPairInterval
+    );
+  },
+});
+
+g.test('addition')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x + y, where x and y are matrices
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', allInputSources)
+      .combine('cols', [2, 3, 4] as const)
+      .combine('rows', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cols = t.params.cols;
+    const rows = t.params.rows;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `addition_${cols}x${rows}_const`
+        : `addition_${cols}x${rows}_non_const`
+    );
+    await run(
+      t,
+      binary('+'),
+      [TypeMat(cols, rows, TypeF32), TypeMat(cols, rows, TypeF32)],
+      TypeMat(cols, rows, TypeF32),
+      t.params,
+      cases
+    );
+  });

--- a/src/webgpu/shader/execution/expression/binary/matrix_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/matrix_arithmetic.spec.ts
@@ -5,7 +5,7 @@ Execution Tests for the matrix arithmetic binary expression operations
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeMat } from '../../../../util/conversion.js';
-import { additionMatrixPairInterval } from '../../../../util/f32_interval.js';
+import { additionMatrixInterval } from '../../../../util/f32_interval.js';
 import { sparseMatrixF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, generateMatrixPairToMatrixCases, run } from '../expression.js';
@@ -20,7 +20,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(2, 2),
       sparseMatrixF32Range(2, 2),
       'f32-only',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_2x2_non_const: () => {
@@ -28,7 +28,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(2, 2),
       sparseMatrixF32Range(2, 2),
       'unfiltered',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_2x3_const: () => {
@@ -36,7 +36,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(2, 3),
       sparseMatrixF32Range(2, 3),
       'f32-only',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_2x3_non_const: () => {
@@ -44,7 +44,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(2, 3),
       sparseMatrixF32Range(2, 3),
       'unfiltered',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_2x4_const: () => {
@@ -52,7 +52,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(2, 4),
       sparseMatrixF32Range(2, 4),
       'f32-only',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_2x4_non_const: () => {
@@ -60,7 +60,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(2, 4),
       sparseMatrixF32Range(2, 4),
       'unfiltered',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_3x2_const: () => {
@@ -68,7 +68,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(3, 2),
       sparseMatrixF32Range(3, 2),
       'f32-only',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_3x2_non_const: () => {
@@ -76,7 +76,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(3, 2),
       sparseMatrixF32Range(3, 2),
       'unfiltered',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_3x3_const: () => {
@@ -84,7 +84,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(3, 3),
       sparseMatrixF32Range(3, 3),
       'f32-only',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_3x3_non_const: () => {
@@ -92,7 +92,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(3, 3),
       sparseMatrixF32Range(3, 3),
       'unfiltered',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_3x4_const: () => {
@@ -100,7 +100,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(3, 4),
       sparseMatrixF32Range(3, 4),
       'f32-only',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_3x4_non_const: () => {
@@ -108,7 +108,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(3, 4),
       sparseMatrixF32Range(3, 4),
       'unfiltered',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_4x2_const: () => {
@@ -116,7 +116,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(4, 2),
       sparseMatrixF32Range(4, 2),
       'f32-only',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_4x2_non_const: () => {
@@ -124,7 +124,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(4, 2),
       sparseMatrixF32Range(4, 2),
       'unfiltered',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_4x3_const: () => {
@@ -132,7 +132,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(4, 3),
       sparseMatrixF32Range(4, 3),
       'f32-only',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_4x3_non_const: () => {
@@ -140,7 +140,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(4, 3),
       sparseMatrixF32Range(4, 3),
       'unfiltered',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_4x4_const: () => {
@@ -148,7 +148,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(4, 4),
       sparseMatrixF32Range(4, 4),
       'f32-only',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
   addition_4x4_non_const: () => {
@@ -156,7 +156,7 @@ export const d = makeCaseCache('binary/matrix_arithmetic', {
       sparseMatrixF32Range(4, 4),
       sparseMatrixF32Range(4, 4),
       'unfiltered',
-      additionMatrixPairInterval
+      additionMatrixInterval
     );
   },
 });

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1358,8 +1358,7 @@ export function additionInterval(x: number | F32Interval, y: number | F32Interva
 }
 
 /** Calculate an acceptance interval of x + y, when x and y are matrices */
-export function additionMatrixPairInterval(x: Matrix<number>, y: Matrix<number>): F32Matrix {
-  // Matrix-Matrix addition
+export function additionMatrixInterval(x: Matrix<number>, y: Matrix<number>): F32Matrix {
   return runBinaryToIntervalOpMatrixComponentWise(
     toF32Matrix(x),
     toF32Matrix(y),

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -637,6 +637,16 @@ interface MatrixToMatrixOp {
   impl: MatrixToMatrix;
 }
 
+/**
+ * A function that converts a pair of matrices to a matrix of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface MatrixPairToMatrix {
+  (x: Matrix<number>, y: Matrix<number>): F32Matrix;
+}
+
 /** Converts a point to an acceptance interval, using a specific function
  *
  * This handles correctly rounding and flushing inputs as needed.
@@ -1122,14 +1132,14 @@ function runVectorPairToVectorOp(x: F32Vector, y: F32Vector, op: VectorPairToVec
  * @param op scalar operation to be run component-wise
  * @returns a vector of intervals with the outputs of op.impl
  */
-function runBinaryToIntervalOpComponentWise(
+function runBinaryToIntervalOpVectorComponentWise(
   x: F32Vector,
   y: F32Vector,
   op: BinaryToIntervalOp
 ): F32Vector {
   assert(
     x.length === y.length,
-    `runBinaryToIntervalOpComponentWise requires vectors of the same length`
+    `runBinaryToIntervalOpVectorComponentWise requires vectors of the same length`
   );
   return toF32Vector(
     x.map((i, idx) => {
@@ -1170,6 +1180,43 @@ function runMatrixToMatrixOp(m: F32Matrix, op: MatrixToMatrixOp): F32Matrix {
   return (result as F32Interval[][]).every(c => c.every(r => r.isFinite()))
     ? result
     : kAnyF32Matrix[result_cols][result_rows];
+}
+
+/**
+ * Calculate the Matrix of acceptance intervals by running a scalar operation
+ * component-wise over a pair of matrices.
+ *
+ * An example of this is performing matrix addition.
+ *
+ * @param x first input domain intervals matrix
+ * @param y second input domain intervals matrix
+ * @param op scalar operation to be run component-wise
+ * @returns a matrix of intervals with the outputs of op.impl
+ */
+function runBinaryToIntervalOpMatrixComponentWise(
+  x: F32Matrix,
+  y: F32Matrix,
+  op: BinaryToIntervalOp
+): F32Matrix {
+  assert(
+    x.length === y.length && x[0].length === y[0].length,
+    `runBinaryToIntervalOpMatrixComponentWise requires matrices of the same dimensions`
+  );
+
+  const cols = x.length;
+  const rows = x[0].length;
+  const flat_x = flatten2DArray(x);
+  const flat_y = flatten2DArray(y);
+
+  return toF32Matrix(
+    unflatten2DArray(
+      flat_x.map((i, idx) => {
+        return runBinaryToIntervalOp(i, flat_y[idx], op);
+      }),
+      cols,
+      rows
+    )
+  );
 }
 
 /** Defines a PointToIntervalOp for an interval of the correctly rounded values around the point */
@@ -1308,6 +1355,16 @@ const AdditionIntervalOp: BinaryToIntervalOp = {
 /** Calculate an acceptance interval of x + y */
 export function additionInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
   return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), AdditionIntervalOp);
+}
+
+/** Calculate an acceptance interval of x + y, when x and y are matrices */
+export function additionMatrixPairInterval(x: Matrix<number>, y: Matrix<number>): F32Matrix {
+  // Matrix-Matrix addition
+  return runBinaryToIntervalOpMatrixComponentWise(
+    toF32Matrix(x),
+    toF32Matrix(y),
+    AdditionIntervalOp
+  );
 }
 
 const AsinIntervalOp: PointToIntervalOp = {
@@ -1552,7 +1609,11 @@ const DistanceIntervalScalarOp: BinaryToIntervalOp = {
 const DistanceIntervalVectorOp: VectorPairToIntervalOp = {
   impl: (x: number[], y: number[]): F32Interval => {
     return lengthInterval(
-      runBinaryToIntervalOpComponentWise(toF32Vector(x), toF32Vector(y), SubtractionIntervalOp)
+      runBinaryToIntervalOpVectorComponentWise(
+        toF32Vector(x),
+        toF32Vector(y),
+        SubtractionIntervalOp
+      )
     );
   },
 };
@@ -1603,7 +1664,7 @@ export function divisionInterval(x: number | F32Interval, y: number | F32Interva
 const DotIntervalOp: VectorPairToIntervalOp = {
   impl: (x: number[], y: number[]): F32Interval => {
     // dot(x, y) = sum of x[i] * y[i]
-    const multiplications = runBinaryToIntervalOpComponentWise(
+    const multiplications = runBinaryToIntervalOpVectorComponentWise(
       toF32Vector(x),
       toF32Vector(y),
       MultiplicationIntervalOp
@@ -2021,7 +2082,7 @@ const ReflectIntervalOp: VectorPairToVectorOp = {
     // y = normal of reflecting surface
     const t = multiplicationInterval(2.0, dotInterval(x, y));
     const rhs = multiplyVectorByScalar(y, t);
-    return runBinaryToIntervalOpComponentWise(toF32Vector(x), rhs, SubtractionIntervalOp);
+    return runBinaryToIntervalOpVectorComponentWise(toF32Vector(x), rhs, SubtractionIntervalOp);
   },
 };
 
@@ -2071,7 +2132,7 @@ export function refractInterval(i: number[], s: number[], r: number): F32Vector 
   const k_sqrt = sqrtInterval(k);
   const t = additionInterval(dot_times_r, k_sqrt); // t = r * dot(i, s) + sqrt(k)
 
-  const result = runBinaryToIntervalOpComponentWise(
+  const result = runBinaryToIntervalOpVectorComponentWise(
     multiplyVectorByScalar(i, r),
     multiplyVectorByScalar(s, t),
     SubtractionIntervalOp

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1201,7 +1201,7 @@ export function unflatten2DArray<T>(n: T[], c: number, r: number): T[][] {
 }
 
 /**
- * Performs a map over a matrix and return the result
+ * Performs a .map over a matrix and return the result
  * The shape of the input and output matrices will be the same
  *
  * @param m input matrix of type T


### PR DESCRIPTION
Issue #1626

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
