### PR TITLE
Test destroyed buffers and textures on submit

### DIFF
--- a/src/webgpu/api/validation/queue/destroyed/buffer.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/buffer.spec.ts
@@ -1,10 +1,5 @@
 export const description = `
 Tests using a destroyed buffer on a queue.
-
-TODO:
-- test renderPass/renderBundle (setVertexBuffer, setIndexBuffer)
-- test renderPass (resolveQuerySet)
-- test renderPass/computePass (setBindGroup)
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
@@ -139,6 +134,160 @@ Tests that using a destroyed buffer in copyTextureToBuffer fails.
 
     if (destroyed) {
       buffer.destroy();
+    }
+
+    t.expectValidationError(() => {
+      t.queue.submit([commandBuffer]);
+    }, destroyed);
+  });
+
+g.test('setBindGroup')
+  .desc(
+    `
+Tests that using a destroyed buffer referenced by a bindGroup set with setBindGroup fails
+- x= {not destroyed (control case), destroyed}
+    `
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('destroyed', [false, true] as const)
+      .combine('encoderType', ['compute pass', 'render pass', 'render bundle'] as const)
+  )
+  .fn(t => {
+    const { destroyed, encoderType } = t.params;
+    const { device } = t;
+    const buffer = t.trackForCleanup(
+      t.device.createBuffer({
+        size: 4,
+        usage: GPUBufferUsage.UNIFORM,
+      })
+    );
+
+    const layout = device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+          buffer: {},
+        },
+      ],
+    });
+
+    const bindGroup = device.createBindGroup({
+      layout,
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setBindGroup(0, bindGroup);
+    const commandBuffer = finish();
+
+    if (destroyed) {
+      buffer.destroy();
+    }
+
+    t.expectValidationError(() => {
+      t.queue.submit([commandBuffer]);
+    }, destroyed);
+  });
+
+g.test('setVertexBuffer')
+  .desc(
+    `
+Tests that using a destroyed buffer referenced in a render pass fails
+- x= {not destroyed (control case), destroyed}
+    `
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('destroyed', [false, true] as const)
+      .combine('encoderType', ['render pass', 'render bundle'] as const)
+  )
+  .fn(t => {
+    const { destroyed, encoderType } = t.params;
+    const vertexBuffer = t.trackForCleanup(
+      t.device.createBuffer({
+        size: 4,
+        usage: GPUBufferUsage.VERTEX,
+      })
+    );
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setVertexBuffer(0, vertexBuffer);
+    const commandBuffer = finish();
+
+    if (destroyed) {
+      vertexBuffer.destroy();
+    }
+
+    t.expectValidationError(() => {
+      t.queue.submit([commandBuffer]);
+    }, destroyed);
+  });
+
+g.test('setIndexBuffer')
+  .desc(
+    `
+Tests that using a destroyed buffer referenced in a render pass fails
+- x= {not destroyed (control case), destroyed}
+    `
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('destroyed', [false, true] as const)
+      .combine('encoderType', ['render pass', 'render bundle'] as const)
+  )
+  .fn(t => {
+    const { destroyed, encoderType } = t.params;
+    const indexBuffer = t.trackForCleanup(
+      t.device.createBuffer({
+        size: 4,
+        usage: GPUBufferUsage.INDEX,
+      })
+    );
+
+    const { encoder, finish } = t.createEncoder(encoderType);
+    encoder.setIndexBuffer(indexBuffer, 'uint16');
+    const commandBuffer = finish();
+
+    if (destroyed) {
+      indexBuffer.destroy();
+    }
+
+    t.expectValidationError(() => {
+      t.queue.submit([commandBuffer]);
+    }, destroyed);
+  });
+
+g.test('resolveQuerySet')
+  .desc(
+    `
+Tests that using a destroyed buffer referenced via resolveQuerySet fails
+- x= {not destroyed (control case), destroyed}
+    `
+  )
+  .paramsSubcasesOnly(u => u.combine('destroyed', [false, true] as const))
+  .fn(t => {
+    const { destroyed } = t.params;
+    const querySet = t.trackForCleanup(
+      t.device.createQuerySet({
+        type: 'occlusion',
+        count: 1,
+      })
+    );
+    const querySetBuffer = t.trackForCleanup(
+      t.device.createBuffer({
+        size: 8,
+        usage: GPUBufferUsage.QUERY_RESOLVE,
+      })
+    );
+
+    const encoder = t.device.createCommandEncoder();
+    encoder.resolveQuerySet(querySet, 0, 1, querySetBuffer, 0);
+    const commandBuffer = encoder.finish();
+
+    if (destroyed) {
+      querySetBuffer.destroy();
     }
 
     t.expectValidationError(() => {


### PR DESCRIPTION
Test destroyed buffer with:
- test renderPass/renderBundle (setVertexBuffer, setIndexBuffer)
- test renderPass (resolveQuerySet)
- test renderPass/computePass (setBindGroup)

Test destroyed texture with:
- test renderPass/computePass (setBindGroup)
- test beginRenderPass target




Issue: #2376
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
