### PR TITLE
Replace Point/Binary/Ternary with Scalar{Pair/Triple}

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1928,13 +1928,13 @@ g.test('ulpInterval')
     );
   });
 
-interface PointToIntervalCase {
+interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
 
 g.test('absInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Common usages
@@ -1975,7 +1975,7 @@ g.test('absInterval')
   });
 
 g.test('acosInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2010,7 +2010,7 @@ g.test('acosInterval')
   });
 
 g.test('acoshAlternativeInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2037,7 +2037,7 @@ g.test('acoshAlternativeInterval')
   });
 
 g.test('acoshPrimaryInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2064,7 +2064,7 @@ g.test('acoshPrimaryInterval')
   });
 
 g.test('asinInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2099,7 +2099,7 @@ g.test('asinInterval')
   });
 
 g.test('asinhInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2124,7 +2124,7 @@ g.test('asinhInterval')
   });
 
 g.test('atanInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2154,7 +2154,7 @@ g.test('atanInterval')
   });
 
 g.test('atanhInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2180,7 +2180,7 @@ g.test('atanhInterval')
   });
 
 g.test('ceilInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2222,7 +2222,7 @@ g.test('ceilInterval')
   });
 
 g.test('cosInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // This test does not include some common cases. i.e. f(x = π/2) = 0,
@@ -2258,7 +2258,7 @@ g.test('cosInterval')
   });
 
 g.test('coshInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2284,7 +2284,7 @@ g.test('coshInterval')
   });
 
 g.test('degreesInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2316,7 +2316,7 @@ g.test('degreesInterval')
   });
 
 g.test('expInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2342,7 +2342,7 @@ g.test('expInterval')
   });
 
 g.test('exp2Interval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2368,7 +2368,7 @@ g.test('exp2Interval')
   });
 
 g.test('floorInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2410,7 +2410,7 @@ g.test('floorInterval')
   });
 
 g.test('fractInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2442,7 +2442,7 @@ g.test('fractInterval')
   });
 
 g.test('inverseSqrtInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: -1, expected: kAnyBounds },
@@ -2470,7 +2470,7 @@ g.test('inverseSqrtInterval')
   });
 
 g.test('lengthIntervalScalar')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2511,7 +2511,7 @@ g.test('lengthIntervalScalar')
   });
 
 g.test('logInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: -1, expected: kAnyBounds },
@@ -2540,7 +2540,7 @@ g.test('logInterval')
   });
 
 g.test('log2Interval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: -1, expected: kAnyBounds },
@@ -2569,7 +2569,7 @@ g.test('log2Interval')
   });
 
 g.test('negationInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2605,7 +2605,7 @@ g.test('negationInterval')
   });
 
 g.test('quantizeToF16Interval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2640,7 +2640,7 @@ g.test('quantizeToF16Interval')
   });
 
 g.test('radiansInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2670,7 +2670,7 @@ g.test('radiansInterval')
   });
 
 g.test('roundInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2716,7 +2716,7 @@ g.test('roundInterval')
   });
 
 g.test('saturateInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Normals
@@ -2754,7 +2754,7 @@ g.test('saturateInterval')
   });
 
 g.test('signInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2786,7 +2786,7 @@ g.test('signInterval')
   });
 
 g.test('sinInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // This test does not include some common cases, i.e. f(x = -π|π) = 0,
@@ -2820,7 +2820,7 @@ g.test('sinInterval')
   });
 
 g.test('sinhInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2845,7 +2845,7 @@ g.test('sinhInterval')
   });
 
 g.test('sqrtInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2870,7 +2870,7 @@ g.test('sqrtInterval')
   });
 
 g.test('tanInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // All of these are hard coded, since the error intervals are difficult to
@@ -2911,7 +2911,7 @@ g.test('tanInterval')
   });
 
 g.test('tanhInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2936,7 +2936,7 @@ g.test('tanhInterval')
   });
 
 g.test('truncInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2975,7 +2975,7 @@ g.test('truncInterval')
     );
   });
 
