### PR TITLE
Convert more OperationError to GPUPipelineError.

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
@@ -177,7 +177,7 @@ g.test('createPipelineAsync,at_over')
         const module = device.createShaderModule({ code });
 
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           t.createPipelineAsync(pipelineType, module),
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`

--- a/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
@@ -179,7 +179,7 @@ g.test('createPipelineAsync,at_over')
         const module = device.createShaderModule({ code });
 
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           t.createPipelineAsync(pipelineType, module),
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
@@ -207,7 +207,7 @@ g.test('createPipelineAsync,at_over')
         const module = device.createShaderModule({ code });
 
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           t.createPipelineAsync(pipelineType, module),
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
@@ -185,7 +185,7 @@ g.test('createPipelineAsync,at_over')
         const module = device.createShaderModule({ code });
 
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           t.createPipelineAsync(pipelineType, module),
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`

--- a/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
@@ -177,7 +177,7 @@ g.test('createPipelineAsync,at_over')
         const module = device.createShaderModule({ code });
 
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           t.createPipelineAsync(pipelineType, module),
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
