### PR TITLE
Clean up enums

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -1,6 +1,5 @@
 import { kUnitCaseParamsBuilder } from '../../../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { keysOf } from '../../../../../common/util/data_tables.js';
 import { getGPU } from '../../../../../common/util/navigator_gpu.js';
 import { assert, range, reorder, ReorderOrder } from '../../../../../common/util/util.js';
 import { kLimitInfo, kTextureFormatInfo } from '../../../../capability_info.js';
@@ -9,45 +8,30 @@ import { align } from '../../../../util/math.js';
 
 type GPUSupportedLimit = keyof GPUSupportedLimits;
 
-const CreatePipelineTypes = {
-  createRenderPipeline: true,
-  createRenderPipelineWithFragmentStage: true,
-  createComputePipeline: true,
-};
-export type CreatePipelineType = keyof typeof CreatePipelineTypes;
-export const kCreatePipelineTypes = keysOf(CreatePipelineTypes);
+export const kCreatePipelineTypes = [
+  'createRenderPipeline',
+  'createRenderPipelineWithFragmentStage',
+  'createComputePipeline',
+] as const;
+export type CreatePipelineType = typeof kCreatePipelineTypes[number];
 
-const RenderEncoderTypes = {
-  render: true,
-  renderBundle: true,
-};
-export type RenderEncoderType = keyof typeof RenderEncoderTypes;
-export const kRenderEncoderTypes = keysOf(RenderEncoderTypes);
+export const kRenderEncoderTypes = ['render', 'renderBundle'] as const;
+export type RenderEncoderType = typeof kRenderEncoderTypes[number];
 
-const EncoderTypes = {
-  compute: true,
-  render: true,
-  renderBundle: true,
-};
-export type EncoderType = keyof typeof EncoderTypes;
-export const kEncoderTypes = keysOf(EncoderTypes);
+export const kEncoderTypes = ['compute', 'render', 'renderBundle'] as const;
+export type EncoderType = typeof kEncoderTypes[number];
 
-const BindGroupTests = {
-  sameGroup: true,
-  differentGroups: true,
-};
-export type BindGroupTest = keyof typeof BindGroupTests;
-export const kBindGroupTests = keysOf(BindGroupTests);
+export const kBindGroupTests = ['sameGroup', 'differentGroups'] as const;
+export type BindGroupTest = typeof kBindGroupTests[number];
 
