### PR TITLE
Update target in tsconfig.json to 'es2020'

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "moduleResolution": "node",
     "esModuleInterop": false,
     "skipLibCheck": true,
+    "target": "es2020"
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
tsconfig-google.json explicitly sets this to 'es2018', so need to override it, to prevent lint warnings about using es2020 specific features.

This would have previously caused warnings when using es2019 specific features, but apparently CTS didn't use any of them.

Issue #2416

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
