### PR TITLE
[wgsl] Cleanup compound statement tests

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
@@ -11,6 +11,53 @@ import { binary, compoundBinary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
 
+function makeBitwiseOrCases(inputType: string) {
+  const V = inputType === 'i32' ? i32 : u32;
+  const cases = [
+    // Static patterns
+    {
+      input: [V(0b00000000000000000000000000000000), V(0b00000000000000000000000000000000)],
+      expected: V(0b00000000000000000000000000000000),
+    },
+    {
+      input: [V(0b11111111111111111111111111111111), V(0b00000000000000000000000000000000)],
+      expected: V(0b11111111111111111111111111111111),
+    },
+    {
+      input: [V(0b00000000000000000000000000000000), V(0b11111111111111111111111111111111)],
+      expected: V(0b11111111111111111111111111111111),
+    },
+    {
+      input: [V(0b11111111111111111111111111111111), V(0b11111111111111111111111111111111)],
+      expected: V(0b11111111111111111111111111111111),
+    },
+    {
+      input: [V(0b10100100010010100100010010100100), V(0b00000000000000000000000000000000)],
+      expected: V(0b10100100010010100100010010100100),
+    },
+    {
+      input: [V(0b00000000000000000000000000000000), V(0b10100100010010100100010010100100)],
+      expected: V(0b10100100010010100100010010100100),
+    },
+    {
+      input: [V(0b01010010001001010010001001010010), V(0b10100100010010100100010010100100)],
+      expected: V(0b11110110011011110110011011110110),
+    },
+  ];
+  // Permute all combinations of a single bit being set for the LHS and RHS
+  for (let i = 0; i < 32; i++) {
+    const lhs = 1 << i;
+    for (let j = 0; j < 32; j++) {
+      const rhs = 1 << j;
+      cases.push({
+        input: [V(lhs), V(rhs)],
+        expected: V(lhs | rhs),
+      });
+    }
+  }
+  return cases;
+}
+
 g.test('bitwise_or')
   .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
   .desc(
@@ -26,62 +73,91 @@ Bitwise-or. Component-wise when T is a vector.
       .combine('type', ['i32', 'u32'] as const)
       .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
-    const V = t.params.type === 'i32' ? i32 : u32;
-    const cases = [
-      // Static patterns
-      {
-        input: [V(0b00000000000000000000000000000000), V(0b00000000000000000000000000000000)],
-        expected: V(0b00000000000000000000000000000000),
-      },
-      {
-        input: [V(0b11111111111111111111111111111111), V(0b00000000000000000000000000000000)],
-        expected: V(0b11111111111111111111111111111111),
-      },
-      {
-        input: [V(0b00000000000000000000000000000000), V(0b11111111111111111111111111111111)],
-        expected: V(0b11111111111111111111111111111111),
-      },
-      {
-        input: [V(0b11111111111111111111111111111111), V(0b11111111111111111111111111111111)],
-        expected: V(0b11111111111111111111111111111111),
-      },
-      {
-        input: [V(0b10100100010010100100010010100100), V(0b00000000000000000000000000000000)],
-        expected: V(0b10100100010010100100010010100100),
-      },
-      {
-        input: [V(0b00000000000000000000000000000000), V(0b10100100010010100100010010100100)],
-        expected: V(0b10100100010010100100010010100100),
-      },
-      {
-        input: [V(0b01010010001001010010001001010010), V(0b10100100010010100100010010100100)],
-        expected: V(0b11110110011011110110011011110110),
-      },
-    ];
-    // Permute all combinations of a single bit being set for the LHS and RHS
-    for (let i = 0; i < 32; i++) {
-      const lhs = 1 << i;
-      for (let j = 0; j < 32; j++) {
-        const rhs = 1 << j;
-        cases.push({
-          input: [V(lhs), V(rhs)],
-          expected: V(lhs | rhs),
-        });
-      }
-    }
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('|') : binary('|'),
-      [type, type],
-      type,
-      t.params,
-      cases
-    );
+    const cases = makeBitwiseOrCases(t.params.type);
+
+    await run(t, binary('|'), [type, type], type, t.params, cases);
   });
