### PR TITLE
[wgsl] Make compound operators explicit.

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/binary.ts
+++ b/src/webgpu/shader/execution/expression/binary/binary.ts
@@ -7,5 +7,5 @@ export function binary(op: string): ShaderBuilder {
 
 /* @returns a ShaderBuilder that evaluates a compound binary operation */
 export function compoundBinary(op: string): ShaderBuilder {
-  return compoundAssignmentBuilder(op + '=');
+  return compoundAssignmentBuilder(op);
 }

--- a/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise.spec.ts
@@ -101,7 +101,7 @@ Bitwise-or. Component-wise when T is a vector.
     const type = scalarType(t.params.type);
     const cases = makeBitwiseOrCases(t.params.type);
 
-    await run(t, compoundBinary('|'), [type, type], type, t.params, cases);
+    await run(t, compoundBinary('|='), [type, type], type, t.params, cases);
   });
 
 function makeBitwiseAndCases(inputType: string) {
@@ -200,7 +200,7 @@ Bitwise-and. Component-wise when T is a vector.
   .fn(async t => {
     const type = scalarType(t.params.type);
     const cases = makeBitwiseAndCases(t.params.type);
-    await run(t, compoundBinary('&'), [type, type], type, t.params, cases);
+    await run(t, compoundBinary('&='), [type, type], type, t.params, cases);
   });
 
 function makeBitwiseExcluseOrCases(inputType: string) {
@@ -299,5 +299,5 @@ Bitwise-exclusive-or. Component-wise when T is a vector.
   .fn(async t => {
     const type = scalarType(t.params.type);
     const cases = makeBitwiseExcluseOrCases(t.params.type);
-    await run(t, compoundBinary('^'), [type, type], type, t.params, cases);
+    await run(t, compoundBinary('^='), [type, type], type, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise_shift.spec.ts
@@ -214,7 +214,7 @@ Shift left (shifted value is concrete)
   .fn(async t => {
     const type = scalarType(t.params.type);
     const cases = makeShiftLeftConcreteCases(t.params.type, t.params.inputSource, type);
-    await run(t, compoundBinary('<<'), [type, TypeU32], type, t.params, cases);
+    await run(t, compoundBinary('<<='), [type, TypeU32], type, t.params, cases);
   });
 
 function makeShiftRightConcreteCases(inputType: string, inputSource: string, type: ScalarType) {
@@ -339,5 +339,5 @@ Shift right (shifted value is concrete)
   .fn(async t => {
     const type = scalarType(t.params.type);
     const cases = makeShiftRightConcreteCases(t.params.type, t.params.inputSource, type);
-    await run(t, compoundBinary('>>'), [type, TypeU32], type, t.params, cases);
+    await run(t, compoundBinary('>>='), [type, TypeU32], type, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bool_logical.spec.ts
@@ -55,7 +55,7 @@ Logical "and". Component-wise when T is a vector. Evaluates both e1 and e2.
       { input: [bool(true), bool(true)], expected: bool(true) },
     ];
 
-    await run(t, compoundBinary('&'), [TypeBool, TypeBool], TypeBool, t.params, cases);
+    await run(t, compoundBinary('&='), [TypeBool, TypeBool], TypeBool, t.params, cases);
   });
 
 g.test('and_short_circuit')
@@ -119,7 +119,7 @@ Logical "or". Component-wise when T is a vector. Evaluates both e1 and e2.
       { input: [bool(true), bool(true)], expected: bool(true) },
     ];
 
-    await run(t, compoundBinary('|'), [TypeBool, TypeBool], TypeBool, t.params, cases);
+    await run(t, compoundBinary('|='), [TypeBool, TypeBool], TypeBool, t.params, cases);
   });
 
 g.test('or_short_circuit')

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -136,7 +136,7 @@ Accuracy: Correctly rounded
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'addition_const' : 'addition_non_const'
     );
-    await run(t, compoundBinary('+'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, compoundBinary('+='), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('subtraction')
@@ -172,7 +172,7 @@ Accuracy: Correctly rounded
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'subtraction_const' : 'subtraction_non_const'
     );
-    await run(t, compoundBinary('-'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, compoundBinary('-='), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('multiplication')
@@ -208,7 +208,7 @@ Accuracy: Correctly rounded
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'multiplication_const' : 'multiplication_non_const'
     );
-    await run(t, compoundBinary('*'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, compoundBinary('*='), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('division')
@@ -244,7 +244,7 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
-    await run(t, compoundBinary('/'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, compoundBinary('/='), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
 g.test('remainder')
@@ -280,5 +280,5 @@ Accuracy: Derived from x - y * trunc(x/y)
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
-    await run(t, compoundBinary('%'), [TypeF32, TypeF32], TypeF32, t.params, cases);
+    await run(t, compoundBinary('%='), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
@@ -1389,7 +1389,7 @@ Accuracy: Correctly rounded
     );
     await run(
       t,
-      compoundBinary('+'),
+      compoundBinary('+='),
       [TypeMat(cols, rows, TypeF32), TypeMat(cols, rows, TypeF32)],
       TypeMat(cols, rows, TypeF32),
       t.params,
@@ -1489,7 +1489,7 @@ Accuracy: Correctly rounded
     );
     await run(
       t,
-      compoundBinary('*'),
+      compoundBinary('*='),
       [TypeMat(cols, rows, TypeF32), TypeF32],
       TypeMat(cols, rows, TypeF32),
       t.params,
@@ -1649,7 +1649,7 @@ Accuracy: Correctly rounded
     );
     await run(
       t,
-      compoundBinary('-'),
+      compoundBinary('-='),
       [TypeMat(cols, rows, TypeF32), TypeMat(cols, rows, TypeF32)],
       TypeMat(cols, rows, TypeF32),
       t.params,

--- a/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
@@ -345,7 +345,7 @@ Expression: x += y
   )
   .fn(async t => {
     const cases = await d.get('addition');
-    await run(t, compoundBinary('+'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(t, compoundBinary('+='), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('subtraction')
@@ -375,7 +375,7 @@ Expression: x -= y
   )
   .fn(async t => {
     const cases = await d.get('subtraction');
-    await run(t, compoundBinary('-'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(t, compoundBinary('-='), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('multiplication')
@@ -405,7 +405,7 @@ Expression: x *= y
   )
   .fn(async t => {
     const cases = await d.get('multiplication');
-    await run(t, compoundBinary('*'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(t, compoundBinary('*='), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('division')
@@ -439,7 +439,7 @@ Expression: x /= y
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
-    await run(t, compoundBinary('/'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(t, compoundBinary('/='), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('remainder')
@@ -473,7 +473,7 @@ Expression: x %= y
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
-    await run(t, compoundBinary('%'), [TypeI32, TypeI32], TypeI32, t.params, cases);
+    await run(t, compoundBinary('%='), [TypeI32, TypeI32], TypeI32, t.params, cases);
   });
 
 g.test('addition_scalar_vector')
@@ -524,7 +524,7 @@ Expression: x += y
     const vec_size = t.params.vectorize_lhs;
     const vec_type = TypeVec(vec_size, TypeI32);
     const cases = await d.get(`addition_vector${vec_size}_scalar`);
-    await run(t, compoundBinary('+'), [vec_type, TypeI32], vec_type, t.params, cases);
+    await run(t, compoundBinary('+='), [vec_type, TypeI32], vec_type, t.params, cases);
   });
 
 g.test('subtraction_scalar_vector')
@@ -575,7 +575,7 @@ Expression: x -= y
     const vec_size = t.params.vectorize_lhs;
     const vec_type = TypeVec(vec_size, TypeI32);
     const cases = await d.get(`subtraction_vector${vec_size}_scalar`);
-    await run(t, compoundBinary('-'), [vec_type, TypeI32], vec_type, t.params, cases);
+    await run(t, compoundBinary('-='), [vec_type, TypeI32], vec_type, t.params, cases);
   });
 
 g.test('multiplication_scalar_vector')
@@ -626,7 +626,7 @@ Expression: x *= y
     const vec_size = t.params.vectorize_lhs;
     const vec_type = TypeVec(vec_size, TypeI32);
     const cases = await d.get(`multiplication_vector${vec_size}_scalar`);
-    await run(t, compoundBinary('*'), [vec_type, TypeI32], vec_type, t.params, cases);
+    await run(t, compoundBinary('*='), [vec_type, TypeI32], vec_type, t.params, cases);
   });
 
 g.test('division_scalar_vector')
@@ -680,7 +680,7 @@ Expression: x /= y
     const vec_type = TypeVec(vec_size, TypeI32);
     const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
     const cases = await d.get(`division_vector${vec_size}_scalar_${source}`);
-    await run(t, compoundBinary('/'), [vec_type, TypeI32], vec_type, t.params, cases);
+    await run(t, compoundBinary('/='), [vec_type, TypeI32], vec_type, t.params, cases);
   });
 
 g.test('remainder_scalar_vector')
@@ -734,5 +734,5 @@ Expression: x %= y
     const vec_type = TypeVec(vec_size, TypeI32);
     const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
     const cases = await d.get(`remainder_vector${vec_size}_scalar_${source}`);
-    await run(t, compoundBinary('%'), [vec_type, TypeI32], vec_type, t.params, cases);
+    await run(t, compoundBinary('%='), [vec_type, TypeI32], vec_type, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -332,7 +332,7 @@ Expression: x += y
   )
   .fn(async t => {
     const cases = await d.get('addition');
-    await run(t, compoundBinary('+'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(t, compoundBinary('+='), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('subtraction')
@@ -362,7 +362,7 @@ Expression: x -= y
   )
   .fn(async t => {
     const cases = await d.get('subtraction');
-    await run(t, compoundBinary('-'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(t, compoundBinary('-='), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('multiplication')
@@ -392,7 +392,7 @@ Expression: x *= y
   )
   .fn(async t => {
     const cases = await d.get('multiplication');
-    await run(t, compoundBinary('*'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(t, compoundBinary('*='), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('division')
@@ -426,7 +426,7 @@ Expression: x /= y
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'division_const' : 'division_non_const'
     );
-    await run(t, compoundBinary('/'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(t, compoundBinary('/='), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('remainder')
@@ -460,7 +460,7 @@ Expression: x %= y
     const cases = await d.get(
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
-    await run(t, compoundBinary('%'), [TypeU32, TypeU32], TypeU32, t.params, cases);
+    await run(t, compoundBinary('%='), [TypeU32, TypeU32], TypeU32, t.params, cases);
   });
 
 g.test('addition_scalar_vector')
@@ -511,7 +511,7 @@ Expression: x += y
     const vec_size = t.params.vectorize_lhs;
     const vec_type = TypeVec(vec_size, TypeU32);
     const cases = await d.get(`addition_vector${vec_size}_scalar`);
-    await run(t, compoundBinary('+'), [vec_type, TypeU32], vec_type, t.params, cases);
+    await run(t, compoundBinary('+='), [vec_type, TypeU32], vec_type, t.params, cases);
   });
 
 g.test('subtraction_scalar_vector')
@@ -562,7 +562,7 @@ Expression: x -= y
     const vec_size = t.params.vectorize_lhs;
     const vec_type = TypeVec(vec_size, TypeU32);
     const cases = await d.get(`subtraction_vector${vec_size}_scalar`);
-    await run(t, compoundBinary('-'), [vec_type, TypeU32], vec_type, t.params, cases);
+    await run(t, compoundBinary('-='), [vec_type, TypeU32], vec_type, t.params, cases);
   });
 
 g.test('multiplication_scalar_vector')
@@ -613,7 +613,7 @@ Expression: x *= y
     const vec_size = t.params.vectorize_lhs;
     const vec_type = TypeVec(vec_size, TypeU32);
     const cases = await d.get(`multiplication_vector${vec_size}_scalar`);
-    await run(t, compoundBinary('*'), [vec_type, TypeU32], vec_type, t.params, cases);
+    await run(t, compoundBinary('*='), [vec_type, TypeU32], vec_type, t.params, cases);
   });
 
 g.test('division_scalar_vector')
@@ -667,7 +667,7 @@ Expression: x /= y
     const vec_type = TypeVec(vec_size, TypeU32);
     const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
     const cases = await d.get(`division_vector${vec_size}_scalar_${source}`);
-    await run(t, compoundBinary('/'), [vec_type, TypeU32], vec_type, t.params, cases);
+    await run(t, compoundBinary('/='), [vec_type, TypeU32], vec_type, t.params, cases);
   });
 
 g.test('remainder_scalar_vector')
@@ -721,5 +721,5 @@ Expression: x %= y
     const vec_type = TypeVec(vec_size, TypeU32);
     const source = t.params.inputSource === 'const' ? 'const' : 'non_const';
     const cases = await d.get(`remainder_vector${vec_size}_scalar_${source}`);
-    await run(t, compoundBinary('%'), [vec_type, TypeU32], vec_type, t.params, cases);
+    await run(t, compoundBinary('%='), [vec_type, TypeU32], vec_type, t.params, cases);
   });


### PR DESCRIPTION
This Cl removes the implicit `=` from `compoundBinary` and has each of the tests pass in the full operator name.

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
