### PR TITLE
Adds stale adapter tests

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -8,7 +8,7 @@ potentially limited native resources.
 import { Fixture } from '../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { getGPU } from '../../../../common/util/navigator_gpu.js';
-import { assert, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
+import { assert, assertReject, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
 import { kFeatureNames, kLimitInfo, kLimits } from '../../../capability_info.js';
 import { clamp, isPowerOfTwo } from '../../../util/math.js';
 
@@ -75,6 +75,72 @@ g.test('invalid')
     const kTimeoutMS = 1000;
     const device = await adapter.requestDevice();
     const lost = await raceWithRejectOnTimeout(device.lost, kTimeoutMS, 'device was not lost');
+    t.expect(lost.reason === undefined);
+  });
+
+g.test('stale')
+  .desc(
+    `
+    Test that adapter.requestDevice() can successfully return a device once, and once only.
+    - Tests that we can successfully resolve after serial and concurrent rejections.
+    - Tests that consecutive valid attempts only succeeds the first time, returning lost device otherwise.`
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('initialError', [undefined, 'TypeError', 'OperationError'])
+      .combine('awaitInitialError', [true, false])
+      .combine('awaitSuccess', [true, false])
+      .filter(({ initialError, awaitInitialError }) => {
+        return initialError !== undefined && !awaitInitialError;
+      })
+  )
+  .fn(async t => {
+    const gpu = getGPU();
+    const adapter = await gpu.requestAdapter();
+    assert(adapter !== null);
+
+    const { initialError, awaitInitialError, awaitSuccess } = t.params;
+
+    switch (initialError) {
+      case undefined:
+        break;
+      case 'TypeError':
+        // Cause a type error by requesting with an unknown feature.
+        if (awaitInitialError) {
+          await assertReject(
+            adapter.requestDevice({ requiredFeatures: ['unknown-feature' as GPUFeatureName] })
+          );
+        } else {
+          t.shouldReject(
+            'TypeError',
+            adapter.requestDevice({ requiredFeatures: ['unknown-feature' as GPUFeatureName] })
+          );
+        }
+        break;
+      case 'OperationError':
+        // Cause an operation error by requesting with an unknown limit.
+        if (awaitInitialError) {
+          await assertReject(adapter.requestDevice({ requiredLimits: { unknownLimitName: 9000 } }));
+        } else {
+          t.shouldReject(
+            'OperationError',
+            adapter.requestDevice({ requiredLimits: { unknownLimitName: 9000 } })
+          );
+        }
+        break;
+    }
+
+    const promise = adapter.requestDevice();
+    if (awaitSuccess) {
+      const device = await promise;
+      assert(device !== null);
+    } else {
+      t.shouldResolve(promise);
+    }
+
+    const kTimeoutMS = 1000;
+    const device = await adapter.requestDevice();
+    const lost = await raceWithRejectOnTimeout(device.lost, kTimeoutMS, 'adapter was not stale');
     t.expect(lost.reason === undefined);
   });
 


### PR DESCRIPTION
Issue: #2380
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.
