### PR TITLE
Only pass depth-stencil load/store values when needed.

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -472,6 +472,7 @@ class F extends GPUTest {
     });
     const bindGroup = this.GetBindGroupForT2TCopyWithDepthTests(bindGroupLayout, copySize[2]);
 
+    const hasStencil = kTextureFormatInfo[sourceTexture.format].stencil;
     const encoder = this.device.createCommandEncoder();
     for (let srcCopyLayer = 0; srcCopyLayer < copySize[2]; ++srcCopyLayer) {
       const renderPass = encoder.beginRenderPass({
@@ -486,8 +487,8 @@ class F extends GPUTest {
           depthClearValue: 0.0,
           depthLoadOp: 'clear',
           depthStoreOp: 'store',
-          stencilLoadOp: 'load',
-          stencilStoreOp: 'store',
+          stencilLoadOp: hasStencil ? 'load' : undefined,
+          stencilStoreOp: hasStencil ? 'store' : undefined,
         },
       });
       renderPass.setBindGroup(0, bindGroup, [srcCopyLayer * kMinDynamicBufferOffsetAlignment]);
@@ -515,12 +516,14 @@ class F extends GPUTest {
     });
     const bindGroup = this.GetBindGroupForT2TCopyWithDepthTests(bindGroupLayout, copySize[2]);
 
-    const outputColorTexture = this.device.createTexture({
-      format: 'rgba8unorm',
-      size: copySize,
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-    });
-    this.trackForCleanup(outputColorTexture);
+    const outputColorTexture = this.trackForCleanup(
+      this.device.createTexture({
+        format: 'rgba8unorm',
+        size: copySize,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      })
+    );
+    const hasStencil = kTextureFormatInfo[destinationTexture.format].stencil;
     const encoder = this.device.createCommandEncoder();
     for (let dstCopyLayer = 0; dstCopyLayer < copySize[2]; ++dstCopyLayer) {
       // If the depth value is not expected, the color of outputColorTexture will remain Red after
@@ -546,8 +549,8 @@ class F extends GPUTest {
           }),
           depthLoadOp: 'load',
           depthStoreOp: 'store',
-          stencilLoadOp: 'load',
-          stencilStoreOp: 'store',
+          stencilLoadOp: hasStencil ? 'load' : undefined,
+          stencilStoreOp: hasStencil ? 'store' : undefined,
         },
       });
       renderPass.setBindGroup(0, bindGroup, [dstCopyLayer * kMinDynamicBufferOffsetAlignment]);
@@ -1173,26 +1176,28 @@ g.test('copy_depth_stencil')
       srcTextureSize.height >> srcCopyLevel,
       srcTextureSize.depthOrArrayLayers - Math.max(srcCopyBaseArrayLayer, dstCopyBaseArrayLayer),
     ];
-    const sourceTexture = t.device.createTexture({
-      format,
-      size: srcTextureSize,
-      usage:
-        GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-      mipLevelCount: srcCopyLevel + 1,
-    });
-    t.trackForCleanup(sourceTexture);
-    const destinationTexture = t.device.createTexture({
-      format,
-      size: [
-        copySize[0] << dstCopyLevel,
-        copySize[1] << dstCopyLevel,
-        srcTextureSize.depthOrArrayLayers,
-      ] as const,
-      usage:
-        GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-      mipLevelCount: dstCopyLevel + 1,
-    });
-    t.trackForCleanup(destinationTexture);
+    const sourceTexture = t.trackForCleanup(
+      t.device.createTexture({
+        format,
+        size: srcTextureSize,
+        usage:
+          GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+        mipLevelCount: srcCopyLevel + 1,
+      })
+    );
+    const destinationTexture = t.trackForCleanup(
+      t.device.createTexture({
+        format,
+        size: [
+          copySize[0] << dstCopyLevel,
+          copySize[1] << dstCopyLevel,
+          srcTextureSize.depthOrArrayLayers,
+        ] as const,
+        usage:
+          GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+        mipLevelCount: dstCopyLevel + 1,
+      })
+    );
 
     let initialStencilData: undefined | Uint8Array = undefined;
     if (kTextureFormatInfo[format].stencil) {

--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -146,10 +146,11 @@ class StencilTest extends TextureTestMixin(GPUTest) {
       })
     );
 
+    const hasDepth = kTextureFormatInfo[depthStencilFormat].depth;
     const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
       view: depthTexture.createView(),
-      depthLoadOp: 'load',
-      depthStoreOp: 'store',
+      depthLoadOp: hasDepth ? 'load' : undefined,
+      depthStoreOp: hasDepth ? 'store' : undefined,
       stencilLoadOp: 'load',
       stencilStoreOp: 'store',
     };


### PR DESCRIPTION
Updates tests to adhere to only pass depth-stencil load/store values when needed based on the format.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.
