### PR TITLE
Check maxBindingsPerBindGroup limit matches spec limits

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxBindingsPerBindGroup.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindingsPerBindGroup.spec.ts
@@ -90,6 +90,6 @@ g.test('validate')
     const minMaxBindingsPerBindGroup = maxBindingsPerShaderStage * maxShaderStagesPerPipeline;
     t.expect(
       maximumLimit >= minMaxBindingsPerBindGroup,
-      `maxBindingsPerBindGroup(${maximumLimit}) >= maxBindingsPerShaderStage(${maxBindingsPerShaderStage}) + maxShaderStagesPerPipeline(${maxShaderStagesPerPipeline} = (${minMaxBindingsPerBindGroup}))`
+      `maxBindingsPerBindGroup(${maximumLimit}) >= maxBindingsPerShaderStage(${maxBindingsPerShaderStage}) * maxShaderStagesPerPipeline(${maxShaderStagesPerPipeline} = (${minMaxBindingsPerBindGroup}))`
     );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindingsPerBindGroup.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindingsPerBindGroup.spec.ts
@@ -75,3 +75,21 @@ g.test('createPipelineAsync,at_over')
       }
     );
   });
+
+g.test('validate')
+  .desc(`Test ${limit} matches the spec limits`)
+  .fn(t => {
+    const { adapter, maximumLimit } = t;
+    const maxBindingsPerShaderStage =
+      adapter.limits.maxSampledTexturesPerShaderStage +
+      adapter.limits.maxSamplersPerShaderStage +
+      adapter.limits.maxStorageBuffersPerShaderStage +
+      adapter.limits.maxStorageTexturesPerShaderStage +
+      adapter.limits.maxUniformBuffersPerShaderStage;
+    const maxShaderStagesPerPipeline = 2;
+    const minMaxBindingsPerBindGroup = maxBindingsPerShaderStage * maxShaderStagesPerPipeline;
+    t.expect(
+      maximumLimit >= minMaxBindingsPerBindGroup,
+      `maxBindingsPerBindGroup(${maximumLimit}) >= maxBindingsPerShaderStage(${maxBindingsPerShaderStage}) + maxShaderStagesPerPipeline(${maxShaderStagesPerPipeline} = (${minMaxBindingsPerBindGroup}))`
+    );
+  });


### PR DESCRIPTION


Issue: #2195, #2277 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
