### PR TITLE
Add f32 matrix-scalar multiplication tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -47,6 +47,7 @@ import {
   mixImpreciseInterval,
   mixPreciseInterval,
   multiplicationInterval,
+  multiplicationMatrixScalarInterval,
   negationInterval,
   normalizeInterval,
   powInterval,
@@ -64,6 +65,7 @@ import {
   sqrtInterval,
   stepInterval,
   subtractionInterval,
+  subtractionMatrixInterval,
   tanInterval,
   tanhInterval,
   toF32Interval,
@@ -78,7 +80,6 @@ import {
   unpack4x8snormInterval,
   unpack4x8unormInterval,
   modfInterval,
-  subtractionMatrixInterval,
 } from '../webgpu/util/f32_interval.js';
 import { hexToF32, hexToF64, oneULP } from '../webgpu/util/math.js';
 
@@ -3956,3 +3957,150 @@ g.test('subtractionMatrixInterval')
       )}]) returned '[${JSON.stringify(got)}]'. Expected '[${JSON.stringify(expected)}]'`
     );
   });
+
+interface MatrixScalarCase {
+  matrix: number[][];
+  scalar: number;
+  expected: IntervalBounds[][] | number[][];
+}
+
+g.test('multiplicationMatrixScalarInterval')
+  .paramsSubcasesOnly<MatrixScalarCase>([
+    // Only testing that different shapes of matrices are handled correctly
+    // here, to reduce test duplication.
+    // multiplicationMatrixScalarInterval uses MultiplicationIntervalOp for calculating intervals,
+    // so the testing for multiplcationInterval covers the actual interval
+    // calculations.
+    {
+      matrix: [
+        [1, 2],
+        [3, 4],
+      ],
+      scalar: 10,
+      expected: [
+        [10, 20],
+        [30, 40],
+      ],
+    },
+    {
+      matrix: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+      scalar: 10,
+      expected: [
+        [10, 20],
+        [30, 40],
+        [50, 60],
+      ],
+    },
+    {
+      matrix: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [7, 8],
+      ],
+      scalar: 10,
+      expected: [
+        [10, 20],
+        [30, 40],
+        [50, 60],
+        [70, 80],
+      ],
+    },
+    {
+      matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+      scalar: 10,
+      expected: [
+        [10, 20, 30],
+        [40, 50, 60],
+      ],
+    },
+    {
+      matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      scalar: 10,
+      expected: [
+        [10, 20, 30],
+        [40, 50, 60],
+        [70, 80, 90],
+      ],
+    },
+    {
+      matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [10, 11, 12],
+      ],
+      scalar: 10,
+      expected: [
+        [10, 20, 30],
+        [40, 50, 60],
+        [70, 80, 90],
+        [100, 110, 120],
+      ],
+    },
+    {
+      matrix: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ],
+      scalar: 10,
+      expected: [
+        [10, 20, 30, 40],
+        [50, 60, 70, 80],
+      ],
+    },
+    {
+      matrix: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+      ],
+      scalar: 10,
+      expected: [
+        [10, 20, 30, 40],
+        [50, 60, 70, 80],
+        [90, 100, 110, 120],
+      ],
+    },
+    {
+      matrix: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+      ],
+      scalar: 10,
+      expected: [
+        [10, 20, 30, 40],
+        [50, 60, 70, 80],
+        [90, 100, 110, 120],
+        [130, 140, 150, 160],
+      ],
+    },
+  ])
+  .fn(t => {
+    const matrix = t.params.matrix;
+    const scalar = t.params.scalar;
+    const expected = toF32Matrix(t.params.expected);
+
+    const got = multiplicationMatrixScalarInterval(matrix, scalar);
+    t.expect(
+      objectEquals(expected, got),
+      `multiplicationMatrixMatrixInterval([${JSON.stringify(
+        matrix
+      )}], ${scalar}) returned '[${JSON.stringify(got)}]'. Expected '[${JSON.stringify(expected)}]'`
+    );
+  });
+
+// There are not explicit tests for multiplicationScalarMatrixInterval since it is just a passthrough to multiplicationMatrixScalarInterval

--- a/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
@@ -8,10 +8,18 @@ import { TypeF32, TypeMat } from '../../../../util/conversion.js';
 import {
   additionMatrixInterval,
   subtractionMatrixInterval,
+  multiplicationMatrixScalarInterval,
+  multiplicationScalarMatrixInterval,
 } from '../../../../util/f32_interval.js';
-import { sparseMatrixF32Range } from '../../../../util/math.js';
+import { sparseF32Range, sparseMatrixF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, generateMatrixPairToMatrixCases, run } from '../expression.js';
+import {
+  allInputSources,
+  generateMatrixPairToMatrixCases,
+  generateMatrixScalarToMatrixCases,
+  generateScalarMatrixToMatrixCases,
+  run,
+} from '../expression.js';
 
 import { binary } from './binary.js';
 
@@ -160,6 +168,295 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
       sparseMatrixF32Range(4, 4),
       'unfiltered',
       additionMatrixInterval
+    );
+  },
+  multiplication_2x2_scalar_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(2, 2),
+      sparseF32Range(),
+      'f32-only',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_2x2_scalar_non_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(2, 2),
+      sparseF32Range(),
+      'unfiltered',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_2x3_scalar_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(2, 3),
+      sparseF32Range(),
+      'f32-only',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_2x3_scalar_non_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(2, 3),
+      sparseF32Range(),
+      'unfiltered',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_2x4_scalar_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(2, 4),
+      sparseF32Range(),
+      'f32-only',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_2x4_scalar_non_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(2, 4),
+      sparseF32Range(),
+      'unfiltered',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_3x2_scalar_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(3, 2),
+      sparseF32Range(),
+      'f32-only',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_3x2_scalar_non_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(3, 2),
+      sparseF32Range(),
+      'unfiltered',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_3x3_scalar_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(3, 3),
+      sparseF32Range(),
+      'f32-only',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_3x3_scalar_non_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(3, 3),
+      sparseF32Range(),
+      'unfiltered',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_3x4_scalar_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(3, 4),
+      sparseF32Range(),
+      'f32-only',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_3x4_scalar_non_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(3, 4),
+      sparseF32Range(),
+      'unfiltered',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_4x2_scalar_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(4, 2),
+      sparseF32Range(),
+      'f32-only',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_4x2_scalar_non_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(4, 2),
+      sparseF32Range(),
+      'unfiltered',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_4x3_scalar_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(4, 3),
+      sparseF32Range(),
+      'f32-only',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_4x3_scalar_non_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(4, 3),
+      sparseF32Range(),
+      'unfiltered',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_4x4_scalar_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(4, 4),
+      sparseF32Range(),
+      'f32-only',
+      multiplicationMatrixScalarInterval
+    );
+  },
+  multiplication_4x4_scalar_non_const: () => {
+    return generateMatrixScalarToMatrixCases(
+      sparseMatrixF32Range(4, 4),
+      sparseF32Range(),
+      'unfiltered',
+      multiplicationMatrixScalarInterval
+    );
+  },
+
+  multiplication_scalar_2x2_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(2, 2),
+      'f32-only',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_2x2_non_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(2, 2),
+      'unfiltered',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_2x3_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(2, 3),
+      'f32-only',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_2x3_non_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(2, 3),
+      'unfiltered',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_2x4_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(2, 4),
+      'f32-only',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_2x4_non_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(2, 4),
+      'unfiltered',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_3x2_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(3, 2),
+      'f32-only',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_3x2_non_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(3, 2),
+      'unfiltered',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_3x3_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(3, 3),
+      'f32-only',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_3x3_non_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(3, 3),
+      'unfiltered',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_3x4_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(3, 4),
+      'f32-only',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_3x4_non_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(3, 4),
+      'unfiltered',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_4x2_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(4, 2),
+      'f32-only',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_4x2_non_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(4, 2),
+      'unfiltered',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_4x3_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(4, 3),
+      'f32-only',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_4x3_non_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(4, 3),
+      'unfiltered',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_4x4_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(4, 4),
+      'f32-only',
+      multiplicationScalarMatrixInterval
+    );
+  },
+  multiplication_scalar_4x4_non_const: () => {
+    return generateScalarMatrixToMatrixCases(
+      sparseF32Range(),
+      sparseMatrixF32Range(4, 4),
+      'unfiltered',
+      multiplicationScalarMatrixInterval
     );
   },
   subtraction_2x2_const: () => {
@@ -334,6 +631,70 @@ Accuracy: Correctly rounded
       t,
       binary('+'),
       [TypeMat(cols, rows, TypeF32), TypeMat(cols, rows, TypeF32)],
+      TypeMat(cols, rows, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('multiplication_matrix_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x * y, where x is a matrix and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', allInputSources)
+      .combine('cols', [2, 3, 4] as const)
+      .combine('rows', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cols = t.params.cols;
+    const rows = t.params.rows;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `multiplication_${cols}x${rows}_scalar_const`
+        : `multiplication_${cols}x${rows}_scalar_non_const`
+    );
+    await run(
+      t,
+      binary('*'),
+      [TypeMat(cols, rows, TypeF32), TypeF32],
+      TypeMat(cols, rows, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('multiplication_scalar_matrix')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x * y, where x is a scalar and y is a matrix
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', allInputSources)
+      .combine('cols', [2, 3, 4] as const)
+      .combine('rows', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cols = t.params.cols;
+    const rows = t.params.rows;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `multiplication_scalar_${cols}x${rows}_const`
+        : `multiplication_scalar_${cols}x${rows}_non_const`
+    );
+    await run(
+      t,
+      binary('*'),
+      [TypeF32, TypeMat(cols, rows, TypeF32)],
       TypeMat(cols, rows, TypeF32),
       t.params,
       cases

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -647,6 +647,25 @@ export interface MatrixPairToMatrix {
   (x: Matrix<number>, y: Matrix<number>): F32Matrix;
 }
 
+/**
+ * A function that converts a matrix and a scalar to a matrix of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface MatrixScalarToMatrix {
+  (x: Matrix<number>, y: number): F32Matrix;
+}
+
+/**
+ * A function that converts a scalar and a matrix to a matrix of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface ScalarMatrixToMatrix {
+  (x: number, y: Matrix<number>): F32Matrix;
+}
 /** Converts a point to an acceptance interval, using a specific function
  *
  * This handles correctly rounding and flushing inputs as needed.
@@ -2002,6 +2021,24 @@ export function multiplicationInterval(
   y: number | F32Interval
 ): F32Interval {
   return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), MultiplicationIntervalOp);
+}
+
+/** Calculate an acceptance interval of x * y, when x is a matrix and y is a scalar */
+export function multiplicationMatrixScalarInterval(mat: Matrix<number>, scalar: number): F32Matrix {
+  const cols = mat.length;
+  const rows = mat[0].length;
+  return toF32Matrix(
+    unflatten2DArray(
+      flatten2DArray(mat).map(e => MultiplicationIntervalOp.impl(e, scalar)),
+      cols,
+      rows
+    )
+  );
+}
+
+/** Calculate an acceptance interval of x * y, when x is a scalar and y is a matrix */
+export function multiplicationScalarMatrixInterval(scalar: number, mat: Matrix<number>): F32Matrix {
+  return multiplicationMatrixScalarInterval(mat, scalar);
 }
 
 const NegationIntervalOp: PointToIntervalOp = {


### PR DESCRIPTION
Covers matrix * scalar and scalar * matrix.

Includes a fix for an issue with offset calculation when writing out arrays

Issue #1626

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
