### PR TITLE
Refactor how floating point intervals are calculated

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1,5 +1,12 @@
+// This is a shim file that performs testing via the old/deprecates f32 API
+// calls.
+// Those currently just pass-through to the new refactored FPContext
+// implementation.
+// As CTS migrates over to directly calling the new API these test will be
+// replaced with direct call tests.
+
 export const description = `
-F32Interval unit tests.
+F32 unit tests.
 `;
 
 import { makeTestGroup } from '../common/framework/test_group.js';
@@ -31,12 +38,10 @@ import {
   dotInterval,
   expInterval,
   exp2Interval,
-  F32Interval,
   faceForwardIntervals,
   floorInterval,
   fmaInterval,
   fractInterval,
-  IntervalBounds,
   inverseSqrtInterval,
   ldexpInterval,
   lengthInterval,
@@ -86,7 +91,9 @@ import {
   determinantInterval,
   isF32Vector,
   isF32Matrix,
+  spanF32Intervals,
 } from '../webgpu/util/f32_interval.js';
+import { FPInterval, IntervalBounds } from '../webgpu/util/floating_point.js';
 import { hexToF32, hexToF64, map2DArray, oneULPF32 } from '../webgpu/util/math.js';
 
 import { UnitTest } from './unit_test.js';
@@ -94,7 +101,10 @@ import { UnitTest } from './unit_test.js';
 export const g = makeTestGroup(UnitTest);
 
 /** Bounds indicating an expectation of an interval of all possible values */
-const kAny: IntervalBounds = [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY];
+const kAnyBounds: IntervalBounds = [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY];
+
+/** Interval from kAnyBounds */
+const kAnyInterval: FPInterval = toF32Interval(kAnyBounds);
 
 /** @returns a number N * ULP greater than the provided number */
 function plusNULP(x: number, n: number): number {
@@ -125,7 +135,7 @@ function applyError(
   expected: number | IntervalBounds,
   error: (n: number) => number
 ): IntervalBounds {
-  if (expected !== kAny) {
+  if (expected !== kAnyBounds) {
     const interval = toF32Interval(expected);
     expected = [interval.begin - error(interval.begin), interval.end + error(interval.end)];
   }
@@ -163,14 +173,14 @@ g.test('constructor')
       // Infinities
       { input: [0, kValue.f32.infinity.positive], expected: [0, Number.POSITIVE_INFINITY] },
       { input: [kValue.f32.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, 0] },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
     ]
   )
   .fn(t => {
-    const i = new F32Interval(...t.params.input);
+    const i = new FPInterval('f32', ...t.params.input);
     t.expect(
       objectEquals(i.bounds(), t.params.expected),
-      `F32Interval([${t.params.input}]) returned ${i}. Expected [${t.params.expected}]`
+      `FPInterval([${t.params.input}]) returned ${i}. Expected [${t.params.expected}]`
     );
   });
 
@@ -410,7 +420,7 @@ g.test('span')
       { intervals: [[2, 5], [0, 1]], expected: [0, 5] },
       { intervals: [[0, 2], [1, 5]], expected: [0, 5] },
       { intervals: [[0, 5], [1, 2]], expected: [0, 5] },
-      { intervals: [[kValue.f32.infinity.negative, 0], [0, kValue.f32.infinity.positive]], expected: kAny },
+      { intervals: [[kValue.f32.infinity.negative, 0], [0, kValue.f32.infinity.positive]], expected: kAnyBounds },
 
       // Multiple Intervals
       { intervals: [[0, 1], [2, 3], [4, 5]], expected: [0, 5] },
@@ -424,23 +434,23 @@ g.test('span')
     ]
   )
   .fn(t => {
-    const intervals = t.params.intervals.map(toF32Interval);
+    const intervals = t.params.intervals.map(i => toF32Interval(i));
     const expected = toF32Interval(t.params.expected);
 
-    const got = F32Interval.span(...intervals);
+    const got = spanF32Intervals(...intervals);
     t.expect(
       objectEquals(got, expected),
       `span({${intervals}}) returned ${got}. Expected ${expected}`
     );
   });
 
