### PR TITLE
Add f32 matrix subtraction tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -78,6 +78,7 @@ import {
   unpack4x8snormInterval,
   unpack4x8unormInterval,
   modfInterval,
+  subtractionMatrixInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -3758,6 +3759,199 @@ g.test('additionMatrixInterval')
     t.expect(
       objectEquals(expected, got),
       `additionMatrixInterval([${JSON.stringify(x)}], [${JSON.stringify(
+        y
+      )}]) returned '[${JSON.stringify(got)}]'. Expected '[${JSON.stringify(expected)}]'`
+    );
+  });
+
+g.test('subtractionMatrixInterval')
+  .paramsSubcasesOnly<MatrixPairCase>([
+    // Only testing that different shapes of matrices are handled correctly
+    // here, to reduce test duplication.
+    // subtractionMatrixInterval uses SubtractionIntervalOp for calculating intervals,
+    // so the testing for subtractionInterval covers the actual interval
+    // calculations.
+    {
+      input: [
+        [
+          [-1, -2],
+          [-3, -4],
+        ],
+        [
+          [10, 20],
+          [30, 40],
+        ],
+      ],
+      expected: [
+        [-11, -22],
+        [-33, -44],
+      ],
+    },
+    {
+      input: [
+        [
+          [-1, -2],
+          [-3, -4],
+          [-5, -6],
+        ],
+        [
+          [10, 20],
+          [30, 40],
+          [50, 60],
+        ],
+      ],
+      expected: [
+        [-11, -22],
+        [-33, -44],
+        [-55, -66],
+      ],
+    },
+    {
+      input: [
+        [
+          [-1, -2],
+          [-3, -4],
+          [-5, -6],
+          [-7, -8],
+        ],
+        [
+          [10, 20],
+          [30, 40],
+          [50, 60],
+          [70, 80],
+        ],
+      ],
+      expected: [
+        [-11, -22],
+        [-33, -44],
+        [-55, -66],
+        [-77, -88],
+      ],
+    },
+    {
+      input: [
+        [
+          [-1, -2, -3],
+          [-4, -5, -6],
+        ],
+        [
+          [10, 20, 30],
+          [40, 50, 60],
+        ],
+      ],
+      expected: [
+        [-11, -22, -33],
+        [-44, -55, -66],
+      ],
+    },
+    {
+      input: [
+        [
+          [-1, -2, -3],
+          [-4, -5, -6],
+          [-7, -8, -9],
+        ],
+        [
+          [10, 20, 30],
+          [40, 50, 60],
+          [70, 80, 90],
+        ],
+      ],
+      expected: [
+        [-11, -22, -33],
+        [-44, -55, -66],
+        [-77, -88, -99],
+      ],
+    },
+    {
+      input: [
+        [
+          [-1, -2, -3],
+          [-4, -5, -6],
+          [-7, -8, -9],
+          [-10, -11, -12],
+        ],
+        [
+          [10, 20, 30],
+          [40, 50, 60],
+          [70, 80, 90],
+          [1000, 1100, 1200],
+        ],
+      ],
+      expected: [
+        [-11, -22, -33],
+        [-44, -55, -66],
+        [-77, -88, -99],
+        [-1010, -1111, -1212],
+      ],
+    },
+    {
+      input: [
+        [
+          [-1, -2, -3, -4],
+          [-5, -6, -7, -8],
+        ],
+        [
+          [10, 20, 30, 40],
+          [50, 60, 70, 80],
+        ],
+      ],
+      expected: [
+        [-11, -22, -33, -44],
+        [-55, -66, -77, -88],
+      ],
+    },
+    {
+      input: [
+        [
+          [-1, -2, -3, -4],
+          [-5, -6, -7, -8],
+          [-9, -10, -11, -12],
+        ],
+        [
+          [10, 20, 30, 40],
+          [50, 60, 70, 80],
+          [90, 1000, 1100, 1200],
+        ],
+      ],
+      expected: [
+        [-11, -22, -33, -44],
+        [-55, -66, -77, -88],
+        [-99, -1010, -1111, -1212],
+      ],
+    },
+    {
+      input: [
+        [
+          [-1, -2, -3, -4],
+          [-5, -6, -7, -8],
+          [-9, -10, -11, -12],
+          [-13, -14, -15, -16],
+        ],
+        [
+          [10, 20, 30, 40],
+          [50, 60, 70, 80],
+          [90, 1000, 1100, 1200],
+          [1300, 1400, 1500, 1600],
+        ],
+      ],
+      expected: [
+        [-11, -22, -33, -44],
+        [-55, -66, -77, -88],
+        [-99, -1010, -1111, -1212],
+        [-1313, -1414, -1515, -1616],
+      ],
+    },
+  ])
+  .fn(t => {
+    const x = t.params.input[0];
+    const y = t.params.input[1];
+    const expected = toF32Matrix(t.params.expected);
+
+    const got = subtractionMatrixInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `subtractionMatrixInterval([${JSON.stringify(x)}], [${JSON.stringify(
         y
       )}]) returned '[${JSON.stringify(got)}]'. Expected '[${JSON.stringify(expected)}]'`
     );

--- a/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
@@ -5,7 +5,10 @@ Execution Tests for the f32 matrix arithmetic binary expression operations
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeMat } from '../../../../util/conversion.js';
-import { additionMatrixInterval } from '../../../../util/f32_interval.js';
+import {
+  additionMatrixInterval,
+  subtractionMatrixInterval,
+} from '../../../../util/f32_interval.js';
 import { sparseMatrixF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, generateMatrixPairToMatrixCases, run } from '../expression.js';
