### PR TITLE
Fixes remaining tests that hit deprecated paths.

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -1032,11 +1032,17 @@ g.test('bindings_in_bundle')
     const bindGroups: GPUBindGroup[] = [];
     if (type0 !== 'render-target') {
       const binding0TexFormat = type0 === 'sampled-texture' ? undefined : 'rgba8unorm';
-      bindGroups[0] = t.createBindGroup(0, view, type0, '2d', { format: binding0TexFormat });
+      bindGroups[0] = t.createBindGroup(0, view, type0, '2d', {
+        format: binding0TexFormat,
+        sampleType: _sampleCount && 'unfilterable-float',
+      });
     }
     if (type1 !== 'render-target') {
       const binding1TexFormat = type1 === 'sampled-texture' ? undefined : 'rgba8unorm';
-      bindGroups[1] = t.createBindGroup(1, view, type1, '2d', { format: binding1TexFormat });
+      bindGroups[1] = t.createBindGroup(1, view, type1, '2d', {
+        format: binding1TexFormat,
+        sampleType: _sampleCount && 'unfilterable-float',
+      });
     }
 
     const encoder = t.device.createCommandEncoder();

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -260,6 +260,7 @@ g.test('subresources,depth_stencil_attachment_and_bind_group')
         { bgLayer: 1, bgLayerCount: 1 },
         { bgLayer: 1, bgLayerCount: 2 },
       ])
+      .beginSubcases()
       .combine('dsReadOnly', [true, false])
       .combine('bgAspect', ['depth-only', 'stencil-only'] as const)
       .combine('inSamePass', [true, false])
@@ -304,11 +305,11 @@ g.test('subresources,depth_stencil_attachment_and_bind_group')
     const depthStencilAttachment: GPURenderPassDepthStencilAttachment = {
       view: attachmentView,
       depthReadOnly: dsReadOnly,
-      depthLoadOp: 'load',
-      depthStoreOp: 'store',
+      depthLoadOp: dsReadOnly ? undefined : 'load',
+      depthStoreOp: dsReadOnly ? undefined : 'store',
       stencilReadOnly: dsReadOnly,
-      stencilLoadOp: 'load',
-      stencilStoreOp: 'store',
+      stencilLoadOp: dsReadOnly ? undefined : 'load',
+      stencilStoreOp: dsReadOnly ? undefined : 'store',
     };
 
     const encoder = t.device.createCommandEncoder();


### PR DESCRIPTION
- Make sure to use 'unfilterable-float' when multisampling.
- Make sure not to pass depth/stencil Load/Store ops in readonly mode.
- Also makes some of the tests under 'subresources,depth_stencil_attachment_and_bind_group' into subcases. This speeds up the tests considerably. Before each test when not hitting any caching took about 1s, but now we batch 8 cases together (running them in parallel) resulting still in about 1s runtime... So almost an 8x speed up! Also greatly increases load-speed of the page since we don't need to create ~300 entries, and just create ~40.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.
