### PR TITLE
[wgsl] Add compound operator tests.

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/binary.ts
+++ b/src/webgpu/shader/execution/expression/binary/binary.ts
@@ -7,3 +7,10 @@ export function binary(op: string): ExpressionBuilder {
     return `(${values_str.join(op)})`;
   };
 }
+
+/* @returns an ExpressionBuilder that evaluates a compound binary operation */
+export function compoundBinary(op: string): ExpressionBuilder {
+  return values => {
+    return op;
+  };
+}

--- a/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
@@ -7,7 +7,7 @@ import { GPUTest } from '../../../../gpu_test.js';
 import { i32, scalarType, u32 } from '../../../../util/conversion.js';
 import { allInputSources, run } from '../expression.js';
 
-import { binary } from './binary.js';
+import { binary, compoundBinary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -26,6 +26,7 @@ Bitwise-or. Component-wise when T is a vector.
       .combine('type', ['i32', 'u32'] as const)
       .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
@@ -72,7 +73,14 @@ Bitwise-or. Component-wise when T is a vector.
         });
       }
     }
-    await run(t, binary('|'), [type, type], type, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('|') : binary('|'),
+      [type, type],
+      type,
+      t.params,
+      cases
+    );
   });
 
 g.test('bitwise_and')
@@ -90,6 +98,7 @@ Bitwise-and. Component-wise when T is a vector.
       .combine('type', ['i32', 'u32'] as const)
       .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
@@ -144,7 +153,14 @@ Bitwise-and. Component-wise when T is a vector.
         });
       }
     }
-    await run(t, binary('&'), [type, type], type, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('&') : binary('&'),
+      [type, type],
+      type,
+      t.params,
+      cases
+    );
   });
 
 g.test('bitwise_exclusive_or')
@@ -162,6 +178,7 @@ Bitwise-exclusive-or. Component-wise when T is a vector.
       .combine('type', ['i32', 'u32'] as const)
       .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
@@ -216,5 +233,12 @@ Bitwise-exclusive-or. Component-wise when T is a vector.
         });
       }
     }
-    await run(t, binary('^'), [type, type], type, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('^') : binary('^'),
+      [type, type],
+      type,
+      t.params,
+      cases
+    );
   });

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -16,7 +16,7 @@ import { fullF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, generateBinaryToF32IntervalCases, run } from '../expression.js';
 
-import { binary } from './binary.js';
+import { binary, compoundBinary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -112,13 +112,23 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'addition_const' : 'addition_non_const'
     );
-    await run(t, binary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('+') : binary('+'),
+      [TypeF32, TypeF32],
+      TypeF32,
+      t.params,
+      cases
+    );
   });
 
 g.test('subtraction')
@@ -130,13 +140,23 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'subtraction_const' : 'subtraction_non_const'
     );
-    await run(t, binary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('-') : binary('-'),
+      [TypeF32, TypeF32],
+      TypeF32,
+      t.params,
+      cases
+    );
   });
 
 g.test('multiplication')
@@ -148,13 +168,23 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'multiplication_const' : 'multiplication_non_const'
     );
-    await run(t, binary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('*') : binary('*'),
+      [TypeF32, TypeF32],
+      TypeF32,
+      t.params,
+      cases
+    );
   });
 
 g.test('division')
@@ -166,13 +196,23 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
-    await run(t, binary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('/') : binary('/'),
+      [TypeF32, TypeF32],
+      TypeF32,
+      t.params,
+      cases
+    );
   });
 
 g.test('remainder')
@@ -184,11 +224,21 @@ Accuracy: Derived from x - y * trunc(x/y)
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
-    await run(t, binary('%'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('%') : binary('%'),
+      [TypeF32, TypeF32],
+      TypeF32,
+      t.params,
+      cases
+    );
   });

--- a/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
@@ -16,7 +16,7 @@ import {
   run,
 } from '../expression.js';
 
-import { binary } from './binary.js';
+import { binary, compoundBinary } from './binary.js';
 
 function i32_add(x: number, y: number): number | undefined {
   return x + y;
@@ -326,11 +326,21 @@ Expression: x + y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get('addition');
-    await run(t, binary('+'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('+') : binary('+'),
+      [TypeI32, TypeI32],
+      TypeI32,
+      t.params,
+      cases
+    );
   });
 
 g.test('subtraction')
