### PR TITLE
Rename to GPUShaderModule.getCompilationInfo()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "gpuweb/types#48dafa2124c767bcc4f84b0d1126bcc478143fad",
+        "@webgpu/types": "gpuweb/types#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1261,9 +1261,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.27",
-      "resolved": "git+ssh://git@github.com/gpuweb/types.git#48dafa2124c767bcc4f84b0d1126bcc478143fad",
-      "integrity": "sha512-9oZDgM+/vhyPDM3twL1KQSs0fLbXvbxrStWi/+tvXnas7pQuQNaNBpge8wNcEUtbLMoORQYDc6hPFCSQKqpNAw==",
+      "version": "0.1.28",
+      "resolved": "git+ssh://git@github.com/gpuweb/types.git#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77",
+      "integrity": "sha512-+iuxedqdbpOGzbCVH/zo2Qfa+17glLxEp2q9qTKgIm5aUUrvw3AobDHGFOf27R6ZAQQ+MwEvdWEKDIuvwmtsCA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -9875,10 +9875,10 @@
       }
     },
     "@webgpu/types": {
-      "version": "git+ssh://git@github.com/gpuweb/types.git#48dafa2124c767bcc4f84b0d1126bcc478143fad",
-      "integrity": "sha512-9oZDgM+/vhyPDM3twL1KQSs0fLbXvbxrStWi/+tvXnas7pQuQNaNBpge8wNcEUtbLMoORQYDc6hPFCSQKqpNAw==",
+      "version": "git+ssh://git@github.com/gpuweb/types.git#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77",
+      "integrity": "sha512-+iuxedqdbpOGzbCVH/zo2Qfa+17glLxEp2q9qTKgIm5aUUrvw3AobDHGFOf27R6ZAQQ+MwEvdWEKDIuvwmtsCA==",
       "dev": true,
-      "from": "@webgpu/types@gpuweb/types#48dafa2124c767bcc4f84b0d1126bcc478143fad"
+      "from": "@webgpu/types@gpuweb/types#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77"
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "gpuweb/types#48dafa2124c767bcc4f84b0d1126bcc478143fad",
+    "@webgpu/types": "gpuweb/types#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/operation/async_ordering/README.txt
+++ b/src/webgpu/api/operation/async_ordering/README.txt
@@ -9,4 +9,4 @@ TODO: plan and implement
 - device.lost
 - queue.onSubmittedWorkDone()
 - buffer.mapAsync()
-- shadermodule.compilationInfo()
+- shadermodule.getCompilationInfo()

--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -103,10 +103,10 @@ const kSourceMaps: { [name: string]: undefined | object } = {
 };
 const kSourceMapsKeys = keysOf(kSourceMaps);
 
-g.test('compilationInfo_returns')
+g.test('getCompilationInfo_returns')
   .desc(
     `
-    Test that compilationInfo() can be called on any ShaderModule.
+    Test that getCompilationInfo() can be called on any ShaderModule.
 
     Note: sourcemaps are not used in the WebGPU API. We are only testing that
     browser that happen to use them don't fail or crash if the sourcemap is
@@ -132,7 +132,7 @@ g.test('compilationInfo_returns')
       !valid
     );
 
-    const info = await shaderModule.compilationInfo();
+    const info = await shaderModule.getCompilationInfo();
 
     t.expect(
       info instanceof GPUCompilationInfo,
@@ -181,7 +181,7 @@ g.test('line_number_and_position')
       return t.device.createShaderModule({ code: _code, ...(sourceMap && { sourceMap }) });
     });
 
-    const info = await shaderModule.compilationInfo();
+    const info = await shaderModule.getCompilationInfo();
 
     let foundAppropriateError = false;
     for (const message of info.messages) {
@@ -235,7 +235,7 @@ g.test('offset_and_length')
       !valid
     );
 
-    const info = await shaderModule.compilationInfo();
+    const info = await shaderModule.getCompilationInfo();
 
     for (const message of info.messages) {
       // Any offsets and lengths should reference valid spans of the shader code.

--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -26,7 +26,7 @@ export class ShaderValidationTest extends GPUTest {
 
     const error = new ErrorWithExtra('', () => ({ shaderModule }));
     this.eventualAsyncExpectation(async () => {
-      const compilationInfo = await shaderModule!.compilationInfo();
+      const compilationInfo = await shaderModule!.getCompilationInfo();
 
       // MAINTENANCE_TODO: Pretty-print error messages with source context.
       const messagesLog = compilationInfo.messages


### PR DESCRIPTION
To follow the upcoming WebGPU spec change

https://github.com/gpuweb/gpuweb/pull/3805#issuecomment-1433931903

Requires
* https://github.com/gpuweb/gpuweb/pull/3805 needs to be merged
* [@webgpu/types](https://github.com/gpuweb/types) needs to updated with the above change

so this PR is still draft. I will switch to ready for review when the aboves are updated.

Issue: #2290

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
