### PR TITLE
Add f32 matrix-vector and vector-matrix multiplication tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -50,6 +50,8 @@ import {
   multiplicationInterval,
   multiplicationMatrixMatrixInterval,
   multiplicationMatrixScalarInterval,
+  multiplicationMatrixVectorInterval,
+  multiplicationVectorMatrixInterval,
   negationInterval,
   normalizeInterval,
   powInterval,
@@ -4603,3 +4605,222 @@ g.test('multiplicationMatrixScalarInterval')
   });
 
 // There are not explicit tests for multiplicationScalarMatrixInterval since it is just a passthrough to multiplicationMatrixScalarInterval
+
+interface MatrixVectorToVectorCase {
+  matrix: number[][];
+  vector: number[];
+  expected: IntervalBounds[] | number[];
+}
+
+g.test('multiplicationMatrixVectorInterval')
+  .paramsSubcasesOnly<MatrixVectorToVectorCase>([
+    // Only testing that different shapes of matrices are handled correctly
+    // here, to reduce test duplication.
+    // multiplicationMatrixVectorInterval uses DotIntervalOp &
+    // TransposeIntervalOp for calculating intervals, so the testing for
+    // dotInterval & transposeInterval covers the actual interval
+    // calculations.
+    {
+      matrix: [
+        [1, 2],
+        [3, 4],
+      ],
+      vector: [11, 22],
+      expected: [77, 110],
+    },
+    {
+      matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+      vector: [11, 22],
+      expected: [99, 132, 165],
+    },
+    {
+      matrix: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ],
+      vector: [11, 22],
+      expected: [121, 154, 187, 220],
+    },
+    {
+      matrix: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+      vector: [11, 22, 33],
+      expected: [242, 308],
+    },
+    {
+      matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      vector: [11, 22, 33],
+      expected: [330, 396, 462],
+    },
+    {
+      matrix: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+      ],
+      vector: [11, 22, 33],
+      expected: [418, 484, 550, 616],
+    },
+    {
+      matrix: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [7, 8],
+      ],
+      vector: [11, 22, 33, 44],
+      expected: [550, 660],
+    },
+    {
+      matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [10, 11, 12],
+      ],
+      vector: [11, 22, 33, 44],
+      expected: [770, 880, 990],
+    },
+    {
+      matrix: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+      ],
+      vector: [11, 22, 33, 44],
+      expected: [990, 1100, 1210, 1320],
+    },
+  ])
+  .fn(t => {
+    const matrix = t.params.matrix;
+    const vector = t.params.vector;
+    const expected = toF32Vector(t.params.expected);
+
+    const got = multiplicationMatrixVectorInterval(matrix, vector);
+    t.expect(
+      objectEquals(expected, got),
+      `multiplicationMatrixVectorInterval([${JSON.stringify(matrix)}], [${JSON.stringify(
+        vector
+      )}]) returned '[${JSON.stringify(got)}]'. Expected '[${JSON.stringify(expected)}]'`
+    );
+  });
+
+interface VectorMatrixToVectorCase {
+  vector: number[];
+  matrix: number[][];
+  expected: IntervalBounds[] | number[];
+}
+
+g.test('multiplicationVectorMatrixInterval')
+  .paramsSubcasesOnly<VectorMatrixToVectorCase>([
+    // Only testing that different shapes of matrices are handled correctly
+    // here, to reduce test duplication.
+    // multiplicationVectorMatrixInterval uses DotIntervalOp for calculating
+    // intervals, so the testing for dotInterval covers the actual interval
+    // calculations.
+    {
+      vector: [1, 2],
+      matrix: [
+        [11, 22],
+        [33, 44],
+      ],
+      expected: [55, 121],
+    },
+    {
+      vector: [1, 2],
+      matrix: [
+        [11, 22],
+        [33, 44],
+        [55, 66],
+      ],
+      expected: [55, 121, 187],
+    },
+    {
+      vector: [1, 2],
+      matrix: [
+        [11, 22],
+        [33, 44],
+        [55, 66],
+        [77, 88],
+      ],
+      expected: [55, 121, 187, 253],
+    },
+    {
+      vector: [1, 2, 3],
+      matrix: [
+        [11, 22, 33],
+        [44, 55, 66],
+      ],
+      expected: [154, 352],
+    },
+    {
+      vector: [1, 2, 3],
+      matrix: [
+        [11, 22, 33],
+        [44, 55, 66],
+        [77, 88, 99],
+      ],
+      expected: [154, 352, 550],
+    },
+    {
+      vector: [1, 2, 3],
+      matrix: [
+        [11, 22, 33],
+        [44, 55, 66],
+        [77, 88, 99],
+        [1010, 1111, 1212],
+      ],
+      expected: [154, 352, 550, 6868],
+    },
+    {
+      vector: [1, 2, 3, 4],
+      matrix: [
+        [11, 22, 33, 44],
+        [55, 66, 77, 88],
+      ],
+      expected: [330, 770],
+    },
+    {
+      vector: [1, 2, 3, 4],
+      matrix: [
+        [11, 22, 33, 44],
+        [55, 66, 77, 88],
+        [99, 1010, 1111, 1212],
+      ],
+      expected: [330, 770, 10300],
+    },
+    {
+      vector: [1, 2, 3, 4],
+      matrix: [
+        [11, 22, 33, 44],
+        [55, 66, 77, 88],
+        [99, 1010, 1111, 1212],
+        [1313, 1414, 1515, 1616],
+      ],
+      expected: [330, 770, 10300, 15150],
+    },
+  ])
+  .fn(t => {
+    const vector = t.params.vector;
+    const matrix = t.params.matrix;
+    const expected = toF32Vector(t.params.expected);
+
+    const got = multiplicationVectorMatrixInterval(vector, matrix);
+    t.expect(
+      objectEquals(expected, got),
+      `multiplicationVectorMatrixInterval([${JSON.stringify(vector)}], [${JSON.stringify(
+        matrix
+      )}]) returned '[${JSON.stringify(got)}]'. Expected '[${JSON.stringify(expected)}]'`
+    );
+  });

