### PR TITLE
Test sign(i32) builtin

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -1,7 +1,7 @@
 export const description = `
 Execution tests for the 'sign' builtin function
 
-S is AbstractFloat, f32, f16
+S is AbstractFloat, AbstractInt, i32, f32, f16
 T is S or vecN<S>
 @const fn sign(e: T ) -> T
 Returns the sign of e. Component-wise when T is a vector.
@@ -9,9 +9,9 @@ Returns the sign of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { TypeF32 } from '../../../../../util/conversion.js';
+import { i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
 import { signInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { fullF32Range, fullI32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
 
@@ -23,18 +23,42 @@ export const d = makeCaseCache('sign', {
   f32: () => {
     return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', signInterval);
   },
+  i32: () =>
+    fullI32Range().map(i => {
+      const signFunc = (i: number): number => (i < 0 ? -1 : i > 0 ? 1 : 0);
+      return { input: [i32(i)], expected: i32(signFunc(i)) };
+    }),
 });
 
 g.test('abstract_float')
-  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .specURL('https://www.w3.org/TR/WGSL/#sign-builtin')
   .desc(`abstract float tests`)
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .unimplemented();
 
+g.test('abstract_int')
+  .specURL('https://www.w3.org/TR/WGSL/#sign-builtin')
+  .desc(`abstract float tests`)
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .unimplemented();
+
+g.test('i32')
+  .specURL('https://www.w3.org/TR/WGSL/#sign-builtin')
+  .desc(`i32 tests`)
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('i32');
+    await run(t, builtin('sign'), [TypeI32], TypeI32, t.params, cases);
+  });
+
 g.test('f32')
-  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .specURL('https://www.w3.org/TR/WGSL/#sign-builtin')
   .desc(`f32 tests`)
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
@@ -45,7 +69,7 @@ g.test('f32')
   });
 
 g.test('f16')
-  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .specURL('https://www.w3.org/TR/WGSL/#sign-builtin')
   .desc(`f16 tests`)
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)


### PR DESCRIPTION
Add sign(AbstractInt) as .unimplemented ()

Fixes: #2057

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
