### PR TITLE
Make all the limits test have no sub cases

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -333,12 +333,10 @@ const kMinimumLimits = new Set<GPUSupportedLimit>([
  */
 export const kMaximumLimitBaseParams = kUnitCaseParamsBuilder
   .combine('limitTest', kMaximumLimitValueTestKeys)
-  .beginSubcases()
   .combine('testValueName', kMaximumTestValueKeys);
 
 export const kMinimumLimitBaseParams = kUnitCaseParamsBuilder
   .combine('limitTest', kMinimumLimitValueTestKeys)
-  .beginSubcases()
   .combine('testValueName', kMinimumTestValueKeys);
 
 export class LimitTestsImpl extends GPUTestBase {


### PR DESCRIPTION
The limits tests need to request new devices with different limits. As such they make a lot of devices. sub cases run in parallel, cases do not, so switching all the sub cases to cases should mean less devices created at once.




Issue: none
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
