### PR TITLE
Add scalar-vector and vector-scalar f32 arithmetic tests

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -4,19 +4,69 @@ Execution Tests for the f32 arithmetic binary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { TypeF32 } from '../../../../util/conversion.js';
+import { TypeF32, TypeVec } from '../../../../util/conversion.js';
 import {
   additionInterval,
   divisionInterval,
+  F32Vector,
   multiplicationInterval,
   remainderInterval,
   subtractionInterval,
+  toF32Vector,
 } from '../../../../util/f32_interval.js';
-import { fullF32Range } from '../../../../util/math.js';
+import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, generateBinaryToF32IntervalCases, run } from '../expression.js';
+import {
+  allInputSources,
+  generateBinaryToF32IntervalCases,
+  generateF32VectorToVectorCases,
+  generateVectorF32ToVectorCases,
+  run,
+} from '../expression.js';
 
 import { binary, compoundBinary } from './binary.js';
+
+// Utility wrappers around the interval generators for the scalar-vector and
+// vector-scalar tests.
+const additionVectorScalarInterval = (v: number[], s: number): F32Vector => {
+  return toF32Vector(v.map(e => additionInterval(e, s)));
+};
+
+const additionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+  return toF32Vector(v.map(e => additionInterval(s, e)));
+};
+
+const subtractionVectorScalarInterval = (v: number[], s: number): F32Vector => {
+  return toF32Vector(v.map(e => subtractionInterval(e, s)));
+};
+
+const subtractionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+  return toF32Vector(v.map(e => subtractionInterval(s, e)));
+};
+
+const multiplicationVectorScalarInterval = (v: number[], s: number): F32Vector => {
+  return toF32Vector(v.map(e => multiplicationInterval(e, s)));
+};
+
+const multiplicationScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+  return toF32Vector(v.map(e => multiplicationInterval(s, e)));
+};
+
+const divisionVectorScalarInterval = (v: number[], s: number): F32Vector => {
+  return toF32Vector(v.map(e => divisionInterval(e, s)));
+};
+
+const divisionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+  return toF32Vector(v.map(e => divisionInterval(s, e)));
+};
+
+const remainderVectorScalarInterval = (v: number[], s: number): F32Vector => {
+  return toF32Vector(v.map(e => remainderInterval(e, s)));
+};
+
+const remainderScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+  return toF32Vector(v.map(e => remainderInterval(s, e)));
+};
 
 export const g = makeTestGroup(GPUTest);
 
@@ -37,6 +87,102 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       additionInterval
     );
   },
