### PR TITLE
Get current texture expiry

### DIFF
--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -292,7 +292,6 @@ Test automatic WebGPU canvas texture expiry on all canvas types with the followi
   as soon as possible after HTML update the rendering.
 
 TODO: test more canvas types, and ways to update the rendering
-- if on the same thread, expiry happens when the document updates its rendering (window "rPAF") OR transferToImageBitmap is called
 - if on a different thread, expiry happens when the worker updates its rendering (worker "rPAF") OR transferToImageBitmap is called
 - [draw, transferControlToOffscreen, then canvas is displayed] on either {main thread, or transferred to worker}
 - [draw, canvas is displayed, then transferControlToOffscreen] on either {main thread, or transferred to worker}

--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -4,6 +4,7 @@ Tests for GPUCanvasContext.getCurrentTexture.
 
 import { SkipTestCase } from '../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { timeout } from '../../../common/util/timeout.js';
 import { assert, unreachable } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
 import { kAllCanvasTypes, createCanvas, CanvasType } from '../../util/create_elements.js';
@@ -300,7 +301,7 @@ Test automatic WebGPU canvas texture expiry on all canvas types with the followi
     // or after transferToImageBitmap (for offscreen canvas).
     function requestPostAnimationFrame(fn: () => void) {
       t.requestNewFrameOnCanvasType(canvasType, ctx, () => {
-        setTimeout(fn);
+        timeout(fn);
       });
     }
 
@@ -315,7 +316,7 @@ Test automatic WebGPU canvas texture expiry on all canvas types with the followi
 
       // Call getCurrentTexture immediately after this frame updating the rendering.
       // It should return a new texture object.
-      setTimeout(() => {
+      timeout(() => {
         t.expect(prevTexture !== ctx.getCurrentTexture());
 
         // prevTexture expired and is invalid, but createView should still succeed.

--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -9,6 +9,8 @@ import { assert, unreachable } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
 import { kAllCanvasTypes, createCanvas, CanvasType } from '../../util/create_elements.js';
 
+const kFormat = 'bgra8unorm';
+
 class GPUContextTest extends GPUTest {
   initCanvasContext(canvasType: CanvasType = 'onscreen'): GPUCanvasContext {
     const canvas = createCanvas(this, canvasType, 2, 2);
@@ -17,7 +19,7 @@ class GPUContextTest extends GPUTest {
 
     ctx.configure({
       device: this.device,
-      format: 'rgba8unorm',
+      format: kFormat,
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
 
@@ -67,7 +69,7 @@ g.test('configured')
     // Once the context has been configured getCurrentTexture can be called.
     ctx.configure({
       device: t.device,
-      format: 'rgba8unorm',
+      format: kFormat,
     });
 
     let prevTexture = ctx.getCurrentTexture();

--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -22,6 +22,7 @@ class GPUContextTest extends GPUTest {
       onscreencanvas.style.left = '0';
       // Set it to transparent so that if multiple canvas are created, they are still visible.
       onscreencanvas.style.opacity = '50%';
+      document.body.appendChild(onscreencanvas);
     }
     const ctx = canvas.getContext('webgpu');
     assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');


### PR DESCRIPTION


Issue: #2385

<hr>

This version of tests seem to fully pass on current Chrome Canary on Windows.
PTAL.

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
