### PR TITLE
Fix maxStorageTexturesPerShaderStage validation tests

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -210,7 +210,7 @@ export function getPerStageWGSLForBindingCombinationStorageTextures(
     bindGroupTest,
     storageDefinitionWGSLSnippetFn,
     (numBindings: number, set: number) =>
-      `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n          ')};`,
+      `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n          ')}`,
     numBindings,
     extraWGSL
   );
@@ -783,6 +783,13 @@ export class LimitTestsImpl extends GPUTestBase {
     msg = ''
   ) {
     if (async) {
+      await this.shouldRejectConditionally(
+        'GPUPipelineError',
+        this.createPipelineAsync(createPipelineType, module),
+        shouldError,
+        msg
+      );
+    } else {
       await this.expectValidationError(
         () => {
           this.createPipeline(createPipelineType, module);
@@ -790,10 +797,28 @@ export class LimitTestsImpl extends GPUTestBase {
         shouldError,
         msg
       );
-    } else {
+    }
+  }
+
+  async testCreateComputePipeline(
+    pipelineDescriptor: GPUComputePipelineDescriptor,
+    async: boolean,
+    shouldError: boolean,
+    msg = ''
+  ) {
+    const { device } = this;
+    if (async) {
       await this.shouldRejectConditionally(
         'GPUPipelineError',
-        this.createPipelineAsync(createPipelineType, module),
+        device.createComputePipelineAsync(pipelineDescriptor),
+        shouldError,
+        msg
+      );
+    } else {
+      await this.expectValidationError(
+        () => {
+          device.createComputePipeline(pipelineDescriptor);
+        },
         shouldError,
         msg
       );


### PR DESCRIPTION
- The total number of fragment output resources must be not greater than maxFragmentCombinedOutputResources, but when testing maximum value, the number of storage textures + color targets exceeds this limit. The combination of fragment output resources has been covered in other tests, we just need to test single storage textures, not need color targets here.
- Remove redundant commas in getPerStageWGSLForBindingCombinationStorageTextures in limit_utils.ts
- Fix testCreatePipeline with async in limit_utils.ts




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
