### PR TITLE
shader/execution: Begin flow control tests

### DIFF
--- a/src/webgpu/shader/execution/flow_control/call.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/call.spec.ts
@@ -1,0 +1,80 @@
+export const description = `
+Flow control tests for function calls.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+import { runFlowControlTest } from './harness.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('call_basic')
+  .desc('Test that flow control enters a called function')
+  .fn(t => {
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  ${f.expect_order(0)}
+  f();
+  ${f.expect_order(2)}
+`,
+      extra: `
+fn f() {
+  ${f.expect_order(1)}
+}`,
+    }));
+  });
+
+g.test('call_nested')
+  .desc('Test that flow control enters a nested function calls')
+  .fn(t => {
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  ${f.expect_order(0)}
+  a();
+  ${f.expect_order(6)}
+`,
+      extra: `
+fn a() {
+  ${f.expect_order(1)}
+  b();
+  ${f.expect_order(5)}
+}
+fn b() {
+  ${f.expect_order(2)}
+  c();
+  ${f.expect_order(4)}
+}
+fn c() {
+  ${f.expect_order(3)}
+}`,
+    }));
+  });
+
+g.test('call_repeated')
+  .desc('Test that flow control enters a nested function calls')
+  .fn(t => {
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  ${f.expect_order(0)}
+  a();
+  ${f.expect_order(10)}
+`,
+      extra: `
+fn a() {
+  ${f.expect_order(1)}
+  b();
+  ${f.expect_order(5)}
+  b();
+  ${f.expect_order(9)}
+}
+fn b() {
+  ${f.expect_order(2, 6)}
+  c();
+  ${f.expect_order(4, 8)}
+}
+fn c() {
+  ${f.expect_order(3, 7)}
+}`,
+    }));
+  });

