### PR TITLE
Implement `frexp` f32 tests

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -26,7 +26,6 @@ import {
   fullI32Range,
   hexToF32,
   hexToF64,
-  isFiniteF32,
   lerp,
   linearRange,
   nextAfterF32,

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -20,11 +20,13 @@ import {
   cartesianProduct,
   correctlyRoundedF32,
   FlushMode,
+  frexp,
   fullF16Range,
   fullF32Range,
   fullI32Range,
   hexToF32,
   hexToF64,
+  isFiniteF32,
   lerp,
   linearRange,
   nextAfterF32,
@@ -418,6 +420,46 @@ g.test('correctlyRoundedF32')
     t.expect(
       objectEquals(expected, got),
       `correctlyRoundedF32(${value}) returned [${got}]. Expected [${expected}]`
+    );
+  });
+
+interface frexpCase {
+  input: number;
+  fract: number;
+  exp: number;
+}
+
+g.test('frexp')
+  .paramsSimple<frexpCase>([
+    { input: 0, fract: 0, exp: 0 },
+    { input: -0, fract: -0, exp: 0 },
+    { input: Number.POSITIVE_INFINITY, fract: Number.POSITIVE_INFINITY, exp: 0 },
+    { input: Number.NEGATIVE_INFINITY, fract: Number.NEGATIVE_INFINITY, exp: 0 },
+    { input: 0.5, fract: 0.5, exp: 0 },
+    { input: -0.5, fract: -0.5, exp: 0 },
+    { input: 1, fract: 0.5, exp: 1 },
+    { input: -1, fract: -0.5, exp: 1 },
+    { input: 2, fract: 0.5, exp: 2 },
+    { input: -2, fract: -0.5, exp: 2 },
+    { input: 10000, fract: 0.6103515625, exp: 14 },
+    { input: -10000, fract: -0.6103515625, exp: 14 },
+    { input: kValue.f32.positive.max, fract: 0.9999999403953552, exp: 128 },
+    { input: kValue.f32.positive.min, fract: 0.5, exp: -125 },
+    { input: kValue.f32.negative.max, fract: -0.5, exp: -125 },
+    { input: kValue.f32.negative.min, fract: -0.9999999403953552, exp: 128 },
+    { input: kValue.f32.subnormal.positive.max, fract: 0.9999998807907104, exp: -126 },
+    { input: kValue.f32.subnormal.positive.min, fract: 0.5, exp: -148 },
+    { input: kValue.f32.subnormal.negative.max, fract: -0.5, exp: -148 },
+    { input: kValue.f32.subnormal.negative.min, fract: -0.9999998807907104, exp: -126 },
+  ])
+  .fn(test => {
+    const input = test.params.input;
+    const got = frexp(input);
+    const expect = { fract: test.params.fract, exp: test.params.exp };
+
+    test.expect(
+      objectEquals(got, expect),
+      `frexp(${input}) returned { fract: ${got.fract}, exp: ${got.exp} }. Expected { fract: ${expect.fract}, exp: ${expect.exp} }`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
@@ -16,7 +16,7 @@ The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf } from '../../../../../util/compare.js';
-import { f32, i32, toVector, TypeF32, TypeI32, TypeVec } from '../../../../../util/conversion';
+import { f32, i32, toVector, TypeF32, TypeI32, TypeVec } from '../../../../../util/conversion.js';
 import {
   cartesianProduct,
   frexp,
@@ -25,7 +25,7 @@ import {
   quantizeToF32,
   vectorF32Range,
 } from '../../../../../util/math.js';
-import { makeCaseCache } from '../../case_cache';
+import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, ExpressionBuilder, run } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);

--- a/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
@@ -15,18 +15,258 @@ The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { allInputSources } from '../../expression.js';
+import { anyOf } from '../../../../../util/compare.js';
+import { f32, i32, toVector, TypeF32, TypeI32, TypeVec } from '../../../../../util/conversion';
+import {
+  cartesianProduct,
+  frexp,
+  fullF32Range,
+  isSubnormalNumberF32,
+  quantizeToF32,
+  vectorF32Range,
+} from '../../../../../util/math.js';
+import { makeCaseCache } from '../../case_cache';
+import { allInputSources, Case, ExpressionBuilder, run } from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('scalar_f32')
+/* @returns an ExpressionBuilder that evaluates frexp and returns .fract from the result structure */
+function fractBuilder(): ExpressionBuilder {
+  return value => `frexp(${value}).fract`;
+}
+
+/* @returns an ExpressionBuilder that evaluates frexp and returns .exp from the result structure */
+function expBuilder(): ExpressionBuilder {
+  return value => `frexp(${value}).exp`;
+}
+
+/* @returns a fract Case for a given vector input */
+function makeVectorCaseFract(v: number[]): Case {
+  v = v.map(quantizeToF32);
+  const fs = v.map(e => {
+    const result = [frexp(e).fract];
+    if (isSubnormalNumberF32(e)) {
+      result.push(frexp(0).fract);
+    }
+    return result;
+  });
+
+  const options = cartesianProduct(...fs);
+  const expected = anyOf(...options.map(o => toVector(o, f32)));
+  return { input: toVector(v, f32), expected };
+}
+
+/* @returns an exp Case for a given vector input */
+function makeVectorCaseExp(v: number[]): Case {
+  v = v.map(quantizeToF32);
+  const fs = v.map(e => {
+    const result = [frexp(e).exp];
+    if (isSubnormalNumberF32(e)) {
+      result.push(frexp(0).exp);
+    }
+    return result;
+  });
+
+  const options = cartesianProduct(...fs);
+  const expected = anyOf(...options.map(o => toVector(o, i32)));
+  return { input: toVector(v, f32), expected };
+}
+
+export const d = makeCaseCache('frexp', {
+  f32_fract: () => {
+    const makeCase = (n: number): Case => {
+      n = quantizeToF32(n);
+      const expected = [f32(frexp(n).fract)];
+      if (isSubnormalNumberF32(n)) {
+        expected.push(f32(frexp(0).fract));
+      }
+      return { input: f32(n), expected: anyOf(...expected) };
+    };
+    return fullF32Range().map(makeCase);
+  },
+  f32_exp: () => {
+    const makeCase = (n: number): Case => {
+      n = quantizeToF32(n);
+      const expected = [i32(frexp(n).exp)];
+      if (isSubnormalNumberF32(n)) {
+        expected.push(i32(frexp(0).exp));
+      }
+      return { input: f32(n), expected: anyOf(...expected) };
+    };
+    return fullF32Range().map(makeCase);
+  },
+  f32_vec2_fract: () => {
+    return vectorF32Range(2).map(makeVectorCaseFract);
+  },
+  f32_vec2_exp: () => {
+    return vectorF32Range(2).map(makeVectorCaseExp);
+  },
+  f32_vec3_fract: () => {
+    return vectorF32Range(3).map(makeVectorCaseFract);
+  },
+  f32_vec3_exp: () => {
+    return vectorF32Range(3).map(makeVectorCaseExp);
+  },
+  f32_vec4_fract: () => {
+    return vectorF32Range(4).map(makeVectorCaseFract);
+  },
+  f32_vec4_exp: () => {
+    return vectorF32Range(4).map(makeVectorCaseExp);
+  },
+});
+
+g.test('f32_fract')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-f32 tests
+T is f32
 
 struct __frexp_result {
-  sig : f32, // significand part
+  fract : f32, // fract part
+  exp : i32  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_fract');
+    await run(t, fractBuilder(), [TypeF32], TypeF32, t.params, cases);
+  });
+
+g.test('f32_exp')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is f32
+
+struct __frexp_result {
+  fract : f32, // fract part
+  exp : i32  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_exp');
+    await run(t, expBuilder(), [TypeF32], TypeI32, t.params, cases);
+  });
+
+g.test('f32_vec2_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec2<f32>
+
+struct __frexp_result {
+  fract : vec2<f32>, // fract part
+  exp : vec2<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec2_fract');
+    await run(t, fractBuilder(), [TypeVec(2, TypeF32)], TypeVec(2, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec2_exp')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec2<f32>
+
+struct __frexp_result_vec2_f32 {
+  fract : vec2<f32>, // fractional part
+  exp : vec2<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec2_exp');
+    await run(t, expBuilder(), [TypeVec(2, TypeF32)], TypeVec(2, TypeI32), t.params, cases);
+  });
+
+g.test('f32_vec3_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec3<f32>
+
+struct __frexp_result_vec3_f32 {
+  fract : vec3<f32>, // fractional part
+  exp : vec3<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec3_fract');
+    await run(t, fractBuilder(), [TypeVec(3, TypeF32)], TypeVec(3, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec3_exp')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec3<f32>
+
+struct __frexp_result_vec3_f32 {
+  fract : vec3<f32>, // fractional part
+  exp : vec3<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec3_exp');
+    await run(t, expBuilder(), [TypeVec(3, TypeF32)], TypeVec(3, TypeI32), t.params, cases);
+  });
+
+g.test('f32_vec4_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec4<f32>
+
+struct __frexp_result_vec4_f32 {
+  fract : vec4<f32>, // fractional part
+  exp : vec4<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec4_fract');
+    await run(t, fractBuilder(), [TypeVec(4, TypeF32)], TypeVec(4, TypeF32), t.params, cases);
+  });
+
+g.test('f32_vec4_exp')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec4<f32>
+
+struct __frexp_result_vec4_f32 {
+  fract : vec4<f32>, // fractional part
+  exp : vec4<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cases = await d.get('f32_vec4_exp');
+    await run(t, expBuilder(), [TypeVec(4, TypeF32)], TypeVec(4, TypeI32), t.params, cases);
+  });
+
+g.test('f16_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is f16
+
+struct __frexp_result {
+  fract : f16, // fract part
   exp : i32  // exponent part
 }
 `
@@ -34,14 +274,14 @@ struct __frexp_result {
   .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
-g.test('scalar_f16')
+g.test('f16_exp')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-f16 tests
+T is f16
 
-struct __frexp_result_f16 {
-  sig : f16, // significand part
+struct __frexp_result {
+  fract : f16, // fract part
   exp : i32  // exponent part
 }
 `
@@ -49,32 +289,92 @@ struct __frexp_result_f16 {
   .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
-g.test('vector_f32')
+g.test('f16_vec2_fract')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-vecN<f32>
+T is vec2<f16>
 
-struct __frexp_result_vecN {
-  sig : vecN<f32>, // significand part
-  exp : vecN<i32>  // exponent part
+struct __frexp_result {
+  fract : vec2<f16>, // fract part
+  exp : vec2<i32>  // exponent part
 }
 `
   )
-  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();
 
-g.test('vector_f16')
+g.test('f16_vec2_exp')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(
     `
-vecN<f16>
+T is vec2<f16>
 
-struct __frexp_result_vecN_f16 {
-  sig : vecN<f16>, // significand part
-  exp : vecN<i32>  // exponent part
+struct __frexp_result_vec2_f16 {
+  fract : vec2<f16>, // fractional part
+  exp : vec2<i32>  // exponent part
 }
 `
   )
-  .params(u => u.combine('inputSource', allInputSources).combine('vectorize', [2, 3, 4] as const))
+  .params(u => u.combine('inputSource', allInputSources))
+  .unimplemented();
+
+g.test('f16_vec3_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec3<f16>
+
+struct __frexp_result_vec3_f16 {
+  fract : vec3<f16>, // fractional part
+  exp : vec3<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .unimplemented();
+
+g.test('f16_vec3_exp')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec3<f16>
+
+struct __frexp_result_vec3_f16 {
+  fract : vec3<f16>, // fractional part
+  exp : vec3<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .unimplemented();
+
+g.test('f16_vec4_fract')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec4<f16>
+
+struct __frexp_result_vec4_f16 {
+  fract : vec4<f16>, // fractional part
+  exp : vec4<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .unimplemented();
+
+g.test('f16_vec4_exp')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(
+    `
+T is vec4<f16>
+
+struct __frexp_result_vec4_f16 {
+  fract : vec4<f16>, // fractional part
+  exp : vec4<i32>  // exponent part
+}
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources))
   .unimplemented();

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -46,7 +46,7 @@ function makeVectorCaseFract(v: number[]): Case {
   return { input: toVector(v, f32), expected: fs };
 }
 
-/* @returns a fract Case for a given vector input */
+/* @returns a whole Case for a given vector input */
 function makeVectorCaseWhole(v: number[]): Case {
   v = v.map(quantizeToF32);
   const ws = v.map(e => {


### PR DESCRIPTION
Fixes #1982
Fixes #1210
Fixes #1208

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
