### PR TITLE
Test import GPUExternalTexture from destroyed device

### DIFF
--- a/src/webgpu/api/validation/gpu_external_texture_expiration.spec.ts
+++ b/src/webgpu/api/validation/gpu_external_texture_expiration.spec.ts
@@ -322,3 +322,42 @@ g.test('import_from_different_video_frame')
       t.submitCommandBuffer(bindGroup, true);
     });
   });
+
+g.test('device_destroyed_before_importing_video_frame')
+  .desc(
+    `
+    Tests that imported GPUExternalTexture from destroyed device and submit
+    it should result in an error.
+    `
+  )
+  .params(u =>
+    u //
+      .combine('sourceType', ['VideoElement', 'VideoFrame'] as const)
+  )
+  .fn(async t => {
+    const sourceType = t.params.sourceType;
+    const videoElement = t.getDefaultVideoElementAndCheck();
+
+    let bindGroup: GPUBindGroup;
+    let externalTexture: GPUExternalTexture;
+    let source: HTMLVideoElement | VideoFrame;
+    await startPlayingAndWaitForVideo(videoElement, async () => {
+      source =
+        sourceType === 'VideoFrame'
+          ? await getVideoFrameFromVideoElement(t, videoElement)
+          : videoElement;
+
+      t.device.destroy();
+      externalTexture = t.device.importExternalTexture({
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        source: source as any,
+      });
+
+      bindGroup = t.device.createBindGroup({
+        layout: t.getDefaultBindGroupLayout(),
+        entries: [{ binding: 0, resource: externalTexture }],
+      });
+
+      t.submitCommandBuffer(bindGroup, false);
+    });
+  });


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
