### PR TITLE
Add validation tests on BGRA8Unorm canvas with StorageBinding usage

### DIFF
--- a/src/webgpu/api/validation/texture/bgra8unorm_storage.spec.ts
+++ b/src/webgpu/api/validation/texture/bgra8unorm_storage.spec.ts
@@ -115,8 +115,8 @@ if the feature bgra8unorm-storage is not enabled.
 g.test('configure_storage_usage_on_canvas_context_without_bgra8unorm_storage')
   .desc(
     `
-Test that it is invalid to configure a GPUCanvasContext with GPUStorageBinding usage and a GPUDevice
-without 'bgra8unorm-storage' enabled.
+Test that it is invalid to configure a GPUCanvasContext to 'GPUStorageBinding' usage with
+'bgra8unorm' format on a GPUDevice with 'bgra8unorm-storage' disabled.
 `
   )
   .params(u =>
@@ -139,14 +139,14 @@ without 'bgra8unorm-storage' enabled.
     const ctx = canvas.getContext('webgpu');
     assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
-    const incompatible = usage & GPUTextureUsage.STORAGE_BINDING;
+    const requiredStorageBinding = !!(usage & GPUTextureUsage.STORAGE_BINDING);
     t.expectValidationError(() => {
       ctx.configure({
         device: t.device,
         format: 'bgra8unorm',
         usage,
       });
-    }, !!incompatible);
+    }, requiredStorageBinding);
   });
 
 g.test('configure_storage_usage_on_canvas_context_with_bgra8unorm_storage')

--- a/src/webgpu/api/validation/texture/bgra8unorm_storage.spec.ts
+++ b/src/webgpu/api/validation/texture/bgra8unorm_storage.spec.ts
@@ -139,14 +139,14 @@ without 'bgra8unorm-storage' enabled.
     const ctx = canvas.getContext('webgpu');
     assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
-    const compatible = usage & GPUTextureUsage.STORAGE_BINDING;
+    const incompatible = usage & GPUTextureUsage.STORAGE_BINDING;
     t.expectValidationError(() => {
       ctx.configure({
         device: t.device,
         format: 'bgra8unorm',
         usage,
       });
-    }, !!compatible);
+    }, !!incompatible);
   });
 
 g.test('configure_storage_usage_on_canvas_context_with_bgra8unorm_storage')

--- a/src/webgpu/api/validation/texture/bgra8unorm_storage.spec.ts
+++ b/src/webgpu/api/validation/texture/bgra8unorm_storage.spec.ts
@@ -3,7 +3,10 @@ Tests for capabilities added by bgra8unorm-storage flag.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { assert } from '../../../../common/util/util.js';
+import { kTextureUsages } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
+import { kAllCanvasTypes, createCanvas } from '../../../util/create_elements.js';
 import { ValidationTest } from '../validation_test.js';
 
 class BGRA8UnormStorageValidationTests extends ValidationTest {
@@ -107,4 +110,96 @@ if the feature bgra8unorm-storage is not enabled.
     const { shaderType } = t.params;
 
     t.testCreateShaderModuleWithBGRA8UnormStorage(shaderType, false);
+  });
+
+g.test('configure_storage_usage_on_canvas_context_without_bgra8unorm_storage')
+  .desc(
+    `
+Test that it is invalid to configure a GPUCanvasContext with GPUStorageBinding usage and a GPUDevice
+without 'bgra8unorm-storage' enabled.
+`
+  )
+  .params(u =>
+    u
+      .combine('canvasType', kAllCanvasTypes)
+      .beginSubcases()
+      .expand('usage', p => {
+        const usageSet = new Set<number>();
+        for (const usage0 of kTextureUsages) {
+          for (const usage1 of kTextureUsages) {
+            usageSet.add(usage0 | usage1);
+          }
+        }
+        return usageSet;
+      })
+  )
+  .fn(t => {
+    const { canvasType, usage } = t.params;
+    const canvas = createCanvas(t, canvasType, 1, 1);
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
+
+    const compatible = usage & GPUTextureUsage.STORAGE_BINDING;
+    t.expectValidationError(() => {
+      ctx.configure({
+        device: t.device,
+        format: 'bgra8unorm',
+        usage,
+      });
+    }, !!compatible);
+  });
+
+g.test('configure_storage_usage_on_canvas_context_with_bgra8unorm_storage')
+  .desc(
+    `
+Test that it is valid to configure a GPUCanvasContext with GPUStorageBinding usage and a GPUDevice
+with 'bgra8unorm-storage' enabled.
+`
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('bgra8unorm-storage');
+  })
+  .params(u =>
+    u
+      .combine('canvasType', kAllCanvasTypes)
+      .beginSubcases()
+      .expand('usage', p => {
+        const usageSet = new Set<number>();
+        for (const usage of kTextureUsages) {
+          usageSet.add(usage | GPUConst.TextureUsage.STORAGE_BINDING);
+        }
+        return usageSet;
+      })
+  )
+  .fn(t => {
+    const { canvasType, usage } = t.params;
+    const canvas = createCanvas(t, canvasType, 1, 1);
+    const ctx = canvas.getContext('webgpu');
+    assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
+
+    ctx.configure({
+      device: t.device,
+      format: 'bgra8unorm',
+      usage,
+    });
+
+    const currentTexture = ctx.getCurrentTexture();
+    const bindGroupLayout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          storageTexture: { access: 'write-only', format: currentTexture.format },
+        },
+      ],
+    });
+    t.device.createBindGroup({
+      layout: bindGroupLayout,
+      entries: [
+        {
+          binding: 0,
+          resource: currentTexture.createView(),
+        },
+      ],
+    });
   });


### PR DESCRIPTION
This patch adds the validation tests about configuring an BGRA8Unorm canvas with StorageBinding usage.




Issue: #2274 

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
