### PR TITLE
Add ImageBitmapRenderingContext canvas for copyToTexture tests

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -1,4 +1,5 @@
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
+import { SkipTestCase } from '../framework/fixture.js';
 import { globalTestConfig } from '../framework/test_config.js';
 import { Logger } from '../internal/logging/logger.js';
 
@@ -63,6 +64,13 @@ export async function assertReject(p: Promise<unknown>, msg?: string): Promise<v
  */
 export function unreachable(msg?: string): never {
   throw new Error(msg);
+}
+
+/**
+ * Throw a `SkipTestCase` exception, which skips the test case.
+ */
+export function skipTestCase(msg: string): never {
+  throw new SkipTestCase(msg);
 }
 
 /**

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -20,7 +20,6 @@ import {
 import { kResourceStates } from '../../../../gpu_test.js';
 import {
   CanvasType,
-  canCopyFromCanvasContext,
   createCanvas,
   createOnscreenCanvas,
   createOffscreenCanvas,
@@ -209,10 +208,7 @@ g.test('source_canvas,contexts')
   Test HTMLCanvasElement as source image with different contexts.
 
   Call HTMLCanvasElement.getContext() with different context type.
-  Only '2d', 'experimental-webgl', 'webgl', 'webgl2' is valid context
-  type.
-
-  Check whether 'OperationError' is generated when context type is invalid.
+  And all of them are valid context type.
   `
   )
   .params(u =>
@@ -245,7 +241,7 @@ g.test('source_canvas,contexts')
       { texture: dstTexture },
       copySize,
       true, // No validation errors.
-      canCopyFromCanvasContext(contextType) ? '' : 'OperationError'
+      ''
     );
   });
 

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -202,54 +202,6 @@ class CopyExternalImageToTextureTest extends ValidationTest {
 
 export const g = makeTestGroup(CopyExternalImageToTextureTest);
 
-g.test('source_offscreenCanvas,contexts')
-  .desc(
-    `
-  Test OffscreenCanvas as source image with different contexts.
-
-  Call OffscreenCanvas.getContext() with different context type.
-  Only '2d', 'webgl', 'webgl2', 'webgpu' is valid context type.
-
-  Check whether 'OperationError' is generated when context type is invalid.
-  `
-  )
-  .params(u =>
-    u //
-      .combine('contextType', kValidCanvasContextIds)
-      .beginSubcases()
-      .combine('copySize', [
-        { width: 0, height: 0, depthOrArrayLayers: 0 },
-        { width: 1, height: 1, depthOrArrayLayers: 1 },
-      ])
-  )
-  .fn(t => {
-    const { contextType, copySize } = t.params;
-    const canvas = createOffscreenCanvas(t, 1, 1);
-    const dstTexture = t.device.createTexture({
-      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
-      format: 'bgra8unorm',
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-    });
-
-    // MAINTENANCE_TODO: Workaround for @types/offscreencanvas missing an overload of
-    // `OffscreenCanvas.getContext` that takes `string` or a union of context types.
-    const ctx = ((canvas as unknown) as HTMLCanvasElement).getContext(contextType);
-
-    if (ctx === null) {
-      t.skip('Failed to get context for canvas element');
-      return;
-    }
-    t.tryTrackForCleanup(ctx);
-
-    t.runTest(
-      { source: canvas },
-      { texture: dstTexture },
-      copySize,
-      true, // No validation errors.
-      ''
-    );
-  });
-
 g.test('source_image,crossOrigin')
   .desc(
     `

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -158,7 +158,7 @@ class CopyExternalImageToTextureTest extends ValidationTest {
   ): HTMLCanvasElement | OffscreenCanvas {
     const canvas = createCanvas(this, canvasType, 1, 1);
     const ctx = canvas.getContext('2d');
-    assert(ctx !== null);
+    assert(ctx instanceof CanvasRenderingContext2D);
     ctx.drawImage(content, 0, 0);
 
     return canvas;
@@ -289,7 +289,7 @@ g.test('source_offscreenCanvas,contexts')
       { texture: dstTexture },
       copySize,
       true, // No validation errors.
-      canCopyFromCanvasContext(contextType) ? '' : 'OperationError'
+      ''
     );
   });
 

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -23,7 +23,6 @@ import {
   createCanvas,
   createOnscreenCanvas,
   createOffscreenCanvas,
-  kValidCanvasContextIds,
 } from '../../../../util/create_elements.js';
 import { ValidationTest } from '../../validation_test.js';
 

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -202,49 +202,6 @@ class CopyExternalImageToTextureTest extends ValidationTest {
 
 export const g = makeTestGroup(CopyExternalImageToTextureTest);
 
-g.test('source_canvas,contexts')
-  .desc(
-    `
-  Test HTMLCanvasElement as source image with different contexts.
-
-  Call HTMLCanvasElement.getContext() with different context type.
-  And all of them are valid context type.
-  `
-  )
-  .params(u =>
-    u //
-      .combine('contextType', kValidCanvasContextIds)
-      .beginSubcases()
-      .combine('copySize', [
-        { width: 0, height: 0, depthOrArrayLayers: 0 },
-        { width: 1, height: 1, depthOrArrayLayers: 1 },
-      ])
-  )
-  .fn(t => {
-    const { contextType, copySize } = t.params;
-    const canvas = createOnscreenCanvas(t, 1, 1);
-    const dstTexture = t.device.createTexture({
-      size: { width: 1, height: 1, depthOrArrayLayers: 1 },
-      format: 'bgra8unorm',
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-    });
-
-    const ctx = canvas.getContext(contextType);
-    if (ctx === null) {
-      t.skip('Failed to get context for canvas element');
-      return;
-    }
-    t.tryTrackForCleanup(ctx);
-
-    t.runTest(
-      { source: canvas },
-      { texture: dstTexture },
-      copySize,
-      true, // No validation errors.
-      ''
-    );
-  });
-
 g.test('source_offscreenCanvas,contexts')
   .desc(
     `

--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -26,7 +26,6 @@ import {
 } from '../../../../capability_info.js';
 import { CommandBufferMaker, EncoderType } from '../../../../util/command_buffer_maker.js';
 import {
-  canCopyFromCanvasContext,
   createCanvas,
   kAllCanvasTypes,
   kValidCanvasContextIds,
@@ -901,9 +900,6 @@ Tests copyExternalImageToTexture from canvas on queue on destroyed device.
     u
       .combine('canvasType', kAllCanvasTypes)
       .combine('contextType', kValidCanvasContextIds)
-      .filter(({ contextType }) => {
-        return canCopyFromCanvasContext(contextType);
-      })
       .beginSubcases()
       .combine('awaitLost', [true, false])
   )

--- a/src/webgpu/util/create_elements.ts
+++ b/src/webgpu/util/create_elements.ts
@@ -27,19 +27,6 @@ export const kValidCanvasContextIds = [
 ] as const;
 export type CanvasContext = typeof kValidCanvasContextIds[number];
 
-/** Helper(s) to determine if context is copyable. */
-export function canCopyFromCanvasContext(contextName: CanvasContext) {
-  switch (contextName) {
-    case '2d':
-    case 'webgl':
-    case 'webgl2':
-    case 'webgpu':
-      return true;
-    default:
-      return false;
-  }
-}
-
 /** Create HTMLCanvas/OffscreenCanvas. */
 export function createCanvas<T extends CanvasType>(
   test: Fixture,

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -650,6 +650,75 @@ g.test('copy_contents_from_gpu_context_canvas')
     });
   });
 
