### PR TITLE
Fix WGSL warning for maxStorageTexturesPerShaderStage.spec.ts

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -223,7 +223,7 @@ export function getPerStageWGSLForBindingCombinationStorageTextures(
     (numBindings: number, set: number) => {
       return bindingCombination === 'compute'
         ? `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n')};`
-        : `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n')}; return vec4f(0);`;
+        : `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n')};`;
     },
     numBindings,
     extraWGSL


### PR DESCRIPTION


Issue: none

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
