### PR TITLE
shader/execution: Flip eval order of assignment

### DIFF
--- a/src/webgpu/shader/execution/flow_control/eval_order.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/eval_order.spec.ts
@@ -790,13 +790,13 @@ fn d() -> i32 {
   });
 
 g.test('1d_array_assignment')
-  .desc('Test RHS of an array element assignment is evaluated before LHS')
+  .desc('Test LHS of an array element assignment is evaluated before RHS')
   .fn(t => {
     runFlowControlTest(t, f => ({
       entrypoint: `
   var arr : array<i32, 8>;
   ${f.expect_order(0)}
-  arr[b()] = arr[a()];
+  arr[a()] = arr[b()];
   ${f.expect_order(3)}
 `,
       extra: `
@@ -813,13 +813,13 @@ fn b() -> i32 {
   });
 
 g.test('2d_array_assignment')
-  .desc('Test RHS of 2D-array element assignment is evaluated before LHS')
+  .desc('Test LHS of 2D-array element assignment is evaluated before RHS')
   .fn(t => {
     runFlowControlTest(t, f => ({
       entrypoint: `
   var arr : array<array<i32, 8>, 8>;
   ${f.expect_order(0)}
-  arr[c()][d()] = arr[a()][b()];
+  arr[a()][b()] = arr[c()][d()];
   ${f.expect_order(5)}
 `,
       extra: `


### PR DESCRIPTION
WG has agreed that LHS should be evaluated before RHS, which matches compound assignment, and JS.

See: https://github.com/gpuweb/gpuweb/issues/3928




Issue: #2312

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
