### PR TITLE
Validate that atomic builtins are only valid in compute and fragment …

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atomicAdd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicAdd.spec.ts
@@ -13,24 +13,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('add')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicAdd(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
   .params(u =>

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicAnd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicAnd.spec.ts
@@ -13,24 +13,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('and')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicAnd(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
   .params(u =>

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicCompareExchangeWeak.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicCompareExchangeWeak.spec.ts
@@ -18,24 +18,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('exchange')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicCompareExchangeWeak(atomic_ptr: ptr<SC, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
 
 struct __atomic_compare_exchange_result<T> {
   old_value : T,    // old value stored in the atomic

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicExchange.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicExchange.spec.ts
@@ -7,24 +7,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('exchange')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicExchange(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
   .params(u =>

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicLoad.spec.ts
@@ -7,24 +7,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-load')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('load')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-load')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicLoad(atomic_ptr: ptr<SC, atomic<T>, read_write>) -> T
+fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
 
 `
   )

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicMax.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicMax.spec.ts
@@ -13,24 +13,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('max')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicMax(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
   .params(u =>

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicMin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicMin.spec.ts
@@ -13,24 +13,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('min')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicMin(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
   .params(u =>

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicOr.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicOr.spec.ts
@@ -13,24 +13,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('or')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicOr(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
   .params(u =>

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicStore.spec.ts
@@ -7,24 +7,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-store')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('store')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-store')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicStore(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T)
+fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
 `
   )
   .params(u =>

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicSub.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicSub.spec.ts
@@ -13,24 +13,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('sub')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicSub(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
   .params(u =>

--- a/src/webgpu/shader/execution/expression/call/builtin/atomicXor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomicXor.spec.ts
@@ -13,24 +13,14 @@ import { GPUTest } from '../../../../../gpu_test.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('stage')
-  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
-  .desc(
-    `
-Atomic built-in functions must not be used in a vertex shader stage.
-`
-  )
-  .params(u => u.combine('stage', ['fragment', 'vertex', 'compute'] as const))
-  .unimplemented();
-
 g.test('xor')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
-SC is storage or workgroup
+AS is storage or workgroup
 T is i32 or u32
 
-fn atomicXor(atomic_ptr: ptr<SC, atomic<T>, read_write>, v: T) -> T
+fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
   .params(u =>

--- a/src/webgpu/shader/validation/expression/call/builtin/atomics.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atomics.spec.ts
@@ -1,0 +1,70 @@
+export const description = `
+Validation tests for atomic builtins.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../../../common/util/data_tables.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kAtomicOps = {
+  add: { src: 'atomicAdd(&a,1)' },
+  sub: { src: 'atomicSub(&a,1)' },
+  max: { src: 'atomicMax(&a,1)' },
+  min: { src: 'atomicMin(&a,1)' },
+  and: { src: 'atomicAnd(&a,1)' },
+  or: { src: 'atomicOr(&a,1)' },
+  xor: { src: 'atomicXor(&a,1)' },
+  load: { src: 'atomicLoad(&a)' },
+  store: { src: 'atomicStore(&a,1)' },
+  exchange: { src: 'atomicExchange(&a,1)' },
+  compareexchangeweak: { src: 'atomicCompareExchangeWeak(&a,1,1)' },
+};
+
+g.test('stage')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+Atomic built-in functions must not be used in a vertex shader stage.
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', ['fragment', 'vertex', 'compute'] as const) //
+      .combine('atomicOp', keysOf(kAtomicOps))
+  )
+  .fn(t => {
+    const atomicOp = kAtomicOps[t.params.atomicOp].src;
+    let code = `
+@group(0) @binding(0) var<storage, read_write> a: atomic<i32>;
+`;
+
+    switch (t.params.stage) {
+      case 'compute':
+        code += `
+@compute @workgroup_size(1,1,1) fn main() {
+  ${atomicOp};
+}`;
+        break;
+
+      case 'fragment':
+        code += `
+@fragment fn main() -> @location(0) vec4<f32> {
+  ${atomicOp};
+  return vec4<f32>();
+}`;
+        break;
+
+      case 'vertex':
+        code += `
+@vertex fn vmain() -> @builtin(position) vec4<f32> {
+  ${atomicOp};
+  return vec4<f32>();
+}`;
+        break;
+    }
+
+    const pass = t.params.stage !== 'vertex';
+    t.expectCompileResult(pass, code);
+  });


### PR DESCRIPTION
…shaders

Moved the stubbed 'stage' tests under validation, and combined them to be able to parameterize them.

Issue: #1273
Issue: #1274
Issue: #1275
Issue: #1276
Issue: #1277
Issue: #1278
Issue: #1279
Issue: #1280
Issue: #1281
Issue: #1282
Issue: #1283
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
