### PR TITLE
Changes for depthWriteEnabled/depthCompare/depthClearValue being required

### DIFF
--- a/src/stress/render/render_pass.spec.ts
+++ b/src/stress/render/render_pass.spec.ts
@@ -126,7 +126,8 @@ pass does a single draw call, with one pass per output fragment.`
         primitive: { topology: 'point-list' },
         depthStencil: {
           format: 'depth24plus-stencil8',
-
+          depthCompare: 'always',
+          depthWriteEnabled: false,
           // Not really used, but it ensures that each pipeline is unique.
           depthBias: i,
         },

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -854,6 +854,8 @@ class ImageCopyTest extends GPUTest {
       },
 
       depthStencil: {
+        depthWriteEnabled: false,
+        depthCompare: 'always',
         format: stencilTextureFormat,
         stencilFront: {
           compare: 'equal',

--- a/src/webgpu/api/operation/render_pass/clear_value.spec.ts
+++ b/src/webgpu/api/operation/render_pass/clear_value.spec.ts
@@ -110,6 +110,7 @@ g.test('stencil_clear_value')
       depthStencil: {
         format: stencilFormat,
         depthCompare: 'always',
+        depthWriteEnabled: false,
         stencilFront: {
           compare: 'equal',
         },

--- a/src/webgpu/api/operation/render_pass/clear_value.spec.ts
+++ b/src/webgpu/api/operation/render_pass/clear_value.spec.ts
@@ -139,6 +139,7 @@ g.test('stencil_clear_value')
 
     const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
       view: stencilTexture.createView(),
+      depthClearValue: 0,
       stencilLoadOp: 'clear',
       stencilStoreOp: 'store',
       stencilClearValue,

--- a/src/webgpu/api/operation/rendering/depth.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth.spec.ts
@@ -147,7 +147,11 @@ g.test('depth_disabled')
   .desc('Tests render results with depth test disabled.')
   .fn(t => {
     const depthSpencilFormat: GPUTextureFormat = 'depth24plus-stencil8';
-    const state = { format: depthSpencilFormat };
+    const state = {
+      format: depthSpencilFormat,
+      depthWriteEnabled: false,
+      depthCompare: 'always' as GPUCompareFunction,
+    };
 
     const testStates = [
       { state, color: kBaseColor, depth: 0.0 },

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -177,7 +177,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
         topology: 'point-list',
         unclippedDepth,
       },
-      depthStencil: { format, depthWriteEnabled: true },
+      depthStencil: { format, depthWriteEnabled: true, depthCompare: 'always' },
       multisample: multisampled ? { count: 4 } : undefined,
       fragment: {
         module,
@@ -426,7 +426,7 @@ to be empty.`
       layout: 'auto',
       vertex: { module, entryPoint: 'vmain' },
       primitive: { topology: 'point-list' },
-      depthStencil: { format, depthWriteEnabled: true },
+      depthStencil: { format, depthWriteEnabled: true, depthCompare: 'always' },
       multisample: multisampled ? { count: 4 } : undefined,
       fragment: { module, entryPoint: 'finit', targets: [] },
     });
