### PR TITLE
Add External Texture VideoFrame visibileRect Tests

### DIFF
--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -3,7 +3,6 @@ Tests for external textures from HTMLVideoElement (and other video-type sources?
 
 - videos with various encodings/formats (webm vp8, webm vp9, ogg theora, mp4), color spaces
   (bt.601, bt.709, bt.2020)
-- TODO: enhance with more cases with crop, rotation, etc.
 
 TODO: consider whether external_texture and copyToTexture video tests should be in the same file
 `;
@@ -339,6 +338,112 @@ it will honor rotation metadata.
     });
   });
 
+g.test('importExternalTexture,sampleWithVideoFrameWithVisibleRectParam')
+  .desc(
+    `
+Tests that we can import VideoFrames and sample the correct sub-rectangle when visibleRect
+parameters are present.
+`
+  )
+  .params(u =>
+    u //
+      .combineWithParams(checkNonStandardIsZeroCopyIfAvailable())
+      .combineWithParams(kVideoExpectations)
+  )
+  .fn(async t => {
+    const videoElement = getVideoElement(t, t.params.videoName);
+
+    await startPlayingAndWaitForVideo(videoElement, async () => {
+      const source = await getVideoFrameFromVideoElement(t, videoElement);
+
+      // All tested videos are derived from an image showing yellow, red, blue or green in each
+      // quadrant. In this test we crop the video to each quadrant and check that desired color
+      // is sampled from each corner of the cropped image.
+      const srcVideoHeight = 240;
+      const srcVideoWidth = 320;
+      let cropParams = [
+        // Top left (yellow)
+        {
+          subRect: { x: 0, y: 0, width: srcVideoWidth / 2, height: srcVideoHeight / 2 },
+          color: t.params._yellowExpectation,
+        },
+        // Top right (red)
+        {
+          subRect: {
+            x: srcVideoWidth / 2,
+            y: 0,
+            width: srcVideoWidth / 2,
+            height: srcVideoHeight / 2,
+          },
+          color: t.params._redExpectation,
+        },
+        // Bottom left (blue)
+        {
+          subRect: {
+            x: 0,
+            y: srcVideoHeight / 2,
+            width: srcVideoWidth / 2,
+            height: srcVideoHeight / 2,
+          },
+          color: t.params._blueExpectation,
+        },
+        // Bottom right (green)
+        {
+          subRect: {
+            x: srcVideoWidth / 2,
+            y: srcVideoHeight / 2,
+            width: srcVideoWidth / 2,
+            height: srcVideoHeight / 2,
+          },
+          color: t.params._greenExpectation,
+        },
+      ];
+
+      for (let cropParam of cropParams) {
+        const subRect = new VideoFrame(source, { visibleRect: cropParam.subRect });
+
+        const colorAttachment = t.device.createTexture({
+          format: kFormat,
+          size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
+          usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+        });
+
+        const pipeline = createExternalTextureSamplingTestPipeline(t);
+        const bindGroup = createExternalTextureSamplingTestBindGroup(t, 
+          t.params.checkNonStandardIsZeroCopy, subRect, pipeline);
+
+        const commandEncoder = t.device.createCommandEncoder();
+        const passEncoder = commandEncoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view: colorAttachment.createView(),
+              clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 1.0 },
+              loadOp: 'clear',
+              storeOp: 'store',
+            },
+          ],
+        });
+        passEncoder.setPipeline(pipeline);
+        passEncoder.setBindGroup(0, bindGroup);
+        passEncoder.draw(6);
+        passEncoder.end();
+        t.device.queue.submit([commandEncoder.finish()]);
+
+        // For validation, we sample a few pixels away from the edges to avoid compression
+        // artifacts.
+        t.expectSinglePixelComparisonsAreOkInTexture({ texture: colorAttachment }, [
+          { coord: { x: kWidth * 0.1, y: kHeight * 0.1 }, exp: cropParam.color },
+          { coord: { x: kWidth * 0.9, y: kHeight * 0.1 }, exp: cropParam.color },
+          { coord: { x: kWidth * 0.1, y: kHeight * 0.9 }, exp: cropParam.color },
+          { coord: { x: kWidth * 0.9, y: kHeight * 0.9 }, exp: cropParam.color },
+        ]);
+
+        subRect.close();
+      }
+
+      source.close();
+    });
+  });
 g.test('importExternalTexture,compute')
   .desc(
     `

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -361,7 +361,7 @@ parameters are present.
       // is sampled from each corner of the cropped image.
       const srcVideoHeight = 240;
       const srcVideoWidth = 320;
-      let cropParams = [
+      const cropParams = [
         // Top left (yellow)
         {
           subRect: { x: 0, y: 0, width: srcVideoWidth / 2, height: srcVideoHeight / 2 },
@@ -399,8 +399,10 @@ parameters are present.
         },
       ];
 
-      for (let cropParam of cropParams) {
-        const subRect = new VideoFrame(source, { visibleRect: cropParam.subRect });
+      for (const cropParam of cropParams) {
+        // MAINTENANCE_TODO: remove cast with TypeScript 4.9.6+.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const subRect = new VideoFrame(source as any, { visibleRect: cropParam.subRect });
 
         const colorAttachment = t.device.createTexture({
           format: kFormat,
@@ -409,8 +411,12 @@ parameters are present.
         });
 
         const pipeline = createExternalTextureSamplingTestPipeline(t);
-        const bindGroup = createExternalTextureSamplingTestBindGroup(t, 
-          t.params.checkNonStandardIsZeroCopy, subRect, pipeline);
+        const bindGroup = createExternalTextureSamplingTestBindGroup(
+          t,
+          t.params.checkNonStandardIsZeroCopy,
+          subRect,
+          pipeline
+        );
 
         const commandEncoder = t.device.createCommandEncoder();
         const passEncoder = commandEncoder.beginRenderPass({


### PR DESCRIPTION


Issue: #910

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
