### PR TITLE
Implement absolute error for `asin` intervals

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -691,6 +691,7 @@ g.test('acosInterval')
       { input: -1/2, expected: [hexToF32(0x4005fa91), hexToF32(0x40061a94)] },  // ~2π/3
       { input: 0, expected: kAny },
       { input: 1/2, expected: [hexToF32(0x3f85fa8f), hexToF32(0x3f861a94)] },  // ~π/3
+      { input: 1, expected: kAny },
       { input: kValue.f32.positive.max, expected: kAny },
       { input: kValue.f32.infinity.positive, expected: kAny },
     ]
@@ -764,16 +765,22 @@ g.test('asinInterval')
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
-      // form due to the inherited nature of the errors.
+      // form due to the irrational nature of the values.
       //
-      // The acceptance interval @ x = -1 and 1 is kAny, because sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inversqrt
+      // The acceptance interval @ x = -1 and 1 is kAny, because sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms
+      // of inversqrt.
       // The acceptance interval @ x = 0 is kAny, because atan2 is not well defined/implemented at 0.
+      // Near 0, but not subnormal the absolute error should be larger, so will be +/- 6.77e-5, away from 0 the atan2
+      // inherited error should be larger.
       { input: kValue.f32.infinity.negative, expected: kAny },
       { input: kValue.f32.negative.min, expected: kAny },
       { input: -1, expected: kAny },
-      { input: -1/2, expected: [hexToF32(0xbf061a96), hexToF32(0xbf05fa8e)] },  // ~-π/6
+      { input: -1/2, expected: [hexToF64(0xbfe0c352, 0xc0000000), hexToF64(0xbfe0bf51, 0xc0000000)] },  // ~-π/6
+      { input: kValue.f32.negative.max, expected: [-6.77e-5, 6.77e-5] },  // ~0
       { input: 0, expected: kAny },
-      { input: 1/2, expected: [hexToF32(0x3f05fa8e), hexToF32(0x3f061a96)] },  // ~π/6
+      { input: kValue.f32.positive.min, expected: [-6.77e-5, 6.77e-5] },  // ~0
+      { input: 1/2, expected: [hexToF64(0x3fe0bf51, 0xc0000000), hexToF64(0x3fe0c352, 0xc0000000)] },  // ~π/6
+      { input: 1, expected: kAny },  // ~π/2
       { input: kValue.f32.positive.max, expected: kAny },
       { input: kValue.f32.infinity.positive, expected: kAny },
     ]

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -764,8 +764,8 @@ g.test('asinInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
-      // form due to the irrational nature of the values.
+      // Some of these are hard coded, since the error intervals are difficult to express in a simple human readable
+      // form due to the complexity of their derivation.
       //
       // The acceptance interval @ x = -1 and 1 is kAny, because sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms
       // of inversqrt.

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1407,9 +1407,9 @@ export function additionMatrixInterval(x: Matrix<number>, y: Matrix<number>): F3
 
 const AsinIntervalOp: PointToIntervalOp = {
   impl: limitPointToIntervalDomain(toF32Interval([-1.0, 1.0]), (n: number) => {
-    // asin(n) = atan2(n, sqrt(1.0 - n * n))
+    // asin(n) = atan2(n, sqrt(1.0 - n * n)) or a polynomial approximation with absolute error
     const x = sqrtInterval(subtractionInterval(1, multiplicationInterval(n, n)));
-    return atan2Interval(n, x);
+    return F32Interval.span(atan2Interval(n, x), absoluteErrorInterval(Math.asin(n), 6.77e-5));
   }),
 };
 


### PR DESCRIPTION
Fixes #2345

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