@@ -341,11 +351,21 @@ Expression: x - y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get('subtraction');
-    await run(t, binary('-'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('-') : binary('-'),
+      [TypeI32, TypeI32],
+      TypeI32,
+      t.params,
+      cases
+    );
   });
 
 g.test('multiplication')
@@ -356,11 +376,21 @@ Expression: x * y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get('multiplication');
-    await run(t, binary('*'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('*') : binary('*'),
+      [TypeI32, TypeI32],
+      TypeI32,
+      t.params,
+      cases
+    );
   });
 
 g.test('division')
@@ -371,13 +401,23 @@ Expression: x / y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
-    await run(t, binary('/'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('/') : binary('/'),
+      [TypeI32, TypeI32],
+      TypeI32,
+      t.params,
+      cases
+    );
   });
 
 g.test('remainder')
@@ -388,13 +428,23 @@ Expression: x % y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
-    await run(t, binary('%'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('%') : binary('%'),
+      [TypeI32, TypeI32],
+      TypeI32,
+      t.params,
+      cases
+    );
   });
 
 g.test('addition_scalar_vector')

--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -15,7 +15,7 @@ import {
   run,
 } from '../expression.js';
 
-import { binary } from './binary.js';
+import { binary, compoundBinary } from './binary.js';
 
 function u32_add(x: number, y: number): number | undefined {
   return x + y;
@@ -313,11 +313,21 @@ Expression: x + y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get('addition');
-    await run(t, binary('+'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('+') : binary('+'),
+      [TypeU32, TypeU32],
+      TypeU32,
+      t.params,
+      cases
+    );
   });
 
 g.test('subtraction')
@@ -328,11 +338,21 @@ Expression: x - y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get('subtraction');
-    await run(t, binary('-'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('-') : binary('-'),
+      [TypeU32, TypeU32],
+      TypeU32,
+      t.params,
+      cases
+    );
   });
 
 g.test('multiplication')
@@ -343,11 +363,21 @@ Expression: x * y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get('multiplication');
-    await run(t, binary('*'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('*') : binary('*'),
+      [TypeU32, TypeU32],
+      TypeU32,
+      t.params,
+      cases
+    );
   });
 
 g.test('division')
@@ -358,13 +388,23 @@ Expression: x / y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
-    await run(t, binary('/'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('/') : binary('/'),
+      [TypeU32, TypeU32],
+      TypeU32,
+      t.params,
+      cases
+    );
   });
 
 g.test('remainder')