+
+g.test('bitwise_or_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
+  .desc(
+    `
+e1 |= e2: T
+T is i32, u32, vecN<i32>, or vecN<u32>
+
+Bitwise-or. Component-wise when T is a vector.
+`
+  )
+  .params(u =>
+    u
+      .combine('type', ['i32', 'u32'] as const)
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const type = scalarType(t.params.type);
+    const cases = makeBitwiseOrCases(t.params.type);
+
+    await run(t, compoundBinary('|'), [type, type], type, t.params, cases);
+  });
+
+function makeBitwiseAndCases(inputType: string) {
+  const V = inputType === 'i32' ? i32 : u32;
+  const cases = [
+    // Static patterns
+    {
+      input: [V(0b00000000000000000000000000000000), V(0b00000000000000000000000000000000)],
+      expected: V(0b00000000000000000000000000000000),
+    },
+    {
+      input: [V(0b11111111111111111111111111111111), V(0b00000000000000000000000000000000)],
+      expected: V(0b00000000000000000000000000000000),
+    },
+    {
+      input: [V(0b00000000000000000000000000000000), V(0b11111111111111111111111111111111)],
+      expected: V(0b00000000000000000000000000000000),
+    },
+    {
+      input: [V(0b11111111111111111111111111111111), V(0b11111111111111111111111111111111)],
+      expected: V(0b11111111111111111111111111111111),
+    },
+    {
+      input: [V(0b10100100010010100100010010100100), V(0b00000000000000000000000000000000)],
+      expected: V(0b00000000000000000000000000000000),
+    },
+    {
+      input: [V(0b10100100010010100100010010100100), V(0b11111111111111111111111111111111)],
+      expected: V(0b10100100010010100100010010100100),
+    },
+    {
+      input: [V(0b00000000000000000000000000000000), V(0b10100100010010100100010010100100)],
+      expected: V(0b00000000000000000000000000000000),
+    },
+    {
+      input: [V(0b11111111111111111111111111111111), V(0b10100100010010100100010010100100)],
+      expected: V(0b10100100010010100100010010100100),
+    },
+    {
+      input: [V(0b01010010001001010010001001010010), V(0b01011011101101011011101101011011)],
+      expected: V(0b01010010001001010010001001010010),
+    },
+  ];
+  // Permute all combinations of a single bit being set for the LHS and all but one bit set for the RHS
+  for (let i = 0; i < 32; i++) {
+    const lhs = 1 << i;
+    for (let j = 0; j < 32; j++) {
+      const rhs = 0xffffffff ^ (1 << j);
+      cases.push({
+        input: [V(lhs), V(rhs)],
+        expected: V(lhs & rhs),
+      });
+    }
+  }
+  return cases;
+}
 
 g.test('bitwise_and')
   .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
@@ -98,70 +174,89 @@ Bitwise-and. Component-wise when T is a vector.
       .combine('type', ['i32', 'u32'] as const)
       .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
-    const V = t.params.type === 'i32' ? i32 : u32;
-    const cases = [
-      // Static patterns
-      {
-        input: [V(0b00000000000000000000000000000000), V(0b00000000000000000000000000000000)],
-        expected: V(0b00000000000000000000000000000000),
-      },
-      {
-        input: [V(0b11111111111111111111111111111111), V(0b00000000000000000000000000000000)],
-        expected: V(0b00000000000000000000000000000000),
-      },
-      {
-        input: [V(0b00000000000000000000000000000000), V(0b11111111111111111111111111111111)],
-        expected: V(0b00000000000000000000000000000000),
-      },
-      {
-        input: [V(0b11111111111111111111111111111111), V(0b11111111111111111111111111111111)],
-        expected: V(0b11111111111111111111111111111111),
-      },
-      {
-        input: [V(0b10100100010010100100010010100100), V(0b00000000000000000000000000000000)],
-        expected: V(0b00000000000000000000000000000000),
-      },
-      {
-        input: [V(0b10100100010010100100010010100100), V(0b11111111111111111111111111111111)],
-        expected: V(0b10100100010010100100010010100100),
-      },
-      {
-        input: [V(0b00000000000000000000000000000000), V(0b10100100010010100100010010100100)],
-        expected: V(0b00000000000000000000000000000000),
-      },
-      {
-        input: [V(0b11111111111111111111111111111111), V(0b10100100010010100100010010100100)],
-        expected: V(0b10100100010010100100010010100100),
-      },
-      {
-        input: [V(0b01010010001001010010001001010010), V(0b01011011101101011011101101011011)],
-        expected: V(0b01010010001001010010001001010010),
-      },
-    ];
-    // Permute all combinations of a single bit being set for the LHS and all but one bit set for the RHS
-    for (let i = 0; i < 32; i++) {
-      const lhs = 1 << i;
-      for (let j = 0; j < 32; j++) {
-        const rhs = 0xffffffff ^ (1 << j);
-        cases.push({
-          input: [V(lhs), V(rhs)],
-          expected: V(lhs & rhs),
-        });
-      }
-    }
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('&') : binary('&'),
-      [type, type],
-      type,
-      t.params,
-      cases
-    );
+    const cases = makeBitwiseAndCases(t.params.type);
+    await run(t, binary('&'), [type, type], type, t.params, cases);
   });
