### PR TITLE
Update tests for min/max spec changes

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1442,8 +1442,8 @@ g.test('saturateInterval')
       // Subnormals
       { input: kValue.f32.subnormal.positive.max, expected: [0.0, kValue.f32.subnormal.positive.max] },
       { input: kValue.f32.subnormal.positive.min, expected: [0.0, kValue.f32.subnormal.positive.min] },
-      { input: kValue.f32.subnormal.negative.min, expected: [0.0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [0.0] },
+      { input: kValue.f32.subnormal.negative.min, expected: [kValue.f32.subnormal.negative.min, 0.0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [kValue.f32.subnormal.negative.max, 0.0] },
 
       // Infinities
       { input: kValue.f32.infinity.positive, expected: kAny },
@@ -1985,15 +1985,18 @@ g.test('maxInterval')
       { input: [-0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
       { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
 
-      // 32-bit normals
+      // 32-bit subnormals
       { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
       { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [0] },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [0] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [0] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [0] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: [1] },
+      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
+
 
       // Infinities
       { input: [0, kValue.f32.infinity.positive], expected: kAny },
@@ -2042,15 +2045,17 @@ g.test('minInterval')
       { input: [-0.1, 0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
       { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
 
-      // 32-bit normals
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0] },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [0] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [0] },
+      // 32-bit subnormals
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
       { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
       { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
       { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
       { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [-1, kValue.f32.subnormal.positive.max], expected: [-1] },
+      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
 
       // Infinities
       { input: [0, kValue.f32.infinity.positive], expected: kAny },
@@ -2433,15 +2438,15 @@ g.test('clampMinMaxInterval')
       { input: [-10, -10, -10], expected: [-10] },
 
       // Subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0, 0], expected: [0] },
-      { input: [0, kValue.f32.subnormal.positive.max, 0], expected: [0] },
-      { input: [0, 0, kValue.f32.subnormal.positive.max], expected: [0] },
+      { input: [kValue.f32.subnormal.positive.max, 0, 0], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [0, kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [0, 0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.subnormal.positive.max, 0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, 0], expected: [0] },
+      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [0, kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.min, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.min, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, kValue.f32.subnormal.positive.max] },
+      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
       { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
 
       // Infinities

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1592,7 +1592,7 @@ export function clampMedianInterval(
 
 const ClampMinMaxIntervalOp: TernaryToIntervalOp = {
   impl: (x: number, low: number, high: number): F32Interval => {
-    return correctlyRoundedInterval(Math.min(Math.max(x, low), high));
+    return minInterval(maxInterval(x, low), high);
   },
 };
 
@@ -2129,6 +2129,11 @@ export function log2Interval(x: number | F32Interval): F32Interval {
 
 const MaxIntervalOp: BinaryToIntervalOp = {
   impl: (x: number, y: number): F32Interval => {
+    // If both of he inputs are subnormal, then either of the inputs can be returned
+    if (isSubnormalNumberF32(x) && isSubnormalNumberF32(y)) {
+      return correctlyRoundedInterval(F32Interval.span(toF32Interval(x), toF32Interval(y)));
+    }
+
     return correctlyRoundedInterval(Math.max(x, y));
   },
 };
@@ -2140,6 +2145,11 @@ export function maxInterval(x: number | F32Interval, y: number | F32Interval): F
 
 const MinIntervalOp: BinaryToIntervalOp = {
   impl: (x: number, y: number): F32Interval => {
+    // If both of he inputs are subnormal, then either of the inputs can be returned
+    if (isSubnormalNumberF32(x) && isSubnormalNumberF32(y)) {
+      return correctlyRoundedInterval(F32Interval.span(toF32Interval(x), toF32Interval(y)));
+    }
+
     return correctlyRoundedInterval(Math.min(x, y));
   },
 };
@@ -2452,9 +2462,9 @@ export function roundInterval(n: number): F32Interval {
 /**
  * Calculate an acceptance interval of saturate(n) as clamp(n, 0.0, 1.0)
  *
- * The definition of saturate is such that both possible implementations of
- * clamp will return the same value, so arbitrarily picking the minmax version
- * to use.
+ * The definition of saturate does not specify which version of clamp to use.
+ * Using min-max here, since it has wider acceptance intervals, that include
+ * all of median's.
  */
 export function saturateInterval(n: number): F32Interval {
   return runTernaryToIntervalOp(

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -72,7 +72,7 @@ export function isSubnormalScalarF32(val: Scalar): boolean {
   return (u32_val & 0x7f800000) === 0;
 }
 
-/** U/** @returns if number is within subnormal range of f32 */
+/** @returns if number is within subnormal range of f32 */
 export function isSubnormalNumberF32(n: number): boolean {
   return n > kValue.f32.negative.max && n < kValue.f32.positive.min;
 }


### PR DESCRIPTION
If both inputs to min and max are subnormal either value may be returned. This has knock on effects for the min-max formulation of clamp and saturation.

Fixes #2403

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
