### PR TITLE
Fix for maxColorAttachmentsBytesPerSample test

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -142,7 +142,7 @@ g.test('limits,maxColorAttachmentBytesPerSample,unaligned')
             'rgba32float',
             'r8unorm',
           ] as GPUTextureFormat[],
-          _success: true,
+          _success: false,
         },
         {
           formats: [
@@ -152,7 +152,7 @@ g.test('limits,maxColorAttachmentBytesPerSample,unaligned')
             'r8unorm',
             'r8unorm',
           ] as GPUTextureFormat[],
-          _success: false,
+          _success: true,
         },
       ])
       .beginSubcases()


### PR DESCRIPTION
webgpu:api,validation,render_pipeline,fragment_state:limits,maxColorAttachmentBytesPerSample,unaligned:


It's a little worrying that
webgpu:api,validation,render_pipeline,fragment_state:limits,maxColorAttachmentBytesPerSample,unaligned:formats=["r32float","rgba8unorm","rgba32float","r8unorm","r8unorm"]

was failing but
webgpu:api,validation,render_pipeline,fragment_state:limits,maxColorAttachmentBytesPerSample,unaligned:formats=["r8unorm","r32float","rgba8unorm","rgba32float","r8unorm"]

was not (on the bots), even though _success was flipped. Locally they both pass now.

Issue: none

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