@@ -375,13 +415,23 @@ Expression: x % y
 `
   )
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
-    await run(t, binary('%'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(
+      t,
+      t.params.compoundStmt ? compoundBinary('%') : binary('%'),
+      [TypeU32, TypeU32],
+      TypeU32,
+      t.params,
+      cases
+    );
   });
 
 g.test('addition_scalar_vector')

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -91,6 +91,8 @@ export const allInputSources: InputSource[] = ['const', 'uniform', 'storage_r', 
 export type Config = {
   // Where the input values are read from
   inputSource: InputSource;
+  // If the expression is a compound statement
+  compoundStmt?: Boolean;
   // If defined, scalar test cases will be packed into vectors of the given
   // width, which must be 2, 3 or 4.
   // Requires that all parameters of the expression overload are of a scalar
@@ -234,7 +236,7 @@ export async function run(
   expressionBuilder: ExpressionBuilder,
   parameterTypes: Array<Type>,
   returnType: Type,
-  cfg: Config = { inputSource: 'storage_r' },
+  cfg: Config = { inputSource: 'storage_r', compoundStmt: false },
   cases: CaseList
 ) {
   // If the 'vectorize' config option was provided, pack the cases into vectors.
@@ -287,6 +289,7 @@ export async function run(
       returnType,
       batchCases,
       cfg.inputSource,
+      cfg.compoundStmt || false,
       pipelineCache
     );
 
@@ -315,6 +318,7 @@ export async function run(
  * @param returnType the return type for the expression overload
  * @param cases list of test cases that fit within the binding limits of the device
  * @param inputSource the source of the input values
+ * @param compoundStmt if the expression is a compound statement
  * @param pipelineCache the cache of compute pipelines, shared between batches
  * @returns a function that checks the results are as expected
  */
@@ -325,6 +329,7 @@ function submitBatch(
   returnType: Type,
   cases: CaseList,
   inputSource: InputSource,
+  compoundStmt: Boolean,
   pipelineCache: PipelineCache
 ): () => void {
   // Construct a buffer to hold the results of the expression tests
@@ -341,6 +346,7 @@ function submitBatch(
     returnType,
     cases,
     inputSource,
+    compoundStmt,
     outputBuffer,
     pipelineCache
   );
@@ -409,6 +415,217 @@ function ith<T>(v: T | T[], i: number): T {
 }
 
 /**
+ * Constructs the shader for a compound const input source
+ * @param expressionBuilder the expression builder function
+ * @param parameterTypes the list of expression parameter types
+ * @param returnType the return type for the expression overload
+ * @param cases list of test cases that fit within the binding limits of the device
+ * @param inputSource the source of the input values
+ * @param wgslStorageType the wgsl storage type
+ * @param wgslOutput the wgsl output location
+ */
+function makeConstCompoundShader(
+  expressionBuilder: ExpressionBuilder,
+  parameterTypes: Array<Type>,
+  returnType: Type,
+  cases: CaseList,
+  wgslStorageType: Type,
+  wgslOutputs: string
+) {
+  const wgslValues = cases.map(c => {
+    const args = parameterTypes.map((_, i) => `(${ith(c.input, i).wgsl()})`);
+    return `  array(${args[0]}, ${args[1]})`;
+  });
+
+  let wgslBody = '';
+  if (globalTestConfig.unrollConstEvalLoops) {
+    wgslBody = wgslValues
+      .map((v, i) => {
+        return `  outputs[${i}].value = values[${i}][0];
+    outputs[${i}].value ${expressionBuilder([])}= values[${i}][1];`;
+      })
+      .join('\n  ');
+  } else {
+    wgslBody = `  for (var i = 0u; i < ${cases.length}; i++) {
+  outputs[i].value = values[i][0];
+  outputs[i].value ${expressionBuilder([])}= values[i][1];
+}`;
+  }
+
+  // the full WGSL shader source
+  return `
+  ${wgslOutputs}
+
+  const values = array<array<${wgslStorageType}, 2>, ${cases.length}>(
+  ${wgslValues.map(s => `${s}`).join(',\n  ')}
+  );
+
+  @compute @workgroup_size(1)
+  fn main() {
+  ${wgslBody}
+  }
+  `;
+}
+
+/**
+ * Constructs the shader for a const input source
+ * @param expressionBuilder the expression builder function
+ * @param parameterTypes the list of expression parameter types
+ * @param returnType the return type for the expression overload
+ * @param cases list of test cases that fit within the binding limits of the device
+ * @param inputSource the source of the input values
+ * @param wgslStorageType the wgsl storage type
+ * @param wgslOutput the wgsl output location
+ */
+function makeConstShader(
+  expressionBuilder: ExpressionBuilder,
+  parameterTypes: Array<Type>,
+  returnType: Type,
+  cases: CaseList,
+  wgslStorageType: Type,
+  wgslOutputs: string
+) {
+  //////////////////////////////////////////////////////////////////////////
+  // Input values are constant values in the WGSL shader
+  //////////////////////////////////////////////////////////////////////////
+  const wgslValues = cases.map(c => {
+    const args = parameterTypes.map((_, i) => `(${ith(c.input, i).wgsl()})`);
+    return `${toStorage(returnType, expressionBuilder(args))}`;
+  });
+
+  const wgslBody = globalTestConfig.unrollConstEvalLoops
+    ? wgslValues.map((_, i) => `outputs[${i}].value = values[${i}];`).join('\n  ')
+    : `for (var i = 0u; i < ${cases.length}; i++) {
+  outputs[i].value = values[i];
+}`;
+
+  // the full WGSL shader source
+  return `
+  ${wgslOutputs}
+
+  const values = array<${wgslStorageType}, ${cases.length}>(
+    ${wgslValues.join(',\n  ')}
+  );
+
+  @compute @workgroup_size(1)
+  fn main() {
+    ${wgslBody}
+  }
+  `;
+}
+
+/**
+ * Constructs the shader for a compound non-const input source
+ * @param expressionBuilder the expression builder function
+ * @param parameterTypes the list of expression parameter types
+ * @param returnType the return type for the expression overload
+ * @param cases list of test cases that fit within the binding limits of the device
+ * @param inputSource the source of the input values
+ * @param wgslOutputs the wgsl output location
+ */
+function makeNonConstCompoundShader(
+  expressionBuilder: ExpressionBuilder,
+  parameterTypes: Array<Type>,
+  returnType: Type,
+  cases: CaseList,
+  inputSource: InputSource,
+  wgslOutputs: string
+) {
+  // input binding var<...> declaration
+  const wgslInputVar = (function () {
+    switch (inputSource) {
+      case 'storage_r':
+        return 'var<storage, read>';
+      case 'storage_rw':
+        return 'var<storage, read_write>';
+      case 'uniform':
+        return 'var<uniform>';
+      default:
+        return '';
+    }
+  })();
+
+  return `
+struct Input {
+${parameterTypes
+  .map((ty, i) => `  @size(${valueStride(ty)}) param${i} : ${storageType(ty)},`)
+  .join('\n')}
+};
+
+${wgslOutputs}
+
+@group(0) @binding(1)
+${wgslInputVar} inputs : array<Input, ${cases.length}>;
+
+@compute @workgroup_size(1)
+fn main() {
+  for(var i = 0; i < ${cases.length}; i++) {
+    outputs[i].value = inputs[i].param0;
+    outputs[i].value ${expressionBuilder([])}= inputs[i].param1;
+  }
+}
+`;
+}
+
+/**
+ * Constructs the shader for a non-const input source
+ * @param expressionBuilder the expression builder function
+ * @param parameterTypes the list of expression parameter types
+ * @param returnType the return type for the expression overload
+ * @param cases list of test cases that fit within the binding limits of the device
+ * @param inputSource the source of the input values
+ * @param wgslOutputs the wgsl output location
+ */
+function makeNonConstShader(
+  expressionBuilder: ExpressionBuilder,
+  parameterTypes: Array<Type>,
+  returnType: Type,
+  cases: CaseList,
+  inputSource: InputSource,
+  wgslOutputs: string
+) {
+  // returns the WGSL expression to load the ith parameter of the given type from the input buffer
+  const paramExpr = (ty: Type, i: number) => fromStorage(ty, `inputs[i].param${i}`);
+
+  // resolves to the expression that calls the builtin
+  const expr = toStorage(returnType, expressionBuilder(parameterTypes.map(paramExpr)));
+
+  // input binding var<...> declaration
+  const wgslInputVar = (function () {
+    switch (inputSource) {
+      case 'storage_r':
+        return 'var<storage, read>';
+      case 'storage_rw':
+        return 'var<storage, read_write>';
+      case 'uniform':
+        return 'var<uniform>';
+      default:
+        return '';
+    }
+  })();
+
+  return `
+struct Input {
+${parameterTypes
+  .map((ty, i) => `  @size(${valueStride(ty)}) param${i} : ${storageType(ty)},`)
+  .join('\n')}
+};
+
+${wgslOutputs}
+
+@group(0) @binding(1)
+${wgslInputVar} inputs : array<Input, ${cases.length}>;
+
+@compute @workgroup_size(1)
+fn main() {
+  for(var i = 0; i < ${cases.length}; i++) {
+    outputs[i].value = ${expr};
+  }
+}
+`;
+}
+
+/**
  * Constructs and returns a GPUComputePipeline and GPUBindGroup for running a
  * batch of test cases. If a pre-created pipeline can be found in
  * @p pipelineCache, then this may be returned instead of creating a new
@@ -419,6 +636,7 @@ function ith<T>(v: T | T[], i: number): T {
  * @param returnType the return type for the expression overload
  * @param cases list of test cases that fit within the binding limits of the device
  * @param inputSource the source of the input values
+ * @param compoundStmt true if the expression is a compound statement
  * @param outputBuffer the buffer that will hold the output values of the tests
  * @param pipelineCache the cache of compute pipelines, shared between batches
  */
@@ -429,6 +647,7 @@ function buildPipeline(
   returnType: Type,
   cases: CaseList,
   inputSource: InputSource,
+  compoundStmt: Boolean,
   outputBuffer: GPUBuffer,
   pipelineCache: PipelineCache
 ): [GPUComputePipeline, GPUBindGroup] {
@@ -455,33 +674,23 @@ struct Output {
 
   switch (inputSource) {
     case 'const': {
-      //////////////////////////////////////////////////////////////////////////
-      // Input values are constant values in the WGSL shader
-      //////////////////////////////////////////////////////////////////////////
-      const wgslValues = cases.map(c => {
-        const args = parameterTypes.map((_, i) => `(${ith(c.input, i).wgsl()})`);
-        return `${toStorage(returnType, expressionBuilder(args))}`;
-      });
-
-      const wgslBody = globalTestConfig.unrollConstEvalLoops
-        ? wgslValues.map((_, i) => `outputs[${i}].value = values[${i}];`).join('\n  ')
-        : `for (var i = 0u; i < ${cases.length}; i++) {
-    outputs[i].value = values[i];
-  }`;
-
-      // the full WGSL shader source
-      const source = `
-${wgslOutputs}
-
-const values = array<${wgslStorageType}, ${cases.length}>(
-  ${wgslValues.join(',\n  ')}
-);
-
-@compute @workgroup_size(1)
-fn main() {
-  ${wgslBody}
-}
-`;
+      const source = compoundStmt
+        ? makeConstCompoundShader(
+            expressionBuilder,
+            parameterTypes,
+            returnType,
+            cases,
+            wgslStorageType,
+            wgslOutputs
+          )
+        : makeConstShader(
+            expressionBuilder,
+            parameterTypes,
+            returnType,
+            cases,
+            wgslStorageType,
+            wgslOutputs
+          );
 
       // build the shader module
       const module = t.device.createShaderModule({ code: source });
@@ -508,44 +717,24 @@ fn main() {
       // Input values come from a uniform or storage buffer
       //////////////////////////////////////////////////////////////////////////
 
-      // returns the WGSL expression to load the ith parameter of the given type from the input buffer
-      const paramExpr = (ty: Type, i: number) => fromStorage(ty, `inputs[i].param${i}`);
-
-      // resolves to the expression that calls the builtin
-      const expr = toStorage(returnType, expressionBuilder(parameterTypes.map(paramExpr)));
-
-      // input binding var<...> declaration
-      const wgslInputVar = (function () {
-        switch (inputSource) {
-          case 'storage_r':
-            return 'var<storage, read>';
-          case 'storage_rw':
-            return 'var<storage, read_write>';
-          case 'uniform':
-            return 'var<uniform>';
-        }
-      })();
-
       // the full WGSL shader source
-      const source = `
-struct Input {
-${parameterTypes
-  .map((ty, i) => `  @size(${valueStride(ty)}) param${i} : ${storageType(ty)},`)
-  .join('\n')}
-};
-
-${wgslOutputs}
-
-@group(0) @binding(1)
-${wgslInputVar} inputs : array<Input, ${cases.length}>;
-
-@compute @workgroup_size(1)
-fn main() {
-  for(var i = 0; i < ${cases.length}; i++) {
-    outputs[i].value = ${expr};
-  }
-}
-`;
+      const source = compoundStmt
+        ? makeNonConstCompoundShader(
+            expressionBuilder,
+            parameterTypes,
+            returnType,
+            cases,
+            inputSource,
+            wgslOutputs
+          )
+        : makeNonConstShader(
+            expressionBuilder,
+            parameterTypes,
+            returnType,
+            cases,
+            inputSource,
+            wgslOutputs
+          );
 
       // size in bytes of the input buffer
       const inputSize = cases.length * valueStrides(parameterTypes);


### PR DESCRIPTION
This CL adds compound operator tests for:
* `|=`
* `&=`
* `^=`
* `+=`
* `-=`
* `/=`
* `*=`
* `%=`

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
