### PR TITLE
Update external_texture,expire test case

### DIFF
--- a/src/webgpu/api/validation/gpu_external_texture_expiration.spec.ts
+++ b/src/webgpu/api/validation/gpu_external_texture_expiration.spec.ts
@@ -1,0 +1,324 @@
+export const description = `
+GPUExternalTexture expiration mechanism validation tests.
+`;
+
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { assert } from '../../../common/util/util.js';
+import {
+  getVideoElement,
+  startPlayingAndWaitForVideo,
+  getVideoFrameFromVideoElement,
+  waitForNextFrame,
+  waitForNextAnimationFrame,
+} from '../../web_platform/util.js';
+
+import { ValidationTest } from './validation_test.js';
+
+class GPUExternalTextureExpireTest extends ValidationTest {
+  submitCommandBuffer(bindGroup: GPUBindGroup, shouldError: boolean): void {
+    const kHeight = 16;
+    const kWidth = 16;
+    const kFormat = 'rgba8unorm';
+
+    const colorAttachment = this.device.createTexture({
+      format: kFormat,
+      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    const passDescriptor = {
+      colorAttachments: [
+        {
+          view: colorAttachment.createView(),
+          clearValue: [0, 0, 0, 1],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    } as const;
+
+    const commandEncoder = this.device.createCommandEncoder();
+    const passEncoder = commandEncoder.beginRenderPass(passDescriptor);
+    passEncoder.setBindGroup(0, bindGroup);
+    passEncoder.end();
+    const commandBuffer = commandEncoder.finish();
+    this.expectValidationError(() => this.device.queue.submit([commandBuffer]), shouldError);
+  }
+
+  getDefaultVideoElementAndCheck(): HTMLVideoElement {
+    const videoElement = getVideoElement(this, 'four-colors-vp9-bt601.webm');
+
+    if (!('requestVideoFrameCallback' in videoElement)) {
+      this.skip('HTMLVideoElement.requestVideoFrameCallback is not supported');
+    }
+
+    return videoElement;
+  }
+
+  getDefaultBindGroupLayout(): GPUBindGroupLayout {
+    return this.device.createBindGroupLayout({
+      entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, externalTexture: {} }],
+    });
+  }
+}
+
+export const g = makeTestGroup(GPUExternalTextureExpireTest);
+
+g.test('import_multiple_times_in_same_task_scope')
+  .desc(
+    `
+    Tests that GPUExternalTexture is valid after been imported in the task.
+    Tests that in the same task scope, import twice on the same video source should return
+    the same GPUExternalTexture and bindGroup doesn't need to be updated.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('sourceType', ['VideoElement', 'VideoFrame'] as const)
+  )
+  .fn(async t => {
+    const sourceType = t.params.sourceType;
+    const videoElement = t.getDefaultVideoElementAndCheck();
+
+    let bindGroup: GPUBindGroup;
+    let externalTexture: GPUExternalTexture;
+    await startPlayingAndWaitForVideo(videoElement, async () => {
+      const source =
+        sourceType === 'VideoFrame'
+          ? await getVideoFrameFromVideoElement(t, videoElement)
+          : videoElement;
+      externalTexture = t.device.importExternalTexture({
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        source: source as any,
+      });
+
+      bindGroup = t.device.createBindGroup({
+        layout: t.getDefaultBindGroupLayout(),
+        entries: [{ binding: 0, resource: externalTexture }],
+      });
+
+      t.submitCommandBuffer(bindGroup, false);
+
+      // Import again in the same task scope should return same object.
+      const shouldBeTheSameExternalTexture = t.device.importExternalTexture({
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        source: source as any,
+      });
+      assert(externalTexture === shouldBeTheSameExternalTexture);
+
+      t.submitCommandBuffer(bindGroup, false);
+    });
+  });
+
+g.test('import_and_use_in_different_microtask')
+  .desc(
+    `
+    Tests that in the same task scope, imported GPUExternalTexture is valid in
+    different microtasks.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('sourceType', ['VideoElement', 'VideoFrame'] as const)
+  )
+  .fn(async t => {
+    const sourceType = t.params.sourceType;
+    const videoElement = t.getDefaultVideoElementAndCheck();
+
+    let bindGroup: GPUBindGroup;
+    let externalTexture: GPUExternalTexture;
+    await startPlayingAndWaitForVideo(videoElement, async () => {
+      const source =
+        sourceType === 'VideoFrame'
+          ? await getVideoFrameFromVideoElement(t, videoElement)
+          : videoElement;
+
+      const importMicrotask = Promise.resolve().then(() => {
+        externalTexture = t.device.importExternalTexture({
+          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+          source: source as any,
+        });
+      });
+
+      const submitMicrotask = Promise.resolve().then(() => {
+        bindGroup = t.device.createBindGroup({
+          layout: t.getDefaultBindGroupLayout(),
+          entries: [{ binding: 0, resource: externalTexture }],
+        });
+        t.submitCommandBuffer(bindGroup, false);
+      });
+      await importMicrotask;
+      await submitMicrotask;
+    });
+  });
+
+g.test('import_and_use_in_different_task')
+  .desc(
+    `
+    Tests that in the different task scope, privious imported GPUExternalTexture
+    should be expired.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('sourceType', ['VideoElement', 'VideoFrame'] as const)
+  )
+  .fn(async t => {
+    const sourceType = t.params.sourceType;
+    const videoElement = t.getDefaultVideoElementAndCheck();
+
+    let bindGroup: GPUBindGroup;
+    let externalTexture: GPUExternalTexture;
+    await startPlayingAndWaitForVideo(videoElement, async () => {
+      const source =
+        sourceType === 'VideoFrame'
+          ? await getVideoFrameFromVideoElement(t, videoElement)
+          : videoElement;
+      externalTexture = t.device.importExternalTexture({
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        source: source as any,
+      });
+
+      bindGroup = t.device.createBindGroup({
+        layout: t.getDefaultBindGroupLayout(),
+        entries: [{ binding: 0, resource: externalTexture }],
+      });
+
+      t.submitCommandBuffer(bindGroup, false);
+    });
+
+    await waitForNextAnimationFrame(() => {
+      // Enter in another task scope, previous GPUExternalTexture should be expired.
+      t.submitCommandBuffer(bindGroup, true);
+    });
+  });
+
+g.test('use_import_to_refresh')
+  .desc(
+    `
+    Tests that in the different task scope, imported GPUExternalTexture
+    again on the same source frame should return the same GPUExternalTexture
+    object and refresh it.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('sourceType', ['VideoElement', 'VideoFrame'] as const)
+  )
+  .fn(async t => {
+    const sourceType = t.params.sourceType;
+    const videoElement = t.getDefaultVideoElementAndCheck();
+
+    let bindGroup: GPUBindGroup;
+    let externalTexture: GPUExternalTexture;
+    let source: HTMLVideoElement | VideoFrame;
+    await startPlayingAndWaitForVideo(videoElement, async () => {
+      source =
+        sourceType === 'VideoFrame'
+          ? await getVideoFrameFromVideoElement(t, videoElement)
+          : videoElement;
+      externalTexture = t.device.importExternalTexture({
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        source: source as any,
+      });
+
+      bindGroup = t.device.createBindGroup({
+        layout: t.getDefaultBindGroupLayout(),
+        entries: [{ binding: 0, resource: externalTexture }],
+      });
+
+      t.submitCommandBuffer(bindGroup, false);
+    });
+
+    await waitForNextAnimationFrame(() => {
+      // Video frame is not updated, import should return the same GPUExternalTexture object.
+      const shouldBeTheSameExternalTexture = t.device.importExternalTexture({
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        source: source as any,
+      });
+      assert(externalTexture === shouldBeTheSameExternalTexture);
+
+      // ImportExternalTexture should refresh expired GPUExternalTexture.
+      t.submitCommandBuffer(bindGroup, false);
+    });
+  });
+
+g.test('webcodec_video_frame_close_expire_immediately')
+  .desc(
+    `
+    Tests that in the same task scope, imported GPUExternalTexture should be expired
+    immediately if webcodec VideoFrame.close() is called.
+    `
+  )
+  .fn(async t => {
+    const videoElement = t.getDefaultVideoElementAndCheck();
+
+    let bindGroup: GPUBindGroup;
+    let externalTexture: GPUExternalTexture;
+    await startPlayingAndWaitForVideo(videoElement, async () => {
+      const source = await getVideoFrameFromVideoElement(t, videoElement);
+      externalTexture = t.device.importExternalTexture({
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        source: source as any,
+      });
+
+      bindGroup = t.device.createBindGroup({
+        layout: t.getDefaultBindGroupLayout(),
+        entries: [{ binding: 0, resource: externalTexture }],
+      });
+
+      t.submitCommandBuffer(bindGroup, false);
+
+      source.close();
+
+      t.submitCommandBuffer(bindGroup, true);
+    });
+  });
+
+g.test('import_from_different_video_frame')
+  .desc(
+    `
+    Tests that imported GPUExternalTexture from different video frame should
+    return different GPUExternalTexture objects.
+    If the frames are from the same HTMLVideoElement source, GPUExternalTexture
+    with old frame should be expired and not been refreshed again.
+    `
+  )
+  .fn(async t => {
+    const videoElement = t.getDefaultVideoElementAndCheck();
+
+    let bindGroup: GPUBindGroup;
+    let externalTexture: GPUExternalTexture;
+    await startPlayingAndWaitForVideo(videoElement, () => {
+      externalTexture = t.device.importExternalTexture({
+        source: videoElement,
+      });
+
+      bindGroup = t.device.createBindGroup({
+        layout: t.getDefaultBindGroupLayout(),
+        entries: [{ binding: 0, resource: externalTexture }],
+      });
+
+      t.submitCommandBuffer(bindGroup, false);
+    });
+
+    // Update new video frame.
+    await waitForNextFrame(videoElement, () => {
+      // Import again for the new video frame.
+      const newValidExternalTexture = t.device.importExternalTexture({
+        source: videoElement,
+      });
+      assert(externalTexture !== newValidExternalTexture);
+
+      // VideoFrame is updated. GPUExternalTexture imported from old frame should be expired and
+      // cannot be refreshed again.
+      // Using the GPUExternalTexture should result in an error.
+      t.submitCommandBuffer(bindGroup, true);
+
+      // Update bindGroup with updated GPUExternalTexture should work.
+      bindGroup = t.device.createBindGroup({
+        layout: t.getDefaultBindGroupLayout(),
+        entries: [{ binding: 0, resource: newValidExternalTexture }],
+      });
+      t.submitCommandBuffer(bindGroup, false);
+    });
+  });

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -249,7 +249,7 @@ it will honor rotation metadata.
   )
   .fn(async t => {
     const sourceType = t.params.sourceType;
-    const videoElement = getVideoElement(t, sourceType, t.params.videoName);
+    const videoElement = getVideoElement(t, t.params.videoName);
 
     await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -8,35 +8,17 @@ Tests for external textures from HTMLVideoElement (and other video-type sources?
 TODO: consider whether external_texture and copyToTexture video tests should be in the same file
 `;
 
-import { getResourcePath } from '../../../common/framework/resources.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { makeTable } from '../../../common/util/data_tables.js';
 import { GPUTest, TextureTestMixin } from '../../gpu_test.js';
 import {
   startPlayingAndWaitForVideo,
   getVideoFrameFromVideoElement,
-  waitForNextFrame,
+  getVideoElement,
 } from '../../web_platform/util.js';
 
 const kHeight = 16;
 const kWidth = 16;
 const kFormat = 'rgba8unorm';
-
-const kVideoInfo = /* prettier-ignore */ makeTable(
-                                ['mimeType'] as const,
-                                [undefined] as const, {
-  // All video names
-  'four-colors-vp8-bt601.webm'  : ['video/webm; codecs=vp8'],
-  'four-colors-theora-bt601.ogv': ['video/ogg; codecs=theora'],
-  'four-colors-h264-bt601.mp4'  : ['video/mp4; codecs=avc1.4d400c'],
-  'four-colors-vp9-bt601.webm'  : ['video/webm; codecs=vp9'],
-  'four-colors-vp9-bt709.webm'  : ['video/webm; codecs=vp9'],
-  'four-colors-vp9-bt2020.webm' : ['video/webm; codecs=vp9'],
-  'four-colors-h264-bt601-rotate-90.mp4'  : ['video/mp4; codecs=avc1.4d400c'],
-  'four-colors-h264-bt601-rotate-180.mp4'  : ['video/mp4; codecs=avc1.4d400c'],
-  'four-colors-h264-bt601-rotate-270.mp4'  : ['video/mp4; codecs=avc1.4d400c']
-} as const);
-type VideoName = keyof typeof kVideoInfo;
 
 // The process to calculate these expected pixel values can be found:
 // https://github.com/gpuweb/cts/pull/2242#issuecomment-1430382811
@@ -184,28 +166,6 @@ function createExternalTextureSamplingTestBindGroup(
   return bindGroup;
 }
 
-function getVideoElement(
-  t: GPUTest,
-  sourceType: 'VideoElement' | 'VideoFrame',
-  videoName: VideoName
-): HTMLVideoElement {
-  if (sourceType === 'VideoFrame' && typeof VideoFrame === 'undefined') {
-    t.skip('WebCodec is not supported');
-  }
-
-  const videoElement = document.createElement('video');
-  const videoInfo = kVideoInfo[videoName];
-
-  if (videoElement.canPlayType(videoInfo.mimeType) === '') {
-    t.skip('Video codec is not supported');
-  }
-
-  const videoUrl = getResourcePath(videoName);
-  videoElement.src = videoUrl;
-
-  return videoElement;
-}
-
 g.test('importExternalTexture,sample')
   .desc(
     `
@@ -220,7 +180,11 @@ for several combinations of video format and color space.
   )
   .fn(async t => {
     const sourceType = t.params.sourceType;
-    const videoElement = getVideoElement(t, sourceType, t.params.videoName);
+    if (sourceType === 'VideoFrame' && typeof VideoFrame === 'undefined') {
+      t.skip('WebCodec is not supported');
+    }
+
+    const videoElement = getVideoElement(t, t.params.videoName);
 
     await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =
@@ -332,94 +296,6 @@ it will honor rotation metadata.
     });
   });
 
-g.test('importExternalTexture,expired')
-  .desc(
-    `
-Tests that GPUExternalTexture.expired is false when HTMLVideoElement is not updated
-or VideoFrame(webcodec) is alive. And it will be changed to true when imported
-HTMLVideoElement is updated or imported VideoFrame is closed. Using expired
-GPUExternalTexture results in an error.
-
-TODO: Make this test work without requestVideoFrameCallback support (in waitForNextFrame).
-`
-  )
-  .params(u =>
-    u //
-      .combine('sourceType', ['VideoElement', 'VideoFrame'] as const)
-  )
-  .fn(async t => {
-    const sourceType = t.params.sourceType;
-    const videoElement = getVideoElement(t, sourceType, 'four-colors-vp9-bt601.webm');
-
-    if (!('requestVideoFrameCallback' in videoElement)) {
-      t.skip('HTMLVideoElement.requestVideoFrameCallback is not supported');
-    }
-
-    const colorAttachment = t.device.createTexture({
-      format: kFormat,
-      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
-    });
-    const passDescriptor = {
-      colorAttachments: [
-        {
-          view: colorAttachment.createView(),
-          clearValue: [0, 0, 0, 1],
-          loadOp: 'clear',
-          storeOp: 'store',
-        },
-      ],
-    } as const;
-
-    const bindGroupLayout = t.device.createBindGroupLayout({
-      entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, externalTexture: {} }],
-    });
-
-    let bindGroup: GPUBindGroup;
-    const useExternalTexture = () => {
-      const commandEncoder = t.device.createCommandEncoder();
-      const passEncoder = commandEncoder.beginRenderPass(passDescriptor);
-      passEncoder.setBindGroup(0, bindGroup);
-      passEncoder.end();
-      return commandEncoder.finish();
-    };
-
-    let externalTexture: GPUExternalTexture;
-    await startPlayingAndWaitForVideo(videoElement, async () => {
-      const source =
-        sourceType === 'VideoFrame'
-          ? await getVideoFrameFromVideoElement(t, videoElement)
-          : videoElement;
-      externalTexture = t.device.importExternalTexture({
-        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-        source: source as any,
-      });
-      // Set `bindGroup` here, which will then be used in microtask1 and microtask3.
-      bindGroup = t.device.createBindGroup({
-        layout: bindGroupLayout,
-        entries: [{ binding: 0, resource: externalTexture }],
-      });
-
-      const commandBuffer = useExternalTexture();
-      t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), false);
-
-      if (sourceType === 'VideoFrame') {
-        (source as VideoFrame).close();
-        const commandBuffer = useExternalTexture();
-        t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), true);
-      }
-    });
-    if (sourceType === 'VideoElement') {
-      // Update new video frame.
-      await waitForNextFrame(videoElement, () => {
-        // VideoFrame is updated. GPUExternalTexture imported from HTMLVideoElement should be expired.
-        // Using the GPUExternalTexture should result in an error.
-        const commandBuffer = useExternalTexture();
-        t.expectGPUError('validation', () => t.device.queue.submit([commandBuffer]), true);
-      });
-    }
-  });
-
 g.test('importExternalTexture,compute')
   .desc(
     `
@@ -434,7 +310,11 @@ compute shader, for several combinations of video format and color space.
   )
   .fn(async t => {
     const sourceType = t.params.sourceType;
-    const videoElement = getVideoElement(t, sourceType, t.params.videoName);
+    if (sourceType === 'VideoFrame' && typeof VideoFrame === 'undefined') {
+      t.skip('WebCodec is not supported');
+    }
+
+    const videoElement = getVideoElement(t, t.params.videoName);
 
     await startPlayingAndWaitForVideo(videoElement, async () => {
       const source =

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -1,6 +1,7 @@
 import { Fixture, SkipTestCase } from '../../common/framework/fixture.js';
 import { getResourcePath } from '../../common/framework/resources.js';
 import { makeTable } from '../../common/util/data_tables.js';
+import { timeout } from '../../common/util/timeout.js';
 import { ErrorWithExtra, raceWithRejectOnTimeout } from '../../common/util/util.js';
 import { GPUTest } from '../gpu_test.js';
 
@@ -95,14 +96,11 @@ export function startPlayingAndWaitForVideo(
  * Fire a `callback` when the script animation reaches a new frame.
  * Returns a promise which resolves after `callback` (which may be async) completes.
  */
-export function waitForNextAnimationFrame(
-  callback: () => unknown | Promise<unknown>
-): Promise<void> {
-  const { promise, callbackAndResolve } = callbackHelper(callback, 'waitForNextFrame timed out');
-
-  window.requestAnimationFrame(() => {
+export function waitForNextTask(callback: () => unknown | Promise<unknown>): Promise<void> {
+  const { promise, callbackAndResolve } = callbackHelper(callback, 'wait for next task timed out');
+  timeout(() => {
     callbackAndResolve();
-  });
+  }, 0);
 
   return promise;
 }

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -1,5 +1,8 @@
 import { Fixture, SkipTestCase } from '../../common/framework/fixture.js';
+import { getResourcePath } from '../../common/framework/resources.js';
+import { makeTable } from '../../common/util/data_tables.js';
 import { ErrorWithExtra, raceWithRejectOnTimeout } from '../../common/util/util.js';
+import { GPUTest } from '../gpu_test.js';
 
 declare global {
   interface HTMLMediaElement {
@@ -8,6 +11,22 @@ declare global {
     captureStream(): MediaStream;
   }
 }
+
+export const kVideoInfo = /* prettier-ignore */ makeTable(
+  ['mimeType'] as const,
+  [undefined] as const, {
+// All video names
+'four-colors-vp8-bt601.webm'  : ['video/webm; codecs=vp8'],
+'four-colors-theora-bt601.ogv': ['video/ogg; codecs=theora'],
+'four-colors-h264-bt601.mp4'  : ['video/mp4; codecs=avc1.4d400c'],
+'four-colors-vp9-bt601.webm'  : ['video/webm; codecs=vp9'],
+'four-colors-vp9-bt709.webm'  : ['video/webm; codecs=vp9'],
+'four-colors-vp9-bt2020.webm' : ['video/webm; codecs=vp9'],
+'four-colors-h264-bt601-rotate-90.mp4'  : ['video/mp4; codecs=avc1.4d400c'],
+'four-colors-h264-bt601-rotate-180.mp4'  : ['video/mp4; codecs=avc1.4d400c'],
+'four-colors-h264-bt601-rotate-270.mp4'  : ['video/mp4; codecs=avc1.4d400c']
+} as const);
+export type VideoName = keyof typeof kVideoInfo;
 
 /**
  * Starts playing a video and waits for it to be consumable.
@@ -73,6 +92,22 @@ export function startPlayingAndWaitForVideo(
 }
 
 /**
+ * Fire a `callback` when the script animation reaches a new frame.
+ * Returns a promise which resolves after `callback` (which may be async) completes.
+ */
+export function waitForNextAnimationFrame(
+  callback: () => unknown | Promise<unknown>
+): Promise<void> {
+  const { promise, callbackAndResolve } = callbackHelper(callback, 'waitForNextFrame timed out');
+
+  window.requestAnimationFrame(() => {
+    callbackAndResolve();
+  });
+
+  return promise;
+}
+
+/**
  * Fire a `callback` when the video reaches a new frame.
  * Returns a promise which resolves after `callback` (which may be async) completes.
  *
@@ -84,10 +119,7 @@ export function waitForNextFrame(
   video: HTMLVideoElement,
   callback: () => unknown | Promise<unknown>
 ): Promise<void> {
-  const { promise, callbackAndResolve } = videoCallbackHelper(
-    callback,
-    'waitForNextFrame timed out'
-  );
+  const { promise, callbackAndResolve } = callbackHelper(callback, 'waitForNextFrame timed out');
 
   if ('requestVideoFrameCallback' in video) {
     video.requestVideoFrameCallback(() => {
@@ -137,11 +169,34 @@ export async function getVideoFrameFromVideoElement(
 }
 
 /**
+ * Create HTMLVideoElement based on VideoName. Check whether video is playable in current
+ * browser environment.
+ * Returns a HTMLVideoElement.
+ *
+ * @param t: GPUTest that requires getting HTMLVideoElement
+ * @param videoName: Required video name
+ *
+ */
+export function getVideoElement(t: GPUTest, videoName: VideoName): HTMLVideoElement {
+  const videoElement = document.createElement('video');
+  const videoInfo = kVideoInfo[videoName];
+
+  if (videoElement.canPlayType(videoInfo.mimeType) === '') {
+    t.skip('Video codec is not supported');
+  }
+
+  const videoUrl = getResourcePath(videoName);
+  videoElement.src = videoUrl;
+
+  return videoElement;
+}
+
+/**
  * Helper for doing something inside of a (possibly async) callback (directly, not in a following
  * microtask), and returning a promise when the callback is done.
  * MAINTENANCE_TODO: Use this in startPlayingAndWaitForVideo (and make sure it works).
  */
-function videoCallbackHelper(
+function callbackHelper(
   callback: () => unknown | Promise<unknown>,
   timeoutMessage: string
 ): { promise: Promise<void>; callbackAndResolve: () => void } {


### PR DESCRIPTION
WebGPU spec updated GPUExternalTexture expire mechanism. It removes GPUExternalTexture.expire and uses auto expiry mechanism.

The basic rules are:
- ImportExternalTexture should return same object if underly resource is the same.
- GPUExternalTexture should be expire if current task scope finished. And could be refreshed by importExternalTexture in new task scope.

This PR updates external_texture,expire cts with these ruels




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
