### PR TITLE
GPUPipelineError.name is GPUPipelineError and not OperationError.

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroups.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroups.spec.ts
@@ -79,7 +79,7 @@ g.test('createPipelineAsync,at_over')
         const module = device.createShaderModule({ code });
 
         const promise = t.createPipelineAsync(createPipelineAsyncType, module);
-        await t.shouldRejectConditionally('OperationError', promise, shouldError);
+        await t.shouldRejectConditionally('GPUPipelineError', promise, shouldError);
       }
     );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindingsPerBindGroup.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindingsPerBindGroup.spec.ts
@@ -71,7 +71,7 @@ g.test('createPipelineAsync,at_over')
         const module = device.createShaderModule({ code });
 
         const promise = t.createPipelineAsync(createPipelineAsyncType, module);
-        await t.shouldRejectConditionally('OperationError', promise, shouldError);
+        await t.shouldRejectConditionally('GPUPipelineError', promise, shouldError);
       }
     );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexAttributes.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexAttributes.spec.ts
@@ -57,7 +57,7 @@ g.test('createRenderPipelineAsync,at_over')
         const pipelineDescriptor = getPipelineDescriptor(device, lastIndex);
 
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           device.createRenderPipelineAsync(pipelineDescriptor),
           shouldError
         );

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
@@ -129,7 +129,7 @@ g.test('createRenderPipelineAsync,at_over')
       async ({ device, testValue, shouldError }) => {
         const pipelineDescriptor = getPipelineDescriptor(device, testValue);
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           device.createRenderPipelineAsync(pipelineDescriptor),
           shouldError
         );

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
@@ -77,7 +77,7 @@ g.test('createRenderPipelineAsync,at_over')
       async ({ device, testValue, shouldError }) => {
         const pipelineDescriptor = getPipelineDescriptor(device, pipelineType, testValue);
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           device.createRenderPipelineAsync(pipelineDescriptor),
           shouldError
         );

--- a/src/webgpu/api/validation/validation_test.ts
+++ b/src/webgpu/api/validation/validation_test.ts
@@ -399,7 +399,7 @@ export class ValidationTest extends GPUTest {
     isAsync: boolean,
     _success: boolean,
     descriptor: GPURenderPipelineDescriptor,
-    errorTypeName: 'OperationError' | 'TypeError' = 'OperationError'
+    errorTypeName: 'GPUPipelineError' | 'TypeError' = 'GPUPipelineError'
   ) {
     if (isAsync) {
       if (_success) {
@@ -408,7 +408,7 @@ export class ValidationTest extends GPUTest {
         this.shouldReject(errorTypeName, this.device.createRenderPipelineAsync(descriptor));
       }
     } else {
-      if (errorTypeName === 'OperationError') {
+      if (errorTypeName === 'GPUPipelineError') {
         this.expectValidationError(() => {
           this.device.createRenderPipeline(descriptor);
         }, !_success);
@@ -425,7 +425,7 @@ export class ValidationTest extends GPUTest {
     isAsync: boolean,
     _success: boolean,
     descriptor: GPUComputePipelineDescriptor,
-    errorTypeName: 'OperationError' | 'TypeError' = 'OperationError'
+    errorTypeName: 'GPUPipelineError' | 'TypeError' = 'GPUPipelineError'
   ) {
     if (isAsync) {
       if (_success) {
@@ -434,7 +434,7 @@ export class ValidationTest extends GPUTest {
         this.shouldReject(errorTypeName, this.device.createComputePipelineAsync(descriptor));
       }
     } else {
-      if (errorTypeName === 'OperationError') {
+      if (errorTypeName === 'GPUPipelineError') {
         this.expectValidationError(() => {
           this.device.createComputePipeline(descriptor);
         }, !_success);


### PR DESCRIPTION
Fixes #2297


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) works with a WIP Chromium CL that fixes the name.

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