--- a/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
@@ -4,21 +4,29 @@ Execution Tests for the f32 matrix arithmetic binary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { TypeF32, TypeMat } from '../../../../util/conversion.js';
+import { TypeF32, TypeMat, TypeVec } from '../../../../util/conversion.js';
 import {
   additionMatrixInterval,
   multiplicationMatrixMatrixInterval,
   multiplicationMatrixScalarInterval,
+  multiplicationMatrixVectorInterval,
   multiplicationScalarMatrixInterval,
+  multiplicationVectorMatrixInterval,
   subtractionMatrixInterval,
 } from '../../../../util/f32_interval.js';
-import { sparseF32Range, sparseMatrixF32Range } from '../../../../util/math.js';
+import {
+  sparseF32Range,
+  sparseMatrixF32Range,
+  sparseVectorF32Range,
+} from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import {
   allInputSources,
   generateMatrixPairToMatrixCases,
   generateMatrixScalarToMatrixCases,
+  generateMatrixVectorToVectorCases,
   generateScalarMatrixToMatrixCases,
+  generateVectorMatrixToVectorCases,
   run,
 } from '../expression.js';
 
@@ -891,6 +899,294 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
       multiplicationScalarMatrixInterval
     );
   },
+  multiplication_2x2_vec2_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(2, 2),
+      sparseVectorF32Range(2),
+      'f32-only',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_2x2_vec2_non_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(2, 2),
+      sparseVectorF32Range(2),
+      'unfiltered',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_2x3_vec2_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(2, 3),
+      sparseVectorF32Range(2),
+      'f32-only',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_2x3_vec2_non_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(2, 3),
+      sparseVectorF32Range(2),
+      'unfiltered',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_2x4_vec2_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(2, 4),
+      sparseVectorF32Range(2),
+      'f32-only',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_2x4_vec2_non_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(2, 4),
+      sparseVectorF32Range(2),
+      'unfiltered',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_3x2_vec3_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(3, 2),
+      sparseVectorF32Range(3),
+      'f32-only',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_3x2_vec3_non_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(3, 2),
+      sparseVectorF32Range(3),
+      'unfiltered',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_3x3_vec3_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(3, 3),
+      sparseVectorF32Range(3),
+      'f32-only',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_3x3_vec3_non_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(3, 3),
+      sparseVectorF32Range(3),
+      'unfiltered',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_3x4_vec3_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(3, 4),
+      sparseVectorF32Range(3),
+      'f32-only',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_3x4_vec3_non_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(3, 4),
+      sparseVectorF32Range(3),
+      'unfiltered',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_4x2_vec4_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(4, 2),
+      sparseVectorF32Range(4),
+      'f32-only',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_4x2_vec4_non_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(4, 2),
+      sparseVectorF32Range(4),
+      'unfiltered',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_4x3_vec4_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(4, 3),
+      sparseVectorF32Range(4),
+      'f32-only',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_4x3_vec4_non_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(4, 3),
+      sparseVectorF32Range(4),
+      'unfiltered',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_4x4_vec4_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(4, 4),
+      sparseVectorF32Range(4),
+      'f32-only',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_4x4_vec4_non_const: () => {
+    return generateMatrixVectorToVectorCases(
+      sparseMatrixF32Range(4, 4),
+      sparseVectorF32Range(4),
+      'unfiltered',
+      multiplicationMatrixVectorInterval
+    );
+  },
+  multiplication_vec2_2x2_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(2),
+      sparseMatrixF32Range(2, 2),
+      'f32-only',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec2_2x2_non_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(2),
+      sparseMatrixF32Range(2, 2),
+      'unfiltered',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec2_3x2_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(2),
+      sparseMatrixF32Range(3, 2),
+      'f32-only',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec2_3x2_non_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(2),
+      sparseMatrixF32Range(3, 2),
+      'unfiltered',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec2_4x2_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(2),
+      sparseMatrixF32Range(4, 2),
+      'f32-only',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec2_4x2_non_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(2),
+      sparseMatrixF32Range(4, 2),
+      'unfiltered',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec3_2x3_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(3),
+      sparseMatrixF32Range(2, 3),
+      'f32-only',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec3_2x3_non_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(3),
+      sparseMatrixF32Range(2, 3),
+      'unfiltered',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec3_3x3_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(3),
+      sparseMatrixF32Range(3, 3),
+      'f32-only',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec3_3x3_non_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(3),
+      sparseMatrixF32Range(3, 3),
+      'unfiltered',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec3_4x3_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(3),
+      sparseMatrixF32Range(4, 3),
+      'f32-only',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec3_4x3_non_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(3),
+      sparseMatrixF32Range(4, 3),
+      'unfiltered',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec4_2x4_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(4),
+      sparseMatrixF32Range(2, 4),
+      'f32-only',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec4_2x4_non_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(4),
+      sparseMatrixF32Range(2, 4),
+      'unfiltered',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec4_3x4_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(4),
+      sparseMatrixF32Range(3, 4),
+      'f32-only',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec4_3x4_non_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(4),
+      sparseMatrixF32Range(3, 4),
+      'unfiltered',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec4_4x4_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(4),
+      sparseMatrixF32Range(4, 4),
+      'f32-only',
+      multiplicationVectorMatrixInterval
+    );
+  },
+  multiplication_vec4_4x4_non_const: () => {
+    return generateVectorMatrixToVectorCases(
+      sparseVectorF32Range(4),
+      sparseMatrixF32Range(4, 4),
+      'unfiltered',
+      multiplicationVectorMatrixInterval
+    );
+  },
   subtraction_2x2_const: () => {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 2),
