### PR TITLE
Fix unexpected failure in api,validation,queue,copyToTexture,CopyExte…

### DIFF
--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -157,7 +157,9 @@ class CopyExternalImageToTextureTest extends ValidationTest {
   ): HTMLCanvasElement | OffscreenCanvas {
     const canvas = createCanvas(this, canvasType, 1, 1);
     const ctx = canvas.getContext('2d');
-    assert(ctx instanceof CanvasRenderingContext2D);
+    assert(
+      ctx instanceof CanvasRenderingContext2D || ctx instanceof OffscreenCanvasRenderingContext2D
+    );
     ctx.drawImage(content, 0, 0);
 
     return canvas;

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -157,9 +157,14 @@ class CopyExternalImageToTextureTest extends ValidationTest {
   ): HTMLCanvasElement | OffscreenCanvas {
     const canvas = createCanvas(this, canvasType, 1, 1);
     const ctx = canvas.getContext('2d');
-    assert(
-      ctx instanceof CanvasRenderingContext2D || ctx instanceof OffscreenCanvasRenderingContext2D
-    );
+    switch (canvasType) {
+      case 'onscreen':
+        assert(ctx instanceof CanvasRenderingContext2D);
+        break;
+      case 'offscreen':
+        assert(ctx instanceof OffscreenCanvasRenderingContext2D);
+        break;
+    }
     ctx.drawImage(content, 0, 0);
 
     return canvas;


### PR DESCRIPTION
…rnalImageToTexture:source_image,crossOrigin:*

In crossOrigin test case, we call getCanvasWithContent() API and assuming context is CanvasRenderingContext2D.

But for OffscreenCanvas, it returns OffscreenCanvasRenderingContext2D, which is different from CanvasRenderingContext2D.

This PR fix the unexpected failure by adding OffscreenCanvasRenderingContext2D into assert




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