+  addition_vec2_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'f32-only',
+      additionVectorScalarInterval
+    );
+  },
+  addition_vec2_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'unfiltered',
+      additionVectorScalarInterval
+    );
+  },
+  addition_vec3_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'f32-only',
+      additionVectorScalarInterval
+    );
+  },
+  addition_vec3_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'unfiltered',
+      additionVectorScalarInterval
+    );
+  },
+  addition_vec4_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'f32-only',
+      additionVectorScalarInterval
+    );
+  },
+  addition_vec4_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'unfiltered',
+      additionVectorScalarInterval
+    );
+  },
+  addition_scalar_vec2_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'f32-only',
+      additionScalarVectorInterval
+    );
+  },
+  addition_scalar_vec2_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'unfiltered',
+      additionScalarVectorInterval
+    );
+  },
+  addition_scalar_vec3_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'f32-only',
+      additionScalarVectorInterval
+    );
+  },
+  addition_scalar_vec3_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'unfiltered',
+      additionScalarVectorInterval
+    );
+  },
+  addition_scalar_vec4_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'f32-only',
+      additionScalarVectorInterval
+    );
+  },
+  addition_scalar_vec4_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'unfiltered',
+      additionScalarVectorInterval
+    );
+  },
   subtraction_const: () => {
     return generateBinaryToF32IntervalCases(
       fullF32Range(),
@@ -51,6 +197,102 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       'unfiltered',
       subtractionInterval
+    );
+  },
+  subtraction_vec2_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'f32-only',
+      subtractionVectorScalarInterval
+    );
+  },
+  subtraction_vec2_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'unfiltered',
+      subtractionVectorScalarInterval
+    );
+  },
+  subtraction_vec3_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'f32-only',
+      subtractionVectorScalarInterval
+    );
+  },
+  subtraction_vec3_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'unfiltered',
+      subtractionVectorScalarInterval
+    );
+  },
+  subtraction_vec4_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'f32-only',
+      subtractionVectorScalarInterval
+    );
+  },
+  subtraction_vec4_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'unfiltered',
+      subtractionVectorScalarInterval
+    );
+  },
+  subtraction_scalar_vec2_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'f32-only',
+      subtractionScalarVectorInterval
+    );
+  },
+  subtraction_scalar_vec2_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'unfiltered',
+      subtractionScalarVectorInterval
+    );
+  },
+  subtraction_scalar_vec3_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'f32-only',
+      subtractionScalarVectorInterval
+    );
+  },
+  subtraction_scalar_vec3_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'unfiltered',
+      subtractionScalarVectorInterval
+    );
+  },
+  subtraction_scalar_vec4_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'f32-only',
+      subtractionScalarVectorInterval
+    );
+  },
+  subtraction_scalar_vec4_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'unfiltered',
+      subtractionScalarVectorInterval
     );
   },
   multiplication_const: () => {
@@ -69,6 +311,102 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       multiplicationInterval
     );
   },
+  multiplication_vec2_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'f32-only',
+      multiplicationVectorScalarInterval
+    );
+  },
+  multiplication_vec2_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'unfiltered',
+      multiplicationVectorScalarInterval
+    );
+  },
+  multiplication_vec3_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'f32-only',
+      multiplicationVectorScalarInterval
+    );
+  },
+  multiplication_vec3_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'unfiltered',
+      multiplicationVectorScalarInterval
+    );
+  },
+  multiplication_vec4_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'f32-only',
+      multiplicationVectorScalarInterval
+    );
+  },
+  multiplication_vec4_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'unfiltered',
+      multiplicationVectorScalarInterval
+    );
+  },
+  multiplication_scalar_vec2_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'f32-only',
+      multiplicationScalarVectorInterval
+    );
+  },
+  multiplication_scalar_vec2_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'unfiltered',
+      multiplicationScalarVectorInterval
+    );
+  },
+  multiplication_scalar_vec3_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'f32-only',
+      multiplicationScalarVectorInterval
+    );
+  },
+  multiplication_scalar_vec3_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'unfiltered',
+      multiplicationScalarVectorInterval
+    );
+  },
+  multiplication_scalar_vec4_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'f32-only',
+      multiplicationScalarVectorInterval
+    );
+  },
+  multiplication_scalar_vec4_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'unfiltered',
+      multiplicationScalarVectorInterval
+    );
+  },
   division_const: () => {
     return generateBinaryToF32IntervalCases(
       fullF32Range(),
@@ -85,6 +423,102 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       divisionInterval
     );
   },
