### PR TITLE
Roll @webgpu/types 48dafa2 -> d1b649b

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "gpuweb/types#48dafa2124c767bcc4f84b0d1126bcc478143fad",
+        "@webgpu/types": "gpuweb/types#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1261,9 +1261,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.27",
-      "resolved": "git+ssh://git@github.com/gpuweb/types.git#48dafa2124c767bcc4f84b0d1126bcc478143fad",
-      "integrity": "sha512-9oZDgM+/vhyPDM3twL1KQSs0fLbXvbxrStWi/+tvXnas7pQuQNaNBpge8wNcEUtbLMoORQYDc6hPFCSQKqpNAw==",
+      "version": "0.1.28",
+      "resolved": "git+ssh://git@github.com/gpuweb/types.git#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77",
+      "integrity": "sha512-+iuxedqdbpOGzbCVH/zo2Qfa+17glLxEp2q9qTKgIm5aUUrvw3AobDHGFOf27R6ZAQQ+MwEvdWEKDIuvwmtsCA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -9875,10 +9875,10 @@
       }
     },
     "@webgpu/types": {
-      "version": "git+ssh://git@github.com/gpuweb/types.git#48dafa2124c767bcc4f84b0d1126bcc478143fad",
-      "integrity": "sha512-9oZDgM+/vhyPDM3twL1KQSs0fLbXvbxrStWi/+tvXnas7pQuQNaNBpge8wNcEUtbLMoORQYDc6hPFCSQKqpNAw==",
+      "version": "git+ssh://git@github.com/gpuweb/types.git#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77",
+      "integrity": "sha512-+iuxedqdbpOGzbCVH/zo2Qfa+17glLxEp2q9qTKgIm5aUUrvw3AobDHGFOf27R6ZAQQ+MwEvdWEKDIuvwmtsCA==",
       "dev": true,
-      "from": "@webgpu/types@gpuweb/types#48dafa2124c767bcc4f84b0d1126bcc478143fad"
+      "from": "@webgpu/types@gpuweb/types#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77"
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "gpuweb/types#48dafa2124c767bcc4f84b0d1126bcc478143fad",
+    "@webgpu/types": "gpuweb/types#d1b649b8baf1c092b07657c8e01bd5a81b3c6e77",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",


### PR DESCRIPTION
Needed for #2291

https://github.com/gpuweb/types/commit/d1b649b8baf1c092b07657c8e01bd5a81b3c6e77 is for upgrading to 0.1.28 so we could use `"@webgpu/types": "0.1.28"` but I didn't want to break `"@webgpu/types": "gpuweb/types#xxx..."` pattern.
