### PR TITLE
fix(gen_wpt_cts_html): use non-zero exit code on incorrect arg count

### DIFF
--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -33,9 +33,10 @@ if (process.argv.length !== 4 && process.argv.length !== 7 && process.argv.lengt
   printUsageAndExit(1);
 }
 
+// prettier-ignore
 const [
-  ,
-  ,
+  , // `node` binary
+  , // this script
   outFile,
   templateFile,
   argsPrefixesFile,

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -29,7 +29,8 @@ and myexpectations.txt is a file containing a list of WPT paths to suppress, e.g
 }
 
 if (process.argv.length !== 4 && process.argv.length !== 7 && process.argv.length !== 8) {
-  printUsageAndExit(0);
+  console.error('incorrect number of arguments!');
+  printUsageAndExit(1);
 }
 
 const [


### PR DESCRIPTION
The `gen_wpt_cts_html` script uses some simple checks against `argv`'s length to ensure that input is valid. When that arg count does not match expected usage, the tool prints instructions with examples of expected usage, and returns an exit code of 0. This is a problem, though, because 0 conventionally indicates that the program ran without issue; by definition, we received incorrect input! This is definitely a case where it should return a non-zero exit code to indicate failure.

Fix this by returning 1 instead of 0. Easy peasy!

---

I figured it was easier to file a PR with the solution up-front, rather than try to engage in discussion before filing. If you want, I'm happy to file a correspondent issue for this.

Issue: #TODO MAYBE?<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [x] ~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~
- [x] ~Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)~

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] ~Tests are properly located in the test tree.~
- [x] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [x] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [x] ~Helpers and types promote readability and maintainability.~

When landing this PR, be sure to make any necessary issue status updates.
