### PR TITLE
wgsl: add i32, u32 comparisons

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/i32_comparison.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/i32_comparison.spec.ts
@@ -1,0 +1,121 @@
+export const description = `
+Execution Tests for the i32 comparison expressions
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { i32, bool, TypeBool, TypeI32 } from '../../../../util/conversion.js';
+import { vectorI32Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
+import { allInputSources, Case, run } from '../expression.js';
+
+import { binary } from './binary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+/**
+ * @returns a test case for the provided left hand & right hand values and
+ * expected boolean result.
+ */
+function makeCase(lhs: number, rhs: number, expected_answer: boolean): Case {
+  return { input: [i32(lhs), i32(rhs)], expected: bool(expected_answer) };
+}
+
+export const d = makeCaseCache('binary/i32_comparison', {
+  equals: () => vectorI32Range(2).map(v => makeCase(v[0], v[1], v[0] === v[1])),
+  not_equals: () => vectorI32Range(2).map(v => makeCase(v[0], v[1], v[0] !== v[1])),
+  less_than: () => vectorI32Range(2).map(v => makeCase(v[0], v[1], v[0] < v[1])),
+  less_equal: () => vectorI32Range(2).map(v => makeCase(v[0], v[1], v[0] <= v[1])),
+  greater_than: () => vectorI32Range(2).map(v => makeCase(v[0], v[1], v[0] > v[1])),
+  greater_equal: () => vectorI32Range(2).map(v => makeCase(v[0], v[1], v[0] >= v[1])),
+});
+
+g.test('equals')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x == y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('equals');
+    await run(t, binary('=='), [TypeI32, TypeI32], TypeBool, t.params, cases);
+  });
+
+g.test('not_equals')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x != y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('not_equals');
+    await run(t, binary('!='), [TypeI32, TypeI32], TypeBool, t.params, cases);
+  });
+
+g.test('less_than')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x < y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('less_than');
+    await run(t, binary('<'), [TypeI32, TypeI32], TypeBool, t.params, cases);
+  });
+
+g.test('less_equals')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x <= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('less_equal');
+    await run(t, binary('<='), [TypeI32, TypeI32], TypeBool, t.params, cases);
+  });
+
+g.test('greater_than')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x > y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('greater_than');
+    await run(t, binary('>'), [TypeI32, TypeI32], TypeBool, t.params, cases);
+  });
+
+g.test('greater_equals')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x >= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('greater_equal');
+    await run(t, binary('>='), [TypeI32, TypeI32], TypeBool, t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/binary/u32_comparison.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_comparison.spec.ts
@@ -1,0 +1,121 @@
+export const description = `
+Execution Tests for the u32 comparison expressions
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { u32, bool, TypeBool, TypeU32 } from '../../../../util/conversion.js';
+import { vectorU32Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
+import { allInputSources, Case, run } from '../expression.js';
+
+import { binary } from './binary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+/**
+ * @returns a test case for the provided left hand & right hand values and
+ * expected boolean result.
+ */
+function makeCase(lhs: number, rhs: number, expected_answer: boolean): Case {
+  return { input: [u32(lhs), u32(rhs)], expected: bool(expected_answer) };
+}
+
+export const d = makeCaseCache('binary/u32_comparison', {
+  equals: () => vectorU32Range(2).map(v => makeCase(v[0], v[1], v[0] === v[1])),
+  not_equals: () => vectorU32Range(2).map(v => makeCase(v[0], v[1], v[0] !== v[1])),
+  less_than: () => vectorU32Range(2).map(v => makeCase(v[0], v[1], v[0] < v[1])),
+  less_equal: () => vectorU32Range(2).map(v => makeCase(v[0], v[1], v[0] <= v[1])),
+  greater_than: () => vectorU32Range(2).map(v => makeCase(v[0], v[1], v[0] > v[1])),
+  greater_equal: () => vectorU32Range(2).map(v => makeCase(v[0], v[1], v[0] >= v[1])),
+});
+
+g.test('equals')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x == y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('equals');
+    await run(t, binary('=='), [TypeU32, TypeU32], TypeBool, t.params, cases);
+  });
+
+g.test('not_equals')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x != y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('not_equals');
+    await run(t, binary('!='), [TypeU32, TypeU32], TypeBool, t.params, cases);
+  });
+
+g.test('less_than')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x < y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('less_than');
+    await run(t, binary('<'), [TypeU32, TypeU32], TypeBool, t.params, cases);
+  });
+
+g.test('less_equals')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x <= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('less_equal');
+    await run(t, binary('<='), [TypeU32, TypeU32], TypeBool, t.params, cases);
+  });
+
+g.test('greater_than')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x > y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('greater_than');
+    await run(t, binary('>'), [TypeU32, TypeU32], TypeBool, t.params, cases);
+  });
+
+g.test('greater_equals')
+  .specURL('https://www.w3.org/TR/WGSL/#comparison-expr')
+  .desc(
+    `
+Expression: x >= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('greater_equal');
+    await run(t, binary('>='), [TypeU32, TypeU32], TypeBool, t.params, cases);
+  });


### PR DESCRIPTION
Fixes: #2404


Issue: #1627

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
