### PR TITLE
OperationError -> GPUPipelineError

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
@@ -221,7 +221,7 @@ g.test('createRenderPipelineAsync,at_over')
         const { pipelineDescriptor, code } = result;
 
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           device.createRenderPipelineAsync(pipelineDescriptor),
           shouldError,
           code

--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachments.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachments.spec.ts
@@ -59,7 +59,7 @@ g.test('createRenderPipelineAsync,at_over')
       async ({ device, testValue, shouldError }) => {
         const pipelineDescriptor = getPipelineDescriptor(device, testValue);
         await t.shouldRejectConditionally(
-          'OperationError',
+          'GPUPipelineError',
           device.createRenderPipelineAsync(pipelineDescriptor),
           shouldError
         );


### PR DESCRIPTION


Issue: none

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
