### PR TITLE
webgpu/shader/execution: Code refactoring

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/binary.ts
+++ b/src/webgpu/shader/execution/expression/binary/binary.ts
@@ -1,16 +1,11 @@
-import { ExpressionBuilder } from '../expression.js';
+import { ShaderBuilder, basicExpressionBuilder, compoundAssignmentBuilder } from '../expression.js';
 
-/* @returns an ExpressionBuilder that evaluates a binary operation */
-export function binary(op: string): ExpressionBuilder {
-  return values => {
-    const values_str = values.map(v => `(${v})`);
-    return `(${values_str.join(op)})`;
-  };
+/* @returns a ShaderBuilder that evaluates a binary operation */
+export function binary(op: string): ShaderBuilder {
+  return basicExpressionBuilder(values => `(${values.map(v => `(${v})`).join(op)})`);
 }
 
-/* @returns an ExpressionBuilder that evaluates a compound binary operation */
-export function compoundBinary(op: string): ExpressionBuilder {
-  return values => {
-    return op;
-  };
+/* @returns a ShaderBuilder that evaluates a compound binary operation */
+export function compoundBinary(op: string): ShaderBuilder {
+  return compoundAssignmentBuilder(op + '=');
 }

--- a/src/webgpu/shader/execution/expression/call/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/builtin.ts
@@ -1,6 +1,6 @@
-import { ExpressionBuilder } from '../../expression.js';
+import { basicExpressionBuilder, ShaderBuilder } from '../../expression.js';
 
-/* @returns an ExpressionBuilder that calls the builtin with the given name */
-export function builtin(name: string): ExpressionBuilder {
-  return values => `${name}(${values.join(', ')})`;
+/* @returns a ShaderBuilder that calls the builtin with the given name */
+export function builtin(name: string): ShaderBuilder {
+  return basicExpressionBuilder(values => `${name}(${values.join(', ')})`);
 }

--- a/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
@@ -26,18 +26,24 @@ import {
   vectorF32Range,
 } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, ExpressionBuilder, run } from '../../expression.js';
+import {
+  allInputSources,
+  basicExpressionBuilder,
+  Case,
+  run,
+  ShaderBuilder,
+} from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
-/* @returns an ExpressionBuilder that evaluates frexp and returns .fract from the result structure */
-function fractBuilder(): ExpressionBuilder {
-  return value => `frexp(${value}).fract`;
+/* @returns an ShaderBuilder that evaluates frexp and returns .fract from the result structure */
+function fractBuilder(): ShaderBuilder {
+  return basicExpressionBuilder(value => `frexp(${value}).fract`);
 }
 
-/* @returns an ExpressionBuilder that evaluates frexp and returns .exp from the result structure */
-function expBuilder(): ExpressionBuilder {
-  return value => `frexp(${value}).exp`;
+/* @returns an ShaderBuilder that evaluates frexp and returns .exp from the result structure */
+function expBuilder(): ShaderBuilder {
+  return basicExpressionBuilder(value => `frexp(${value}).exp`);
 }
 
 /* @returns a fract Case for a given vector input */

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -22,18 +22,24 @@ import { f32, toVector, TypeF32, TypeVec } from '../../../../../util/conversion.
 import { modfInterval } from '../../../../../util/f32_interval.js';
 import { fullF32Range, quantizeToF32, vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, ExpressionBuilder, run } from '../../expression.js';
+import {
+  allInputSources,
+  basicExpressionBuilder,
+  Case,
+  run,
+  ShaderBuilder,
+} from '../../expression.js';
 
 export const g = makeTestGroup(GPUTest);
 
-/* @returns an ExpressionBuilder that evaluates modf and returns .whole from the result structure */
-function wholeBuilder(): ExpressionBuilder {
-  return value => `modf(${value}).whole`;
+/* @returns an ShaderBuilder that evaluates modf and returns .whole from the result structure */
+function wholeBuilder(): ShaderBuilder {
+  return basicExpressionBuilder(value => `modf(${value}).whole`);
 }
 
-/* @returns an ExpressionBuilder that evaluates modf and returns .fract from the result structure */
-function fractBuilder(): ExpressionBuilder {
-  return value => `modf(${value}).fract`;
+/* @returns an ShaderBuilder that evaluates modf and returns .fract from the result structure */
+function fractBuilder(): ShaderBuilder {
+  return basicExpressionBuilder(value => `modf(${value}).fract`);
 }
 
 /* @returns a fract Case for a given vector input */

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -1,5 +1,5 @@
 import { globalTestConfig } from '../../../../common/framework/test_config.js';
-import { assert, objectEquals, unreachable } from '../../../../common/util/util.js';
+import { objectEquals, unreachable } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
 import { compare, Comparator, anyOf } from '../../../util/compare.js';
 import {
@@ -91,8 +91,6 @@ export const allInputSources: InputSource[] = ['const', 'uniform', 'storage_r', 
 export type Config = {
   // Where the input values are read from
   inputSource: InputSource;
-  // If the expression is a compound statement
-  compoundStmt?: Boolean;
   // If defined, scalar test cases will be packed into vectors of the given
   // width, which must be 2, 3 or 4.
   // Requires that all parameters of the expression overload are of a scalar
@@ -194,11 +192,6 @@ function toStorage(ty: Type, expr: string): string {
   return expr;
 }
 
-// ExpressionBuilder returns the WGSL used to test an expression.
-export interface ExpressionBuilder {
-  (values: Array<string>): string;
-}
-
 // A Pipeline is a map of WGSL shader source to a built pipeline
 type PipelineCache = Map<String, GPUComputePipeline>;
 
@@ -219,32 +212,33 @@ function getOrCreate<K, V>(map: Map<K, V>, key: K, create: () => V) {
   map.set(key, value);
   return value;
 }
+
 /**
  * Runs the list of expression tests, possibly splitting the tests into multiple
  * dispatches to keep the input data within the buffer binding limits.
  * run() will pack the scalar test cases into smaller set of vectorized tests
  * if `cfg.vectorize` is defined.
  * @param t the GPUTest
- * @param expressionBuilder the expression builder function
+ * @param shaderBuilder the shader builder function
  * @param parameterTypes the list of expression parameter types
- * @param returnType the return type for the expression overload
+ * @param resultType the return type for the expression overload
  * @param cfg test configuration values
  * @param cases list of test cases
  */
 export async function run(
   t: GPUTest,
-  expressionBuilder: ExpressionBuilder,
+  shaderBuilder: ShaderBuilder,
   parameterTypes: Array<Type>,
-  returnType: Type,
-  cfg: Config = { inputSource: 'storage_r', compoundStmt: false },
+  resultType: Type,
+  cfg: Config = { inputSource: 'storage_r' },
   cases: CaseList
 ) {
   // If the 'vectorize' config option was provided, pack the cases into vectors.
   if (cfg.vectorize !== undefined) {
-    const packed = packScalarsToVector(parameterTypes, returnType, cases, cfg.vectorize);
+    const packed = packScalarsToVector(parameterTypes, resultType, cases, cfg.vectorize);
     cases = packed.cases;
     parameterTypes = packed.parameterTypes;
-    returnType = packed.returnType;
+    resultType = packed.resultType;
   }
 
   // The size of the input buffer may exceed the maximum buffer binding size,
@@ -284,12 +278,11 @@ export async function run(
 
     const checkBatch = submitBatch(
       t,
-      expressionBuilder,
+      shaderBuilder,
       parameterTypes,
-      returnType,
+      resultType,
       batchCases,
       cfg.inputSource,
-      cfg.compoundStmt || false,
       pipelineCache
     );
 
@@ -313,27 +306,25 @@ export async function run(
  * Submits the list of expression tests. The input data must fit within the
  * buffer binding limits of the given inputSource.
  * @param t the GPUTest
- * @param expressionBuilder the expression builder function
+ * @param shaderBuilder the shader builder function
  * @param parameterTypes the list of expression parameter types
- * @param returnType the return type for the expression overload
+ * @param resultType the return type for the expression overload
  * @param cases list of test cases that fit within the binding limits of the device
  * @param inputSource the source of the input values
- * @param compoundStmt if the expression is a compound statement
  * @param pipelineCache the cache of compute pipelines, shared between batches
  * @returns a function that checks the results are as expected
  */
 function submitBatch(
   t: GPUTest,
-  expressionBuilder: ExpressionBuilder,
+  shaderBuilder: ShaderBuilder,
   parameterTypes: Array<Type>,
-  returnType: Type,
+  resultType: Type,
   cases: CaseList,
   inputSource: InputSource,
-  compoundStmt: Boolean,
   pipelineCache: PipelineCache
 ): () => void {
   // Construct a buffer to hold the results of the expression tests
-  const outputBufferSize = cases.length * valueStride(returnType);
+  const outputBufferSize = cases.length * valueStride(resultType);
   const outputBuffer = t.device.createBuffer({
     size: outputBufferSize,
     usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
@@ -341,12 +332,11 @@ function submitBatch(
 
   const [pipeline, group] = buildPipeline(
     t,
-    expressionBuilder,
+    shaderBuilder,
     parameterTypes,
-    returnType,
+    resultType,
     cases,
     inputSource,
-    compoundStmt,
     outputBuffer,
     pipelineCache
   );
@@ -369,7 +359,7 @@ function submitBatch(
       // Read the outputs from the output buffer
       const outputs = new Array<Value>(cases.length);
       for (let i = 0; i < cases.length; i++) {
-        outputs[i] = returnType.read(outputData, i * valueStride(returnType));
+        outputs[i] = resultType.read(outputData, i * valueStride(resultType));
       }
 
       // The list of expectation failures
@@ -401,228 +391,220 @@ function submitBatch(
 }
 
 /**
- * @param v either an array of T or a single element of type T
- * @param i the value index to
- * @returns the i'th value of v, if v is an array, otherwise v (i must be 0)
+ * map is a helper for returning a new array with each element of @p v
+ * transformed with @p fn.
+ * If @p v is not an array, then @p fn is called with (v, 0).
  */
-function ith<T>(v: T | T[], i: number): T {
+function map<T, U>(v: T | T[], fn: (value: T, index?: number) => U): U[] {
   if (v instanceof Array) {
-    assert(i < v.length);
-    return v[i];
+    return v.map(fn);
   }
-  assert(i === 0);
-  return v;
+  return [fn(v, 0)];
 }
 
 /**
- * Constructs the shader for a compound const input source
- * @param expressionBuilder the expression builder function
+ * ShaderBuilder is a function used to construct the WGSL shader used by an
+ * expression test.
  * @param parameterTypes the list of expression parameter types
- * @param returnType the return type for the expression overload
+ * @param resultType the return type for the expression overload
  * @param cases list of test cases that fit within the binding limits of the device
  * @param inputSource the source of the input values
- * @param wgslStorageType the wgsl storage type
- * @param wgslOutput the wgsl output location
  */
-function makeConstCompoundShader(
-  expressionBuilder: ExpressionBuilder,
+export type ShaderBuilder = (
   parameterTypes: Array<Type>,
-  returnType: Type,
+  resultType: Type,
   cases: CaseList,
-  wgslStorageType: Type,
-  wgslOutputs: string
-) {
-  const wgslValues = cases.map(c => {
-    const args = parameterTypes.map((_, i) => `(${ith(c.input, i).wgsl()})`);
-    return `  array(${args[0]}, ${args[1]})`;
-  });
+  inputSource: InputSource
+) => string;
 
-  let wgslBody = '';
-  if (globalTestConfig.unrollConstEvalLoops) {
-    wgslBody = wgslValues
-      .map((v, i) => {
-        return `  outputs[${i}].value = values[${i}][0];
-    outputs[${i}].value ${expressionBuilder([])}= values[${i}][1];`;
-      })
-      .join('\n  ');
-  } else {
-    wgslBody = `  for (var i = 0u; i < ${cases.length}; i++) {
-  outputs[i].value = values[i][0];
-  outputs[i].value ${expressionBuilder([])}= values[i][1];
+/**
+ * Helper that returns the WGSL to declare the output storage buffer for a shader
+ */
+function wgslOutputs(resultType: Type, count: number): string {
+  return `
+struct Output {
+  @size(${valueStride(resultType)}) value : ${storageType(resultType)}
+};
+@group(0) @binding(0) var<storage, read_write> outputs : array<Output, ${count}>;`;
+}
+
+/**
+ * Helper that returns the WGSL 'var' declaration for the given input source
+ */
+function wgslInputVar(inputSource: InputSource, count: number) {
+  switch (inputSource) {
+    case 'storage_r':
+      return `@group(0) @binding(1) var<storage, read> inputs : array<Input, ${count}>;`;
+    case 'storage_rw':
+      return `@group(0) @binding(1) var<storage, read_write> inputs : array<Input, ${count}>;`;
+    case 'uniform':
+      return `@group(0) @binding(1) var<uniform> inputs : array<Input, ${count}>;`;
+  }
+  throw new Error(`InputSource ${inputSource} does not use an input var`);
+}
+
+/**
+ * ExpressionBuilder returns the WGSL used to evaluate an expression with the
+ * given input values.
+ */
+export type ExpressionBuilder = (values: Array<string>) => string;
+
+/**
+ * Returns a ShaderBuilder that builds a basic expression test shader.
+ * @param expressionBuilder the expression builder
+ */
+export function basicExpressionBuilder(expressionBuilder: ExpressionBuilder): ShaderBuilder {
+  return (
+    parameterTypes: Array<Type>,
+    resultType: Type,
+    cases: CaseList,
+    inputSource: InputSource
+  ) => {
+    if (inputSource === 'const') {
+      //////////////////////////////////////////////////////////////////////////
+      // Constant eval
+      //////////////////////////////////////////////////////////////////////////
+      let body = '';
+      if (globalTestConfig.unrollConstEvalLoops) {
+        body = cases.map((_, i) => `  outputs[${i}].value = values[${i}];`).join('\n  ');
+      } else {
+        body = `
+  for (var i = 0u; i < ${cases.length}; i++) {
+    outputs[i].value = values[i];
+  }`;
+      }
+
+      return `
+${wgslOutputs(resultType, cases.length)}
+
+const values = array(
+  ${cases
+    .map(c => toStorage(resultType, expressionBuilder(map(c.input, v => v.wgsl()))))
+    .join(',\n  ')}
+);
+
+@compute @workgroup_size(1)
+fn main() {
+${body}
 }`;
-  }
+    } else {
+      //////////////////////////////////////////////////////////////////////////
+      // Runtime eval
+      //////////////////////////////////////////////////////////////////////////
 
-  // the full WGSL shader source
-  return `
-  ${wgslOutputs}
+      // returns the WGSL expression to load the ith parameter of the given type from the input buffer
+      const paramExpr = (ty: Type, i: number) => fromStorage(ty, `inputs[i].param${i}`);
 
-  const values = array<array<${wgslStorageType}, 2>, ${cases.length}>(
-  ${wgslValues.map(s => `${s}`).join(',\n  ')}
-  );
+      // resolves to the expression that calls the builtin
+      const expr = toStorage(resultType, expressionBuilder(parameterTypes.map(paramExpr)));
 
-  @compute @workgroup_size(1)
-  fn main() {
-  ${wgslBody}
-  }
-  `;
-}
-
-/**
- * Constructs the shader for a const input source
- * @param expressionBuilder the expression builder function
- * @param parameterTypes the list of expression parameter types
- * @param returnType the return type for the expression overload
- * @param cases list of test cases that fit within the binding limits of the device
- * @param inputSource the source of the input values
- * @param wgslStorageType the wgsl storage type
- * @param wgslOutput the wgsl output location
- */
-function makeConstShader(
-  expressionBuilder: ExpressionBuilder,
-  parameterTypes: Array<Type>,
-  returnType: Type,
-  cases: CaseList,
-  wgslStorageType: Type,
-  wgslOutputs: string
-) {
-  //////////////////////////////////////////////////////////////////////////
-  // Input values are constant values in the WGSL shader
-  //////////////////////////////////////////////////////////////////////////
-  const wgslValues = cases.map(c => {
-    const args = parameterTypes.map((_, i) => `(${ith(c.input, i).wgsl()})`);
-    return `${toStorage(returnType, expressionBuilder(args))}`;
-  });
-
-  const wgslBody = globalTestConfig.unrollConstEvalLoops
-    ? wgslValues.map((_, i) => `outputs[${i}].value = values[${i}];`).join('\n  ')
-    : `for (var i = 0u; i < ${cases.length}; i++) {
-  outputs[i].value = values[i];
-}`;
-
-  // the full WGSL shader source
-  return `
-  ${wgslOutputs}
-
-  const values = array<${wgslStorageType}, ${cases.length}>(
-    ${wgslValues.join(',\n  ')}
-  );
-
-  @compute @workgroup_size(1)
-  fn main() {
-    ${wgslBody}
-  }
-  `;
-}
-
-/**
- * Constructs the shader for a compound non-const input source
- * @param expressionBuilder the expression builder function
- * @param parameterTypes the list of expression parameter types
- * @param returnType the return type for the expression overload
- * @param cases list of test cases that fit within the binding limits of the device
- * @param inputSource the source of the input values
- * @param wgslOutputs the wgsl output location
- */
-function makeNonConstCompoundShader(
-  expressionBuilder: ExpressionBuilder,
-  parameterTypes: Array<Type>,
-  returnType: Type,
-  cases: CaseList,
-  inputSource: InputSource,
-  wgslOutputs: string
-) {
-  // input binding var<...> declaration
-  const wgslInputVar = (function () {
-    switch (inputSource) {
-      case 'storage_r':
-        return 'var<storage, read>';
-      case 'storage_rw':
-        return 'var<storage, read_write>';
-      case 'uniform':
-        return 'var<uniform>';
-      default:
-        return '';
-    }
-  })();
-
-  return `
+      return `
 struct Input {
 ${parameterTypes
   .map((ty, i) => `  @size(${valueStride(ty)}) param${i} : ${storageType(ty)},`)
   .join('\n')}
 };
 
-${wgslOutputs}
+${wgslOutputs(resultType, cases.length)}
 
-@group(0) @binding(1)
-${wgslInputVar} inputs : array<Input, ${cases.length}>;
-
-@compute @workgroup_size(1)
-fn main() {
-  for(var i = 0; i < ${cases.length}; i++) {
-    outputs[i].value = inputs[i].param0;
-    outputs[i].value ${expressionBuilder([])}= inputs[i].param1;
-  }
-}
-`;
-}
-
-/**
- * Constructs the shader for a non-const input source
- * @param expressionBuilder the expression builder function
- * @param parameterTypes the list of expression parameter types
- * @param returnType the return type for the expression overload
- * @param cases list of test cases that fit within the binding limits of the device
- * @param inputSource the source of the input values
- * @param wgslOutputs the wgsl output location
- */
-function makeNonConstShader(
-  expressionBuilder: ExpressionBuilder,
-  parameterTypes: Array<Type>,
-  returnType: Type,
-  cases: CaseList,
-  inputSource: InputSource,
-  wgslOutputs: string
-) {
-  // returns the WGSL expression to load the ith parameter of the given type from the input buffer
-  const paramExpr = (ty: Type, i: number) => fromStorage(ty, `inputs[i].param${i}`);
-
-  // resolves to the expression that calls the builtin
-  const expr = toStorage(returnType, expressionBuilder(parameterTypes.map(paramExpr)));
-
-  // input binding var<...> declaration
-  const wgslInputVar = (function () {
-    switch (inputSource) {
-      case 'storage_r':
-        return 'var<storage, read>';
-      case 'storage_rw':
-        return 'var<storage, read_write>';
-      case 'uniform':
-        return 'var<uniform>';
-      default:
-        return '';
-    }
-  })();
-
-  return `
-struct Input {
-${parameterTypes
-  .map((ty, i) => `  @size(${valueStride(ty)}) param${i} : ${storageType(ty)},`)
-  .join('\n')}
-};
-
-${wgslOutputs}
-
-@group(0) @binding(1)
-${wgslInputVar} inputs : array<Input, ${cases.length}>;
+${wgslInputVar(inputSource, cases.length)}
 
 @compute @workgroup_size(1)
 fn main() {
-  for(var i = 0; i < ${cases.length}; i++) {
+  for (var i = 0; i < ${cases.length}; i++) {
     outputs[i].value = ${expr};
   }
 }
 `;
+    }
+  };
+}
+
+/**
+ * Returns a ShaderBuilder that builds a compound assignment operator test shader.
+ * @param op the compound operator
+ */
+export function compoundAssignmentBuilder(op: string): ShaderBuilder {
+  return (
+    parameterTypes: Array<Type>,
+    resultType: Type,
+    cases: CaseList,
+    inputSource: InputSource
+  ) => {
+    //////////////////////////////////////////////////////////////////////////
+    // Input validation
+    //////////////////////////////////////////////////////////////////////////
+    if (parameterTypes.length !== 2) {
+      throw new Error(`compoundBinaryOp() requires exactly two parameters values per case`);
+    }
+    const lhsType = parameterTypes[0];
+    const rhsType = parameterTypes[1];
+    if (!objectEquals(lhsType, resultType)) {
+      throw new Error(
+        `compoundBinaryOp() requires result type (${resultType}) to be equal to the LHS type (${lhsType})`
+      );
+    }
+    if (inputSource === 'const') {
+      //////////////////////////////////////////////////////////////////////////
+      // Constant eval
+      //////////////////////////////////////////////////////////////////////////
+      let body = '';
+      if (globalTestConfig.unrollConstEvalLoops) {
+        body = cases
+          .map((_, i) => {
+            return `
+  outputs[${i}].value = lhs[${i}];
+  outputs[${i}].value ${op} rhs[${i}];`;
+          })
+          .join('\n  ');
+      } else {
+        body = `
+  for (var i = 0u; i < ${cases.length}; i++) {
+    outputs[i].value = lhs[i];
+    outputs[i].value ${op} rhs[i];
+  }`;
+      }
+
+      const values = cases.map(c => (c.input as Value[]).map(v => v.wgsl()));
+
+      return `
+${wgslOutputs(resultType, cases.length)}
+
+const lhs = array(
+${values.map(c => `${c[0]}`).join(',\n  ')}
+      );
+const rhs = array(
+${values.map(c => `${c[1]}`).join(',\n  ')}
+);
+
+@compute @workgroup_size(1)
+fn main() {
+${body}
+}`;
+    } else {
+      //////////////////////////////////////////////////////////////////////////
+      // Runtime eval
+      //////////////////////////////////////////////////////////////////////////
+      return `
+${wgslOutputs(resultType, cases.length)}
+
+struct Input {
+  @size(${valueStride(lhsType)}) lhs : ${storageType(lhsType)},
+  @size(${valueStride(rhsType)}) rhs : ${storageType(rhsType)},
+}
+
+${wgslInputVar(inputSource, cases.length)}
+
+@compute @workgroup_size(1)
+fn main() {
+  for (var i = 0; i < ${cases.length}; i++) {
+    outputs[i].value = inputs[i].lhs;
+    outputs[i].value ${op} inputs[i].rhs;
+  }
+}
+`;
+    }
+  };
 }
 
 /**
@@ -631,36 +613,24 @@ fn main() {
  * @p pipelineCache, then this may be returned instead of creating a new
  * pipeline.
  * @param t the GPUTest
- * @param expressionBuilder the expression builder function
+ * @param shaderBuilder the shader builder
  * @param parameterTypes the list of expression parameter types
- * @param returnType the return type for the expression overload
+ * @param resultType the return type for the expression overload
  * @param cases list of test cases that fit within the binding limits of the device
  * @param inputSource the source of the input values
- * @param compoundStmt true if the expression is a compound statement
  * @param outputBuffer the buffer that will hold the output values of the tests
  * @param pipelineCache the cache of compute pipelines, shared between batches
  */
 function buildPipeline(
   t: GPUTest,
-  expressionBuilder: ExpressionBuilder,
+  shaderBuilder: ShaderBuilder,
   parameterTypes: Array<Type>,
-  returnType: Type,
+  resultType: Type,
   cases: CaseList,
   inputSource: InputSource,
-  compoundStmt: Boolean,
   outputBuffer: GPUBuffer,
   pipelineCache: PipelineCache
 ): [GPUComputePipeline, GPUBindGroup] {
-  // wgsl declaration of output buffer and binding
-  const wgslValueStride = valueStride(returnType);
-  const wgslStorageType = storageType(returnType);
-  const wgslOutputs = `
-struct Output {
-  @size(${wgslValueStride}) value : ${wgslStorageType}
-};
-@group(0) @binding(0) var<storage, read_write> outputs : array<Output, ${cases.length}>;
-`;
-
   cases.forEach(c => {
     const inputTypes = c.input instanceof Array ? c.input.map(i => i.type) : [c.input.type];
     if (!objectEquals(inputTypes, parameterTypes)) {
@@ -672,26 +642,10 @@ struct Output {
     }
   });
 
+  const source = shaderBuilder(parameterTypes, resultType, cases, inputSource);
+
   switch (inputSource) {
     case 'const': {
-      const source = compoundStmt
-        ? makeConstCompoundShader(
-            expressionBuilder,
-            parameterTypes,
-            returnType,
-            cases,
-            wgslStorageType,
-            wgslOutputs
-          )
-        : makeConstShader(
-            expressionBuilder,
-            parameterTypes,
-            returnType,
-            cases,
-            wgslStorageType,
-            wgslOutputs
-          );
-
       // build the shader module
       const module = t.device.createShaderModule({ code: source });
 
@@ -713,28 +667,7 @@ struct Output {
     case 'uniform':
     case 'storage_r':
     case 'storage_rw': {
-      //////////////////////////////////////////////////////////////////////////
       // Input values come from a uniform or storage buffer
-      //////////////////////////////////////////////////////////////////////////
-
-      // the full WGSL shader source
-      const source = compoundStmt
-        ? makeNonConstCompoundShader(
-            expressionBuilder,
-            parameterTypes,
-            returnType,
-            cases,
-            inputSource,
-            wgslOutputs
-          )
-        : makeNonConstShader(
-            expressionBuilder,
-            parameterTypes,
-            returnType,
-            cases,
-            inputSource,
-            wgslOutputs
-          );
 
       // size in bytes of the input buffer
       const inputSize = cases.length * valueStrides(parameterTypes);
@@ -802,10 +735,10 @@ struct Output {
  */
 function packScalarsToVector(
   parameterTypes: Array<Type>,
-  returnType: Type,
+  resultType: Type,
   cases: CaseList,
   vectorWidth: number
-): { cases: CaseList; parameterTypes: Array<Type>; returnType: Type } {
+): { cases: CaseList; parameterTypes: Array<Type>; resultType: Type } {
   // Validate that the parameters and return type are all vectorizable
   for (let i = 0; i < parameterTypes.length; i++) {
     const ty = parameterTypes[i];
@@ -815,15 +748,15 @@ function packScalarsToVector(
       );
     }
   }
-  if (!(returnType instanceof ScalarType)) {
+  if (!(resultType instanceof ScalarType)) {
     throw new Error(
-      `packScalarsToVector() can only be used with a scalar return type, but the return type is a ${returnType}'`
+      `packScalarsToVector() can only be used with a scalar return type, but the return type is a ${resultType}'`
     );
   }
 
   const packedCases: Array<Case> = [];
   const packedParameterTypes = parameterTypes.map(p => TypeVec(vectorWidth, p as ScalarType));
-  const packedReturnType = new VectorType(vectorWidth, returnType);
+  const packedResultType = new VectorType(vectorWidth, resultType);
 
   const clampCaseIdx = (idx: number) => Math.min(idx, cases.length - 1);
 
@@ -857,8 +790,8 @@ function packScalarsToVector(
       }
       return {
         matched,
-        got: `${packedReturnType}(${gElements.join(', ')})`,
-        expected: `${packedReturnType}(${eElements.join(', ')})`,
+        got: `${packedResultType}(${gElements.join(', ')})`,
+        expected: `${packedResultType}(${eElements.join(', ')})`,
       };
     };
 
@@ -870,7 +803,7 @@ function packScalarsToVector(
   return {
     cases: packedCases,
     parameterTypes: packedParameterTypes,
-    returnType: packedReturnType,
+    resultType: packedResultType,
   };
 }
 

--- a/src/webgpu/shader/execution/expression/unary/bool_conversion.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/bool_conversion.spec.ts
@@ -23,7 +23,7 @@ import {
   isSubnormalNumberF32,
 } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, ExpressionBuilder, run } from '../expression.js';
+import { allInputSources, run, ShaderBuilder } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -61,7 +61,7 @@ export const d = makeCaseCache('unary/bool_conversion', {
 });
 
 /** Generate expression builder based on how the test case is to be vectorized */
-function vectorizeToExpression(vectorize: undefined | 2 | 3 | 4): ExpressionBuilder {
+function vectorizeToExpression(vectorize: undefined | 2 | 3 | 4): ShaderBuilder {
   return vectorize === undefined ? unary('bool') : unary(`vec${vectorize}<bool>`);
 }
 

--- a/src/webgpu/shader/execution/expression/unary/f32_conversion.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_conversion.spec.ts
@@ -23,12 +23,7 @@ import {
   sparseMatrixF32Range,
 } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import {
-  allInputSources,
-  ExpressionBuilder,
-  generateMatrixToMatrixCases,
-  run,
-} from '../expression.js';
+import { allInputSources, generateMatrixToMatrixCases, run, ShaderBuilder } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -184,13 +179,13 @@ export const d = makeCaseCache('unary/f32_conversion', {
   },
 });
 
-/** Generate expression builder based on how the test case is to be vectorized */
-function vectorizeToExpression(vectorize: undefined | 2 | 3 | 4): ExpressionBuilder {
+/** Generate a ShaderBuilder based on how the test case is to be vectorized */
+function vectorizeToExpression(vectorize: undefined | 2 | 3 | 4): ShaderBuilder {
   return vectorize === undefined ? unary('f32') : unary(`vec${vectorize}<f32>`);
 }
 
-/** Generate expression builder for a matrix of the provided dimensions */
-function matrixExperession(cols: number, rows: number): ExpressionBuilder {
+/** Generate a ShaderBuilder for a matrix of the provided dimensions */
+function matrixExperession(cols: number, rows: number): ShaderBuilder {
   return unary(`mat${cols}x${rows}<f32>`);
 }
 

--- a/src/webgpu/shader/execution/expression/unary/i32_conversion.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/i32_conversion.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../util/conversion.js';
 import { fullF32Range, fullI32Range, fullU32Range, quantizeToF32 } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, ExpressionBuilder, run } from '../expression.js';
+import { allInputSources, run, ShaderBuilder } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -72,8 +72,8 @@ export const d = makeCaseCache('unary/i32_conversion', {
   },
 });
 
-/** Generate expression builder based on how the test case is to be vectorized */
-function vectorizeToExpression(vectorize: undefined | 2 | 3 | 4): ExpressionBuilder {
+/** Generate a ShaderBuilder based on how the test case is to be vectorized */
+function vectorizeToExpression(vectorize: undefined | 2 | 3 | 4): ShaderBuilder {
   return vectorize === undefined ? unary('i32') : unary(`vec${vectorize}<i32>`);
 }
 

--- a/src/webgpu/shader/execution/expression/unary/u32_conversion.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/u32_conversion.spec.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../util/conversion.js';
 import { fullF32Range, fullI32Range, fullU32Range, quantizeToF32 } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, ExpressionBuilder, run } from '../expression.js';
+import { allInputSources, run, ShaderBuilder } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -68,8 +68,8 @@ export const d = makeCaseCache('unary/u32_conversion', {
   },
 });
 
-/** Generate expression builder based on how the test case is to be vectorized */
-function vectorizeToExpression(vectorize: undefined | 2 | 3 | 4): ExpressionBuilder {
+/** Generate a ShaderBuilder based on how the test case is to be vectorized */
+function vectorizeToExpression(vectorize: undefined | 2 | 3 | 4): ShaderBuilder {
   return vectorize === undefined ? unary('u32') : unary(`vec${vectorize}<u32>`);
 }
 

--- a/src/webgpu/shader/execution/expression/unary/unary.ts
+++ b/src/webgpu/shader/execution/expression/unary/unary.ts
@@ -1,6 +1,6 @@
-import { ExpressionBuilder } from '../expression.js';
+import { basicExpressionBuilder, ShaderBuilder } from '../expression.js';
 
-/* @returns an ExpressionBuilder that evaluates a prefix unary operation */
-export function unary(op: string): ExpressionBuilder {
-  return value => `${op}(${value})`;
+/* @returns a ShaderBuilder that evaluates a prefix unary operation */
+export function unary(op: string): ShaderBuilder {
+  return basicExpressionBuilder(value => `${op}(${value})`);
 }


### PR DESCRIPTION
A general code reshuffling to clean up some of the compound operator logic added in #2422




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
