### PR TITLE
Add more increment and decrement tests.

### DIFF
--- a/src/webgpu/shader/execution/statement/increment_decrement.spec.ts
+++ b/src/webgpu/shader/execution/statement/increment_decrement.spec.ts
@@ -239,8 +239,48 @@ g.test('scalar_u32_decrement_underflow')
     );
   });
 
-g.test('vector_element_increment')
-  .desc('Tests increment of vector values')
+g.test('vec2_element_increment')
+  .desc('Tests increment of ve2 values')
+  .fn(t => {
+    runStatementTest(
+      t,
+      'i32',
+      new Int32Array([-9, 11]),
+      `
+    var a = vec2(-10, 10);
+
+    a.x++;
+    a.g++;
+
+    push_output(a.x);
+    push_output(a.y);
+`
+    );
+  });
+
+g.test('vec3_element_increment')
+  .desc('Tests increment of vec3 values')
+  .fn(t => {
+    runStatementTest(
+      t,
+      'i32',
+      new Int32Array([-9, 11, kValue.i32.negative.min + 1]),
+      `
+    var a = vec3(-10, 10, ${kValue.i32.negative.min});
+
+    a.x++;
+    a.g++;
+    a.z++;
+
+    push_output(a.x);
+    push_output(a.y);
+    push_output(a.z);
+`
+    );
+  });
+
+g.test('vec4_element_increment')
+  .desc('Tests increment of vec4 values')
   .fn(t => {
     runStatementTest(
       t,
@@ -262,8 +302,48 @@ g.test('vector_element_increment')
     );
   });
 
-g.test('vector_element_decrement')
-  .desc('Tests decrement of vector values')
+g.test('vec2_element_decrement')
+  .desc('Tests decrement of vec2 values')
+  .fn(t => {
+    runStatementTest(
+      t,
+      'i32',
+      new Int32Array([-11, 9]),
+      `
+    var a = vec2(-10, 10);
+
+    a.x--;
+    a.g--;
+
+    push_output(a.x);
+    push_output(a.y);
+`
+    );
+  });
+
+g.test('vec3_element_decrement')
+  .desc('Tests decrement of vec3 values')
+  .fn(t => {
+    runStatementTest(
+      t,
+      'i32',
+      new Int32Array([-11, 9, kValue.i32.negative.min]),
+      `
+    var a = vec3(-10, 10, ${kValue.i32.negative.min + 1});
+
+    a.x--;
+    a.g--;
+    a.z--;
+
+    push_output(a.x);
+    push_output(a.y);
+    push_output(a.z);
+`
+    );
+  });
+
+g.test('vec4_element_decrement')
+  .desc('Tests decrement of vec4 values')
   .fn(t => {
     runStatementTest(
       t,


### PR DESCRIPTION
This CL adds the requested `vec2` and `vec3` increment and decrement test cases.

Issue #1646

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
