### PR TITLE
Test maxDynamic(Uniform|Storage)BuffersPerPipelineLayout

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout.spec.ts
@@ -1,0 +1,38 @@
+import { range } from '../../../../../common/util/util.js';
+import { GPUConst } from '../../../../constants.js';
+
+import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+
+const limit = 'maxDynamicStorageBuffersPerPipelineLayout';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createBindGroupLayout,at_over')
+  .desc(`Test using createBindGroupLayout at and over ${limit} limit`)
+  .params(
+    kLimitBaseParams.combine('visibility', [
+      GPUConst.ShaderStage.FRAGMENT,
+      GPUConst.ShaderStage.COMPUTE,
+      GPUConst.ShaderStage.COMPUTE | GPUConst.ShaderStage.FRAGMENT,
+    ])
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        await t.expectValidationError(() => {
+          device.createBindGroupLayout({
+            entries: range(testValue, i => ({
+              binding: i,
+              visibility,
+              buffer: {
+                type: 'storage',
+                hasDynamicOffset: true,
+              },
+            })),
+          });
+        }, shouldError);
+      }
+    );
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout.spec.ts
@@ -1,0 +1,41 @@
+import { range } from '../../../../../common/util/util.js';
+import { GPUConst } from '../../../../constants.js';
+
+import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+
+const limit = 'maxDynamicUniformBuffersPerPipelineLayout';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createBindGroupLayout,at_over')
+  .desc(`Test using createBindGroupLayout at and over ${limit} limit`)
+  .params(
+    kLimitBaseParams.combine('visibility', [
+      GPUConst.ShaderStage.VERTEX,
+      GPUConst.ShaderStage.FRAGMENT,
+      GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
+      GPUConst.ShaderStage.COMPUTE,
+      GPUConst.ShaderStage.COMPUTE | GPUConst.ShaderStage.VERTEX,
+      GPUConst.ShaderStage.COMPUTE | GPUConst.ShaderStage.FRAGMENT,
+      GPUConst.ShaderStage.COMPUTE | GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
+    ])
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, visibility } = t.params;
+    await t.testDeviceWithRequestedLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError }) => {
+        await t.expectValidationError(() => {
+          device.createBindGroupLayout({
+            entries: range(testValue, i => ({
+              binding: i,
+              visibility,
+              buffer: {
+                hasDynamicOffset: true,
+              },
+            })),
+          });
+        }, shouldError);
+      }
+    );
+  });


### PR DESCRIPTION
There's no way to set hasDynamicOffset in auto layouts right?

Issue: #2195 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