-const BindingCombinations = {
-  vertex: true,
-  fragment: true,
-  vertexAndFragmentWithPossibleVertexStageOverflow: true,
-  vertexAndFragmentWithPossibleFragmentStageOverflow: true,
-  compute: true,
-};
-export type BindingCombination = keyof typeof BindingCombinations;
-export const kBindingCombinations = keysOf(BindingCombinations);
+export const kBindingCombinations = [
+  'vertex',
+  'fragment',
+  'vertexAndFragmentWithPossibleVertexStageOverflow',
+  'vertexAndFragmentWithPossibleFragmentStageOverflow',
+  'compute',
+] as const;
+export type BindingCombination = typeof kBindingCombinations[number];
 
 export function getPipelineTypeForBindingCombination(bindingCombination: BindingCombination) {
   switch (bindingCombination) {
@@ -232,20 +216,12 @@ export function getPerStageWGSLForBindingCombinationStorageTextures(
   );
 }
 
-const LimitModes = {
-  defaultLimit: true,
-  adapterLimit: true,
-};
-export type LimitMode = keyof typeof LimitModes;
-export const kLimitModes = keysOf(LimitModes);
+export const kLimitModes = ['defaultLimit', 'adapterLimit'] as const;
+export type LimitMode = typeof kLimitModes[number];
 export type LimitsRequest = Record<string, LimitMode>;
 
-export const MaximumTestValues = {
-  atLimit: true,
-  overLimit: true,
-};
-export type MaximumTestValue = keyof typeof MaximumTestValues;
-export const kMaximumTestValueKeys = keysOf(MaximumTestValues);
+export const kMaximumTestValues = ['atLimit', 'overLimit'] as const;
+export type MaximumTestValue = typeof kMaximumTestValues[number];
 
 export function getMaximumTestValue(limit: number, testValue: MaximumTestValue) {
   switch (testValue) {
@@ -256,22 +232,17 @@ export function getMaximumTestValue(limit: number, testValue: MaximumTestValue) 
   }
 }
 
-export const MinimumTestValues = {
-  atLimit: true,
-  underLimit: true,
-};
-export type MinimumTestValue = keyof typeof MinimumTestValues;
-export const kMinimumTestValueKeys = keysOf(MinimumTestValues);
+export const kMinimumTestValues = ['atLimit', 'underLimit'] as const;
+export type MinimumTestValue = typeof kMinimumTestValues[number];
 
-export const MaximumLimitValueTests = {
-  atDefault: true,
-  underDefault: true,
-  betweenDefaultAndMaximum: true,
-  atMaximum: true,
-  overMaximum: true,
-};
-export type MaximumLimitValueTest = keyof typeof MaximumLimitValueTests;
-export const kMaximumLimitValueTestKeys = keysOf(MaximumLimitValueTests);
+export const kMaximumLimitValueTests = [
+  'atDefault',
+  'underDefault',
+  'betweenDefaultAndMaximum',
+  'atMaximum',
+  'overMaximum',
+] as const;
+export type MaximumLimitValueTest = typeof kMaximumLimitValueTests[number];
 
 export function getLimitValue(
   defaultLimit: number,
@@ -292,15 +263,14 @@ export function getLimitValue(
   }
 }
 
-export const MinimumLimitValueTests = {
-  atDefault: true,
-  overDefault: true,
-  betweenDefaultAndMinimum: true,
-  atMinimum: true,
-  underMinimum: true,
-};
-export type MinimumLimitValueTest = keyof typeof MinimumLimitValueTests;
-export const kMinimumLimitValueTestKeys = keysOf(MinimumLimitValueTests);
+export const kMinimumLimitValueTests = [
+  'atDefault',
+  'overDefault',
+  'betweenDefaultAndMinimum',
+  'atMinimum',
+  'underMinimum',
+] as const;
+export type MinimumLimitValueTest = typeof kMinimumLimitValueTests[number];
 
 export function getDefaultLimit(limit: GPUSupportedLimit): number {
   return (kLimitInfo as Record<string, { default: number }>)[limit].default;
@@ -332,12 +302,12 @@ const kMinimumLimits = new Set<GPUSupportedLimit>([
  * Adds the default parameters to a limit test
  */
 export const kMaximumLimitBaseParams = kUnitCaseParamsBuilder
-  .combine('limitTest', kMaximumLimitValueTestKeys)
-  .combine('testValueName', kMaximumTestValueKeys);
+  .combine('limitTest', kMaximumLimitValueTests)
+  .combine('testValueName', kMaximumTestValues);
 
 export const kMinimumLimitBaseParams = kUnitCaseParamsBuilder
-  .combine('limitTest', kMinimumLimitValueTestKeys)
-  .combine('testValueName', kMinimumTestValueKeys);
+  .combine('limitTest', kMinimumLimitValueTests)
+  .combine('testValueName', kMinimumTestValues);
 
 export class LimitTestsImpl extends GPUTestBase {
   _adapter: GPUAdapter | null = null;

--- a/src/webgpu/api/validation/capability_checks/limits/maxComputeWorkgroupsPerDimension.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxComputeWorkgroupsPerDimension.spec.ts
@@ -1,16 +1,13 @@
-import { keysOf } from '../../../../../common/util/data_tables.js';
-
 import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const limit = 'maxComputeWorkgroupsPerDimension';
 export const { g, description } = makeLimitTestGroup(limit);
 
-const CreateComputePipelineTypes = {
-  createComputePipeline: true,
-  createComputePipelineAsync: true,
-};
-type CreateComputePipelineType = keyof typeof CreateComputePipelineTypes;
-const kCreateComputePipelineTypes = keysOf(CreateComputePipelineTypes);
+const kCreateComputePipelineTypes = [
+  'createComputePipeline',
+  'createComputePipelineAsync',
+] as const;
+type CreateComputePipelineType = typeof kCreateComputePipelineTypes[number];
 
 async function createComputePipeline(
   device: GPUDevice,

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBufferBindingSize.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBufferBindingSize.spec.ts
@@ -1,4 +1,3 @@
-import { keysOf } from '../../../../../common/util/data_tables.js';
 import { align, roundDown } from '../../../../util/math.js';
 
 import {
@@ -10,12 +9,8 @@ import {
   MaximumTestValue,
 } from './limit_utils.js';
 
-const BufferParts = {
-  wholeBuffer: true,
-  biggerBufferWithOffset: true,
-};
-type BufferPart = keyof typeof BufferParts;
-const kBufferPartsKeys = keysOf(BufferParts);
+const kBufferParts = ['wholeBuffer', 'biggerBufferWithOffset'] as const;
+type BufferPart = typeof kBufferParts[number];
 
 function getSizeAndOffsetForBufferPart(device: GPUDevice, bufferPart: BufferPart, size: number) {
   const align = device.limits.minUniformBufferOffsetAlignment;
@@ -82,7 +77,7 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createBindGroup,at_over')
   .desc(`Test using createBindGroup at and over ${limit} limit`)
-  .params(kMaximumLimitBaseParams.combine('bufferPart', kBufferPartsKeys))
+  .params(kMaximumLimitBaseParams.combine('bufferPart', kBufferParts))
   .fn(async t => {
     const { limitTest, testValueName, bufferPart } = t.params;
     const { defaultLimit, adapterLimit: maximumLimit } = t;

--- a/src/webgpu/api/validation/capability_checks/limits/maxUniformBufferBindingSize.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxUniformBufferBindingSize.spec.ts
@@ -1,5 +1,3 @@
-import { keysOf } from '../../../../../common/util/data_tables.js';
-
 import {
   LimitMode,
   getDefaultLimit,
@@ -7,12 +5,8 @@ import {
   makeLimitTestGroup,
 } from './limit_utils.js';
 
-const BufferParts = {
-  wholeBuffer: true,
-  biggerBufferWithOffset: true,
-};
-type BufferPart = keyof typeof BufferParts;
-const kBufferPartsKeys = keysOf(BufferParts);
+const kBufferParts = ['wholeBuffer', 'biggerBufferWithOffset'] as const;
+type BufferPart = typeof kBufferParts[number];
 
 function getSizeAndOffsetForBufferPart(device: GPUDevice, bufferPart: BufferPart, size: number) {
   const align = device.limits.minUniformBufferOffsetAlignment;
@@ -32,7 +26,7 @@ const kExtraLimits = { maxBufferSize: 'maxLimit' as LimitMode };
 
 g.test('createBindGroup,at_over')
   .desc(`Test using at and over ${limit} limit`)
-  .params(kMaximumLimitBaseParams.combine('bufferPart', kBufferPartsKeys))
+  .params(kMaximumLimitBaseParams.combine('bufferPart', kBufferParts))
   .fn(async t => {
     const { limitTest, testValueName, bufferPart } = t.params;
     await t.testDeviceWithRequestedMaximumLimits(

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
@@ -1,14 +1,9 @@
-import { keysOf } from '../../../../../common/util/data_tables.js';
 import { range } from '../../../../../common/util/util.js';
 
 import { kRenderEncoderTypes, kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
-const PipelineTypes = {
-  withoutLocations: true,
-  withLocations: true,
-};
-type PipelineType = keyof typeof PipelineTypes;
-const kPipelineTypes = keysOf(PipelineTypes);
+const kPipelineTypes = ['withoutLocations', 'withLocations'] as const;
+type PipelineType = typeof kPipelineTypes[number];
 
 function getPipelineDescriptor(
   device: GPUDevice,


### PR DESCRIPTION
Switch to a better and less verbose enum style

Issue: None

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
