### PR TITLE
Emit `f32` values for F32Interval.toString()

### DIFF
--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -2,7 +2,7 @@ import { assert, unreachable } from '../../common/util/util.js';
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 
 import { kValue } from './constants.js';
-import { reinterpretF32AsU32, reinterpretU32AsF32 } from './conversion.js';
+import { f32, reinterpretF32AsU32, reinterpretU32AsF32 } from './conversion.js';
 import {
   calculatePermutations,
   cartesianProduct,
@@ -99,7 +99,7 @@ export class F32Interval {
 
   /** @returns a string representation for logging purposes */
   public toString(): string {
-    return `[${this.bounds()}]`;
+    return `[${this.bounds().map(f32)}]`;
   }
 
   /** @returns a singleton for interval of all possible values


### PR DESCRIPTION
The existing version of toString will emit the TS `number` as a string, which will just be the decimal numeric value.

In test logs it is normally more useful to have the value converted to `f32`, since that includes the hex encoding.

This format is what is already used for the input and returned values in the logs. This should only be changing expectation strings.

Fixes #2295


**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
