### PR TITLE
shader/execution:  Add more complex flow control tests

### DIFF
--- a/src/webgpu/shader/execution/flow_control/for.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/for.spec.ts
@@ -87,7 +87,36 @@ fn initializer() -> i32 {
   ${f.expect_order(1)}
   return ${f.value(0)};
 }
-      `,
+`,
+    }));
+  });
+
+g.test('for_complex_initalizer')
+  .desc('Test flow control for a complex for-loop initializer')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  ${f.expect_order(0)}
+  for (var i = initializer(max(a(), b())); i < ${f.value(5)}; i++) {
+    ${f.expect_order(4, 5, 6)}
+  }
+  ${f.expect_order(7)}
+`,
+      extra: `
+fn a() -> i32 {
+  ${f.expect_order(1)}
+  return ${f.value(1)};
+}
+fn b() -> i32 {
+  ${f.expect_order(2)}
+  return ${f.value(2)};
+}
+fn initializer(v : i32) -> i32 {
+  ${f.expect_order(3)}
+  return v;
+}
+`,
     }));
   });
 
@@ -108,7 +137,36 @@ fn condition(i : i32) -> bool {
   ${f.expect_order(1, 3, 5, 7)}
   return i < ${f.value(3)};
 }
-      `,
+`,
+    }));
+  });
+
+g.test('for_complex_condition')
+  .desc('Test flow control for a for-loop condition')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; condition(i, a() * b()); i++) {
+    ${f.expect_order(4, 8)}
+  }
+  ${f.expect_order(12)}
+`,
+      extra: `
+fn a() -> i32 {
+  ${f.expect_order(1, 5, 9)}
+  return ${f.value(1)};
+}
+fn b() -> i32 {
+  ${f.expect_order(2, 6, 10)}
+  return ${f.value(2)};
+}
+fn condition(i : i32, j : i32) -> bool {
+  ${f.expect_order(3, 7, 11)}
+  return i < j;
+}
+`,
     }));
   });
 
@@ -129,6 +187,85 @@ fn cont(i : i32) -> i32 {
   ${f.expect_order(2, 4, 6)}
   return i + 1;
 }
-      `,
+`,
     }));
+  });
+
+g.test('for_complex_continuing')
+  .desc('Test flow control for a for-loop continuing statement')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; i < ${f.value(3)}; i += cont(a(), b())) {
+    ${f.expect_order(1, 5, 9)}
+  }
+  ${f.expect_order(13)}
+`,
+      extra: `
+fn a() -> i32 {
+  ${f.expect_order(2, 6, 10)}
+  return ${f.value(1)};
+}
+fn b() -> i32 {
+  ${f.expect_order(3, 7, 11)}
+  return ${f.value(2)};
+}
+fn cont(i : i32, j : i32) -> i32 {
+  ${f.expect_order(4, 8, 12)}
+  return j >> u32(i);
+}
+`,
+    }));
+  });
+
+g.test('nested_for_break')
+  .desc('Test flow control for a for-loop break statement in an outer for-loop')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; i < ${f.value(2)}; i++) {
+    ${f.expect_order(1, 5)}
+    for (var i = ${f.value(5)}; i < ${f.value(7)}; i++) {
+      ${f.expect_order(2, 4, 6, 8)}
+      if (i == ${f.value(6)}) {
+        break;
+        ${f.expect_not_reached()}
+      }
+      ${f.expect_order(3, 7)}
+    }
+  }
+  ${f.expect_order(9)}
+`
+    );
+  });
+
+g.test('nested_for_continue')
+  .desc('Test flow control for a for-loop continue statement in an outer for-loop')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; i < ${f.value(2)}; i++) {
+    ${f.expect_order(1, 5)}
+    for (var i = ${f.value(5)}; i < ${f.value(7)}; i++) {
+      ${f.expect_order(2, 3, 6, 7)}
+      if (i == ${f.value(5)}) {
+        continue;
+        ${f.expect_not_reached()}
+      }
+      ${f.expect_order(4, 8)}
+    }
+  }
+  ${f.expect_order(9)}
+`
+    );
   });

--- a/src/webgpu/shader/execution/flow_control/if.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/if.spec.ts
@@ -70,3 +70,33 @@ g.test('else_if')
 `
     );
   });
