### PR TITLE
Implement absolute error for `acos` intervals

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -681,16 +681,19 @@ g.test('acosInterval')
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult to express in a closed human readable
-      // form due to the inherited nature of the errors.
+      // form due to the complexity of their derivation.
       //
       // The acceptance interval @ x = -1 and 1 is kAny, because sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inverseqrt
       // The acceptance interval @ x = 0 is kAny, because atan2 is not well defined/implemented at 0.
+      // Near 1, the absolute error should be larger and, away from 1 the atan2
+      // inherited error should be larger.
       { input: kValue.f32.infinity.negative, expected: kAny },
       { input: kValue.f32.negative.min, expected: kAny },
       { input: -1, expected: kAny },
       { input: -1/2, expected: [hexToF32(0x4005fa91), hexToF32(0x40061a94)] },  // ~2π/3
       { input: 0, expected: kAny },
       { input: 1/2, expected: [hexToF32(0x3f85fa8f), hexToF32(0x3f861a94)] },  // ~π/3
+      { input: minusOneULP(1), expected: [hexToF64(0x3f2ffdff, 0x60000000), hexToF64(0x3f3b106f, 0xc9334fb9)] },  // ~0.0003
       { input: 1, expected: kAny },
       { input: kValue.f32.positive.max, expected: kAny },
       { input: kValue.f32.infinity.positive, expected: kAny },

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1346,9 +1346,9 @@ export function absInterval(n: number): F32Interval {
 
 const AcosIntervalOp: PointToIntervalOp = {
   impl: limitPointToIntervalDomain(toF32Interval([-1.0, 1.0]), (n: number) => {
-    // acos(n) = atan2(sqrt(1.0 - n * n), n)
+    // acos(n) = atan2(sqrt(1.0 - n * n), n) or a polynomial approximation with absolute error
     const y = sqrtInterval(subtractionInterval(1, multiplicationInterval(n, n)));
-    return atan2Interval(y, n);
+    return F32Interval.span(atan2Interval(y, n), absoluteErrorInterval(Math.acos(n), 6.77e-5));
   }),
 };
 


### PR DESCRIPTION
Fixes #2371

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
