### PR TITLE
Rename maximumLimit to adapterLimit and related changes

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -230,24 +230,22 @@ export function getPerStageWGSLForBindingCombinationStorageTextures(
   );
 }
 
-// MAINTENANCE_TODO: rename LimitsModes to MaximumLimitsModes and update its derivatives.
 const LimitModes = {
   defaultLimit: true,
-  maxLimit: true,
+  adapterLimit: true,
 };
 export type LimitMode = keyof typeof LimitModes;
 export const kLimitModes = keysOf(LimitModes);
 export type LimitsRequest = Record<string, LimitMode>;
 
-// MAINTENANCE_TODO: rename TestValues to MaximumTestValues and update its derivatives.
-export const TestValues = {
+export const MaximumTestValues = {
   atLimit: true,
   overLimit: true,
 };
-export type TestValue = keyof typeof TestValues;
-export const kTestValueKeys = keysOf(TestValues);
+export type MaximumTestValue = keyof typeof MaximumTestValues;
+export const kMaximumTestValueKeys = keysOf(MaximumTestValues);
 
-export function getTestValue(limit: number, testValue: TestValue) {
+export function getMaximumTestValue(limit: number, testValue: MaximumTestValue) {
   switch (testValue) {
     case 'atLimit':
       return limit;
@@ -263,21 +261,20 @@ export const MinimumTestValues = {
 export type MinimumTestValue = keyof typeof MinimumTestValues;
 export const kMinimumTestValueKeys = keysOf(MinimumTestValues);
 
-// MAINTENANCE_TODO: rename LimitValueTests to MaximumLimitValueTests and update its derivatives.
-export const LimitValueTests = {
+export const MaximumLimitValueTests = {
   atDefault: true,
   underDefault: true,
   betweenDefaultAndMaximum: true,
   atMaximum: true,
   overMaximum: true,
 };
-export type LimitValueTest = keyof typeof LimitValueTests;
-export const kLimitValueTestKeys = keysOf(LimitValueTests);
+export type MaximumLimitValueTest = keyof typeof MaximumLimitValueTests;
+export const kMaximumLimitValueTestKeys = keysOf(MaximumLimitValueTests);
 
 export function getLimitValue(
   defaultLimit: number,
   maximumLimit: number,
-  limitValueTest: LimitValueTest
+  limitValueTest: MaximumLimitValueTest
 ) {
   switch (limitValueTest) {
     case 'atDefault':
@@ -307,11 +304,10 @@ export function getDefaultLimit(limit: GPUSupportedLimit): number {
   return (kLimitInfo as Record<string, { default: number }>)[limit].default;
 }
 
-// MAINTENANCE_TODO: rename maximumLimit here and in LimitTestImpl to adapterLimit
 export type DeviceAndLimits = {
   device: GPUDevice;
   defaultLimit: number;
-  maximumLimit: number;
+  adapterLimit: number;
   requestedLimit: number;
   actualLimit: number;
 };
@@ -321,8 +317,8 @@ export type SpecificLimitTestInputs = DeviceAndLimits & {
   shouldError: boolean;
 };
 
-export type LimitTestInputs = SpecificLimitTestInputs & {
-  testValueName: TestValue;
+export type MaximumLimitTestInputs = SpecificLimitTestInputs & {
+  testValueName: MaximumTestValue;
 };
 
 const kMinimumLimits = new Set<GPUSupportedLimit>([
@@ -333,10 +329,10 @@ const kMinimumLimits = new Set<GPUSupportedLimit>([
 /**
  * Adds the default parameters to a limit test
  */
-export const kLimitBaseParams = kUnitCaseParamsBuilder
-  .combine('limitTest', kLimitValueTestKeys)
+export const kMaximumLimitBaseParams = kUnitCaseParamsBuilder
+  .combine('limitTest', kMaximumLimitValueTestKeys)
   .beginSubcases()
-  .combine('testValueName', kTestValueKeys);
+  .combine('testValueName', kMaximumTestValueKeys);
 
 export const kMinimumLimitBaseParams = kUnitCaseParamsBuilder
   .combine('limitTest', kMinimumLimitValueTestKeys)
@@ -348,7 +344,7 @@ export class LimitTestsImpl extends GPUTestBase {
   _device: GPUDevice | undefined = undefined;
   limit: GPUSupportedLimit = '' as GPUSupportedLimit;
   defaultLimit = 0;
-  maximumLimit = 0;
+  adapterLimit = 0;
 
   async init() {
     await super.init();
@@ -356,9 +352,9 @@ export class LimitTestsImpl extends GPUTestBase {
     this._adapter = await gpu.requestAdapter();
     const limit = this.limit;
     this.defaultLimit = getDefaultLimit(limit);
-    this.maximumLimit = this.adapter.limits[limit] as number;
+    this.adapterLimit = this.adapter.limits[limit] as number;
     assert(!Number.isNaN(this.defaultLimit));
-    assert(!Number.isNaN(this.maximumLimit));
+    assert(!Number.isNaN(this.adapterLimit));
   }
 
   get adapter(): GPUAdapter {
@@ -374,22 +370,22 @@ export class LimitTestsImpl extends GPUTestBase {
   async requestDeviceWithLimits(
     adapter: GPUAdapter,
     requiredLimits: Record<string, number>,
-    shouldReject: boolean
+    shouldReject: boolean,
+    requiredFeatures?: GPUFeatureName[]
   ) {
     if (shouldReject) {
       this.shouldReject('OperationError', adapter.requestDevice({ requiredLimits }));
       return undefined;
     } else {
-      return await adapter.requestDevice({ requiredLimits });
+      return await adapter.requestDevice({ requiredLimits, requiredFeatures });
     }
   }
 
-  // MAINTENANCE_TODO: rename to getDefaultOrAdapterLimit
-  getDefaultOrMaximumLimit(limit: GPUSupportedLimit, limitMode: LimitMode) {
+  getDefaultOrAdapterLimit(limit: GPUSupportedLimit, limitMode: LimitMode) {
     switch (limitMode) {
       case 'defaultLimit':
         return getDefaultLimit(limit);
-      case 'maxLimit':
+      case 'adapterLimit':
         return this.adapter.limits[limit];
     }
   }
@@ -401,9 +397,10 @@ export class LimitTestsImpl extends GPUTestBase {
    */
   async _getDeviceWithSpecificLimit(
     requestedLimit: number,
-    extraLimits?: LimitsRequest
+    extraLimits?: LimitsRequest,
+    features?: GPUFeatureName[]
   ): Promise<DeviceAndLimits | undefined> {
-    const { adapter, limit, maximumLimit, defaultLimit } = this;
+    const { adapter, limit, adapterLimit, defaultLimit } = this;
 
     const requiredLimits: Record<string, number> = {};
     requiredLimits[limit] = requestedLimit;
@@ -419,31 +416,48 @@ export class LimitTestsImpl extends GPUTestBase {
     }
 
     const shouldReject = kMinimumLimits.has(limit)
-      ? requestedLimit < maximumLimit
-      : requestedLimit > maximumLimit;
+      ? requestedLimit < adapterLimit
+      : requestedLimit > adapterLimit;
 
-    const device = await this.requestDeviceWithLimits(adapter, requiredLimits, shouldReject);
+    const device = await this.requestDeviceWithLimits(
+      adapter,
+      requiredLimits,
+      shouldReject,
+      features
+    );
     const actualLimit = (device ? device.limits[limit] : 0) as number;
 
     if (shouldReject) {
-      this.expect(!device);
+      this.expect(!device, 'expected no device');
     } else {
       if (kMinimumLimits.has(limit)) {
         if (requestedLimit <= defaultLimit) {
-          this.expect(actualLimit === requestedLimit);
+          this.expect(
+            actualLimit === requestedLimit,
+            `expected actual actualLimit: ${actualLimit} to equal defaultLimit: ${requestedLimit}`
+          );
         } else {
-          this.expect(actualLimit === defaultLimit);
+          this.expect(
+            actualLimit === defaultLimit,
+            `expected actual actualLimit: ${actualLimit} to equal defaultLimit: ${defaultLimit}`
+          );
         }
       } else {
         if (requestedLimit <= defaultLimit) {
-          this.expect(actualLimit === defaultLimit);
+          this.expect(
+            actualLimit === defaultLimit,
+            `expected actual actualLimit: ${actualLimit} to equal defaultLimit: ${defaultLimit}`
+          );
         } else {
-          this.expect(actualLimit === requestedLimit);
+          this.expect(
+            actualLimit === requestedLimit,
+            `expected actual actualLimit: ${actualLimit} to equal requestedLimit: ${requestedLimit}`
+          );
         }
       }
     }
 
-    return device ? { device, defaultLimit, maximumLimit, requestedLimit, actualLimit } : undefined;
+    return device ? { device, defaultLimit, adapterLimit, requestedLimit, actualLimit } : undefined;
   }
 
   /**
@@ -451,18 +465,19 @@ export class LimitTestsImpl extends GPUTestBase {
    * is correct or that the device failed to create if the requested limit is
    * beyond the maximum supported by the device.
    */
-  async _getDeviceWithRequestedLimit(
-    limitValueTest: LimitValueTest,
-    extraLimits?: LimitsRequest
+  async _getDeviceWithRequestedMaximumLimit(
+    limitValueTest: MaximumLimitValueTest,
+    extraLimits?: LimitsRequest,
+    features?: GPUFeatureName[]
   ): Promise<DeviceAndLimits | undefined> {
-    const { defaultLimit, maximumLimit } = this;
+    const { defaultLimit, adapterLimit: maximumLimit } = this;
 
     const requestedLimit = getLimitValue(defaultLimit, maximumLimit, limitValueTest);
-    return this._getDeviceWithSpecificLimit(requestedLimit, extraLimits);
+    return this._getDeviceWithSpecificLimit(requestedLimit, extraLimits, features);
   }
 
   /**
-   * Call the given function and check no WebGPU errors are leaked
+   * Call the given function and check no WebGPU errors are leaked.
    */
   async _testThenDestroyDevice(
     deviceAndLimits: DeviceAndLimits,
@@ -488,9 +503,12 @@ export class LimitTestsImpl extends GPUTestBase {
     const outOfMemoryError = await device.popErrorScope();
     const internalError = await device.popErrorScope();
 
-    this.expect(!validationError, validationError?.message || '');
-    this.expect(!outOfMemoryError, outOfMemoryError?.message || '');
-    this.expect(!internalError, internalError?.message || '');
+    this.expect(!validationError, `unexpected validation error: ${validationError?.message || ''}`);
+    this.expect(
+      !outOfMemoryError,
+      `unexpected out-of-memory error: ${outOfMemoryError?.message || ''}`
+    );
+    this.expect(!internalError, `unexpected internal error: ${internalError?.message || ''}`);
 
     device.destroy();
     this._device = undefined;
@@ -506,11 +524,16 @@ export class LimitTestsImpl extends GPUTestBase {
     deviceLimitValue: number,
     testValue: number,
     fn: (inputs: SpecificLimitTestInputs) => void | Promise<void>,
-    extraLimits?: LimitsRequest
+    extraLimits?: LimitsRequest,
+    features?: GPUFeatureName[]
   ) {
     assert(!this._device);
 
-    const deviceAndLimits = await this._getDeviceWithSpecificLimit(deviceLimitValue, extraLimits);
+    const deviceAndLimits = await this._getDeviceWithSpecificLimit(
+      deviceLimitValue,
+      extraLimits,
+      features
+    );
     // If we request over the limit requestDevice will throw
     if (!deviceAndLimits) {
       return;
@@ -525,22 +548,22 @@ export class LimitTestsImpl extends GPUTestBase {
    * If the device is created then we call a test function, checking
    * that the function does not leak any GPU errors.
    */
-  async testDeviceWithRequestedLimits(
-    limitTest: LimitValueTest,
-    testValueName: TestValue,
-    fn: (inputs: LimitTestInputs) => void | Promise<void>,
+  async testDeviceWithRequestedMaximumLimits(
+    limitTest: MaximumLimitValueTest,
+    testValueName: MaximumTestValue,
+    fn: (inputs: MaximumLimitTestInputs) => void | Promise<void>,
     extraLimits?: LimitsRequest
   ) {
     assert(!this._device);
 
-    const deviceAndLimits = await this._getDeviceWithRequestedLimit(limitTest, extraLimits);
+    const deviceAndLimits = await this._getDeviceWithRequestedMaximumLimit(limitTest, extraLimits);
     // If we request over the limit requestDevice will throw
     if (!deviceAndLimits) {
       return;
     }
 
     const { actualLimit } = deviceAndLimits;
-    const testValue = getTestValue(actualLimit, testValueName);
+    const testValue = getMaximumTestValue(actualLimit, testValueName);
 
     await this._testThenDestroyDevice(
       deviceAndLimits,
@@ -994,6 +1017,18 @@ export class LimitTestsImpl extends GPUTestBase {
     prep();
 
     await this.expectValidationError(test, shouldError, msg);
+  }
+
+  getModuleForWorkgroupSize(size: number[]) {
+    const { device } = this;
+    return device.createShaderModule({
+      code: `
+        @group(0) @binding(0) var<storage, read_write> d: f32;
+        @compute @workgroup_size(${size.join(',')}) fn main() {
+          d = 0;
+        }
+      `,
+    });
   }
 }
 

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroups.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroups.spec.ts
@@ -4,7 +4,7 @@ import {
   kCreatePipelineTypes,
   kCreatePipelineAsyncTypes,
   kEncoderTypes,
-  kLimitBaseParams,
+  kMaximumLimitBaseParams,
   makeLimitTestGroup,
 } from './limit_utils.js';
 
@@ -13,10 +13,10 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createPipelineLayout,at_over')
   .desc(`Test using createPipelineLayout at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -41,11 +41,11 @@ g.test('createPipelineLayout,at_over')
 
 g.test('createPipeline,at_over')
   .desc(`Test using createRenderPipeline and createComputePipeline at and over ${limit} limit`)
-  .params(kLimitBaseParams.combine('createPipelineType', kCreatePipelineTypes))
+  .params(kMaximumLimitBaseParams.combine('createPipelineType', kCreatePipelineTypes))
   .fn(async t => {
     const { limitTest, testValueName, createPipelineType } = t.params;
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -65,11 +65,11 @@ g.test('createPipelineAsync,at_over')
   .desc(
     `Test using createRenderPipelineAsync and createComputePipelineAsync at and over ${limit} limit`
   )
-  .params(kLimitBaseParams.combine('createPipelineAsyncType', kCreatePipelineAsyncTypes))
+  .params(kMaximumLimitBaseParams.combine('createPipelineAsyncType', kCreatePipelineAsyncTypes))
   .fn(async t => {
     const { limitTest, testValueName, createPipelineAsyncType } = t.params;
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -86,10 +86,10 @@ g.test('createPipelineAsync,at_over')
 
 g.test('setBindGroup,at_over')
   .desc(`Test using setBindGroup at and over ${limit} limit`)
-  .params(kLimitBaseParams.combine('encoderType', kEncoderTypes))
+  .params(kMaximumLimitBaseParams.combine('encoderType', kEncoderTypes))
   .fn(async t => {
     const { limitTest, testValueName, encoderType } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ testValue, actualLimit, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindingsPerBindGroup.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindingsPerBindGroup.spec.ts
@@ -1,7 +1,7 @@
 import {
   kCreatePipelineTypes,
   kCreatePipelineAsyncTypes,
-  kLimitBaseParams,
+  kMaximumLimitBaseParams,
   makeLimitTestGroup,
 } from './limit_utils.js';
 
@@ -10,10 +10,10 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createBindGroupLayout,at_over')
   .desc(`Test using createBindGroupLayout at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -34,10 +34,10 @@ g.test('createBindGroupLayout,at_over')
 
 g.test('createPipeline,at_over')
   .desc(`Test using createRenderPipeline and createComputePipeline at and over ${limit} limit`)
-  .params(kLimitBaseParams.combine('createPipelineType', kCreatePipelineTypes))
+  .params(kMaximumLimitBaseParams.combine('createPipelineType', kCreatePipelineTypes))
   .fn(async t => {
     const { limitTest, testValueName, createPipelineType } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -57,11 +57,11 @@ g.test('createPipelineAsync,at_over')
   .desc(
     `Test using createRenderPipelineAsync and createComputePipelineAsync at and over ${limit} limit`
   )
-  .params(kLimitBaseParams.combine('createPipelineAsyncType', kCreatePipelineAsyncTypes))
+  .params(kMaximumLimitBaseParams.combine('createPipelineAsyncType', kCreatePipelineAsyncTypes))
   .fn(async t => {
     const { limitTest, testValueName, createPipelineAsyncType } = t.params;
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -79,7 +79,7 @@ g.test('createPipelineAsync,at_over')
 g.test('validate')
   .desc(`Test ${limit} matches the spec limits`)
   .fn(t => {
-    const { adapter, maximumLimit } = t;
+    const { adapter, adapterLimit } = t;
     const maxBindingsPerShaderStage =
       adapter.limits.maxSampledTexturesPerShaderStage +
       adapter.limits.maxSamplersPerShaderStage +
@@ -89,7 +89,7 @@ g.test('validate')
     const maxShaderStagesPerPipeline = 2;
     const minMaxBindingsPerBindGroup = maxBindingsPerShaderStage * maxShaderStagesPerPipeline;
     t.expect(
-      maximumLimit >= minMaxBindingsPerBindGroup,
-      `maxBindingsPerBindGroup(${maximumLimit}) >= maxBindingsPerShaderStage(${maxBindingsPerShaderStage}) * maxShaderStagesPerPipeline(${maxShaderStagesPerPipeline} = (${minMaxBindingsPerBindGroup}))`
+      adapterLimit >= minMaxBindingsPerBindGroup,
+      `maxBindingsPerBindGroup(${adapterLimit}) >= maxBindingsPerShaderStage(${maxBindingsPerShaderStage}) * maxShaderStagesPerPipeline(${maxShaderStagesPerPipeline} = (${minMaxBindingsPerBindGroup}))`
     );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxBufferSize.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBufferSize.spec.ts
@@ -1,14 +1,14 @@
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const limit = 'maxBufferSize';
 export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createBuffer,at_over')
   .desc(`Test using at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
@@ -3,7 +3,7 @@ import { kTextureSampleCounts, kTextureFormatInfo } from '../../../../capability
 import { align } from '../../../../util/math.js';
 
 import {
-  kLimitBaseParams,
+  kMaximumLimitBaseParams,
   kLimitModes,
   LimitTestsImpl,
   makeLimitTestGroup,
@@ -147,7 +147,7 @@ export const { g, description } = makeLimitTestGroup(limit);
 g.test('createRenderPipeline,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipeline`)
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('maxColorAttachmentsLimitMode', kLimitModes)
       .combine('sampleCount', kTextureSampleCounts)
       .combine('interleaveFormat', kInterleaveFormats)
@@ -160,7 +160,7 @@ g.test('createRenderPipeline,at_over')
       sampleCount,
       interleaveFormat,
     } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
@@ -191,7 +191,7 @@ g.test('createRenderPipeline,at_over')
 g.test('createRenderPipelineAsync,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipelineAsync`)
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('maxColorAttachmentsLimitMode', kLimitModes)
       .combine('sampleCount', kTextureSampleCounts)
       .combine('interleaveFormat', kInterleaveFormats)
@@ -204,7 +204,7 @@ g.test('createRenderPipelineAsync,at_over')
       sampleCount,
       interleaveFormat,
     } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
@@ -234,7 +234,7 @@ g.test('createRenderPipelineAsync,at_over')
 g.test('beginRenderPass,at_over')
   .desc(`Test using at and over ${limit} limit in beginRenderPass`)
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('maxColorAttachmentsLimitMode', kLimitModes)
       .combine('sampleCount', kTextureSampleCounts)
       .combine('interleaveFormat', kInterleaveFormats)
@@ -247,7 +247,7 @@ g.test('beginRenderPass,at_over')
       sampleCount,
       interleaveFormat,
     } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
@@ -284,7 +284,7 @@ g.test('beginRenderPass,at_over')
 g.test('createRenderBundle,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderBundle`)
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('maxColorAttachmentsLimitMode', kLimitModes)
       .combine('sampleCount', kTextureSampleCounts)
       .combine('interleaveFormat', kInterleaveFormats)
@@ -297,7 +297,7 @@ g.test('createRenderBundle,at_over')
       sampleCount,
       interleaveFormat,
     } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachments.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachments.spec.ts
@@ -1,6 +1,6 @@
 import { range } from '../../../../../common/util/util.js';
 
-import { kLimitBaseParams, getDefaultLimit, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, getDefaultLimit, makeLimitTestGroup } from './limit_utils.js';
 
 function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderPipelineDescriptor {
   const code = `
@@ -32,10 +32,10 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createRenderPipeline,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipeline`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -50,10 +50,10 @@ g.test('createRenderPipeline,at_over')
 
 g.test('createRenderPipelineAsync,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipelineAsync`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -69,10 +69,10 @@ g.test('createRenderPipelineAsync,at_over')
 
 g.test('beginRenderPass,at_over')
   .desc(`Test using at and over ${limit} limit in beginRenderPass`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -106,10 +106,10 @@ g.test('beginRenderPass,at_over')
 
 g.test('createRenderBundle,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderBundle`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -125,7 +125,7 @@ g.test('createRenderBundle,at_over')
 g.test('validate')
   .desc(`Test ${limit} against maxColorAttachmentBytesPerSample`)
   .fn(t => {
-    const { adapter, defaultLimit, maximumLimit } = t;
+    const { adapter, defaultLimit, adapterLimit: maximumLimit } = t;
     const minColorAttachmentBytesPerSample = getDefaultLimit('maxColorAttachmentBytesPerSample');
     // The smallest attachment is 1 byte
     // so make sure maxColorAttachments < maxColorAttachmentBytesPerSample

--- a/src/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout.spec.ts
@@ -1,7 +1,7 @@
 import { range } from '../../../../../common/util/util.js';
 import { GPUConst } from '../../../../constants.js';
 
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const limit = 'maxDynamicStorageBuffersPerPipelineLayout';
 export const { g, description } = makeLimitTestGroup(limit);
@@ -9,7 +9,7 @@ export const { g, description } = makeLimitTestGroup(limit);
 g.test('createBindGroupLayout,at_over')
   .desc(`Test using createBindGroupLayout at and over ${limit} limit`)
   .params(
-    kLimitBaseParams.combine('visibility', [
+    kMaximumLimitBaseParams.combine('visibility', [
       GPUConst.ShaderStage.FRAGMENT,
       GPUConst.ShaderStage.COMPUTE,
       GPUConst.ShaderStage.COMPUTE | GPUConst.ShaderStage.FRAGMENT,
@@ -17,7 +17,7 @@ g.test('createBindGroupLayout,at_over')
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout.spec.ts
@@ -1,7 +1,7 @@
 import { range } from '../../../../../common/util/util.js';
 import { GPUConst } from '../../../../constants.js';
 
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const limit = 'maxDynamicUniformBuffersPerPipelineLayout';
 export const { g, description } = makeLimitTestGroup(limit);
@@ -9,7 +9,7 @@ export const { g, description } = makeLimitTestGroup(limit);
 g.test('createBindGroupLayout,at_over')
   .desc(`Test using createBindGroupLayout at and over ${limit} limit`)
   .params(
-    kLimitBaseParams.combine('visibility', [
+    kMaximumLimitBaseParams.combine('visibility', [
       GPUConst.ShaderStage.VERTEX,
       GPUConst.ShaderStage.FRAGMENT,
       GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
@@ -21,7 +21,7 @@ g.test('createBindGroupLayout,at_over')
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderComponents.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderComponents.spec.ts
@@ -1,6 +1,6 @@
 import { assert, range } from '../../../../../common/util/util.js';
 
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 function getTypeForNumComponents(numComponents: number) {
   return numComponents > 1 ? `vec${numComponents}f` : 'f32';
@@ -94,7 +94,7 @@ export const { g, description } = makeLimitTestGroup(limit);
 g.test('createRenderPipeline,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipeline`)
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('pointList', [false, true])
       .combine('frontFacing', [false, true])
       .combine('sampleIndex', [false, true])
@@ -111,7 +111,7 @@ g.test('createRenderPipeline,at_over')
       sampleMaskIn,
       sampleMaskOut,
     } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -139,7 +139,7 @@ g.test('createRenderPipeline,at_over')
 g.test('createRenderPipelineAsync,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipelineAsync`)
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('pointList', [false, true])
       .combine('frontFacing', [false, true])
       .combine('sampleIndex', [false, true])
@@ -156,7 +156,7 @@ g.test('createRenderPipelineAsync,at_over')
       sampleMaskIn,
       sampleMaskOut,
     } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
@@ -1,4 +1,4 @@
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderPipelineDescriptor {
   const code = `
@@ -28,10 +28,10 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createRenderPipeline,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipeline`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -47,10 +47,10 @@ g.test('createRenderPipeline,at_over')
 
 g.test('createRenderPipelineAsync,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipelineAsync`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
@@ -7,7 +7,7 @@ import {
 import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
 
 import {
-  kLimitBaseParams,
+  kMaximumLimitBaseParams,
   makeLimitTestGroup,
   kBindGroupTests,
   kBindingCombinations,
@@ -47,13 +47,13 @@ g.test('createBindGroupLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', kShaderStageCombinationsWithStage)
       .combine('order', kReorderOrderKeys)
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -75,13 +75,13 @@ g.test('createPipelineLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', kShaderStageCombinationsWithStage)
       .combine('order', kReorderOrderKeys)
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -109,7 +109,7 @@ g.test('createPipeline,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', kBindingCombinations)
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -118,7 +118,7 @@ g.test('createPipeline,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
@@ -153,7 +153,7 @@ g.test('createPipelineAsync,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', kBindingCombinations)
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -162,7 +162,7 @@ g.test('createPipelineAsync,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
@@ -7,7 +7,7 @@ import {
 import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
 
 import {
-  kLimitBaseParams,
+  kMaximumLimitBaseParams,
   makeLimitTestGroup,
   kBindGroupTests,
   kBindingCombinations,
@@ -47,13 +47,13 @@ g.test('createBindGroupLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', kShaderStageCombinationsWithStage)
       .combine('order', kReorderOrderKeys)
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -75,13 +75,13 @@ g.test('createPipelineLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', kShaderStageCombinationsWithStage)
       .combine('order', kReorderOrderKeys)
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -109,7 +109,7 @@ g.test('createPipeline,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', kBindingCombinations)
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -118,7 +118,7 @@ g.test('createPipeline,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
@@ -154,7 +154,7 @@ g.test('createPipelineAsync,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', kBindingCombinations)
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -163,7 +163,7 @@ g.test('createPipelineAsync,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBufferBindingSize.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBufferBindingSize.spec.ts
@@ -2,11 +2,11 @@ import { keysOf } from '../../../../../common/util/data_tables.js';
 import { align, roundDown } from '../../../../util/math.js';
 
 import {
-  kLimitBaseParams,
+  kMaximumLimitBaseParams,
   makeLimitTestGroup,
-  LimitValueTest,
-  TestValue,
-  kLimitValueTestKeys,
+  MaximumLimitValueTest,
+  MaximumTestValue,
+  kMaximumLimitValueTestKeys,
 } from './limit_utils.js';
 
 const BufferParts = {
@@ -29,7 +29,7 @@ function getSizeAndOffsetForBufferPart(device: GPUDevice, bufferPart: BufferPart
 const kStorageBufferRequiredSizeAlignment = 4;
 
 function getDeviceLimitToRequest(
-  limitValueTest: LimitValueTest,
+  limitValueTest: MaximumLimitValueTest,
   defaultLimit: number,
   maximumLimit: number
 ) {
@@ -47,7 +47,7 @@ function getDeviceLimitToRequest(
   }
 }
 
-function getTestValue(testValueName: TestValue, requestedLimit: number) {
+function getTestValue(testValueName: MaximumTestValue, requestedLimit: number) {
   switch (testValueName) {
     case 'atLimit':
       return roundDown(requestedLimit, kStorageBufferRequiredSizeAlignment);
@@ -61,8 +61,8 @@ function getTestValue(testValueName: TestValue, requestedLimit: number) {
 }
 
 function getDeviceLimitToRequestAndValueToTest(
-  limitValueTest: LimitValueTest,
-  testValueName: TestValue,
+  limitValueTest: MaximumLimitValueTest,
+  testValueName: MaximumTestValue,
   defaultLimit: number,
   maximumLimit: number
 ) {
@@ -78,10 +78,10 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createBindGroup,at_over')
   .desc(`Test using createBindGroup at and over ${limit} limit`)
-  .params(kLimitBaseParams.combine('bufferPart', kBufferPartsKeys))
+  .params(kMaximumLimitBaseParams.combine('bufferPart', kBufferPartsKeys))
   .fn(async t => {
     const { limitTest, testValueName, bufferPart } = t.params;
-    const { defaultLimit, maximumLimit } = t;
+    const { defaultLimit, adapterLimit: maximumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,
@@ -140,10 +140,10 @@ g.test('createBindGroup,at_over')
 
 g.test('validate,maxBufferSize')
   .desc(`Test that ${limit} <= maxBufferSize`)
-  .params(u => u.combine('limitTest', kLimitValueTestKeys))
+  .params(u => u.combine('limitTest', kMaximumLimitValueTestKeys))
   .fn(async t => {
     const { limitTest } = t.params;
-    const { defaultLimit, maximumLimit } = t;
+    const { defaultLimit, adapterLimit: maximumLimit } = t;
     const requestedLimit = getDeviceLimitToRequest(limitTest, defaultLimit, maximumLimit);
 
     await t.testDeviceWithSpecificLimits(requestedLimit, 0, ({ device, actualLimit }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
@@ -7,7 +7,7 @@ import {
 import { GPUConst } from '../../../../constants.js';
 
 import {
-  kLimitBaseParams,
+  kMaximumLimitBaseParams,
   makeLimitTestGroup,
   kBindGroupTests,
   kBindingCombinations,
@@ -48,7 +48,7 @@ g.test('createBindGroupLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', [
         GPUConst.ShaderStage.VERTEX,
         GPUConst.ShaderStage.FRAGMENT,
@@ -69,7 +69,7 @@ g.test('createBindGroupLayout,at_over')
       return;
     }
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -90,7 +90,7 @@ g.test('createPipelineLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', [
         GPUConst.ShaderStage.VERTEX,
         GPUConst.ShaderStage.FRAGMENT,
@@ -111,7 +111,7 @@ g.test('createPipelineLayout,at_over')
       return;
     }
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -139,7 +139,7 @@ g.test('createPipeline,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', kBindingCombinations)
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -148,7 +148,7 @@ g.test('createPipeline,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
@@ -183,7 +183,7 @@ g.test('createPipelineAsync,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', kBindingCombinations)
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -192,7 +192,7 @@ g.test('createPipelineAsync,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
@@ -7,7 +7,7 @@ import {
 import { GPUConst } from '../../../../constants.js';
 
 import {
-  kLimitBaseParams,
+  kMaximumLimitBaseParams,
   makeLimitTestGroup,
   kBindGroupTests,
   getPipelineTypeForBindingCombination,
@@ -47,7 +47,7 @@ g.test('createBindGroupLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', [
         GPUConst.ShaderStage.FRAGMENT,
         GPUConst.ShaderStage.COMPUTE,
@@ -57,7 +57,7 @@ g.test('createBindGroupLayout,at_over')
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -79,7 +79,7 @@ g.test('createPipelineLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', [
         GPUConst.ShaderStage.FRAGMENT,
         GPUConst.ShaderStage.COMPUTE,
@@ -89,7 +89,7 @@ g.test('createPipelineLayout,at_over')
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -117,7 +117,7 @@ g.test('createPipeline,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', ['fragment', 'compute'] as BindingCombination[])
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -126,7 +126,7 @@ g.test('createPipeline,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
@@ -161,7 +161,7 @@ g.test('createPipelineAsync,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', ['fragment', 'compute'] as BindingCombination[])
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -170,7 +170,7 @@ g.test('createPipelineAsync,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxTextureArrayLayers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxTextureArrayLayers.spec.ts
@@ -1,14 +1,14 @@
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const limit = 'maxTextureArrayLayers';
 export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createTexture,at_over')
   .desc(`Test using at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension1D.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension1D.spec.ts
@@ -1,14 +1,14 @@
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const limit = 'maxTextureDimension1D';
 export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createTexture,at_over')
   .desc(`Test using at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension2D.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension2D.spec.ts
@@ -1,17 +1,17 @@
 import { getGPU } from '../../../../../common/util/navigator_gpu.js';
 import { kAllCanvasTypes, createCanvas } from '../../../../util/create_elements.js';
 
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const limit = 'maxTextureDimension2D';
 export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createTexture,at_over')
   .desc(`Test using at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, shouldError, testValue, actualLimit }) => {
@@ -46,10 +46,10 @@ g.test('createTexture,at_over')
 
 g.test('configure,at_over')
   .desc(`Test using at and over ${limit} limit`)
-  .params(kLimitBaseParams.combine('canvasType', kAllCanvasTypes))
+  .params(kMaximumLimitBaseParams.combine('canvasType', kAllCanvasTypes))
   .fn(async t => {
     const { limitTest, testValueName, canvasType } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, shouldError, testValue, actualLimit }) => {
@@ -82,10 +82,10 @@ g.test('configure,at_over')
 
 g.test('getCurrentTexture,at_over')
   .desc(`Test using at and over ${limit} limit`)
-  .params(kLimitBaseParams.combine('canvasType', kAllCanvasTypes))
+  .params(kMaximumLimitBaseParams.combine('canvasType', kAllCanvasTypes))
   .fn(async t => {
     const { limitTest, testValueName, canvasType } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, shouldError, testValue, actualLimit }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension3D.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension3D.spec.ts
@@ -1,14 +1,14 @@
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const limit = 'maxTextureDimension3D';
 export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createTexture,at_over')
   .desc(`Test using at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, shouldError, testValue }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxUniformBufferBindingSize.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxUniformBufferBindingSize.spec.ts
@@ -1,6 +1,10 @@
 import { keysOf } from '../../../../../common/util/data_tables.js';
 
-import { kLimitBaseParams, kLimitValueTestKeys, makeLimitTestGroup } from './limit_utils.js';
+import {
+  kMaximumLimitBaseParams,
+  kMaximumLimitValueTestKeys,
+  makeLimitTestGroup,
+} from './limit_utils.js';
 
 const BufferParts = {
   wholeBuffer: true,
@@ -24,10 +28,10 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createBindGroup,at_over')
   .desc(`Test using at and over ${limit} limit`)
-  .params(kLimitBaseParams.combine('bufferPart', kBufferPartsKeys))
+  .params(kMaximumLimitBaseParams.combine('bufferPart', kBufferPartsKeys))
   .fn(async t => {
     const { limitTest, testValueName, bufferPart } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -74,10 +78,14 @@ g.test('createBindGroup,at_over')
 
 g.test('validate,maxBufferSize')
   .desc(`Test that ${limit} <= maxBufferSize`)
-  .params(u => u.combine('limitTest', kLimitValueTestKeys))
+  .params(u => u.combine('limitTest', kMaximumLimitValueTestKeys))
   .fn(async t => {
     const { limitTest } = t.params;
-    await t.testDeviceWithRequestedLimits(limitTest, 'atLimit', ({ device, actualLimit }) => {
-      t.expect(actualLimit <= device.limits.maxBufferSize);
-    });
+    await t.testDeviceWithRequestedMaximumLimits(
+      limitTest,
+      'atLimit',
+      ({ device, actualLimit }) => {
+        t.expect(actualLimit <= device.limits.maxBufferSize);
+      }
+    );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
@@ -7,7 +7,7 @@ import {
 import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
 
 import {
-  kLimitBaseParams,
+  kMaximumLimitBaseParams,
   makeLimitTestGroup,
   kBindGroupTests,
   kBindingCombinations,
@@ -47,13 +47,13 @@ g.test('createBindGroupLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', kShaderStageCombinationsWithStage)
       .combine('order', kReorderOrderKeys)
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -75,13 +75,13 @@ g.test('createPipelineLayout,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('visibility', kShaderStageCombinationsWithStage)
       .combine('order', kReorderOrderKeys)
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -109,7 +109,7 @@ g.test('createPipeline,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', kBindingCombinations)
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -118,7 +118,7 @@ g.test('createPipeline,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
@@ -153,7 +153,7 @@ g.test('createPipelineAsync,at_over')
   `
   )
   .params(
-    kLimitBaseParams
+    kMaximumLimitBaseParams
       .combine('bindingCombination', kBindingCombinations)
       .combine('order', kReorderOrderKeys)
       .combine('bindGroupTest', kBindGroupTests)
@@ -162,7 +162,7 @@ g.test('createPipelineAsync,at_over')
     const { limitTest, testValueName, bindingCombination, order, bindGroupTest } = t.params;
     const pipelineType = getPipelineAsyncTypeForBindingCombination(bindingCombination);
 
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexAttributes.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexAttributes.spec.ts
@@ -1,4 +1,4 @@
-import { kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 function getPipelineDescriptor(device: GPUDevice, lastIndex: number): GPURenderPipelineDescriptor {
   const code = `
@@ -27,10 +27,10 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createRenderPipeline,at_over')
   .desc(`Test using createRenderPipeline at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -46,10 +46,10 @@ g.test('createRenderPipeline,at_over')
 
 g.test('createRenderPipelineAsync,at_over')
   .desc(`Test using createRenderPipelineAsync at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
@@ -1,6 +1,11 @@
 import { roundDown } from '../../../../util/math.js';
 
-import { kLimitBaseParams, makeLimitTestGroup, LimitValueTest, TestValue } from './limit_utils.js';
+import {
+  kMaximumLimitBaseParams,
+  makeLimitTestGroup,
+  MaximumLimitValueTest,
+  MaximumTestValue,
+} from './limit_utils.js';
 
 function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderPipelineDescriptor {
   const code = `
@@ -33,7 +38,7 @@ function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderP
 const kMinAttributeStride = 4;
 
 function getDeviceLimitToRequest(
-  limitValueTest: LimitValueTest,
+  limitValueTest: MaximumLimitValueTest,
   defaultLimit: number,
   maximumLimit: number
 ) {
@@ -54,7 +59,7 @@ function getDeviceLimitToRequest(
   }
 }
 
-function getTestValue(testValueName: TestValue, requestedLimit: number) {
+function getTestValue(testValueName: MaximumTestValue, requestedLimit: number) {
   switch (testValueName) {
     case 'atLimit':
       return requestedLimit;
@@ -64,8 +69,8 @@ function getTestValue(testValueName: TestValue, requestedLimit: number) {
 }
 
 function getDeviceLimitToRequestAndValueToTest(
-  limitValueTest: LimitValueTest,
-  testValueName: TestValue,
+  limitValueTest: MaximumLimitValueTest,
+  testValueName: MaximumTestValue,
   defaultLimit: number,
   maximumLimit: number
 ) {
@@ -85,10 +90,10 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createRenderPipeline,at_over')
   .desc(`Test using createRenderPipeline at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    const { defaultLimit, maximumLimit } = t;
+    const { defaultLimit, adapterLimit: maximumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,
@@ -111,10 +116,10 @@ g.test('createRenderPipeline,at_over')
 
 g.test('createRenderPipelineAsync,at_over')
   .desc(`Test using createRenderPipelineAsync at and over ${limit} limit`)
-  .params(kLimitBaseParams)
+  .params(kMaximumLimitBaseParams)
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
-    const { defaultLimit, maximumLimit } = t;
+    const { defaultLimit, adapterLimit: maximumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
@@ -1,7 +1,7 @@
 import { keysOf } from '../../../../../common/util/data_tables.js';
 import { range } from '../../../../../common/util/util.js';
 
-import { kRenderEncoderTypes, kLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kRenderEncoderTypes, kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const PipelineTypes = {
   withoutLocations: true,
@@ -50,10 +50,10 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createRenderPipeline,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipeline`)
-  .params(kLimitBaseParams.combine('pipelineType', kPipelineTypes))
+  .params(kMaximumLimitBaseParams.combine('pipelineType', kPipelineTypes))
   .fn(async t => {
     const { limitTest, testValueName, pipelineType } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -68,10 +68,10 @@ g.test('createRenderPipeline,at_over')
 
 g.test('createRenderPipelineAsync,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipelineAsync`)
-  .params(kLimitBaseParams.combine('pipelineType', kPipelineTypes))
+  .params(kMaximumLimitBaseParams.combine('pipelineType', kPipelineTypes))
   .fn(async t => {
     const { limitTest, testValueName, pipelineType } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
@@ -87,10 +87,10 @@ g.test('createRenderPipelineAsync,at_over')
 
 g.test('setVertexBuffer,at_over')
   .desc(`Test using at and over ${limit} limit in setVertexBuffer`)
-  .params(kLimitBaseParams.combine('encoderType', kRenderEncoderTypes))
+  .params(kMaximumLimitBaseParams.combine('encoderType', kRenderEncoderTypes))
   .fn(async t => {
     const { limitTest, testValueName, encoderType } = t.params;
-    await t.testDeviceWithRequestedLimits(
+    await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError, actualLimit }) => {

--- a/src/webgpu/api/validation/capability_checks/limits/minStorageBufferOffsetAlignment.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/minStorageBufferOffsetAlignment.spec.ts
@@ -58,7 +58,7 @@ g.test('createBindGroup,at_over')
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
     // note: LimitTest.maximum is the adapter.limits[limit] value
-    const { defaultLimit, maximumLimit: minimumLimit } = t;
+    const { defaultLimit, adapterLimit: minimumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,
@@ -111,7 +111,7 @@ g.test('setBindGroup,at_over')
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
     // note: LimitTest.maximum is the adapter.limits[limit] value
-    const { defaultLimit, maximumLimit: minimumLimit } = t;
+    const { defaultLimit, adapterLimit: minimumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,
@@ -172,12 +172,12 @@ g.test('validate,powerOf2')
   .desc('Verify that ${limit} is power of 2')
   .fn(t => {
     t.expect(isPowerOfTwo(t.defaultLimit));
-    t.expect(isPowerOfTwo(t.maximumLimit));
+    t.expect(isPowerOfTwo(t.adapterLimit));
   });
 
 g.test('validate,greaterThanOrEqualTo32')
   .desc('Verify that ${limit} is >= 32')
   .fn(t => {
     t.expect(t.defaultLimit >= 32);
-    t.expect(t.maximumLimit >= 32);
+    t.expect(t.adapterLimit >= 32);
   });

--- a/src/webgpu/api/validation/capability_checks/limits/minUniformBufferOffsetAlignment.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/minUniformBufferOffsetAlignment.spec.ts
@@ -61,7 +61,7 @@ g.test('createBindGroup,at_over')
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
     // note: LimitTest.maximum is the adapter.limits[limit] value
-    const { defaultLimit, maximumLimit: minimumLimit } = t;
+    const { defaultLimit, adapterLimit: minimumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,
@@ -114,7 +114,7 @@ g.test('setBindGroup,at_over')
   .fn(async t => {
     const { limitTest, testValueName } = t.params;
     // note: LimitTest.maximum is the adapter.limits[limit] value
-    const { defaultLimit, maximumLimit: minimumLimit } = t;
+    const { defaultLimit, adapterLimit: minimumLimit } = t;
     const { requestedLimit, testValue } = getDeviceLimitToRequestAndValueToTest(
       limitTest,
       testValueName,
@@ -175,12 +175,12 @@ g.test('validate,powerOf2')
   .desc('Verify that ${limit} is power of 2')
   .fn(t => {
     t.expect(isPowerOfTwo(t.defaultLimit));
-    t.expect(isPowerOfTwo(t.maximumLimit));
+    t.expect(isPowerOfTwo(t.adapterLimit));
   });
 
 g.test('validate,greaterThanOrEqualTo32')
   .desc('Verify that ${limit} is >= 32')
   .fn(t => {
     t.expect(t.defaultLimit >= 32);
-    t.expect(t.maximumLimit >= 32);
+    t.expect(t.adapterLimit >= 32);
   });


### PR DESCRIPTION
Most of the limits are maximums. Various names were just LimitXXX or maximumLimit but given a few limits are minimums it becomes confusing when using these names so, rename a bunch of stuff




Issue: #2328 
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