+
+g.test('nested_if_else')
+  .desc('Test flow control for nested if-else statements')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+${f.expect_order(0)}
+if (${f.value(true)}) {
+  ${f.expect_order(1)}
+  if (${f.value(false)}) {
+    ${f.expect_not_reached()}
+  } else {
+    ${f.expect_order(2)}
+    if (${f.value(true)}) {
+      ${f.expect_order(3)}
+    } else {
+      ${f.expect_not_reached()}
+    }
+    ${f.expect_order(4)}
+  }
+  ${f.expect_order(5)}
+} else {
+  ${f.expect_not_reached()}
+}
+${f.expect_order(6)}
+`
+    );
+  });

--- a/src/webgpu/shader/execution/flow_control/loop.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/loop.spec.ts
@@ -83,3 +83,43 @@ g.test('loop_continuing_basic')
 `
     );
   });
+
+g.test('nested_loops')
+  .desc('Test flow control for a loop nested in another loop')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  var i = ${f.value(0)};
+  loop {
+    ${f.expect_order(1, 11, 21)}
+    if i == ${f.value(6)} {
+      ${f.expect_order(22)}
+      break;
+      ${f.expect_not_reached()}
+    }
+    ${f.expect_order(2, 12)}
+    loop {
+      i++;
+      ${f.expect_order(3, 6, 9, 13, 16, 19)}
+      if (i % ${f.value(3)}) == 0 {
+        ${f.expect_order(10, 20)}
+        break;
+        ${f.expect_not_reached()}
+      }
+      ${f.expect_order(4, 7, 14, 17)}
+      if (i & ${f.value(1)}) == 0 {
+        ${f.expect_order(8, 15)}
+        continue;
+        ${f.expect_not_reached()}
+      }
+      ${f.expect_order(5, 18)}
+    }
+  }
+  ${f.expect_order(23)}
+`
+    );
+  });

--- a/src/webgpu/shader/execution/flow_control/switch.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/switch.spec.ts
@@ -90,9 +90,21 @@ g.test('switch_multiple_case_default')
     }
   }
   ${f.expect_order(2)}
+  switch (${f.value(1)}) {
+    case 0, 1: {
+      ${f.expect_order(3)}
+      break;
+    }
+    case 2, 3, default: {
+      ${f.expect_not_reached()}
+      break;
+    }
+  }
+  ${f.expect_order(4)}
 `
     );
   });
+
 g.test('switch_default')
   .desc('Test that flow control executes the switch default block')
   .params(u => u.combine('preventValueOptimizations', [true, false]))

--- a/src/webgpu/shader/execution/flow_control/while.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/while.spec.ts
@@ -76,3 +76,65 @@ g.test('while_continue')
 `
     );
   });
+
+g.test('while_nested_break')
+  .desc('Test that flow control exits a nested while-loop when reaching a break statement')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  var i = ${f.value(0)};
+  while (i < ${f.value(3)}) {
+    ${f.expect_order(1, 5, 11)}
+    i++;
+    var j = ${f.value(0)};
+    while (j < i) {
+      ${f.expect_order(2, 6, 8, 12)}
+      j++;
+      if ((i+j) & 2) == 0 {
+        ${f.expect_order(9, 13)}
+        break;
+        ${f.expect_not_reached()}
+      }
+      ${f.expect_order(3, 7)}
+    }
+    ${f.expect_order(4, 10, 14)}
+  }
+  ${f.expect_order(15)}
+`
+    );
+  });
+
+g.test('while_nested_continue')
+  .desc('Test flow control for a nested while-loop with a continue statement')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  var i = ${f.value(0)};
+  while (i < ${f.value(3)}) {
+    ${f.expect_order(1, 5, 11)}
+    i++;
+    var j = ${f.value(0)};
+    while (j < i) {
+      ${f.expect_order(2, 6, 8, 12, 14, 16)}
+      j++;
+      if ((i+j) & 2) == 0 {
+        ${f.expect_order(9, 13, 15)}
+        continue;
+        ${f.expect_not_reached()}
+      }
+      ${f.expect_order(3, 7, 17)}
+    }
+    ${f.expect_order(4, 10, 18)}
+  }
+  ${f.expect_order(19)}
+`
+    );
+  });


### PR DESCRIPTION


Issue: #2312

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
