### PR TITLE
Return correctlyRoundedInterval for f32->f32 conversions

### DIFF
--- a/src/webgpu/shader/execution/expression/unary/f32_conversion.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_conversion.spec.ts
@@ -48,7 +48,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   },
   f32: () => {
     return fullF32Range().map(f => {
-      return { input: f32(f), expected: f32(f) };
+      return { input: f32(f), expected: correctlyRoundedInterval(f) };
     });
   },
   f32_mat2x2_const: () => {


### PR DESCRIPTION
Fixes #2435

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
