### PR TITLE
webgpu/shader/validation: Remove types as keywords

### DIFF
--- a/src/webgpu/shader/validation/parse/identifiers.spec.ts
+++ b/src/webgpu/shader/validation/parse/identifiers.spec.ts
@@ -23,24 +23,7 @@ const kValidIdentifiers = new Set([
   'שָׁלוֹם',
   'गुलाबी',
   'փիրուզ',
-]);
-const kInvalidIdentifiers = new Set([
-  '_', // Single underscore is a syntactic token for phony assignment.
-  '__', // Leading double underscore is reserved.
-  '__foo', // Leading double underscore is reserved.
-  '0foo', // Must start with single underscore or a letter.
-  // No punctuation:
-  'foo.bar',
-  'foo-bar',
-  'foo+bar',
-  'foo#bar',
-  'foo!bar',
-  'foo\\bar',
-  'foo/bar',
-  'foo,bar',
-  'foo@bar',
-  'foo::bar',
-  // Type-defining Keywords:
+  // Builtin type identifiers:
   'array',
   'atomic',
   'bool',
@@ -79,6 +62,23 @@ const kInvalidIdentifiers = new Set([
   'vec2',
   'vec3',
   'vec4',
+]);
+const kInvalidIdentifiers = new Set([
+  '_', // Single underscore is a syntactic token for phony assignment.
+  '__', // Leading double underscore is reserved.
+  '__foo', // Leading double underscore is reserved.
+  '0foo', // Must start with single underscore or a letter.
+  // No punctuation:
+  'foo.bar',
+  'foo-bar',
+  'foo+bar',
+  'foo#bar',
+  'foo!bar',
+  'foo\\bar',
+  'foo/bar',
+  'foo,bar',
+  'foo@bar',
+  'foo::bar',
   // Other Keywords:
   'bitcast',
   'break',
@@ -264,7 +264,8 @@ g.test('identifiers')
     u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
   )
   .fn(t => {
-    const code = `var<private> ${t.params.ident} : i32;`;
+    const type = t.params.ident === 'i32' ? 'u32' : 'i32';
+    const code = `var<private> ${t.params.ident} : ${type};`;
     t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
   });
 


### PR DESCRIPTION
The working group has agreed that types should be identifiers that can be shadowed.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
