### PR TITLE
Require npm >=8.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,8 @@
         "typescript": "~4.7.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
+        "npm": ">=8.5.2"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dev": "node tools/dev_server"
   },
   "engines": {
-    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
+    "npm" : ">=8.5.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prior to this version, the @webgpu/types dependency-by-revision (#2332) won't work because the integrity hash is system-dependent. Starting with 8.5.2, integrity checks are skipped for git dependencies (though integrity hashes are still generated, despite the comment in the thread). See:
https://github.com/npm/cli/issues/2846#issuecomment-1055916073

If your npm version isn't high enough, it should generate a warning (just warning, not hard error) every time you run `npm install` or `npm ci`.