+
+g.test('bitwise_and_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
+  .desc(
+    `
+e1 &= e2: T
+T is i32, u32, vecN<i32>, or vecN<u32>
+
+Bitwise-and. Component-wise when T is a vector.
+`
+  )
+  .params(u =>
+    u
+      .combine('type', ['i32', 'u32'] as const)
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const type = scalarType(t.params.type);
+    const cases = makeBitwiseAndCases(t.params.type);
+    await run(t, compoundBinary('&'), [type, type], type, t.params, cases);
+  });
+
+function makeBitwiseExcluseOrCases(inputType: string) {
+  const V = inputType === 'i32' ? i32 : u32;
+  const cases = [
+    // Static patterns
+    {
+      input: [V(0b00000000000000000000000000000000), V(0b00000000000000000000000000000000)],
+      expected: V(0b00000000000000000000000000000000),
+    },
+    {
+      input: [V(0b11111111111111111111111111111111), V(0b00000000000000000000000000000000)],
+      expected: V(0b11111111111111111111111111111111),
+    },
+    {
+      input: [V(0b00000000000000000000000000000000), V(0b11111111111111111111111111111111)],
+      expected: V(0b11111111111111111111111111111111),
+    },
+    {
+      input: [V(0b11111111111111111111111111111111), V(0b11111111111111111111111111111111)],
+      expected: V(0b00000000000000000000000000000000),
+    },
+    {
+      input: [V(0b10100100010010100100010010100100), V(0b00000000000000000000000000000000)],
+      expected: V(0b10100100010010100100010010100100),
+    },
+    {
+      input: [V(0b10100100010010100100010010100100), V(0b11111111111111111111111111111111)],
+      expected: V(0b01011011101101011011101101011011),
+    },
+    {
+      input: [V(0b00000000000000000000000000000000), V(0b10100100010010100100010010100100)],
+      expected: V(0b10100100010010100100010010100100),
+    },
+    {
+      input: [V(0b11111111111111111111111111111111), V(0b10100100010010100100010010100100)],
+      expected: V(0b01011011101101011011101101011011),
+    },
+    {
+      input: [V(0b01010010001001010010001001010010), V(0b01011011101101011011101101011011)],
+      expected: V(0b00001001100100001001100100001001),
+    },
+  ];
+  // Permute all combinations of a single bit being set for the LHS and all but one bit set for the RHS
+  for (let i = 0; i < 32; i++) {
+    const lhs = 1 << i;
+    for (let j = 0; j < 32; j++) {
+      const rhs = 0xffffffff ^ (1 << j);
+      cases.push({
+        input: [V(lhs), V(rhs)],
+        expected: V(lhs ^ rhs),
+      });
+    }
+  }
+  return cases;
+}
 
 g.test('bitwise_exclusive_or')
   .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
@@ -178,67 +273,31 @@ Bitwise-exclusive-or. Component-wise when T is a vector.
       .combine('type', ['i32', 'u32'] as const)
       .combine('inputSource', allInputSources)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
