### PR TITLE
Update tests to use `alias`.

### DIFF
--- a/src/webgpu/shader/validation/parse/semicolon.spec.ts
+++ b/src/webgpu/shader/validation/parse/semicolon.spec.ts
@@ -51,8 +51,8 @@ g.test('after_func_decl')
 g.test('after_type_alias_decl')
   .desc(`Test that a semicolon must be placed after an type alias declaration.`)
   .fn(t => {
-    t.expectCompileResult(/* pass */ true, `type T = i32;`);
-    t.expectCompileResult(/* pass */ false, `type T = i32`);
+    t.expectCompileResult(/* pass */ true, `alias T = i32;`);
+    t.expectCompileResult(/* pass */ false, `alias T = i32`);
   });
 
 g.test('after_return')

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -258,12 +258,12 @@ g.test('reuse_builtin_name')
   .params(u =>
     u
       .combineWithParams(kBuiltins)
-      .combine('use', ['type_name', 'struct', 'function', 'module-var', 'function-var'])
+      .combine('use', ['alias', 'struct', 'function', 'module-var', 'function-var'])
   )
   .fn(t => {
     let code = '';
-    if (t.params.use === 'type_name') {
-      code += `type ${t.params.name} = i32;`;
+    if (t.params.use === 'alias') {
+      code += `alias ${t.params.name} = i32;`;
     } else if (t.params.use === `struct`) {
       code += `struct ${t.params.name} { i: f32, }`;
     } else if (t.params.use === `function`) {

--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -158,7 +158,7 @@ g.test('type')
               `;
     }
     if (t.params.type === 'MyAlias') {
-      code += 'type MyAlias = i32;\n';
+      code += 'alias MyAlias = i32;\n';
     }
 
     code += generateShader({


### PR DESCRIPTION
The `type` token was removed in favour of `alias`. This CL updates the CTS tests to match.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
