### PR TITLE
Depend on github.com/gpuweb/types instead of npm @webgpu/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "0.1.27",
+        "@webgpu/types": "gpuweb/types#48dafa2124c767bcc4f84b0d1126bcc478143fad",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1262,9 +1262,10 @@
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.27.tgz",
+      "resolved": "git+ssh://git@github.com/gpuweb/types.git#48dafa2124c767bcc4f84b0d1126bcc478143fad",
       "integrity": "sha512-9oZDgM+/vhyPDM3twL1KQSs0fLbXvbxrStWi/+tvXnas7pQuQNaNBpge8wNcEUtbLMoORQYDc6hPFCSQKqpNAw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -9874,10 +9875,10 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.27.tgz",
+      "version": "git+ssh://git@github.com/gpuweb/types.git#48dafa2124c767bcc4f84b0d1126bcc478143fad",
       "integrity": "sha512-9oZDgM+/vhyPDM3twL1KQSs0fLbXvbxrStWi/+tvXnas7pQuQNaNBpge8wNcEUtbLMoORQYDc6hPFCSQKqpNAw==",
-      "dev": true
+      "dev": true,
+      "from": "@webgpu/types@gpuweb/types#48dafa2124c767bcc4f84b0d1126bcc478143fad"
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "0.1.27",
+    "@webgpu/types": "gpuweb/types#48dafa2124c767bcc4f84b0d1126bcc478143fad",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",


### PR DESCRIPTION
This pattern unblocks CTS changes on needing to wait for someone to do a new package release.