-    const V = t.params.type === 'i32' ? i32 : u32;
-    const cases = [
-      // Static patterns
-      {
-        input: [V(0b00000000000000000000000000000000), V(0b00000000000000000000000000000000)],
-        expected: V(0b00000000000000000000000000000000),
-      },
-      {
-        input: [V(0b11111111111111111111111111111111), V(0b00000000000000000000000000000000)],
-        expected: V(0b11111111111111111111111111111111),
-      },
-      {
-        input: [V(0b00000000000000000000000000000000), V(0b11111111111111111111111111111111)],
-        expected: V(0b11111111111111111111111111111111),
-      },
-      {
-        input: [V(0b11111111111111111111111111111111), V(0b11111111111111111111111111111111)],
-        expected: V(0b00000000000000000000000000000000),
-      },
-      {
-        input: [V(0b10100100010010100100010010100100), V(0b00000000000000000000000000000000)],
-        expected: V(0b10100100010010100100010010100100),
-      },
-      {
-        input: [V(0b10100100010010100100010010100100), V(0b11111111111111111111111111111111)],
-        expected: V(0b01011011101101011011101101011011),
-      },
-      {
-        input: [V(0b00000000000000000000000000000000), V(0b10100100010010100100010010100100)],
-        expected: V(0b10100100010010100100010010100100),
-      },
-      {
-        input: [V(0b11111111111111111111111111111111), V(0b10100100010010100100010010100100)],
-        expected: V(0b01011011101101011011101101011011),
-      },
-      {
-        input: [V(0b01010010001001010010001001010010), V(0b01011011101101011011101101011011)],
-        expected: V(0b00001001100100001001100100001001),
-      },
-    ];
-    // Permute all combinations of a single bit being set for the LHS and all but one bit set for the RHS
-    for (let i = 0; i < 32; i++) {
-      const lhs = 1 << i;
-      for (let j = 0; j < 32; j++) {
-        const rhs = 0xffffffff ^ (1 << j);
-        cases.push({
-          input: [V(lhs), V(rhs)],
-          expected: V(lhs ^ rhs),
-        });
-      }
-    }
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('^') : binary('^'),
-      [type, type],
-      type,
-      t.params,
-      cases
-    );
+    const cases = makeBitwiseExcluseOrCases(t.params.type);
+    await run(t, binary('^'), [type, type], type, t.params, cases);
+  });
+
+g.test('bitwise_exclusive_or_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
+  .desc(
+    `
+e1 ^= e2: T
+T is i32, u32, vecN<i32>, or vecN<u32>
+
+Bitwise-exclusive-or. Component-wise when T is a vector.
+`
+  )
+  .params(u =>
+    u
+      .combine('type', ['i32', 'u32'] as const)
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const type = scalarType(t.params.type);
+    const cases = makeBitwiseExcluseOrCases(t.params.type);
+    await run(t, compoundBinary('^'), [type, type], type, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise_shift.spec.ts
@@ -4,10 +4,10 @@ Execution Tests for the bitwise shift binary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { i32, scalarType, TypeU32, u32 } from '../../../../util/conversion.js';
+import { i32, scalarType, ScalarType, TypeU32, u32 } from '../../../../util/conversion.js';
 import { allInputSources, CaseList, run } from '../expression.js';
 
-import { binary } from './binary.js';
+import { binary, compoundBinary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -103,6 +103,78 @@ function generate_shift_right_cases(e1: number, e1Type: string, is_const: boolea
   return cases;
 }
 
+function makeShiftLeftConcreteCases(inputType: string, inputSource: string, type: ScalarType) {
+  const V = inputType === 'i32' ? i32 : u32;
+  const is_const = inputSource === 'const';
+
+  const cases: CaseList = [
+    {
+      input: /*  */ [V(0b00000000000000000000000000000001), u32(1)],
+      expected: /**/ V(0b00000000000000000000000000000010),
+    },
+    {
+      input: /*  */ [V(0b00000000000000000000000000000011), u32(1)],
+      expected: /**/ V(0b00000000000000000000000000000110),
+    },
+  ];
+
+  const add_unsigned_overflow_cases = !is_const || is_unsiged(inputType);
+  const add_signed_overflow_cases = !is_const || !is_unsiged(inputType);
+
+  if (add_unsigned_overflow_cases) {
+    // Cases that are fine for unsigned values, but would overflow (sign change) signed
+    // values when const evaluated.
+    cases.push(
+      ...[
+        {
+          input: [/*  */ V(0b01000000000000000000000000000000), u32(1)],
+          expected: /**/ V(0b10000000000000000000000000000000),
+        },
+        {
+          input: [/*  */ V(0b01111111111111111111111111111111), u32(1)],
+          expected: /**/ V(0b11111111111111111111111111111110),
+        },
+        {
+          input: [/*  */ V(0b00000000000000000000000000000001), u32(31)],
+          expected: /**/ V(0b10000000000000000000000000000000),
+        },
+      ]
+    );
+  }
+  if (add_signed_overflow_cases) {
+    // Cases that are fine for signed values (no sign change), but would overflow
+    // unsigned values when const evaluated.
+    cases.push(
+      ...[
+        {
+          input: [/*  */ V(0b11000000000000000000000000000000), u32(1)],
+          expected: /**/ V(0b10000000000000000000000000000000),
+        },
+        {
+          input: [/*  */ V(0b11111111111111111111111111111111), u32(1)],
+          expected: /**/ V(0b11111111111111111111111111111110),
+        },
+        {
+          input: [/*  */ V(0b11111111111111111111111111111111), u32(31)],
+          expected: /**/ V(0b10000000000000000000000000000000),
+        },
+      ]
+    );
+  }
+
+  // Generate cases that shift input value by [0,63] (invalid const eval cases are not returned).
+  cases.push(...generate_shift_left_cases(0b00000000000000000000000000000000, inputType, is_const));
+  cases.push(...generate_shift_left_cases(0b00000000000000000000000000000001, inputType, is_const));
+  cases.push(...generate_shift_left_cases(0b00000000000000000000000000000010, inputType, is_const));
+  cases.push(...generate_shift_left_cases(0b00000000000000000000000000000011, inputType, is_const));
+  cases.push(...generate_shift_left_cases(0b10000000000000000000000000000000, inputType, is_const));
+  cases.push(...generate_shift_left_cases(0b01000000000000000000000000000000, inputType, is_const));
+  cases.push(...generate_shift_left_cases(0b11000000000000000000000000000000, inputType, is_const));
+  cases.push(...generate_shift_left_cases(0b00010000001000001000010001010101, inputType, is_const));
+  cases.push(...generate_shift_left_cases(0b11101111110111110111101110101010, inputType, is_const));
+  return cases;
+}
+
 g.test('shift_left_concrete')
   .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
   .desc(
@@ -120,94 +192,113 @@ Shift left (shifted value is concrete)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
-    const V = t.params.type === 'i32' ? i32 : u32;
-    const is_const = t.params.inputSource === 'const';
-
-    const cases: CaseList = [
-      {
-        input: /*  */ [V(0b00000000000000000000000000000001), u32(1)],
-        expected: /**/ V(0b00000000000000000000000000000010),
-      },
-      {
-        input: /*  */ [V(0b00000000000000000000000000000011), u32(1)],
-        expected: /**/ V(0b00000000000000000000000000000110),
-      },
-    ];
-
-    const add_unsigned_overflow_cases = !is_const || is_unsiged(t.params.type);
-    const add_signed_overflow_cases = !is_const || !is_unsiged(t.params.type);
-
-    if (add_unsigned_overflow_cases) {
-      // Cases that are fine for unsigned values, but would overflow (sign change) signed
-      // values when const evaluated.
-      cases.push(
-        ...[
-          {
-            input: [/*  */ V(0b01000000000000000000000000000000), u32(1)],
-            expected: /**/ V(0b10000000000000000000000000000000),
-          },
-          {
-            input: [/*  */ V(0b01111111111111111111111111111111), u32(1)],
-            expected: /**/ V(0b11111111111111111111111111111110),
-          },
-          {
-            input: [/*  */ V(0b00000000000000000000000000000001), u32(31)],
-            expected: /**/ V(0b10000000000000000000000000000000),
-          },
-        ]
-      );
-    }
-    if (add_signed_overflow_cases) {
-      // Cases that are fine for signed values (no sign change), but would overflow
-      // unsigned values when const evaluated.
-      cases.push(
-        ...[
-          {
-            input: [/*  */ V(0b11000000000000000000000000000000), u32(1)],
-            expected: /**/ V(0b10000000000000000000000000000000),
-          },
-          {
-            input: [/*  */ V(0b11111111111111111111111111111111), u32(1)],
-            expected: /**/ V(0b11111111111111111111111111111110),
-          },
-          {
-            input: [/*  */ V(0b11111111111111111111111111111111), u32(31)],
-            expected: /**/ V(0b10000000000000000000000000000000),
-          },
-        ]
-      );
-    }
-
-    // Generate cases that shift input value by [0,63] (invalid const eval cases are not returned).
-    cases.push(
-      ...generate_shift_left_cases(0b00000000000000000000000000000000, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_left_cases(0b00000000000000000000000000000001, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_left_cases(0b00000000000000000000000000000010, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_left_cases(0b00000000000000000000000000000011, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_left_cases(0b10000000000000000000000000000000, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_left_cases(0b01000000000000000000000000000000, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_left_cases(0b11000000000000000000000000000000, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_left_cases(0b00010000001000001000010001010101, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_left_cases(0b11101111110111110111101110101010, t.params.type, is_const)
-    );
+    const cases = makeShiftLeftConcreteCases(t.params.type, t.params.inputSource, type);
     await run(t, binary('<<'), [type, TypeU32], type, t.params, cases);
   });
+
+g.test('shift_left_concrete_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
+  .desc(
+    `
+e1 <<= e2
+
+Shift left (shifted value is concrete)
+`
+  )
+  .params(u =>
+    u
+      .combine('type', ['i32', 'u32'] as const)
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const type = scalarType(t.params.type);
+    const cases = makeShiftLeftConcreteCases(t.params.type, t.params.inputSource, type);
+    await run(t, compoundBinary('<<'), [type, TypeU32], type, t.params, cases);
+  });
+
+function makeShiftRightConcreteCases(inputType: string, inputSource: string, type: ScalarType) {
+  const V = inputType === 'i32' ? i32 : u32;
+  const is_const = inputSource === 'const';
+
+  const cases: CaseList = [
+    {
+      input: /*  */ [V(0b00000000000000000000000000000001), u32(1)],
+      expected: /**/ V(0b00000000000000000000000000000000),
+    },
+    {
+      input: /*  */ [V(0b00000000000000000000000000000011), u32(1)],
+      expected: /**/ V(0b00000000000000000000000000000001),
+    },
+    {
+      input: /*  */ [V(0b01000000000000000000000000000000), u32(1)],
+      expected: /**/ V(0b00100000000000000000000000000000),
+    },
+    {
+      input: /*  */ [V(0b01100000000000000000000000000000), u32(1)],
+      expected: /**/ V(0b00110000000000000000000000000000),
+    },
+  ];
+  if (is_unsiged(inputType)) {
+    // No sign extension
+    cases.push(
+      ...[
+        {
+          input: /*  */ [V(0b10000000000000000000000000000000), u32(1)],
+          expected: /**/ V(0b01000000000000000000000000000000),
+        },
+        {
+          input: /*  */ [V(0b11000000000000000000000000000000), u32(1)],
+          expected: /**/ V(0b01100000000000000000000000000000),
+        },
+      ]
+    );
+  } else {
+    cases.push(
+      // Sign extension if msb is 1
+      ...[
+        {
+          input: /*  */ [V(0b10000000000000000000000000000000), u32(1)],
+          expected: /**/ V(0b11000000000000000000000000000000),
+        },
+        {
+          input: /*  */ [V(0b11000000000000000000000000000000), u32(1)],
+          expected: /**/ V(0b11100000000000000000000000000000),
+        },
+      ]
+    );
+  }
+
+  // Generate cases that shift input value by [0,63] (invalid const eval cases are not returned).
+  cases.push(
+    ...generate_shift_right_cases(0b00000000000000000000000000000000, inputType, is_const)
+  );
+  cases.push(
+    ...generate_shift_right_cases(0b00000000000000000000000000000001, inputType, is_const)
+  );
+  cases.push(
+    ...generate_shift_right_cases(0b00000000000000000000000000000010, inputType, is_const)
+  );
+  cases.push(
+    ...generate_shift_right_cases(0b00000000000000000000000000000011, inputType, is_const)
+  );
+  cases.push(
+    ...generate_shift_right_cases(0b10000000000000000000000000000000, inputType, is_const)
+  );
+  cases.push(
+    ...generate_shift_right_cases(0b01000000000000000000000000000000, inputType, is_const)
+  );
+  cases.push(
+    ...generate_shift_right_cases(0b11000000000000000000000000000000, inputType, is_const)
+  );
+  cases.push(
+    ...generate_shift_right_cases(0b00010000001000001000010001010101, inputType, is_const)
+  );
+  cases.push(
+    ...generate_shift_right_cases(0b11101111110111110111101110101010, inputType, is_const)
+  );
+  return cases;
+}
 
 g.test('shift_right_concrete')
   .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
@@ -226,84 +317,27 @@ Shift right (shifted value is concrete)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
-    const V = t.params.type === 'i32' ? i32 : u32;
-    const is_const = t.params.inputSource === 'const';
-
-    const cases: CaseList = [
-      {
-        input: /*  */ [V(0b00000000000000000000000000000001), u32(1)],
-        expected: /**/ V(0b00000000000000000000000000000000),
-      },
-      {
-        input: /*  */ [V(0b00000000000000000000000000000011), u32(1)],
-        expected: /**/ V(0b00000000000000000000000000000001),
-      },
-      {
-        input: /*  */ [V(0b01000000000000000000000000000000), u32(1)],
-        expected: /**/ V(0b00100000000000000000000000000000),
-      },
-      {
-        input: /*  */ [V(0b01100000000000000000000000000000), u32(1)],
-        expected: /**/ V(0b00110000000000000000000000000000),
-      },
-    ];
-    if (is_unsiged(t.params.type)) {
-      // No sign extension
-      cases.push(
-        ...[
-          {
-            input: /*  */ [V(0b10000000000000000000000000000000), u32(1)],
-            expected: /**/ V(0b01000000000000000000000000000000),
-          },
-          {
-            input: /*  */ [V(0b11000000000000000000000000000000), u32(1)],
-            expected: /**/ V(0b01100000000000000000000000000000),
-          },
-        ]
-      );
-    } else {
-      cases.push(
-        // Sign extension if msb is 1
-        ...[
-          {
-            input: /*  */ [V(0b10000000000000000000000000000000), u32(1)],
-            expected: /**/ V(0b11000000000000000000000000000000),
-          },
-          {
-            input: /*  */ [V(0b11000000000000000000000000000000), u32(1)],
-            expected: /**/ V(0b11100000000000000000000000000000),
-          },
-        ]
-      );
-    }
-
-    // Generate cases that shift input value by [0,63] (invalid const eval cases are not returned).
-    cases.push(
-      ...generate_shift_right_cases(0b00000000000000000000000000000000, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_right_cases(0b00000000000000000000000000000001, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_right_cases(0b00000000000000000000000000000010, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_right_cases(0b00000000000000000000000000000011, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_right_cases(0b10000000000000000000000000000000, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_right_cases(0b01000000000000000000000000000000, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_right_cases(0b11000000000000000000000000000000, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_right_cases(0b00010000001000001000010001010101, t.params.type, is_const)
-    );
-    cases.push(
-      ...generate_shift_right_cases(0b11101111110111110111101110101010, t.params.type, is_const)
-    );
+    const cases = makeShiftRightConcreteCases(t.params.type, t.params.inputSource, type);
     await run(t, binary('>>'), [type, TypeU32], type, t.params, cases);
+  });
+
+g.test('shift_right_concrete_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#bit-expr')
+  .desc(
+    `
+e1 >>= e2
+
+Shift right (shifted value is concrete)
+`
+  )
+  .params(u =>
+    u
+      .combine('type', ['i32', 'u32'] as const)
+      .combine('inputSource', allInputSources)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const type = scalarType(t.params.type);
+    const cases = makeShiftRightConcreteCases(t.params.type, t.params.inputSource, type);
+    await run(t, compoundBinary('>>'), [type, TypeU32], type, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -112,23 +112,31 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'addition_const' : 'addition_non_const'
     );
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('+') : binary('+'),
-      [TypeF32, TypeF32],
-      TypeF32,
-      t.params,
-      cases
+    await run(t, binary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+  });
+
+g.test('addition_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x *= y
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'addition_const' : 'addition_non_const'
     );
+    await run(t, compoundBinary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('subtraction')
@@ -140,23 +148,31 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'subtraction_const' : 'subtraction_non_const'
     );
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('-') : binary('-'),
-      [TypeF32, TypeF32],
-      TypeF32,
-      t.params,
-      cases
+    await run(t, binary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+  });
+
+g.test('subtraction_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x -= y
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'subtraction_const' : 'subtraction_non_const'
     );
+    await run(t, compoundBinary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('multiplication')
@@ -168,23 +184,31 @@ Accuracy: Correctly rounded
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'multiplication_const' : 'multiplication_non_const'
     );
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('*') : binary('*'),
-      [TypeF32, TypeF32],
-      TypeF32,
-      t.params,
-      cases
+    await run(t, binary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+  });
+
+g.test('multiplication_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x *= y
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'multiplication_const' : 'multiplication_non_const'
     );
+    await run(t, compoundBinary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('division')
@@ -196,23 +220,31 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('/') : binary('/'),
-      [TypeF32, TypeF32],
-      TypeF32,
-      t.params,
-      cases
+    await run(t, binary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+  });
+
+g.test('division_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x /= y
+Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
+    await run(t, compoundBinary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('remainder')
@@ -224,21 +256,29 @@ Accuracy: Derived from x - y * trunc(x/y)
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('%') : binary('%'),
-      [TypeF32, TypeF32],
-      TypeF32,
-      t.params,
-      cases
+    await run(t, binary('%'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+  });
+
+g.test('remainder_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x %= y
+Accuracy: Derived from x - y * trunc(x/y)
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
+    await run(t, compoundBinary('%'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
@@ -30,7 +30,7 @@ import {
   run,
 } from '../expression.js';
 
-import { binary } from './binary.js';
+import { binary, compoundBinary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -1365,6 +1365,38 @@ Accuracy: Correctly rounded
     );
   });
 
+g.test('addition_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x =+ y, where x and y are matrices
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', allInputSources)
+      .combine('cols', [2, 3, 4] as const)
+      .combine('rows', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cols = t.params.cols;
+    const rows = t.params.rows;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `addition_${cols}x${rows}_const`
+        : `addition_${cols}x${rows}_non_const`
+    );
+    await run(
+      t,
+      compoundBinary('+'),
+      [TypeMat(cols, rows, TypeF32), TypeMat(cols, rows, TypeF32)],
+      TypeMat(cols, rows, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
 g.test('multiplication_matrix_matrix')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
   .desc(
@@ -1426,6 +1458,38 @@ Accuracy: Correctly rounded
     await run(
       t,
       binary('*'),
+      [TypeMat(cols, rows, TypeF32), TypeF32],
+      TypeMat(cols, rows, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('multiplication_matrix_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x *= y, where x is a matrix and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', allInputSources)
+      .combine('cols', [2, 3, 4] as const)
+      .combine('rows', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cols = t.params.cols;
+    const rows = t.params.rows;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `multiplication_${cols}x${rows}_scalar_const`
+        : `multiplication_${cols}x${rows}_scalar_non_const`
+    );
+    await run(
+      t,
+      compoundBinary('*'),
       [TypeMat(cols, rows, TypeF32), TypeF32],
       TypeMat(cols, rows, TypeF32),
       t.params,
@@ -1554,6 +1618,38 @@ Accuracy: Correctly rounded
     await run(
       t,
       binary('-'),
+      [TypeMat(cols, rows, TypeF32), TypeMat(cols, rows, TypeF32)],
+      TypeMat(cols, rows, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('subtraction_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x -= y, where x and y are matrices
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', allInputSources)
+      .combine('cols', [2, 3, 4] as const)
+      .combine('rows', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cols = t.params.cols;
+    const rows = t.params.rows;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `subtraction_${cols}x${rows}_const`
+        : `subtraction_${cols}x${rows}_non_const`
+    );
+    await run(
+      t,
+      compoundBinary('-'),
       [TypeMat(cols, rows, TypeF32), TypeMat(cols, rows, TypeF32)],
       TypeMat(cols, rows, TypeF32),
       t.params,

--- a/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
@@ -326,21 +326,26 @@ Expression: x + y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get('addition');
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('+') : binary('+'),
-      [TypeI32, TypeI32],
-      TypeI32,
-      t.params,
-      cases
-    );
+    await run(t, binary('+'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });
+
+g.test('addition_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x += y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('addition');
+    await run(t, compoundBinary('+'), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('subtraction')
@@ -351,21 +356,26 @@ Expression: x - y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get('subtraction');
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('-') : binary('-'),
-      [TypeI32, TypeI32],
-      TypeI32,
-      t.params,
-      cases
-    );
+    await run(t, binary('-'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });
+
+g.test('subtraction_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x -= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('subtraction');
+    await run(t, compoundBinary('-'), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('multiplication')
@@ -376,21 +386,26 @@ Expression: x * y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get('multiplication');
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('*') : binary('*'),
-      [TypeI32, TypeI32],
-      TypeI32,
-      t.params,
-      cases
-    );
+    await run(t, binary('*'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });
+
+g.test('multiplication_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x *= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('multiplication');
+    await run(t, compoundBinary('*'), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('division')
@@ -401,23 +416,30 @@ Expression: x / y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('/') : binary('/'),
-      [TypeI32, TypeI32],
-      TypeI32,
-      t.params,
-      cases
+    await run(t, binary('/'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });
+
+g.test('division_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x /= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
+    await run(t, compoundBinary('/'), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('remainder')
@@ -428,23 +450,30 @@ Expression: x % y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('%') : binary('%'),
-      [TypeI32, TypeI32],
-      TypeI32,
-      t.params,
-      cases
+    await run(t, binary('%'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+  });
+
+g.test('remainder_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x %= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
+    await run(t, compoundBinary('%'), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('addition_scalar_vector')
@@ -481,6 +510,23 @@ Expression: x + y
     await run(t, binary('+'), [vec_type, TypeI32], vec_type, t.params, cases);
   });
 
+g.test('addition_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x += y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeI32);
+    const cases = await d.get(`addition_vector${vec_size}_scalar`);
+    await run(t, compoundBinary('+'), [vec_type, TypeI32], vec_type, t.params, cases);
+  });
+
 g.test('subtraction_scalar_vector')
   .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
@@ -515,6 +561,23 @@ Expression: x - y
     await run(t, binary('-'), [vec_type, TypeI32], vec_type, t.params, cases);
   });
 
+g.test('subtraction_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x -= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeI32);
+    const cases = await d.get(`subtraction_vector${vec_size}_scalar`);
+    await run(t, compoundBinary('-'), [vec_type, TypeI32], vec_type, t.params, cases);
+  });
+
 g.test('multiplication_scalar_vector')
   .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
@@ -547,6 +610,23 @@ Expression: x * y
     const vec_type = TypeVec(vec_size, TypeI32);
     const cases = await d.get(`multiplication_vector${vec_size}_scalar`);
     await run(t, binary('*'), [vec_type, TypeI32], vec_type, t.params, cases);
+  });
+
+g.test('multiplication_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x *= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeI32);
+    const cases = await d.get(`multiplication_vector${vec_size}_scalar`);
+    await run(t, compoundBinary('*'), [vec_type, TypeI32], vec_type, t.params, cases);
   });
 
 g.test('division_scalar_vector')
@@ -585,6 +665,24 @@ Expression: x / y
     await run(t, binary('/'), [vec_type, TypeI32], vec_type, t.params, cases);
   });
 
+g.test('division_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x /= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeI32);
+    const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
+    const cases = await d.get(`division_vector${vec_size}_scalar_${source}`);
+    await run(t, compoundBinary('/'), [vec_type, TypeI32], vec_type, t.params, cases);
+  });
+
 g.test('remainder_scalar_vector')
   .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
@@ -619,4 +717,22 @@ Expression: x % y
     const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
     const cases = await d.get(`remainder_vector${vec_size}_scalar_${source}`);
     await run(t, binary('%'), [vec_type, TypeI32], vec_type, t.params, cases);
+  });
+
+g.test('remainder_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x %= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeI32);
+    const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
+    const cases = await d.get(`remainder_vector${vec_size}_scalar_${source}`);
+    await run(t, compoundBinary('%'), [vec_type, TypeI32], vec_type, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -313,21 +313,26 @@ Expression: x + y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get('addition');
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('+') : binary('+'),
-      [TypeU32, TypeU32],
-      TypeU32,
-      t.params,
-      cases
-    );
+    await run(t, binary('+'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('addition_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x += y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('addition');
+    await run(t, compoundBinary('+'), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('subtraction')
@@ -338,21 +343,26 @@ Expression: x - y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get('subtraction');
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('-') : binary('-'),
-      [TypeU32, TypeU32],
-      TypeU32,
-      t.params,
-      cases
-    );
+    await run(t, binary('-'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('subtraction_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x -= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('subtraction');
+    await run(t, compoundBinary('-'), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('multiplication')
@@ -363,21 +373,26 @@ Expression: x * y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get('multiplication');
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('*') : binary('*'),
-      [TypeU32, TypeU32],
-      TypeU32,
-      t.params,
-      cases
-    );
+    await run(t, binary('*'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('multiplication_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x *= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('multiplication');
+    await run(t, compoundBinary('*'), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('division')
@@ -388,23 +403,30 @@ Expression: x / y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('/') : binary('/'),
-      [TypeU32, TypeU32],
-      TypeU32,
-      t.params,
-      cases
+    await run(t, binary('/'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('division_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x /= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
+    await run(t, compoundBinary('/'), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('remainder')
@@ -415,23 +437,30 @@ Expression: x % y
 `
   )
   .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('compoundStmt', [false, true] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
-    await run(
-      t,
-      t.params.compoundStmt ? compoundBinary('%') : binary('%'),
-      [TypeU32, TypeU32],
-      TypeU32,
-      t.params,
-      cases
+    await run(t, binary('%'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+  });
+
+g.test('remainder_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x %= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get(
+      t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
+    await run(t, compoundBinary('%'), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('addition_scalar_vector')
@@ -468,6 +497,23 @@ Expression: x + y
     await run(t, binary('+'), [vec_type, TypeU32], vec_type, t.params, cases);
   });
 
+g.test('addition_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x += y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const cases = await d.get(`addition_vector${vec_size}_scalar`);
+    await run(t, compoundBinary('+'), [vec_type, TypeU32], vec_type, t.params, cases);
+  });
+
 g.test('subtraction_scalar_vector')
   .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
@@ -502,6 +548,23 @@ Expression: x - y
     await run(t, binary('-'), [vec_type, TypeU32], vec_type, t.params, cases);
   });
 
+g.test('subtraction_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x -= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const cases = await d.get(`subtraction_vector${vec_size}_scalar`);
+    await run(t, compoundBinary('-'), [vec_type, TypeU32], vec_type, t.params, cases);
+  });
+
 g.test('multiplication_scalar_vector')
   .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
@@ -534,6 +597,23 @@ Expression: x * y
     const vec_type = TypeVec(vec_size, TypeU32);
     const cases = await d.get(`multiplication_vector${vec_size}_scalar`);
     await run(t, binary('*'), [vec_type, TypeU32], vec_type, t.params, cases);
+  });
+
+g.test('multiplication_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x *= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const cases = await d.get(`multiplication_vector${vec_size}_scalar`);
+    await run(t, compoundBinary('*'), [vec_type, TypeU32], vec_type, t.params, cases);
   });
 
 g.test('division_scalar_vector')
@@ -572,6 +652,24 @@ Expression: x / y
     await run(t, binary('/'), [vec_type, TypeU32], vec_type, t.params, cases);
   });
 
+g.test('division_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x /= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
+    const cases = await d.get(`division_vector${vec_size}_scalar_${source}`);
+    await run(t, compoundBinary('/'), [vec_type, TypeU32], vec_type, t.params, cases);
+  });
+
 g.test('remainder_scalar_vector')
   .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
   .desc(
@@ -606,4 +704,22 @@ Expression: x % y
     const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
     const cases = await d.get(`remainder_vector${vec_size}_scalar_${source}`);
     await run(t, binary('%'), [vec_type, TypeU32], vec_type, t.params, cases);
+  });
+
+g.test('remainder_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#arithmetic-expr')
+  .desc(
+    `
+Expression: x %= y
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize_lhs', [2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const vec_size = t.params.vectorize_lhs;
+    const vec_type = TypeVec(vec_size, TypeU32);
+    const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
+    const cases = await d.get(`remainder_vector${vec_size}_scalar_${source}`);
+    await run(t, compoundBinary('%'), [vec_type, TypeU32], vec_type, t.params, cases);
   });


### PR DESCRIPTION
This CL splits the compound statement test into their own tests instead of as parameters to the non-compound test. Tests have been added for the various `vec * scalar` or other similar mixed type test.

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