--- a/src/webgpu/shader/execution/flow_control/for.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/for.spec.ts
@@ -1,0 +1,128 @@
+export const description = `
+Flow control tests for for-loops.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+import { runFlowControlTest } from './harness.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('for_basic')
+  .desc('Test that flow control executes a for-loop body the correct number of times')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; i < ${f.value(3)}; i++) {
+    ${f.expect_order(1, 2, 3)}
+  }
+  ${f.expect_order(4)}
+`
+    );
+  });
+
+g.test('for_break')
+  .desc('Test that flow control exits a for-loop when reaching a break statement')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; i < ${f.value(5)}; i++) {
+    ${f.expect_order(1, 3, 5, 7)}
+    if (i == 3) {
+      break;
+      ${f.expect_not_reached()}
+    }
+    ${f.expect_order(2, 4, 6)}
+  }
+  ${f.expect_order(8)}
+`
+    );
+  });
+
+g.test('for_continue')
+  .desc('Test flow control for a for-loop continue statement')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; i < ${f.value(5)}; i++) {
+    ${f.expect_order(1, 3, 5, 7, 8)}
+    if (i == 3) {
+      continue;
+      ${f.expect_not_reached()}
+    }
+    ${f.expect_order(2, 4, 6, 9)}
+  }
+  ${f.expect_order(10)}
+`
+    );
+  });
+
+g.test('for_initalizer')
+  .desc('Test flow control for a for-loop initializer')
+  .fn(t => {
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  ${f.expect_order(0)}
+  for (var i = initializer(); i < ${f.value(3)}; i++) {
+    ${f.expect_order(2, 3, 4)}
+  }
+  ${f.expect_order(5)}
+`,
+      extra: `
+fn initializer() -> u32 {
+  ${f.expect_order(1)}
+  return ${f.value(0)};
+}
+      `,
+    }));
+  });
+
+g.test('for_condition')
+  .desc('Test flow control for a for-loop condition')
+  .fn(t => {
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; condition(i); i++) {
+    ${f.expect_order(2, 4, 6)}
+  }
+  ${f.expect_order(8)}
+`,
+      extra: `
+fn condition(i : u32) -> bool {
+  ${f.expect_order(1, 3, 5, 7)}
+  return i < ${f.value(3)};
+}
+      `,
+    }));
+  });
+
+g.test('for_continuing')
+  .desc('Test flow control for a for-loop continuing statement')
+  .fn(t => {
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; i < ${f.value(3)}; i = cont(i)) {
+    ${f.expect_order(1, 3, 5)}
+  }
+  ${f.expect_order(7)}
+`,
+      extra: `
+fn cont(i : u32) -> u32 {
+  ${f.expect_order(2, 4, 6)}
+  return i + 1;
+}
+      `,
+    }));
+  });

--- a/src/webgpu/shader/execution/flow_control/harness.ts
+++ b/src/webgpu/shader/execution/flow_control/harness.ts
@@ -1,0 +1,263 @@
+import { Colors } from '../../../../common/util/colors.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+/**
+ * The builder interface for the runFlowControlTest() callback.
+ * This interface is indented to be used to inject WGSL logic into the test shader.
+ * @see runFlowControlTest
+ */
+interface FlowControlTestBuilder {
+  /**
+   * Emits an expression to load the given value from a storage buffer, preventing the shader
+   * compiler from knowing the value at compile time. This can prevent constant folding, loop
+   * unrolling, dead-code optimizations etc, which would could all affect the tests.
+   */
+  value(v: number | boolean): string;
+
+  /**
+   * Emits an expectation that the statement will be executed at the given chronological events.
+   * @param event one or more chronological events, the first being 0.
+   */
+  expect_order(...event: number[]): string;
+
+  /**
+   * Emits an expectation that the statement will not be reached.
+   */
+  expect_not_reached(): string;
+}
+
+/**
+ * Builds, runs then checks the output of a flow control shader test.
+ *
+ * @p build_wgsl is a function that's called to build the WGSL shader.
+ * This function takes a FlowControlTestBuilder as the single argument, and
+ * returns either a string which is embedded into the WGSL entrypoint function,
+ * or an object of the signature `{ entrypoint: string; extra: string }` which
+ * contains the entrypoint code, along with additional module-scope code.
+ *
+ * The FlowControlTestBuilder should be used to insert expectations into WGSL to
+ * validate control flow. FlowControlTestBuilder also can be used to add values
+ * to the shader which cannot be optimized away.
+ *
+ * Example, testing that an if-statement behaves as expected:
+ *
+ * ```
+ *   runFlowControlTest(t, f =>
+ *   `
+ *    ${f.expect_order(0)}
+ *    if (${f.value(true)}) {
+ *      ${f.expect_order(1)}
+ *    } else {
+ *      ${f.expect_not_reached()}
+ *    }
+ *    ${f.expect_order(2)}
+ *  `);
+ * ```
+ *
+ * @param t The test object
+ * @param builder The shader builder function that takes a FlowControlTestBuilder as the single
+ * argument, and returns either a WGSL string which is embedded into the WGSL entrypoint function,
+ * or a structure with entrypoint-scoped WGSL code and extra module-scope WGSL code.
+ */
+export function runFlowControlTest(
+  t: GPUTest,
+  build_wgsl: (builder: FlowControlTestBuilder) => string | { entrypoint: string; extra: string }
+) {
+  const inputData = new Array<number>();
+
+  type ExpectedEvents = {
+    kind: 'events';
+    stack: string | undefined;
+    values: number[];
+    counter: number;
+  };
+  type ExpectedNotReached = {
+    kind: 'not-reached';
+    stack: string | undefined;
+  };
+
+  const expectations = new Array<ExpectedEvents | ExpectedNotReached>();
+
+  const build_wgsl_result = build_wgsl({
+    value: v => {
+      if (typeof v === 'boolean') {
+        inputData.push(v ? 1 : 0);
+        return `inputs[${inputData.length - 1}] != 0`;
+      }
+      inputData.push(v);
+      return `inputs[${inputData.length - 1}]`;
+    },
+    expect_order: (...expected) => {
+      expectations.push({
+        kind: 'events',
+        stack: Error().stack,
+        values: expected,
+        counter: 0,
+      });
+      return `push_output(${expectations.length - 1});`;
+    },
+    expect_not_reached: () => {
+      expectations.push({
+        kind: 'not-reached',
+        stack: Error().stack,
+      });
+      return `push_output(${expectations.length - 1});`;
+    },
+  });
+
+  const built_wgsl =
+    typeof build_wgsl_result === 'string'
+      ? { entrypoint: build_wgsl_result, extra: '' }
+      : build_wgsl_result;
+
+  const main_wgsl = built_wgsl.entrypoint !== undefined ? built_wgsl : built_wgsl.entrypoint;
+
+  const wgsl = `
+struct Outputs {
+  count : u32,
+  data  : array<u32>,
+};
+@group(0) @binding(0) var<storage, read>       inputs  : array<u32>;
+@group(0) @binding(1) var<storage, read_write> outputs : Outputs;
+
+fn push_output(value : u32) {
+  outputs.data[outputs.count] = value;
+  outputs.count++;
+}
+
+@compute @workgroup_size(1)
+fn main() {
+  _ = &inputs;
+  _ = &outputs;
+  ${main_wgsl.entrypoint}
+}
+${main_wgsl.extra}
+`;
+
+  const pipeline = t.device.createComputePipeline({
+    layout: 'auto',
+    compute: {
+      module: t.device.createShaderModule({ code: wgsl }),
+      entryPoint: 'main',
+    },
+  });
+
+  // If there are no inputs, just put a single value in the buffer to keep makeBufferWithContents() happy.
+  if (inputData.length === 0) {
+    inputData.push(0);
+  }
+
+  const inputBuffer = t.makeBufferWithContents(new Uint32Array(inputData), GPUBufferUsage.STORAGE);
+
+  const maxOutputValues = 1000;
+  const outputBuffer = t.device.createBuffer({
+    size: 4 * (1 + maxOutputValues),
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+  });
+
+  const bindGroup = t.device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [
+      { binding: 0, resource: { buffer: inputBuffer } },
+      { binding: 1, resource: { buffer: outputBuffer } },
+    ],
+  });
+
+  // Run the shader.
+  const encoder = t.device.createCommandEncoder();
+  const pass = encoder.beginComputePass();
+  pass.setPipeline(pipeline);
+  pass.setBindGroup(0, bindGroup);
+  pass.dispatchWorkgroups(1);
+  pass.end();
+  t.queue.submit([encoder.finish()]);
+
+  t.eventualExpectOK(
+    t
+      .readGPUBufferRangeTyped(outputBuffer, {
+        type: Uint32Array,
+        typedLength: outputBuffer.size / 4,
+      })
+      .then(outputs => {
+        // outputs[0]    is the number of outputted values
+        // outputs[1..N] holds the outputted values
+        const outputCount = outputs.data[0];
+        if (outputCount > maxOutputValues) {
+          return new Error(
+            `output data count (${outputCount}) exceeds limit of ${maxOutputValues}`
+          );
+        }
+
+        // returns an Error with the given message and WGSL source
+        const fail = (err: string) => Error(`${err}\nWGSL:\n${Colors.dim(Colors.blue(wgsl))}`);
+
+        // returns a colorized string of the expect_order() call, highlighting the event number that
+        // caused an error.
+        const expect_order_err = (expectation: ExpectedEvents, err_idx: number) => {
+          let out = 'expect_order(';
+          for (let i = 0; i < expectation.values.length; i++) {
+            if (i > 0) {
+              out += ', ';
+            }
+            if (i < err_idx) {
+              out += Colors.green(`${expectation.values[i]}`);
+            } else if (i > err_idx) {
+              out += Colors.dim(`${expectation.values[i]}`);
+            } else {
+              out += Colors.red(`${expectation.values[i]}`);
+            }
+          }
+          out += ')';
+          return out;
+        };
+
+        // Each of the outputted values represents an event
+        // Check that each event is as expected
+        for (let event = 0; event < outputCount; event++) {
+          const expectationIndex = outputs.data[1 + event]; // 0 is count
+          if (expectationIndex >= expectations.length) {
+            return fail(
+              `outputs.data[${event}] value (${expectationIndex}) exceeds number of expectations (${expectations.length})`
+            );
+          }
+          const expectation = expectations[expectationIndex];
+          switch (expectation.kind) {
+            case 'not-reached':
+              return fail(`expect_not_reached() reached at event ${event}\n${expectation.stack}`);
+            case 'events':
+              if (expectation.counter >= expectation.values.length) {
+                return fail(
+                  `${expect_order_err(
+                    expectation,
+                    expectation.counter
+                  )}) unexpectedly reached at event ${Colors.red(`${event}`)}\n${expectation.stack}`
+                );
+              }
+              if (event !== expectation.values[expectation.counter]) {
+                return fail(
+                  `${expect_order_err(expectation, expectation.counter)} expected event ${
+                    expectation.values[expectation.counter]
+                  }, got ${event}\n${expectation.stack}`
+                );
+              }
+
+              expectation.counter++;
+              break;
+          }
+        }
+
+        // Finally check that all expect_order() calls were reached
+        for (const expectation of expectations) {
+          if (expectation.kind === 'events' && expectation.counter !== expectation.values.length) {
+            return fail(
+              `${expect_order_err(expectation, expectation.counter)} event ${
+                expectation.values[expectation.counter]
+              } was not reached\n${expectation.stack}`
+            );
+          }
+        }
+        outputs.cleanup();
+        return undefined;
+      })
+  );
+}

--- a/src/webgpu/shader/execution/flow_control/if.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/if.spec.ts
@@ -1,0 +1,69 @@
+export const description = `
+Flow control tests for if-statements.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+import { runFlowControlTest } from './harness.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('if_true')
+  .desc(
+    "Test that flow control executes the 'true' block of an if statement and not the 'false' block"
+  )
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+  ${f.expect_order(0)}
+  if (${f.value(true)}) {
+    ${f.expect_order(1)}
+  } else {
+    ${f.expect_not_reached()}
+  }
+  ${f.expect_order(2)}
+`
+    );
+  });
+
+g.test('if_false')
+  .desc(
+    "Test that flow control executes the 'false' block of an if statement and not the 'true' block"
+  )
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+  ${f.expect_order(0)}
+  if (${f.value(false)}) {
+    ${f.expect_not_reached()}
+  } else {
+    ${f.expect_order(1)}
+  }
+  ${f.expect_order(2)}
+`
+    );
+  });
+
+g.test('else_if')
+  .desc("Test that flow control executes the correct 'else if' block of an if statement")
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+  ${f.expect_order(0)}
+  if (${f.value(false)}) {
+    ${f.expect_not_reached()}
+  } else if (${f.value(false)}) {
+    ${f.expect_not_reached()}
+  } else if (${f.value(true)}) {
+    ${f.expect_order(1)}
+  } else if (${f.value(false)}) {
+    ${f.expect_not_reached()}
+  }
+  ${f.expect_order(2)}
+`
+    );
+  });

--- a/src/webgpu/shader/execution/flow_control/loop.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/loop.spec.ts
@@ -1,0 +1,82 @@
+export const description = `
+Flow control tests for loops.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+import { runFlowControlTest } from './harness.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('loop_break')
+  .desc('Test that flow control exits a loop when reaching a break statement')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  var i = ${f.value(0)};
+  loop {
+    ${f.expect_order(1, 3, 5, 7)}
+    if i == 3 {
+      break;
+    }
+    ${f.expect_order(2, 4, 6)}
+    i++;
+  }
+  ${f.expect_order(8)}
+`
+    );
+  });
+
+g.test('loop_continue')
+  .desc('Test flow control for a loop continue statement')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  var i = ${f.value(0)};
+  loop {
+    ${f.expect_order(1, 3, 5, 7, 8)}
+    if i == 3 {
+      i++;
+      continue;
+      ${f.expect_not_reached()}
+    }
+    ${f.expect_order(2, 4, 6, 9)}
+    if i == 4 {
+      break;
+    }
+    i++;
+  }
+  ${f.expect_order(10)}
+`
+    );
+  });
+
+g.test('loop_continuing_basic')
+  .desc('Test basic flow control for a loop continuing block')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  var i = ${f.value(0)};
+  loop {
+    ${f.expect_order(1, 3, 5)}
+    i++;
+
+    continuing {
+      ${f.expect_order(2, 4, 6)}
+      break if i == 3;
+    }
+  }
+  ${f.expect_order(7)}
+`
+    );
+  });

--- a/src/webgpu/shader/execution/flow_control/return.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/return.spec.ts
@@ -1,0 +1,53 @@
+export const description = `
+Flow control tests for return statements.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+import { runFlowControlTest } from './harness.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('return')
+  .desc("Test that flow control does not execute after a 'return' statement")
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+  ${f.expect_order(0)}
+  return;
+  ${f.expect_not_reached()}
+`
+    );
+  });
+
+g.test('return_conditional_true')
+  .desc("Test that flow control does not execute after a 'return' statement in a if (true) block")
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+  ${f.expect_order(0)}
+  if (${f.value(true)}) {
+    return;
+  }
+  ${f.expect_not_reached()}
+`
+    );
+  });
+
+g.test('return_conditional_false')
+  .desc("Test that flow control does not execute after a 'return' statement in a if (false) block")
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+  ${f.expect_order(0)}
+  if (${f.value(false)}) {
+    return;
+  }
+  ${f.expect_order(1)}
+`
+    );
+  });

--- a/src/webgpu/shader/execution/flow_control/switch.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/switch.spec.ts
@@ -1,0 +1,139 @@
+export const description = `
+Flow control tests for switch statements.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+import { runFlowControlTest } from './harness.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('switch')
+  .desc('Test that flow control executes the correct switch case block')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+  ${f.expect_order(0)}
+  switch (${f.value(1)}) {
+    case 0: {
+      ${f.expect_not_reached()}
+      break;
+    }
+    case 1: {
+      ${f.expect_order(1)}
+      break;
+    }
+    case 2: {
+      ${f.expect_not_reached()}
+      break;
+    }
+    default: {
+      ${f.expect_not_reached()}
+      break;
+    }
+  }
+  ${f.expect_order(2)}
+`
+    );
+  });
+
+g.test('switch_multiple_case')
+  .desc(
+    'Test that flow control executes the correct switch case block with multiple cases per block'
+  )
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+  ${f.expect_order(0)}
+  switch (${f.value(2)}) {
+    case 0, 1: {
+      ${f.expect_not_reached()}
+      break;
+    }
+    case 2, 3: {
+      ${f.expect_order(1)}
+      break;
+    }
+    default: {
+      ${f.expect_not_reached()}
+      break;
+    }
+  }
+  ${f.expect_order(2)}
+`
+    );
+  });
+
+g.test('switch_multiple_case_default')
+  .desc(
+    'Test that flow control executes the correct switch case block with multiple cases per block (combined with default)'
+  )
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+  ${f.expect_order(0)}
+  switch (${f.value(2)}) {
+    case 0, 1: {
+      ${f.expect_not_reached()}
+      break;
+    }
+    case 2, 3, default: {
+      ${f.expect_order(1)}
+      break;
+    }
+  }
+  ${f.expect_order(2)}
+`
+    );
+  });
+g.test('switch_default')
+  .desc('Test that flow control executes the switch default block')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+${f.expect_order(0)}
+switch (${f.value(4)}) {
+  case 0: {
+    ${f.expect_not_reached()}
+    break;
+  }
+  case 1: {
+    ${f.expect_not_reached()}
+    break;
+  }
+  case 2: {
+    ${f.expect_not_reached()}
+    break;
+  }
+  default: {
+    ${f.expect_order(1)}
+    break;
+  }
+}
+${f.expect_order(2)}
+`
+    );
+  });
+
+g.test('switch_default_only')
+  .desc('Test that flow control executes the switch default block, which is the only case')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+${f.expect_order(0)}
+switch (${f.value(4)}) {
+default: {
+  ${f.expect_order(1)}
+  break;
+}
+}
+${f.expect_order(2)}
+`
+    );
+  });

--- a/src/webgpu/shader/execution/flow_control/while.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/while.spec.ts
@@ -1,0 +1,75 @@
+export const description = `
+Flow control tests for while-loops.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+import { runFlowControlTest } from './harness.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('while_basic')
+  .desc('Test that flow control executes a while-loop body the correct number of times')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  var i = ${f.value(0)};
+  while (i < ${f.value(5)}) {
+    ${f.expect_order(1, 2, 3, 4, 5)}
+    i++;
+  }
+  ${f.expect_order(6)}
+`
+    );
+  });
+
+g.test('while_break')
+  .desc('Test that flow control exits a while-loop when reaching a break statement')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  var i = ${f.value(0)};
+  while (i < ${f.value(5)}) {
+    ${f.expect_order(1, 3, 5, 7)}
+    if (i == 3) {
+      break;
+      ${f.expect_not_reached()}
+    }
+    ${f.expect_order(2, 4, 6)}
+    i++;
+  }
+  ${f.expect_order(8)}
+`
+    );
+  });
+
+g.test('while_continue')
+  .desc('Test flow control for a while-loop continue statement')
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  var i = ${f.value(0)};
+  while (i < ${f.value(5)}) {
+    ${f.expect_order(1, 3, 5, 7, 8)}
+    if (i == 3) {
+      i++;
+      continue;
+      ${f.expect_not_reached()}
+    }
+    ${f.expect_order(2, 4, 6, 9)}
+    i++;
+  }
+  ${f.expect_order(10)}
+`
+    );
+  });


### PR DESCRIPTION
Add a new flow control test harness, and start fleshing out some of the flow control tests.




Issue: #2312

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
