### PR TITLE
Test maxInterStageShaderComponents and maxInterStageShaderVariables

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
@@ -1,0 +1,66 @@
+import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+
+function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderPipelineDescriptor {
+  const code = `
+    struct VSOut {
+      @builtin(position) p: vec4f,
+      @location(${testValue}) v: f32,
+    }
+    @vertex fn vs() -> VSOut {
+      var o: VSOut;
+      o.p = vec4f(0);
+      o.v = 1.0;
+      return o;
+    }
+  `;
+  const module = device.createShaderModule({ code });
+  return {
+    layout: 'auto',
+    vertex: {
+      module,
+      entryPoint: 'vs',
+    },
+  };
+}
+
+const limit = 'maxInterStageShaderVariables';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createRenderPipeline,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderPipeline`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const lastIndex = testValue - 1;
+        const pipelineDescriptor = getPipelineDescriptor(device, lastIndex);
+
+        await t.expectValidationError(() => {
+          device.createRenderPipeline(pipelineDescriptor);
+        }, shouldError);
+      }
+    );
+  });
+
+g.test('createRenderPipelineAsync,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderPipelineAsync`)
+  .params(kLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        const lastIndex = testValue - 1;
+        const pipelineDescriptor = getPipelineDescriptor(device, lastIndex);
+        await t.shouldRejectConditionally(
+          'GPUPipelineError',
+          device.createRenderPipelineAsync(pipelineDescriptor),
+          shouldError
+        );
+      }
+    );
+  });

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -1060,6 +1060,7 @@ export const kLimitInfo = /* prettier-ignore */ makeTable(
   'maxVertexAttributes':                       [           ,        16,                          ],
   'maxVertexBufferArrayStride':                [           ,      2048,                          ],
   'maxInterStageShaderComponents':             [           ,        60,                          ],
+  'maxInterStageShaderVariables':              [           ,        16,                          ],
 
   'maxColorAttachments':                       [           ,         8,                          ],
   'maxColorAttachmentBytesPerSample':          [           ,        32,                          ],


### PR DESCRIPTION
the `maxInterStageShaderComponents` test seems to fail (it doesn't not get an validation error when it should) when taking into account things like point-list, front-facing, sample-index, sample-mask

If you run the test the error message includes the WGSL. For example this WGSL seems like it should fail validation but does not

> testValueName="overLimit";pointList=false;frontFacing=false;sampleIndex=true;sampleMaskIn=false;sampleMaskOut=true
no error when one was expected: 

```
    // test value                        : 61
    // maxInterStageShaderComponents     : 60
    // num components in vertex shader   : 60
    // num components in fragment shader : 60 + sample_index
    // maxVertexShaderOutputComponents   : 61
    // maxFragmentShaderInputComponents  : 60
    // maxInterStageVariables:           : 16
    // num used inter stage variables    : 15

    struct VSOut {
      @builtin(position) p: vec4f,
      
      @location(0) v4_0: vec4f,
@location(1) v4_1: vec4f,
@location(2) v4_2: vec4f,
@location(3) v4_3: vec4f,
@location(4) v4_4: vec4f,
@location(5) v4_5: vec4f,
@location(6) v4_6: vec4f,
@location(7) v4_7: vec4f,
@location(8) v4_8: vec4f,
@location(9) v4_9: vec4f,
@location(10) v4_10: vec4f,
@location(11) v4_11: vec4f,
@location(12) v4_12: vec4f,
@location(13) v4_13: vec4f,
@location(14) v4_14: vec4f,
      
  
    }
    struct FSIn {
      
      @builtin(sample_index) sampleIndex: u32,
      
      
      @location(0) v4_0: vec4f,
@location(1) v4_1: vec4f,
@location(2) v4_2: vec4f,
@location(3) v4_3: vec4f,
@location(4) v4_4: vec4f,
@location(5) v4_5: vec4f,
@location(6) v4_6: vec4f,
@location(7) v4_7: vec4f,
@location(8) v4_8: vec4f,
@location(9) v4_9: vec4f,
@location(10) v4_10: vec4f,
@location(11) v4_11: vec4f,
@location(12) v4_12: vec4f,
@location(13) v4_13: vec4f,
@location(14) v4_14: vec4f,
      
  
    }
    struct FSOut {
      @location(0) color: vec4f,
      @builtin(sample_mask) sampleMask: u32,
    }
    @vertex fn vs() -> VSOut {
      var o: VSOut;
      o.p = vec4f(0);
      return o;
    }
    @fragment fn fs(i: FSIn) -> FSOut {
      var o: FSOut;
      o.color = vec4f(0);
      return o;
    }
```

As you can see, `maxInterStageShaderComponents ` is 60 but we're testing 61 (so it should fail)

`maxFragmentShaderInputComponents` is computed as 60 (61 - 1 because we're using sample_index)

The fragment shader generated uses 15 vec4f so 60 components. The actual limit should be 59 (60 - 1 for sample_mask) so this seems like it should fail validation


Issue: #2195 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
