### PR TITLE
Add tests for unary~ i32, u32, and vectors of them

### DIFF
--- a/src/webgpu/shader/execution/expression/unary/i32_complement.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/i32_complement.spec.ts
@@ -1,0 +1,37 @@
+export const description = `
+Execution Tests for the i32 bitwise complement operation
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { i32, TypeI32 } from '../../../../util/conversion.js';
+import { fullI32Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
+import { allInputSources, run } from '../expression.js';
+
+import { unary } from './unary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unary/i32_complement', {
+  complement: () => {
+    return [-1, 0, 1, ...fullI32Range()].map(e => {
+      return { input: i32(e), expected: i32(~e) };
+    });
+  },
+});
+
+g.test('i32_complement')
+  .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
+  .desc(
+    `
+Expression: ~x
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('complement');
+    await run(t, unary('~'), [TypeI32], TypeI32, t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/unary/i32_complement.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/i32_complement.spec.ts
@@ -15,7 +15,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unary/i32_complement', {
   complement: () => {
-    return [-1, 0, 1, ...fullI32Range()].map(e => {
+    return fullI32Range().map(e => {
       return { input: i32(e), expected: i32(~e) };
     });
   },

--- a/src/webgpu/shader/execution/expression/unary/u32_complement.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/u32_complement.spec.ts
@@ -15,7 +15,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unary/u32_complement', {
   complement: () => {
-    return [0, 1, ...fullU32Range()].map(e => {
+    return fullU32Range().map(e => {
       return { input: u32(e), expected: u32(~e) };
     });
   },

--- a/src/webgpu/shader/execution/expression/unary/u32_complement.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/u32_complement.spec.ts
@@ -1,0 +1,37 @@
+export const description = `
+Execution Tests for the u32 bitwise complement operation
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { u32, TypeU32 } from '../../../../util/conversion.js';
+import { fullU32Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
+import { allInputSources, run } from '../expression.js';
+
+import { unary } from './unary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unary/u32_complement', {
+  complement: () => {
+    return [0, 1, ...fullU32Range()].map(e => {
+      return { input: u32(e), expected: u32(~e) };
+    });
+  },
+});
+
+g.test('u32_complement')
+  .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
+  .desc(
+    `
+Expression: ~x
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('complement');
+    await run(t, unary('~'), [TypeU32], TypeU32, t.params, cases);
+  });


### PR DESCRIPTION
Added a TODO for AbstractInt

Part of #1631

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
