### PR TITLE
Implement `determinant` f32 tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
@@ -31,7 +31,7 @@ const kDeterminantMatrixF32Values = {
   ]),
   3: kDeterminantValues.map((f, idx) => [
     [idx % 9 === 0 ? f : idx, idx % 9 === 1 ? f : -idx, idx % 9 === 2 ? f : idx],
-    [idx % 9 === 3 ? f : -idx, idx % 9 === 4 ? f : idx, -idx % 9 === 5 ? f : -idx],
+    [idx % 9 === 3 ? f : -idx, idx % 9 === 4 ? f : idx, idx % 9 === 5 ? f : -idx],
     [idx % 9 === 6 ? f : idx, idx % 9 === 7 ? f : -idx, idx % 9 === 8 ? f : idx],
   ]),
   4: kDeterminantValues.map((f, idx) => [
@@ -39,7 +39,7 @@ const kDeterminantMatrixF32Values = {
       idx % 16 === 0 ? f : idx,
       idx % 16 === 1 ? f : -idx,
       idx % 16 === 2 ? f : idx,
-      idx % 16 === 3 ? f : idx,
+      idx % 16 === 3 ? f : -idx,
     ],
     [
       idx % 16 === 4 ? f : -idx,

--- a/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
@@ -4,14 +4,108 @@ Execution tests for the 'determinant' builtin function
 T is AbstractFloat, f32, or f16
 @const determinant(e: matCxC<T> ) -> T
 Returns the determinant of e.
-
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { TypeF32, TypeMat } from '../../../../../util/conversion.js';
+import { determinantInterval } from '../../../../../util/f32_interval.js';
+import { makeCaseCache } from '../../case_cache.js';
+import { allInputSources, generateMatrixToScalarCases, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
+
+// Accuracy for determinant is only defined for e, where e is an integer and
+// |e| < quadroot(2**21) [~38],
+// due to computational complexity of calculating the general solution, so
+// custom matrices are used.
+
+const kDeterminantValues = [-38, -10, -5, -1, 0, 1, 5, 10, 38];
+
+const kDeterminantMatrixF32Values = {
+  2: kDeterminantValues.map((f, idx) => [
+    [idx % 4 === 0 ? f : idx, idx % 4 === 1 ? f : -idx],
+    [idx % 4 === 2 ? f : -idx, idx % 4 === 3 ? f : idx],
+  ]),
+  3: kDeterminantValues.map((f, idx) => [
+    [idx % 9 === 0 ? f : idx, idx % 9 === 1 ? f : -idx, idx % 9 === 2 ? f : idx],
+    [idx % 9 === 3 ? f : -idx, idx % 9 === 4 ? f : idx, -idx % 9 === 5 ? f : -idx],
+    [idx % 9 === 6 ? f : idx, idx % 9 === 7 ? f : -idx, idx % 9 === 8 ? f : idx],
+  ]),
+  4: kDeterminantValues.map((f, idx) => [
+    [
+      idx % 16 === 0 ? f : idx,
+      idx % 16 === 1 ? f : -idx,
+      idx % 16 === 2 ? f : idx,
+      idx % 16 === 3 ? f : idx,
+    ],
+    [
+      idx % 16 === 4 ? f : -idx,
+      idx % 16 === 5 ? f : idx,
+      idx % 16 === 6 ? f : -idx,
+      idx % 16 === 7 ? f : idx,
+    ],
+    [
+      idx % 16 === 8 ? f : idx,
+      idx % 16 === 9 ? f : -idx,
+      idx % 16 === 10 ? f : idx,
+      idx % 16 === 11 ? f : -idx,
+    ],
+    [
+      idx % 16 === 12 ? f : -idx,
+      idx % 16 === 13 ? f : idx,
+      idx % 16 === 14 ? f : -idx,
+      idx % 16 === 15 ? f : idx,
+    ],
+  ]),
+};
+
+export const d = makeCaseCache('determinant', {
+  f32_mat2x2_const: () => {
+    return generateMatrixToScalarCases(
+      kDeterminantMatrixF32Values[2],
+      'f32-only',
+      determinantInterval
+    );
+  },
+  f32_mat2x2_non_const: () => {
+    return generateMatrixToScalarCases(
+      kDeterminantMatrixF32Values[2],
+      'unfiltered',
+      determinantInterval
+    );
+  },
+  f32_mat3x3_const: () => {
+    return generateMatrixToScalarCases(
+      kDeterminantMatrixF32Values[3],
+      'f32-only',
+      determinantInterval
+    );
+  },
+  f32_mat3x3_non_const: () => {
+    return generateMatrixToScalarCases(
+      kDeterminantMatrixF32Values[3],
+      'unfiltered',
+      determinantInterval
+    );
+  },
+  f32_mat4x4_const: () => {
+    return generateMatrixToScalarCases(
+      kDeterminantMatrixF32Values[4],
+      'f32-only',
+      determinantInterval
+    );
+  },
+  f32_mat4x4_non_const: () => {
+    return generateMatrixToScalarCases(
+      kDeterminantMatrixF32Values[4],
+      'unfiltered',
+      determinantInterval
+    );
+  },
+});
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
@@ -22,8 +116,16 @@ g.test('abstract_float')
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')
   .desc(`f32 tests`)
-  .params(u => u.combine('inputSource', allInputSources).combine('dimension', [2, 3, 4] as const))
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `f32_mat${dim}x${dim}_const`
+        : `f32_mat${dim}x${dim}_non_const`
+    );
+    await run(t, builtin('determinant'), [TypeMat(dim, dim, TypeF32)], TypeF32, t.params, cases);
+  });
 
 g.test('f16')
   .specURL('https://www.w3.org/TR/WGSL/#matrix-builtin-functions')

--- a/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
@@ -19,9 +19,11 @@ export const g = makeTestGroup(GPUTest);
 
 // Accuracy for determinant is only defined for e, where e is an integer and
 // |e| < quadroot(2**21) [~38],
-// due to computational complexity of calculating the general solution, so
-// custom matrices are used.
-
+// due to computational complexity of calculating the general solution for 4x4,
+// so custom matrices are used.
+//
+// Note: For 2x2 and 3x3 the limits are squareroot and cuberoot instead of
+// quadroot, but using the tighter 4x4 limits for all cases for simplicity.
 const kDeterminantValues = [-38, -10, -5, -1, 0, 1, 5, 10, 38];
 
 const kDeterminantMatrixF32Values = {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -623,6 +623,22 @@ interface VectorPairToVectorOp {
 }
 
 /**
+ * A function that converts a matrix to an acceptance interval.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface MatrixToScalar {
+  (m: Matrix<number>): F32Interval;
+}
+
+/** Operation used to implement a MatrixToMatrix */
+interface MatrixToMatrixOp {
+  // Re-using the *Op interface pattern for symmetry with the other operations.
+  /** @returns a matrix of acceptance intervals for a function on matrix x */
+  impl: MatrixToMatrix;
+}
+
+/**
  * A function that converts a matrix to a matrix of acceptance intervals.
  * This is the public facing API for builtin implementations that is called
  * from tests.
@@ -1268,7 +1284,7 @@ const CorrectlyRoundedIntervalOp: PointToIntervalOp = {
 };
 
 /** @returns an interval of the correctly rounded values around the point */
-export function correctlyRoundedInterval(n: number): F32Interval {
+export function correctlyRoundedInterval(n: number | F32Interval): F32Interval {
   return runPointToIntervalOp(toF32Interval(n), CorrectlyRoundedIntervalOp);
 }
 
@@ -1642,6 +1658,148 @@ const DegreesIntervalOp: PointToIntervalOp = {
 /** Calculate an acceptance interval of degrees(x) */
 export function degreesInterval(n: number): F32Interval {
   return runPointToIntervalOp(toF32Interval(n), DegreesIntervalOp);
+}
+
+/**
+ * Calculate the minor of a NxN matrix.
+ *
+ * The ijth minor of a square matrix, is the N-1xN-1 matrix created by removing
+ * the ith column and jth row from the original matrix.
+ */
+function minorNxN(m: Matrix<number>, col: number, row: number): Matrix<number> {
+  const dim = m.length;
+  assert(m.length === m[0].length, `minorMatrix is only defined for square matrices`);
+  assert(col >= 0 && col < dim, `col ${col} needs be in [0, # of columns '${dim}')`);
+  assert(row >= 0 && row < dim, `row ${row} needs be in [0, # of rows '${dim}')`);
+
+  const result: Matrix<number> = [...Array(dim - 1)].map(_ => [...Array(dim - 1)]);
+
+  const col_indices: number[] = [...Array(dim).keys()].filter(e => e !== col);
+  const row_indices: number[] = [...Array(dim).keys()].filter(e => e !== row);
+
+  col_indices.forEach((c, i) => {
+    row_indices.forEach((r, j) => {
+      result[i][j] = m[c][r];
+    });
+  });
+  return result;
+}
+
+/** Calculate an acceptance interval for determinant(m), where m is a 2x2 matrix */
+function determinant2x2Interval(m: Matrix<number>): F32Interval {
+  assert(
+    m.length === m[0].length && m.length === 2,
+    `determinant2x2Interval called on non-2x2 matrix`
+  );
+  return subtractionInterval(
+    multiplicationInterval(m[0][0], m[1][1]),
+    multiplicationInterval(m[0][1], m[1][0])
+  );
+}
+
+/** Calculate an acceptance interval for determinant(m), where m is a 3x3 matrix */
+function determinant3x3Interval(m: Matrix<number>): F32Interval {
+  assert(
+    m.length === m[0].length && m.length === 3,
+    `determinant3x3Interval called on non-3x3 matrix`
+  );
+
+  // M is a 3x3 matrix
+  // det(M) is A + B + C, where A, B, C are three elements in a row/column times
+  // their own co-factor.
+  // (The co-factor is the determinant of the minor of that position with the
+  // appropriate +/-)
+  // For simplicity sake A, B, C are calculated as the elements of the first
+  // column
+  const A = multiplicationInterval(m[0][0], determinant2x2Interval(minorNxN(m, 0, 0)));
+  const B = multiplicationInterval(
+    m[0][1],
+    multiplicationInterval(-1, determinant2x2Interval(minorNxN(m, 0, 1)))
+  );
+  const C = multiplicationInterval(m[0][2], determinant2x2Interval(minorNxN(m, 0, 2)));
+
+  // Need to calculate permutations, since for fp addition is not transitive,
+  // so A + B + C is not guaranteed to equal B + C + A, etc.
+  const permutations: F32Interval[][] = calculatePermutations([A, B, C]);
+  return F32Interval.span(
+    ...permutations.map(p =>
+      p.reduce((prev: F32Interval, cur: F32Interval) => additionInterval(prev, cur))
+    )
+  );
+}
+
+/** Calculate an acceptance interval for determinant(m), where m is a 4x4 matrix */
+function determinant4x4Interval(m: Matrix<number>): F32Interval {
+  assert(
+    m.length === m[0].length && m.length === 4,
+    `determinant3x3Interval called on non-4x4 matrix`
+  );
+
+  // M is a 4x4 matrix
+  // det(M) is A + B + C + D, where A, B, C, D are four elements in a row/column
+  // times their own co-factor.
+  // (The co-factor is the determinant of the minor of that position with the
+  // appropriate +/-)
+  // For simplicity sake A, B, C, D are calculated as the elements of the
+  // first column
+  const A = multiplicationInterval(m[0][0], determinant3x3Interval(minorNxN(m, 0, 0)));
+  const B = multiplicationInterval(
+    m[0][1],
+    multiplicationInterval(-1, determinant3x3Interval(minorNxN(m, 0, 1)))
+  );
+  const C = multiplicationInterval(m[0][2], determinant3x3Interval(minorNxN(m, 0, 2)));
+  const D = multiplicationInterval(
+    m[0][3],
+    multiplicationInterval(-1, determinant3x3Interval(minorNxN(m, 0, 3)))
+  );
+
+  // Need to calculate permutations, since for fp addition is not transitive,
+  // so A + B + C + D is not guaranteed to equal B + C + A + D, etc.
+  const permutations: F32Interval[][] = calculatePermutations([A, B, C, D]);
+  return F32Interval.span(
+    ...permutations.map(p =>
+      p.reduce((prev: F32Interval, cur: F32Interval) => additionInterval(prev, cur))
+    )
+  );
+}
+
+/**
+ * Calculate an acceptance interval for determinant(x)
+ *
+ * This code calculates 3x3 and 4x4 determinants using the textbook co-factor
+ * method, using the first column for the co-factor selection.
+ *
+ * For matrices composed of integer elements, e, with |e|^4 < 2**21, this
+ * should be fine.
+ *
+ * For e, where e is subnormal or 4*(e^4) might not be precisely expressible as
+ * a f32 values, this approach breaks down, because the rule of all co-factor
+ * definitions of determinant being equal doesn't hold in these cases.
+ *
+ * The general solution for this is to calculate all of the permutations of the
+ * operations in the worked out formula for determinant.
+ * For 3x3 this is tractable, but for 4x4 this works out to ~23! permutations
+ * that need to be calculated.
+ * Thus CTS testing, and the spec definition of accuracy is restricted to the
+ * space that the simple implementation is valid.
+ */
+export function determinantInterval(x: Matrix<number>): F32Interval {
+  const dim = x.length;
+  assert(
+    x[0].length === dim && (dim === 2 || dim === 3 || dim === 4),
+    `determinantInterval only defined for 2x2, 3x3 and 4x4 matrices`
+  );
+  switch (dim) {
+    case 2:
+      return determinant2x2Interval(x);
+    case 3:
+      return determinant3x3Interval(x);
+    case 4:
+      return determinant4x4Interval(x);
+  }
+  unreachable(
+    "determinantInterval called on x, where which has an unexpected dimension of '${dim}'"
+  );
 }
 
 const DistanceIntervalScalarOp: BinaryToIntervalOp = {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1712,13 +1712,10 @@ function determinant3x3Interval(m: Matrix<number>): F32Interval {
   // For simplicity sake A, B, C are calculated as the elements of the first
   // column
   const A = multiplicationInterval(m[0][0], determinant2x2Interval(minorNxN(m, 0, 0)));
-  const B = multiplicationInterval(
-    m[0][1],
-    multiplicationInterval(-1, determinant2x2Interval(minorNxN(m, 0, 1)))
-  );
+  const B = multiplicationInterval(-m[0][1], determinant2x2Interval(minorNxN(m, 0, 1)));
   const C = multiplicationInterval(m[0][2], determinant2x2Interval(minorNxN(m, 0, 2)));
 
-  // Need to calculate permutations, since for fp addition is not transitive,
+  // Need to calculate permutations, since for fp addition is not associative,
   // so A + B + C is not guaranteed to equal B + C + A, etc.
   const permutations: F32Interval[][] = calculatePermutations([A, B, C]);
   return F32Interval.span(
@@ -1743,17 +1740,11 @@ function determinant4x4Interval(m: Matrix<number>): F32Interval {
   // For simplicity sake A, B, C, D are calculated as the elements of the
   // first column
   const A = multiplicationInterval(m[0][0], determinant3x3Interval(minorNxN(m, 0, 0)));
-  const B = multiplicationInterval(
-    m[0][1],
-    multiplicationInterval(-1, determinant3x3Interval(minorNxN(m, 0, 1)))
-  );
+  const B = multiplicationInterval(-m[0][1], determinant3x3Interval(minorNxN(m, 0, 1)));
   const C = multiplicationInterval(m[0][2], determinant3x3Interval(minorNxN(m, 0, 2)));
-  const D = multiplicationInterval(
-    m[0][3],
-    multiplicationInterval(-1, determinant3x3Interval(minorNxN(m, 0, 3)))
-  );
+  const D = multiplicationInterval(-m[0][3], determinant3x3Interval(minorNxN(m, 0, 3)));
 
-  // Need to calculate permutations, since for fp addition is not transitive,
+  // Need to calculate permutations, since for fp addition is not associative
   // so A + B + C + D is not guaranteed to equal B + C + A + D, etc.
   const permutations: F32Interval[][] = calculatePermutations([A, B, C, D]);
   return F32Interval.span(

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1129,7 +1129,7 @@ export function cartesianProduct<T>(...inputs: T[][]): T[][] {
  * entries.
  *
  * Only feasible for inputs of lengths 5 or so, since the number of permutations
- * is (inpyt.length)!, so will cause the stack to explode for longer inputs.
+ * is (input.length)!, so will cause the stack to explode for longer inputs.
  *
  * This code could be made iterative using something like
  * Steinhaus–Johnson–Trotter and additionally turned into a generator to reduce

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -894,7 +894,7 @@ const kSparseMatrixF32Values = {
     ]),
     3: kInterestingF32Values.map((f, idx) => [
       [idx % 9 === 0 ? f : idx, idx % 9 === 1 ? f : -idx, idx % 9 === 2 ? f : idx],
-      [idx % 9 === 3 ? f : -idx, idx % 9 === 4 ? f : idx, -idx % 9 === 5 ? f : -idx],
+      [idx % 9 === 3 ? f : -idx, idx % 9 === 4 ? f : idx, idx % 9 === 5 ? f : -idx],
       [idx % 9 === 6 ? f : idx, idx % 9 === 7 ? f : -idx, idx % 9 === 8 ? f : idx],
     ]),
     4: kInterestingF32Values.map((f, idx) => [
@@ -927,16 +927,16 @@ const kSparseMatrixF32Values = {
     ]),
     3: kInterestingF32Values.map((f, idx) => [
       [idx % 12 === 0 ? f : idx, idx % 12 === 1 ? f : -idx, idx % 12 === 2 ? f : idx],
-      [idx % 12 === 3 ? f : -idx, idx % 12 === 4 ? f : idx, -idx % 12 === 5 ? f : -idx],
+      [idx % 12 === 3 ? f : -idx, idx % 12 === 4 ? f : idx, idx % 12 === 5 ? f : -idx],
       [idx % 12 === 6 ? f : idx, idx % 12 === 7 ? f : -idx, idx % 12 === 8 ? f : idx],
-      [idx % 12 === 9 ? f : -idx, idx % 12 === 10 ? f : idx, -idx % 12 === 11 ? f : idx],
+      [idx % 12 === 9 ? f : -idx, idx % 12 === 10 ? f : idx, idx % 12 === 11 ? f : -idx],
     ]),
     4: kInterestingF32Values.map((f, idx) => [
       [
         idx % 16 === 0 ? f : idx,
         idx % 16 === 1 ? f : -idx,
         idx % 16 === 2 ? f : idx,
-        idx % 16 === 3 ? f : idx,
+        idx % 16 === 3 ? f : -idx,
       ],
       [
         idx % 16 === 4 ? f : -idx,

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1128,6 +1128,14 @@ export function cartesianProduct<T>(...inputs: T[][]): T[][] {
  * Recursively calculates all of the permutations, does not cull duplicate
  * entries.
  *
+ * Only feasible for inputs of lengths 5 or so, since the number of permutations
+ * is (inpyt.length)!, so will cause the stack to explode for longer inputs.
+ *
+ * This code could be made iterative using something like
+ * Steinhaus–Johnson–Trotter and additionally turned into a generator to reduce
+ * the stack size, but there is still a fundamental combinatorial explosion
+ * here that will affect runtime.
+ *
  * @param input the array to get permutations of
  */
 export function calculatePermutations<T>(input: T[]): T[][] {


### PR DESCRIPTION
Issue #1245

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
