### PR TITLE
shader/execution: Add a continue in switch flow control test

### DIFF
--- a/src/webgpu/shader/execution/flow_control/complex.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/complex.spec.ts
@@ -1,0 +1,42 @@
+export const description = `
+Flow control tests for interesting complex cases.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+import { runFlowControlTest } from './harness.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('continue_in_switch_in_for_loop')
+  .desc('Test flow control for a continue statement in a switch, in a for-loop')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f =>
+        `
+  ${f.expect_order(0)}
+  for (var i = ${f.value(0)}; i < 3; i++) {
+    ${f.expect_order(1, 4, 6)}
+    switch (i) {
+      case 2: {
+        ${f.expect_order(7)}
+        break;
+      }
+      case 1: {
+        ${f.expect_order(5)}
+        continue;
+      }
+      default: {
+        ${f.expect_order(2)}
+        break;
+      }
+    }
+    ${f.expect_order(3, 8)}
+  }
+  ${f.expect_order(9)}
+`
+    );
+  });


### PR DESCRIPTION
This requires special casing in tint, and so is an interesting edge case.




Issue: #2312

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