+  division_vec2_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'f32-only',
+      divisionVectorScalarInterval
+    );
+  },
+  division_vec2_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'unfiltered',
+      divisionVectorScalarInterval
+    );
+  },
+  division_vec3_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'f32-only',
+      divisionVectorScalarInterval
+    );
+  },
+  division_vec3_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'unfiltered',
+      divisionVectorScalarInterval
+    );
+  },
+  division_vec4_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'f32-only',
+      divisionVectorScalarInterval
+    );
+  },
+  division_vec4_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'unfiltered',
+      divisionVectorScalarInterval
+    );
+  },
+  division_scalar_vec2_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'f32-only',
+      divisionScalarVectorInterval
+    );
+  },
+  division_scalar_vec2_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'unfiltered',
+      divisionScalarVectorInterval
+    );
+  },
+  division_scalar_vec3_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'f32-only',
+      divisionScalarVectorInterval
+    );
+  },
+  division_scalar_vec3_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'unfiltered',
+      divisionScalarVectorInterval
+    );
+  },
+  division_scalar_vec4_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'f32-only',
+      divisionScalarVectorInterval
+    );
+  },
+  division_scalar_vec4_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'unfiltered',
+      divisionScalarVectorInterval
+    );
+  },
   remainder_const: () => {
     return generateBinaryToF32IntervalCases(
       fullF32Range(),
@@ -99,6 +533,102 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       'unfiltered',
       remainderInterval
+    );
+  },
+  remainder_vec2_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'f32-only',
+      remainderVectorScalarInterval
+    );
+  },
+  remainder_vec2_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(2),
+      fullF32Range(),
+      'unfiltered',
+      remainderVectorScalarInterval
+    );
+  },
+  remainder_vec3_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'f32-only',
+      remainderVectorScalarInterval
+    );
+  },
+  remainder_vec3_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(3),
+      fullF32Range(),
+      'unfiltered',
+      remainderVectorScalarInterval
+    );
+  },
+  remainder_vec4_scalar_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'f32-only',
+      remainderVectorScalarInterval
+    );
+  },
+  remainder_vec4_scalar_non_const: () => {
+    return generateVectorF32ToVectorCases(
+      sparseVectorF32Range(4),
+      fullF32Range(),
+      'unfiltered',
+      remainderVectorScalarInterval
+    );
+  },
+  remainder_scalar_vec2_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'f32-only',
+      remainderScalarVectorInterval
+    );
+  },
+  remainder_scalar_vec2_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(2),
+      'unfiltered',
+      remainderScalarVectorInterval
+    );
+  },
+  remainder_scalar_vec3_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'f32-only',
+      remainderScalarVectorInterval
+    );
+  },
+  remainder_scalar_vec3_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(3),
+      'unfiltered',
+      remainderScalarVectorInterval
+    );
+  },
+  remainder_scalar_vec4_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'f32-only',
+      remainderScalarVectorInterval
+    );
+  },
+  remainder_scalar_vec4_non_const: () => {
+    return generateF32VectorToVectorCases(
+      fullF32Range(),
+      sparseVectorF32Range(4),
+      'unfiltered',
+      remainderScalarVectorInterval
     );
   },
 });
