### PR TITLE
Set depthWriteEnabled to false when depth stencil format is stencil8

### DIFF
--- a/src/webgpu/api/operation/rendering/stencil.spec.ts
+++ b/src/webgpu/api/operation/rendering/stencil.spec.ts
@@ -553,9 +553,11 @@ g.test('stencil_reference_initialized')
       passOp: 'keep',
     } as const;
 
+    const hasDepth = kTextureFormatInfo[format].depth;
+
     const baseState = {
       format,
-      depthWriteEnabled: true,
+      depthWriteEnabled: hasDepth,
       depthCompare: 'always',
       stencilFront: baseStencilState,
       stencilBack: baseStencilState,
@@ -563,7 +565,7 @@ g.test('stencil_reference_initialized')
 
     const testState = {
       format,
-      depthWriteEnabled: true,
+      depthWriteEnabled: hasDepth,
       depthCompare: 'always',
       stencilFront: testStencilState,
       stencilBack: testStencilState,


### PR DESCRIPTION
This patch fixes a bug in the test
operation,rendering,stencil:stencil_reference_initialized:format="stencil8" by setting depthWriteEnabled to false when depth stencil format is stencil8. According to the latest WebGPU SPEC, depthWriteEnabled cannot be true when the depth stencil attachment format doesn't have depth aspect.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
