### PR TITLE
Fixes bug in maxColorAtthacmentBytesPerSample limits test

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
@@ -1,4 +1,4 @@
-import { assert, range } from '../../../../../common/util/util.js';
+import { assert } from '../../../../../common/util/util.js';
 import { kTextureSampleCounts, kTextureFormatInfo } from '../../../../capability_info.js';
 import { align } from '../../../../util/math.js';
 
@@ -219,8 +219,8 @@ g.test('beginRenderPass,at_over')
         const textures = createTextures(t, targets);
 
         const pass = encoder.beginRenderPass({
-          colorAttachments: range(testValue, i => ({
-            view: textures[i].createView(),
+          colorAttachments: textures.map(texture => ({
+            view: texture.createView(),
             loadOp: 'clear',
             storeOp: 'store',
           })),


### PR DESCRIPTION
Now that Chrome/Dawn respects this limit most of these tests started passing but 1 had a bug

Issue: #2195 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