@@ -139,6 +669,84 @@ Accuracy: Correctly rounded
     await run(t, compoundBinary('+='), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
+g.test('addition_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x + y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `addition_vec${dim}_scalar_const`
+        : `addition_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      binary('+'),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('addition_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x += y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `addition_vec${dim}_scalar_const`
+        : `addition_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      compoundBinary('+='),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('addition_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x + y, where x is a scalar and y is a vector
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `addition_scalar_vec${dim}_const`
+        : `addition_scalar_vec${dim}_non_const`
+    );
+    await run(
+      t,
+      binary('+'),
+      [TypeF32, TypeVec(dim, TypeF32)],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
 g.test('subtraction')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
   .desc(
@@ -173,6 +781,84 @@ Accuracy: Correctly rounded
       t.params.inputSource === 'const' ? 'subtraction_const' : 'subtraction_non_const'
     );
     await run(t, compoundBinary('-='), [TypeF32, TypeF32], TypeF32, t.params, cases);
+  });
+
+g.test('subtraction_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x - y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `subtraction_vec${dim}_scalar_const`
+        : `subtraction_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      binary('-'),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('subtraction_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x -= y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `subtraction_vec${dim}_scalar_const`
+        : `subtraction_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      compoundBinary('-='),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('subtraction_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x - y, where x is a scalar and y is a vector
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `subtraction_scalar_vec${dim}_const`
+        : `subtraction_scalar_vec${dim}_non_const`
+    );
+    await run(
+      t,
+      binary('-'),
+      [TypeF32, TypeVec(dim, TypeF32)],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
   });
 
 g.test('multiplication')
@@ -211,6 +897,84 @@ Accuracy: Correctly rounded
     await run(t, compoundBinary('*='), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
+g.test('multiplication_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x * y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `multiplication_vec${dim}_scalar_const`
+        : `multiplication_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      binary('*'),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('multiplication_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x *= y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `multiplication_vec${dim}_scalar_const`
+        : `multiplication_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      compoundBinary('*='),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('multiplication_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x * y, where x is a scalar and y is a vector
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `multiplication_scalar_vec${dim}_const`
+        : `multiplication_scalar_vec${dim}_non_const`
+    );
+    await run(
+      t,
+      binary('*'),
+      [TypeF32, TypeVec(dim, TypeF32)],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
 g.test('division')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
   .desc(
@@ -247,6 +1011,84 @@ Accuracy: 2.5 ULP for |y| in the range [2^-126, 2^126]
     await run(t, compoundBinary('/='), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
+g.test('division_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x / y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `division_vec${dim}_scalar_const`
+        : `division_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      binary('/'),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('division_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x /= y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `division_vec${dim}_scalar_const`
+        : `division_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      compoundBinary('/='),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('division_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x / y, where x is a scalar and y is a vector
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `division_scalar_vec${dim}_const`
+        : `division_scalar_vec${dim}_non_const`
+    );
+    await run(
+      t,
+      binary('/'),
+      [TypeF32, TypeVec(dim, TypeF32)],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
 g.test('remainder')
   .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
   .desc(
@@ -281,4 +1123,82 @@ Accuracy: Derived from x - y * trunc(x/y)
       t.params.inputSource === 'const' ? 'remainder_const' : 'remainder_non_const'
     );
     await run(t, compoundBinary('%='), [TypeF32, TypeF32], TypeF32, t.params, cases);
+  });
+
+g.test('remainder_vector_scalar')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x % y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `remainder_vec${dim}_scalar_const`
+        : `remainder_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      binary('%'),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('remainder_vector_scalar_compound')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x %= y, where x is a vector and y is a scalar
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `remainder_vec${dim}_scalar_const`
+        : `remainder_vec${dim}_scalar_non_const`
+    );
+    await run(
+      t,
+      compoundBinary('%='),
+      [TypeVec(dim, TypeF32), TypeF32],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
+  });
+
+g.test('remainder_scalar_vector')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: x % y, where x is a scalar and y is a vector
+Accuracy: Correctly rounded
+`
+  )
+  .params(u => u.combine('inputSource', allInputSources).combine('dim', [2, 3, 4] as const))
+  .fn(async t => {
+    const dim = t.params.dim;
+    const cases = await d.get(
+      t.params.inputSource === 'const'
+        ? `remainder_scalar_vec${dim}_const`
+        : `remainder_scalar_vec${dim}_non_const`
+    );
+    await run(
+      t,
+      binary('%'),
+      [TypeF32, TypeVec(dim, TypeF32)],
+      TypeVec(dim, TypeF32),
+      t.params,
+      cases
+    );
   });

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -1459,7 +1459,6 @@ function makeMatrixScalarToMatrixCase(
  * @param ops callbacks that implement generating an matrix of acceptance
  *            intervals for a pair of matrices.
  */
-
 export function generateMatrixScalarToMatrixCases(
   mats: number[][][],
   scalars: number[],

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -623,6 +623,26 @@ interface VectorPairToVectorOp {
 }
 
 /**
+ * A function that converts a vector and a scalar to a vector of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface VectorScalarToVector {
+  (x: number[], y: number): F32Vector;
+}
+
+/**
+ * A function that converts a scalar and a vector  to a vector of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface ScalarVectorToVector {
+  (x: number, y: number[]): F32Vector;
+}
+
+/**
  * A function that converts a matrix to an acceptance interval.
  * This is the public facing API for builtin implementations that is called
  * from tests.


### PR DESCRIPTION
Issue #1626
Fixes #2441

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