-interface IsF32VectorCase {
-  input: (number | IntervalBounds | F32Interval)[];
+interface isF32VectorCase {
+  input: (number | IntervalBounds | FPInterval)[];
   expected: boolean;
 }
 
 g.test('isF32Vector')
-  .paramsSubcasesOnly<IsF32VectorCase>([
+  .paramsSubcasesOnly<isF32VectorCase>([
     // numbers
     { input: [1, 2], expected: false },
     { input: [1, 2, 3], expected: false },
@@ -478,7 +488,10 @@ g.test('isF32Vector')
     // F32Interval, valid dimensions
     { input: [toF32Interval([1]), toF32Interval([2])], expected: true },
     { input: [toF32Interval([1, 2]), toF32Interval([2, 3])], expected: true },
-    { input: [toF32Interval([1]), toF32Interval([2]), toF32Interval([3])], expected: true },
+    {
+      input: [toF32Interval([1]), toF32Interval([2]), toF32Interval([3])],
+      expected: true,
+    },
     {
       input: [toF32Interval([1, 2]), toF32Interval([2, 3]), toF32Interval([3, 4])],
       expected: true,
@@ -497,7 +510,7 @@ g.test('isF32Vector')
       expected: true,
     },
 
-    // F32Interval, invalid dimensions
+    // FPInterval, invalid dimensions
     { input: [toF32Interval([1])], expected: false },
     {
       input: [
@@ -525,13 +538,13 @@ g.test('isF32Vector')
     t.expect(got === expected, `isF32Vector([${input}]) returned ${got}. Expected ${expected}`);
   });
 
-interface ToF32VectorCase {
-  input: (number | IntervalBounds | F32Interval)[];
+interface toF32VectorCase {
+  input: (number | IntervalBounds | FPInterval)[];
   expected: (number | IntervalBounds)[];
 }
 
 g.test('toF32Vector')
-  .paramsSubcasesOnly<ToF32VectorCase>([
+  .paramsSubcasesOnly<toF32VectorCase>([
     // numbers
     { input: [1, 2], expected: [1, 2] },
     { input: [1, 2, 3], expected: [1, 2, 3] },
@@ -587,7 +600,10 @@ g.test('toF32Vector')
         [2, 3],
       ],
     },
-    { input: [toF32Interval([1]), toF32Interval([2]), toF32Interval([3])], expected: [1, 2, 3] },
+    {
+      input: [toF32Interval([1]), toF32Interval([2]), toF32Interval([3])],
+      expected: [1, 2, 3],
+    },
     {
       input: [toF32Interval([1, 2]), toF32Interval([2, 3]), toF32Interval([3, 4])],
       expected: [
@@ -620,13 +636,13 @@ g.test('toF32Vector')
     { input: [1, [2], toF32Interval([3])], expected: [1, 2, 3] },
     { input: [1, toF32Interval([2]), [3], 4], expected: [1, 2, 3, 4] },
     {
-      input: [1, [2], [2, 3], F32Interval.any()],
-      expected: [1, 2, [2, 3], kAny],
+      input: [1, [2], [2, 3], kAnyInterval],
+      expected: [1, 2, [2, 3], kAnyBounds],
     },
   ])
   .fn(t => {
     const input = t.params.input;
-    const expected = t.params.expected.map(toF32Interval);
+    const expected = t.params.expected.map(e => toF32Interval(e));
 
     const got = toF32Vector(input);
     t.expect(
@@ -635,13 +651,13 @@ g.test('toF32Vector')
     );
   });
 
-interface IsF32MatrixCase {
-  input: (number | IntervalBounds | F32Interval)[][];
+interface isF32MatrixCase {
+  input: (number | IntervalBounds | FPInterval)[][];
   expected: boolean;
 }
 
 g.test('isF32Matrix')
-  .paramsSubcasesOnly<IsF32MatrixCase>([
+  .paramsSubcasesOnly<isF32MatrixCase>([
     // numbers
     {
       input: [
@@ -790,7 +806,7 @@ g.test('isF32Matrix')
       expected: false,
     },
 
-    // F32Interval, valid dimensions
+    // FPInterval, valid dimensions
     {
       input: [
         [toF32Interval(1), toF32Interval(2)],
@@ -981,9 +997,12 @@ g.test('isF32Matrix')
       expected: true,
     },
 
-    // F32Interval, invalid dimensions
+    // FPInterval, invalid dimensions
     { input: [[toF32Interval(1)]], expected: false },
-    { input: [[toF32Interval(1)], [toF32Interval(3), toF32Interval(4)]], expected: false },
+    {
+      input: [[toF32Interval(1)], [toF32Interval(3), toF32Interval(4)]],
+      expected: false,
+    },
     {
       input: [
         [toF32Interval(1), toF32Interval(2)],
@@ -1055,13 +1074,13 @@ g.test('isF32Matrix')
     t.expect(got === expected, `isF32Matrix([${input}]) returned ${got}. Expected ${expected}`);
   });
 
-interface ToF32MatrixCase {
-  input: (number | IntervalBounds | F32Interval)[][];
+interface toF32MatrixCase {
+  input: (number | IntervalBounds | FPInterval)[][];
   expected: (number | IntervalBounds)[][];
 }
 
 g.test('toF32Matrix')
-  .paramsSubcasesOnly<ToF32MatrixCase>([
+  .paramsSubcasesOnly<toF32MatrixCase>([
     // numbers
     {
       input: [
@@ -1282,7 +1301,7 @@ g.test('toF32Matrix')
       ],
     },
 
-    // F32Interval
+    // FPInterval
     {
       input: [
         [toF32Interval(1), toF32Interval(2)],
@@ -1698,7 +1717,7 @@ g.test('toF32Matrix')
   ])
   .fn(t => {
     const input = t.params.input;
-    const expected = map2DArray(t.params.expected, toF32Interval);
+    const expected = map2DArray(t.params.expected, e => toF32Interval(e));
 
     const got = toF32Matrix(input);
     t.expect(
@@ -1717,8 +1736,8 @@ g.test('correctlyRoundedInterval')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, expected: kAny },
-      { value: kValue.f32.infinity.negative, expected: kAny },
+      { value: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, expected: kAnyBounds },
       { value: kValue.f32.positive.max, expected: kValue.f32.positive.max },
       { value: kValue.f32.negative.min, expected: kValue.f32.negative.min },
       { value: kValue.f32.positive.min, expected: kValue.f32.positive.min },
@@ -1756,7 +1775,6 @@ g.test('correctlyRoundedInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = correctlyRoundedInterval(t.params.value);
     t.expect(
       objectEquals(expected, got),
@@ -1775,21 +1793,21 @@ g.test('absoluteErrorInterval')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, error: 0, expected: kAny },
-      { value: kValue.f32.infinity.positive, error: 2 ** -11, expected: kAny },
-      { value: kValue.f32.infinity.positive, error: 1, expected: kAny },
-      { value: kValue.f32.infinity.negative, error: 0, expected: kAny },
-      { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: kAny },
-      { value: kValue.f32.infinity.negative, error: 1, expected: kAny },
+      { value: kValue.f32.infinity.positive, error: 0, expected: kAnyBounds },
+      { value: kValue.f32.infinity.positive, error: 2 ** -11, expected: kAnyBounds },
+      { value: kValue.f32.infinity.positive, error: 1, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, error: 0, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, error: 1, expected: kAnyBounds },
       { value: kValue.f32.positive.max, error: 0, expected: kValue.f32.positive.max },
       { value: kValue.f32.positive.max, error: 2 ** -11, expected: kValue.f32.positive.max },
-      { value: kValue.f32.positive.max, error: kValue.f32.positive.max, expected: kAny },
+      { value: kValue.f32.positive.max, error: kValue.f32.positive.max, expected: kAnyBounds },
       { value: kValue.f32.positive.min, error: 0, expected: kValue.f32.positive.min },
       { value: kValue.f32.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
       { value: kValue.f32.positive.min, error: 1, expected: [-1, 1] },
       { value: kValue.f32.negative.min, error: 0, expected: kValue.f32.negative.min },
       { value: kValue.f32.negative.min, error: 2 ** -11, expected: kValue.f32.negative.min },
-      { value: kValue.f32.negative.min, error: kValue.f32.positive.max, expected: kAny },
+      { value: kValue.f32.negative.min, error: kValue.f32.positive.max, expected: kAnyBounds },
       { value: kValue.f32.negative.max, error: 0, expected: kValue.f32.negative.max },
       { value: kValue.f32.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
       { value: kValue.f32.negative.max, error: 1, expected: [-1, 1] },
@@ -1830,7 +1848,6 @@ g.test('absoluteErrorInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = absoluteErrorInterval(t.params.value, t.params.error);
     t.expect(
       objectEquals(expected, got),
@@ -1849,21 +1866,21 @@ g.test('ulpInterval')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, num_ulp: 0, expected: kAny },
-      { value: kValue.f32.infinity.positive, num_ulp: 1, expected: kAny },
-      { value: kValue.f32.infinity.positive, num_ulp: 4096, expected: kAny },
-      { value: kValue.f32.infinity.negative, num_ulp: 0, expected: kAny },
-      { value: kValue.f32.infinity.negative, num_ulp: 1, expected: kAny },
-      { value: kValue.f32.infinity.negative, num_ulp: 4096, expected: kAny },
+      { value: kValue.f32.infinity.positive, num_ulp: 0, expected: kAnyBounds },
+      { value: kValue.f32.infinity.positive, num_ulp: 1, expected: kAnyBounds },
+      { value: kValue.f32.infinity.positive, num_ulp: 4096, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, num_ulp: 0, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, num_ulp: 1, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, num_ulp: 4096, expected: kAnyBounds },
       { value: kValue.f32.positive.max, num_ulp: 0, expected: kValue.f32.positive.max },
-      { value: kValue.f32.positive.max, num_ulp: 1, expected: kAny },
-      { value: kValue.f32.positive.max, num_ulp: 4096, expected: kAny },
+      { value: kValue.f32.positive.max, num_ulp: 1, expected: kAnyBounds },
+      { value: kValue.f32.positive.max, num_ulp: 4096, expected: kAnyBounds },
       { value: kValue.f32.positive.min, num_ulp: 0, expected: kValue.f32.positive.min },
       { value: kValue.f32.positive.min, num_ulp: 1, expected: [0, plusOneULP(kValue.f32.positive.min)] },
       { value: kValue.f32.positive.min, num_ulp: 4096, expected: [0, plusNULP(kValue.f32.positive.min, 4096)] },
       { value: kValue.f32.negative.min, num_ulp: 0, expected: kValue.f32.negative.min },
-      { value: kValue.f32.negative.min, num_ulp: 1, expected: kAny },
-      { value: kValue.f32.negative.min, num_ulp: 4096, expected: kAny },
+      { value: kValue.f32.negative.min, num_ulp: 1, expected: kAnyBounds },
+      { value: kValue.f32.negative.min, num_ulp: 4096, expected: kAnyBounds },
       { value: kValue.f32.negative.max, num_ulp: 0, expected: kValue.f32.negative.max },
       { value: kValue.f32.negative.max, num_ulp: 1, expected: [minusOneULP(kValue.f32.negative.max), 0] },
       { value: kValue.f32.negative.max, num_ulp: 4096, expected: [minusNULP(kValue.f32.negative.max, 4096), 0] },
@@ -1904,7 +1921,6 @@ g.test('ulpInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = ulpInterval(t.params.value, t.params.num_ulp);
     t.expect(
       objectEquals(expected, got),
@@ -1928,8 +1944,8 @@ g.test('absInterval')
       { input: -0.1, expected: [hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)] },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAny },
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
       { input: kValue.f32.positive.min, expected: kValue.f32.positive.min },
       { input: kValue.f32.negative.min, expected: kValue.f32.positive.max },
@@ -1951,7 +1967,6 @@ g.test('absInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = absInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -1967,27 +1982,26 @@ g.test('acosInterval')
       // to express in a closed human-readable form due to the complexity of
       // their derivation.
       //
-      // The acceptance interval @ x = -1 and 1 is kAny, because
+      // The acceptance interval @ x = -1 and 1 is kAnyBounds, because
       // sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inverseqrt
-      // The acceptance interval @ x = 0 is kAny, because atan2 is not
+      // The acceptance interval @ x = 0 is kAnyBounds, because atan2 is not
       // well-defined/implemented at 0.
       // Near 1, the absolute error should be larger and, away from 1 the atan2
       // inherited error should be larger.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
-      { input: -1, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: kAnyBounds },
       { input: -1/2, expected: [hexToF32(0x4005fa91), hexToF32(0x40061a94)] },  // ~2π/3
-      { input: 0, expected: kAny },
+      { input: 0, expected: kAnyBounds },
       { input: 1/2, expected: [hexToF32(0x3f85fa8f), hexToF32(0x3f861a94)] },  // ~π/3
       { input: minusOneULP(1), expected: [hexToF64(0x3f2f_fdff_6000_0000n), hexToF64(0x3f3b_106f_c933_4fb9n)] },  // ~0.0003
-      { input: 1, expected: kAny },
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: 1, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = acosInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2002,20 +2016,19 @@ g.test('acoshAlternativeInterval')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
-      { input: -1, expected: kAny },
-      { input: 0, expected: kAny },
-      { input: 1, expected: kAny },  // 1/0 occurs in inverseSqrt in this formulation
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
+      { input: 1, expected: kAnyBounds },  // 1/0 occurs in inverseSqrt in this formulation
       { input: 1.1, expected: [hexToF64(0x3fdc_6368_8000_0000n), hexToF64(0x3fdc_636f_2000_0000n)] },  // ~0.443..., differs from the primary in the later digits
       { input: 10, expected: [hexToF64(0x4007_f21e_4000_0000n), hexToF64(0x4007_f21f_6000_0000n)] },  // ~2.993...
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = acoshAlternativeInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2030,20 +2043,19 @@ g.test('acoshPrimaryInterval')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
-      { input: -1, expected: kAny },
-      { input: 0, expected: kAny },
-      { input: 1, expected: kAny },  // 1/0 occurs in inverseSqrt in this formulation
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
+      { input: 1, expected: kAnyBounds },  // 1/0 occurs in inverseSqrt in this formulation
       { input: 1.1, expected: [hexToF64(0x3fdc_6368_2000_0000n), hexToF64(0x3fdc_636f_8000_0000n)] }, // ~0.443..., differs from the alternative in the later digits
       { input: 10, expected: [hexToF64(0x4007_f21e_4000_0000n), hexToF64(0x4007_f21f_6000_0000n)] },  // ~2.993...
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = acoshPrimaryInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2058,28 +2070,27 @@ g.test('asinInterval')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a simple human-readable form due to the complexity of their derivation.
       //
-      // The acceptance interval @ x = -1 and 1 is kAny, because
+      // The acceptance interval @ x = -1 and 1 is kAnyBounds, because
       // sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inversqrt.
-      // The acceptance interval @ x = 0 is kAny, because atan2 is not
+      // The acceptance interval @ x = 0 is kAnyBounds, because atan2 is not
       // well-defined/implemented at 0.
       // Near 0, but not subnormal the absolute error should be larger, so will
       // be +/- 6.77e-5, away from 0 the atan2 inherited error should be larger.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
-      { input: -1, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: kAnyBounds },
       { input: -1/2, expected: [hexToF64(0xbfe0_c352_c000_0000n), hexToF64(0xbfe0_bf51_c000_0000n)] },  // ~-π/6
       { input: kValue.f32.negative.max, expected: [-6.77e-5, 6.77e-5] },  // ~0
-      { input: 0, expected: kAny },
+      { input: 0, expected: kAnyBounds },
       { input: kValue.f32.positive.min, expected: [-6.77e-5, 6.77e-5] },  // ~0
       { input: 1/2, expected: [hexToF64(0x3fe0_bf51_c000_0000n), hexToF64(0x3fe0_c352_c000_0000n)] },  // ~π/6
-      { input: 1, expected: kAny },  // ~π/2
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: 1, expected: kAnyBounds },  // ~π/2
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = asinInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2094,18 +2105,17 @@ g.test('asinhInterval')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
       { input: -1, expected: [hexToF64(0xbfec_343a_8000_0000n), hexToF64(0xbfec_3432_8000_0000n)] },  // ~-0.88137...
       { input: 0, expected: [hexToF64(0xbeaa_0000_2000_0000n), hexToF64(0x3eb1_ffff_d000_0000n)] },  // ~0
       { input: 1, expected: [hexToF64(0x3fec_3435_4000_0000n), hexToF64(0x3fec_3437_8000_0000n)] },  // ~0.88137...
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = asinhInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2117,7 +2127,7 @@ g.test('atanInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: hexToF32(0xbfddb3d7), expected: [kValue.f32.negative.pi.third, plusOneULP(kValue.f32.negative.pi.third)] }, // x = -√3
       { input: -1, expected: [kValue.f32.negative.pi.quarter, plusOneULP(kValue.f32.negative.pi.quarter)] },
       { input: hexToF32(0xbf13cd3a), expected: [kValue.f32.negative.pi.sixth, plusOneULP(kValue.f32.negative.pi.sixth)] },  // x = -1/√3
@@ -2125,7 +2135,7 @@ g.test('atanInterval')
       { input: hexToF32(0x3f13cd3a), expected: [minusOneULP(kValue.f32.positive.pi.sixth), kValue.f32.positive.pi.sixth] },  // x = 1/√3
       { input: 1, expected: [minusOneULP(kValue.f32.positive.pi.quarter), kValue.f32.positive.pi.quarter] },
       { input: hexToF32(0x3fddb3d7), expected: [minusOneULP(kValue.f32.positive.pi.third), kValue.f32.positive.pi.third] }, // x = √3
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
@@ -2149,20 +2159,19 @@ g.test('atanhInterval')
     [
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
-      { input: -1, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: kAnyBounds },
       { input: -0.1, expected: [hexToF64(0xbfb9_af9a_6000_0000n), hexToF64(0xbfb9_af8c_c000_0000n)] },  // ~-0.1003...
       { input: 0, expected: [hexToF64(0xbe96_0000_2000_0000n), hexToF64(0x3e98_0000_0000_0000n)] },  // ~0
       { input: 0.1, expected: [hexToF64(0x3fb9_af8b_8000_0000n), hexToF64(0x3fb9_af9b_0000_0000n)] },  // ~0.1003...
-      { input: 1, expected: kAny },
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: 1, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = atanhInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2187,8 +2196,8 @@ g.test('ceilInterval')
       { input: -1.9, expected: -1 },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAny },
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
       { input: kValue.f32.positive.min, expected: 1 },
       { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
@@ -2205,7 +2214,6 @@ g.test('ceilInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = ceilInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2223,15 +2231,15 @@ g.test('cosInterval')
       // substantially different, so instead of getting 0 you get a value on the
       // order of 10^-8 away from 0, thus difficult to express in a
       // human-readable manner.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
       { input: kValue.f32.negative.pi.whole, expected: [-1, plusOneULP(-1)] },
       { input: kValue.f32.negative.pi.third, expected: [minusOneULP(1/2), 1/2] },
       { input: 0, expected: [1, 1] },
       { input: kValue.f32.positive.pi.third, expected: [minusOneULP(1/2), 1/2] },
       { input: kValue.f32.positive.pi.whole, expected: [-1, plusOneULP(-1)] },
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
@@ -2256,13 +2264,13 @@ g.test('coshInterval')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
       { input: -1, expected: [ hexToF32(0x3fc583a4), hexToF32(0x3fc583b1)] },  // ~1.1543...
       { input: 0, expected: [hexToF32(0x3f7ffffd), hexToF32(0x3f800002)] },  // ~1
       { input: 1, expected: [ hexToF32(0x3fc583a4), hexToF32(0x3fc583b1)] },  // ~1.1543...
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
@@ -2279,8 +2287,8 @@ g.test('degreesInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
       { input: kValue.f32.negative.pi.whole, expected: [minusOneULP(-180), plusOneULP(-180)] },
       { input: kValue.f32.negative.pi.three_quarters, expected: [minusOneULP(-135), plusOneULP(-135)] },
       { input: kValue.f32.negative.pi.half, expected: [minusOneULP(-90), plusOneULP(-90)] },
@@ -2294,13 +2302,12 @@ g.test('degreesInterval')
       { input: kValue.f32.positive.pi.half, expected: [minusOneULP(90), plusOneULP(90)] },
       { input: kValue.f32.positive.pi.three_quarters, expected: [minusOneULP(135), plusOneULP(135)] },
       { input: kValue.f32.positive.pi.whole, expected: [minusOneULP(180), plusOneULP(180)] },
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = degreesInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2312,10 +2319,10 @@ g.test('expInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: 0, expected: 1 },
       { input: 1, expected: [kValue.f32.positive.e, plusOneULP(kValue.f32.positive.e)] },
-      { input: 89, expected: kAny },
+      { input: 89, expected: kAnyBounds },
     ]
   )
   .fn(t => {
@@ -2338,10 +2345,10 @@ g.test('exp2Interval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: 0, expected: 1 },
       { input: 1, expected: 2 },
-      { input: 128, expected: kAny },
+      { input: 128, expected: kAnyBounds },
     ]
   )
   .fn(t => {
@@ -2377,8 +2384,8 @@ g.test('floorInterval')
       { input: -1.9, expected: -2 },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAny },
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
       { input: kValue.f32.positive.min, expected: 0 },
       { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
@@ -2395,7 +2402,6 @@ g.test('floorInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = floorInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2418,8 +2424,8 @@ g.test('fractInterval')
       { input: -1.1, expected: [hexToF64(0x3fec_cccc_c000_0000n), hexToF64(0x3fec_cccd_0000_0000n), ] }, // ~0.9
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAny },
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: kValue.f32.positive.max, expected: 0 },
       { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
       { input: kValue.f32.negative.min, expected: 0 },
@@ -2428,7 +2434,6 @@ g.test('fractInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = fractInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2440,13 +2445,13 @@ g.test('inverseSqrtInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: -1, expected: kAny },
-      { input: 0, expected: kAny },
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
       { input: 0.04, expected: [minusOneULP(5), plusOneULP(5)] },
       { input: 1, expected: 1 },
       { input: 100, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
       { input: kValue.f32.positive.max, expected: [hexToF32(0x1f800000), plusNULP(hexToF32(0x1f800000), 2)] },  // ~5.421...e-20, i.e. 1/√max f32
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
@@ -2472,8 +2477,8 @@ g.test('lengthIntervalScalar')
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
       //
-      // length(0) = kAny, because length uses sqrt, which is defined as 1/inversesqrt
-      {input: 0, expected: kAny },
+      // length(0) = kAnyBounds, because length uses sqrt, which is defined as 1/inversesqrt
+      {input: 0, expected: kAnyBounds },
       {input: 1.0, expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       {input: -1.0, expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       {input: 0.1, expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
@@ -2482,23 +2487,22 @@ g.test('lengthIntervalScalar')
       {input: -10.0, expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
 
       // Subnormal Cases
-      { input: kValue.f32.subnormal.negative.min, expected: kAny },
-      { input: kValue.f32.subnormal.negative.max, expected: kAny },
-      { input: kValue.f32.subnormal.positive.min, expected: kAny },
-      { input: kValue.f32.subnormal.positive.max, expected: kAny },
+      { input: kValue.f32.subnormal.negative.min, expected: kAnyBounds },
+      { input: kValue.f32.subnormal.negative.max, expected: kAnyBounds },
+      { input: kValue.f32.subnormal.positive.min, expected: kAnyBounds },
+      { input: kValue.f32.subnormal.positive.max, expected: kAnyBounds },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAny },
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
-      { input: kValue.f32.negative.max, expected: kAny },
-      { input: kValue.f32.positive.min, expected: kAny },
-      { input: kValue.f32.positive.max, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: kValue.f32.negative.max, expected: kAnyBounds },
+      { input: kValue.f32.positive.min, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = lengthInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2510,8 +2514,8 @@ g.test('logInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: -1, expected: kAny },
-      { input: 0, expected: kAny },
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
       { input: 1, expected: 0 },
       { input: kValue.f32.positive.e, expected: [minusOneULP(1), 1] },
       { input: kValue.f32.positive.max, expected: [minusOneULP(hexToF32(0x42b17218)), hexToF32(0x42b17218)] },  // ~88.72...
@@ -2539,8 +2543,8 @@ g.test('log2Interval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: -1, expected: kAny },
-      { input: 0, expected: kAny },
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
       { input: 1, expected: 0 },
       { input: 2, expected: 1 },
       { input: kValue.f32.positive.max, expected: [minusOneULP(128), 128] },
@@ -2577,8 +2581,8 @@ g.test('negationInterval')
       { input: -1.9, expected: [minusOneULP(hexToF32(0x3ff33334)), hexToF32(0x3ff33334)] },  // ~1.9
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAny },
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: kValue.f32.positive.max, expected: kValue.f32.negative.min },
       { input: kValue.f32.positive.min, expected: kValue.f32.negative.max },
       { input: kValue.f32.negative.min, expected: kValue.f32.positive.max },
@@ -2593,7 +2597,6 @@ g.test('negationInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = negationInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2605,8 +2608,8 @@ g.test('quantizeToF16Interval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
       { input: kValue.f16.negative.min, expected: kValue.f16.negative.min },
       { input: -1, expected: -1 },
       { input: -0.1, expected: [hexToF32(0xbdcce000), hexToF32(0xbdccc000)] },  // ~-0.1
@@ -2622,8 +2625,8 @@ g.test('quantizeToF16Interval')
       { input: 0.1, expected: [hexToF32(0x3dccc000), hexToF32(0x3dcce000)] },  // ~0.1
       { input: 1, expected: 1 },
       { input: kValue.f16.positive.max, expected: kValue.f16.positive.max },
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
@@ -2640,7 +2643,7 @@ g.test('radiansInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: -180, expected: [minusOneULP(kValue.f32.negative.pi.whole), plusOneULP(kValue.f32.negative.pi.whole)] },
       { input: -135, expected: [minusOneULP(kValue.f32.negative.pi.three_quarters), plusOneULP(kValue.f32.negative.pi.three_quarters)] },
       { input: -90, expected: [minusOneULP(kValue.f32.negative.pi.half), plusOneULP(kValue.f32.negative.pi.half)] },
@@ -2654,12 +2657,11 @@ g.test('radiansInterval')
       { input: 90, expected: [minusOneULP(kValue.f32.positive.pi.half), plusOneULP(kValue.f32.positive.pi.half)] },
       { input: 135, expected: [minusOneULP(kValue.f32.positive.pi.three_quarters), plusOneULP(kValue.f32.positive.pi.three_quarters)] },
       { input: 180, expected: [minusOneULP(kValue.f32.positive.pi.whole), plusOneULP(kValue.f32.positive.pi.whole)] },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = radiansInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2688,8 +2690,8 @@ g.test('roundInterval')
       { input: -1.9, expected: -2 },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAny },
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
       { input: kValue.f32.positive.min, expected: 0 },
       { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
@@ -2706,7 +2708,6 @@ g.test('roundInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = roundInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2739,13 +2740,12 @@ g.test('saturateInterval')
       { input: kValue.f32.subnormal.negative.max, expected: [kValue.f32.subnormal.negative.max, 0.0] },
 
       // Infinities
-      { input: kValue.f32.infinity.positive, expected: kAny },
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = saturateInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2757,7 +2757,7 @@ g.test('signInterval')
   .paramsSubcasesOnly<PointToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: kValue.f32.negative.min, expected: -1 },
       { input: -10, expected: -1 },
       { input: -1, expected: -1 },
@@ -2773,12 +2773,11 @@ g.test('signInterval')
       { input: 1, expected: 1 },
       { input: 10, expected: 1 },
       { input: kValue.f32.positive.max, expected: 1 },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = signInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2796,13 +2795,13 @@ g.test('sinInterval')
       // substantially different, so instead of getting 0 you get a value on the
       // order of 10^-8 away from it, thus difficult to express in a
       // human-readable manner.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
       { input: kValue.f32.negative.pi.half, expected: [-1, plusOneULP(-1)] },
       { input: 0, expected: 0 },
       { input: kValue.f32.positive.pi.half, expected: [minusOneULP(1), 1] },
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
@@ -2827,18 +2826,17 @@ g.test('sinhInterval')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
       { input: -1, expected: [ hexToF32(0xbf966d05), hexToF32(0xbf966cf8)] },  // ~-1.175...
       { input: 0, expected: [hexToF32(0xb4600000), hexToF32(0x34600000)] },  // ~0
       { input: 1, expected: [ hexToF32(0x3f966cf8), hexToF32(0x3f966d05)] },  // ~1.175...
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = sinhInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2853,18 +2851,17 @@ g.test('sqrtInterval')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: -1, expected: kAny },
-      { input: 0, expected: kAny },
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
       { input: 0.01, expected: [hexToF64(0x3fb9_9998_b000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
       { input: 1, expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: 4, expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
       { input: 100, expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = sqrtInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2893,20 +2890,19 @@ g.test('tanInterval')
       //
       // The examples here have been manually traced to confirm the expectation
       // values are correct.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
       { input: kValue.f32.negative.pi.whole, expected: [hexToF64(0xbf40_02bc_9000_0000n), hexToF64(0x3f40_0144_f000_0000n)] },  // ~0.0
-      { input: kValue.f32.negative.pi.half, expected: kAny },
+      { input: kValue.f32.negative.pi.half, expected: kAnyBounds },
       { input: 0, expected: [hexToF64(0xbf40_0200_b000_0000n), hexToF64(0x3f40_0200_b000_0000n)] },  // ~0.0
-      { input: kValue.f32.positive.pi.half, expected: kAny },
+      { input: kValue.f32.positive.pi.half, expected: kAnyBounds },
       { input: kValue.f32.positive.pi.whole, expected: [hexToF64(0xbf40_0144_f000_0000n), hexToF64(0x3f40_02bc_9000_0000n)] },  // ~0.0
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = tanInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2921,18 +2917,17 @@ g.test('tanhInterval')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAny },
-      { input: kValue.f32.negative.min, expected: kAny },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
       { input: -1, expected: [hexToF64(0xbfe8_5efd_1000_0000n), hexToF64(0xbfe8_5ef8_9000_0000n)] },  // ~-0.7615...
       { input: 0, expected: [hexToF64(0xbe8c_0000_b000_0000n), hexToF64(0x3e8c_0000_b000_0000n)] },  // ~0
       { input: 1, expected: [hexToF64(0x3fe8_5ef8_9000_0000n), hexToF64(0x3fe8_5efd_1000_0000n)] },  // ~0.7615...
-      { input: kValue.f32.positive.max, expected: kAny },
-      { input: kValue.f32.infinity.positive, expected: kAny },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = tanhInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2957,8 +2952,8 @@ g.test('truncInterval')
       { input: -1.9, expected: -1 },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAny },
-      { input: kValue.f32.infinity.negative, expected: kAny },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
       { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
       { input: kValue.f32.positive.min, expected: 0 },
       { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
@@ -2973,7 +2968,6 @@ g.test('truncInterval')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = truncInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -2983,7 +2977,7 @@ g.test('truncInterval')
 
 interface BinaryToIntervalCase {
   // input is a pair of independent values, not a range, so should not be
-  // converted to a F32Interval.
+  // converted to a FPInterval.
   input: [number, number];
   expected: number | IntervalBounds;
 }
@@ -3024,20 +3018,19 @@ g.test('additionInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = additionInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -3069,49 +3062,48 @@ g.test('atan2Interval')
       { input: [1, hexToF32(0x3fddb3d7)], expected: [minusNULP(kValue.f32.positive.pi.sixth, 4097), plusNULP(kValue.f32.positive.pi.sixth, 4096)] },  // x = √3
       { input: [1, 1], expected: [minusNULP(kValue.f32.positive.pi.quarter, 4097), plusNULP(kValue.f32.positive.pi.quarter, 4096)] },
       // { input: [hexToF32(0x3fddb3d7), 1], expected: [hexToF64(0x3ff0_bf52_0000_0000n), hexToF64(0x3ff0_c352_6000_0000n)] },  // y = √3
-      { input: [Number.POSITIVE_INFINITY, 1], expected: kAny },
+      { input: [Number.POSITIVE_INFINITY, 1], expected: kAnyBounds },
 
       // positive y, negative x
       { input: [1, -1], expected: [minusNULP(kValue.f32.positive.pi.three_quarters, 4096), plusNULP(kValue.f32.positive.pi.three_quarters, 4097)] },
-      { input: [Number.POSITIVE_INFINITY, -1], expected: kAny },
+      { input: [Number.POSITIVE_INFINITY, -1], expected: kAnyBounds },
 
       // negative y, negative x
       { input: [-1, -1], expected: [minusNULP(kValue.f32.negative.pi.three_quarters, 4097), plusNULP(kValue.f32.negative.pi.three_quarters, 4096)] },
-      { input: [Number.NEGATIVE_INFINITY, -1], expected: kAny },
+      { input: [Number.NEGATIVE_INFINITY, -1], expected: kAnyBounds },
 
       // negative y, positive x
       { input: [-1, 1], expected: [minusNULP(kValue.f32.negative.pi.quarter, 4096), plusNULP(kValue.f32.negative.pi.quarter, 4097)] },
-      { input: [Number.NEGATIVE_INFINITY, 1], expected: kAny },
+      { input: [Number.NEGATIVE_INFINITY, 1], expected: kAnyBounds },
 
       // Discontinuity @ origin (0,0)
-      { input: [0, 0], expected: kAny },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: kAny },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: kAny },
-      { input: [0, kValue.f32.positive.min], expected: kAny },
-      { input: [0, kValue.f32.negative.max], expected: kAny },
-      { input: [0, kValue.f32.positive.max], expected: kAny },
-      { input: [0, kValue.f32.negative.min], expected: kAny },
-      { input: [0, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [0, 1], expected: kAny },
-      { input: [kValue.f32.subnormal.positive.max, 1], expected: kAny },
-      { input: [kValue.f32.subnormal.negative.min, 1], expected: kAny },
+      { input: [0, 0], expected: kAnyBounds },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: kAnyBounds },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: kAnyBounds },
+      { input: [0, kValue.f32.positive.min], expected: kAnyBounds },
+      { input: [0, kValue.f32.negative.max], expected: kAnyBounds },
+      { input: [0, kValue.f32.positive.max], expected: kAnyBounds },
+      { input: [0, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [0, 1], expected: kAnyBounds },
+      { input: [kValue.f32.subnormal.positive.max, 1], expected: kAnyBounds },
+      { input: [kValue.f32.subnormal.negative.min, 1], expected: kAnyBounds },
 
       // When atan(y/x) ~ 0, test that ULP applied to result of atan2, not the intermediate atan(y/x) value
       {input: [hexToF32(0x80800000), hexToF32(0xbf800000)], expected: [minusNULP(kValue.f32.negative.pi.whole, 4096), plusNULP(kValue.f32.negative.pi.whole, 4096)] },
       {input: [hexToF32(0x00800000), hexToF32(0xbf800000)], expected: [minusNULP(kValue.f32.positive.pi.whole, 4096), plusNULP(kValue.f32.positive.pi.whole, 4096)] },
 
-      // Very large |x| values should cause kAny to be returned, due to the restrictions on division
-      { input: [1, kValue.f32.positive.max], expected: kAny },
-      { input: [1, kValue.f32.positive.nearest_max], expected: kAny },
-      { input: [1, kValue.f32.negative.min], expected: kAny },
-      { input: [1, kValue.f32.negative.nearest_min], expected: kAny },
+      // Very large |x| values should cause kAnyBounds to be returned, due to the restrictions on division
+      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
+      { input: [1, kValue.f32.positive.nearest_max], expected: kAnyBounds },
+      { input: [1, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [1, kValue.f32.negative.nearest_min], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [y, x] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = atan2Interval(y, x);
     t.expect(
       objectEquals(expected, got),
@@ -3127,15 +3119,15 @@ g.test('distanceIntervalScalar')
       // to express in a closed human-readable  form due to the inherited nature
       // of the errors.
       //
-      // distance(x, y), where x - y = 0 has an acceptance interval of kAny,
-      // because distance(x, y) = length(x - y), and length(0) = kAny
-      { input: [0, 0], expected: kAny },
+      // distance(x, y), where x - y = 0 has an acceptance interval of kAnyBounds,
+      // because distance(x, y) = length(x - y), and length(0) = kAnyBounds
+      { input: [0, 0], expected: kAnyBounds },
       { input: [1.0, 0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [0.0, 1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [1.0, 1.0], expected: kAny },
+      { input: [1.0, 1.0], expected: kAnyBounds },
       { input: [-0.0, -1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [0.0, -1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [-1.0, -1.0], expected: kAny },
+      { input: [-1.0, -1.0], expected: kAnyBounds },
       { input: [0.1, 0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
       { input: [0, 0.1], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
       { input: [-0.1, 0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
@@ -3146,23 +3138,22 @@ g.test('distanceIntervalScalar')
       { input: [0, -10.0], expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
 
       // Subnormal Cases
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: kAny },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: kAny },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: kAny },
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: kAny },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: kAnyBounds },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: kAnyBounds },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: kAnyBounds },
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: kAnyBounds },
 
       // Edge cases
-      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
-      { input: [kValue.f32.negative.min, 0], expected: kAny },
-      { input: [kValue.f32.negative.max, 0], expected: kAny },
-      { input: [kValue.f32.positive.min, 0], expected: kAny },
-      { input: [kValue.f32.positive.max, 0], expected: kAny },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.negative.min, 0], expected: kAnyBounds },
+      { input: [kValue.f32.negative.max, 0], expected: kAnyBounds },
+      { input: [kValue.f32.positive.min, 0], expected: kAnyBounds },
+      { input: [kValue.f32.positive.max, 0], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = distanceInterval(...t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -3195,15 +3186,15 @@ g.test('divisionInterval')
       { input: [-1, -0.1], expected: [minusOneULP(10), plusOneULP(10)] },
 
       // Denominator out of range
-      { input: [1, kValue.f32.infinity.positive], expected: kAny },
-      { input: [1, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
-      { input: [1, kValue.f32.positive.max], expected: kAny },
-      { input: [1, kValue.f32.negative.min], expected: kAny },
-      { input: [1, 0], expected: kAny },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: kAny },
+      { input: [1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [1, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
+      { input: [1, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [1, 0], expected: kAnyBounds },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: kAnyBounds },
     ]
   )
   .fn(t => {
@@ -3252,18 +3243,17 @@ g.test('ldexpInterval')
       { input: [-1.9999998807907104, 127], expected: kValue.f32.negative.min },
 
       // Out of Bounds
-      { input: [1, 128], expected: kAny },
-      { input: [-1, 128], expected: kAny },
-      { input: [100, 126], expected: kAny },
-      { input: [-100, 126], expected: kAny },
-      { input: [kValue.f32.positive.max, kValue.i32.positive.max], expected: kAny },
-      { input: [kValue.f32.negative.min, kValue.i32.positive.max], expected: kAny },
+      { input: [1, 128], expected: kAnyBounds },
+      { input: [-1, 128], expected: kAnyBounds },
+      { input: [100, 126], expected: kAnyBounds },
+      { input: [-100, 126], expected: kAnyBounds },
+      { input: [kValue.f32.positive.max, kValue.i32.positive.max], expected: kAnyBounds },
+      { input: [kValue.f32.negative.min, kValue.i32.positive.max], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = ldexpInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -3310,20 +3300,19 @@ g.test('maxInterval')
 
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = maxInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -3369,20 +3358,19 @@ g.test('minInterval')
       { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = minInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -3424,28 +3412,27 @@ g.test('multiplicationInterval')
       { input: [-0.1, -0.1], expected: [minusNULP(hexToF32(0x3c23d70a), 2), plusOneULP(hexToF32(0x3c23d70a))] },  // ~0.01
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAny },
-      { input: [1, kValue.f32.infinity.positive], expected: kAny },
-      { input: [-1, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [1, kValue.f32.infinity.negative], expected: kAny },
-      { input: [-1, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [-1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [1, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [-1, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
 
       // Edge of f32
-      { input: [kValue.f32.positive.max, kValue.f32.positive.max], expected: kAny },
-      { input: [kValue.f32.negative.min, kValue.f32.negative.min], expected: kAny },
-      { input: [kValue.f32.positive.max, kValue.f32.negative.min], expected: kAny },
-      { input: [kValue.f32.negative.min, kValue.f32.positive.max], expected: kAny },
+      { input: [kValue.f32.positive.max, kValue.f32.positive.max], expected: kAnyBounds },
+      { input: [kValue.f32.negative.min, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [kValue.f32.positive.max, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [kValue.f32.negative.min, kValue.f32.positive.max], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = multiplicationInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -3482,21 +3469,20 @@ g.test('remainderInterval')
       { input: [-1, -0.1], expected: [hexToF32(0xbdccccd8), hexToF32(0x34000000)] }, // ~[-0.1, 0]
 
       // Denominator out of range
-      { input: [1, kValue.f32.infinity.positive], expected: kAny },
-      { input: [1, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
-      { input: [1, kValue.f32.positive.max], expected: kAny },
-      { input: [1, kValue.f32.negative.min], expected: kAny },
-      { input: [1, 0], expected: kAny },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: kAny },
+      { input: [1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [1, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
+      { input: [1, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [1, 0], expected: kAnyBounds },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = remainderInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -3511,26 +3497,25 @@ g.test('powInterval')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: [-1, 0], expected: kAny },
-      { input: [0, 0], expected: kAny },
+      { input: [-1, 0], expected: kAnyBounds },
+      { input: [0, 0], expected: kAnyBounds },
       { input: [1, 0], expected: [minusNULP(1, 3), hexToF64(0x3ff0_0000_3000_0000n)] },  // ~1
       { input: [2, 0], expected: [minusNULP(1, 3), hexToF64(0x3ff0_0000_3000_0000n)] },  // ~1
       { input: [kValue.f32.positive.max, 0], expected: [minusNULP(1, 3), hexToF64(0x3ff0_0000_3000_0000n)] },  // ~1
-      { input: [0, 1], expected: kAny },
+      { input: [0, 1], expected: kAnyBounds },
       { input: [1, 1], expected: [hexToF64(0x3fef_fffe_dfff_fe00n), hexToF64(0x3ff0_0000_c000_0200n)] },  // ~1
       { input: [1, 100], expected: [hexToF64(0x3fef_ffba_3fff_3800n), hexToF64(0x3ff0_0023_2000_c800n)] },  // ~1
-      { input: [1, kValue.f32.positive.max], expected: kAny },
+      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
       { input: [2, 1], expected: [hexToF64(0x3fff_fffe_a000_0200n), hexToF64(0x4000_0001_0000_0200n)] },  // ~2
       { input: [2, 2], expected: [hexToF64(0x400f_fffd_a000_0400n), hexToF64(0x4010_0001_a000_0400n)] },  // ~4
       { input: [10, 10], expected: [hexToF64(0x4202_a04f_51f7_7000n), hexToF64(0x4202_a070_ee08_e000n)] },  // ~10000000000
       { input: [10, 1], expected: [hexToF64(0x4023_fffe_0b65_8b00n), hexToF64(0x4024_0002_149a_7c00n)] },  // ~10
-      { input: [kValue.f32.positive.max, 1], expected: kAny },
+      { input: [kValue.f32.positive.max, 1], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = powInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -3594,20 +3579,19 @@ g.test('stepInterval')
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min], expected: [0, 1] },
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [edge, x] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = stepInterval(edge, x);
     t.expect(
       objectEquals(expected, got),
@@ -3651,20 +3635,19 @@ g.test('subtractionInterval')
       { input: [0, kValue.f32.subnormal.negative.min], expected: [0, kValue.f32.subnormal.positive.max] },
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = subtractionInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -3711,16 +3694,15 @@ g.test('clampMedianInterval')
       { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: kValue.f32.positive.max },
 
       // Infinities
-      { input: [0, 1, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y, z] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = clampMedianInterval(x, y, z);
     t.expect(
       objectEquals(expected, got),
@@ -3762,16 +3744,15 @@ g.test('clampMinMaxInterval')
       { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
 
       // Infinities
-      { input: [0, 1, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [x, y, z] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = clampMinMaxInterval(x, y, z);
     t.expect(
       objectEquals(expected, got),
@@ -3812,16 +3793,15 @@ g.test('fmaInterval')
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max], expected: [hexToF32(0x80000002), 0] },
 
       // Infinities
-      { input: [0, 1, kValue.f32.infinity.positive], expected: kAny },
-      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAny },
-      { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: kAny },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = fmaInterval(...t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -3883,16 +3863,16 @@ g.test('mixImpreciseInterval')
       { input: [-1.0, 1.0, 2.0], expected: 3.0 },
 
       // Infinities
-      { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kAny },
-      { input: [kValue.f32.infinity.positive, 0.0, 0.5], expected: kAny },
-      { input: [kValue.f32.infinity.negative, 1.0, 0.5], expected: kAny },
-      { input: [1.0, kValue.f32.infinity.negative, 0.5], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, 0.5], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative, 0.5], expected: kAny },
-      { input: [0.0, 1.0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [1.0, 0.0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [0.0, 1.0, kValue.f32.infinity.positive], expected: kAny },
-      { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0.0, 0.5], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 1.0, 0.5], expected: kAnyBounds },
+      { input: [1.0, kValue.f32.infinity.negative, 0.5], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, 0.5], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative, 0.5], expected: kAnyBounds },
+      { input: [0.0, 1.0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [1.0, 0.0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [0.0, 1.0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kAnyBounds },
 
       // Showing how precise and imprecise versions diff
       { input: [kValue.f32.negative.min, 10.0, 1.0], expected: 0.0 },
@@ -3901,7 +3881,6 @@ g.test('mixImpreciseInterval')
   .fn(t => {
     const [x, y, z] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = mixImpreciseInterval(x, y, z);
     t.expect(
       objectEquals(expected, got),
@@ -3963,16 +3942,16 @@ g.test('mixPreciseInterval')
       { input: [-1.0, 1.0, 2.0], expected: 3.0 },
 
       // Infinities
-      { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kAny },
-      { input: [kValue.f32.infinity.positive, 0.0, 0.5], expected: kAny },
-      { input: [kValue.f32.infinity.negative, 1.0, 0.5], expected: kAny },
-      { input: [1.0, kValue.f32.infinity.negative, 0.5], expected: kAny },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, 0.5], expected: kAny },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative, 0.5], expected: kAny },
-      { input: [0.0, 1.0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [1.0, 0.0, kValue.f32.infinity.negative], expected: kAny },
-      { input: [0.0, 1.0, kValue.f32.infinity.positive], expected: kAny },
-      { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kAny },
+      { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0.0, 0.5], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 1.0, 0.5], expected: kAnyBounds },
+      { input: [1.0, kValue.f32.infinity.negative, 0.5], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, 0.5], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative, 0.5], expected: kAnyBounds },
+      { input: [0.0, 1.0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [1.0, 0.0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [0.0, 1.0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kAnyBounds },
 
       // Showing how precise and imprecise versions diff
       { input: [kValue.f32.negative.min, 10.0, 1.0], expected: 10.0 },
@@ -3981,7 +3960,6 @@ g.test('mixPreciseInterval')
   .fn(t => {
     const [x, y, z] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = mixPreciseInterval(x, y, z);
     t.expect(
       objectEquals(expected, got),
@@ -4020,24 +3998,23 @@ g.test('smoothStepInterval')
       { input: [kValue.f32.subnormal.positive.min, 2, 1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
       { input: [kValue.f32.subnormal.negative.max, 2, 1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
       { input: [kValue.f32.subnormal.negative.min, 2, 1], expected: [hexToF32(0x3efffff8), hexToF32(0x3f000007)] },  // ~0.5
-      { input: [0, kValue.f32.subnormal.positive.max, 1], expected: kAny },
-      { input: [0, kValue.f32.subnormal.positive.min, 1], expected: kAny },
-      { input: [0, kValue.f32.subnormal.negative.max, 1], expected: kAny },
-      { input: [0, kValue.f32.subnormal.negative.min, 1], expected: kAny },
+      { input: [0, kValue.f32.subnormal.positive.max, 1], expected: kAnyBounds },
+      { input: [0, kValue.f32.subnormal.positive.min, 1], expected: kAnyBounds },
+      { input: [0, kValue.f32.subnormal.negative.max, 1], expected: kAnyBounds },
+      { input: [0, kValue.f32.subnormal.negative.min, 1], expected: kAnyBounds },
 
       // Infinities
-      { input: [0, 2, Number.POSITIVE_INFINITY], expected: kAny },
-      { input: [0, 2, Number.NEGATIVE_INFINITY], expected: kAny },
-      { input: [Number.POSITIVE_INFINITY, 2, 1], expected: kAny },
-      { input: [Number.NEGATIVE_INFINITY, 2, 1], expected: kAny },
-      { input: [0, Number.POSITIVE_INFINITY, 1], expected: kAny },
-      { input: [0, Number.NEGATIVE_INFINITY, 1], expected: kAny },
+      { input: [0, 2, Number.POSITIVE_INFINITY], expected: kAnyBounds },
+      { input: [0, 2, Number.NEGATIVE_INFINITY], expected: kAnyBounds },
+      { input: [Number.POSITIVE_INFINITY, 2, 1], expected: kAnyBounds },
+      { input: [Number.NEGATIVE_INFINITY, 2, 1], expected: kAnyBounds },
+      { input: [0, Number.POSITIVE_INFINITY, 1], expected: kAnyBounds },
+      { input: [0, Number.NEGATIVE_INFINITY, 1], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const [low, high, x] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = smoothStepInterval(low, high, x);
     t.expect(
       objectEquals(expected, got),
@@ -4091,9 +4068,7 @@ interface PointToVectorCase {
     )
     .fn(t => {
       const expected = toF32Vector(t.params.expected);
-
       const got = unpack2x16snormInterval(t.params.input);
-
       t.expect(
         objectEquals(expected, got),
         `unpack2x16snormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
@@ -4121,15 +4096,13 @@ interface PointToVectorCase {
         { input: 0x000083ff, expected: [[kValue.f16.subnormal.negative.min, 0], 0] },
 
         // f16 out of bounds
-        { input: 0x7c000000, expected: [kAny, kAny] },
-        { input: 0xffff0000, expected: [kAny, kAny] },
+        { input: 0x7c000000, expected: [kAnyBounds, kAnyBounds] },
+        { input: 0xffff0000, expected: [kAnyBounds, kAnyBounds] },
       ]
     )
     .fn(t => {
       const expected = toF32Vector(t.params.expected);
-
       const got = unpack2x16floatInterval(t.params.input);
-
       t.expect(
         objectEquals(expected, got),
         `unpack2x16floatInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
@@ -4154,9 +4127,7 @@ interface PointToVectorCase {
     )
     .fn(t => {
       const expected = toF32Vector(t.params.expected);
-
       const got = unpack2x16unormInterval(t.params.input);
-
       t.expect(
         objectEquals(expected, got),
         `unpack2x16unormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
@@ -4193,9 +4164,7 @@ interface PointToVectorCase {
     )
     .fn(t => {
       const expected = toF32Vector(t.params.expected);
-
       const got = unpack4x8snormInterval(t.params.input);
-
       t.expect(
         objectEquals(expected, got),
         `unpack4x8snormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
@@ -4226,9 +4195,7 @@ interface PointToVectorCase {
     )
     .fn(t => {
       const expected = toF32Vector(t.params.expected);
-
       const got = unpack4x8unormInterval(t.params.input);
-
       t.expect(
         objectEquals(expected, got),
         `unpack4x8unormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
@@ -4277,14 +4244,13 @@ g.test('lengthIntervalVector')
       {input: [0.1, 0.0, 0.0, 0.0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
 
       // Test that dot going OOB bounds in the intermediate calculations propagates
-      { input: [kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], expected: kAny },
-      { input: [kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], expected: kAny },
-      { input: [kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], expected: kAny },
+      { input: [kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], expected: kAnyBounds },
     ]
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = lengthInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -4305,11 +4271,11 @@ g.test('distanceIntervalVector')
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
       //
-      // distance(x, y), where x - y = 0 has an acceptance interval of kAny,
-      // because distance(x, y) = length(x - y), and length(0) = kAny
+      // distance(x, y), where x - y = 0 has an acceptance interval of kAnyBounds,
+      // because distance(x, y) = length(x - y), and length(0) = kAnyBounds
 
       // vec2
-      { input: [[1.0, 0.0], [1.0, 0.0]], expected: kAny },
+      { input: [[1.0, 0.0], [1.0, 0.0]], expected: kAnyBounds },
       { input: [[1.0, 0.0], [0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 0.0], [1.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[-1.0, 0.0], [0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
@@ -4318,7 +4284,7 @@ g.test('distanceIntervalVector')
       { input: [[0.1, 0.0], [0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
 
       // vec3
-      { input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: kAny },
+      { input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: kAnyBounds },
       { input: [[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 1.0, 0.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
@@ -4333,7 +4299,7 @@ g.test('distanceIntervalVector')
       { input: [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
 
       // vec4
-      { input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: kAny },
+      { input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: kAnyBounds },
       { input: [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
@@ -4352,7 +4318,6 @@ g.test('distanceIntervalVector')
   )
   .fn(t => {
     const expected = toF32Interval(t.params.expected);
-
     const got = distanceInterval(...t.params.input);
     t.expect(
       objectEquals(expected, got),
@@ -4392,12 +4357,12 @@ g.test('dotInterval')
       { input: [[0.1, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9999_8000_0000n), hexToF64(0x3fb9_9999_a000_0000n)]},  // ~0.1
 
       // Test that going out of bounds in the intermediate calculations is caught correctly.
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kAny },
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kAny },
-      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kAny },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kAny },
-      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kAny },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kAny },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kAnyBounds },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kAnyBounds },
+      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kAnyBounds },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kAnyBounds },
+      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kAnyBounds },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kAnyBounds },
 
       // https://github.com/gpuweb/cts/issues/2155
       { input: [[kValue.f32.positive.max, 1.0, 2.0, 3.0], [-1.0, kValue.f32.positive.max, -2.0, -3.0]], expected: [-13, 0] },
@@ -4406,7 +4371,6 @@ g.test('dotInterval')
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = dotInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -4448,7 +4412,6 @@ g.test('normalizeInterval')
   .fn(t => {
     const x = t.params.input;
     const expected = toF32Vector(t.params.expected);
-
     const got = normalizeInterval(x);
     t.expect(
       objectEquals(expected, got),
@@ -4496,7 +4459,6 @@ g.test('crossInterval')
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Vector(t.params.expected);
-
     const got = crossInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -4542,25 +4504,26 @@ g.test('reflectInterval')
       { input: [[kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.max, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]], expected: [[hexToF32(0x80fffffe), hexToF32(0x00800001)], [hexToF32(0x80ffffff), hexToF32(0x00000002)], [hexToF32(0x80fffffe), hexToF32(0x00000002)], [hexToF32(0x80fffffe), hexToF32(0x00000002)]] },  // [~0.0, ~0.0, ~0.0, ~0.0]
 
       // Test that dot going OOB bounds in the intermediate calculations propagates
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: [kAny, kAny, kAny] },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
 
       // Test that post-dot going OOB propagates
-      { input: [[kValue.f32.positive.max, 1.0, 2.0, 3.0], [-1.0, kValue.f32.positive.max, -2.0, -3.0]], expected: [kAny, kAny, kAny, kAny] },
+      { input: [[kValue.f32.positive.max, 1.0, 2.0, 3.0], [-1.0, kValue.f32.positive.max, -2.0, -3.0]], expected: [kAnyBounds, kAnyBounds, kAnyBounds, kAnyBounds] },
     ]
   )
   .fn(t => {
     const [x, y] = t.params.input;
     const expected = toF32Vector(t.params.expected);
-
     const got = reflectInterval(x, y);
     t.expect(
       objectEquals(expected, got),
-      `reflectInterval([${x}], [${y}]) returned ${got}. Expected ${expected}`
+      `reflectInterval([${x}], [${y}]) returned ${JSON.stringify(got)}. Expected ${JSON.stringify(
+        expected
+      )}`
     );
   });
 
@@ -4629,7 +4592,6 @@ g.test('faceForwardIntervals')
   .fn(t => {
     const [x, y, z] = t.params.input;
     const expected = t.params.expected.map(e => (e !== undefined ? toF32Vector(e) : undefined));
-
     const got = faceForwardIntervals(x, y, z);
     t.expect(
       objectEquals(expected, got),
@@ -4662,7 +4624,7 @@ interface RefractCase {
       { input: [[1, 1], [0.1, 0], 10], expected: [0, 0] },
 
       // k contains 0
-      { input: [[1, 1], [0.1, 0], 1.005038], expected: [kAny, kAny] },
+      { input: [[1, 1], [0.1, 0], 1.005038], expected: [kAnyBounds, kAnyBounds] },
 
       // k > 0
       // vec2
@@ -4684,18 +4646,17 @@ interface RefractCase {
                                                               [hexToF32(0xc20dfa80), hexToF32(0xc20df500)]] },  // ~-35.494...
 
       // Test that dot going OOB bounds in the intermediate calculations propagates
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kAny, kAny, kAny] },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kAny, kAny, kAny] },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
     ]
     )
     .fn(t => {
       const [i, s, r] = t.params.input;
       const expected = toF32Vector(t.params.expected);
-
       const got = refractInterval(i, s, r);
       t.expect(
         objectEquals(expected, got),
@@ -4859,7 +4820,6 @@ g.test('determinantInterval')
   .fn(t => {
     const input = t.params.input;
     const expected = toF32Interval(t.params.expected);
-
     const got = determinantInterval(input);
     t.expect(
       objectEquals(expected, got),
@@ -5002,7 +4962,6 @@ g.test('transposeInterval')
   .fn(t => {
     const input = t.params.input;
     const expected = toF32Matrix(t.params.expected);
-
     const got = transposeInterval(input);
     t.expect(
       objectEquals(expected, got),
@@ -5200,7 +5159,6 @@ g.test('additionMatrixInterval')
     const x = t.params.input[0];
     const y = t.params.input[1];
     const expected = toF32Matrix(t.params.expected);
-
     const got = additionMatrixInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -5393,7 +5351,6 @@ g.test('subtractionMatrixInterval')
     const x = t.params.input[0];
     const y = t.params.input[1];
     const expected = toF32Matrix(t.params.expected);
-
     const got = subtractionMatrixInterval(x, y);
     t.expect(
       objectEquals(expected, got),
@@ -5892,7 +5849,6 @@ g.test('multiplicationMatrixMatrixInterval')
     const [x, y] = t.params.input;
     const expected = toF32Matrix(t.params.expected);
     const got = multiplicationMatrixMatrixInterval(x, y);
-
     t.expect(
       objectEquals(expected, got),
       `multiplicationMatrixMatrixInterval([${JSON.stringify(x)}], [${JSON.stringify(
@@ -6036,7 +5992,6 @@ g.test('multiplicationMatrixScalarInterval')
     const matrix = t.params.matrix;
     const scalar = t.params.scalar;
     const expected = toF32Matrix(t.params.expected);
-
     const got = multiplicationMatrixScalarInterval(matrix, scalar);
     t.expect(
       objectEquals(expected, got),
@@ -6149,7 +6104,6 @@ g.test('multiplicationMatrixVectorInterval')
     const matrix = t.params.matrix;
     const vector = t.params.vector;
     const expected = toF32Vector(t.params.expected);
-
     const got = multiplicationMatrixVectorInterval(matrix, vector);
     t.expect(
       objectEquals(expected, got),
@@ -6258,7 +6212,6 @@ g.test('multiplicationVectorMatrixInterval')
     const vector = t.params.vector;
     const matrix = t.params.matrix;
     const expected = toF32Vector(t.params.expected);
-
     const got = multiplicationVectorMatrixInterval(vector, matrix);
     t.expect(
       objectEquals(expected, got),

--- a/src/unittests/serialization.spec.ts
+++ b/src/unittests/serialization.spec.ts
@@ -31,11 +31,8 @@ import {
   vec3,
   vec4,
 } from '../webgpu/util/conversion.js';
-import {
-  deserializeF32Interval,
-  serializeF32Interval,
-  toF32Interval,
-} from '../webgpu/util/f32_interval.js';
+import { toF32Interval } from '../webgpu/util/f32_interval.js';
+import { deserializeFPInterval, serializeFPInterval } from '../webgpu/util/floating_point.js';
 
 import { UnitTest } from './unit_test.js';
 
@@ -244,8 +241,8 @@ g.test('f32_interval').fn(t => {
     toF32Interval([kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max]),
     toF32Interval([kValue.f32.infinity.negative, kValue.f32.infinity.positive]),
   ]) {
-    const serialized = serializeF32Interval(interval);
-    const deserialized = deserializeF32Interval(serialized);
+    const serialized = serializeFPInterval(interval);
+    const deserialized = deserializeFPInterval(serialized);
     t.expect(
       objectEquals(interval, deserialized),
       `interval ${interval} -> serialize -> deserialize -> ${deserialized}`

--- a/src/webgpu/shader/execution/expression/case_cache.ts
+++ b/src/webgpu/shader/execution/expression/case_cache.ts
@@ -9,11 +9,11 @@ import {
   Matrix,
 } from '../../../util/conversion.js';
 import {
-  deserializeF32Interval,
-  F32Interval,
-  SerializedF32Interval,
-  serializeF32Interval,
-} from '../../../util/f32_interval.js';
+  deserializeFPInterval,
+  FPInterval,
+  SerializedFPInterval,
+  serializeFPInterval,
+} from '../../../util/floating_point.js';
 import { flatten2DArray, unflatten2DArray } from '../../../util/math.js';
 
 import { Case, CaseList, Expectation } from './expression.js';
@@ -35,7 +35,7 @@ type SerializedExpectationValue = {
  */
 type SerializedExpectationInterval = {
   kind: 'interval';
-  value: SerializedF32Interval;
+  value: SerializedFPInterval;
 };
 
 /**
@@ -45,7 +45,7 @@ type SerializedExpectationInterval = {
  */
 type SerializedExpectationIntervals = {
   kind: 'intervals';
-  value: SerializedF32Interval[];
+  value: SerializedFPInterval[];
 };
 
 /**
@@ -58,7 +58,7 @@ type SerializedExpectation2DIntervalArray = {
   kind: '2d-interval-array';
   cols: number;
   rows: number;
-  value: SerializedF32Interval[];
+  value: SerializedFPInterval[];
 };
 
 /**
@@ -87,23 +87,23 @@ export function serializeExpectation(e: Expectation): SerializedExpectation {
   if (e instanceof Scalar || e instanceof Vector || e instanceof Matrix) {
     return { kind: 'value', value: serializeValue(e) };
   }
-  if (e instanceof F32Interval) {
-    return { kind: 'interval', value: serializeF32Interval(e) };
+  if (e instanceof FPInterval) {
+    return { kind: 'interval', value: serializeFPInterval(e) };
   }
   if (e instanceof Array) {
     if (e[0] instanceof Array) {
-      e = e as F32Interval[][];
+      e = e as FPInterval[][];
       const cols = e.length;
       const rows = e[0].length;
       return {
         kind: '2d-interval-array',
         cols,
         rows,
-        value: flatten2DArray(e).map(serializeF32Interval),
+        value: flatten2DArray(e).map(serializeFPInterval),
       };
     } else {
-      e = e as F32Interval[];
-      return { kind: 'intervals', value: e.map(serializeF32Interval) };
+      e = e as FPInterval[];
+      return { kind: 'intervals', value: e.map(serializeFPInterval) };
     }
   }
   if (e instanceof Function) {
@@ -129,11 +129,11 @@ export function deserializeExpectation(data: SerializedExpectation): Expectation
     case 'value':
       return deserializeValue(data.value);
     case 'interval':
-      return deserializeF32Interval(data.value);
+      return deserializeFPInterval(data.value);
     case 'intervals':
-      return data.value.map(deserializeF32Interval);
+      return data.value.map(deserializeFPInterval);
     case '2d-interval-array':
-      return unflatten2DArray(data.value.map(deserializeF32Interval), data.cols, data.rows);
+      return unflatten2DArray(data.value.map(deserializeFPInterval), data.cols, data.rows);
     case 'comparator':
       return deserializeComparator(data.value);
   }

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -20,7 +20,6 @@ import {
 } from '../../../util/conversion.js';
 import {
   BinaryToInterval,
-  F32Interval,
   MatrixPairToMatrix,
   MatrixScalarToMatrix,
   MatrixToMatrix,
@@ -38,6 +37,7 @@ import {
   VectorToInterval,
   VectorToVector,
 } from '../../../util/f32_interval.js';
+import { FPInterval } from '../../../util/floating_point.js';
 import {
   cartesianProduct,
   map2DArray,
@@ -47,12 +47,12 @@ import {
   quantizeToU32,
 } from '../../../util/math.js';
 
-export type Expectation = Value | F32Interval | F32Interval[] | F32Interval[][] | Comparator;
+export type Expectation = Value | FPInterval | FPInterval[] | FPInterval[][] | Comparator;
 
 /** Is this expectation actually a Comparator */
 function isComparator(e: Expectation): boolean {
   return !(
-    e instanceof F32Interval ||
+    e instanceof FPInterval ||
     e instanceof Scalar ||
     e instanceof Vector ||
     e instanceof Matrix ||
@@ -823,7 +823,7 @@ export type IntervalFilter =
 
 /**
  * @returns a Case for the param and unary interval generator provided
- * The Case will use use an interval comparator for matching results.
+ * The Case will use an interval comparator for matching results.
  * @param param the param to pass in
  * @param filter what interval filtering to apply
  * @param ops callbacks that implement generating an acceptance interval for an

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -9,7 +9,7 @@ import {
 import { Expectation, toComparator } from '../shader/execution/expression/expression.js';
 
 import { isFloatValue, Matrix, Scalar, Value, Vector } from './conversion.js';
-import { F32Interval } from './f32_interval.js';
+import { FPInterval } from './floating_point.js';
 
 /** Comparison describes the result of a Comparator function. */
 export interface Comparison {
@@ -108,10 +108,10 @@ function compareValue(got: Value, expected: Value): Comparison {
 /**
  * Tests it a 'got' Value is contained in 'expected' interval, returning the Comparison information.
  * @param got the Value obtained from the test
- * @param expected the expected F32Interval
+ * @param expected the expected FPInterval
  * @returns the comparison results
  */
-function compareInterval(got: Value, expected: F32Interval): Comparison {
+function compareInterval(got: Value, expected: FPInterval): Comparison {
   {
     // Check type
     const gTy = got.type;
@@ -141,10 +141,10 @@ function compareInterval(got: Value, expected: F32Interval): Comparison {
 /**
  * Tests it a 'got' Value is contained in 'expected' vector, returning the Comparison information.
  * @param got the Value obtained from the test, is expected to be a Vector
- * @param expected the expected array of F32Intervals, one for each element of the vector
+ * @param expected the expected array of FPIntervals, one for each element of the vector
  * @returns the comparison results
  */
-function compareVector(got: Value, expected: F32Interval[]): Comparison {
+function compareVector(got: Value, expected: FPInterval[]): Comparison {
   // Check got type
   if (!(got instanceof Vector)) {
     return {
@@ -206,10 +206,10 @@ function convertArrayToString<T>(m: T[]): string {
 /**
  * Tests it a 'got' Value is contained in 'expected' matrix, returning the Comparison information.
  * @param got the Value obtained from the test, is expected to be a Matrix
- * @param expected the expected array of array of F32Intervals, representing a column-major matrix
+ * @param expected the expected array of array of FPIntervals, representing a column-major matrix
  * @returns the comparison results
  */
-function compareMatrix(got: Value, expected: F32Interval[][]): Comparison {
+function compareMatrix(got: Value, expected: FPInterval[][]): Comparison {
   // Check got type
   if (!(got instanceof Matrix)) {
     return {
@@ -281,19 +281,19 @@ function compareMatrix(got: Value, expected: F32Interval[][]): Comparison {
  */
 export function compare(
   got: Value,
-  expected: Value | F32Interval | F32Interval[] | F32Interval[][]
+  expected: Value | FPInterval | FPInterval[] | FPInterval[][]
 ): Comparison {
   if (expected instanceof Array) {
     if (expected[0] instanceof Array) {
-      expected = expected as F32Interval[][];
+      expected = expected as FPInterval[][];
       return compareMatrix(got, expected);
     } else {
-      expected = expected as F32Interval[];
+      expected = expected as FPInterval[];
       return compareVector(got, expected);
     }
   }
 
-  if (expected instanceof F32Interval) {
+  if (expected instanceof FPInterval) {
     return compareInterval(got, expected);
   }
 

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -2,7 +2,7 @@
 // They currently just pass-through to the refactored FPContext implementation.
 // As CTS migrates over to directly calling the new API, these will be removed.
 
-import { FPInterval, FPMatrix, FPVector, IntervalBounds, kFPContext } from './floating_point.js';
+import { FPInterval, FPMatrix, FPVector, IntervalBounds, FP } from './floating_point.js';
 
 // Interfaces
 
@@ -81,107 +81,107 @@ export type F32Vector = FPVector;
 // Utilities
 
 export function toF32Interval(n: number | IntervalBounds | FPInterval): FPInterval {
-  return kFPContext.f32.toInterval(n);
+  return FP.f32.toInterval(n);
 }
 
 export function isF32Vector(v: (number | IntervalBounds | FPInterval)[]): v is FPVector {
-  return kFPContext.f32.isVector(v);
+  return FP.f32.isVector(v);
 }
 
 export function toF32Vector(v: (number | IntervalBounds | FPInterval)[]): FPVector {
-  return kFPContext.f32.toVector(v);
+  return FP.f32.toVector(v);
 }
 
 export function spanF32Intervals(...intervals: FPInterval[]): FPInterval {
-  return kFPContext.f32.spanIntervals(...intervals);
+  return FP.f32.spanIntervals(...intervals);
 }
 
 export function isF32Matrix(
   m: (number | IntervalBounds | FPInterval)[][] | FPVector[]
 ): m is FPMatrix {
-  return kFPContext.f32.isMatrix(m);
+  return FP.f32.isMatrix(m);
 }
 
 export function toF32Matrix(m: (number | IntervalBounds | FPInterval)[][] | FPVector[]): FPMatrix {
-  return kFPContext.f32.toMatrix(m);
+  return FP.f32.toMatrix(m);
 }
 
 // Accuracy Interval
 
 export function correctlyRoundedInterval(n: number | FPInterval): FPInterval {
-  return kFPContext.f32.correctlyRoundedInterval(n);
+  return FP.f32.correctlyRoundedInterval(n);
 }
 
 export function correctlyRoundedMatrix(m: number[][]): FPMatrix {
-  return kFPContext.f32.correctlyRoundedMatrix(m);
+  return FP.f32.correctlyRoundedMatrix(m);
 }
 
 export function absoluteErrorInterval(n: number, error_range: number): FPInterval {
-  return kFPContext.f32.absoluteErrorInterval(n, error_range);
+  return FP.f32.absoluteErrorInterval(n, error_range);
 }
 
 export function ulpInterval(n: number, numULP: number): FPInterval {
-  return kFPContext.f32.ulpInterval(n, numULP);
+  return FP.f32.ulpInterval(n, numULP);
 }
 
 export function absInterval(n: number): FPInterval {
-  return kFPContext.f32.absInterval(n);
+  return FP.f32.absInterval(n);
 }
 
 export function acosInterval(n: number): FPInterval {
-  return kFPContext.f32.acosInterval(n);
+  return FP.f32.acosInterval(n);
 }
 
-export const acoshIntervals = kFPContext.f32.acoshIntervals;
+export const acoshIntervals = FP.f32.acoshIntervals;
 
 export function acoshAlternativeInterval(x: number | FPInterval): FPInterval {
-  return kFPContext.f32.acoshAlternativeInterval(x);
+  return FP.f32.acoshAlternativeInterval(x);
 }
 
 export function acoshPrimaryInterval(x: number | FPInterval): FPInterval {
-  return kFPContext.f32.acoshPrimaryInterval(x);
+  return FP.f32.acoshPrimaryInterval(x);
 }
 
 export function additionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return kFPContext.f32.additionInterval(x, y);
+  return FP.f32.additionInterval(x, y);
 }
 
 export function additionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
-  return kFPContext.f32.additionMatrixInterval(x, y);
+  return FP.f32.additionMatrixInterval(x, y);
 }
 
 export function asinInterval(n: number): FPInterval {
-  return kFPContext.f32.asinInterval(n);
+  return FP.f32.asinInterval(n);
 }
 
 export function asinhInterval(n: number): FPInterval {
-  return kFPContext.f32.asinhInterval(n);
+  return FP.f32.asinhInterval(n);
 }
 
 export function atanInterval(n: number | FPInterval): FPInterval {
-  return kFPContext.f32.atanInterval(n);
+  return FP.f32.atanInterval(n);
 }
 
 export function atan2Interval(y: number | FPInterval, x: number | FPInterval): FPInterval {
-  return kFPContext.f32.atan2Interval(y, x);
+  return FP.f32.atan2Interval(y, x);
 }
 
 export function atanhInterval(n: number): FPInterval {
-  return kFPContext.f32.atanhInterval(n);
+  return FP.f32.atanhInterval(n);
 }
 
 export function ceilInterval(n: number): FPInterval {
-  return kFPContext.f32.ceilInterval(n);
+  return FP.f32.ceilInterval(n);
 }
 
-export const clampIntervals = kFPContext.f32.clampIntervals;
+export const clampIntervals = FP.f32.clampIntervals;
 
 export function clampMedianInterval(
   x: number | FPInterval,
   y: number | FPInterval,
   z: number | FPInterval
 ): FPInterval {
-  return kFPContext.f32.clampMedianInterval(x, y, z);
+  return FP.f32.clampMedianInterval(x, y, z);
 }
 
 export function clampMinMaxInterval(
@@ -189,47 +189,47 @@ export function clampMinMaxInterval(
   y: number | FPInterval,
   z: number | FPInterval
 ): FPInterval {
-  return kFPContext.f32.clampMinMaxInterval(x, y, z);
+  return FP.f32.clampMinMaxInterval(x, y, z);
 }
 
 export function cosInterval(n: number): FPInterval {
-  return kFPContext.f32.cosInterval(n);
+  return FP.f32.cosInterval(n);
 }
 
 export function coshInterval(n: number): FPInterval {
-  return kFPContext.f32.coshInterval(n);
+  return FP.f32.coshInterval(n);
 }
 
 export function crossInterval(x: number[], y: number[]): FPVector {
-  return kFPContext.f32.crossInterval(x, y);
+  return FP.f32.crossInterval(x, y);
 }
 
 export function degreesInterval(n: number): FPInterval {
-  return kFPContext.f32.degreesInterval(n);
+  return FP.f32.degreesInterval(n);
 }
 
 export function determinantInterval(m: number[][]): FPInterval {
-  return kFPContext.f32.determinantInterval(m);
+  return FP.f32.determinantInterval(m);
 }
 
 export function distanceInterval(x: number | number[], y: number | number[]): FPInterval {
-  return kFPContext.f32.distanceInterval(x, y);
+  return FP.f32.distanceInterval(x, y);
 }
 
 export function divisionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return kFPContext.f32.divisionInterval(x, y);
+  return FP.f32.divisionInterval(x, y);
 }
 
 export function dotInterval(x: number[] | FPInterval[], y: number[] | FPInterval[]): FPInterval {
-  return kFPContext.f32.dotInterval(x, y);
+  return FP.f32.dotInterval(x, y);
 }
 
 export function expInterval(x: number | FPInterval): FPInterval {
-  return kFPContext.f32.expInterval(x);
+  return FP.f32.expInterval(x);
 }
 
 export function exp2Interval(x: number | FPInterval): FPInterval {
-  return kFPContext.f32.exp2Interval(x);
+  return FP.f32.exp2Interval(x);
 }
 
 export function faceForwardIntervals(
@@ -237,191 +237,191 @@ export function faceForwardIntervals(
   y: number[],
   z: number[]
 ): (FPVector | undefined)[] {
-  return kFPContext.f32.faceForwardIntervals(x, y, z);
+  return FP.f32.faceForwardIntervals(x, y, z);
 }
 
 export function floorInterval(n: number): FPInterval {
-  return kFPContext.f32.floorInterval(n);
+  return FP.f32.floorInterval(n);
 }
 
 export function fmaInterval(x: number, y: number, z: number): FPInterval {
-  return kFPContext.f32.fmaInterval(x, y, z);
+  return FP.f32.fmaInterval(x, y, z);
 }
 
 export function fractInterval(n: number): FPInterval {
-  return kFPContext.f32.fractInterval(n);
+  return FP.f32.fractInterval(n);
 }
 
 export function inverseSqrtInterval(n: number | FPInterval): FPInterval {
-  return kFPContext.f32.inverseSqrtInterval(n);
+  return FP.f32.inverseSqrtInterval(n);
 }
 
 export function ldexpInterval(e1: number, e2: number): FPInterval {
-  return kFPContext.f32.ldexpInterval(e1, e2);
+  return FP.f32.ldexpInterval(e1, e2);
 }
 
 export function lengthInterval(n: number | FPInterval | number[] | FPVector): FPInterval {
-  return kFPContext.f32.lengthInterval(n);
+  return FP.f32.lengthInterval(n);
 }
 
 export function logInterval(x: number | FPInterval): FPInterval {
-  return kFPContext.f32.logInterval(x);
+  return FP.f32.logInterval(x);
 }
 
 export function log2Interval(x: number | FPInterval): FPInterval {
-  return kFPContext.f32.log2Interval(x);
+  return FP.f32.log2Interval(x);
 }
 
 export function maxInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return kFPContext.f32.maxInterval(x, y);
+  return FP.f32.maxInterval(x, y);
 }
 
 export function minInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return kFPContext.f32.minInterval(x, y);
+  return FP.f32.minInterval(x, y);
 }
 
-export const mixIntervals = kFPContext.f32.mixIntervals;
+export const mixIntervals = FP.f32.mixIntervals;
 
 export function mixImpreciseInterval(x: number, y: number, z: number): FPInterval {
-  return kFPContext.f32.mixImpreciseInterval(x, y, z);
+  return FP.f32.mixImpreciseInterval(x, y, z);
 }
 
 export function mixPreciseInterval(x: number, y: number, z: number): FPInterval {
-  return kFPContext.f32.mixPreciseInterval(x, y, z);
+  return FP.f32.mixPreciseInterval(x, y, z);
 }
 
 export function modfInterval(n: number): { fract: FPInterval; whole: FPInterval } {
-  return kFPContext.f32.modfInterval(n);
+  return FP.f32.modfInterval(n);
 }
 
 export function multiplicationInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return kFPContext.f32.multiplicationInterval(x, y);
+  return FP.f32.multiplicationInterval(x, y);
 }
 
 export function multiplicationMatrixScalarInterval(mat: number[][], scalar: number): FPMatrix {
-  return kFPContext.f32.multiplicationMatrixScalarInterval(mat, scalar);
+  return FP.f32.multiplicationMatrixScalarInterval(mat, scalar);
 }
 
 export function multiplicationScalarMatrixInterval(scalar: number, mat: number[][]): FPMatrix {
-  return kFPContext.f32.multiplicationScalarMatrixInterval(scalar, mat);
+  return FP.f32.multiplicationScalarMatrixInterval(scalar, mat);
 }
 
 export function multiplicationMatrixMatrixInterval(mat_x: number[][], mat_y: number[][]): FPMatrix {
-  return kFPContext.f32.multiplicationMatrixMatrixInterval(mat_x, mat_y);
+  return FP.f32.multiplicationMatrixMatrixInterval(mat_x, mat_y);
 }
 
 export function multiplicationMatrixVectorInterval(x: number[][], y: number[]): FPVector {
-  return kFPContext.f32.multiplicationMatrixVectorInterval(x, y);
+  return FP.f32.multiplicationMatrixVectorInterval(x, y);
 }
 
 export function multiplicationVectorMatrixInterval(x: number[], y: number[][]): FPVector {
-  return kFPContext.f32.multiplicationVectorMatrixInterval(x, y);
+  return FP.f32.multiplicationVectorMatrixInterval(x, y);
 }
 
 export function negationInterval(n: number): FPInterval {
-  return kFPContext.f32.negationInterval(n);
+  return FP.f32.negationInterval(n);
 }
 
 export function normalizeInterval(n: number[]): FPVector {
-  return kFPContext.f32.normalizeInterval(n);
+  return FP.f32.normalizeInterval(n);
 }
 
 export function powInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return kFPContext.f32.powInterval(x, y);
+  return FP.f32.powInterval(x, y);
 }
 
 export function quantizeToF16Interval(n: number): FPInterval {
-  return kFPContext.f32.quantizeToF16Interval(n);
+  return FP.f32.quantizeToF16Interval(n);
 }
 
 export function radiansInterval(n: number): FPInterval {
-  return kFPContext.f32.radiansInterval(n);
+  return FP.f32.radiansInterval(n);
 }
 
 export function reflectInterval(x: number[], y: number[]): FPVector {
-  return kFPContext.f32.reflectInterval(x, y);
+  return FP.f32.reflectInterval(x, y);
 }
 
 export function refractInterval(i: number[], s: number[], r: number): FPVector {
-  return kFPContext.f32.refractInterval(i, s, r);
+  return FP.f32.refractInterval(i, s, r);
 }
 
 export function remainderInterval(x: number, y: number): FPInterval {
-  return kFPContext.f32.remainderInterval(x, y);
+  return FP.f32.remainderInterval(x, y);
 }
 
 export function roundInterval(n: number): FPInterval {
-  return kFPContext.f32.roundInterval(n);
+  return FP.f32.roundInterval(n);
 }
 
 export function saturateInterval(n: number): FPInterval {
-  return kFPContext.f32.saturateInterval(n);
+  return FP.f32.saturateInterval(n);
 }
 
 export function signInterval(n: number): FPInterval {
-  return kFPContext.f32.signInterval(n);
+  return FP.f32.signInterval(n);
 }
 
 export function sinInterval(n: number): FPInterval {
-  return kFPContext.f32.sinInterval(n);
+  return FP.f32.sinInterval(n);
 }
 
 export function sinhInterval(n: number): FPInterval {
-  return kFPContext.f32.sinhInterval(n);
+  return FP.f32.sinhInterval(n);
 }
 
 export function smoothStepInterval(low: number, high: number, x: number): FPInterval {
-  return kFPContext.f32.smoothStepInterval(low, high, x);
+  return FP.f32.smoothStepInterval(low, high, x);
 }
 
 export function sqrtInterval(n: number | FPInterval): FPInterval {
-  return kFPContext.f32.sqrtInterval(n);
+  return FP.f32.sqrtInterval(n);
 }
 
 export function stepInterval(edge: number, x: number): FPInterval {
-  return kFPContext.f32.stepInterval(edge, x);
+  return FP.f32.stepInterval(edge, x);
 }
 
 export function subtractionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return kFPContext.f32.subtractionInterval(x, y);
+  return FP.f32.subtractionInterval(x, y);
 }
 
 export function subtractionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
-  return kFPContext.f32.subtractionMatrixInterval(x, y);
+  return FP.f32.subtractionMatrixInterval(x, y);
 }
 
 export function tanInterval(n: number): FPInterval {
-  return kFPContext.f32.tanInterval(n);
+  return FP.f32.tanInterval(n);
 }
 
 export function tanhInterval(n: number): FPInterval {
-  return kFPContext.f32.tanhInterval(n);
+  return FP.f32.tanhInterval(n);
 }
 
 export function transposeInterval(m: number[][]): FPMatrix {
-  return kFPContext.f32.transposeInterval(m);
+  return FP.f32.transposeInterval(m);
 }
 
 export function truncInterval(n: number | FPInterval): FPInterval {
-  return kFPContext.f32.truncInterval(n);
+  return FP.f32.truncInterval(n);
 }
 
 export function unpack2x16floatInterval(n: number): FPVector {
-  return kFPContext.f32.unpack2x16floatInterval(n);
+  return FP.f32.unpack2x16floatInterval(n);
 }
 
 export function unpack2x16snormInterval(n: number): FPVector {
-  return kFPContext.f32.unpack2x16snormInterval(n);
+  return FP.f32.unpack2x16snormInterval(n);
 }
 
 export function unpack2x16unormInterval(n: number): FPVector {
-  return kFPContext.f32.unpack2x16unormInterval(n);
+  return FP.f32.unpack2x16unormInterval(n);
 }
 
 export function unpack4x8snormInterval(n: number): FPVector {
-  return kFPContext.f32.unpack4x8snormInterval(n);
+  return FP.f32.unpack4x8snormInterval(n);
 }
 
 export function unpack4x8unormInterval(n: number): FPVector {
-  return kFPContext.f32.unpack4x8unormInterval(n);
+  return FP.f32.unpack4x8unormInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -1,2767 +1,427 @@
-import { assert, unreachable } from '../../common/util/util.js';
-import { Float16Array } from '../../external/petamoriken/float16/float16.js';
+// This is a shim file with all the old/deprecated f32 API calls.
+// They currently just pass-through to the refactored FPContext implementation.
+// As CTS migrates over to directly calling the new API, these will be removed.
 
-import { kValue } from './constants.js';
-import { f32, reinterpretF32AsU32, reinterpretU32AsF32 } from './conversion.js';
-import {
-  calculatePermutations,
-  cartesianProduct,
-  correctlyRoundedF16,
-  correctlyRoundedF32,
-  flatten2DArray,
-  flushSubnormalNumberF32,
-  isFiniteF16,
-  isFiniteF32,
-  isSubnormalNumberF16,
-  isSubnormalNumberF32,
-  map2DArray,
-  oneULPF32,
-  unflatten2DArray,
-} from './math.js';
+import { FPInterval, FPMatrix, FPVector, IntervalBounds, kFPContext } from './floating_point.js';
 
-/**
- * Representation of bounds for an interval as an array with either one or two
- * elements. Single element indicates that the interval is a single point. For
- * two elements, the first is the lower bound of the interval and the second is
- * the upper bound.
- */
-export type IntervalBounds = [number] | [number, number];
+// Interfaces
 
-/** Represents a closed interval in the f32 range */
-export class F32Interval {
-  public readonly begin: number;
-  public readonly end: number;
-  private static _any: F32Interval;
-
-  /** Constructor
-   *
-   * `toF32Interval` is the preferred way to create F32Intervals
-   *
-   * @param bounds either a pair of numbers indicating the beginning then the
-   *               end of the interval, or a single element array indicating the
-   *               interval is a point
-   */
-  public constructor(...bounds: IntervalBounds) {
-    const [begin, end] = bounds.length === 2 ? bounds : [bounds[0], bounds[0]];
-    assert(!Number.isNaN(begin) && !Number.isNaN(end), `bounds need to be non-NaN`);
-    assert(begin <= end, `bounds[0] (${begin}) must be less than or equal to bounds[1]  (${end})`);
-
-    this.begin = begin;
-    this.end = end;
-  }
-
-  /** @returns begin and end if non-point interval, otherwise just begin */
-  public bounds(): IntervalBounds {
-    return this.isPoint() ? [this.begin] : [this.begin, this.end];
-  }
-
-  /** @returns if a point or interval is completely contained by this interval */
-  public contains(n: number | F32Interval): boolean {
-    if (Number.isNaN(n)) {
-      // Being the any interval indicates that accuracy is not defined for this
-      // test, so the test is just checking that this input doesn't cause the
-      // implementation to misbehave, so NaN is accepted.
-      return this.begin === Number.NEGATIVE_INFINITY && this.end === Number.POSITIVE_INFINITY;
-    }
-    const i = toF32Interval(n);
-    return this.begin <= i.begin && this.end >= i.end;
-  }
-
-  /** @returns if any values in the interval may be flushed to zero, this
-   *           includes any subnormals and zero itself.
-   */
-  public containsZeroOrSubnormals(): boolean {
-    return !(
-      this.end < kValue.f32.subnormal.negative.min || this.begin > kValue.f32.subnormal.positive.max
-    );
-  }
-
-  /** @returns if this interval contains a single point */
-  public isPoint(): boolean {
-    return this.begin === this.end;
-  }
-
-  /** @returns if this interval only contains f32 finite values */
-  public isFinite(): boolean {
-    return isFiniteF32(this.begin) && isFiniteF32(this.end);
-  }
-
-  /** @returns an interval with the tightest bounds that includes all provided intervals */
-  static span(...intervals: F32Interval[]): F32Interval {
-    assert(intervals.length > 0, `span of an empty list of F32Intervals is not allowed`);
-    let begin = Number.POSITIVE_INFINITY;
-    let end = Number.NEGATIVE_INFINITY;
-    intervals.forEach(i => {
-      begin = Math.min(i.begin, begin);
-      end = Math.max(i.end, end);
-    });
-    return new F32Interval(begin, end);
-  }
-
-  /** @returns a string representation for logging purposes */
-  public toString(): string {
-    return `[${this.bounds().map(f32)}]`;
-  }
-
-  /** @returns a singleton for interval of all possible values
-   * This interval is used in situations where accuracy is not defined, so any
-   * result is valid.
-   */
-  public static any(): F32Interval {
-    if (this._any === undefined) {
-      this._any = new F32Interval(Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
-    }
-    return this._any;
-  }
-}
-
-/**
- * SerializedF32Interval holds the serialized form of a F32Interval.
- * This form can be safely encoded to JSON.
- */
-export type SerializedF32Interval = { begin: number; end: number } | 'any';
-
-/** serializeF32Interval() converts a F32Interval to a SerializedF32Interval */
-export function serializeF32Interval(i: F32Interval): SerializedF32Interval {
-  return i === F32Interval.any()
-    ? 'any'
-    : { begin: reinterpretF32AsU32(i.begin), end: reinterpretF32AsU32(i.end) };
-}
-
-/** serializeF32Interval() converts a SerializedF32Interval to a F32Interval */
-export function deserializeF32Interval(data: SerializedF32Interval): F32Interval {
-  return data === 'any'
-    ? F32Interval.any()
-    : toF32Interval([reinterpretU32AsF32(data.begin), reinterpretU32AsF32(data.end)]);
-}
-
-/** @returns an interval containing the point or the original interval */
-export function toF32Interval(n: number | IntervalBounds | F32Interval): F32Interval {
-  if (n instanceof F32Interval) {
-    return n;
-  }
-
-  if (n instanceof Array) {
-    return new F32Interval(...n);
-  }
-
-  return new F32Interval(n, n);
-}
-
-/** F32Interval of [-π, π] */
-const kNegPiToPiInterval = toF32Interval([
-  kValue.f32.negative.pi.whole,
-  kValue.f32.positive.pi.whole,
-]);
-
-/** F32Interval of values greater than 0 and less than or equal to f32 max */
-const kGreaterThanZeroInterval = toF32Interval([
-  kValue.f32.subnormal.positive.min,
-  kValue.f32.positive.max,
-]);
-
-/**
- * Representation of a vec2/3/4 of floating point intervals as an array of F32Intervals.
- * */
-export type F32Vector =
-  | [F32Interval, F32Interval]
-  | [F32Interval, F32Interval, F32Interval]
-  | [F32Interval, F32Interval, F32Interval, F32Interval];
-
-/** Narrow an array of values to F32Vector if possible */
-export function isF32Vector(v: (number | IntervalBounds | F32Interval)[]): v is F32Vector {
-  if (v.every(e => e instanceof F32Interval)) {
-    return v.length === 2 || v.length === 3 || v.length === 4;
-  }
-  return false;
-}
-
-/** @returns an F32Vector representation of an array of values if possible */
-export function toF32Vector(v: (number | IntervalBounds | F32Interval)[]): F32Vector {
-  if (isF32Vector(v)) {
-    return v;
-  }
-
-  const f = v.map(toF32Interval);
-  // The return of the map above is a F32Interval[], which needs to be narrowed
-  // to F32Vector, since F32Vector is defined as fixed length tuples.
-  if (isF32Vector(f)) {
-    return f;
-  }
-  unreachable(`Cannot convert [${v}] to F32Vector`);
-}
-
-/** F32Vector with all zero elements */
-const kZeroVector = {
-  2: toF32Vector([0, 0]),
-  3: toF32Vector([0, 0, 0]),
-  4: toF32Vector([0, 0, 0, 0]),
-};
-
-/** F32Vector with all F32Interval.any() elements */
-const kAnyVector = {
-  2: toF32Vector([F32Interval.any(), F32Interval.any()]),
-  3: toF32Vector([F32Interval.any(), F32Interval.any(), F32Interval.any()]),
-  4: toF32Vector([F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()]),
-};
-
-/**
- * @returns a F32Vector where each element is the span for corresponding
- *          elements at the same index in the input vectors
- */
-function spanF32Vector(...vectors: F32Vector[]): F32Vector {
-  assert(isF32Vector(vectors[0]), '');
-  const vector_length = vectors[0].length;
-  assert(
-    vectors.every(e => e.length === vector_length),
-    `Vector span is not defined for vectors of differing lengths`
-  );
-
-  const result: F32Interval[] = new Array<F32Interval>(vector_length);
-
-  for (let i = 0; i < vector_length; i++) {
-    result[i] = F32Interval.span(...vectors.map(v => v[i]));
-  }
-  return toF32Vector(result);
-}
-
-/**
- * @retuns the vector result of multiplying the given vector by the given scalar
- */
-function multiplyVectorByScalar(v: number[], c: number | F32Interval): F32Vector {
-  return toF32Vector(v.map(x => multiplicationInterval(x, c)));
-}
-
-/**
- * Short hand for an Array of Arrays that contains a column-major matrix
- *
- * This isn't exported outside of this file to avoid colliding with the Matrix
- * container for going in/out of a shader that the test runner uses.
- */
-type Matrix<T> = T[][];
-
-/** Representation of a matCxR of floating point intervals as an array of arrays of F32Intervals. This maps onto the WGSL concept of matrix. Internally  */
-// prettier-ignore;
-export type F32Matrix =
-  | [[F32Interval, F32Interval], [F32Interval, F32Interval]]
-  | [[F32Interval, F32Interval], [F32Interval, F32Interval], [F32Interval, F32Interval]]
-  | [
-      [F32Interval, F32Interval],
-      [F32Interval, F32Interval],
-      [F32Interval, F32Interval],
-      [F32Interval, F32Interval]
-    ]
-  | [[F32Interval, F32Interval, F32Interval], [F32Interval, F32Interval, F32Interval]]
-  | [
-      [F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval]
-    ]
-  | [
-      [F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval]
-    ]
-  | [
-      [F32Interval, F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval, F32Interval]
-    ]
-  | [
-      [F32Interval, F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval, F32Interval]
-    ]
-  | [
-      [F32Interval, F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval, F32Interval],
-      [F32Interval, F32Interval, F32Interval, F32Interval]
-    ];
-
-/** Narrow an array of an array of values to F32Matrix if possible */
-export function isF32Matrix(
-  m: Matrix<number | IntervalBounds | F32Interval> | F32Vector[]
-): m is F32Matrix {
-  if (!m.every(c => c.every(e => e instanceof F32Interval))) {
-    return false;
-  }
-  // At this point m guaranteed to be a F32Interval[][], but maybe typed as a
-  // F32Vector[].
-  // Coercing the type since F32Vector[] is functionally equivalent to
-  // F32Interval[][] for .length and .every, but they are not generally
-  // compatible, since tuples are not equivalent to arrays, so TS considers c in
-  // .every to be unresolvable below, even though our usage is safe.
-  m = m as F32Interval[][];
-
-  if (m.length > 4 || m.length < 2) {
-    return false;
-  }
-
-  const num_rows = m[0].length;
-  if (num_rows > 4 || num_rows < 2) {
-    return false;
-  }
-
-  return m.every(c => c.length === num_rows);
-}
-
-/** @returns an F32Matrix representation of an array of an array of values if possible */
-export function toF32Matrix(
-  m: Matrix<number | IntervalBounds | F32Interval> | F32Vector[]
-): F32Matrix {
-  if (isF32Matrix(m)) {
-    return m;
-  }
-
-  const result = map2DArray(m, toF32Interval);
-
-  // The return of the map above is a F32Interval[][], which needs to be
-  // narrowed to F32Matrix, since F32Matrix is defined as fixed length tuples.
-  if (isF32Matrix(result)) {
-    return result;
-  }
-  unreachable(`Cannot convert ${m} to F32Matrix`);
-}
-
-/** F32Matrix with all F32Interval.any() elements */
-const kAnyF32Matrix = {
-  2: {
-    2: toF32Matrix([
-      [F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any()],
-    ]),
-    3: toF32Matrix([
-      [F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any()],
-    ]),
-    4: toF32Matrix([
-      [F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()],
-    ]),
-  },
-  3: {
-    2: toF32Matrix([
-      [F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any()],
-    ]),
-    3: toF32Matrix([
-      [F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any()],
-    ]),
-    4: toF32Matrix([
-      [F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()],
-    ]),
-  },
-  4: {
-    2: toF32Matrix([
-      [F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any()],
-    ]),
-    3: toF32Matrix([
-      [F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any()],
-    ]),
-    4: toF32Matrix([
-      [F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()],
-      [F32Interval.any(), F32Interval.any(), F32Interval.any(), F32Interval.any()],
-    ]),
-  },
-};
-
-/**
- * @returns a F32Matrix where each element is the span for corresponding
- *          elements at the same index in the input matrices
- */
-function spanF32Matrix(...matrices: F32Matrix[]): F32Matrix {
-  // Coercing the type of matrices, since tuples are not generally compatible
-  // with Arrays, but they are functionally equivalent for the usages in this
-  // function.
-  const ms = matrices as Matrix<F32Interval>[];
-  const num_cols = ms[0].length;
-  const num_rows = ms[0][0].length;
-  assert(
-    ms.every(m => m.length === num_cols && m.every(r => r.length === num_rows)),
-    `Matrix span is not defined for Matrices of differing dimensions`
-  );
-
-  const result: Matrix<F32Interval> = [...Array(num_cols)].map(_ => [...Array(num_rows)]);
-  for (let i = 0; i < num_cols; i++) {
-    for (let j = 0; j < num_rows; j++) {
-      result[i][j] = F32Interval.span(...ms.map(m => m[i][j]));
-    }
-  }
-
-  return toF32Matrix(result);
-}
-
-/**
- * @returns the input plus zero if any of the entries are f32 subnormal,
- * otherwise returns the input.
- */
-function addFlushedIfNeededF32(values: number[]): number[] {
-  return values.some(v => v !== 0 && isSubnormalNumberF32(v)) ? values.concat(0) : values;
-}
-
-/**
- * @returns the input plus zero if any of the entries are f16 subnormal,
- * otherwise returns the input
- */
-function addFlushedIfNeededF16(values: number[]): number[] {
-  return values.some(v => v !== 0 && isSubnormalNumberF16(v)) ? values.concat(0) : values;
-}
-
-/**
- * A function that converts a point to an acceptance interval.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface PointToInterval {
-  (x: number): F32Interval;
+  (x: number): FPInterval;
 }
 
-/** Operation used to implement a PointToInterval */
-export interface PointToIntervalOp {
-  /** @returns acceptance interval for a function at point x */
-  impl: PointToInterval;
-
-  /**
-   * Calculates where in the domain defined by x the min/max extrema of impl
-   * occur and returns a span of those points to be used as the domain instead.
-   *
-   * Used by runPointToIntervalOp before invoking impl.
-   * If not defined, the bounds of the existing domain are assumed to be the
-   * extrema.
-   *
-   * This is only implemented for operations that meet all of the following
-   * criteria:
-   *   a) non-monotonic
-   *   b) used in inherited accuracy calculations
-   *   c) need to take in an interval for b)
-   *      i.e. fooInterval takes in x: number | F32Interval, not x: number
-   */
-  extrema?: (x: F32Interval) => F32Interval;
-}
-
-/**
- * Restrict the inputs to an PointToInterval operation
- *
- * Only used for operations that have tighter domain requirements than 'must be
- * f32 finite'.
- *
- * @param domain interval to restrict inputs to
- * @param impl operation implementation to run if input is within the required domain
- * @returns a PointToInterval that calls impl if domain contains the input,
- *          otherwise it returns the any() interval */
-function limitPointToIntervalDomain(domain: F32Interval, impl: PointToInterval): PointToInterval {
-  return (n: number): F32Interval => {
-    return domain.contains(n) ? impl(n) : F32Interval.any();
-  };
-}
-
-/**
- * A function that converts a pair of points to an acceptance interval.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface BinaryToInterval {
-  (x: number, y: number): F32Interval;
+  (x: number, y: number): FPInterval;
 }
 
-/** Operation used to implement a BinaryToInterval */
-interface BinaryToIntervalOp {
-  /** @returns acceptance interval for a function at point (x, y) */
-  impl: BinaryToInterval;
-  /**
-   * Calculates where in domain defined by x & y the min/max extrema of impl
-   * occur and returns spans of those points to be used as the domain instead.
-   *
-   * Used by runBinaryToIntervalOp before invoking impl.
-   * If not defined, the bounds of the existing domain are assumed to be the
-   * extrema.
-   *
-   * This is only implemented for functions that meet all of the following
-   * criteria:
-   *   a) non-monotonic
-   *   b) used in inherited accuracy calculations
-   *   c) need to take in an interval for b)
-   */
-  extrema?: (x: F32Interval, y: F32Interval) => [F32Interval, F32Interval];
-}
-
-/** Domain for a BinaryToInterval implementation */
-interface BinaryToIntervalDomain {
-  // Arrays to support discrete valid domain intervals
-  x: F32Interval[];
-  y: F32Interval[];
-}
-
-/**
- * Restrict the inputs to a BinaryToInterval
- *
- * Only used for operations that have tighter domain requirements than 'must be
- * f32 finite'.
- *
- * @param domain set of intervals to restrict inputs to
- * @param impl operation implementation to run if input is within the required domain
- * @returns a BinaryToInterval that calls impl if domain contains the input,
- *          otherwise it returns the any() interval */
-function limitBinaryToIntervalDomain(
-  domain: BinaryToIntervalDomain,
-  impl: BinaryToInterval
-): BinaryToInterval {
-  return (x: number, y: number): F32Interval => {
-    if (!domain.x.some(d => d.contains(x)) || !domain.y.some(d => d.contains(y))) {
-      return F32Interval.any();
-    }
-
-    return impl(x, y);
-  };
-}
-
-/**
- * A function that converts a triplet of points to an acceptance interval.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface TernaryToInterval {
-  (x: number, y: number, z: number): F32Interval;
+  (x: number, y: number, z: number): FPInterval;
 }
 
-/** Operation used to implement a TernaryToInterval */
-interface TernaryToIntervalOp {
-  // Re-using the *Op interface pattern for symmetry with the other operations.
-  /** @returns acceptance interval for a function at point (x, y, z) */
-  impl: TernaryToInterval;
-}
-
-// Currently PointToVector is not integrated with the rest of the floating point
-// framework, because the only builtins that use it are actually
-// u32 -> [f32, f32, f32, f32] functions, so the whole rounding and interval
-// process doesn't get applied to the inputs.
-// They do use the framework internally by invoking divisionInterval on segments
-// of the input.
-/**
- * A function that converts a point to a vector of acceptance intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface PointToVector {
-  (n: number): F32Vector;
+  (n: number): FPVector;
 }
 
-/**
- * A function that converts a vector to an acceptance interval.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface VectorToInterval {
-  (x: number[]): F32Interval;
+  (x: number[]): FPInterval;
 }
 
-/** Operation used to implement a VectorToInterval */
-interface VectorToIntervalOp {
-  // Re-using the *Op interface pattern for symmetry with the other operations.
-  /** @returns acceptance interval for a function on vector x */
-  impl: VectorToInterval;
-}
-
-/**
- * A function that converts a pair of vectors to an acceptance interval.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface VectorPairToInterval {
-  (x: number[], y: number[]): F32Interval;
+  (x: number[], y: number[]): FPInterval;
 }
 
-/** Operation used to implement a VectorPairToInterval */
-interface VectorPairToIntervalOp {
-  // Re-using the *Op interface pattern for symmetry with the other operations.
-  /** @returns acceptance interval for a function on vectors (x, y) */
-  impl: VectorPairToInterval;
-}
-
-/**
- * A function that converts a vector to a vector of acceptance intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface VectorToVector {
-  (x: number[]): F32Vector;
+  (x: number[]): FPVector;
 }
 
-/** Operation used to implement a VectorToVector */
-interface VectorToVectorOp {
-  // Re-using the *Op interface pattern for symmetry with the other operations.
-  /** @returns a vector of acceptance intervals for a function on vector x */
-  impl: VectorToVector;
-}
-
-/**
- * A function that converts a pair of vectors to a vector of acceptance
- * intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface VectorPairToVector {
-  (x: number[], y: number[]): F32Vector;
+  (x: number[], y: number[]): FPVector;
 }
 
-/** Operation used to implement a VectorPairToVector */
-interface VectorPairToVectorOp {
-  // Re-using the *Op interface pattern for symmetry with the other operations.
-  /** @returns a vector of acceptance intervals for a function on vectors (x, y) */
-  impl: VectorPairToVector;
-}
-
-/**
- * A function that converts a vector and a scalar to a vector of acceptance
- * intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface VectorScalarToVector {
-  (x: number[], y: number): F32Vector;
+  (x: number[], y: number): FPVector;
 }
 
-/**
- * A function that converts a scalar and a vector  to a vector of acceptance
- * intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface ScalarVectorToVector {
-  (x: number, y: number[]): F32Vector;
+  (x: number, y: number[]): FPVector;
 }
 
-/**
- * A function that converts a matrix to an acceptance interval.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface MatrixToScalar {
-  (m: Matrix<number>): F32Interval;
+  (m: number[][]): FPInterval;
 }
 
-/** Operation used to implement a MatrixToMatrix */
-interface MatrixToMatrixOp {
-  // Re-using the *Op interface pattern for symmetry with the other operations.
-  /** @returns a matrix of acceptance intervals for a function on matrix x */
-  impl: MatrixToMatrix;
-}
-
-/**
- * A function that converts a matrix to a matrix of acceptance intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface MatrixToMatrix {
-  (m: Matrix<number>): F32Matrix;
+  (m: number[][]): FPMatrix;
 }
 
-/** Operation used to implement a MatrixToMatrix */
-interface MatrixToMatrixOp {
-  // Re-using the *Op interface pattern for symmetry with the other operations.
-  /** @returns a matrix of acceptance intervals for a function on matrix x */
-  impl: MatrixToMatrix;
-}
-
-/**
- * A function that converts a pair of matrices to a matrix of acceptance
- * intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface MatrixPairToMatrix {
-  (x: Matrix<number>, y: Matrix<number>): F32Matrix;
+  (x: number[][], y: number[][]): FPMatrix;
 }
 
-/**
- * A function that converts a matrix and a scalar to a matrix of acceptance
- * intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface MatrixScalarToMatrix {
-  (x: Matrix<number>, y: number): F32Matrix;
+  (x: number[][], y: number): FPMatrix;
 }
 
-/**
- * A function that converts a matrix and a vector to a vector of acceptance
- * intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
-export interface MatrixVectorToVector {
-  (x: Matrix<number>, y: number[]): F32Vector;
-}
-
-/**
- * A function that converts a vector and a matrix to a vector of acceptance
- * intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
-export interface VectorMatrixToVector {
-  (x: number[], y: Matrix<number>): F32Vector;
-}
-
-/**
- * A function that converts a scalar and a matrix to a matrix of acceptance
- * intervals.
- * This is the public facing API for builtin implementations that is called
- * from tests.
- */
 export interface ScalarMatrixToMatrix {
-  (x: number, y: Matrix<number>): F32Matrix;
-}
-/** Converts a point to an acceptance interval, using a specific function
- *
- * This handles correctly rounding and flushing inputs as needed.
- * Duplicate inputs are pruned before invoking op.impl.
- * op.extrema is invoked before this point in the call stack.
- * op.domain is tested before this point in the call stack.
- *
- * @param n value to flush & round then invoke op.impl on
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function roundAndFlushPointToInterval(n: number, op: PointToIntervalOp) {
-  assert(!Number.isNaN(n), `flush not defined for NaN`);
-  const values = correctlyRoundedF32(n);
-  const inputs = addFlushedIfNeededF32(values);
-  const results = new Set<F32Interval>(inputs.map(op.impl));
-  return F32Interval.span(...results);
+  (x: number, y: number[][]): FPMatrix;
 }
 
-/** Converts a pair to an acceptance interval, using a specific function
- *
- * This handles correctly rounding and flushing inputs as needed.
- * Duplicate inputs are pruned before invoking op.impl.
- * All unique combinations of x & y are run.
- * op.extrema is invoked before this point in the call stack.
- * op.domain is tested before this point in the call stack.
- *
- * @param x first param to flush & round then invoke op.impl on
- * @param y second param to flush & round then invoke op.impl on
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function roundAndFlushBinaryToInterval(x: number, y: number, op: BinaryToIntervalOp): F32Interval {
-  assert(!Number.isNaN(x), `flush not defined for NaN`);
-  assert(!Number.isNaN(y), `flush not defined for NaN`);
-  const x_values = correctlyRoundedF32(x);
-  const y_values = correctlyRoundedF32(y);
-  const x_inputs = addFlushedIfNeededF32(x_values);
-  const y_inputs = addFlushedIfNeededF32(y_values);
-  const intervals = new Set<F32Interval>();
-  x_inputs.forEach(inner_x => {
-    y_inputs.forEach(inner_y => {
-      intervals.add(op.impl(inner_x, inner_y));
-    });
-  });
-  return F32Interval.span(...intervals);
+export interface MatrixVectorToVector {
+  (x: number[][], y: number[]): FPVector;
 }
 
-/** Converts a triplet to an acceptance interval, using a specific function
- *
- * This handles correctly rounding and flushing inputs as needed.
- * Duplicate inputs are pruned before invoking op.impl.
- * All unique combinations of x, y & z are run.
- *
- * @param x first param to flush & round then invoke op.impl on
- * @param y second param to flush & round then invoke op.impl on
- * @param z third param to flush & round then invoke op.impl on
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function roundAndFlushTernaryToInterval(
-  x: number,
-  y: number,
-  z: number,
-  op: TernaryToIntervalOp
-): F32Interval {
-  assert(!Number.isNaN(x), `flush not defined for NaN`);
-  assert(!Number.isNaN(y), `flush not defined for NaN`);
-  assert(!Number.isNaN(z), `flush not defined for NaN`);
-  const x_values = correctlyRoundedF32(x);
-  const y_values = correctlyRoundedF32(y);
-  const z_values = correctlyRoundedF32(z);
-  const x_inputs = addFlushedIfNeededF32(x_values);
-  const y_inputs = addFlushedIfNeededF32(y_values);
-  const z_inputs = addFlushedIfNeededF32(z_values);
-  const intervals = new Set<F32Interval>();
-  // prettier-ignore
-  x_inputs.forEach(inner_x => {
-    y_inputs.forEach(inner_y => {
-      z_inputs.forEach(inner_z => {
-        intervals.add(op.impl(inner_x, inner_y, inner_z));
-      });
-    });
-  });
-
-  return F32Interval.span(...intervals);
+export interface VectorMatrixToVector {
+  (x: number[], y: number[][]): FPVector;
 }
 
-/** Converts a vector to an acceptance interval using a specific function
- *
- * This handles correctly rounding and flushing inputs as needed.
- * Duplicate inputs are pruned before invoking op.impl.
- *
- * @param x param to flush & round then invoke op.impl on
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function roundAndFlushVectorToInterval(x: number[], op: VectorToIntervalOp): F32Interval {
-  assert(
-    x.every(e => !Number.isNaN(e)),
-    `flush not defined for NaN`
-  );
+// Containers
 
-  const x_rounded: number[][] = x.map(correctlyRoundedF32);
-  const x_flushed: number[][] = x_rounded.map(addFlushedIfNeededF32);
-  const x_inputs = cartesianProduct<number>(...x_flushed);
+export type F32Vector = FPVector;
 
-  const intervals = new Set<F32Interval>();
-  x_inputs.forEach(inner_x => {
-    intervals.add(op.impl(inner_x));
-  });
-  return F32Interval.span(...intervals);
+// Utilities
+
+export function toF32Interval(n: number | IntervalBounds | FPInterval): FPInterval {
+  return kFPContext.f32.toInterval(n);
 }
 
-/** Converts a pair of vectors to an acceptance interval using a specific function
- *
- * This handles correctly rounding and flushing inputs as needed.
- * Duplicate inputs are pruned before invoking op.impl.
- * All unique combinations of x & y are run.
- *
- * @param x first param to flush & round then invoke op.impl on
- * @param y second param to flush & round then invoke op.impl on
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function roundAndFlushVectorPairToInterval(
-  x: number[],
-  y: number[],
-  op: VectorPairToIntervalOp
-): F32Interval {
-  assert(
-    x.every(e => !Number.isNaN(e)),
-    `flush not defined for NaN`
-  );
-  assert(
-    y.every(e => !Number.isNaN(e)),
-    `flush not defined for NaN`
-  );
-
-  const x_rounded: number[][] = x.map(correctlyRoundedF32);
-  const y_rounded: number[][] = y.map(correctlyRoundedF32);
-  const x_flushed: number[][] = x_rounded.map(addFlushedIfNeededF32);
-  const y_flushed: number[][] = y_rounded.map(addFlushedIfNeededF32);
-  const x_inputs = cartesianProduct<number>(...x_flushed);
-  const y_inputs = cartesianProduct<number>(...y_flushed);
-
-  const intervals = new Set<F32Interval>();
-  x_inputs.forEach(inner_x => {
-    y_inputs.forEach(inner_y => {
-      intervals.add(op.impl(inner_x, inner_y));
-    });
-  });
-  return F32Interval.span(...intervals);
+export function isF32Vector(v: (number | IntervalBounds | FPInterval)[]): v is FPVector {
+  return kFPContext.f32.isVector(v);
 }
 
-/** Converts a vector to a vector of acceptance intervals using a specific
- * function
- *
- * This handles correctly rounding and flushing inputs as needed.
- * Duplicate inputs are pruned before invoking op.impl.
- *
- * @param x param to flush & round then invoke op.impl on
- * @param op operation defining the function being run
- * @returns a vector of spans for each outputs of op.impl
- */
-function roundAndFlushVectorToVector(x: number[], op: VectorToVectorOp): F32Vector {
-  assert(
-    x.every(e => !Number.isNaN(e)),
-    `flush not defined for NaN`
-  );
-
-  const x_rounded: number[][] = x.map(correctlyRoundedF32);
-  const x_flushed: number[][] = x_rounded.map(addFlushedIfNeededF32);
-  const x_inputs = cartesianProduct<number>(...x_flushed);
-
-  const interval_vectors = new Set<F32Vector>();
-  x_inputs.forEach(inner_x => {
-    interval_vectors.add(op.impl(inner_x));
-  });
-
-  return spanF32Vector(...interval_vectors);
+export function toF32Vector(v: (number | IntervalBounds | FPInterval)[]): FPVector {
+  return kFPContext.f32.toVector(v);
 }
 
-/**
- * Converts a pair of vectors to a vector of acceptance intervals using a
- * specific function
- *
- * This handles correctly rounding and flushing inputs as needed.
- * Duplicate inputs are pruned before invoking op.impl.
- *
- * @param x first param to flush & round then invoke op.impl on
- * @param x second param to flush & round then invoke op.impl on
- * @param op operation defining the function being run
- * @returns a vector of spans for each output of op.impl
- */
-function roundAndFlushVectorPairToVector(
-  x: number[],
-  y: number[],
-  op: VectorPairToVectorOp
-): F32Vector {
-  assert(
-    x.every(e => !Number.isNaN(e)),
-    `flush not defined for NaN`
-  );
-  assert(
-    y.every(e => !Number.isNaN(e)),
-    `flush not defined for NaN`
-  );
-
-  const x_rounded: number[][] = x.map(correctlyRoundedF32);
-  const y_rounded: number[][] = y.map(correctlyRoundedF32);
-  const x_flushed: number[][] = x_rounded.map(addFlushedIfNeededF32);
-  const y_flushed: number[][] = y_rounded.map(addFlushedIfNeededF32);
-  const x_inputs = cartesianProduct<number>(...x_flushed);
-  const y_inputs = cartesianProduct<number>(...y_flushed);
-
-  const interval_vectors = new Set<F32Vector>();
-  x_inputs.forEach(inner_x => {
-    y_inputs.forEach(inner_y => {
-      interval_vectors.add(op.impl(inner_x, inner_y));
-    });
-  });
-
-  return spanF32Vector(...interval_vectors);
+export function spanF32Intervals(...intervals: FPInterval[]): FPInterval {
+  return kFPContext.f32.spanIntervals(...intervals);
 }
 
-/** Converts a matrix to a matrix of acceptance intervals using a specific
- * function
- *
- * This handles correctly rounding and flushing inputs as needed.
- * Duplicate inputs are pruned before invoking op.impl.
- *
- * @param m param to flush & round then invoke op.impl on
- * @param op operation defining the function being run
- * @returns a matrix of spans for each outputs of op.impl
- */
-function roundAndFlushMatrixToMatrix(m: Matrix<number>, op: MatrixToMatrixOp): F32Matrix {
-  const num_cols = m.length;
-  const num_rows = m[0].length;
-  assert(
-    m.every(c => c.every(r => !Number.isNaN(r))),
-    `flush not defined for NaN`
-  );
-
-  const m_flat = flatten2DArray(m);
-  const m_rounded: number[][] = m_flat.map(correctlyRoundedF32);
-  const m_flushed: number[][] = m_rounded.map(e => addFlushedIfNeededF32(e));
-  const m_options: number[][] = cartesianProduct<number>(...m_flushed);
-  const m_inputs: Matrix<number>[] = m_options.map(e => unflatten2DArray(e, num_cols, num_rows));
-
-  const interval_matrices = new Set<F32Matrix>();
-  m_inputs.forEach(inner_m => {
-    interval_matrices.add(op.impl(inner_m));
-  });
-
-  return spanF32Matrix(...interval_matrices);
+export function isF32Matrix(
+  m: (number | IntervalBounds | FPInterval)[][] | FPVector[]
+): m is FPMatrix {
+  return kFPContext.f32.isMatrix(m);
 }
 
-/** Calculate the acceptance interval for a unary function over an interval
- *
- * If the interval is actually a point, this just decays to
- * roundAndFlushPointToInterval.
- *
- * The provided domain interval may be adjusted if the operation defines an
- * extrema function.
- *
- * @param x input domain interval
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function runPointToIntervalOp(x: F32Interval, op: PointToIntervalOp): F32Interval {
-  if (!x.isFinite()) {
-    return F32Interval.any();
-  }
-
-  if (op.extrema !== undefined) {
-    x = op.extrema(x);
-  }
-
-  const result = F32Interval.span(...x.bounds().map(b => roundAndFlushPointToInterval(b, op)));
-  return result.isFinite() ? result : F32Interval.any();
+export function toF32Matrix(m: (number | IntervalBounds | FPInterval)[][] | FPVector[]): FPMatrix {
+  return kFPContext.f32.toMatrix(m);
 }
 
-/** Calculate the acceptance interval for a binary function over an interval
- *
- * The provided domain intervals may be adjusted if the operation defines an
- * extrema function.
- *
- * @param x first input domain interval
- * @param y second input domain interval
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function runBinaryToIntervalOp(
-  x: F32Interval,
-  y: F32Interval,
-  op: BinaryToIntervalOp
-): F32Interval {
-  if (!x.isFinite() || !y.isFinite()) {
-    return F32Interval.any();
-  }
+// Accuracy Interval
 
-  if (op.extrema !== undefined) {
-    [x, y] = op.extrema(x, y);
-  }
-
-  const outputs = new Set<F32Interval>();
-  x.bounds().forEach(inner_x => {
-    y.bounds().forEach(inner_y => {
-      outputs.add(roundAndFlushBinaryToInterval(inner_x, inner_y, op));
-    });
-  });
-
-  const result = F32Interval.span(...outputs);
-  return result.isFinite() ? result : F32Interval.any();
+export function correctlyRoundedInterval(n: number | FPInterval): FPInterval {
+  return kFPContext.f32.correctlyRoundedInterval(n);
 }
 
-/** Calculate the acceptance interval for a ternary function over an interval
- *
- * @param x first input domain interval
- * @param y second input domain interval
- * @param z third input domain interval
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function runTernaryToIntervalOp(
-  x: F32Interval,
-  y: F32Interval,
-  z: F32Interval,
-  op: TernaryToIntervalOp
-): F32Interval {
-  if (!x.isFinite() || !y.isFinite() || !z.isFinite()) {
-    return F32Interval.any();
-  }
-
-  const outputs = new Set<F32Interval>();
-  x.bounds().forEach(inner_x => {
-    y.bounds().forEach(inner_y => {
-      z.bounds().forEach(inner_z => {
-        outputs.add(roundAndFlushTernaryToInterval(inner_x, inner_y, inner_z, op));
-      });
-    });
-  });
-
-  const result = F32Interval.span(...outputs);
-  return result.isFinite() ? result : F32Interval.any();
+export function correctlyRoundedMatrix(m: number[][]): FPMatrix {
+  return kFPContext.f32.correctlyRoundedMatrix(m);
 }
 
-/** Calculate the acceptance interval for a vector function over given intervals
- *
- * @param x input domain intervals vector
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function runVectorToIntervalOp(x: F32Vector, op: VectorToIntervalOp): F32Interval {
-  if (x.some(e => !e.isFinite())) {
-    return F32Interval.any();
-  }
-
-  const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
-
-  const outputs = new Set<F32Interval>();
-  x_values.forEach(inner_x => {
-    outputs.add(roundAndFlushVectorToInterval(inner_x, op));
-  });
-
-  const result = F32Interval.span(...outputs);
-  return result.isFinite() ? result : F32Interval.any();
+export function absoluteErrorInterval(n: number, error_range: number): FPInterval {
+  return kFPContext.f32.absoluteErrorInterval(n, error_range);
 }
 
-/** Calculate the acceptance interval for a vector pair function over given intervals
- *
- * @param x first input domain intervals vector
- * @param y second input domain intervals vector
- * @param op operation defining the function being run
- * @returns a span over all of the outputs of op.impl
- */
-function runVectorPairToIntervalOp(
-  x: F32Vector,
-  y: F32Vector,
-  op: VectorPairToIntervalOp
-): F32Interval {
-  if (x.some(e => !e.isFinite()) || y.some(e => !e.isFinite())) {
-    return F32Interval.any();
-  }
-
-  const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
-  const y_values = cartesianProduct<number>(...y.map(e => e.bounds()));
-
-  const outputs = new Set<F32Interval>();
-  x_values.forEach(inner_x => {
-    y_values.forEach(inner_y => {
-      outputs.add(roundAndFlushVectorPairToInterval(inner_x, inner_y, op));
-    });
-  });
-
-  const result = F32Interval.span(...outputs);
-  return result.isFinite() ? result : F32Interval.any();
+export function ulpInterval(n: number, numULP: number): FPInterval {
+  return kFPContext.f32.ulpInterval(n, numULP);
 }
 
-/** Calculate the vector of acceptance intervals for a pair of vector function over
- * given intervals
- *
- * @param x input domain intervals vector
- * @param op operation defining the function being run
- * @returns a vector of spans over all of the outputs of op.impl
- */
-function runVectorToVectorOp(x: F32Vector, op: VectorToVectorOp): F32Vector {
-  if (x.some(e => !e.isFinite())) {
-    return kAnyVector[x.length];
-  }
-
-  const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
-
-  const outputs = new Set<F32Vector>();
-  x_values.forEach(inner_x => {
-    outputs.add(roundAndFlushVectorToVector(inner_x, op));
-  });
-
-  const result = spanF32Vector(...outputs);
-  return result.every(e => e.isFinite()) ? result : toF32Vector(x.map(_ => F32Interval.any()));
+export function absInterval(n: number): FPInterval {
+  return kFPContext.f32.absInterval(n);
 }
 
-/**
- * Calculate the vector of acceptance intervals by running a scalar operation
- * component-wise over a vector.
- *
- * This is used for situations where a component-wise operation, like vector
- * negation, is needed as part of a inherited accuracy, but the top-level
- * operation test don't require an explicit vector definition of the function,
- * due to the generated vectorize tests being sufficient.
- *
- * @param x input domain intervals vector
- * @param op scalar operation to be run component-wise
- * @returns a vector of intervals with the outputs of op.impl
- */
-function runPointToIntervalOpComponentWise(x: F32Vector, op: PointToIntervalOp): F32Vector {
-  return toF32Vector(
-    x.map(i => {
-      return runPointToIntervalOp(i, op);
-    })
-  );
+export function acosInterval(n: number): FPInterval {
+  return kFPContext.f32.acosInterval(n);
 }
 
-/** Calculate the vector of acceptance intervals for a vector function over
- * given intervals
- *
- * @param x first input domain intervals vector
- * @param y second input domain intervals vector
- * @param op operation defining the function being run
- * @returns a vector of spans over all of the outputs of op.impl
- */
-function runVectorPairToVectorOp(x: F32Vector, y: F32Vector, op: VectorPairToVectorOp): F32Vector {
-  if (x.some(e => !e.isFinite()) || y.some(e => !e.isFinite())) {
-    return kAnyVector[x.length];
-  }
+export const acoshIntervals = kFPContext.f32.acoshIntervals;
 
-  const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
-  const y_values = cartesianProduct<number>(...y.map(e => e.bounds()));
-
-  const outputs = new Set<F32Vector>();
-  x_values.forEach(inner_x => {
-    y_values.forEach(inner_y => {
-      outputs.add(roundAndFlushVectorPairToVector(inner_x, inner_y, op));
-    });
-  });
-
-  const result = spanF32Vector(...outputs);
-  return result.every(e => e.isFinite()) ? result : toF32Vector(x.map(_ => F32Interval.any()));
+export function acoshAlternativeInterval(x: number | FPInterval): FPInterval {
+  return kFPContext.f32.acoshAlternativeInterval(x);
 }
 
-/**
- * Calculate the vector of acceptance intervals by running a scalar operation
- * component-wise over a pair vectors.
- *
- * This is used for situations where a component-wise operation, like vector
- * subtraction, is needed as part of a inherited accuracy, but the top-level
- * operation test don't require an explicit vector definition of the function,
- * due to the generated vectorize tests being sufficient.
- *
- * @param x first input domain intervals vector
- * @param y second input domain intervals vector
- * @param op scalar operation to be run component-wise
- * @returns a vector of intervals with the outputs of op.impl
- */
-function runBinaryToIntervalOpVectorComponentWise(
-  x: F32Vector,
-  y: F32Vector,
-  op: BinaryToIntervalOp
-): F32Vector {
-  assert(
-    x.length === y.length,
-    `runBinaryToIntervalOpVectorComponentWise requires vectors of the same length`
-  );
-  return toF32Vector(
-    x.map((i, idx) => {
-      return runBinaryToIntervalOp(i, y[idx], op);
-    })
-  );
+export function acoshPrimaryInterval(x: number | FPInterval): FPInterval {
+  return kFPContext.f32.acoshPrimaryInterval(x);
 }
 
-/** Calculate the matrix of acceptance intervals for a pair of matrix function over
- * given intervals
- *
- * @param x input domain intervals matrix
- * @param x input domain intervals matrix
- * @param op operation defining the function being run
- * @returns a matrix of spans over all of the outputs of op.impl
- */
-function runMatrixToMatrixOp(m: F32Matrix, op: MatrixToMatrixOp): F32Matrix {
-  const num_cols = m.length;
-  const num_rows = m[0].length;
-  if (m.some(c => c.some(r => !r.isFinite()))) {
-    return kAnyF32Matrix[num_cols][num_rows];
-  }
-
-  const m_flat: F32Interval[] = flatten2DArray(m);
-  const m_values: number[][] = cartesianProduct<number>(...m_flat.map(e => e.bounds()));
-
-  const outputs = new Set<F32Matrix>();
-  m_values.forEach(inner_m => {
-    const unflat_m = unflatten2DArray(inner_m, num_cols, num_rows);
-    outputs.add(roundAndFlushMatrixToMatrix(unflat_m, op));
-  });
-
-  const result = spanF32Matrix(...outputs);
-  const result_cols = result.length;
-  const result_rows = result[0].length;
-
-  // F32Matrix has to be coerced to F32Interval[][] to use .every. This should
-  // always be safe, since F32Matrix are defined as fixed length array of
-  // arrays.
-  return (result as F32Interval[][]).every(c => c.every(r => r.isFinite()))
-    ? result
-    : kAnyF32Matrix[result_cols][result_rows];
+export function additionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  return kFPContext.f32.additionInterval(x, y);
 }
 
-/**
- * Calculate the Matrix of acceptance intervals by running a scalar operation
- * component-wise over a pair of matrices.
- *
- * An example of this is performing matrix addition.
- *
- * @param x first input domain intervals matrix
- * @param y second input domain intervals matrix
- * @param op scalar operation to be run component-wise
- * @returns a matrix of intervals with the outputs of op.impl
- */
-function runBinaryToIntervalOpMatrixComponentWise(
-  x: F32Matrix,
-  y: F32Matrix,
-  op: BinaryToIntervalOp
-): F32Matrix {
-  assert(
-    x.length === y.length && x[0].length === y[0].length,
-    `runBinaryToIntervalOpMatrixComponentWise requires matrices of the same dimensions`
-  );
-
-  const cols = x.length;
-  const rows = x[0].length;
-  const flat_x = flatten2DArray(x);
-  const flat_y = flatten2DArray(y);
-
-  return toF32Matrix(
-    unflatten2DArray(
-      flat_x.map((i, idx) => {
-        return runBinaryToIntervalOp(i, flat_y[idx], op);
-      }),
-      cols,
-      rows
-    )
-  );
+export function additionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
+  return kFPContext.f32.additionMatrixInterval(x, y);
 }
 
-/** Defines a PointToIntervalOp for an interval of the correctly rounded values around the point */
-const CorrectlyRoundedIntervalOp: PointToIntervalOp = {
-  impl: (n: number) => {
-    assert(!Number.isNaN(n), `absolute not defined for NaN`);
-    return toF32Interval(n);
-  },
-};
-
-/** @returns an interval of the correctly rounded values around the point */
-export function correctlyRoundedInterval(n: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), CorrectlyRoundedIntervalOp);
+export function asinInterval(n: number): FPInterval {
+  return kFPContext.f32.asinInterval(n);
 }
 
-/** @returns a matrix of correctly rounded intervals for the provided matrix */
-export function correctlyRoundedMatrix(m: Matrix<number>): F32Matrix {
-  return toF32Matrix(map2DArray(m, correctlyRoundedInterval));
+export function asinhInterval(n: number): FPInterval {
+  return kFPContext.f32.asinhInterval(n);
 }
 
-/** @returns a PointToIntervalOp for [n - error_range, n + error_range] */
-function AbsoluteErrorIntervalOp(error_range: number): PointToIntervalOp {
-  const op: PointToIntervalOp = {
-    impl: (_: number) => {
-      return F32Interval.any();
-    },
-  };
-
-  if (isFiniteF32(error_range)) {
-    op.impl = (n: number) => {
-      assert(!Number.isNaN(n), `absolute error not defined for NaN`);
-      return toF32Interval([n - error_range, n + error_range]);
-    };
-  }
-
-  return op;
+export function atanInterval(n: number | FPInterval): FPInterval {
+  return kFPContext.f32.atanInterval(n);
 }
 
-/** @returns an interval of the absolute error around the point */
-export function absoluteErrorInterval(n: number, error_range: number): F32Interval {
-  error_range = Math.abs(error_range);
-  return runPointToIntervalOp(toF32Interval(n), AbsoluteErrorIntervalOp(error_range));
+export function atan2Interval(y: number | FPInterval, x: number | FPInterval): FPInterval {
+  return kFPContext.f32.atan2Interval(y, x);
 }
 
-/** @returns a PointToIntervalOp for [n - numULP * ULP(n), n + numULP * ULP(n)] */
-function ULPIntervalOp(numULP: number): PointToIntervalOp {
-  const op: PointToIntervalOp = {
-    impl: (_: number) => {
-      return F32Interval.any();
-    },
-  };
-
-  if (isFiniteF32(numULP)) {
-    op.impl = (n: number) => {
-      assert(!Number.isNaN(n), `ULP error not defined for NaN`);
-
-      const ulp = oneULPF32(n);
-      const begin = n - numULP * ulp;
-      const end = n + numULP * ulp;
-
-      return toF32Interval([
-        Math.min(begin, flushSubnormalNumberF32(begin)),
-        Math.max(end, flushSubnormalNumberF32(end)),
-      ]);
-    };
-  }
-
-  return op;
+export function atanhInterval(n: number): FPInterval {
+  return kFPContext.f32.atanhInterval(n);
 }
 
-/** @returns an interval of N * ULP around the point */
-export function ulpInterval(n: number, numULP: number): F32Interval {
-  numULP = Math.abs(numULP);
-  return runPointToIntervalOp(toF32Interval(n), ULPIntervalOp(numULP));
+export function ceilInterval(n: number): FPInterval {
+  return kFPContext.f32.ceilInterval(n);
 }
 
-const AbsIntervalOp: PointToIntervalOp = {
-  impl: (n: number) => {
-    return correctlyRoundedInterval(Math.abs(n));
-  },
-};
+export const clampIntervals = kFPContext.f32.clampIntervals;
 
-/** Calculate an acceptance interval for abs(n) */
-export function absInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), AbsIntervalOp);
-}
-
-const AcosIntervalOp: PointToIntervalOp = {
-  impl: limitPointToIntervalDomain(toF32Interval([-1.0, 1.0]), (n: number) => {
-    // acos(n) = atan2(sqrt(1.0 - n * n), n) or a polynomial approximation with absolute error
-    const y = sqrtInterval(subtractionInterval(1, multiplicationInterval(n, n)));
-    return F32Interval.span(atan2Interval(y, n), absoluteErrorInterval(Math.acos(n), 6.77e-5));
-  }),
-};
-
-/** Calculate an acceptance interval for acos(n) */
-export function acosInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), AcosIntervalOp);
-}
-
-/** All acceptance interval functions for acosh(x) */
-export const acoshIntervals: PointToInterval[] = [acoshAlternativeInterval, acoshPrimaryInterval];
-
-const AcoshAlternativeIntervalOp: PointToIntervalOp = {
-  impl: (x: number): F32Interval => {
-    // acosh(x) = log(x + sqrt((x + 1.0f) * (x - 1.0)))
-    const inner_value = multiplicationInterval(
-      additionInterval(x, 1.0),
-      subtractionInterval(x, 1.0)
-    );
-    const sqrt_value = sqrtInterval(inner_value);
-    return logInterval(additionInterval(x, sqrt_value));
-  },
-};
-
-/** Calculate an acceptance interval of acosh(x) using log(x + sqrt((x + 1.0f) * (x - 1.0))) */
-export function acoshAlternativeInterval(x: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(x), AcoshAlternativeIntervalOp);
-}
-
-const AcoshPrimaryIntervalOp: PointToIntervalOp = {
-  impl: (x: number): F32Interval => {
-    // acosh(x) = log(x + sqrt(x * x - 1.0))
-    const inner_value = subtractionInterval(multiplicationInterval(x, x), 1.0);
-    const sqrt_value = sqrtInterval(inner_value);
-    return logInterval(additionInterval(x, sqrt_value));
-  },
-};
-
-/** Calculate an acceptance interval of acosh(x) using log(x + sqrt(x * x - 1.0)) */
-export function acoshPrimaryInterval(x: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(x), AcoshPrimaryIntervalOp);
-}
-
-const AdditionIntervalOp: BinaryToIntervalOp = {
-  impl: (x: number, y: number): F32Interval => {
-    return correctlyRoundedInterval(x + y);
-  },
-};
-
-/** Calculate an acceptance interval of x + y */
-export function additionInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), AdditionIntervalOp);
-}
-
-/** Calculate an acceptance interval of x + y, when x and y are matrices */
-export function additionMatrixInterval(x: Matrix<number>, y: Matrix<number>): F32Matrix {
-  return runBinaryToIntervalOpMatrixComponentWise(
-    toF32Matrix(x),
-    toF32Matrix(y),
-    AdditionIntervalOp
-  );
-}
-
-const AsinIntervalOp: PointToIntervalOp = {
-  impl: limitPointToIntervalDomain(toF32Interval([-1.0, 1.0]), (n: number) => {
-    // asin(n) = atan2(n, sqrt(1.0 - n * n)) or a polynomial approximation with absolute error
-    const x = sqrtInterval(subtractionInterval(1, multiplicationInterval(n, n)));
-    return F32Interval.span(atan2Interval(n, x), absoluteErrorInterval(Math.asin(n), 6.77e-5));
-  }),
-};
-
-/** Calculate an acceptance interval for asin(n) */
-export function asinInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), AsinIntervalOp);
-}
-
-const AsinhIntervalOp: PointToIntervalOp = {
-  impl: (x: number): F32Interval => {
-    // asinh(x) = log(x + sqrt(x * x + 1.0))
-    const inner_value = additionInterval(multiplicationInterval(x, x), 1.0);
-    const sqrt_value = sqrtInterval(inner_value);
-    return logInterval(additionInterval(x, sqrt_value));
-  },
-};
-
-/** Calculate an acceptance interval of asinh(x) */
-export function asinhInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), AsinhIntervalOp);
-}
-
-const AtanIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return ulpInterval(Math.atan(n), 4096);
-  },
-};
-
-/** Calculate an acceptance interval of atan(x) */
-export function atanInterval(n: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), AtanIntervalOp);
-}
-
-const Atan2IntervalOp: BinaryToIntervalOp = {
-  impl: limitBinaryToIntervalDomain(
-    {
-      // For atan2, there params are labelled (y, x), not (x, y), so domain.x is first parameter (y), and domain.y is
-      // the second parameter (x)
-      x: [
-        toF32Interval([kValue.f32.negative.min, kValue.f32.negative.max]),
-        toF32Interval([kValue.f32.positive.min, kValue.f32.positive.max]),
-      ], // first param must be finite and normal
-      y: [toF32Interval([-(2 ** 126), -(2 ** -126)]), toF32Interval([2 ** -126, 2 ** 126])], // inherited from division
-    },
-    (y: number, x: number): F32Interval => {
-      const atan_yx = Math.atan(y / x);
-      // x > 0, atan(y/x)
-      if (x > 0) {
-        return ulpInterval(atan_yx, 4096);
-      }
-
-      // x < 0, y > 0, atan(y/x) + π
-      if (y > 0) {
-        return ulpInterval(atan_yx + kValue.f32.positive.pi.whole, 4096);
-      }
-
-      // x < 0, y < 0, atan(y/x) - π
-      return ulpInterval(atan_yx - kValue.f32.positive.pi.whole, 4096);
-    }
-  ),
-  extrema: (y: F32Interval, x: F32Interval): [F32Interval, F32Interval] => {
-    // There is discontinuity + undefined behaviour at y/x = 0 that will dominate the accuracy
-    if (y.contains(0)) {
-      if (x.contains(0)) {
-        return [toF32Interval(0), toF32Interval(0)];
-      }
-      return [toF32Interval(0), x];
-    }
-    return [y, x];
-  },
-};
-
-/** Calculate an acceptance interval of atan2(y, x) */
-export function atan2Interval(y: number | F32Interval, x: number | F32Interval): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(y), toF32Interval(x), Atan2IntervalOp);
-}
-
-const AtanhIntervalOp: PointToIntervalOp = {
-  impl: (n: number) => {
-    // atanh(x) = log((1.0 + x) / (1.0 - x)) * 0.5
-    const numerator = additionInterval(1.0, n);
-    const denominator = subtractionInterval(1.0, n);
-    const log_interval = logInterval(divisionInterval(numerator, denominator));
-    return multiplicationInterval(log_interval, 0.5);
-  },
-};
-
-/** Calculate an acceptance interval of atanh(x) */
-export function atanhInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), AtanhIntervalOp);
-}
-
-const CeilIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return correctlyRoundedInterval(Math.ceil(n));
-  },
-};
-
-/** Calculate an acceptance interval of ceil(x) */
-export function ceilInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), CeilIntervalOp);
-}
-
-const ClampMedianIntervalOp: TernaryToIntervalOp = {
-  impl: (x: number, y: number, z: number): F32Interval => {
-    return correctlyRoundedInterval(
-      // Default sort is string sort, so have to implement numeric comparison.
-      // Cannot use the b-a one liner, because that assumes no infinities.
-      [x, y, z].sort((a, b) => {
-        if (a < b) {
-          return -1;
-        }
-        if (a > b) {
-          return 1;
-        }
-        return 0;
-      })[1]
-    );
-  },
-};
-
-/** All acceptance interval functions for clamp(x, y, z) */
-export const clampIntervals: TernaryToInterval[] = [clampMinMaxInterval, clampMedianInterval];
-
-/** Calculate an acceptance interval of clamp(x, y, z) via median(x, y, z) */
 export function clampMedianInterval(
-  x: number | F32Interval,
-  y: number | F32Interval,
-  z: number | F32Interval
-): F32Interval {
-  return runTernaryToIntervalOp(
-    toF32Interval(x),
-    toF32Interval(y),
-    toF32Interval(z),
-    ClampMedianIntervalOp
-  );
+  x: number | FPInterval,
+  y: number | FPInterval,
+  z: number | FPInterval
+): FPInterval {
+  return kFPContext.f32.clampMedianInterval(x, y, z);
 }
 
-const ClampMinMaxIntervalOp: TernaryToIntervalOp = {
-  impl: (x: number, low: number, high: number): F32Interval => {
-    return minInterval(maxInterval(x, low), high);
-  },
-};
-
-/** Calculate an acceptance interval of clamp(x, high, low) via min(max(x, low), high) */
 export function clampMinMaxInterval(
-  x: number | F32Interval,
-  low: number | F32Interval,
-  high: number | F32Interval
-): F32Interval {
-  return runTernaryToIntervalOp(
-    toF32Interval(x),
-    toF32Interval(low),
-    toF32Interval(high),
-    ClampMinMaxIntervalOp
-  );
+  x: number | FPInterval,
+  y: number | FPInterval,
+  z: number | FPInterval
+): FPInterval {
+  return kFPContext.f32.clampMinMaxInterval(x, y, z);
 }
 
-const CosIntervalOp: PointToIntervalOp = {
-  impl: limitPointToIntervalDomain(
-    kNegPiToPiInterval,
-    (n: number): F32Interval => {
-      return absoluteErrorInterval(Math.cos(n), 2 ** -11);
-    }
-  ),
-};
-
-/** Calculate an acceptance interval of cos(x) */
-export function cosInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), CosIntervalOp);
+export function cosInterval(n: number): FPInterval {
+  return kFPContext.f32.cosInterval(n);
 }
 
-const CoshIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    // cosh(x) = (exp(x) + exp(-x)) * 0.5
-    const minus_n = negationInterval(n);
-    return multiplicationInterval(additionInterval(expInterval(n), expInterval(minus_n)), 0.5);
-  },
-};
-
-/** Calculate an acceptance interval of cosh(x) */
-export function coshInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), CoshIntervalOp);
+export function coshInterval(n: number): FPInterval {
+  return kFPContext.f32.coshInterval(n);
 }
 
-const CrossIntervalOp: VectorPairToVectorOp = {
-  impl: (x: number[], y: number[]): F32Vector => {
-    assert(x.length === 3, `CrossIntervalOp received x with ${x.length} instead of 3`);
-    assert(y.length === 3, `CrossIntervalOp received y with ${y.length} instead of 3`);
-
-    // cross(x, y) = r, where
-    //   r[0] = x[1] * y[2] - x[2] * y[1]
-    //   r[1] = x[2] * y[0] - x[0] * y[2]
-    //   r[2] = x[0] * y[1] - x[1] * y[0]
-
-    const r0 = subtractionInterval(
-      multiplicationInterval(x[1], y[2]),
-      multiplicationInterval(x[2], y[1])
-    );
-    const r1 = subtractionInterval(
-      multiplicationInterval(x[2], y[0]),
-      multiplicationInterval(x[0], y[2])
-    );
-    const r2 = subtractionInterval(
-      multiplicationInterval(x[0], y[1]),
-      multiplicationInterval(x[1], y[0])
-    );
-    return [r0, r1, r2];
-  },
-};
-
-export function crossInterval(x: number[], y: number[]): F32Vector {
-  assert(x.length === 3, `Cross is only defined for vec3`);
-  assert(y.length === 3, `Cross is only defined for vec3`);
-  return runVectorPairToVectorOp(toF32Vector(x), toF32Vector(y), CrossIntervalOp);
+export function crossInterval(x: number[], y: number[]): FPVector {
+  return kFPContext.f32.crossInterval(x, y);
 }
 
-const DegreesIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return multiplicationInterval(n, 57.295779513082322865);
-  },
-};
-
-/** Calculate an acceptance interval of degrees(x) */
-export function degreesInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), DegreesIntervalOp);
+export function degreesInterval(n: number): FPInterval {
+  return kFPContext.f32.degreesInterval(n);
 }
 
-/**
- * Calculate the minor of a NxN matrix.
- *
- * The ijth minor of a square matrix, is the N-1xN-1 matrix created by removing
- * the ith column and jth row from the original matrix.
- */
-function minorNxN(m: Matrix<number>, col: number, row: number): Matrix<number> {
-  const dim = m.length;
-  assert(m.length === m[0].length, `minorMatrix is only defined for square matrices`);
-  assert(col >= 0 && col < dim, `col ${col} needs be in [0, # of columns '${dim}')`);
-  assert(row >= 0 && row < dim, `row ${row} needs be in [0, # of rows '${dim}')`);
-
-  const result: Matrix<number> = [...Array(dim - 1)].map(_ => [...Array(dim - 1)]);
-
-  const col_indices: number[] = [...Array(dim).keys()].filter(e => e !== col);
-  const row_indices: number[] = [...Array(dim).keys()].filter(e => e !== row);
-
-  col_indices.forEach((c, i) => {
-    row_indices.forEach((r, j) => {
-      result[i][j] = m[c][r];
-    });
-  });
-  return result;
+export function determinantInterval(m: number[][]): FPInterval {
+  return kFPContext.f32.determinantInterval(m);
 }
 
-/** Calculate an acceptance interval for determinant(m), where m is a 2x2 matrix */
-function determinant2x2Interval(m: Matrix<number>): F32Interval {
-  assert(
-    m.length === m[0].length && m.length === 2,
-    `determinant2x2Interval called on non-2x2 matrix`
-  );
-  return subtractionInterval(
-    multiplicationInterval(m[0][0], m[1][1]),
-    multiplicationInterval(m[0][1], m[1][0])
-  );
+export function distanceInterval(x: number | number[], y: number | number[]): FPInterval {
+  return kFPContext.f32.distanceInterval(x, y);
 }
 
-/** Calculate an acceptance interval for determinant(m), where m is a 3x3 matrix */
-function determinant3x3Interval(m: Matrix<number>): F32Interval {
-  assert(
-    m.length === m[0].length && m.length === 3,
-    `determinant3x3Interval called on non-3x3 matrix`
-  );
-
-  // M is a 3x3 matrix
-  // det(M) is A + B + C, where A, B, C are three elements in a row/column times
-  // their own co-factor.
-  // (The co-factor is the determinant of the minor of that position with the
-  // appropriate +/-)
-  // For simplicity sake A, B, C are calculated as the elements of the first
-  // column
-  const A = multiplicationInterval(m[0][0], determinant2x2Interval(minorNxN(m, 0, 0)));
-  const B = multiplicationInterval(-m[0][1], determinant2x2Interval(minorNxN(m, 0, 1)));
-  const C = multiplicationInterval(m[0][2], determinant2x2Interval(minorNxN(m, 0, 2)));
-
-  // Need to calculate permutations, since for fp addition is not associative,
-  // so A + B + C is not guaranteed to equal B + C + A, etc.
-  const permutations: F32Interval[][] = calculatePermutations([A, B, C]);
-  return F32Interval.span(
-    ...permutations.map(p =>
-      p.reduce((prev: F32Interval, cur: F32Interval) => additionInterval(prev, cur))
-    )
-  );
+export function divisionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  return kFPContext.f32.divisionInterval(x, y);
 }
 
-/** Calculate an acceptance interval for determinant(m), where m is a 4x4 matrix */
-function determinant4x4Interval(m: Matrix<number>): F32Interval {
-  assert(
-    m.length === m[0].length && m.length === 4,
-    `determinant3x3Interval called on non-4x4 matrix`
-  );
-
-  // M is a 4x4 matrix
-  // det(M) is A + B + C + D, where A, B, C, D are four elements in a row/column
-  // times their own co-factor.
-  // (The co-factor is the determinant of the minor of that position with the
-  // appropriate +/-)
-  // For simplicity sake A, B, C, D are calculated as the elements of the
-  // first column
-  const A = multiplicationInterval(m[0][0], determinant3x3Interval(minorNxN(m, 0, 0)));
-  const B = multiplicationInterval(-m[0][1], determinant3x3Interval(minorNxN(m, 0, 1)));
-  const C = multiplicationInterval(m[0][2], determinant3x3Interval(minorNxN(m, 0, 2)));
-  const D = multiplicationInterval(-m[0][3], determinant3x3Interval(minorNxN(m, 0, 3)));
-
-  // Need to calculate permutations, since for fp addition is not associative
-  // so A + B + C + D is not guaranteed to equal B + C + A + D, etc.
-  const permutations: F32Interval[][] = calculatePermutations([A, B, C, D]);
-  return F32Interval.span(
-    ...permutations.map(p =>
-      p.reduce((prev: F32Interval, cur: F32Interval) => additionInterval(prev, cur))
-    )
-  );
+export function dotInterval(x: number[] | FPInterval[], y: number[] | FPInterval[]): FPInterval {
+  return kFPContext.f32.dotInterval(x, y);
 }
 
-/**
- * Calculate an acceptance interval for determinant(x)
- *
- * This code calculates 3x3 and 4x4 determinants using the textbook co-factor
- * method, using the first column for the co-factor selection.
- *
- * For matrices composed of integer elements, e, with |e|^4 < 2**21, this
- * should be fine.
- *
- * For e, where e is subnormal or 4*(e^4) might not be precisely expressible as
- * a f32 values, this approach breaks down, because the rule of all co-factor
- * definitions of determinant being equal doesn't hold in these cases.
- *
- * The general solution for this is to calculate all of the permutations of the
- * operations in the worked out formula for determinant.
- * For 3x3 this is tractable, but for 4x4 this works out to ~23! permutations
- * that need to be calculated.
- * Thus CTS testing, and the spec definition of accuracy is restricted to the
- * space that the simple implementation is valid.
- */
-export function determinantInterval(x: Matrix<number>): F32Interval {
-  const dim = x.length;
-  assert(
-    x[0].length === dim && (dim === 2 || dim === 3 || dim === 4),
-    `determinantInterval only defined for 2x2, 3x3 and 4x4 matrices`
-  );
-  switch (dim) {
-    case 2:
-      return determinant2x2Interval(x);
-    case 3:
-      return determinant3x3Interval(x);
-    case 4:
-      return determinant4x4Interval(x);
-  }
-  unreachable(
-    "determinantInterval called on x, where which has an unexpected dimension of '${dim}'"
-  );
+export function expInterval(x: number | FPInterval): FPInterval {
+  return kFPContext.f32.expInterval(x);
 }
 
-const DistanceIntervalScalarOp: BinaryToIntervalOp = {
-  impl: (x: number, y: number): F32Interval => {
-    return lengthInterval(subtractionInterval(x, y));
-  },
-};
-
-const DistanceIntervalVectorOp: VectorPairToIntervalOp = {
-  impl: (x: number[], y: number[]): F32Interval => {
-    return lengthInterval(
-      runBinaryToIntervalOpVectorComponentWise(
-        toF32Vector(x),
-        toF32Vector(y),
-        SubtractionIntervalOp
-      )
-    );
-  },
-};
-
-/** Calculate an acceptance interval of distance(x, y) */
-export function distanceInterval(x: number | number[], y: number | number[]): F32Interval {
-  if (x instanceof Array && y instanceof Array) {
-    assert(
-      x.length === y.length,
-      `distanceInterval requires both params to have the same number of elements`
-    );
-    return runVectorPairToIntervalOp(toF32Vector(x), toF32Vector(y), DistanceIntervalVectorOp);
-  } else if (!(x instanceof Array) && !(y instanceof Array)) {
-    return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), DistanceIntervalScalarOp);
-  }
-  unreachable(
-    `distanceInterval requires both params to both the same type, either scalars or vectors`
-  );
+export function exp2Interval(x: number | FPInterval): FPInterval {
+  return kFPContext.f32.exp2Interval(x);
 }
 
-const DivisionIntervalOp: BinaryToIntervalOp = {
-  impl: limitBinaryToIntervalDomain(
-    {
-      x: [toF32Interval([kValue.f32.negative.min, kValue.f32.positive.max])],
-      y: [toF32Interval([-(2 ** 126), -(2 ** -126)]), toF32Interval([2 ** -126, 2 ** 126])],
-    },
-    (x: number, y: number): F32Interval => {
-      if (y === 0) {
-        return F32Interval.any();
-      }
-      return ulpInterval(x / y, 2.5);
-    }
-  ),
-  extrema: (x: F32Interval, y: F32Interval): [F32Interval, F32Interval] => {
-    // division has a discontinuity at y = 0.
-    if (y.contains(0)) {
-      y = toF32Interval(0);
-    }
-    return [x, y];
-  },
-};
-
-/** Calculate an acceptance interval of x / y */
-export function divisionInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), DivisionIntervalOp);
-}
-
-const DotIntervalOp: VectorPairToIntervalOp = {
-  impl: (x: number[], y: number[]): F32Interval => {
-    // dot(x, y) = sum of x[i] * y[i]
-    const multiplications = runBinaryToIntervalOpVectorComponentWise(
-      toF32Vector(x),
-      toF32Vector(y),
-      MultiplicationIntervalOp
-    );
-
-    // vec2 doesn't require permutations, since a + b = b + a for floats
-    if (multiplications.length === 2) {
-      return additionInterval(multiplications[0], multiplications[1]);
-    }
-
-    // The spec does not state the ordering of summation, so all of the permutations are calculated and their results
-    // spanned, since addition of more then two floats is not transitive, i.e. a + b + c is not guaranteed to equal
-    // b + a + c
-    const permutations: F32Interval[][] = calculatePermutations(multiplications);
-    return F32Interval.span(
-      ...permutations.map(p => p.reduce((prev, cur) => additionInterval(prev, cur)))
-    );
-  },
-};
-
-export function dotInterval(x: number[] | F32Interval[], y: number[] | F32Interval[]): F32Interval {
-  assert(x.length === y.length, `dot not defined for vectors with different lengths`);
-  return runVectorPairToIntervalOp(toF32Vector(x), toF32Vector(y), DotIntervalOp);
-}
-
-const ExpIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return ulpInterval(Math.exp(n), 3 + 2 * Math.abs(n));
-  },
-};
-
-/** Calculate an acceptance interval for exp(x) */
-export function expInterval(x: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(x), ExpIntervalOp);
-}
-
-const Exp2IntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return ulpInterval(Math.pow(2, n), 3 + 2 * Math.abs(n));
-  },
-};
-
-/** Calculate an acceptance interval for exp2(x) */
-export function exp2Interval(x: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(x), Exp2IntervalOp);
-}
-
-/**
- * Calculate the acceptance intervals for faceForward(x, y, z)
- *
- * faceForward(x, y, z) = select(-x, x, dot(z, y) < 0.0)
- *
- * This builtin selects from two discrete results (delta rounding/flushing), so
- * the majority of the framework code is not appropriate, since the framework
- * attempts to span results.
- *
- * Thus a bespoke implementation is used instead of
- * defining a Op and running that through the framework.
- */
 export function faceForwardIntervals(
   x: number[],
   y: number[],
   z: number[]
-): (F32Vector | undefined)[] {
-  const x_vec = toF32Vector(x);
-  // Running vector through runPointToIntervalOpComponentWise to make sure that flushing/rounding is handled, since
-  // toF32Vector does not perform those operations.
-  const positive_x = runPointToIntervalOpComponentWise(x_vec, { impl: toF32Interval });
-  const negative_x = runPointToIntervalOpComponentWise(x_vec, NegationIntervalOp);
-
-  const dot_interval = dotInterval(z, y);
-
-  const results: (F32Vector | undefined)[] = [];
-
-  if (!dot_interval.isFinite()) {
-    // dot calculation went out of bounds
-    // Inserting undefine in the result, so that the test running framework is aware
-    // of this potential OOB.
-    // For const-eval tests, it means that the test case should be skipped,
-    // since the shader will fail to compile.
-    // For non-const-eval the undefined should be stripped out of the possible
-    // results.
-
-    results.push(undefined);
-  }
-
-  // Because the result of dot can be an interval, it might span across 0, thus
-  // it is possible that both -x and x are valid responses.
-  if (dot_interval.begin < 0 || dot_interval.end < 0) {
-    results.push(positive_x);
-  }
-
-  if (dot_interval.begin >= 0 || dot_interval.end >= 0) {
-    results.push(negative_x);
-  }
-
-  assert(
-    results.length > 0 || results.every(r => r === undefined),
-    `faceForwardInterval selected neither positive x or negative x for the result, this shouldn't be possible`
-  );
-  return results;
+): (FPVector | undefined)[] {
+  return kFPContext.f32.faceForwardIntervals(x, y, z);
 }
 
-const FloorIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return correctlyRoundedInterval(Math.floor(n));
-  },
-};
-
-/** Calculate an acceptance interval of floor(x) */
-export function floorInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), FloorIntervalOp);
+export function floorInterval(n: number): FPInterval {
+  return kFPContext.f32.floorInterval(n);
 }
 
-const FmaIntervalOp: TernaryToIntervalOp = {
-  impl: (x: number, y: number, z: number): F32Interval => {
-    return additionInterval(multiplicationInterval(x, y), z);
-  },
-};
-
-/** Calculate an acceptance interval for fma(x, y, z) */
-export function fmaInterval(x: number, y: number, z: number): F32Interval {
-  return runTernaryToIntervalOp(
-    toF32Interval(x),
-    toF32Interval(y),
-    toF32Interval(z),
-    FmaIntervalOp
-  );
+export function fmaInterval(x: number, y: number, z: number): FPInterval {
+  return kFPContext.f32.fmaInterval(x, y, z);
 }
 
-const FractIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    // fract(x) = x - floor(x) is defined in the spec.
-    // For people coming from a non-graphics background this will cause some unintuitive results. For example,
-    // fract(-1.1) is not 0.1 or -0.1, but instead 0.9.
-    // This is how other shading languages operate and allows for a desirable wrap around in graphics programming.
-    const result = subtractionInterval(n, floorInterval(n));
-    if (result.contains(1)) {
-      // Very small negative numbers can lead to catastrophic cancellation, thus calculating a fract of 1.0, which is
-      // technically not a fractional part, so some implementations clamp the result to next nearest number.
-      return F32Interval.span(result, toF32Interval(kValue.f32.positive.less_than_one));
-    }
-    return result;
-  },
-};
-
-/** Calculate an acceptance interval of fract(x) */
-export function fractInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), FractIntervalOp);
+export function fractInterval(n: number): FPInterval {
+  return kFPContext.f32.fractInterval(n);
 }
 
-const InverseSqrtIntervalOp: PointToIntervalOp = {
-  impl: limitPointToIntervalDomain(
-    kGreaterThanZeroInterval,
-    (n: number): F32Interval => {
-      return ulpInterval(1 / Math.sqrt(n), 2);
-    }
-  ),
-};
-
-/** Calculate an acceptance interval of inverseSqrt(x) */
-export function inverseSqrtInterval(n: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), InverseSqrtIntervalOp);
+export function inverseSqrtInterval(n: number | FPInterval): FPInterval {
+  return kFPContext.f32.inverseSqrtInterval(n);
 }
 
-const LdexpIntervalOp: BinaryToIntervalOp = {
-  impl: limitBinaryToIntervalDomain(
-    // Implementing SPIR-V's more restrictive domain until
-    // https://github.com/gpuweb/gpuweb/issues/3134 is resolved
-    {
-      x: [toF32Interval([kValue.f32.negative.min, kValue.f32.positive.max])],
-      y: [toF32Interval([-126, 128])],
-    },
-    (e1: number, e2: number): F32Interval => {
-      // Though the spec says the result of ldexp(e1, e2) = e1 * 2 ^ e2, the
-      // accuracy is listed as correctly rounded to the true value, so the
-      // inheritance framework does not need to be invoked to determine bounds.
-      // Instead the value at a higher precision is calculated and passed to
-      // correctlyRoundedInterval.
-      const result = e1 * 2 ** e2;
-      if (Number.isNaN(result)) {
-        // Overflowed TS's number type, so definitely out of bounds for f32
-        return F32Interval.any();
-      }
-      return correctlyRoundedInterval(result);
-    }
-  ),
-};
-
-/** Calculate an acceptance interval of ldexp(e1, e2) */
-export function ldexpInterval(e1: number, e2: number): F32Interval {
-  return roundAndFlushBinaryToInterval(e1, e2, LdexpIntervalOp);
+export function ldexpInterval(e1: number, e2: number): FPInterval {
+  return kFPContext.f32.ldexpInterval(e1, e2);
 }
 
-const LengthIntervalScalarOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return sqrtInterval(multiplicationInterval(n, n));
-  },
-};
-
-const LengthIntervalVectorOp: VectorToIntervalOp = {
-  impl: (n: number[]): F32Interval => {
-    return sqrtInterval(dotInterval(n, n));
-  },
-};
-
-/** Calculate an acceptance interval of length(x) */
-export function lengthInterval(n: number | F32Interval | number[] | F32Vector): F32Interval {
-  if (n instanceof Array) {
-    return runVectorToIntervalOp(toF32Vector(n), LengthIntervalVectorOp);
-  } else {
-    return runPointToIntervalOp(toF32Interval(n), LengthIntervalScalarOp);
-  }
+export function lengthInterval(n: number | FPInterval | number[] | FPVector): FPInterval {
+  return kFPContext.f32.lengthInterval(n);
 }
 
-const LogIntervalOp: PointToIntervalOp = {
-  impl: limitPointToIntervalDomain(
-    kGreaterThanZeroInterval,
-    (n: number): F32Interval => {
-      if (n >= 0.5 && n <= 2.0) {
-        return absoluteErrorInterval(Math.log(n), 2 ** -21);
-      }
-      return ulpInterval(Math.log(n), 3);
-    }
-  ),
-};
-
-/** Calculate an acceptance interval of log(x) */
-export function logInterval(x: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(x), LogIntervalOp);
+export function logInterval(x: number | FPInterval): FPInterval {
+  return kFPContext.f32.logInterval(x);
 }
 
-const Log2IntervalOp: PointToIntervalOp = {
-  impl: limitPointToIntervalDomain(
-    kGreaterThanZeroInterval,
-    (n: number): F32Interval => {
-      if (n >= 0.5 && n <= 2.0) {
-        return absoluteErrorInterval(Math.log2(n), 2 ** -21);
-      }
-      return ulpInterval(Math.log2(n), 3);
-    }
-  ),
-};
-
-/** Calculate an acceptance interval of log2(x) */
-export function log2Interval(x: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(x), Log2IntervalOp);
+export function log2Interval(x: number | FPInterval): FPInterval {
+  return kFPContext.f32.log2Interval(x);
 }
 
-const MaxIntervalOp: BinaryToIntervalOp = {
-  impl: (x: number, y: number): F32Interval => {
-    // If both of he inputs are subnormal, then either of the inputs can be returned
-    if (isSubnormalNumberF32(x) && isSubnormalNumberF32(y)) {
-      return correctlyRoundedInterval(F32Interval.span(toF32Interval(x), toF32Interval(y)));
-    }
-
-    return correctlyRoundedInterval(Math.max(x, y));
-  },
-};
-
-/** Calculate an acceptance interval of max(x, y) */
-export function maxInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), MaxIntervalOp);
+export function maxInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  return kFPContext.f32.maxInterval(x, y);
 }
 
-const MinIntervalOp: BinaryToIntervalOp = {
-  impl: (x: number, y: number): F32Interval => {
-    // If both of he inputs are subnormal, then either of the inputs can be returned
-    if (isSubnormalNumberF32(x) && isSubnormalNumberF32(y)) {
-      return correctlyRoundedInterval(F32Interval.span(toF32Interval(x), toF32Interval(y)));
-    }
-
-    return correctlyRoundedInterval(Math.min(x, y));
-  },
-};
-
-/** Calculate an acceptance interval of min(x, y) */
-export function minInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), MinIntervalOp);
+export function minInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  return kFPContext.f32.minInterval(x, y);
 }
 
-const MixImpreciseIntervalOp: TernaryToIntervalOp = {
-  impl: (x: number, y: number, z: number): F32Interval => {
-    // x + (y - x) * z =
-    //  x + t, where t = (y - x) * z
-    const t = multiplicationInterval(subtractionInterval(y, x), z);
-    return additionInterval(x, t);
-  },
-};
+export const mixIntervals = kFPContext.f32.mixIntervals;
 
-/** All acceptance interval functions for mix(x, y, z) */
-export const mixIntervals: TernaryToInterval[] = [mixImpreciseInterval, mixPreciseInterval];
-
-/** Calculate an acceptance interval of mix(x, y, z) using x + (y - x) * z */
-export function mixImpreciseInterval(x: number, y: number, z: number): F32Interval {
-  return runTernaryToIntervalOp(
-    toF32Interval(x),
-    toF32Interval(y),
-    toF32Interval(z),
-    MixImpreciseIntervalOp
-  );
+export function mixImpreciseInterval(x: number, y: number, z: number): FPInterval {
+  return kFPContext.f32.mixImpreciseInterval(x, y, z);
 }
 
-const MixPreciseIntervalOp: TernaryToIntervalOp = {
-  impl: (x: number, y: number, z: number): F32Interval => {
-    // x * (1.0 - z) + y * z =
-    //   t + s, where t = x * (1.0 - z), s = y * z
-    const t = multiplicationInterval(x, subtractionInterval(1.0, z));
-    const s = multiplicationInterval(y, z);
-    return additionInterval(t, s);
-  },
-};
-
-/** Calculate an acceptance interval of mix(x, y, z) using x * (1.0 - z) + y * z */
-export function mixPreciseInterval(x: number, y: number, z: number): F32Interval {
-  return runTernaryToIntervalOp(
-    toF32Interval(x),
-    toF32Interval(y),
-    toF32Interval(z),
-    MixPreciseIntervalOp
-  );
+export function mixPreciseInterval(x: number, y: number, z: number): FPInterval {
+  return kFPContext.f32.mixPreciseInterval(x, y, z);
 }
 
-/** Calculate an acceptance interval of modf(x) */
-export function modfInterval(n: number): { fract: F32Interval; whole: F32Interval } {
-  const fract = correctlyRoundedInterval(n % 1.0);
-  const whole = correctlyRoundedInterval(n - (n % 1.0));
-  return { fract, whole };
+export function modfInterval(n: number): { fract: FPInterval; whole: FPInterval } {
+  return kFPContext.f32.modfInterval(n);
 }
 
-const MultiplicationInnerOp = {
-  impl: (x: number, y: number): F32Interval => {
-    return correctlyRoundedInterval(x * y);
-  },
-};
-
-const MultiplicationIntervalOp: BinaryToIntervalOp = {
-  impl: (x: number, y: number): F32Interval => {
-    return roundAndFlushBinaryToInterval(x, y, MultiplicationInnerOp);
-  },
-};
-
-/** Calculate an acceptance interval of x * y */
-export function multiplicationInterval(
-  x: number | F32Interval,
-  y: number | F32Interval
-): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), MultiplicationIntervalOp);
+export function multiplicationInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  return kFPContext.f32.multiplicationInterval(x, y);
 }
 
-/** Calculate an acceptance interval of x * y, when x is a matrix and y is a scalar */
-export function multiplicationMatrixScalarInterval(mat: Matrix<number>, scalar: number): F32Matrix {
-  const cols = mat.length;
-  const rows = mat[0].length;
-  return toF32Matrix(
-    unflatten2DArray(
-      flatten2DArray(mat).map(e => MultiplicationIntervalOp.impl(e, scalar)),
-      cols,
-      rows
-    )
-  );
+export function multiplicationMatrixScalarInterval(mat: number[][], scalar: number): FPMatrix {
+  return kFPContext.f32.multiplicationMatrixScalarInterval(mat, scalar);
 }
 
-/** Calculate an acceptance interval of x * y, when x is a scalar and y is a matrix */
-export function multiplicationScalarMatrixInterval(scalar: number, mat: Matrix<number>): F32Matrix {
-  return multiplicationMatrixScalarInterval(mat, scalar);
+export function multiplicationScalarMatrixInterval(scalar: number, mat: number[][]): FPMatrix {
+  return kFPContext.f32.multiplicationScalarMatrixInterval(scalar, mat);
 }
 
-/** Calculate an acceptance interval of x * y, when x is a matrix and y is a matrix */
-export function multiplicationMatrixMatrixInterval(
-  mat_x: Matrix<number>,
-  mat_y: Matrix<number>
-): F32Matrix {
-  const x_cols = mat_x.length;
-  const x_rows = mat_x[0].length;
-  const y_cols = mat_y.length;
-  const y_rows = mat_y[0].length;
-  assert(x_cols === y_rows, `'mat${x_cols}x${x_rows} * mat${y_cols}x${y_rows}' is not defined`);
-
-  const x_transposed = transposeInterval(mat_x);
-
-  const result: Matrix<F32Interval> = [...Array(y_cols)].map(_ => [...Array(x_rows)]);
-  mat_y.forEach((y, i) => {
-    x_transposed.forEach((x, j) => {
-      result[i][j] = dotInterval(x, y);
-    });
-  });
-
-  return result as F32Matrix;
+export function multiplicationMatrixMatrixInterval(mat_x: number[][], mat_y: number[][]): FPMatrix {
+  return kFPContext.f32.multiplicationMatrixMatrixInterval(mat_x, mat_y);
 }
 
-/** Calculate an acceptance interval of x * y, when x is a matrix and y is a vector */
-export function multiplicationMatrixVectorInterval(x: Matrix<number>, y: number[]): F32Vector {
-  const cols = x.length;
-  const rows = x[0].length;
-  assert(y.length === cols, `'mat${cols}x${rows} * vec${y.length}' is not defined`);
-
-  return transposeInterval(x).map(e => dotInterval(e, y)) as F32Vector;
+export function multiplicationMatrixVectorInterval(x: number[][], y: number[]): FPVector {
+  return kFPContext.f32.multiplicationMatrixVectorInterval(x, y);
 }
 
-/** Calculate an acceptance interval of x * y, when x is a vector and y is a matrix */
-export function multiplicationVectorMatrixInterval(x: number[], y: Matrix<number>): F32Vector {
-  const cols = y.length;
-  const rows = y[0].length;
-  assert(x.length === rows, `'vec${x.length} * mat${cols}x${rows}' is not defined`);
-
-  return y.map(e => dotInterval(x, e)) as F32Vector;
+export function multiplicationVectorMatrixInterval(x: number[], y: number[][]): FPVector {
+  return kFPContext.f32.multiplicationVectorMatrixInterval(x, y);
 }
 
-const NegationIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return correctlyRoundedInterval(-n);
-  },
-};
-
-/** Calculate an acceptance interval of -x */
-export function negationInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), NegationIntervalOp);
+export function negationInterval(n: number): FPInterval {
+  return kFPContext.f32.negationInterval(n);
 }
 
-const NormalizeIntervalOp: VectorToVectorOp = {
-  impl: (n: number[]): F32Vector => {
-    const length = lengthInterval(n);
-    return toF32Vector(n.map(e => divisionInterval(e, length)));
-  },
-};
-
-/** Calculate an acceptance interval of normalize(x) */
-export function normalizeInterval(n: number[]): F32Vector {
-  return runVectorToVectorOp(toF32Vector(n), NormalizeIntervalOp);
+export function normalizeInterval(n: number[]): FPVector {
+  return kFPContext.f32.normalizeInterval(n);
 }
 
-const PowIntervalOp: BinaryToIntervalOp = {
-  // pow(x, y) has no explicit domain restrictions, but inherits the x <= 0
-  // domain restriction from log2(x). Invoking log2Interval(x) in impl will
-  // enforce this, so there is no need to wrap the impl call here.
-  impl: (x: number, y: number): F32Interval => {
-    return exp2Interval(multiplicationInterval(y, log2Interval(x)));
-  },
-};
-
-/** Calculate an acceptance interval of pow(x, y) */
-export function powInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), PowIntervalOp);
+export function powInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  return kFPContext.f32.powInterval(x, y);
 }
 
-// Once a full implementation of F16Interval exists, the correctlyRounded for
-// that can potentially be used instead of having a bespoke operation
-// implementation.
-const QuantizeToF16IntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    const rounded = correctlyRoundedF16(n);
-    const flushed = addFlushedIfNeededF16(rounded);
-    return F32Interval.span(...flushed.map(toF32Interval));
-  },
-};
-
-/** Calculate an acceptance interval of quanitizeToF16(x) */
-export function quantizeToF16Interval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), QuantizeToF16IntervalOp);
+export function quantizeToF16Interval(n: number): FPInterval {
+  return kFPContext.f32.quantizeToF16Interval(n);
 }
 
-const RadiansIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return multiplicationInterval(n, 0.017453292519943295474);
-  },
-};
-
-/** Calculate an acceptance interval of radians(x) */
-export function radiansInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), RadiansIntervalOp);
+export function radiansInterval(n: number): FPInterval {
+  return kFPContext.f32.radiansInterval(n);
 }
 
-const ReflectIntervalOp: VectorPairToVectorOp = {
-  impl: (x: number[], y: number[]): F32Vector => {
-    assert(
-      x.length === y.length,
-      `ReflectIntervalOp received x (${x}) and y (${y}) with different numbers of elements`
-    );
-
-    // reflect(x, y) = x - 2.0 * dot(x, y) * y
-    //               = x - t * y, t = 2.0 * dot(x, y)
-    // x = incident vector
-    // y = normal of reflecting surface
-    const t = multiplicationInterval(2.0, dotInterval(x, y));
-    const rhs = multiplyVectorByScalar(y, t);
-    return runBinaryToIntervalOpVectorComponentWise(toF32Vector(x), rhs, SubtractionIntervalOp);
-  },
-};
-
-/** Calculate an acceptance interval of reflect(x, y) */
-export function reflectInterval(x: number[], y: number[]): F32Vector {
-  assert(
-    x.length === y.length,
-    `reflect is only defined for vectors with the same number of elements`
-  );
-  return runVectorPairToVectorOp(toF32Vector(x), toF32Vector(y), ReflectIntervalOp);
+export function reflectInterval(x: number[], y: number[]): FPVector {
+  return kFPContext.f32.reflectInterval(x, y);
 }
 
-/**
- * Calculate acceptance interval vectors of reflect(i, s, r)
- *
- * refract is a singular function in the sense that it is the only builtin that
- * takes in (F32Vector, F32Vector, F32) and returns F32Vector and is basically
- * defined in terms of other functions.
- *
- * Instead of implementing all of the framework code to integrate it with its
- * own operation type/etc, it instead has a bespoke implementation that is a
- * composition of other builtin functions that use the framework.
- */
-export function refractInterval(i: number[], s: number[], r: number): F32Vector {
-  assert(
-    i.length === s.length,
-    `refract is only defined for vectors with the same number of elements`
-  );
-
-  const r_squared = multiplicationInterval(r, r);
-  const dot = dotInterval(s, i);
-  const dot_squared = multiplicationInterval(dot, dot);
-  const one_minus_dot_squared = subtractionInterval(1, dot_squared);
-  const k = subtractionInterval(1.0, multiplicationInterval(r_squared, one_minus_dot_squared));
-
-  if (!k.isFinite() || k.containsZeroOrSubnormals()) {
-    // There is a discontinuity at k == 0, due to sqrt(k) being calculated, so exiting early
-    return kAnyVector[toF32Vector(i).length];
-  }
-
-  if (k.end < 0.0) {
-    // if k is negative, then the zero vector is the valid response
-    return kZeroVector[toF32Vector(i).length];
-  }
-
-  const dot_times_r = multiplicationInterval(dot, r);
-  const k_sqrt = sqrtInterval(k);
-  const t = additionInterval(dot_times_r, k_sqrt); // t = r * dot(i, s) + sqrt(k)
-
-  const result = runBinaryToIntervalOpVectorComponentWise(
-    multiplyVectorByScalar(i, r),
-    multiplyVectorByScalar(s, t),
-    SubtractionIntervalOp
-  ); // (i * r) - (s * t)
-  return result;
+export function refractInterval(i: number[], s: number[], r: number): FPVector {
+  return kFPContext.f32.refractInterval(i, s, r);
 }
 
-const RemainderIntervalOp: BinaryToIntervalOp = {
-  impl: (x: number, y: number): F32Interval => {
-    // x % y = x - y * trunc(x/y)
-    return subtractionInterval(x, multiplicationInterval(y, truncInterval(divisionInterval(x, y))));
-  },
-};
-
-/** Calculate an acceptance interval for x % y */
-export function remainderInterval(x: number, y: number): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), RemainderIntervalOp);
+export function remainderInterval(x: number, y: number): FPInterval {
+  return kFPContext.f32.remainderInterval(x, y);
 }
 
-const RoundIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    const k = Math.floor(n);
-    const diff_before = n - k;
-    const diff_after = k + 1 - n;
-    if (diff_before < diff_after) {
-      return correctlyRoundedInterval(k);
-    } else if (diff_before > diff_after) {
-      return correctlyRoundedInterval(k + 1);
-    }
-
-    // n is in the middle of two integers.
-    // The tie breaking rule is 'k if k is even, k + 1 if k is odd'
-    if (k % 2 === 0) {
-      return correctlyRoundedInterval(k);
-    }
-    return correctlyRoundedInterval(k + 1);
-  },
-};
-
-/** Calculate an acceptance interval of round(x) */
-export function roundInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), RoundIntervalOp);
+export function roundInterval(n: number): FPInterval {
+  return kFPContext.f32.roundInterval(n);
 }
 
-/**
- * Calculate an acceptance interval of saturate(n) as clamp(n, 0.0, 1.0)
- *
- * The definition of saturate does not specify which version of clamp to use.
- * Using min-max here, since it has wider acceptance intervals, that include
- * all of median's.
- */
-export function saturateInterval(n: number): F32Interval {
-  return runTernaryToIntervalOp(
-    toF32Interval(n),
-    toF32Interval(0.0),
-    toF32Interval(1.0),
-    ClampMinMaxIntervalOp
-  );
+export function saturateInterval(n: number): FPInterval {
+  return kFPContext.f32.saturateInterval(n);
 }
 
-const SignIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    if (n > 0.0) {
-      return correctlyRoundedInterval(1.0);
-    }
-    if (n < 0.0) {
-      return correctlyRoundedInterval(-1.0);
-    }
-
-    return correctlyRoundedInterval(0.0);
-  },
-};
-
-/** Calculate an acceptance interval of sin(x) */
-export function signInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), SignIntervalOp);
+export function signInterval(n: number): FPInterval {
+  return kFPContext.f32.signInterval(n);
 }
 
-const SinIntervalOp: PointToIntervalOp = {
-  impl: limitPointToIntervalDomain(
-    kNegPiToPiInterval,
-    (n: number): F32Interval => {
-      return absoluteErrorInterval(Math.sin(n), 2 ** -11);
-    }
-  ),
-};
-
-/** Calculate an acceptance interval of sin(x) */
-export function sinInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), SinIntervalOp);
+export function sinInterval(n: number): FPInterval {
+  return kFPContext.f32.sinInterval(n);
 }
 
-const SinhIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    // sinh(x) = (exp(x) - exp(-x)) * 0.5
-    const minus_n = negationInterval(n);
-    return multiplicationInterval(subtractionInterval(expInterval(n), expInterval(minus_n)), 0.5);
-  },
-};
-
-/** Calculate an acceptance interval of sinh(x) */
-export function sinhInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), SinhIntervalOp);
+export function sinhInterval(n: number): FPInterval {
+  return kFPContext.f32.sinhInterval(n);
 }
 
-const SmoothStepOp: TernaryToIntervalOp = {
-  impl: (low: number, high: number, x: number): F32Interval => {
-    // For clamp(foo, 0.0, 1.0) the different implementations of clamp provide
-    // the same value, so arbitrarily picking the minmax version to use.
-    // t = clamp((x - low) / (high - low), 0.0, 1.0)
-    // prettier-ignore
-    const t = clampMedianInterval(
-      divisionInterval(
-        subtractionInterval(x, low),
-        subtractionInterval(high, low)),
-      0.0,
-      1.0);
-    // Inherited from t * t * (3.0 - 2.0 * t)
-    // prettier-ignore
-    return multiplicationInterval(
-      t,
-      multiplicationInterval(t,
-        subtractionInterval(3.0,
-          multiplicationInterval(2.0, t))));
-  },
-};
-
-/** Calculate an acceptance interval of smoothStep(low, high, x) */
-export function smoothStepInterval(low: number, high: number, x: number): F32Interval {
-  return runTernaryToIntervalOp(
-    toF32Interval(low),
-    toF32Interval(high),
-    toF32Interval(x),
-    SmoothStepOp
-  );
+export function smoothStepInterval(low: number, high: number, x: number): FPInterval {
+  return kFPContext.f32.smoothStepInterval(low, high, x);
 }
 
-const SqrtIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return divisionInterval(1.0, inverseSqrtInterval(n));
-  },
-};
-
-/** Calculate an acceptance interval of sqrt(x) */
-export function sqrtInterval(n: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), SqrtIntervalOp);
+export function sqrtInterval(n: number | FPInterval): FPInterval {
+  return kFPContext.f32.sqrtInterval(n);
 }
 
-const StepIntervalOp: BinaryToIntervalOp = {
-  impl: (edge: number, x: number): F32Interval => {
-    if (edge <= x) {
-      return correctlyRoundedInterval(1.0);
-    }
-    return correctlyRoundedInterval(0.0);
-  },
-};
-
-/** Calculate an acceptance 'interval' for step(edge, x)
- *
- * step only returns two possible values, so its interval requires special
- * interpretation in CTS tests.
- * This interval will be one of four values: [0, 0], [0, 1], [1, 1] & [-∞, +∞].
- * [0, 0] and [1, 1] indicate that the correct answer in point they encapsulate.
- * [0, 1] should not be treated as a span, i.e. 0.1 is acceptable, but instead
- * indicate either 0.0 or 1.0 are acceptable answers.
- * [-∞, +∞] is treated as the any interval, since an undefined or infinite value was passed in.
- */
-export function stepInterval(edge: number, x: number): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(edge), toF32Interval(x), StepIntervalOp);
+export function stepInterval(edge: number, x: number): FPInterval {
+  return kFPContext.f32.stepInterval(edge, x);
 }
 
-const SubtractionIntervalOp: BinaryToIntervalOp = {
-  impl: (x: number, y: number): F32Interval => {
-    return correctlyRoundedInterval(x - y);
-  },
-};
-
-/** Calculate an acceptance interval of x - y */
-export function subtractionInterval(x: number | F32Interval, y: number | F32Interval): F32Interval {
-  return runBinaryToIntervalOp(toF32Interval(x), toF32Interval(y), SubtractionIntervalOp);
+export function subtractionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  return kFPContext.f32.subtractionInterval(x, y);
 }
 
-/** Calculate an acceptance interval of x - y, when x and y are matrices */
-export function subtractionMatrixInterval(x: Matrix<number>, y: Matrix<number>): F32Matrix {
-  return runBinaryToIntervalOpMatrixComponentWise(
-    toF32Matrix(x),
-    toF32Matrix(y),
-    SubtractionIntervalOp
-  );
+export function subtractionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
+  return kFPContext.f32.subtractionMatrixInterval(x, y);
 }
 
-const TanIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return divisionInterval(sinInterval(n), cosInterval(n));
-  },
-};
-
-/** Calculate an acceptance interval of tan(x) */
-export function tanInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), TanIntervalOp);
+export function tanInterval(n: number): FPInterval {
+  return kFPContext.f32.tanInterval(n);
 }
 
-const TanhIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return divisionInterval(sinhInterval(n), coshInterval(n));
-  },
-};
-
-/** Calculate an acceptance interval of tanh(x) */
-export function tanhInterval(n: number): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), TanhIntervalOp);
+export function tanhInterval(n: number): FPInterval {
+  return kFPContext.f32.tanhInterval(n);
 }
 
-const TransposeIntervalOp: MatrixToMatrixOp = {
-  impl: (m: Matrix<number>): F32Matrix => {
-    const num_cols = m.length;
-    const num_rows = m[0].length;
-    const result: Matrix<F32Interval> = [...Array(num_rows)].map(_ => [...Array(num_cols)]);
-
-    for (let i = 0; i < num_cols; i++) {
-      for (let j = 0; j < num_rows; j++) {
-        result[j][i] = correctlyRoundedInterval(m[i][j]);
-      }
-    }
-    return toF32Matrix(result);
-  },
-};
-
-/** Calculate an acceptance interval of transpose(m) */
-export function transposeInterval(m: number[][]): F32Matrix {
-  return runMatrixToMatrixOp(toF32Matrix(m), TransposeIntervalOp);
+export function transposeInterval(m: number[][]): FPMatrix {
+  return kFPContext.f32.transposeInterval(m);
 }
 
-const TruncIntervalOp: PointToIntervalOp = {
-  impl: (n: number): F32Interval => {
-    return correctlyRoundedInterval(Math.trunc(n));
-  },
-};
-
-/** Calculate an acceptance interval of trunc(x) */
-export function truncInterval(n: number | F32Interval): F32Interval {
-  return runPointToIntervalOp(toF32Interval(n), TruncIntervalOp);
+export function truncInterval(n: number | FPInterval): FPInterval {
+  return kFPContext.f32.truncInterval(n);
 }
 
-/**
- * Once-allocated ArrayBuffer/views to avoid overhead of allocation when converting between numeric formats
- *
- * unpackData* is shared between all of the unpack*Interval functions, so to avoid re-entrancy problems, they should
- * not call each other or themselves directly or indirectly.
- */
-const unpackData = new ArrayBuffer(4);
-const unpackDataU32 = new Uint32Array(unpackData);
-const unpackDataU16 = new Uint16Array(unpackData);
-const unpackDataU8 = new Uint8Array(unpackData);
-const unpackDataI16 = new Int16Array(unpackData);
-const unpackDataI8 = new Int8Array(unpackData);
-const unpackDataF16 = new Float16Array(unpackData);
-
-/** Calculate an acceptance interval vector for unpack2x16float(x) */
-export function unpack2x16floatInterval(n: number): F32Vector {
-  assert(
-    n >= kValue.u32.min && n <= kValue.u32.max,
-    'unpack2x16floatInterval only accepts values on the bounds of u32'
-  );
-  unpackDataU32[0] = n;
-  if (unpackDataF16.some(f => !isFiniteF16(f))) {
-    return [F32Interval.any(), F32Interval.any()];
-  }
-
-  const result: F32Vector = [
-    quantizeToF16Interval(unpackDataF16[0]),
-    quantizeToF16Interval(unpackDataF16[1]),
-  ];
-
-  if (result.some(r => !r.isFinite())) {
-    return [F32Interval.any(), F32Interval.any()];
-  }
-  return result;
+export function unpack2x16floatInterval(n: number): FPVector {
+  return kFPContext.f32.unpack2x16floatInterval(n);
 }
 
-const Unpack2x16snormIntervalOp = (n: number): F32Interval => {
-  return maxInterval(divisionInterval(n, 32767), -1);
-};
-
-/** Calculate an acceptance interval vector for unpack2x16snorm(x) */
-export function unpack2x16snormInterval(n: number): F32Vector {
-  assert(
-    n >= kValue.u32.min && n <= kValue.u32.max,
-    'unpack2x16snormInterval only accepts values on the bounds of u32'
-  );
-  unpackDataU32[0] = n;
-  return [Unpack2x16snormIntervalOp(unpackDataI16[0]), Unpack2x16snormIntervalOp(unpackDataI16[1])];
+export function unpack2x16snormInterval(n: number): FPVector {
+  return kFPContext.f32.unpack2x16snormInterval(n);
 }
 
-const Unpack2x16unormIntervalOp = (n: number): F32Interval => {
-  return divisionInterval(n, 65535);
-};
-
-/** Calculate an acceptance interval vector for unpack2x16unorm(x) */
-export function unpack2x16unormInterval(n: number): F32Vector {
-  assert(
-    n >= kValue.u32.min && n <= kValue.u32.max,
-    'unpack2x16unormInterval only accepts values on the bounds of u32'
-  );
-  unpackDataU32[0] = n;
-  return [Unpack2x16unormIntervalOp(unpackDataU16[0]), Unpack2x16unormIntervalOp(unpackDataU16[1])];
+export function unpack2x16unormInterval(n: number): FPVector {
+  return kFPContext.f32.unpack2x16unormInterval(n);
 }
 
-const Unpack4x8snormIntervalOp = (n: number): F32Interval => {
-  return maxInterval(divisionInterval(n, 127), -1);
-};
-
-/** Calculate an acceptance interval vector for unpack4x8snorm(x) */
-export function unpack4x8snormInterval(n: number): F32Vector {
-  assert(
-    n >= kValue.u32.min && n <= kValue.u32.max,
-    'unpack4x8snormInterval only accepts values on the bounds of u32'
-  );
-  unpackDataU32[0] = n;
-  return [
-    Unpack4x8snormIntervalOp(unpackDataI8[0]),
-    Unpack4x8snormIntervalOp(unpackDataI8[1]),
-    Unpack4x8snormIntervalOp(unpackDataI8[2]),
-    Unpack4x8snormIntervalOp(unpackDataI8[3]),
-  ];
+export function unpack4x8snormInterval(n: number): FPVector {
+  return kFPContext.f32.unpack4x8snormInterval(n);
 }
 
-const Unpack4x8unormIntervalOp = (n: number): F32Interval => {
-  return divisionInterval(n, 255);
-};
-
-/** Calculate an acceptance interval vector for unpack4x8unorm(x) */
-export function unpack4x8unormInterval(n: number): F32Vector {
-  assert(
-    n >= kValue.u32.min && n <= kValue.u32.max,
-    'unpack4x8unormInterval only accepts values on the bounds of u32'
-  );
-  unpackDataU32[0] = n;
-  return [
-    Unpack4x8unormIntervalOp(unpackDataU8[0]),
-    Unpack4x8unormIntervalOp(unpackDataU8[1]),
-    Unpack4x8unormIntervalOp(unpackDataU8[2]),
-    Unpack4x8unormIntervalOp(unpackDataU8[3]),
-  ];
+export function unpack4x8unormInterval(n: number): FPVector {
+  return kFPContext.f32.unpack4x8unormInterval(n);
 }

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1,0 +1,3090 @@
+import { assert, unreachable } from '../../common/util/util.js';
+import { Float16Array } from '../../external/petamoriken/float16/float16.js';
+
+import { kValue } from './constants.js';
+import { f32, reinterpretF32AsU32, reinterpretU32AsF32, Scalar } from './conversion.js';
+import {
+  calculatePermutations,
+  cartesianProduct,
+  correctlyRoundedF16,
+  correctlyRoundedF32,
+  flatten2DArray,
+  FlushMode,
+  flushSubnormalNumberF32,
+  isFiniteF16,
+  isFiniteF32,
+  isSubnormalNumberF16,
+  isSubnormalNumberF32,
+  map2DArray,
+  oneULPF32,
+  unflatten2DArray,
+} from './math.js';
+
+/** Indicate the kind of WGSL floating point numbers being operated on */
+export type FPKind = 'f32';
+
+// Containers
+
+/**
+ * Representation of bounds for an interval as an array with either one or two
+ * elements. Single element indicates that the interval is a single point. For
+ * two elements, the first is the lower bound of the interval and the second is
+ * the upper bound.
+ */
+export type IntervalBounds = [number] | [number, number];
+
+/** Represents a closed interval of floating point numbers */
+export class FPInterval {
+  public readonly kind: FPKind;
+  public readonly begin: number;
+  public readonly end: number;
+  // context is JS private, so that objectEquals does not see it when comparing
+  // FPIntervals, since it may not have been initialized yet, but that should
+  // impact equality.
+  #context?: FPContext;
+
+  /**
+   * Constructor
+   *
+   * `FPContext.toInterval` is the preferred way to create FPIntervals
+   *
+   * @param kind the floating point number type this is an interval for
+   * @param bounds beginning and end of the interval
+   */
+  public constructor(kind: FPKind, ...bounds: IntervalBounds) {
+    this.kind = kind;
+
+    const [begin, end] = bounds.length === 2 ? bounds : [bounds[0], bounds[0]];
+    assert(!Number.isNaN(begin) && !Number.isNaN(end), `bounds need to be non-NaN`);
+    assert(begin <= end, `bounds[0] (${begin}) must be less than or equal to bounds[1]  (${end})`);
+
+    this.begin = begin;
+    this.end = end;
+  }
+
+  /** @returns the floating point context for this interval */
+  public context(): FPContext {
+    // context is not fetched and stored at creation time, because there is a
+    // potential dependency cycle between kFPContext and interval on startup.
+    if (this.#context === undefined) {
+      assert(this.kind !== undefined);
+      this.#context = kFPContext[this.kind];
+    }
+    return this.#context;
+  }
+  /** @returns begin and end if non-point interval, otherwise just begin */
+  public bounds(): IntervalBounds {
+    return this.isPoint() ? [this.begin] : [this.begin, this.end];
+  }
+
+  /** @returns if a point or interval is completely contained by this interval */
+  public contains(n: number | FPInterval): boolean {
+    if (Number.isNaN(n)) {
+      // Being the 'any' interval indicates that accuracy is not defined for this
+      // test, so the test is just checking that this input doesn't cause the
+      // implementation to misbehave, so NaN is accepted.
+      return this.begin === Number.NEGATIVE_INFINITY && this.end === Number.POSITIVE_INFINITY;
+    }
+
+    if (n instanceof FPInterval) {
+      return this.begin <= n.begin && this.end >= n.end;
+    }
+    return this.begin <= n && this.end >= n;
+  }
+
+  /** @returns if any values in the interval may be flushed to zero, this
+   *           includes any subnormals and zero itself.
+   */
+  public containsZeroOrSubnormals(): boolean {
+    return !(
+      this.end < this.context().constants().negative.subnormal.min ||
+      this.begin > this.context().constants().positive.subnormal.max
+    );
+  }
+
+  /** @returns if this interval contains a single point */
+  public isPoint(): boolean {
+    return this.begin === this.end;
+  }
+
+  /** @returns if this interval only contains f32 finite values */
+  public isFinite(): boolean {
+    return this.context().isFinite(this.begin) && this.context().isFinite(this.end);
+  }
+
+  /** @returns a string representation for logging purposes */
+  public toString(): string {
+    return `{ '${this.kind}', [${this.bounds().map(this.context().scalarBuilder)}] }`;
+  }
+}
+
+/**
+ * SerializedFPInterval holds the serialized form of a FPInterval.
+ * This form can be safely encoded to JSON.
+ */
+// When non-f32 contexts are defined this will need to be extended to include a
+// kind entry to differentiate.
+export type SerializedFPInterval = { begin: number; end: number } | 'any';
+
+/** serializeFPInterval() converts a FPInterval to a SerializedFPInterval */
+export function serializeFPInterval(i: FPInterval): SerializedFPInterval {
+  // When non-f32 contexts are defined this will need to be re-written to pull
+  // the kind from i to get the context, and embed the kind in the serialized
+  // form
+  return i === kFPContext['f32'].constants().anyInterval
+    ? 'any'
+    : { begin: reinterpretF32AsU32(i.begin), end: reinterpretF32AsU32(i.end) };
+}
+
+/** serializeFPInterval() converts a SerializedFPInterval to a FPInterval */
+export function deserializeFPInterval(data: SerializedFPInterval): FPInterval {
+  // When non-f32 contexts are defined this will need to be re-written to pull
+  // the kind from serialized data to get the context and perform unpacking
+  const context = kFPContext['f32'];
+  return data === 'any'
+    ? context.constants().anyInterval
+    : context.toInterval([reinterpretU32AsF32(data.begin), reinterpretU32AsF32(data.end)]);
+}
+
+/**
+ * Representation of a vec2/3/4 of floating point intervals as an array of
+ * FPIntervals.
+ */
+export type FPVector =
+  | [FPInterval, FPInterval]
+  | [FPInterval, FPInterval, FPInterval]
+  | [FPInterval, FPInterval, FPInterval, FPInterval];
+
+/**
+ * Shorthand for an Array of Arrays that contains a column-major matrix
+ *
+ * This isn't exported outside of this file to avoid colliding with the Matrix
+ * container for going in/out of a shader that the test runner uses.
+ */
+type Matrix<T> = T[][];
+
+/**
+ * Representation of a matCxR of floating point intervals as an array of arrays
+ * of FPIntervals. This maps onto the WGSL concept of matrix. Internally
+ */
+export type FPMatrix =
+  | [[FPInterval, FPInterval], [FPInterval, FPInterval]]
+  | [[FPInterval, FPInterval], [FPInterval, FPInterval], [FPInterval, FPInterval]]
+  | [
+      [FPInterval, FPInterval],
+      [FPInterval, FPInterval],
+      [FPInterval, FPInterval],
+      [FPInterval, FPInterval]
+    ]
+  | [[FPInterval, FPInterval, FPInterval], [FPInterval, FPInterval, FPInterval]]
+  | [
+      [FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval]
+    ]
+  | [
+      [FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval]
+    ]
+  | [
+      [FPInterval, FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval, FPInterval]
+    ]
+  | [
+      [FPInterval, FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval, FPInterval]
+    ]
+  | [
+      [FPInterval, FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval, FPInterval],
+      [FPInterval, FPInterval, FPInterval, FPInterval]
+    ];
+
+// Utilities
+
+/** @returns input with an appended 0, if inputs contains non-zero subnormals */
+// When f16 context is defined, this can be replaced with something like
+// `kFPContext['f16'].addFlushIfNeeded`
+function addFlushedIfNeededF16(values: number[]): number[] {
+  return values.some(v => v !== 0 && isSubnormalNumberF16(v)) ? values.concat(0) : values;
+}
+
+// Operations
+
+/**
+ * A function that converts a point to an acceptance interval.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface PointToInterval {
+  (x: number): FPInterval;
+}
+
+/** Operation used to implement a PointToInterval */
+interface PointToIntervalOp {
+  /** @returns acceptance interval for a function at point x */
+  impl: PointToInterval;
+
+  /**
+   * Calculates where in the domain defined by x the min/max extrema of impl
+   * occur and returns a span of those points to be used as the domain instead.
+   *
+   * Used by this.runPointToIntervalOp before invoking impl.
+   * If not defined, the bounds of the existing domain are assumed to be the
+   * extrema.
+   *
+   * This is only implemented for operations that meet all the following
+   * criteria:
+   *   a) non-monotonic
+   *   b) used in inherited accuracy calculations
+   *   c) need to take in an interval for b)
+   *      i.e. fooInterval takes in x: number | FPInterval, not x: number
+   */
+  extrema?: (x: FPInterval) => FPInterval;
+}
+
+/**
+ * A function that converts a pair of points to an acceptance interval.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface BinaryToInterval {
+  (x: number, y: number): FPInterval;
+}
+
+/** Operation used to implement a BinaryToInterval */
+interface BinaryToIntervalOp {
+  /** @returns acceptance interval for a function at point (x, y) */
+  impl: BinaryToInterval;
+  /**
+   * Calculates where in domain defined by x & y the min/max extrema of impl
+   * occur and returns spans of those points to be used as the domain instead.
+   *
+   * Used by runBinaryToIntervalOp before invoking impl.
+   * If not defined, the bounds of the existing domain are assumed to be the
+   * extrema.
+   *
+   * This is only implemented for functions that meet all of the following
+   * criteria:
+   *   a) non-monotonic
+   *   b) used in inherited accuracy calculations
+   *   c) need to take in an interval for b)
+   */
+  extrema?: (x: FPInterval, y: FPInterval) => [FPInterval, FPInterval];
+}
+
+/** Domain for a BinaryToInterval implementation */
+interface BinaryToIntervalDomain {
+  // Arrays to support discrete valid domain intervals
+  x: FPInterval[];
+  y: FPInterval[];
+}
+
+/**
+ * A function that converts a triplet of points to an acceptance interval.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface TernaryToInterval {
+  (x: number, y: number, z: number): FPInterval;
+}
+
+/** Operation used to implement a TernaryToInterval */
+interface TernaryToIntervalOp {
+  // Re-using the *Op interface pattern for symmetry with the other operations.
+  /** @returns acceptance interval for a function at point (x, y, z) */
+  impl: TernaryToInterval;
+}
+
+// Currently PointToVector is not integrated with the rest of the floating point
+// framework, because the only builtins that use it are actually
+// u32 -> [f32, f32, f32, f32] functions, so the whole rounding and interval
+// process doesn't get applied to the inputs.
+// They do use the framework internally by invoking divisionInterval on segments
+// of the input.
+/**
+ * A function that converts a point to a vector of acceptance intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface PointToVector {
+  (n: number): FPVector;
+}
+
+/**
+ * A function that converts a vector to an acceptance interval.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface VectorToInterval {
+  (x: number[]): FPInterval;
+}
+
+/** Operation used to implement a VectorToInterval */
+interface VectorToIntervalOp {
+  // Re-using the *Op interface pattern for symmetry with the other operations.
+  /** @returns acceptance interval for a function on vector x */
+  impl: VectorToInterval;
+}
+
+/**
+ * A function that converts a pair of vectors to an acceptance interval.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface VectorPairToInterval {
+  (x: number[], y: number[]): FPInterval;
+}
+
+/** Operation used to implement a VectorPairToInterval */
+interface VectorPairToIntervalOp {
+  // Re-using the *Op interface pattern for symmetry with the other operations.
+  /** @returns acceptance interval for a function on vectors (x, y) */
+  impl: VectorPairToInterval;
+}
+
+/**
+ * A function that converts a vector to a vector of acceptance intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface VectorToVector {
+  (x: number[]): FPVector;
+}
+
+/** Operation used to implement a VectorToVector */
+interface VectorToVectorOp {
+  // Re-using the *Op interface pattern for symmetry with the other operations.
+  /** @returns a vector of acceptance intervals for a function on vector x */
+  impl: VectorToVector;
+}
+
+/**
+ * A function that converts a pair of vectors to a vector of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface VectorPairToVector {
+  (x: number[], y: number[]): FPVector;
+}
+
+/** Operation used to implement a VectorPairToVector */
+interface VectorPairToVectorOp {
+  // Re-using the *Op interface pattern for symmetry with the other operations.
+  /** @returns a vector of acceptance intervals for a function on vectors (x, y) */
+  impl: VectorPairToVector;
+}
+
+/**
+ * A function that converts a vector and a scalar to a vector of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface VectorScalarToVector {
+  (x: number[], y: number): FPVector;
+}
+
+/**
+ * A function that converts a scalar and a vector  to a vector of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface ScalarVectorToVector {
+  (x: number, y: number[]): FPVector;
+}
+
+/**
+ * A function that converts a matrix to an acceptance interval.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface MatrixToScalar {
+  (m: Matrix<number>): FPInterval;
+}
+
+/** Operation used to implement a MatrixToMatrix */
+interface MatrixToMatrixOp {
+  // Re-using the *Op interface pattern for symmetry with the other operations.
+  /** @returns a matrix of acceptance intervals for a function on matrix x */
+  impl: MatrixToMatrix;
+}
+
+/**
+ * A function that converts a matrix to a matrix of acceptance intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface MatrixToMatrix {
+  (m: Matrix<number>): FPMatrix;
+}
+
+/** Operation used to implement a MatrixToMatrix */
+interface MatrixToMatrixOp {
+  // Re-using the *Op interface pattern for symmetry with the other operations.
+  /** @returns a matrix of acceptance intervals for a function on matrix x */
+  impl: MatrixToMatrix;
+}
+
+/**
+ * A function that converts a pair of matrices to a matrix of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface MatrixPairToMatrix {
+  (x: Matrix<number>, y: Matrix<number>): FPMatrix;
+}
+
+/**
+ * A function that converts a matrix and a scalar to a matrix of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface MatrixScalarToMatrix {
+  (x: Matrix<number>, y: number): FPMatrix;
+}
+
+/**
+ * A function that converts a scalar and a matrix to a matrix of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface ScalarMatrixToMatrix {
+  (x: number, y: Matrix<number>): FPMatrix;
+}
+
+/**
+ * A function that converts a matrix and a vector to a vector of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface MatrixVectorToVector {
+  (x: Matrix<number>, y: number[]): FPVector;
+}
+
+/**
+ * A function that converts a vector and a matrix to a vector of acceptance
+ * intervals.
+ * This is the public facing API for builtin implementations that is called
+ * from tests.
+ */
+export interface VectorMatrixToVector {
+  (x: number[], y: Matrix<number>): FPVector;
+}
+
+// Context
+
+/**
+ * Typed structure containing all the limits/constants defined for each
+ * WGSL floating point kind
+ */
+interface FPConstants {
+  positive: {
+    min: number;
+    max: number;
+    infinity: number;
+    nearest_max: number;
+    less_than_one: number;
+    subnormal: {
+      min: number;
+      max: number;
+    };
+    pi: {
+      whole: number;
+      three_quarters: number;
+      half: number;
+      third: number;
+      quarter: number;
+      sixth: number;
+    };
+    e: number;
+  };
+  negative: {
+    min: number;
+    max: number;
+    infinity: number;
+    nearest_min: number;
+    less_than_one: number;
+    subnormal: {
+      min: number;
+      max: number;
+    };
+    pi: {
+      whole: number;
+      three_quarters: number;
+      half: number;
+      third: number;
+      quarter: number;
+      sixth: number;
+    };
+  };
+  anyInterval: FPInterval;
+  zeroInterval: FPInterval;
+  negPiToPiInterval: FPInterval;
+  greaterThanZeroInterval: FPInterval;
+  zeroVector: {
+    2: FPVector;
+    3: FPVector;
+    4: FPVector;
+  };
+  anyVector: {
+    2: FPVector;
+    3: FPVector;
+    4: FPVector;
+  };
+  anyMatrix: {
+    2: {
+      2: FPMatrix;
+      3: FPMatrix;
+      4: FPMatrix;
+    };
+    3: {
+      2: FPMatrix;
+      3: FPMatrix;
+      4: FPMatrix;
+    };
+    4: {
+      2: FPMatrix;
+      3: FPMatrix;
+      4: FPMatrix;
+    };
+  };
+}
+
+abstract class FPContext {
+  public readonly kind: FPKind;
+  protected constructor(k: FPKind) {
+    this.kind = k;
+  }
+
+  public abstract constants(): FPConstants;
+
+  // Utilities - Implemented
+  /** @returns an interval containing the point or the original interval */
+  public toInterval(n: number | IntervalBounds | FPInterval): FPInterval {
+    if (n instanceof FPInterval) {
+      if (n.kind === this.kind) {
+        return n;
+      }
+      return new FPInterval(this.kind, ...n.bounds());
+    }
+
+    if (n instanceof Array) {
+      return new FPInterval(this.kind, ...n);
+    }
+
+    return new FPInterval(this.kind, n, n);
+  }
+
+  /**
+   * @returns an interval with the tightest bounds that includes all provided
+   *          intervals
+   */
+  public spanIntervals(...intervals: FPInterval[]): FPInterval {
+    assert(intervals.length > 0, `span of an empty list of FPIntervals is not allowed`);
+    assert(
+      intervals.every(i => i.kind === this.kind),
+      `span is only defined for intervals with the same kind`
+    );
+    let begin = Number.POSITIVE_INFINITY;
+    let end = Number.NEGATIVE_INFINITY;
+    intervals.forEach(i => {
+      begin = Math.min(i.begin, begin);
+      end = Math.max(i.end, end);
+    });
+    return this.toInterval([begin, end]);
+  }
+
+  /** Narrow an array of values to FPVector if possible */
+  public isVector(v: (number | IntervalBounds | FPInterval)[]): v is FPVector {
+    if (v.every(e => e instanceof FPInterval && e.kind === this.kind)) {
+      return v.length === 2 || v.length === 3 || v.length === 4;
+    }
+    return false;
+  }
+
+  /** @returns an FPVector representation of an array of values if possible */
+  public toVector(v: (number | IntervalBounds | FPInterval)[]): FPVector {
+    if (this.isVector(v)) {
+      return v;
+    }
+
+    const f = v.map(e => this.toInterval(e));
+    // The return of the map above is a FPInterval[], which needs to be narrowed
+    // to FPVector, since FPVector is defined as fixed length tuples.
+    if (this.isVector(f)) {
+      return f;
+    }
+    unreachable(`Cannot convert [${v}] to FPVector`);
+  }
+
+  /**
+   * @returns a FPVector where each element is the span for corresponding
+   *          elements at the same index in the input vectors
+   */
+  public spanVectors(...vectors: FPVector[]): FPVector {
+    assert(
+      vectors.every(e => this.isVector(e)),
+      'Vector span is not defined for vectors of differing floating point kinds'
+    );
+
+    const vector_length = vectors[0].length;
+    assert(
+      vectors.every(e => e.length === vector_length),
+      `Vector span is not defined for vectors of differing lengths`
+    );
+
+    const result: FPInterval[] = new Array<FPInterval>(vector_length);
+
+    for (let i = 0; i < vector_length; i++) {
+      result[i] = this.spanIntervals(...vectors.map(v => v[i]));
+    }
+    return this.toVector(result);
+  }
+
+  /** Narrow an array of an array of values to FPMatrix if possible */
+  public isMatrix(m: Matrix<number | IntervalBounds | FPInterval> | FPVector[]): m is FPMatrix {
+    if (!m.every(c => c.every(e => e instanceof FPInterval && e.kind === this.kind))) {
+      return false;
+    }
+    // At this point m guaranteed to be a FPInterval[][], but maybe typed as a
+    // FPVector[].
+    // Coercing the type since FPVector[] is functionally equivalent to
+    // FPInterval[][] for .length and .every, but they are type compatible,
+    // since tuples are not equivalent to arrays, so TS considers c in .every to
+    // be unresolvable below, even though our usage is safe.
+    m = m as FPInterval[][];
+
+    if (m.length > 4 || m.length < 2) {
+      return false;
+    }
+
+    const num_rows = m[0].length;
+    if (num_rows > 4 || num_rows < 2) {
+      return false;
+    }
+
+    return m.every(c => c.length === num_rows);
+  }
+
+  /** @returns an FPMatrix representation of an array of an array of values if possible */
+  public toMatrix(m: Matrix<number | IntervalBounds | FPInterval> | FPVector[]): FPMatrix {
+    if (this.isMatrix(m)) {
+      return m;
+    }
+
+    const result = map2DArray(m, this.toInterval.bind(this));
+
+    // The return of the map above is a FPInterval[][], which needs to be
+    // narrowed to FPMatrix, since FPMatrix is defined as fixed length tuples.
+    if (this.isMatrix(result)) {
+      return result;
+    }
+    unreachable(`Cannot convert ${m} to FPMatrix`);
+  }
+
+  /**
+   * @returns a FPMatrix where each element is the span for corresponding
+   *          elements at the same index in the input matrices
+   */
+  public spanMatrices(...matrices: FPMatrix[]): FPMatrix {
+    // Coercing the type of matrices, since tuples are not generally compatible
+    // with Arrays, but they are functionally equivalent for the usages in this
+    // function.
+    const ms = matrices as Matrix<FPInterval>[];
+    const num_cols = ms[0].length;
+    const num_rows = ms[0][0].length;
+    assert(
+      ms.every(m => m.length === num_cols && m.every(r => r.length === num_rows)),
+      `Matrix span is not defined for Matrices of differing dimensions`
+    );
+
+    const result: Matrix<FPInterval> = [...Array(num_cols)].map(_ => [...Array(num_rows)]);
+    for (let i = 0; i < num_cols; i++) {
+      for (let j = 0; j < num_rows; j++) {
+        result[i][j] = this.spanIntervals(...ms.map(m => m[i][j]));
+      }
+    }
+
+    return this.toMatrix(result);
+  }
+
+  /** @returns input with an appended 0, if inputs contains non-zero subnormals */
+  public addFlushedIfNeeded(values: number[]): number[] {
+    const subnormals = values.filter(this.isSubnormal);
+    const needs_zero = subnormals.length > 0 && subnormals.every(s => s !== 0);
+    return needs_zero ? values.concat(0) : values;
+  }
+
+  /**
+   * Restrict the inputs to an PointToInterval operation
+   *
+   * Only used for operations that have tighter domain requirements than 'must
+   * be finite'.
+   *
+   * @param domain interval to restrict inputs to
+   * @param impl operation implementation to run if input is within the required domain
+   * @returns a PointToInterval that calls impl if domain contains the input,
+   *          otherwise it returns an any interval */
+  protected limitPointToIntervalDomain(domain: FPInterval, impl: PointToInterval): PointToInterval {
+    return (n: number): FPInterval => {
+      return domain.contains(n) ? impl(n) : this.constants().anyInterval;
+    };
+  }
+
+  /**
+   * Restrict the inputs to a BinaryToInterval
+   *
+   * Only used for operations that have tighter domain requirements than 'must be
+   * finite'.
+   *
+   * @param domain set of intervals to restrict inputs to
+   * @param impl operation implementation to run if input is within the required domain
+   * @returns a BinaryToInterval that calls impl if domain contains the input,
+   *          otherwise it returns an any interval */
+  protected limitBinaryToIntervalDomain(
+    domain: BinaryToIntervalDomain,
+    impl: BinaryToInterval
+  ): BinaryToInterval {
+    return (x: number, y: number): FPInterval => {
+      if (!domain.x.some(d => d.contains(x)) || !domain.y.some(d => d.contains(y))) {
+        return this.constants().anyInterval;
+      }
+
+      return impl(x, y);
+    };
+  }
+
+  // Utilities - Defined by subclass
+  /** @returns all valid roundings of input */
+  public abstract readonly correctlyRounded: (n: number) => number[];
+  /** @returns true if input is considered finite, otherwise false */
+  public abstract readonly isFinite: (n: number) => boolean;
+  /** @returns true if input is considered subnormal, otherwise false */
+  public abstract readonly isSubnormal: (n: number) => boolean;
+  /** @returns 0 if the provided number is subnormal, otherwise returns the proved number */
+  public abstract readonly flushSubnormal: (n: number) => number;
+  /** @returns 1 * ULP(number) */
+  public abstract readonly oneULP: (target: number, mode?: FlushMode) => number;
+  /** @returns a builder for converting numbers to Scalars */
+  public abstract readonly scalarBuilder: (n: number) => Scalar;
+
+  // Framework
+  /**
+   * Converts a point to an acceptance interval, using a specific function
+   *
+   * This handles correctly rounding and flushing inputs as needed.
+   * Duplicate inputs are pruned before invoking op.impl.
+   * op.extrema is invoked before this point in the call stack.
+   * op.domain is tested before this point in the call stack.
+   *
+   * @param n value to flush & round then invoke op.impl on
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private roundAndFlushPointToInterval(n: number, op: PointToIntervalOp) {
+    assert(!Number.isNaN(n), `flush not defined for NaN`);
+    const values = this.correctlyRounded(n);
+    const inputs = this.addFlushedIfNeeded(values);
+    const results = new Set<FPInterval>(inputs.map(op.impl));
+    return this.spanIntervals(...results);
+  }
+
+  /**
+   * Converts a pair to an acceptance interval, using a specific function
+   *
+   * This handles correctly rounding and flushing inputs as needed.
+   * Duplicate inputs are pruned before invoking op.impl.
+   * All unique combinations of x & y are run.
+   * op.extrema is invoked before this point in the call stack.
+   * op.domain is tested before this point in the call stack.
+   *
+   * @param x first param to flush & round then invoke op.impl on
+   * @param y second param to flush & round then invoke op.impl on
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private roundAndFlushBinaryToInterval(x: number, y: number, op: BinaryToIntervalOp): FPInterval {
+    assert(!Number.isNaN(x), `flush not defined for NaN`);
+    assert(!Number.isNaN(y), `flush not defined for NaN`);
+    const x_values = this.correctlyRounded(x);
+    const y_values = this.correctlyRounded(y);
+    const x_inputs = this.addFlushedIfNeeded(x_values);
+    const y_inputs = this.addFlushedIfNeeded(y_values);
+    const intervals = new Set<FPInterval>();
+    x_inputs.forEach(inner_x => {
+      y_inputs.forEach(inner_y => {
+        intervals.add(op.impl(inner_x, inner_y));
+      });
+    });
+    return this.spanIntervals(...intervals);
+  }
+
+  /**
+   * Converts a triplet to an acceptance interval, using a specific function
+   *
+   * This handles correctly rounding and flushing inputs as needed.
+   * Duplicate inputs are pruned before invoking op.impl.
+   * All unique combinations of x, y & z are run.
+   *
+   * @param x first param to flush & round then invoke op.impl on
+   * @param y second param to flush & round then invoke op.impl on
+   * @param z third param to flush & round then invoke op.impl on
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private roundAndFlushTernaryToInterval(
+    x: number,
+    y: number,
+    z: number,
+    op: TernaryToIntervalOp
+  ): FPInterval {
+    assert(!Number.isNaN(x), `flush not defined for NaN`);
+    assert(!Number.isNaN(y), `flush not defined for NaN`);
+    assert(!Number.isNaN(z), `flush not defined for NaN`);
+    const x_values = this.correctlyRounded(x);
+    const y_values = this.correctlyRounded(y);
+    const z_values = this.correctlyRounded(z);
+    const x_inputs = this.addFlushedIfNeeded(x_values);
+    const y_inputs = this.addFlushedIfNeeded(y_values);
+    const z_inputs = this.addFlushedIfNeeded(z_values);
+    const intervals = new Set<FPInterval>();
+    // prettier-ignore
+    x_inputs.forEach(inner_x => {
+      y_inputs.forEach(inner_y => {
+        z_inputs.forEach(inner_z => {
+          intervals.add(op.impl(inner_x, inner_y, inner_z));
+        });
+      });
+    });
+
+    return this.spanIntervals(...intervals);
+  }
+
+  /**
+   * Converts a vector to an acceptance interval using a specific function
+   *
+   * This handles correctly rounding and flushing inputs as needed.
+   * Duplicate inputs are pruned before invoking op.impl.
+   *
+   * @param x param to flush & round then invoke op.impl on
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private roundAndFlushVectorToInterval(x: number[], op: VectorToIntervalOp): FPInterval {
+    assert(
+      x.every(e => !Number.isNaN(e)),
+      `flush not defined for NaN`
+    );
+
+    const x_rounded: number[][] = x.map(this.correctlyRounded);
+    const x_flushed: number[][] = x_rounded.map(this.addFlushedIfNeeded.bind(this));
+    const x_inputs = cartesianProduct<number>(...x_flushed);
+
+    const intervals = new Set<FPInterval>();
+    x_inputs.forEach(inner_x => {
+      intervals.add(op.impl(inner_x));
+    });
+    return this.spanIntervals(...intervals);
+  }
+
+  /**
+   * Converts a pair of vectors to an acceptance interval using a specific
+   * function
+   *
+   * This handles correctly rounding and flushing inputs as needed.
+   * Duplicate inputs are pruned before invoking op.impl.
+   * All unique combinations of x & y are run.
+   *
+   * @param x first param to flush & round then invoke op.impl on
+   * @param y second param to flush & round then invoke op.impl on
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private roundAndFlushVectorPairToInterval(
+    x: number[],
+    y: number[],
+    op: VectorPairToIntervalOp
+  ): FPInterval {
+    assert(
+      x.every(e => !Number.isNaN(e)),
+      `flush not defined for NaN`
+    );
+    assert(
+      y.every(e => !Number.isNaN(e)),
+      `flush not defined for NaN`
+    );
+
+    const x_rounded: number[][] = x.map(this.correctlyRounded);
+    const y_rounded: number[][] = y.map(this.correctlyRounded);
+    const x_flushed: number[][] = x_rounded.map(this.addFlushedIfNeeded.bind(this));
+    const y_flushed: number[][] = y_rounded.map(this.addFlushedIfNeeded.bind(this));
+    const x_inputs = cartesianProduct<number>(...x_flushed);
+    const y_inputs = cartesianProduct<number>(...y_flushed);
+
+    const intervals = new Set<FPInterval>();
+    x_inputs.forEach(inner_x => {
+      y_inputs.forEach(inner_y => {
+        intervals.add(op.impl(inner_x, inner_y));
+      });
+    });
+    return this.spanIntervals(...intervals);
+  }
+
+  /**
+   * Converts a vector to a vector of acceptance intervals using a specific
+   * function
+   *
+   * This handles correctly rounding and flushing inputs as needed.
+   * Duplicate inputs are pruned before invoking op.impl.
+   *
+   * @param x param to flush & round then invoke op.impl on
+   * @param op operation defining the function being run
+   * @returns a vector of spans for each outputs of op.impl
+   */
+  private roundAndFlushVectorToVector(x: number[], op: VectorToVectorOp): FPVector {
+    assert(
+      x.every(e => !Number.isNaN(e)),
+      `flush not defined for NaN`
+    );
+
+    const x_rounded: number[][] = x.map(this.correctlyRounded);
+    const x_flushed: number[][] = x_rounded.map(this.addFlushedIfNeeded.bind(this));
+    const x_inputs = cartesianProduct<number>(...x_flushed);
+
+    const interval_vectors = new Set<FPVector>();
+    x_inputs.forEach(inner_x => {
+      interval_vectors.add(op.impl(inner_x));
+    });
+
+    return this.spanVectors(...interval_vectors);
+  }
+
+  /**
+   * Converts a pair of vectors to a vector of acceptance intervals using a
+   * specific function
+   *
+   * This handles correctly rounding and flushing inputs as needed.
+   * Duplicate inputs are pruned before invoking op.impl.
+   *
+   * @param x first param to flush & round then invoke op.impl on
+   * @param x second param to flush & round then invoke op.impl on
+   * @param op operation defining the function being run
+   * @returns a vector of spans for each output of op.impl
+   */
+  private roundAndFlushVectorPairToVector(
+    x: number[],
+    y: number[],
+    op: VectorPairToVectorOp
+  ): FPVector {
+    assert(
+      x.every(e => !Number.isNaN(e)),
+      `flush not defined for NaN`
+    );
+    assert(
+      y.every(e => !Number.isNaN(e)),
+      `flush not defined for NaN`
+    );
+
+    const x_rounded: number[][] = x.map(this.correctlyRounded);
+    const y_rounded: number[][] = y.map(this.correctlyRounded);
+    const x_flushed: number[][] = x_rounded.map(this.addFlushedIfNeeded.bind(this));
+    const y_flushed: number[][] = y_rounded.map(this.addFlushedIfNeeded.bind(this));
+    const x_inputs = cartesianProduct<number>(...x_flushed);
+    const y_inputs = cartesianProduct<number>(...y_flushed);
+
+    const interval_vectors = new Set<FPVector>();
+    x_inputs.forEach(inner_x => {
+      y_inputs.forEach(inner_y => {
+        interval_vectors.add(op.impl(inner_x, inner_y));
+      });
+    });
+
+    return this.spanVectors(...interval_vectors);
+  }
+
+  /**
+   * Converts a matrix to a matrix of acceptance intervals using a specific
+   * function
+   *
+   * This handles correctly rounding and flushing inputs as needed.
+   * Duplicate inputs are pruned before invoking op.impl.
+   *
+   * @param m param to flush & round then invoke op.impl on
+   * @param op operation defining the function being run
+   * @returns a matrix of spans for each outputs of op.impl
+   */
+  private roundAndFlushMatrixToMatrix(m: Matrix<number>, op: MatrixToMatrixOp): FPMatrix {
+    const num_cols = m.length;
+    const num_rows = m[0].length;
+    assert(
+      m.every(c => c.every(r => !Number.isNaN(r))),
+      `flush not defined for NaN`
+    );
+
+    const m_flat = flatten2DArray(m);
+    const m_rounded: number[][] = m_flat.map(this.correctlyRounded);
+    const m_flushed: number[][] = m_rounded.map(this.addFlushedIfNeeded.bind(this));
+    const m_options: number[][] = cartesianProduct<number>(...m_flushed);
+    const m_inputs: Matrix<number>[] = m_options.map(e => unflatten2DArray(e, num_cols, num_rows));
+
+    const interval_matrices = new Set<FPMatrix>();
+    m_inputs.forEach(inner_m => {
+      interval_matrices.add(op.impl(inner_m));
+    });
+
+    return this.spanMatrices(...interval_matrices);
+  }
+
+  /**
+   * Calculate the acceptance interval for a unary function over an interval
+   *
+   * If the interval is actually a point, this just decays to
+   * roundAndFlushPointToInterval.
+   *
+   * The provided domain interval may be adjusted if the operation defines an
+   * extrema function.
+   *
+   * @param x input domain interval
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private runPointToIntervalOp(x: FPInterval, op: PointToIntervalOp): FPInterval {
+    if (!x.isFinite()) {
+      return this.constants().anyInterval;
+    }
+
+    if (op.extrema !== undefined) {
+      x = op.extrema(x);
+    }
+
+    const result = this.spanIntervals(
+      ...x.bounds().map(b => this.roundAndFlushPointToInterval(b, op))
+    );
+    return result.isFinite() ? result : this.constants().anyInterval;
+  }
+
+  /**
+   * Calculate the acceptance interval for a binary function over an interval
+   *
+   * The provided domain intervals may be adjusted if the operation defines an
+   * extrema function.
+   *
+   * @param x first input domain interval
+   * @param y second input domain interval
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private runBinaryToIntervalOp(x: FPInterval, y: FPInterval, op: BinaryToIntervalOp): FPInterval {
+    if (!x.isFinite() || !y.isFinite()) {
+      return this.constants().anyInterval;
+    }
+
+    if (op.extrema !== undefined) {
+      [x, y] = op.extrema(x, y);
+    }
+
+    const outputs = new Set<FPInterval>();
+    x.bounds().forEach(inner_x => {
+      y.bounds().forEach(inner_y => {
+        outputs.add(this.roundAndFlushBinaryToInterval(inner_x, inner_y, op));
+      });
+    });
+
+    const result = this.spanIntervals(...outputs);
+    return result.isFinite() ? result : this.constants().anyInterval;
+  }
+
+  /**
+   * Calculate the acceptance interval for a ternary function over an interval
+   *
+   * @param x first input domain interval
+   * @param y second input domain interval
+   * @param z third input domain interval
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private runTernaryToIntervalOp(
+    x: FPInterval,
+    y: FPInterval,
+    z: FPInterval,
+    op: TernaryToIntervalOp
+  ): FPInterval {
+    if (!x.isFinite() || !y.isFinite() || !z.isFinite()) {
+      return this.constants().anyInterval;
+    }
+
+    const outputs = new Set<FPInterval>();
+    x.bounds().forEach(inner_x => {
+      y.bounds().forEach(inner_y => {
+        z.bounds().forEach(inner_z => {
+          outputs.add(this.roundAndFlushTernaryToInterval(inner_x, inner_y, inner_z, op));
+        });
+      });
+    });
+
+    const result = this.spanIntervals(...outputs);
+    return result.isFinite() ? result : this.constants().anyInterval;
+  }
+
+  /**
+   * Calculate the acceptance interval for a vector function over given
+   * intervals
+   *
+   * @param x input domain intervals vector
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private runVectorToIntervalOp(x: FPVector, op: VectorToIntervalOp): FPInterval {
+    if (x.some(e => !e.isFinite())) {
+      return this.constants().anyInterval;
+    }
+
+    const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
+
+    const outputs = new Set<FPInterval>();
+    x_values.forEach(inner_x => {
+      outputs.add(this.roundAndFlushVectorToInterval(inner_x, op));
+    });
+
+    const result = this.spanIntervals(...outputs);
+    return result.isFinite() ? result : this.constants().anyInterval;
+  }
+
+  /**
+   * Calculate the acceptance interval for a vector pair function over given
+   * intervals
+   *
+   * @param x first input domain intervals vector
+   * @param y second input domain intervals vector
+   * @param op operation defining the function being run
+   * @returns a span over all the outputs of op.impl
+   */
+  private runVectorPairToIntervalOp(
+    x: FPVector,
+    y: FPVector,
+    op: VectorPairToIntervalOp
+  ): FPInterval {
+    if (x.some(e => !e.isFinite()) || y.some(e => !e.isFinite())) {
+      return this.constants().anyInterval;
+    }
+
+    const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
+    const y_values = cartesianProduct<number>(...y.map(e => e.bounds()));
+
+    const outputs = new Set<FPInterval>();
+    x_values.forEach(inner_x => {
+      y_values.forEach(inner_y => {
+        outputs.add(this.roundAndFlushVectorPairToInterval(inner_x, inner_y, op));
+      });
+    });
+
+    const result = this.spanIntervals(...outputs);
+    return result.isFinite() ? result : this.constants().anyInterval;
+  }
+
+  /**
+   * Calculate the vector of acceptance intervals for a pair of vector function
+   * over given intervals
+   *
+   * @param x input domain intervals vector
+   * @param op operation defining the function being run
+   * @returns a vector of spans over all the outputs of op.impl
+   */
+  private runVectorToVectorOp(x: FPVector, op: VectorToVectorOp): FPVector {
+    if (x.some(e => !e.isFinite())) {
+      return this.constants().anyVector[x.length];
+    }
+
+    const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
+
+    const outputs = new Set<FPVector>();
+    x_values.forEach(inner_x => {
+      outputs.add(this.roundAndFlushVectorToVector(inner_x, op));
+    });
+
+    const result = this.spanVectors(...outputs);
+    return result.every(e => e.isFinite()) ? result : this.constants().anyVector[result.length];
+  }
+
+  /**
+   * Calculate the vector of acceptance intervals by running a scalar operation
+   * component-wise over a vector.
+   *
+   * This is used for situations where a component-wise operation, like vector
+   * negation, is needed as part of an inherited accuracy, but the top-level
+   * operation test don't require an explicit vector definition of the function,
+   * due to the generated 'vectorize' tests being sufficient.
+   *
+   * @param x input domain intervals vector
+   * @param op scalar operation to be run component-wise
+   * @returns a vector of intervals with the outputs of op.impl
+   */
+  private runPointToIntervalOpComponentWise(x: FPVector, op: PointToIntervalOp): FPVector {
+    return this.toVector(x.map(e => this.runPointToIntervalOp(e, op)));
+  }
+
+  /**
+   * Calculate the vector of acceptance intervals for a vector function over
+   * given intervals
+   *
+   * @param x first input domain intervals vector
+   * @param y second input domain intervals vector
+   * @param op operation defining the function being run
+   * @returns a vector of spans over all the outputs of op.impl
+   */
+  private runVectorPairToVectorOp(x: FPVector, y: FPVector, op: VectorPairToVectorOp): FPVector {
+    if (x.some(e => !e.isFinite()) || y.some(e => !e.isFinite())) {
+      return this.constants().anyVector[x.length];
+    }
+
+    const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
+    const y_values = cartesianProduct<number>(...y.map(e => e.bounds()));
+
+    const outputs = new Set<FPVector>();
+    x_values.forEach(inner_x => {
+      y_values.forEach(inner_y => {
+        outputs.add(this.roundAndFlushVectorPairToVector(inner_x, inner_y, op));
+      });
+    });
+
+    const result = this.spanVectors(...outputs);
+    return result.every(e => e.isFinite()) ? result : this.constants().anyVector[result.length];
+  }
+
+  /**
+   * Calculate the vector of acceptance intervals by running a scalar operation
+   * component-wise over a pair of vectors.
+   *
+   * This is used for situations where a component-wise operation, like vector
+   * subtraction, is needed as part of an inherited accuracy, but the top-level
+   * operation test don't require an explicit vector definition of the function,
+   * due to the generated 'vectorize' tests being sufficient.
+   *
+   * @param x first input domain intervals vector
+   * @param y second input domain intervals vector
+   * @param op scalar operation to be run component-wise
+   * @returns a vector of intervals with the outputs of op.impl
+   */
+  private runBinaryToIntervalOpVectorComponentWise(
+    x: FPVector,
+    y: FPVector,
+    op: BinaryToIntervalOp
+  ): FPVector {
+    assert(
+      x.length === y.length,
+      `runBinaryToIntervalOpVectorComponentWise requires vectors of the same dimensions`
+    );
+
+    return this.toVector(
+      x.map((i, idx) => {
+        return this.runBinaryToIntervalOp(i, y[idx], op);
+      })
+    );
+  }
+
+  /**
+   * Calculate the matrix of acceptance intervals for a pair of matrix function over
+   * given intervals
+   *
+   * @param x input domain intervals matrix
+   * @param x input domain intervals matrix
+   * @param op operation defining the function being run
+   * @returns a matrix of spans over all the outputs of op.impl
+   */
+  private runMatrixToMatrixOp(m: FPMatrix, op: MatrixToMatrixOp): FPMatrix {
+    const num_cols = m.length;
+    const num_rows = m[0].length;
+    if (m.some(c => c.some(r => !r.isFinite()))) {
+      return this.constants().anyMatrix[num_cols][num_rows];
+    }
+
+    const m_flat: FPInterval[] = flatten2DArray(m);
+    const m_values: number[][] = cartesianProduct<number>(...m_flat.map(e => e.bounds()));
+
+    const outputs = new Set<FPMatrix>();
+    m_values.forEach(inner_m => {
+      const unflat_m = unflatten2DArray(inner_m, num_cols, num_rows);
+      outputs.add(this.roundAndFlushMatrixToMatrix(unflat_m, op));
+    });
+
+    const result = this.spanMatrices(...outputs);
+    const result_cols = result.length;
+    const result_rows = result[0].length;
+
+    // FPMatrix has to be coerced to FPInterval[][] to use .every. This should
+    // always be safe, since FPMatrix are defined as fixed length array of
+    // arrays.
+    return (result as FPInterval[][]).every(c => c.every(r => r.isFinite()))
+      ? result
+      : this.constants().anyMatrix[result_cols][result_rows];
+  }
+
+  /**
+   * Calculate the Matrix of acceptance intervals by running a scalar operation
+   * component-wise over a pair of matrices.
+   *
+   * An example of this is performing matrix addition.
+   *
+   * @param x first input domain intervals matrix
+   * @param y second input domain intervals matrix
+   * @param op scalar operation to be run component-wise
+   * @returns a matrix of intervals with the outputs of op.impl
+   */
+  private runBinaryToIntervalOpMatrixComponentWise(
+    x: FPMatrix,
+    y: FPMatrix,
+    op: BinaryToIntervalOp
+  ): FPMatrix {
+    assert(
+      x.length === y.length && x[0].length === y[0].length,
+      `runBinaryToIntervalOpMatrixComponentWise requires matrices of the same dimensions`
+    );
+
+    const cols = x.length;
+    const rows = x[0].length;
+    const flat_x = flatten2DArray(x);
+    const flat_y = flatten2DArray(y);
+
+    return this.toMatrix(
+      unflatten2DArray(
+        flat_x.map((i, idx) => {
+          return this.runBinaryToIntervalOp(i, flat_y[idx], op);
+        }),
+        cols,
+        rows
+      )
+    );
+  }
+
+  // API - Fundamental Error Intervals
+
+  /**
+   * Defines a PointToIntervalOp for an interval of the correctly rounded values
+   * around the point
+   */
+  private readonly CorrectlyRoundedIntervalOp: PointToIntervalOp = {
+    impl: (n: number) => {
+      assert(!Number.isNaN(n), `absolute not defined for NaN`);
+      return this.toInterval(n);
+    },
+  };
+
+  /** @returns an interval of the correctly rounded values around the point */
+  public correctlyRoundedInterval(n: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.CorrectlyRoundedIntervalOp);
+  }
+
+  /** @returns a matrix of correctly rounded intervals for the provided matrix */
+  public correctlyRoundedMatrix(m: Matrix<number>): FPMatrix {
+    return this.toMatrix(map2DArray(m, this.correctlyRoundedInterval.bind(this)));
+  }
+
+  /** @returns a PointToIntervalOp for [n - error_range, n + error_range] */
+  private AbsoluteErrorIntervalOp(error_range: number): PointToIntervalOp {
+    const op: PointToIntervalOp = {
+      impl: (_: number) => {
+        return this.constants().anyInterval;
+      },
+    };
+
+    if (isFiniteF32(error_range)) {
+      op.impl = (n: number) => {
+        assert(!Number.isNaN(n), `absolute error not defined for NaN`);
+        return this.toInterval([n - error_range, n + error_range]);
+      };
+    }
+
+    return op;
+  }
+
+  /** @returns an interval of the absolute error around the point */
+  public absoluteErrorInterval(n: number, error_range: number): FPInterval {
+    error_range = Math.abs(error_range);
+    return this.runPointToIntervalOp(this.toInterval(n), this.AbsoluteErrorIntervalOp(error_range));
+  }
+
+  /** @returns a PointToIntervalOp for [n - numULP * ULP(n), n + numULP * ULP(n)] */
+  private ULPIntervalOp(numULP: number): PointToIntervalOp {
+    const op: PointToIntervalOp = {
+      impl: (_: number) => {
+        return this.constants().anyInterval;
+      },
+    };
+
+    if (this.isFinite(numULP)) {
+      op.impl = (n: number) => {
+        assert(!Number.isNaN(n), `ULP error not defined for NaN`);
+
+        const ulp = this.oneULP(n);
+        const begin = n - numULP * ulp;
+        const end = n + numULP * ulp;
+
+        return this.toInterval([
+          Math.min(begin, this.flushSubnormal(begin)),
+          Math.max(end, this.flushSubnormal(end)),
+        ]);
+      };
+    }
+
+    return op;
+  }
+
+  /** @returns an interval of N * ULP around the point */
+  public ulpInterval(n: number, numULP: number): FPInterval {
+    numULP = Math.abs(numULP);
+    return this.runPointToIntervalOp(this.toInterval(n), this.ULPIntervalOp(numULP));
+  }
+
+  // API - Acceptance Intervals
+
+  private readonly AbsIntervalOp: PointToIntervalOp = {
+    impl: (n: number) => {
+      return this.correctlyRoundedInterval(Math.abs(n));
+    },
+  };
+
+  /** Calculate an acceptance interval for abs(n) */
+  public absInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.AbsIntervalOp);
+  }
+
+  private readonly AcosIntervalOp: PointToIntervalOp = {
+    impl: this.limitPointToIntervalDomain(this.toInterval([-1.0, 1.0]), (n: number) => {
+      // acos(n) = atan2(sqrt(1.0 - n * n), n) or a polynomial approximation with absolute error
+      const y = this.sqrtInterval(this.subtractionInterval(1, this.multiplicationInterval(n, n)));
+      return this.spanIntervals(
+        this.atan2Interval(y, n),
+        this.absoluteErrorInterval(Math.acos(n), 6.77e-5)
+      );
+    }),
+  };
+
+  /** Calculate an acceptance interval for acos(n) */
+  public acosInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.AcosIntervalOp);
+  }
+
+  /** All acceptance interval functions for acosh(x) */
+  public readonly acoshIntervals: PointToInterval[] = [
+    this.acoshAlternativeInterval.bind(this),
+    this.acoshPrimaryInterval.bind(this),
+  ];
+
+  private readonly AcoshAlternativeIntervalOp: PointToIntervalOp = {
+    impl: (x: number): FPInterval => {
+      // acosh(x) = log(x + sqrt((x + 1.0f) * (x - 1.0)))
+      const inner_value = this.multiplicationInterval(
+        this.additionInterval(x, 1.0),
+        this.subtractionInterval(x, 1.0)
+      );
+      const sqrt_value = this.sqrtInterval(inner_value);
+      return this.logInterval(this.additionInterval(x, sqrt_value));
+    },
+  };
+
+  /** Calculate an acceptance interval of acosh(x) using log(x + sqrt((x + 1.0f) * (x - 1.0))) */
+  public acoshAlternativeInterval(x: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(x), this.AcoshAlternativeIntervalOp);
+  }
+
+  private readonly AcoshPrimaryIntervalOp: PointToIntervalOp = {
+    impl: (x: number): FPInterval => {
+      // acosh(x) = log(x + sqrt(x * x - 1.0))
+      const inner_value = this.subtractionInterval(this.multiplicationInterval(x, x), 1.0);
+      const sqrt_value = this.sqrtInterval(inner_value);
+      return this.logInterval(this.additionInterval(x, sqrt_value));
+    },
+  };
+
+  /** Calculate an acceptance interval of acosh(x) using log(x + sqrt(x * x - 1.0)) */
+  public acoshPrimaryInterval(x: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(x), this.AcoshPrimaryIntervalOp);
+  }
+
+  private readonly AdditionIntervalOp: BinaryToIntervalOp = {
+    impl: (x: number, y: number): FPInterval => {
+      return this.correctlyRoundedInterval(x + y);
+    },
+  };
+
+  /** Calculate an acceptance interval of x + y */
+  public additionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+    return this.runBinaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(y),
+      this.AdditionIntervalOp
+    );
+  }
+
+  /** Calculate an acceptance interval of x + y, when x and y are matrices */
+  public additionMatrixInterval(x: Matrix<number>, y: Matrix<number>): FPMatrix {
+    return this.runBinaryToIntervalOpMatrixComponentWise(
+      this.toMatrix(x),
+      this.toMatrix(y),
+      this.AdditionIntervalOp
+    );
+  }
+
+  private readonly AsinIntervalOp: PointToIntervalOp = {
+    impl: this.limitPointToIntervalDomain(this.toInterval([-1.0, 1.0]), (n: number) => {
+      // asin(n) = atan2(n, sqrt(1.0 - n * n)) or a polynomial approximation with absolute error
+      const x = this.sqrtInterval(this.subtractionInterval(1, this.multiplicationInterval(n, n)));
+      return this.spanIntervals(
+        this.atan2Interval(n, x),
+        this.absoluteErrorInterval(Math.asin(n), 6.77e-5)
+      );
+    }),
+  };
+
+  /** Calculate an acceptance interval for asin(n) */
+  public asinInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.AsinIntervalOp);
+  }
+
+  private readonly AsinhIntervalOp: PointToIntervalOp = {
+    impl: (x: number): FPInterval => {
+      // asinh(x) = log(x + sqrt(x * x + 1.0))
+      const inner_value = this.additionInterval(this.multiplicationInterval(x, x), 1.0);
+      const sqrt_value = this.sqrtInterval(inner_value);
+      return this.logInterval(this.additionInterval(x, sqrt_value));
+    },
+  };
+
+  /** Calculate an acceptance interval of asinh(x) */
+  public asinhInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.AsinhIntervalOp);
+  }
+
+  private readonly AtanIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.ulpInterval(Math.atan(n), 4096);
+    },
+  };
+
+  /** Calculate an acceptance interval of atan(x) */
+  public atanInterval(n: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.AtanIntervalOp);
+  }
+
+  private readonly Atan2IntervalOp: BinaryToIntervalOp = {
+    impl: this.limitBinaryToIntervalDomain(
+      {
+        // For atan2, there params are labelled (y, x), not (x, y), so domain.x is first parameter (y), and domain.y is
+        // the second parameter (x)
+        x: [
+          this.toInterval([kValue.f32.negative.min, kValue.f32.negative.max]),
+          this.toInterval([kValue.f32.positive.min, kValue.f32.positive.max]),
+        ], // first param must be finite and normal
+        y: [this.toInterval([-(2 ** 126), -(2 ** -126)]), this.toInterval([2 ** -126, 2 ** 126])], // inherited from division
+      },
+      (y: number, x: number): FPInterval => {
+        const atan_yx = Math.atan(y / x);
+        // x > 0, atan(y/x)
+        if (x > 0) {
+          return this.ulpInterval(atan_yx, 4096);
+        }
+
+        // x < 0, y > 0, atan(y/x) + π
+        if (y > 0) {
+          return this.ulpInterval(atan_yx + kValue.f32.positive.pi.whole, 4096);
+        }
+
+        // x < 0, y < 0, atan(y/x) - π
+        return this.ulpInterval(atan_yx - kValue.f32.positive.pi.whole, 4096);
+      }
+    ),
+    extrema: (y: FPInterval, x: FPInterval): [FPInterval, FPInterval] => {
+      // There is discontinuity + undefined behaviour at y/x = 0 that will dominate the accuracy
+      if (y.contains(0)) {
+        if (x.contains(0)) {
+          return [this.toInterval(0), this.toInterval(0)];
+        }
+        return [this.toInterval(0), x];
+      }
+      return [y, x];
+    },
+  };
+
+  /** Calculate an acceptance interval of atan2(y, x) */
+  public atan2Interval(y: number | FPInterval, x: number | FPInterval): FPInterval {
+    return this.runBinaryToIntervalOp(this.toInterval(y), this.toInterval(x), this.Atan2IntervalOp);
+  }
+
+  private readonly AtanhIntervalOp: PointToIntervalOp = {
+    impl: (n: number) => {
+      // atanh(x) = log((1.0 + x) / (1.0 - x)) * 0.5
+      const numerator = this.additionInterval(1.0, n);
+      const denominator = this.subtractionInterval(1.0, n);
+      const log_interval = this.logInterval(this.divisionInterval(numerator, denominator));
+      return this.multiplicationInterval(log_interval, 0.5);
+    },
+  };
+
+  /** Calculate an acceptance interval of atanh(x) */
+  public atanhInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.AtanhIntervalOp);
+  }
+
+  private readonly CeilIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.correctlyRoundedInterval(Math.ceil(n));
+    },
+  };
+
+  /** Calculate an acceptance interval of ceil(x) */
+  public ceilInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.CeilIntervalOp);
+  }
+
+  /** All acceptance interval functions for clamp(x, y, z) */
+  public readonly clampIntervals: TernaryToInterval[] = [
+    this.clampMinMaxInterval.bind(this),
+    this.clampMedianInterval.bind(this),
+  ];
+
+  private readonly ClampMedianIntervalOp: TernaryToIntervalOp = {
+    impl: (x: number, y: number, z: number): FPInterval => {
+      return this.correctlyRoundedInterval(
+        // Default sort is string sort, so have to implement numeric comparison.
+        // Cannot use the b-a one-liner, because that assumes no infinities.
+        [x, y, z].sort((a, b) => {
+          if (a < b) {
+            return -1;
+          }
+          if (a > b) {
+            return 1;
+          }
+          return 0;
+        })[1]
+      );
+    },
+  };
+
+  /** Calculate an acceptance interval of clamp(x, y, z) via median(x, y, z) */
+  public clampMedianInterval(
+    x: number | FPInterval,
+    y: number | FPInterval,
+    z: number | FPInterval
+  ): FPInterval {
+    return this.runTernaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(y),
+      this.toInterval(z),
+      this.ClampMedianIntervalOp
+    );
+  }
+
+  private readonly ClampMinMaxIntervalOp: TernaryToIntervalOp = {
+    impl: (x: number, low: number, high: number): FPInterval => {
+      return this.minInterval(this.maxInterval(x, low), high);
+    },
+  };
+
+  /** Calculate an acceptance interval of clamp(x, high, low) via min(max(x, low), high) */
+  public clampMinMaxInterval(
+    x: number | FPInterval,
+    low: number | FPInterval,
+    high: number | FPInterval
+  ): FPInterval {
+    return this.runTernaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(low),
+      this.toInterval(high),
+      this.ClampMinMaxIntervalOp
+    );
+  }
+
+  private readonly CosIntervalOp: PointToIntervalOp = {
+    impl: this.limitPointToIntervalDomain(
+      this.constants().negPiToPiInterval,
+      (n: number): FPInterval => {
+        return this.absoluteErrorInterval(Math.cos(n), 2 ** -11);
+      }
+    ),
+  };
+
+  /** Calculate an acceptance interval of cos(x) */
+  public cosInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.CosIntervalOp);
+  }
+
+  private readonly CoshIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      // cosh(x) = (exp(x) + exp(-x)) * 0.5
+      const minus_n = this.negationInterval(n);
+      return this.multiplicationInterval(
+        this.additionInterval(this.expInterval(n), this.expInterval(minus_n)),
+        0.5
+      );
+    },
+  };
+
+  /** Calculate an acceptance interval of cosh(x) */
+  public coshInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.CoshIntervalOp);
+  }
+
+  private readonly CrossIntervalOp: VectorPairToVectorOp = {
+    impl: (x: number[], y: number[]): FPVector => {
+      assert(x.length === 3, `CrossIntervalOp received x with ${x.length} instead of 3`);
+      assert(y.length === 3, `CrossIntervalOp received y with ${y.length} instead of 3`);
+
+      // cross(x, y) = r, where
+      //   r[0] = x[1] * y[2] - x[2] * y[1]
+      //   r[1] = x[2] * y[0] - x[0] * y[2]
+      //   r[2] = x[0] * y[1] - x[1] * y[0]
+
+      const r0 = this.subtractionInterval(
+        this.multiplicationInterval(x[1], y[2]),
+        this.multiplicationInterval(x[2], y[1])
+      );
+      const r1 = this.subtractionInterval(
+        this.multiplicationInterval(x[2], y[0]),
+        this.multiplicationInterval(x[0], y[2])
+      );
+      const r2 = this.subtractionInterval(
+        this.multiplicationInterval(x[0], y[1]),
+        this.multiplicationInterval(x[1], y[0])
+      );
+      return [r0, r1, r2];
+    },
+  };
+
+  public crossInterval(x: number[], y: number[]): FPVector {
+    assert(x.length === 3, `Cross is only defined for vec3`);
+    assert(y.length === 3, `Cross is only defined for vec3`);
+    return this.runVectorPairToVectorOp(this.toVector(x), this.toVector(y), this.CrossIntervalOp);
+  }
+
+  private readonly DegreesIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.multiplicationInterval(n, 57.295779513082322865);
+    },
+  };
+
+  /** Calculate an acceptance interval of degrees(x) */
+  public degreesInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.DegreesIntervalOp);
+  }
+
+  /**
+   * Calculate the minor of a NxN matrix.
+   *
+   * The ijth minor of a square matrix, is the N-1xN-1 matrix created by removing
+   * the ith column and jth row from the original matrix.
+   */
+  private minorNxN(m: Matrix<number>, col: number, row: number): Matrix<number> {
+    const dim = m.length;
+    assert(m.length === m[0].length, `minorMatrix is only defined for square matrices`);
+    assert(col >= 0 && col < dim, `col ${col} needs be in [0, # of columns '${dim}')`);
+    assert(row >= 0 && row < dim, `row ${row} needs be in [0, # of rows '${dim}')`);
+
+    const result: Matrix<number> = [...Array(dim - 1)].map(_ => [...Array(dim - 1)]);
+
+    const col_indices: number[] = [...Array(dim).keys()].filter(e => e !== col);
+    const row_indices: number[] = [...Array(dim).keys()].filter(e => e !== row);
+
+    col_indices.forEach((c, i) => {
+      row_indices.forEach((r, j) => {
+        result[i][j] = m[c][r];
+      });
+    });
+    return result;
+  }
+
+  /** Calculate an acceptance interval for determinant(m), where m is a 2x2 matrix */
+  private determinant2x2Interval(m: Matrix<number>): FPInterval {
+    assert(
+      m.length === m[0].length && m.length === 2,
+      `determinant2x2Interval called on non-2x2 matrix`
+    );
+    return this.subtractionInterval(
+      this.multiplicationInterval(m[0][0], m[1][1]),
+      this.multiplicationInterval(m[0][1], m[1][0])
+    );
+  }
+
+  /** Calculate an acceptance interval for determinant(m), where m is a 3x3 matrix */
+  private determinant3x3Interval(m: Matrix<number>): FPInterval {
+    assert(
+      m.length === m[0].length && m.length === 3,
+      `determinant3x3Interval called on non-3x3 matrix`
+    );
+
+    // M is a 3x3 matrix
+    // det(M) is A + B + C, where A, B, C are three elements in a row/column times
+    // their own co-factor.
+    // (The co-factor is the determinant of the minor of that position with the
+    // appropriate +/-)
+    // For simplicity sake A, B, C are calculated as the elements of the first
+    // column
+    const A = this.multiplicationInterval(
+      m[0][0],
+      this.determinant2x2Interval(this.minorNxN(m, 0, 0))
+    );
+    const B = this.multiplicationInterval(
+      -m[0][1],
+      this.determinant2x2Interval(this.minorNxN(m, 0, 1))
+    );
+    const C = this.multiplicationInterval(
+      m[0][2],
+      this.determinant2x2Interval(this.minorNxN(m, 0, 2))
+    );
+
+    // Need to calculate permutations, since for fp addition is not associative,
+    // so A + B + C is not guaranteed to equal B + C + A, etc.
+    const permutations: FPInterval[][] = calculatePermutations([A, B, C]);
+    return this.spanIntervals(
+      ...permutations.map(p =>
+        p.reduce((prev: FPInterval, cur: FPInterval) => this.additionInterval(prev, cur))
+      )
+    );
+  }
+
+  /** Calculate an acceptance interval for determinant(m), where m is a 4x4 matrix */
+  private determinant4x4Interval(m: Matrix<number>): FPInterval {
+    assert(
+      m.length === m[0].length && m.length === 4,
+      `determinant3x3Interval called on non-4x4 matrix`
+    );
+
+    // M is a 4x4 matrix
+    // det(M) is A + B + C + D, where A, B, C, D are four elements in a row/column
+    // times their own co-factor.
+    // (The co-factor is the determinant of the minor of that position with the
+    // appropriate +/-)
+    // For simplicity sake A, B, C, D are calculated as the elements of the
+    // first column
+    const A = this.multiplicationInterval(
+      m[0][0],
+      this.determinant3x3Interval(this.minorNxN(m, 0, 0))
+    );
+    const B = this.multiplicationInterval(
+      -m[0][1],
+      this.determinant3x3Interval(this.minorNxN(m, 0, 1))
+    );
+    const C = this.multiplicationInterval(
+      m[0][2],
+      this.determinant3x3Interval(this.minorNxN(m, 0, 2))
+    );
+    const D = this.multiplicationInterval(
+      -m[0][3],
+      this.determinant3x3Interval(this.minorNxN(m, 0, 3))
+    );
+
+    // Need to calculate permutations, since for fp addition is not associative
+    // so A + B + C + D is not guaranteed to equal B + C + A + D, etc.
+    const permutations: FPInterval[][] = calculatePermutations([A, B, C, D]);
+    return this.spanIntervals(
+      ...permutations.map(p =>
+        p.reduce((prev: FPInterval, cur: FPInterval) => this.additionInterval(prev, cur))
+      )
+    );
+  }
+
+  /**
+   * Calculate an acceptance interval for determinant(x)
+   *
+   * This code calculates 3x3 and 4x4 determinants using the textbook co-factor
+   * method, using the first column for the co-factor selection.
+   *
+   * For matrices composed of integer elements, e, with |e|^4 < 2**21, this
+   * should be fine.
+   *
+   * For e, where e is subnormal or 4*(e^4) might not be precisely expressible as
+   * a f32 values, this approach breaks down, because the rule of all co-factor
+   * definitions of determinant being equal doesn't hold in these cases.
+   *
+   * The general solution for this is to calculate all the permutations of the
+   * operations in the worked out formula for determinant.
+   * For 3x3 this is tractable, but for 4x4 this works out to ~23! permutations
+   * that need to be calculated.
+   * Thus, CTS testing and the spec definition of accuracy is restricted to the
+   * space that the simple implementation is valid.
+   */
+  public determinantInterval(x: Matrix<number>): FPInterval {
+    const dim = x.length;
+    assert(
+      x[0].length === dim && (dim === 2 || dim === 3 || dim === 4),
+      `determinantInterval only defined for 2x2, 3x3 and 4x4 matrices`
+    );
+    switch (dim) {
+      case 2:
+        return this.determinant2x2Interval(x);
+      case 3:
+        return this.determinant3x3Interval(x);
+      case 4:
+        return this.determinant4x4Interval(x);
+    }
+    unreachable(
+      "determinantInterval called on x, where which has an unexpected dimension of '${dim}'"
+    );
+  }
+
+  private readonly DistanceIntervalScalarOp: BinaryToIntervalOp = {
+    impl: (x: number, y: number): FPInterval => {
+      return this.lengthInterval(this.subtractionInterval(x, y));
+    },
+  };
+
+  private readonly DistanceIntervalVectorOp: VectorPairToIntervalOp = {
+    impl: (x: number[], y: number[]): FPInterval => {
+      return this.lengthInterval(
+        this.runBinaryToIntervalOpVectorComponentWise(
+          this.toVector(x),
+          this.toVector(y),
+          this.SubtractionIntervalOp
+        )
+      );
+    },
+  };
+
+  /** Calculate an acceptance interval of distance(x, y) */
+  public distanceInterval(x: number | number[], y: number | number[]): FPInterval {
+    if (x instanceof Array && y instanceof Array) {
+      assert(
+        x.length === y.length,
+        `distanceInterval requires both params to have the same number of elements`
+      );
+      return this.runVectorPairToIntervalOp(
+        this.toVector(x),
+        this.toVector(y),
+        this.DistanceIntervalVectorOp
+      );
+    } else if (!(x instanceof Array) && !(y instanceof Array)) {
+      return this.runBinaryToIntervalOp(
+        this.toInterval(x),
+        this.toInterval(y),
+        this.DistanceIntervalScalarOp
+      );
+    }
+    unreachable(
+      `distanceInterval requires both params to both the same type, either scalars or vectors`
+    );
+  }
+
+  private readonly DivisionIntervalOp: BinaryToIntervalOp = {
+    impl: this.limitBinaryToIntervalDomain(
+      {
+        x: [this.toInterval([kValue.f32.negative.min, kValue.f32.positive.max])],
+        y: [this.toInterval([-(2 ** 126), -(2 ** -126)]), this.toInterval([2 ** -126, 2 ** 126])],
+      },
+      (x: number, y: number): FPInterval => {
+        if (y === 0) {
+          return this.constants().anyInterval;
+        }
+        return this.ulpInterval(x / y, 2.5);
+      }
+    ),
+    extrema: (x: FPInterval, y: FPInterval): [FPInterval, FPInterval] => {
+      // division has a discontinuity at y = 0.
+      if (y.contains(0)) {
+        y = this.toInterval(0);
+      }
+      return [x, y];
+    },
+  };
+
+  /** Calculate an acceptance interval of x / y */
+  public divisionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+    return this.runBinaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(y),
+      this.DivisionIntervalOp
+    );
+  }
+
+  private readonly DotIntervalOp: VectorPairToIntervalOp = {
+    impl: (x: number[], y: number[]): FPInterval => {
+      // dot(x, y) = sum of x[i] * y[i]
+      const multiplications = this.runBinaryToIntervalOpVectorComponentWise(
+        this.toVector(x),
+        this.toVector(y),
+        this.MultiplicationIntervalOp
+      );
+
+      // vec2 doesn't require permutations, since a + b = b + a for floats
+      if (multiplications.length === 2) {
+        return this.additionInterval(multiplications[0], multiplications[1]);
+      }
+
+      // The spec does not state the ordering of summation, so all the
+      // permutations are calculated and their results spanned, since addition
+      // of more than two floats is not transitive, i.e. a + b + c is not
+      // guaranteed to equal b + a + c
+      const permutations: FPInterval[][] = calculatePermutations(multiplications);
+      return this.spanIntervals(
+        ...permutations.map(p => p.reduce((prev, cur) => this.additionInterval(prev, cur)))
+      );
+    },
+  };
+
+  public dotInterval(x: number[] | FPInterval[], y: number[] | FPInterval[]): FPInterval {
+    assert(x.length === y.length, `dot not defined for vectors with different lengths`);
+    return this.runVectorPairToIntervalOp(this.toVector(x), this.toVector(y), this.DotIntervalOp);
+  }
+
+  private readonly ExpIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.ulpInterval(Math.exp(n), 3 + 2 * Math.abs(n));
+    },
+  };
+
+  /** Calculate an acceptance interval for exp(x) */
+  public expInterval(x: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(x), this.ExpIntervalOp);
+  }
+
+  private readonly Exp2IntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.ulpInterval(Math.pow(2, n), 3 + 2 * Math.abs(n));
+    },
+  };
+
+  /** Calculate an acceptance interval for exp2(x) */
+  public exp2Interval(x: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(x), this.Exp2IntervalOp);
+  }
+
+  /**
+   * Calculate the acceptance intervals for faceForward(x, y, z)
+   *
+   * faceForward(x, y, z) = select(-x, x, dot(z, y) < 0.0)
+   *
+   * This builtin selects from two discrete results (delta rounding/flushing),
+   * so the majority of the framework code is not appropriate, since the
+   * framework attempts to span results.
+   *
+   * Thus, a bespoke implementation is used instead of
+   * defining an Op and running that through the framework.
+   */
+  public faceForwardIntervals(x: number[], y: number[], z: number[]): (FPVector | undefined)[] {
+    const x_vec = this.toVector(x);
+    // Running vector through this.runPointToIntervalOpComponentWise to make
+    // sure that flushing/rounding is handled, since toVector does not perform
+    // those operations.
+    const positive_x = this.runPointToIntervalOpComponentWise(x_vec, {
+      impl: (i: number): FPInterval => {
+        return this.toInterval(i);
+      },
+    });
+    const negative_x = this.runPointToIntervalOpComponentWise(x_vec, this.NegationIntervalOp);
+
+    const dot_interval = this.dotInterval(z, y);
+
+    const results: (FPVector | undefined)[] = [];
+
+    if (!dot_interval.isFinite()) {
+      // dot calculation went out of bounds
+      // Inserting undefined in the result, so that the test running framework
+      // is aware of this potential OOB.
+      // For const-eval tests, it means that the test case should be skipped,
+      // since the shader will fail to compile.
+      // For non-const-eval the undefined should be stripped out of the possible
+      // results.
+
+      results.push(undefined);
+    }
+
+    // Because the result of dot can be an interval, it might span across 0, thus
+    // it is possible that both -x and x are valid responses.
+    if (dot_interval.begin < 0 || dot_interval.end < 0) {
+      results.push(positive_x);
+    }
+
+    if (dot_interval.begin >= 0 || dot_interval.end >= 0) {
+      results.push(negative_x);
+    }
+
+    assert(
+      results.length > 0 || results.every(r => r === undefined),
+      `faceForwardInterval selected neither positive x or negative x for the result, this shouldn't be possible`
+    );
+    return results;
+  }
+
+  private readonly FloorIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.correctlyRoundedInterval(Math.floor(n));
+    },
+  };
+
+  /** Calculate an acceptance interval of floor(x) */
+  public floorInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.FloorIntervalOp);
+  }
+
+  private readonly FmaIntervalOp: TernaryToIntervalOp = {
+    impl: (x: number, y: number, z: number): FPInterval => {
+      return this.additionInterval(this.multiplicationInterval(x, y), z);
+    },
+  };
+
+  /** Calculate an acceptance interval for fma(x, y, z) */
+  public fmaInterval(x: number, y: number, z: number): FPInterval {
+    return this.runTernaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(y),
+      this.toInterval(z),
+      this.FmaIntervalOp
+    );
+  }
+
+  private readonly FractIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      // fract(x) = x - floor(x) is defined in the spec.
+      // For people coming from a non-graphics background this will cause some
+      // unintuitive results. For example,
+      // fract(-1.1) is not 0.1 or -0.1, but instead 0.9.
+      // This is how other shading languages operate and allows for a desirable
+      // wrap around in graphics programming.
+      const result = this.subtractionInterval(n, this.floorInterval(n));
+      if (result.contains(1)) {
+        // Very small negative numbers can lead to catastrophic cancellation,
+        // thus calculating a fract of 1.0, which is technically not a
+        // fractional part, so some implementations clamp the result to next
+        // nearest number.
+        return this.spanIntervals(result, this.toInterval(kValue.f32.positive.less_than_one));
+      }
+      return result;
+    },
+  };
+
+  /** Calculate an acceptance interval of fract(x) */
+  public fractInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.FractIntervalOp);
+  }
+
+  private readonly InverseSqrtIntervalOp: PointToIntervalOp = {
+    impl: this.limitPointToIntervalDomain(
+      this.constants().greaterThanZeroInterval,
+      (n: number): FPInterval => {
+        return this.ulpInterval(1 / Math.sqrt(n), 2);
+      }
+    ),
+  };
+
+  /** Calculate an acceptance interval of inverseSqrt(x) */
+  public inverseSqrtInterval(n: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.InverseSqrtIntervalOp);
+  }
+
+  private readonly LdexpIntervalOp: BinaryToIntervalOp = {
+    impl: this.limitBinaryToIntervalDomain(
+      // Implementing SPIR-V's more restrictive domain until
+      // https://github.com/gpuweb/gpuweb/issues/3134 is resolved
+      {
+        x: [this.toInterval([kValue.f32.negative.min, kValue.f32.positive.max])],
+        y: [this.toInterval([-126, 128])],
+      },
+      (e1: number, e2: number): FPInterval => {
+        // Though the spec says the result of ldexp(e1, e2) = e1 * 2 ^ e2, the
+        // accuracy is listed as correctly rounded to the true value, so the
+        // inheritance framework does not need to be invoked to determine
+        // bounds.
+        // Instead, the value at a higher precision is calculated and passed to
+        // correctlyRoundedInterval.
+        const result = e1 * 2 ** e2;
+        if (Number.isNaN(result)) {
+          // Overflowed TS's number type, so definitely out of bounds for f32
+          return this.constants().anyInterval;
+        }
+        return this.correctlyRoundedInterval(result);
+      }
+    ),
+  };
+
+  /** Calculate an acceptance interval of ldexp(e1, e2) */
+  public ldexpInterval(e1: number, e2: number): FPInterval {
+    return this.roundAndFlushBinaryToInterval(e1, e2, this.LdexpIntervalOp);
+  }
+
+  private readonly LengthIntervalScalarOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.sqrtInterval(this.multiplicationInterval(n, n));
+    },
+  };
+
+  private readonly LengthIntervalVectorOp: VectorToIntervalOp = {
+    impl: (n: number[]): FPInterval => {
+      return this.sqrtInterval(this.dotInterval(n, n));
+    },
+  };
+
+  /** Calculate an acceptance interval of length(x) */
+  public lengthInterval(n: number | FPInterval | number[] | FPVector): FPInterval {
+    if (n instanceof Array) {
+      return this.runVectorToIntervalOp(this.toVector(n), this.LengthIntervalVectorOp);
+    } else {
+      return this.runPointToIntervalOp(this.toInterval(n), this.LengthIntervalScalarOp);
+    }
+  }
+
+  private readonly LogIntervalOp: PointToIntervalOp = {
+    impl: this.limitPointToIntervalDomain(
+      this.constants().greaterThanZeroInterval,
+      (n: number): FPInterval => {
+        if (n >= 0.5 && n <= 2.0) {
+          return this.absoluteErrorInterval(Math.log(n), 2 ** -21);
+        }
+        return this.ulpInterval(Math.log(n), 3);
+      }
+    ),
+  };
+
+  /** Calculate an acceptance interval of log(x) */
+  public logInterval(x: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(x), this.LogIntervalOp);
+  }
+
+  private readonly Log2IntervalOp: PointToIntervalOp = {
+    impl: this.limitPointToIntervalDomain(
+      this.constants().greaterThanZeroInterval,
+      (n: number): FPInterval => {
+        if (n >= 0.5 && n <= 2.0) {
+          return this.absoluteErrorInterval(Math.log2(n), 2 ** -21);
+        }
+        return this.ulpInterval(Math.log2(n), 3);
+      }
+    ),
+  };
+
+  /** Calculate an acceptance interval of log2(x) */
+  public log2Interval(x: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(x), this.Log2IntervalOp);
+  }
+
+  private readonly MaxIntervalOp: BinaryToIntervalOp = {
+    impl: (x: number, y: number): FPInterval => {
+      // If both of he inputs are subnormal, then either of the inputs can be returned
+      if (isSubnormalNumberF32(x) && isSubnormalNumberF32(y)) {
+        return this.correctlyRoundedInterval(
+          this.spanIntervals(this.toInterval(x), this.toInterval(y))
+        );
+      }
+
+      return this.correctlyRoundedInterval(Math.max(x, y));
+    },
+  };
+
+  /** Calculate an acceptance interval of max(x, y) */
+  public maxInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+    return this.runBinaryToIntervalOp(this.toInterval(x), this.toInterval(y), this.MaxIntervalOp);
+  }
+
+  private readonly MinIntervalOp: BinaryToIntervalOp = {
+    impl: (x: number, y: number): FPInterval => {
+      // If both of he inputs are subnormal, then either of the inputs can be returned
+      if (isSubnormalNumberF32(x) && isSubnormalNumberF32(y)) {
+        return this.correctlyRoundedInterval(
+          this.spanIntervals(this.toInterval(x), this.toInterval(y))
+        );
+      }
+
+      return this.correctlyRoundedInterval(Math.min(x, y));
+    },
+  };
+
+  /** Calculate an acceptance interval of min(x, y) */
+  public minInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+    return this.runBinaryToIntervalOp(this.toInterval(x), this.toInterval(y), this.MinIntervalOp);
+  }
+
+  /** All acceptance interval functions for mix(x, y, z) */
+  public readonly mixIntervals: TernaryToInterval[] = [
+    this.mixImpreciseInterval.bind(this),
+    this.mixPreciseInterval.bind(this),
+  ];
+
+  private readonly MixImpreciseIntervalOp: TernaryToIntervalOp = {
+    impl: (x: number, y: number, z: number): FPInterval => {
+      // x + (y - x) * z =
+      //  x + t, where t = (y - x) * z
+      const t = this.multiplicationInterval(this.subtractionInterval(y, x), z);
+      return this.additionInterval(x, t);
+    },
+  };
+
+  /** Calculate an acceptance interval of mix(x, y, z) using x + (y - x) * z */
+  public mixImpreciseInterval(x: number, y: number, z: number): FPInterval {
+    return this.runTernaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(y),
+      this.toInterval(z),
+      this.MixImpreciseIntervalOp
+    );
+  }
+
+  private readonly MixPreciseIntervalOp: TernaryToIntervalOp = {
+    impl: (x: number, y: number, z: number): FPInterval => {
+      // x * (1.0 - z) + y * z =
+      //   t + s, where t = x * (1.0 - z), s = y * z
+      const t = this.multiplicationInterval(x, this.subtractionInterval(1.0, z));
+      const s = this.multiplicationInterval(y, z);
+      return this.additionInterval(t, s);
+    },
+  };
+
+  /** Calculate an acceptance interval of mix(x, y, z) using x * (1.0 - z) + y * z */
+  public mixPreciseInterval(x: number, y: number, z: number): FPInterval {
+    return this.runTernaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(y),
+      this.toInterval(z),
+      this.MixPreciseIntervalOp
+    );
+  }
+
+  /** Calculate an acceptance interval of modf(x) */
+  public modfInterval(n: number): { fract: FPInterval; whole: FPInterval } {
+    const fract = this.correctlyRoundedInterval(n % 1.0);
+    const whole = this.correctlyRoundedInterval(n - (n % 1.0));
+    return { fract, whole };
+  }
+
+  private readonly MultiplicationInnerOp = {
+    impl: (x: number, y: number): FPInterval => {
+      return this.correctlyRoundedInterval(x * y);
+    },
+  };
+
+  private readonly MultiplicationIntervalOp: BinaryToIntervalOp = {
+    impl: (x: number, y: number): FPInterval => {
+      return this.roundAndFlushBinaryToInterval(x, y, this.MultiplicationInnerOp);
+    },
+  };
+
+  /** Calculate an acceptance interval of x * y */
+  public multiplicationInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+    return this.runBinaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(y),
+      this.MultiplicationIntervalOp
+    );
+  }
+
+  /**
+   * @returns the vector result of multiplying the given vector by the given
+   *          scalar
+   */
+  private multiplyVectorByScalar(v: number[], c: number | FPInterval): FPVector {
+    return this.toVector(v.map(x => this.multiplicationInterval(x, c)));
+  }
+
+  /** Calculate an acceptance interval of x * y, when x is a matrix and y is a scalar */
+  public multiplicationMatrixScalarInterval(mat: Matrix<number>, scalar: number): FPMatrix {
+    const cols = mat.length;
+    const rows = mat[0].length;
+    return this.toMatrix(
+      unflatten2DArray(
+        flatten2DArray(mat).map(e => this.MultiplicationIntervalOp.impl(e, scalar)),
+        cols,
+        rows
+      )
+    );
+  }
+
+  /** Calculate an acceptance interval of x * y, when x is a scalar and y is a matrix */
+  public multiplicationScalarMatrixInterval(scalar: number, mat: Matrix<number>): FPMatrix {
+    return this.multiplicationMatrixScalarInterval(mat, scalar);
+  }
+
+  /** Calculate an acceptance interval of x * y, when x is a matrix and y is a matrix */
+  public multiplicationMatrixMatrixInterval(
+    mat_x: Matrix<number>,
+    mat_y: Matrix<number>
+  ): FPMatrix {
+    const x_cols = mat_x.length;
+    const x_rows = mat_x[0].length;
+    const y_cols = mat_y.length;
+    const y_rows = mat_y[0].length;
+    assert(x_cols === y_rows, `'mat${x_cols}x${x_rows} * mat${y_cols}x${y_rows}' is not defined`);
+
+    const x_transposed = this.transposeInterval(mat_x);
+
+    const result: Matrix<FPInterval> = [...Array(y_cols)].map(_ => [...Array(x_rows)]);
+    mat_y.forEach((y, i) => {
+      x_transposed.forEach((x, j) => {
+        result[i][j] = this.dotInterval(x, y);
+      });
+    });
+
+    return result as FPMatrix;
+  }
+
+  /** Calculate an acceptance interval of x * y, when x is a matrix and y is a vector */
+  public multiplicationMatrixVectorInterval(x: Matrix<number>, y: number[]): FPVector {
+    const cols = x.length;
+    const rows = x[0].length;
+    assert(y.length === cols, `'mat${cols}x${rows} * vec${y.length}' is not defined`);
+
+    return this.transposeInterval(x).map(e => this.dotInterval(e, y)) as FPVector;
+  }
+
+  /** Calculate an acceptance interval of x * y, when x is a vector and y is a matrix */
+  public multiplicationVectorMatrixInterval(x: number[], y: Matrix<number>): FPVector {
+    const cols = y.length;
+    const rows = y[0].length;
+    assert(x.length === rows, `'vec${x.length} * mat${cols}x${rows}' is not defined`);
+
+    return y.map(e => this.dotInterval(x, e)) as FPVector;
+  }
+
+  private readonly NegationIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.correctlyRoundedInterval(-n);
+    },
+  };
+
+  /** Calculate an acceptance interval of -x */
+  public negationInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.NegationIntervalOp);
+  }
+
+  private readonly NormalizeIntervalOp: VectorToVectorOp = {
+    impl: (n: number[]): FPVector => {
+      const length = this.lengthInterval(n);
+      return this.toVector(n.map(e => this.divisionInterval(e, length)));
+    },
+  };
+
+  /** Calculate an acceptance interval of normalize(x) */
+  public normalizeInterval(n: number[]): FPVector {
+    return this.runVectorToVectorOp(this.toVector(n), this.NormalizeIntervalOp);
+  }
+
+  private readonly PowIntervalOp: BinaryToIntervalOp = {
+    // pow(x, y) has no explicit domain restrictions, but inherits the x <= 0
+    // domain restriction from log2(x). Invoking log2Interval(x) in impl will
+    // enforce this, so there is no need to wrap the impl call here.
+    impl: (x: number, y: number): FPInterval => {
+      return this.exp2Interval(this.multiplicationInterval(y, this.log2Interval(x)));
+    },
+  };
+
+  /** Calculate an acceptance interval of pow(x, y) */
+  public powInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+    return this.runBinaryToIntervalOp(this.toInterval(x), this.toInterval(y), this.PowIntervalOp);
+  }
+
+  // Once a full implementation of F16Interval exists, the correctlyRounded for
+  // that can potentially be used instead of having a bespoke operation
+  // implementation.
+  private readonly QuantizeToF16IntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      const rounded = correctlyRoundedF16(n);
+      const flushed = addFlushedIfNeededF16(rounded);
+      return this.spanIntervals(...flushed.map(f => this.toInterval(f)));
+    },
+  };
+
+  /** Calculate an acceptance interval of quantizeToF16(x) */
+  public quantizeToF16Interval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.QuantizeToF16IntervalOp);
+  }
+
+  private readonly RadiansIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.multiplicationInterval(n, 0.017453292519943295474);
+    },
+  };
+
+  /** Calculate an acceptance interval of radians(x) */
+  public radiansInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.RadiansIntervalOp);
+  }
+
+  private readonly ReflectIntervalOp: VectorPairToVectorOp = {
+    impl: (x: number[], y: number[]): FPVector => {
+      assert(
+        x.length === y.length,
+        `ReflectIntervalOp received x (${x}) and y (${y}) with different numbers of elements`
+      );
+
+      // reflect(x, y) = x - 2.0 * dot(x, y) * y
+      //               = x - t * y, t = 2.0 * dot(x, y)
+      // x = incident vector
+      // y = normal of reflecting surface
+      const t = this.multiplicationInterval(2.0, this.dotInterval(x, y));
+      const rhs = this.multiplyVectorByScalar(y, t);
+      return this.runBinaryToIntervalOpVectorComponentWise(
+        this.toVector(x),
+        rhs,
+        this.SubtractionIntervalOp
+      );
+    },
+  };
+
+  /** Calculate an acceptance interval of reflect(x, y) */
+  public reflectInterval(x: number[], y: number[]): FPVector {
+    assert(
+      x.length === y.length,
+      `reflect is only defined for vectors with the same number of elements`
+    );
+    return this.runVectorPairToVectorOp(this.toVector(x), this.toVector(y), this.ReflectIntervalOp);
+  }
+
+  /**
+   * Calculate acceptance interval vectors of reflect(i, s, r)
+   *
+   * refract is a singular function in the sense that it is the only builtin that
+   * takes in (FPVector, FPVector, F32) and returns FPVector and is basically
+   * defined in terms of other functions.
+   *
+   * Instead of implementing all the framework code to integrate it with its
+   * own operation type, etc, it instead has a bespoke implementation that is a
+   * composition of other builtin functions that use the framework.
+   */
+  public refractInterval(i: number[], s: number[], r: number): FPVector {
+    assert(
+      i.length === s.length,
+      `refract is only defined for vectors with the same number of elements`
+    );
+
+    const r_squared = this.multiplicationInterval(r, r);
+    const dot = this.dotInterval(s, i);
+    const dot_squared = this.multiplicationInterval(dot, dot);
+    const one_minus_dot_squared = this.subtractionInterval(1, dot_squared);
+    const k = this.subtractionInterval(
+      1.0,
+      this.multiplicationInterval(r_squared, one_minus_dot_squared)
+    );
+
+    if (!k.isFinite() || k.containsZeroOrSubnormals()) {
+      // There is a discontinuity at k == 0, due to sqrt(k) being calculated, so exiting early
+      return this.constants().anyVector[this.toVector(i).length];
+    }
+
+    if (k.end < 0.0) {
+      // if k is negative, then the zero vector is the valid response
+      return this.constants().zeroVector[this.toVector(i).length];
+    }
+
+    const dot_times_r = this.multiplicationInterval(dot, r);
+    const k_sqrt = this.sqrtInterval(k);
+    const t = this.additionInterval(dot_times_r, k_sqrt); // t = r * dot(i, s) + sqrt(k)
+
+    const result = this.runBinaryToIntervalOpVectorComponentWise(
+      this.multiplyVectorByScalar(i, r),
+      this.multiplyVectorByScalar(s, t),
+      this.SubtractionIntervalOp
+    ); // (i * r) - (s * t)
+    return result;
+  }
+
+  private readonly RemainderIntervalOp: BinaryToIntervalOp = {
+    impl: (x: number, y: number): FPInterval => {
+      // x % y = x - y * trunc(x/y)
+      return this.subtractionInterval(
+        x,
+        this.multiplicationInterval(y, this.truncInterval(this.divisionInterval(x, y)))
+      );
+    },
+  };
+
+  /** Calculate an acceptance interval for x % y */
+  public remainderInterval(x: number, y: number): FPInterval {
+    return this.runBinaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(y),
+      this.RemainderIntervalOp
+    );
+  }
+
+  private readonly RoundIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      const k = Math.floor(n);
+      const diff_before = n - k;
+      const diff_after = k + 1 - n;
+      if (diff_before < diff_after) {
+        return this.correctlyRoundedInterval(k);
+      } else if (diff_before > diff_after) {
+        return this.correctlyRoundedInterval(k + 1);
+      }
+
+      // n is in the middle of two integers.
+      // The tie breaking rule is 'k if k is even, k + 1 if k is odd'
+      if (k % 2 === 0) {
+        return this.correctlyRoundedInterval(k);
+      }
+      return this.correctlyRoundedInterval(k + 1);
+    },
+  };
+
+  /** Calculate an acceptance interval of round(x) */
+  public roundInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.RoundIntervalOp);
+  }
+
+  /**
+   * Calculate an acceptance interval of saturate(n) as clamp(n, 0.0, 1.0)
+   *
+   * The definition of saturate does not specify which version of clamp to use.
+   * Using min-max here, since it has wider acceptance intervals, that include
+   * all of median's.
+   */
+  public saturateInterval(n: number): FPInterval {
+    return this.runTernaryToIntervalOp(
+      this.toInterval(n),
+      this.toInterval(0.0),
+      this.toInterval(1.0),
+      this.ClampMinMaxIntervalOp
+    );
+  }
+
+  private readonly SignIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      if (n > 0.0) {
+        return this.correctlyRoundedInterval(1.0);
+      }
+      if (n < 0.0) {
+        return this.correctlyRoundedInterval(-1.0);
+      }
+
+      return this.correctlyRoundedInterval(0.0);
+    },
+  };
+
+  /** Calculate an acceptance interval of sign(x) */
+  public signInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.SignIntervalOp);
+  }
+
+  private readonly SinIntervalOp: PointToIntervalOp = {
+    impl: this.limitPointToIntervalDomain(
+      this.constants().negPiToPiInterval,
+      (n: number): FPInterval => {
+        return this.absoluteErrorInterval(Math.sin(n), 2 ** -11);
+      }
+    ),
+  };
+
+  /** Calculate an acceptance interval of sin(x) */
+  public sinInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.SinIntervalOp);
+  }
+
+  private readonly SinhIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      // sinh(x) = (exp(x) - exp(-x)) * 0.5
+      const minus_n = this.negationInterval(n);
+      return this.multiplicationInterval(
+        this.subtractionInterval(this.expInterval(n), this.expInterval(minus_n)),
+        0.5
+      );
+    },
+  };
+
+  /** Calculate an acceptance interval of sinh(x) */
+  public sinhInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.SinhIntervalOp);
+  }
+
+  private readonly SmoothStepOp: TernaryToIntervalOp = {
+    impl: (low: number, high: number, x: number): FPInterval => {
+      // For clamp(foo, 0.0, 1.0) the different implementations of clamp provide
+      // the same value, so arbitrarily picking the minmax version to use.
+      // t = clamp((x - low) / (high - low), 0.0, 1.0)
+      // prettier-ignore
+      const t = this.clampMedianInterval(
+        this.divisionInterval(
+          this.subtractionInterval(x, low),
+          this.subtractionInterval(high, low)),
+        0.0,
+        1.0);
+      // Inherited from t * t * (3.0 - 2.0 * t)
+      // prettier-ignore
+      return this.multiplicationInterval(
+        t,
+        this.multiplicationInterval(t,
+          this.subtractionInterval(3.0,
+            this.multiplicationInterval(2.0, t))));
+    },
+  };
+
+  /** Calculate an acceptance interval of smoothStep(low, high, x) */
+  public smoothStepInterval(low: number, high: number, x: number): FPInterval {
+    return this.runTernaryToIntervalOp(
+      this.toInterval(low),
+      this.toInterval(high),
+      this.toInterval(x),
+      this.SmoothStepOp
+    );
+  }
+
+  private readonly SqrtIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.divisionInterval(1.0, this.inverseSqrtInterval(n));
+    },
+  };
+
+  /** Calculate an acceptance interval of sqrt(x) */
+  public sqrtInterval(n: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.SqrtIntervalOp);
+  }
+
+  private readonly StepIntervalOp: BinaryToIntervalOp = {
+    impl: (edge: number, x: number): FPInterval => {
+      if (edge <= x) {
+        return this.correctlyRoundedInterval(1.0);
+      }
+      return this.correctlyRoundedInterval(0.0);
+    },
+  };
+
+  /** Calculate an acceptance 'interval' for step(edge, x)
+   *
+   * step only returns two possible values, so its interval requires special
+   * interpretation in CTS tests.
+   * This interval will be one of four values: [0, 0], [0, 1], [1, 1] & [-∞, +∞].
+   * [0, 0] and [1, 1] indicate that the correct answer in point they encapsulate.
+   * [0, 1] should not be treated as a span, i.e. 0.1 is acceptable, but instead
+   * indicate either 0.0 or 1.0 are acceptable answers.
+   * [-∞, +∞] is treated as any interval, since an undefined or infinite value
+   * was passed in.
+   */
+  public stepInterval(edge: number, x: number): FPInterval {
+    return this.runBinaryToIntervalOp(
+      this.toInterval(edge),
+      this.toInterval(x),
+      this.StepIntervalOp
+    );
+  }
+
+  private readonly SubtractionIntervalOp: BinaryToIntervalOp = {
+    impl: (x: number, y: number): FPInterval => {
+      return this.correctlyRoundedInterval(x - y);
+    },
+  };
+
+  /** Calculate an acceptance interval of x - y */
+  public subtractionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+    return this.runBinaryToIntervalOp(
+      this.toInterval(x),
+      this.toInterval(y),
+      this.SubtractionIntervalOp
+    );
+  }
+
+  /** Calculate an acceptance interval of x - y, when x and y are matrices */
+  public subtractionMatrixInterval(x: Matrix<number>, y: Matrix<number>): FPMatrix {
+    return this.runBinaryToIntervalOpMatrixComponentWise(
+      this.toMatrix(x),
+      this.toMatrix(y),
+      this.SubtractionIntervalOp
+    );
+  }
+
+  private readonly TanIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.divisionInterval(this.sinInterval(n), this.cosInterval(n));
+    },
+  };
+
+  /** Calculate an acceptance interval of tan(x) */
+  public tanInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.TanIntervalOp);
+  }
+
+  private readonly TanhIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.divisionInterval(this.sinhInterval(n), this.coshInterval(n));
+    },
+  };
+
+  /** Calculate an acceptance interval of tanh(x) */
+  public tanhInterval(n: number): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.TanhIntervalOp);
+  }
+
+  private readonly TransposeIntervalOp: MatrixToMatrixOp = {
+    impl: (m: Matrix<number>): FPMatrix => {
+      const num_cols = m.length;
+      const num_rows = m[0].length;
+      const result: Matrix<FPInterval> = [...Array(num_rows)].map(_ => [...Array(num_cols)]);
+
+      for (let i = 0; i < num_cols; i++) {
+        for (let j = 0; j < num_rows; j++) {
+          result[j][i] = this.correctlyRoundedInterval(m[i][j]);
+        }
+      }
+      return this.toMatrix(result);
+    },
+  };
+
+  /** Calculate an acceptance interval of transpose(m) */
+  public transposeInterval(m: Matrix<number>): FPMatrix {
+    return this.runMatrixToMatrixOp(this.toMatrix(m), this.TransposeIntervalOp);
+  }
+
+  private readonly TruncIntervalOp: PointToIntervalOp = {
+    impl: (n: number): FPInterval => {
+      return this.correctlyRoundedInterval(Math.trunc(n));
+    },
+  };
+
+  /** Calculate an acceptance interval of trunc(x) */
+  public truncInterval(n: number | FPInterval): FPInterval {
+    return this.runPointToIntervalOp(this.toInterval(n), this.TruncIntervalOp);
+  }
+
+  /**
+   * Once-allocated ArrayBuffer/views to avoid overhead of allocation when
+   * converting between numeric formats
+   *
+   * unpackData* is shared between all of the unpack*Interval functions, so to
+   * avoid re-entrancy problems, they should not call each other or themselves
+   * directly or indirectly.
+   */
+  private readonly unpackData = new ArrayBuffer(4);
+  private readonly unpackDataU32 = new Uint32Array(this.unpackData);
+  private readonly unpackDataU16 = new Uint16Array(this.unpackData);
+  private readonly unpackDataU8 = new Uint8Array(this.unpackData);
+  private readonly unpackDataI16 = new Int16Array(this.unpackData);
+  private readonly unpackDataI8 = new Int8Array(this.unpackData);
+  private readonly unpackDataF16 = new Float16Array(this.unpackData);
+
+  /** Calculate an acceptance interval vector for unpack2x16float(x) */
+  public unpack2x16floatInterval(n: number): FPVector {
+    assert(
+      n >= kValue.u32.min && n <= kValue.u32.max,
+      'unpack2x16floatInterval only accepts values on the bounds of u32'
+    );
+    this.unpackDataU32[0] = n;
+    if (this.unpackDataF16.some(f => !isFiniteF16(f))) {
+      return [this.constants().anyInterval, this.constants().anyInterval];
+    }
+
+    const result: FPVector = [
+      this.quantizeToF16Interval(this.unpackDataF16[0]),
+      this.quantizeToF16Interval(this.unpackDataF16[1]),
+    ];
+
+    if (result.some(r => !r.isFinite())) {
+      return [this.constants().anyInterval, this.constants().anyInterval];
+    }
+    return result;
+  }
+
+  /** Calculate an acceptance interval vector for unpack2x16snorm(x) */
+  public unpack2x16snormInterval(n: number): FPVector {
+    assert(
+      n >= kValue.u32.min && n <= kValue.u32.max,
+      'unpack2x16snormInterval only accepts values on the bounds of u32'
+    );
+    const op = (n: number): FPInterval => {
+      return this.maxInterval(this.divisionInterval(n, 32767), -1);
+    };
+
+    this.unpackDataU32[0] = n;
+    return [op(this.unpackDataI16[0]), op(this.unpackDataI16[1])];
+  }
+
+  /** Calculate an acceptance interval vector for unpack2x16unorm(x) */
+  public unpack2x16unormInterval(n: number): FPVector {
+    assert(
+      n >= kValue.u32.min && n <= kValue.u32.max,
+      'unpack2x16unormInterval only accepts values on the bounds of u32'
+    );
+    const op = (n: number): FPInterval => {
+      return this.divisionInterval(n, 65535);
+    };
+
+    this.unpackDataU32[0] = n;
+    return [op(this.unpackDataU16[0]), op(this.unpackDataU16[1])];
+  }
+
+  /** Calculate an acceptance interval vector for unpack4x8snorm(x) */
+  public unpack4x8snormInterval(n: number): FPVector {
+    assert(
+      n >= kValue.u32.min && n <= kValue.u32.max,
+      'unpack4x8snormInterval only accepts values on the bounds of u32'
+    );
+    const op = (n: number): FPInterval => {
+      return this.maxInterval(this.divisionInterval(n, 127), -1);
+    };
+    this.unpackDataU32[0] = n;
+    return [
+      op(this.unpackDataI8[0]),
+      op(this.unpackDataI8[1]),
+      op(this.unpackDataI8[2]),
+      op(this.unpackDataI8[3]),
+    ];
+  }
+
+  /** Calculate an acceptance interval vector for unpack4x8unorm(x) */
+  public unpack4x8unormInterval(n: number): FPVector {
+    assert(
+      n >= kValue.u32.min && n <= kValue.u32.max,
+      'unpack4x8unormInterval only accepts values on the bounds of u32'
+    );
+    const op = (n: number): FPInterval => {
+      return this.divisionInterval(n, 255);
+    };
+
+    this.unpackDataU32[0] = n;
+    return [
+      op(this.unpackDataU8[0]),
+      op(this.unpackDataU8[1]),
+      op(this.unpackDataU8[2]),
+      op(this.unpackDataU8[3]),
+    ];
+  }
+}
+
+// Pre-defined values that get used multiple times in _constants' initializers. Cannot use FPContext members, since this
+// executes before they are defined.
+const kF32AnyInterval = new FPInterval('f32', Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
+const kF32ZeroInterval = new FPInterval('f32', 0);
+
+class F32Context extends FPContext {
+  private static _constants: FPConstants = {
+    positive: {
+      min: kValue.f32.positive.min,
+      max: kValue.f32.positive.max,
+      infinity: kValue.f32.infinity.positive,
+      nearest_max: kValue.f32.positive.nearest_max,
+      less_than_one: kValue.f32.positive.less_than_one,
+      subnormal: {
+        min: kValue.f32.subnormal.positive.min,
+        max: kValue.f32.subnormal.positive.max,
+      },
+      pi: {
+        whole: kValue.f32.positive.pi.whole,
+        three_quarters: kValue.f32.positive.pi.three_quarters,
+        half: kValue.f32.positive.pi.half,
+        third: kValue.f32.positive.pi.third,
+        quarter: kValue.f32.positive.pi.quarter,
+        sixth: kValue.f32.positive.pi.sixth,
+      },
+      e: kValue.f32.positive.e,
+    },
+    negative: {
+      min: kValue.f32.negative.min,
+      max: kValue.f32.negative.max,
+      infinity: kValue.f32.infinity.negative,
+      nearest_min: kValue.f32.negative.nearest_min,
+      less_than_one: kValue.f32.negative.less_than_one,
+      subnormal: {
+        min: kValue.f32.subnormal.negative.min,
+        max: kValue.f32.subnormal.negative.max,
+      },
+      pi: {
+        whole: kValue.f32.negative.pi.whole,
+        three_quarters: kValue.f32.negative.pi.three_quarters,
+        half: kValue.f32.negative.pi.half,
+        third: kValue.f32.negative.pi.third,
+        quarter: kValue.f32.negative.pi.quarter,
+        sixth: kValue.f32.negative.pi.sixth,
+      },
+    },
+    anyInterval: kF32AnyInterval,
+    zeroInterval: kF32ZeroInterval,
+    // Have to use the constants.ts values here, because values defined in the
+    // initializer cannot be referenced in the initializer
+    negPiToPiInterval: new FPInterval(
+      'f32',
+      kValue.f32.negative.pi.whole,
+      kValue.f32.positive.pi.whole
+    ),
+    greaterThanZeroInterval: new FPInterval(
+      'f32',
+      kValue.f32.subnormal.positive.min,
+      kValue.f32.positive.max
+    ),
+    zeroVector: {
+      2: [kF32ZeroInterval, kF32ZeroInterval],
+      3: [kF32ZeroInterval, kF32ZeroInterval, kF32ZeroInterval],
+      4: [kF32ZeroInterval, kF32ZeroInterval, kF32ZeroInterval, kF32ZeroInterval],
+    },
+    anyVector: {
+      2: [kF32AnyInterval, kF32AnyInterval],
+      3: [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+      4: [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+    },
+    anyMatrix: {
+      2: {
+        2: [
+          [kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval],
+        ],
+        3: [
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+        ],
+        4: [
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+        ],
+      },
+      3: {
+        2: [
+          [kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval],
+        ],
+        3: [
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+        ],
+        4: [
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+        ],
+      },
+      4: {
+        2: [
+          [kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval],
+        ],
+        3: [
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+        ],
+        4: [
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+        ],
+      },
+    },
+  };
+
+  public constructor() {
+    super('f32');
+  }
+
+  public constants(): FPConstants {
+    return F32Context._constants;
+  }
+
+  // Overrides - Utilities
+  public readonly correctlyRounded = correctlyRoundedF32;
+  public readonly isFinite = isFiniteF32;
+  public readonly isSubnormal = isSubnormalNumberF32;
+  public readonly flushSubnormal = flushSubnormalNumberF32;
+  public readonly oneULP = oneULPF32;
+  public readonly scalarBuilder = f32;
+}
+
+export const kFPContext = {
+  f32: new F32Context(),
+};


### PR DESCRIPTION
Introduces a FPContext class that things like limits, constants, utilities, and interval generators exist in. This reorganizes the existing collection of free functions that all loosely depend on F32Interval into a tighter structure where they pull information about how to build intervals and what the limits for floating point numbers are from their context.

There is currently one concrete implementation of FPContext class for f32, there will be more in the future to support abstrate float and f16.

There is currently code in the generic FPContext class that is f32 specific, like magic numbers for precision. As things like abstract float and f16 are implemented I expect there to be refactorings to move these things around, either adding more constants, or moving specific interval generators down to specific floating point implementations.

All of the implementation code has been moved to floating_point.ts

f32_interval.ts contains pass-through shims that allow existing code and tests to use the old API for generating intervals. Future patches will work through migrating the rest of the CTS off of the old API. Currently testing for the interval generators runs through the shim, so that the codepath being used in CTS is under test, and it reduces the diff for this patch.

Most of the existing code outside of the interval generators doesn't need to change at this point, expect for specific locations like serialization/deserialization, where FPInterval (formally F32Interval) is used explicitly. This is due to FPInterval being an actual class vs type/interface, so it it is non-trivial to alias it in the shim. So for the few places where the refactoring needed to leak out it has, instead of going through heroeics for conceptual purity.

Issue #2416

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