@@ -1164,6 +1460,70 @@ Accuracy: Correctly rounded
       binary('*'),
       [TypeF32, TypeMat(cols, rows, TypeF32)],
       TypeMat(cols, rows, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('multiplication_matrix_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x * y, where x is a matrix and y is a vector
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', allInputSources)
+      .combine('cols', [2, 3, 4] as const)
+      .combine('rows', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cols = t.params.cols;
+    const rows = t.params.rows;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `multiplication_${cols}x${rows}_vec${cols}_const`
+        : `multiplication_${cols}x${rows}_vec${cols}_non_const`
+    );
+    await run(
+      t,
+      binary('*'),
+      [TypeMat(cols, rows, TypeF32), TypeVec(cols, TypeF32)],
+      TypeVec(rows, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('multiplication_vector_matrix')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x * y, where x is a vector and y is is a matrix
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', allInputSources)
+      .combine('cols', [2, 3, 4] as const)
+      .combine('rows', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cols = t.params.cols;
+    const rows = t.params.rows;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `multiplication_vec${rows}_${cols}x${rows}_const`
+        : `multiplication_vec${rows}_${cols}x${rows}_non_const`
+    );
+    await run(
+      t,
+      binary('*'),
+      [TypeVec(rows, TypeF32), TypeMat(cols, rows, TypeF32)],
+      TypeVec(cols, TypeF32),
       t.params,
       cases
     );

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -24,10 +24,12 @@ import {
   MatrixPairToMatrix,
   MatrixScalarToMatrix,
   MatrixToMatrix,
+  MatrixVectorToVector,
   PointToInterval,
   PointToVector,
   ScalarMatrixToMatrix,
   TernaryToInterval,
+  VectorMatrixToVector,
   VectorPairToInterval,
   VectorPairToVector,
   VectorToInterval,
@@ -1237,6 +1239,118 @@ export function generateScalarMatrixToMatrixCases(
   mats.forEach(mat => {
     scalars.forEach(scalar => {
       const c = makeScalarMatrixToMatrixCase(scalar, mat, filter, ...ops);
+      if (c !== undefined) {
+        cases.push(c);
+      }
+    });
+  });
+  return cases;
+}
+
+/**
+ * @returns a Case for the params and the vector of intervals generator provided
+ * @param mat the matrix param to pass in
+ * @param vec the vector to pass in
+ * @param filter what interval filtering to apply
+ * @param ops callbacks that implement generating a vector of acceptance
+ *            intervals for a matrix and a vector.
+ */
+function makeMatrixVectorToVectorCase(
+  mat: number[][],
+  vec: number[],
+  filter: IntervalFilter,
+  ...ops: MatrixVectorToVector[]
+): Case | undefined {
+  mat = map2DArray(mat, quantizeToF32);
+  vec = vec.map(quantizeToF32);
+  const mat_f32 = map2DArray(mat, f32);
+  const vec_f32 = vec.map(f32);
+
+  const results = ops.map(o => o(mat, vec));
+  if (filter === 'f32-only' && results.some(v => v.some(e => !e.isFinite()))) {
+    return undefined;
+  }
+  return {
+    input: [new Matrix(mat_f32), new Vector(vec_f32)],
+    expected: anyOf(...results),
+  };
+}
+
+/**
+ * @returns an array of Cases for operations over a range of inputs
+ * @param mats array of inputs to try for the matrix input
+ * @param vecs array of inputs to try for the vector input
+ * @param filter what interval filtering to apply
+ * @param ops callbacks that implement generating a vector of acceptance
+ *            intervals for a matrix and a vector.
+ */
+export function generateMatrixVectorToVectorCases(
+  mats: number[][][],
+  vecs: number[][],
+  filter: IntervalFilter,
+  ...ops: MatrixVectorToVector[]
+): Case[] {
+  // Cannot use cartesianProduct here, due to heterogeneous types
+  const cases: Case[] = [];
+  mats.forEach(mat => {
+    vecs.forEach(vec => {
+      const c = makeMatrixVectorToVectorCase(mat, vec, filter, ...ops);
+      if (c !== undefined) {
+        cases.push(c);
+      }
+    });
+  });
+  return cases;
+}
+
+/**
+ * @returns a Case for the params and the vector of intervals generator provided
+ * @param vec the vector to pass in
+ * @param mat the matrix param to pass in
+ * @param filter what interval filtering to apply
+ * @param ops callbacks that implement generating a vector of acceptance
+ *            intervals for a vector and a matrix.
+ */
+function makeVectorMatrixToVectorCase(
+  vec: number[],
+  mat: number[][],
+  filter: IntervalFilter,
+  ...ops: VectorMatrixToVector[]
+): Case | undefined {
+  vec = vec.map(quantizeToF32);
+  mat = map2DArray(mat, quantizeToF32);
+  const vec_f32 = vec.map(f32);
+  const mat_f32 = map2DArray(mat, f32);
+
+  const results = ops.map(o => o(vec, mat));
+  if (filter === 'f32-only' && results.some(v => v.some(e => !e.isFinite()))) {
+    return undefined;
+  }
+  return {
+    input: [new Vector(vec_f32), new Matrix(mat_f32)],
+    expected: anyOf(...results),
+  };
+}
+
+/**
+ * @returns an array of Cases for operations over a range of inputs
+ * @param vecs array of inputs to try for the vector input
+ * @param mats array of inputs to try for the matrix input
+ * @param filter what interval filtering to apply
+ * @param ops callbacks that implement generating a vector of acceptance
+ *            intervals for a vector and a matrix.
+ */
+export function generateVectorMatrixToVectorCases(
+  vecs: number[][],
+  mats: number[][][],
+  filter: IntervalFilter,
+  ...ops: VectorMatrixToVector[]
+): Case[] {
+  // Cannot use cartesianProduct here, due to heterogeneous types
+  const cases: Case[] = [];
+  vecs.forEach(vec => {
+    mats.forEach(mat => {
+      const c = makeVectorMatrixToVectorCase(vec, mat, filter, ...ops);
       if (c !== undefined) {
         cases.push(c);
       }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -658,6 +658,26 @@ export interface MatrixScalarToMatrix {
 }
 
 /**
+ * A function that converts a matrix and a vector to a vector of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface MatrixVectorToVector {
+  (x: Matrix<number>, y: number[]): F32Vector;
+}
+
+/**
+ * A function that converts a vector and a matrix to a vector of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface VectorMatrixToVector {
+  (x: number[], y: Matrix<number>): F32Vector;
+}
+
+/**
  * A function that converts a scalar and a matrix to a matrix of acceptance
  * intervals.
  * This is the public facing API for builtin implementations that is called
@@ -2062,6 +2082,24 @@ export function multiplicationMatrixMatrixInterval(
   });
 
   return result as F32Matrix;
+}
+
+/** Calculate an acceptance interval of x * y, when x is a matrix and y is a vector */
+export function multiplicationMatrixVectorInterval(x: Matrix<number>, y: number[]): F32Vector {
+  const cols = x.length;
+  const rows = x[0].length;
+  assert(y.length === cols, `'mat${cols}x${rows} * vec${y.length}' is not defined`);
+
+  return transposeInterval(x).map(e => dotInterval(e, y)) as F32Vector;
+}
+
+/** Calculate an acceptance interval of x * y, when x is a vector and y is a matrix */
+export function multiplicationVectorMatrixInterval(x: number[], y: Matrix<number>): F32Vector {
+  const cols = y.length;
+  const rows = y[0].length;
+  assert(x.length === rows, `'vec${x.length} * mat${cols}x${rows}' is not defined`);
+
+  return y.map(e => dotInterval(x, e)) as F32Vector;
 }
 
 const NegationIntervalOp: PointToIntervalOp = {


### PR DESCRIPTION
Issue #1626

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
