### PR TITLE
Modify zero init tests to pollute workgroup memory

### DIFF
--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -1,8 +1,7 @@
 export const description = `Test that variables in the shader are zero initialized`;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { iterRange } from '../../../common/util/util.js';
-import { unreachable } from '../../../common/util/util.js';
+import { iterRange, unreachable } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
 import {
   ScalarType,

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -1,6 +1,7 @@
 export const description = `Test that variables in the shader are zero initialized`;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { iterRange } from '../../../common/util/util.js';
 import { unreachable } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
 import {
@@ -51,8 +52,6 @@ export const g = makeTestGroup(GPUTest);
 g.test('compute,zero_init')
   .desc(
     `Test that uninitialized variables in workgroup, private, and function storage classes are initialized to zero.
-
-    TODO: Run a shader before the test to attempt to fill memory with garbage`
   )
   .params(u =>
     u
@@ -396,6 +395,82 @@ g.test('compute,zero_init')
         _ = zero;
       }
     `;
+
+    if (t.params.storageClass == 'workgroup') {
+      // Populate the maximum amount of workgroup memory with known values to
+      // ensure initialization overrides in another shader.
+      const wg_memory_limits = t.device.limits.maxComputeWorkgroupStorageSize;
+      const wg_x_dim = t.device.limits.maxComputeWorkgroupSizeX;
+
+      const wgsl = `
+      @group(0) @binding(0) var<storage, read> inputs : array<u32>;
+      @group(0) @binding(1) var<storage, read_write> outputs : array<u32>;
+      var<workgroup> wg_mem : array<u32, ${wg_memory_limits} / 4>;
+
+      @compute @workgroup_size(${wg_x_dim})
+      fn fill(@builtin(local_invocation_index) lid : u32) {
+        const num_u32_per_invocation = ${wg_memory_limits} / (4 * ${wg_x_dim});
+
+        for (var i = 0u; i < num_u32_per_invocation; i++) {
+          let idx = num_u32_per_invocation * lid + i;
+          wg_mem[idx] = inputs[idx];
+        }
+        workgroupBarrier();
+        // Copy out to avoid wg_mem being elided.
+        for (var i = 0u; i < num_u32_per_invocation; i++) {
+          let idx = num_u32_per_invocation * lid + i;
+          outputs[idx] = wg_mem[idx];
+        }
+      }
+      `;
+
+      const fillPipeline = t.device.createComputePipeline({
+        layout: 'auto',
+        compute: {
+          module: t.device.createShaderModule({
+            code: wgsl,
+          }),
+          entryPoint: 'fill',
+        },
+      });
+
+      const inputBuffer = t.makeBufferWithContents(
+        new Uint32Array([...iterRange(wg_memory_limits / 4, x => 0xdeadbeef)]),
+        GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST
+      );
+      t.trackForCleanup(inputBuffer);
+      const outputBuffer = t.device.createBuffer({
+        size: wg_memory_limits,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      });
+      t.trackForCleanup(outputBuffer);
+
+      const bg = t.device.createBindGroup({
+        layout: fillPipeline.getBindGroupLayout(0),
+        entries: [
+          {
+            binding: 0,
+            resource: {
+              buffer: inputBuffer,
+            },
+          },
+          {
+            binding: 1,
+            resource: {
+              buffer: outputBuffer,
+            },
+          },
+        ],
+      });
+
+      const e = t.device.createCommandEncoder();
+      const p = e.beginComputePass();
+      p.setPipeline(fillPipeline);
+      p.setBindGroup(0, bg);
+      p.dispatchWorkgroups(1);
+      p.end();
+      t.queue.submit([e.finish()]);
+    }
 
     const pipeline = t.device.createComputePipeline({
       layout: 'auto',

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -51,7 +51,7 @@ function prettyPrint(t: ShaderTypeInfo): string {
 export const g = makeTestGroup(GPUTest);
 g.test('compute,zero_init')
   .desc(
-    `Test that uninitialized variables in workgroup, private, and function storage classes are initialized to zero.
+    `Test that uninitialized variables in workgroup, private, and function storage classes are initialized to zero.`
   )
   .params(u =>
     u

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -396,7 +396,7 @@ g.test('compute,zero_init')
       }
     `;
 
-    if (t.params.storageClass == 'workgroup') {
+    if (t.params.storageClass === 'workgroup') {
       // Populate the maximum amount of workgroup memory with known values to
       // ensure initialization overrides in another shader.
       const wg_memory_limits = t.device.limits.maxComputeWorkgroupStorageSize;


### PR DESCRIPTION
* Before workgroup subcases for zero initialization, run a separate compute pipeline that writes the max amount of workgroup memory with a non-zero value




Issue: #1565

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