@@ -159,6 +162,150 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
       additionMatrixInterval
     );
   },
+  subtraction_2x2_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 2),
+      sparseMatrixF32Range(2, 2),
+      'f32-only',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_2x2_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 2),
+      sparseMatrixF32Range(2, 2),
+      'unfiltered',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_2x3_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 3),
+      sparseMatrixF32Range(2, 3),
+      'f32-only',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_2x3_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 3),
+      sparseMatrixF32Range(2, 3),
+      'unfiltered',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_2x4_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 4),
+      sparseMatrixF32Range(2, 4),
+      'f32-only',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_2x4_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(2, 4),
+      sparseMatrixF32Range(2, 4),
+      'unfiltered',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_3x2_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 2),
+      sparseMatrixF32Range(3, 2),
+      'f32-only',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_3x2_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 2),
+      sparseMatrixF32Range(3, 2),
+      'unfiltered',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_3x3_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 3),
+      sparseMatrixF32Range(3, 3),
+      'f32-only',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_3x3_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 3),
+      sparseMatrixF32Range(3, 3),
+      'unfiltered',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_3x4_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 4),
+      sparseMatrixF32Range(3, 4),
+      'f32-only',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_3x4_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(3, 4),
+      sparseMatrixF32Range(3, 4),
+      'unfiltered',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_4x2_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 2),
+      sparseMatrixF32Range(4, 2),
+      'f32-only',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_4x2_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 2),
+      sparseMatrixF32Range(4, 2),
+      'unfiltered',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_4x3_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 3),
+      sparseMatrixF32Range(4, 3),
+      'f32-only',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_4x3_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 3),
+      sparseMatrixF32Range(4, 3),
+      'unfiltered',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_4x4_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 4),
+      sparseMatrixF32Range(4, 4),
+      'f32-only',
+      subtractionMatrixInterval
+    );
+  },
+  subtraction_4x4_non_const: () => {
+    return generateMatrixPairToMatrixCases(
+      sparseMatrixF32Range(4, 4),
+      sparseMatrixF32Range(4, 4),
+      'unfiltered',
+      subtractionMatrixInterval
+    );
+  },
 });
 
 g.test('addition')
@@ -186,6 +333,38 @@ Accuracy: Correctly rounded
     await run(
       t,
       binary('+'),
+      [TypeMat(cols, rows, TypeF32), TypeMat(cols, rows, TypeF32)],
+      TypeMat(cols, rows, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('subtraction')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x - y, where x and y are matrices
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', allInputSources)
+      .combine('cols', [2, 3, 4] as const)
+      .combine('rows', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cols = t.params.cols;
+    const rows = t.params.rows;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `subtraction_${cols}x${rows}_const`
+        : `subtraction_${cols}x${rows}_non_const`
+    );
+    await run(
+      t,
+      binary('-'),
       [TypeMat(cols, rows, TypeF32), TypeMat(cols, rows, TypeF32)],
       TypeMat(cols, rows, TypeF32),
       t.params,

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -2314,6 +2314,15 @@ export function subtractionInterval(x: number | F32Interval, y: number | F32Inte
   return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), SubtractionIntervalOp);
 }
 
+/** Calculate an acceptance interval of x - y, when x and y are matrices */
+export function subtractionMatrixInterval(x: Matrix<number>, y: Matrix<number>): F32Matrix {
+  return runBinaryToIntervalOpMatrixComponentWise(
+    toF32Matrix(x),
+    toF32Matrix(y),
+    SubtractionIntervalOp
+  );
+}
+
 const TanIntervalOp: PointToIntervalOp = {
   impl: (n: number): F32Interval => {
     return divisionInterval(sinInterval(n), cosInterval(n));


### PR DESCRIPTION

Issue #1626

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
