### PR TITLE
Fix normalization checks

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -283,7 +283,7 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
         { constants: { 9999: 0 }, _success: false },
         { constants: { 1000: 0, c2: 0 }, _success: false },
         { constants: { 数: 0 }, _success: true },
-        { constants: { séquençage: 0 }, _success: true }, // test unicode normalization
+        { constants: { séquençage: 0 }, _success: false }, // test unicode is not normalized
       ] as { constants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(t => {
@@ -297,14 +297,14 @@ Tests calling createComputePipeline(Async) validation for overridable constants 
             override c0: bool = true;      // type: bool
             override c1: u32 = 0u;          // default override
             override 数: u32 = 0u;          // non-ASCII
-            override sequencage: u32 = 0u;  // unicode normalization
+            override séquençage: u32 = 0u;  // normalizable unicode (WGSL does not normalize)
             @id(1000) override c2: u32 = 10u;  // default
             @id(1) override c3: u32 = 11u;     // default
             @compute @workgroup_size(1) fn main () {
               // make sure the overridable constants are not optimized out
               _ = u32(c0);
               _ = u32(c1);
-              _ = u32(c2 + sequencage);
+              _ = u32(c2 + séquençage);
               _ = u32(c3 + 数);
             }`,
         }),

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -30,7 +30,7 @@ Tests calling createRenderPipeline(Async) validation for overridable constants i
         { vertexConstants: { w: 1 }, _success: false }, // pipeline constant id is specified for w
         { vertexConstants: { 1: 1, z: 1 }, _success: false }, // pipeline constant id is specified for z
         { vertexConstants: { 数: 1 }, _success: true }, // test non-ASCII
-        { vertexConstants: { séquençage: 0 }, _success: true }, // test unicode normalization
+        { vertexConstants: { séquençage: 0 }, _success: false }, // test unicode normalization
       ] as { vertexConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(t => {
@@ -44,11 +44,11 @@ Tests calling createRenderPipeline(Async) validation for overridable constants i
             override x: f32 = 0.0;
             override y: f32 = 0.0;
             override 数: f32 = 0.0;
-            override sequencage: f32 = 0.0;
+            override séquençage: f32 = 0.0;
             @id(1) override z: f32 = 0.0;
             @id(1000) override w: f32 = 1.0;
             @vertex fn main() -> @builtin(position) vec4<f32> {
-              return vec4<f32>(x, y, z, w + 数 + sequencage);
+              return vec4<f32>(x, y, z, w + 数 + séquençage);
             }`,
         }),
         entryPoint: 'main',
@@ -87,7 +87,7 @@ Tests calling createRenderPipeline(Async) validation for overridable constants i
         { fragmentConstants: { a: 1 }, _success: false }, // pipeline constant id is specified for a
         { fragmentConstants: { 1: 1, b: 1 }, _success: false }, // pipeline constant id is specified for b
         { fragmentConstants: { 数: 1 }, _success: true }, // test non-ASCII
-        { fragmentConstants: { séquençage: 0 }, _success: true }, // test unicode normalization
+        { fragmentConstants: { séquençage: 0 }, _success: false }, // test unicode is not normalized
       ] as { fragmentConstants: Record<string, GPUPipelineConstantValue>; _success: boolean }[])
   )
   .fn(t => {

--- a/src/webgpu/api/validation/shader_module/entry_point.spec.ts
+++ b/src/webgpu/api/validation/shader_module/entry_point.spec.ts
@@ -37,7 +37,7 @@ const kEntryPointTestCases = [
   { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: 'main_t12V5' },
   { shaderModuleEntryPoint: 'main_t12V3', stageEntryPoint: '_main_t12V3' },
   { shaderModuleEntryPoint: 'séquençage', stageEntryPoint: 'séquençage' },
-  { shaderModuleEntryPoint: 'séquençage', stageEntryPoint: 'sequencage' },
+  { shaderModuleEntryPoint: 'séquençage', stageEntryPoint: 'séquençage' },
 ];
 
 g.test('compute')


### PR DESCRIPTION
These were wrong period (not sure why). Also, WebGPU does not normalize.




Issue: #none

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