@@ -440,7 +440,7 @@ to be empty.`
         topology: 'point-list',
         unclippedDepth,
       },
-      depthStencil: { format, depthCompare: 'not-equal' },
+      depthStencil: { format, depthCompare: 'not-equal', depthWriteEnabled: false },
       multisample: multisampled ? { count: 4 } : undefined,
       fragment: { module, entryPoint: 'ftest', targets: [{ format: 'r8unorm' }] },
     });

--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -555,12 +555,16 @@ g.test('stencil_reference_initialized')
 
     const baseState = {
       format,
+      depthWriteEnabled: true,
+      depthCompare: 'always',
       stencilFront: baseStencilState,
       stencilBack: baseStencilState,
     } as const;
 
     const testState = {
       format,
+      depthWriteEnabled: true,
+      depthCompare: 'always',
       stencilFront: testStencilState,
       stencilBack: testStencilState,
     } as const;

--- a/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_ds_test.ts
@@ -55,6 +55,7 @@ function getDepthTestEqualPipeline(
     depthStencil: {
       format,
       depthCompare: 'equal',
+      depthWriteEnabled: false,
     },
     primitive: { topology: 'triangle-list' },
     multisample: { count: sampleCount },
@@ -85,6 +86,8 @@ function getStencilTestEqualPipeline(
       targets: [{ format: 'r8unorm' }],
     },
     depthStencil: {
+      depthWriteEnabled: false,
+      depthCompare: 'always',
       format,
       stencilFront: { compare: 'equal' },
       stencilBack: { compare: 'equal' },

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -359,6 +359,8 @@ g.test('depth_stencil_state')
         },
         depthStencil: {
           format,
+          depthCompare: 'always',
+          depthWriteEnabled: false,
         },
         fragment: {
           module: t.device.createShaderModule({

--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -465,7 +465,9 @@ Test that the depth attachment format in render passes or bundles match the pipe
 
     const pipeline = t.createRenderPipeline(
       [{ format: 'rgba8unorm', writeMask: 0 }],
-      pipelineFormat !== undefined ? { format: pipelineFormat } : undefined
+      pipelineFormat !== undefined
+        ? { format: pipelineFormat, depthCompare: 'always', depthWriteEnabled: false }
+        : undefined
     );
 
     const { encoder, validateFinishAndSubmit } = t.createEncoder(encoderType, {
@@ -551,6 +553,7 @@ Test that the depth stencil read only state in render passes or bundles is compa
         : {
             format,
             depthWriteEnabled,
+            depthCompare: 'always',
             stencilWriteMask,
             stencilFront,
             stencilBack,
@@ -627,7 +630,9 @@ Test that the sample count in render passes or bundles match the pipeline sample
 
     const pipeline = t.createRenderPipeline(
       colorFormats.map(format => ({ format, writeMask: 0 })),
-      depthStencilFormat ? { format: depthStencilFormat } : undefined,
+      depthStencilFormat
+        ? { format: depthStencilFormat, depthWriteEnabled: false, depthCompare: 'always' }
+        : undefined,
       pipelineSampleCount
     );
 

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -862,6 +862,7 @@ g.test('depth_stencil_attachment')
       view: t.createTexture({ format }).createView(),
       depthReadOnly,
       stencilReadOnly,
+      depthClearValue: 0,
     };
 
     if (setDepthLoadStoreOp) {

--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -29,7 +29,9 @@ g.test('format')
     const { isAsync, format } = t.params;
     const info = kTextureFormatInfo[format];
 
-    const descriptor = t.getDescriptor({ depthStencil: { format } });
+    const descriptor = t.getDescriptor({
+      depthStencil: { format, depthWriteEnabled: false, depthCompare: 'always' },
+    });
 
     t.doCreateRenderPipelineTest(isAsync, info.depth || info.stencil, descriptor);
   });
@@ -42,7 +44,7 @@ g.test('depth_test')
     u
       .combine('isAsync', [false, true])
       .combine('format', kDepthStencilFormats)
-      .combine('depthCompare', [undefined, ...kCompareFunctions])
+      .combine('depthCompare', kCompareFunctions)
   )
   .beforeAllSubcases(t => {
     const { format } = t.params;
@@ -54,7 +56,7 @@ g.test('depth_test')
     const info = kTextureFormatInfo[format];
 
     const descriptor = t.getDescriptor({
-      depthStencil: { format, depthCompare },
+      depthStencil: { format, depthCompare, depthWriteEnabled: false },
     });
 
     const depthTestEnabled = depthCompare !== undefined && depthCompare !== 'always';
@@ -81,7 +83,7 @@ g.test('depth_write')
     const info = kTextureFormatInfo[format];
 
     const descriptor = t.getDescriptor({
-      depthStencil: { format, depthWriteEnabled },
+      depthStencil: { format, depthWriteEnabled, depthCompare: 'always' },
     });
     t.doCreateRenderPipelineTest(isAsync, !depthWriteEnabled || info.depth, descriptor);
   });
@@ -104,7 +106,9 @@ g.test('depth_write,frag_depth')
     const descriptor = t.getDescriptor({
       // Keep one color target so that the pipeline is still valid with no depth stencil target.
       targets: [{ format: 'rgba8unorm' }],
-      depthStencil: format ? { format, depthWriteEnabled: true } : undefined,
+      depthStencil: format
+        ? { format, depthWriteEnabled: true, depthCompare: 'always' }
+        : undefined,
       fragmentShaderCode: getFragmentShaderCodeWithOutput(
         [{ values: [1, 1, 1, 1], plainType: 'f32', componentCount: 4 }],
         { value: 0.5 }
@@ -137,9 +141,23 @@ g.test('stencil_test')
 
     let descriptor: GPURenderPipelineDescriptor;
     if (face === 'front') {
-      descriptor = t.getDescriptor({ depthStencil: { format, stencilFront: { compare } } });
+      descriptor = t.getDescriptor({
+        depthStencil: {
+          format,
+          depthWriteEnabled: false,
+          depthCompare: 'always',
+          stencilFront: { compare },
+        },
+      });
     } else {
-      descriptor = t.getDescriptor({ depthStencil: { format, stencilBack: { compare } } });
+      descriptor = t.getDescriptor({
+        depthStencil: {
+          format,
+          depthWriteEnabled: false,
+          depthCompare: 'always',
+          stencilBack: { compare },
+        },
+      });
     }
 
     const stencilTestEnabled = compare !== undefined && compare !== 'always';
@@ -173,25 +191,30 @@ g.test('stencil_write')
     const { isAsync, format, faceAndOpType, op } = t.params;
     const info = kTextureFormatInfo[format];
 
+    const common = {
+      format,
+      depthWriteEnabled: false,
+      depthCompare: 'always' as GPUCompareFunction,
+    };
     let depthStencil: GPUDepthStencilState;
     switch (faceAndOpType) {
       case 'frontFailOp':
-        depthStencil = { format, stencilFront: { failOp: op } };
+        depthStencil = { ...common, stencilFront: { failOp: op } };
         break;
       case 'frontDepthFailOp':
-        depthStencil = { format, stencilFront: { depthFailOp: op } };
+        depthStencil = { ...common, stencilFront: { depthFailOp: op } };
         break;
       case 'frontPassOp':
-        depthStencil = { format, stencilFront: { passOp: op } };
+        depthStencil = { ...common, stencilFront: { passOp: op } };
         break;
       case 'backFailOp':
-        depthStencil = { format, stencilBack: { failOp: op } };
+        depthStencil = { ...common, stencilBack: { failOp: op } };
         break;
       case 'backDepthFailOp':
-        depthStencil = { format, stencilBack: { depthFailOp: op } };
+        depthStencil = { ...common, stencilBack: { depthFailOp: op } };
         break;
       case 'backPassOp':
-        depthStencil = { format, stencilBack: { passOp: op } };
+        depthStencil = { ...common, stencilBack: { passOp: op } };
         break;
       default:
         unreachable();

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -302,7 +302,7 @@ g.test('pipeline_output_targets')
     const descriptor = t.getDescriptor({
       targets: format ? [{ format, writeMask }] : [],
       // To have a dummy depthStencil attachment to avoid having no attachment at all which is invalid
-      depthStencil: { format: 'depth24plus' },
+      depthStencil: { format: 'depth24plus', depthWriteEnabled: false, depthCompare: 'always' },
       fragmentShaderCode: getFragmentShaderCodeWithOutput(
         shaderOutput
           ? [{ values, plainType: shaderOutput.scalar, componentCount: shaderOutput.count }]

--- a/src/webgpu/api/validation/render_pipeline/misc.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/misc.spec.ts
@@ -43,7 +43,11 @@ state (and thus has no color state), and can be created with or without depth st
     if (depthStencilFormat === '') {
       depthStencilState = undefined;
     } else {
-      depthStencilState = { format: depthStencilFormat };
+      depthStencilState = {
+        format: depthStencilFormat,
+        depthWriteEnabled: false,
+        depthCompare: 'always',
+      };
     }
 
     // Having targets or not should have no effect in result, since it will not appear in the


### PR DESCRIPTION
This work was done by @greggman, I just cherry-picked his commits into a PR.

Issue: https://github.com/gpuweb/gpuweb/pull/3849

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
