### PR TITLE
Test rg11b10ufloat-renderable makes the format resolvable and MSAAable

### DIFF
--- a/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
+++ b/src/webgpu/api/validation/texture/rg11b10ufloat_renderable.spec.ts
@@ -31,11 +31,11 @@ Note, the createTexture tests cover these validation cases where this feature is
     t.device.createTexture(descriptor);
   });
 
-g.test('begin_render_pass')
+g.test('begin_render_pass_single_sampled')
   .desc(
     `
 Test that it is valid to begin render pass with rg11b10ufloat texture format
-iff rg11b10ufloat-renderable feature is enabled.
+iff rg11b10ufloat-renderable feature is enabled. Single sampled case.
 `
   )
   .beforeAllSubcases(t => {
@@ -49,7 +49,7 @@ iff rg11b10ufloat-renderable feature is enabled.
       usage: GPUConst.TextureUsage.RENDER_ATTACHMENT,
     });
     const encoder = t.device.createCommandEncoder();
-    encoder.beginRenderPass({
+    const pass = encoder.beginRenderPass({
       colorAttachments: [
         {
           view: texture.createView(),
@@ -59,6 +59,47 @@ iff rg11b10ufloat-renderable feature is enabled.
         },
       ],
     });
+    pass.end();
+    encoder.finish();
+  });
+
+g.test('begin_render_pass_msaa_and_resolve')
+  .desc(
+    `
+Test that it is valid to begin render pass with rg11b10ufloat texture format
+iff rg11b10ufloat-renderable feature is enabled. MSAA and resolve case.
+`
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('rg11b10ufloat-renderable');
+  })
+  .fn(t => {
+    const renderTexture = t.device.createTexture({
+      size: [1, 1, 1],
+      format: 'rg11b10ufloat',
+      sampleCount: 4,
+      usage: GPUConst.TextureUsage.RENDER_ATTACHMENT,
+    });
+    const resolveTexture = t.device.createTexture({
+      size: [1, 1, 1],
+      format: 'rg11b10ufloat',
+      sampleCount: 1,
+      usage: GPUConst.TextureUsage.RENDER_ATTACHMENT,
+    });
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: renderTexture.createView(),
+          resolveTarget: resolveTexture.createView(),
+          clearValue: { r: 1.0, g: 0.0, b: 0.0, a: 1.0 },
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.end();
+    encoder.finish();
   });
 
 g.test('begin_render_bundle_encoder')


### PR DESCRIPTION
This is a test for https://github.com/gpuweb/gpuweb/issues/3566




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
