### PR TITLE
Validate maxColorAttachments and maxColorAttachmentBytesPerSample

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
@@ -1,0 +1,322 @@
+import { assert, range } from '../../../../../common/util/util.js';
+import { kTextureSampleCounts, kTextureFormatInfo } from '../../../../capability_info.js';
+import { align } from '../../../../util/math.js';
+
+import {
+  kLimitBaseParams,
+  kLimitModes,
+  LimitTestsImpl,
+  makeLimitTestGroup,
+} from './limit_utils.js';
+
+const kFormatsToUseBySize: GPUTextureFormat[] = [
+  'rgba32float',
+  'rgba16float',
+  'rgba8unorm',
+  'rg8unorm',
+  'r8unorm',
+];
+
+const kInterleaveFormats: GPUTextureFormat[] = [
+  'rgba16float',
+  'rg16float',
+  'rgba8unorm',
+  'rg8unorm',
+  'r8unorm',
+];
+
+function getAttachments(interleaveFormat: GPUTextureFormat, testValue: number) {
+  let bytesPerSample = 0;
+  const targets: GPUColorTargetState[] = [];
+
+  const addTexture = (format: GPUTextureFormat) => {
+    const { renderTargetPixelByteCost, renderTargetComponentAlignment } = kTextureFormatInfo[
+      format
+    ];
+    const alignedBytesPerSample = align(bytesPerSample, renderTargetComponentAlignment!);
+    const bytesRemaining = testValue - alignedBytesPerSample;
+    if (renderTargetPixelByteCost! > bytesRemaining) {
+      return false;
+    }
+    targets.push({ format, writeMask: 0 });
+    bytesPerSample = alignedBytesPerSample + renderTargetPixelByteCost!;
+    return true;
+  };
+
+  while (bytesPerSample < testValue) {
+    addTexture(interleaveFormat);
+    for (const format of kFormatsToUseBySize) {
+      if (addTexture(format)) {
+        break;
+      }
+    }
+  }
+
+  assert(bytesPerSample === testValue);
+  return targets;
+}
+
+function getDescription(
+  testValue: number,
+  actualLimit: number,
+  sampleCount: number,
+  targets: GPUColorTargetState[]
+) {
+  return `
+    // testValue  : ${testValue}
+    // actualLimit: ${actualLimit}
+    // sampleCount: ${sampleCount}
+    // targets:
+    ${(() => {
+      let offset = 0;
+      return targets
+        .map(({ format }) => {
+          const { renderTargetPixelByteCost, renderTargetComponentAlignment } = kTextureFormatInfo[
+            format
+          ];
+          offset = align(offset, renderTargetComponentAlignment!);
+          const s = `//   ${format.padEnd(11)} (offset: ${offset
+            .toString()
+            .padStart(
+              2
+            )}, align: ${renderTargetComponentAlignment}, size: ${renderTargetPixelByteCost})`;
+          offset += renderTargetPixelByteCost!;
+          return s;
+        })
+        .join('\n    ');
+    })()}
+  `;
+}
+
+function getPipelineDescriptor(
+  device: GPUDevice,
+  actualLimit: number,
+  interleaveFormat: GPUTextureFormat,
+  sampleCount: number,
+  testValue: number
+): { pipelineDescriptor: GPURenderPipelineDescriptor; code: string } | undefined {
+  const targets = getAttachments(interleaveFormat, testValue);
+  if (!targets) {
+    return;
+  }
+
+  const code = `
+    ${getDescription(testValue, actualLimit, sampleCount, targets)}
+    @vertex fn vs() -> @builtin(position) vec4f {
+      return vec4f(0);
+    }
+
+    @fragment fn fs() -> @location(0) vec4f {
+      return vec4f(0);
+    }
+  `;
+  const module = device.createShaderModule({ code });
+  const pipelineDescriptor: GPURenderPipelineDescriptor = {
+    layout: 'auto',
+    vertex: {
+      module,
+      entryPoint: 'vs',
+    },
+    fragment: {
+      module,
+      entryPoint: 'fs',
+      targets,
+    },
+    multisample: {
+      count: sampleCount,
+    },
+  };
+  return { pipelineDescriptor, code };
+}
+
+function createTextures(t: LimitTestsImpl, targets: GPUColorTargetState[]) {
+  return targets.map(({ format }) =>
+    t.trackForCleanup(
+      t.device.createTexture({
+        size: [1, 1],
+        format,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT,
+      })
+    )
+  );
+}
+
+const limit = 'maxColorAttachmentBytesPerSample';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createRenderPipeline,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderPipeline`)
+  .params(
+    kLimitBaseParams
+      .combine('maxColorAttachmentsLimitMode', kLimitModes)
+      .combine('sampleCount', kTextureSampleCounts)
+      .combine('interleaveFormat', kInterleaveFormats)
+  )
+  .fn(async t => {
+    const {
+      limitTest,
+      testValueName,
+      maxColorAttachmentsLimitMode,
+      sampleCount,
+      interleaveFormat,
+    } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const result = getPipelineDescriptor(
+          device,
+          actualLimit,
+          interleaveFormat,
+          sampleCount,
+          testValue
+        );
+        if (!result) {
+          return;
+        }
+        const { pipelineDescriptor, code } = result;
+
+        await t.expectValidationError(
+          () => {
+            device.createRenderPipeline(pipelineDescriptor);
+          },
+          shouldError,
+          code
+        );
+      },
+      { maxColorAttachments: maxColorAttachmentsLimitMode }
+    );
+  });
+
+g.test('createRenderPipelineAsync,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderPipelineAsync`)
+  .params(
+    kLimitBaseParams
+      .combine('maxColorAttachmentsLimitMode', kLimitModes)
+      .combine('sampleCount', kTextureSampleCounts)
+      .combine('interleaveFormat', kInterleaveFormats)
+  )
+  .fn(async t => {
+    const {
+      limitTest,
+      testValueName,
+      maxColorAttachmentsLimitMode,
+      sampleCount,
+      interleaveFormat,
+    } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const result = getPipelineDescriptor(
+          device,
+          actualLimit,
+          interleaveFormat,
+          sampleCount,
+          testValue
+        );
+        if (!result) {
+          return;
+        }
+        const { pipelineDescriptor, code } = result;
+
+        await t.shouldRejectConditionally(
+          'OperationError',
+          device.createRenderPipelineAsync(pipelineDescriptor),
+          shouldError,
+          code
+        );
+      },
+      { maxColorAttachments: maxColorAttachmentsLimitMode }
+    );
+  });
+
+g.test('beginRenderPass,at_over')
+  .desc(`Test using at and over ${limit} limit in beginRenderPass`)
+  .params(
+    kLimitBaseParams
+      .combine('maxColorAttachmentsLimitMode', kLimitModes)
+      .combine('sampleCount', kTextureSampleCounts)
+      .combine('interleaveFormat', kInterleaveFormats)
+  )
+  .fn(async t => {
+    const {
+      limitTest,
+      testValueName,
+      maxColorAttachmentsLimitMode,
+      sampleCount,
+      interleaveFormat,
+    } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const targets = getAttachments(interleaveFormat, testValue);
+        const maxColorAttachments = device.limits.maxColorAttachments;
+        if (targets.length > maxColorAttachments) {
+          return;
+        }
+
+        const encoder = device.createCommandEncoder();
+        const textures = createTextures(t, targets);
+
+        const pass = encoder.beginRenderPass({
+          colorAttachments: range(testValue, i => ({
+            view: textures[i].createView(),
+            loadOp: 'clear',
+            storeOp: 'store',
+          })),
+        });
+        pass.end();
+
+        await t.expectValidationError(
+          () => {
+            encoder.finish();
+          },
+          shouldError,
+          getDescription(testValue, actualLimit, sampleCount, targets)
+        );
+      },
+      { maxColorAttachments: maxColorAttachmentsLimitMode }
+    );
+  });
+
+g.test('createRenderBundle,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderBundle`)
+  .params(
+    kLimitBaseParams
+      .combine('maxColorAttachmentsLimitMode', kLimitModes)
+      .combine('sampleCount', kTextureSampleCounts)
+      .combine('interleaveFormat', kInterleaveFormats)
+  )
+  .fn(async t => {
+    const {
+      limitTest,
+      testValueName,
+      maxColorAttachmentsLimitMode,
+      sampleCount,
+      interleaveFormat,
+    } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, actualLimit, shouldError }) => {
+        const targets = getAttachments(interleaveFormat, testValue);
+        const maxColorAttachments = device.limits.maxColorAttachments;
+        if (targets.length > maxColorAttachments) {
+          return;
+        }
+
+        await t.expectValidationError(
+          () => {
+            device.createRenderBundleEncoder({
+              colorFormats: targets.map(({ format }) => format),
+            });
+          },
+          shouldError,
+          getDescription(testValue, actualLimit, sampleCount, targets)
+        );
+      },
+      { maxColorAttachments: maxColorAttachmentsLimitMode }
+    );
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachments.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachments.spec.ts
@@ -1,0 +1,134 @@
+import { range } from '../../../../../common/util/util.js';
+
+import { kLimitBaseParams, getDefaultLimit, makeLimitTestGroup } from './limit_utils.js';
+
+function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderPipelineDescriptor {
+  const code = `
+    @vertex fn vs() -> @builtin(position) vec4f {
+      return vec4f(0);
+    }
+
+    @fragment fn fs() -> @location(0) vec4f {
+      return vec4f(0);
+    }
+  `;
+  const module = device.createShaderModule({ code });
+  return {
+    layout: 'auto',
+    vertex: {
+      module,
+      entryPoint: 'vs',
+    },
+    fragment: {
+      module,
+      entryPoint: 'fs',
+      targets: new Array(testValue).fill({ format: 'r8unorm', writeMask: 0 }),
+    },
+  };
+}
+
+const limit = 'maxColorAttachments';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createRenderPipeline,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderPipeline`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const pipelineDescriptor = getPipelineDescriptor(device, testValue);
+
+        await t.expectValidationError(() => {
+          device.createRenderPipeline(pipelineDescriptor);
+        }, shouldError);
+      }
+    );
+  });
+
+g.test('createRenderPipelineAsync,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderPipelineAsync`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const pipelineDescriptor = getPipelineDescriptor(device, testValue);
+        await t.shouldRejectConditionally(
+          'OperationError',
+          device.createRenderPipelineAsync(pipelineDescriptor),
+          shouldError
+        );
+      }
+    );
+  });
+
+g.test('beginRenderPass,at_over')
+  .desc(`Test using at and over ${limit} limit in beginRenderPass`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const encoder = device.createCommandEncoder();
+
+        const textures = range(testValue, _ =>
+          t.trackForCleanup(
+            device.createTexture({
+              size: [1, 1],
+              format: 'r8unorm',
+              usage: GPUTextureUsage.RENDER_ATTACHMENT,
+            })
+          )
+        );
+
+        const pass = encoder.beginRenderPass({
+          colorAttachments: range(testValue, i => ({
+            view: textures[i].createView(),
+            loadOp: 'clear',
+            storeOp: 'store',
+          })),
+        });
+        pass.end();
+
+        await t.expectValidationError(() => {
+          encoder.finish();
+        }, shouldError);
+      }
+    );
+  });
+
+g.test('createRenderBundle,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderBundle`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        await t.expectValidationError(() => {
+          device.createRenderBundleEncoder({
+            colorFormats: new Array(testValue).fill('r8unorm'),
+          });
+        }, shouldError);
+      }
+    );
+  });
+
+g.test('validate')
+  .desc(`Test ${limit} against maxColorAttachmentBytesPerSample`)
+  .fn(t => {
+    const { adapter, defaultLimit, maximumLimit } = t;
+    const minColorAttachmentBytesPerSample = getDefaultLimit('maxColorAttachmentBytesPerSample');
+    // The smallest attachment is 1 byte
+    // so make sure maxColorAttachments < maxColorAttachmentBytesPerSample
+    t.expect(defaultLimit <= minColorAttachmentBytesPerSample);
+    t.expect(maximumLimit <= adapter.limits.maxColorAttachmentBytesPerSample);
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBufferBindingSize.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBufferBindingSize.spec.ts
@@ -81,7 +81,7 @@ g.test('createBindGroup,at_over')
   .params(kLimitBaseParams.combine('bufferPart', kBufferPartsKeys))
   .fn(async t => {
     const { limitTest, testValueName, bufferPart } = t.params;
-    const { adapter, defaultLimit, maximumLimit } = await t.getAdapterAndLimits();
+    const { defaultLimit, maximumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,
@@ -90,7 +90,6 @@ g.test('createBindGroup,at_over')
     );
 
     await t.testDeviceWithSpecificLimits(
-      adapter,
       requestedLimit,
       testValue,
       async ({ device, testValue, shouldError }) => {
@@ -144,10 +143,10 @@ g.test('validate,maxBufferSize')
   .params(u => u.combine('limitTest', kLimitValueTestKeys))
   .fn(async t => {
     const { limitTest } = t.params;
-    const { adapter, defaultLimit, maximumLimit } = await t.getAdapterAndLimits();
+    const { defaultLimit, maximumLimit } = t;
     const requestedLimit = getDeviceLimitToRequest(limitTest, defaultLimit, maximumLimit);
 
-    await t.testDeviceWithSpecificLimits(adapter, requestedLimit, 0, ({ device, actualLimit }) => {
+    await t.testDeviceWithSpecificLimits(requestedLimit, 0, ({ device, actualLimit }) => {
       t.expect(actualLimit <= device.limits.maxBufferSize);
     });
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
@@ -88,7 +88,7 @@ g.test('createRenderPipeline,at_over')
   .params(kLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    const { adapter, defaultLimit, maximumLimit } = await t.getAdapterAndLimits();
+    const { defaultLimit, maximumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,
@@ -97,7 +97,6 @@ g.test('createRenderPipeline,at_over')
     );
 
     await t.testDeviceWithSpecificLimits(
-      adapter,
       requestedLimit,
       testValue,
       async ({ device, testValue, shouldError }) => {
@@ -115,7 +114,7 @@ g.test('createRenderPipelineAsync,at_over')
   .params(kLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    const { adapter, defaultLimit, maximumLimit } = await t.getAdapterAndLimits();
+    const { defaultLimit, maximumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,
@@ -123,7 +122,6 @@ g.test('createRenderPipelineAsync,at_over')
       maximumLimit
     );
     await t.testDeviceWithSpecificLimits(
-      adapter,
       requestedLimit,
       testValue,
       async ({ device, testValue, shouldError }) => {


### PR DESCRIPTION
`maxColorAttachmentBytesPerSample` appears to not be enforced, assuming there's no bug in the test.

Issue: #2195 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