-interface BinaryToIntervalCase {
+interface ScalarPairToIntervalCase {
   // input is a pair of independent values, not a range, so should not be
   // converted to a FPInterval.
   input: [number, number];
@@ -2983,7 +2983,7 @@ interface BinaryToIntervalCase {
 }
 
 g.test('additionInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3040,7 +3040,7 @@ g.test('additionInterval')
 
 // Note: atan2's parameters are labelled (y, x) instead of (x, y)
 g.test('atan2Interval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3112,7 +3112,7 @@ g.test('atan2Interval')
   });
 
 g.test('distanceIntervalScalar')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3162,7 +3162,7 @@ g.test('distanceIntervalScalar')
   });
 
 g.test('divisionInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3214,7 +3214,7 @@ g.test('divisionInterval')
   });
 
 g.test('ldexpInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3262,7 +3262,7 @@ g.test('ldexpInterval')
   });
 
 g.test('maxInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3321,7 +3321,7 @@ g.test('maxInterval')
   });
 
 g.test('minInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3379,7 +3379,7 @@ g.test('minInterval')
   });
 
 g.test('multiplicationInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3441,7 +3441,7 @@ g.test('multiplicationInterval')
   });
 
 g.test('remainderInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3491,7 +3491,7 @@ g.test('remainderInterval')
   });
 
 g.test('powInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3524,7 +3524,7 @@ g.test('powInterval')
   });
 
 g.test('stepInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3600,7 +3600,7 @@ g.test('stepInterval')
   });
 
 g.test('subtractionInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3655,13 +3655,13 @@ g.test('subtractionInterval')
     );
   });
 
-interface TernaryToIntervalCase {
+interface ScalarTripleToIntervalCase {
   input: [number, number, number];
   expected: number | IntervalBounds;
 }
 
 g.test('clampMedianInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Normals
@@ -3711,7 +3711,7 @@ g.test('clampMedianInterval')
   });
 
 g.test('clampMinMaxInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Normals
@@ -3761,7 +3761,7 @@ g.test('clampMinMaxInterval')
   });
 
 g.test('fmaInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Normals
@@ -3810,7 +3810,7 @@ g.test('fmaInterval')
   });
 
 g.test('mixImpreciseInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3889,7 +3889,7 @@ g.test('mixImpreciseInterval')
   });
 
 g.test('mixPreciseInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3968,7 +3968,7 @@ g.test('mixPreciseInterval')
   });
 
 g.test('smoothStepInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -4022,7 +4022,7 @@ g.test('smoothStepInterval')
     );
   });
 
