### PR TITLE
Fix fragment shader in maxInterStageShaderComponents validation

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderComponents.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderComponents.spec.ts
@@ -54,7 +54,7 @@ function getPipelineDescriptor(
       ${varyings}
     }
     struct FSIn {
-      ${pointList ? '@builtin(front_facing) frontFacing: bool,' : ''}
+      ${frontFacing ? '@builtin(front_facing) frontFacing: bool,' : ''}
       ${sampleIndex ? '@builtin(sample_index) sampleIndex: u32,' : ''}
       ${sampleMaskIn ? '@builtin(sample_mask) sampleMask: u32,' : ''}
       ${varyings}
@@ -83,6 +83,15 @@ function getPipelineDescriptor(
     vertex: {
       module,
       entryPoint: 'vs',
+    },
+    fragment: {
+      module,
+      entryPoint: 'fs',
+      targets: [
+        {
+          format: 'rgba8unorm',
+        },
+      ],
     },
   };
   return { pipelineDescriptor, code };


### PR DESCRIPTION
- Add fragment state in pipelineDescriptor, otherwise no validation happens in fragment stage when creating the render pipeline.
- Fix 'front_facing' builtin in fragment shader.

With these fixes, all maxInterStageShaderComponents validation test pass.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
