### PR TITLE
Fix writable binding aliasing in webgpu:api,validation,resource_usages,texture,in_pass_encoder

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -234,15 +234,23 @@ g.test('subresources_and_binding_types_combination_for_color')
   .params(u =>
     u
       .combine('compute', [false, true])
-      .combineWithParams([
-        { _usageOK: true, type0: 'sampled-texture', type1: 'sampled-texture' },
-        { _usageOK: false, type0: 'sampled-texture', type1: 'writeonly-storage-texture' },
-        { _usageOK: false, type0: 'sampled-texture', type1: 'render-target' },
-        // Race condition upon multiple writable storage texture is valid.
-        { _usageOK: true, type0: 'writeonly-storage-texture', type1: 'writeonly-storage-texture' },
-        { _usageOK: false, type0: 'writeonly-storage-texture', type1: 'render-target' },
-        { _usageOK: false, type0: 'render-target', type1: 'render-target' },
-      ] as const)
+      .expandWithParams(
+        p =>
+          [
+            { _usageOK: true, type0: 'sampled-texture', type1: 'sampled-texture' },
+            { _usageOK: false, type0: 'sampled-texture', type1: 'writeonly-storage-texture' },
+            { _usageOK: false, type0: 'sampled-texture', type1: 'render-target' },
+            // Race condition upon multiple writable storage texture is valid.
+            // For p.compute === true, fails at pass.dispatch because aliasing exists.
+            {
+              _usageOK: !p.compute,
+              type0: 'writeonly-storage-texture',
+              type1: 'writeonly-storage-texture',
+            },
+            { _usageOK: false, type0: 'writeonly-storage-texture', type1: 'render-target' },
+            { _usageOK: false, type0: 'render-target', type1: 'render-target' },
+          ] as const
+      )
       .beginSubcases()
       .combine('binding0InBundle', [false, true])
       .combine('binding1InBundle', [false, true])


### PR DESCRIPTION


Issue: https://github.com/gpuweb/cts/issues/2232

Related dawn issue: https://bugs.chromium.org/p/dawn/issues/detail?id=1642

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
