### PR TITLE
Set depthClearValue when depthLoadOp is clear

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -860,6 +860,10 @@ g.test('depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadO
     const depthAttachmentView = depthAttachment.createView();
 
     const encoder = t.device.createCommandEncoder();
+
+    // If depthLoadOp is "clear", depthClearValue must be provided and must be between 0.0 and 1.0,
+    // and it will be ignored if depthLoadOp is not "clear".
+    const depthClearValue = depthLoadOp === 'clear' ? 0 : undefined;
     const renderPassDescriptor: GPURenderPassDescriptor = {
       colorAttachments: [],
       depthStencilAttachment: {
@@ -870,6 +874,7 @@ g.test('depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadO
         stencilLoadOp,
         stencilStoreOp,
         stencilReadOnly,
+        depthClearValue,
       },
     };
     const pass = encoder.beginRenderPass(renderPassDescriptor);


### PR DESCRIPTION
This patch adds the missing depthClearValue when depthLoadOp is clear as the latest WebGPU SPEC requires depthClearValue must be provided and must be between 0.0 and 1.0 if depthLoadOp is "clear".




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