-interface PointToVectorCase {
+interface ScalarToVectorCase {
   input: number;
   expected: (number | IntervalBounds)[];
 }
@@ -4054,7 +4054,7 @@ interface PointToVectorCase {
   ]; // ~-0.5..., due to lack of precision in i16
 
   g.test('unpack2x16snormInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds] },
@@ -4076,7 +4076,7 @@ interface PointToVectorCase {
     });
 
   g.test('unpack2x16floatInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
         // f16 normals
@@ -4115,7 +4115,7 @@ interface PointToVectorCase {
   ]; // ~0.5..., due to lack of precision in u16
 
   g.test('unpack2x16unormInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
       { input: 0x00000000, expected: [kZeroBounds, kZeroBounds] },
@@ -4144,7 +4144,7 @@ interface PointToVectorCase {
   ]; // ~-0.49606..., due to lack of precision in i8
 
   g.test('unpack4x8snormInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
@@ -4177,7 +4177,7 @@ interface PointToVectorCase {
   ]; // ~0.50196..., due to lack of precision in u8
 
   g.test('unpack4x8unormInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kZeroBounds] },

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -19,17 +19,17 @@ import {
   ScalarBuilder,
 } from '../../../util/conversion.js';
 import {
-  BinaryToInterval,
+  ScalarPairToInterval,
   MatrixPairToMatrix,
   MatrixScalarToMatrix,
   MatrixToMatrix,
   MatrixToScalar,
   MatrixVectorToVector,
-  PointToInterval,
-  PointToVector,
+  ScalarToInterval,
+  ScalarToVector,
   ScalarMatrixToMatrix,
   ScalarVectorToVector,
-  TernaryToInterval,
+  ScalarTripleToInterval,
   VectorMatrixToVector,
   VectorPairToInterval,
   VectorPairToVector,
@@ -832,7 +832,7 @@ export type IntervalFilter =
 function makeUnaryToF32IntervalCase(
   param: number,
   filter: IntervalFilter,
-  ...ops: PointToInterval[]
+  ...ops: ScalarToInterval[]
 ): Case | undefined {
   param = quantizeToF32(param);
 
@@ -853,7 +853,7 @@ function makeUnaryToF32IntervalCase(
 export function generateUnaryToF32IntervalCases(
   params: number[],
   filter: IntervalFilter,
-  ...ops: PointToInterval[]
+  ...ops: ScalarToInterval[]
 ): Case[] {
   return params.reduce((cases, e) => {
     const c = makeUnaryToF32IntervalCase(e, filter, ...ops);
@@ -877,7 +877,7 @@ function makeBinaryToF32IntervalCase(
   param0: number,
   param1: number,
   filter: IntervalFilter,
-  ...ops: BinaryToInterval[]
+  ...ops: ScalarPairToInterval[]
 ): Case | undefined {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
@@ -901,7 +901,7 @@ export function generateBinaryToF32IntervalCases(
   param0s: number[],
   param1s: number[],
   filter: IntervalFilter,
-  ...ops: BinaryToInterval[]
+  ...ops: ScalarPairToInterval[]
 ): Case[] {
   return cartesianProduct(param0s, param1s).reduce((cases, e) => {
     const c = makeBinaryToF32IntervalCase(e[0], e[1], filter, ...ops);
@@ -927,7 +927,7 @@ function makeTernaryToF32IntervalCase(
   param1: number,
   param2: number,
   filter: IntervalFilter,
-  ...ops: TernaryToInterval[]
+  ...ops: ScalarTripleToInterval[]
 ): Case | undefined {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
@@ -957,7 +957,7 @@ export function generateTernaryToF32IntervalCases(
   param1s: number[],
   param2s: number[],
   filter: IntervalFilter,
-  ...ops: TernaryToInterval[]
+  ...ops: ScalarTripleToInterval[]
 ): Case[] {
   return cartesianProduct(param0s, param1s, param2s).reduce((cases, e) => {
     const c = makeTernaryToF32IntervalCase(e[0], e[1], e[2], filter, ...ops);
@@ -1657,7 +1657,7 @@ export function generateVectorMatrixToVectorCases(
 function makeU32ToVectorCase(
   param: number,
   filter: IntervalFilter,
-  ...ops: PointToVector[]
+  ...ops: ScalarToVector[]
 ): Case | undefined {
   param = Math.trunc(param);
   const param_u32 = u32(param);
@@ -1683,7 +1683,7 @@ function makeU32ToVectorCase(
 export function generateU32ToVectorCases(
   params: number[],
   filter: IntervalFilter,
-  ...ops: PointToVector[]
+  ...ops: ScalarToVector[]
 ): Case[] {
   return params.reduce((cases, e) => {
     const c = makeU32ToVectorCase(e, filter, ...ops);

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -6,19 +6,19 @@ import { FPInterval, FPMatrix, FPVector, IntervalBounds, FP } from './floating_p
 
 // Interfaces
 
-export interface PointToInterval {
+export interface ScalarToInterval {
   (x: number): FPInterval;
 }
 
-export interface BinaryToInterval {
+export interface ScalarPairToInterval {
   (x: number, y: number): FPInterval;
 }
 
-export interface TernaryToInterval {
+export interface ScalarTripleToInterval {
   (x: number, y: number, z: number): FPInterval;
 }
 
-export interface PointToVector {
+export interface ScalarToVector {
   (n: number): FPVector;
 }
 


### PR DESCRIPTION
This makes the scalar part of the name clearer, instead of being implied, and follows the convention of later additions like VectorPairToVector or ScalarVectorVector.

Issue #2416

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