+g.test('copy_contents_from_ImageBitmapRendering_context_canvas')
+  .desc(
+    `
+  Test HTMLCanvasElement and OffscreenCanvas with ImageBitmapRendering context
+  can be copied to WebGPU texture correctly.
+
+  It creates HTMLCanvasElement/OffscreenCanvas with 'ImageBitmapRendering'.
+  Use fillRect(2d context) to render red rect for top-left,
+  green rect for top-right, blue rect for bottom-left and white for bottom-right on a
+  2d context canvas and create imageBitmap with that canvas. Use transferFromImageBitmap()
+  to render the imageBitmap to source canvas.
+
+  Then call copyExternalImageToTexture() to do a full copy to the 0 mipLevel
+  of dst texture, and read the contents out to compare with the canvas contents.
+
+  Provide premultiplied input if 'premultipliedAlpha' in 'GPUImageCopyTextureTagged'
+  is set to 'true' and unpremultiplied input if it is set to 'false'.
+
+  If 'flipY' in 'GPUImageCopyExternalImage' is set to 'true', copy will ensure the result
+  is flipped.
+
+  The tests covers:
+  - Valid canvas type
+  - Valid ImageBitmapRendering context type
+  - Valid dstColorFormat of copyExternalImageToTexture()
+  - Valid dest alphaMode
+  - Valid 'flipY' config in 'GPUImageCopyExternalImage' (named 'srcDoFlipYDuringCopy' in cases)
+  - TODO(#913): color space tests need to be added
+
+  And the expected results are all passed.
+  `
+  )
+  .params(u =>
+    u
+      .combine('canvasType', kAllCanvasTypes)
+      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstAlphaMode', kCanvasAlphaModes)
+      .combine('srcDoFlipYDuringCopy', [true, false])
+      .beginSubcases()
+      .combine('width', [1, 2, 4, 15])
+      .combine('height', [1, 2, 4, 15])
+  )
+  .fn(async t => {
+    const { width, height, canvasType, dstAlphaMode } = t.params;
+
+    const canvas = createCanvas(t, canvasType, width, height);
+
+    const imageBitmapRenderingContext = canvas.getContext('bitmaprenderer');
+
+    if (!(imageBitmapRenderingContext instanceof ImageBitmapRenderingContext)) {
+      t.skip(canvasType + ' canvas imageBitmap rendering context not available');
+    }
+
+    const { canvas: sourceContentCanvas, expectedSourceData } = t.init2DCanvasContent({
+      canvasType,
+      width,
+      height,
+    });
+
+    const imageBitmap = await createImageBitmap(sourceContentCanvas, { premultiplyAlpha: 'none' });
+    imageBitmapRenderingContext?.transferFromImageBitmap(imageBitmap);
+
+    t.doCopyContentsTest(canvas, expectedSourceData, {
+      srcPremultiplied: false,
+      dstPremultiplied: dstAlphaMode === 'premultiplied',
+      ...t.params,
+    });
+  });
+
 g.test('color_space_conversion')
   .desc(
     `

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -651,14 +651,14 @@ g.test('copy_contents_from_gpu_context_canvas')
     });
   });
 
-g.test('copy_contents_from_ImageBitmapRendering_context_canvas')
+g.test('copy_contents_from_bitmaprenderer_context_canvas')
   .desc(
     `
-  Test HTMLCanvasElement and OffscreenCanvas with ImageBitmapRendering context
+  Test HTMLCanvasElement and OffscreenCanvas with ImageBitmapRenderingContext
   can be copied to WebGPU texture correctly.
 
-  It creates HTMLCanvasElement/OffscreenCanvas with 'ImageBitmapRendering'.
-  Use fillRect(2d context) to render red rect for top-left,
+  It creates HTMLCanvasElement/OffscreenCanvas with 'bitmaprenderer'.
+  First, use fillRect(2d context) to render red rect for top-left,
   green rect for top-right, blue rect for bottom-left and white for bottom-right on a
   2d context canvas and create imageBitmap with that canvas. Use transferFromImageBitmap()
   to render the imageBitmap to source canvas.

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -3,6 +3,7 @@ copyToTexture with HTMLCanvasElement and OffscreenCanvas sources.
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { skipTestCase } from '../../../common/util/util.js';
 import {
   kCanvasAlphaModes,
   kTextureFormatInfo,
@@ -700,7 +701,7 @@ g.test('copy_contents_from_ImageBitmapRendering_context_canvas')
     const imageBitmapRenderingContext = canvas.getContext('bitmaprenderer');
 
     if (!(imageBitmapRenderingContext instanceof ImageBitmapRenderingContext)) {
-      t.skip(canvasType + ' canvas imageBitmap rendering context not available');
+      skipTestCase(canvasType + ' canvas imageBitmap rendering context not available');
     }
 
     const { canvas: sourceContentCanvas, expectedSourceData } = t.init2DCanvasContent({
@@ -710,7 +711,7 @@ g.test('copy_contents_from_ImageBitmapRendering_context_canvas')
     });
 
     const imageBitmap = await createImageBitmap(sourceContentCanvas, { premultiplyAlpha: 'none' });
-    imageBitmapRenderingContext?.transferFromImageBitmap(imageBitmap);
+    imageBitmapRenderingContext.transferFromImageBitmap(imageBitmap);
 
     t.doCopyContentsTest(canvas, expectedSourceData, {
       srcPremultiplied: false,


### PR DESCRIPTION
This PR added test cases that useImageBitmapRenderingContet canvas as source input for CopyExternalImageToTexture().




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
