### PR TITLE
[wgsl] Compound assignment for boolean operations.

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
@@ -7,7 +7,7 @@ import { GPUTest } from '../../../../gpu_test.js';
 import { bool, TypeBool } from '../../../../util/conversion.js';
 import { allInputSources, run } from '../expression.js';
 
-import { binary } from './binary.js';
+import { binary, compoundBinary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -34,6 +34,28 @@ Logical "and". Component-wise when T is a vector. Evaluates both e1 and e2.
     ];
 
     await run(t, binary('&'), [TypeBool, TypeBool], TypeBool, t.params, cases);
+  });
+
+g.test('and_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#logical-expr')
+  .desc(
+    `
+Expression: e1 &= e2
+Logical "and". Component-wise when T is a vector. Evaluates both e1 and e2.
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = [
+      { input: [bool(false), bool(false)], expected: bool(false) },
+      { input: [bool(true), bool(false)], expected: bool(false) },
+      { input: [bool(false), bool(true)], expected: bool(false) },
+      { input: [bool(true), bool(true)], expected: bool(true) },
+    ];
+
+    await run(t, compoundBinary('&'), [TypeBool, TypeBool], TypeBool, t.params, cases);
   });
 
 g.test('and_short_circuit')
@@ -76,6 +98,28 @@ Logical "or". Component-wise when T is a vector. Evaluates both e1 and e2.
     ];
 
     await run(t, binary('|'), [TypeBool, TypeBool], TypeBool, t.params, cases);
+  });
+
+g.test('or_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#logical-expr')
+  .desc(
+    `
+Expression: e1 |= e2
+Logical "or". Component-wise when T is a vector. Evaluates both e1 and e2.
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = [
+      { input: [bool(false), bool(false)], expected: bool(false) },
+      { input: [bool(true), bool(false)], expected: bool(true) },
+      { input: [bool(false), bool(true)], expected: bool(true) },
+      { input: [bool(true), bool(true)], expected: bool(true) },
+    ];
+
+    await run(t, compoundBinary('|'), [TypeBool, TypeBool], TypeBool, t.params, cases);
   });
 
 g.test('or_short_circuit')

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -600,8 +600,9 @@ ${wgslInputVar(inputSource, cases.length)}
 @compute @workgroup_size(1)
 fn main() {
   for (var i = 0; i < ${cases.length}; i++) {
-    outputs[i].value = inputs[i].lhs;
-    outputs[i].value ${op} inputs[i].rhs;
+    var ret = ${lhsType}(inputs[i].lhs);
+    ret ${op} ${rhsType}(inputs[i].rhs);
+    outputs[i].value = ${storageType(resultType)}(ret);
   }
 }
 `;

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -553,15 +553,17 @@ export function compoundAssignmentBuilder(op: string): ShaderBuilder {
         body = cases
           .map((_, i) => {
             return `
-  outputs[${i}].value = lhs[${i}];
-  outputs[${i}].value ${op} rhs[${i}];`;
+  var ret_${i} = lhs[${i}];
+  ret_${i} ${op} rhs[${i}];
+  outputs[${i}].value = ${storageType(resultType)}(ret_${i});`;
           })
           .join('\n  ');
       } else {
         body = `
   for (var i = 0u; i < ${cases.length}; i++) {
-    outputs[i].value = lhs[i];
-    outputs[i].value ${op} rhs[i];
+    var ret = lhs[i];
+    ret ${op} rhs[i];
+    outputs[i].value = ${storageType(resultType)}(ret);
   }`;
       }
 


### PR DESCRIPTION
This CL adds compound assignment for the boolean operations (`&=` and `|=`).

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
