### PR TITLE
Fix issues in LimitTestsImpl

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -210,7 +210,7 @@ export function getPerStageWGSLForBindingCombinationStorageTextures(
     bindGroupTest,
     storageDefinitionWGSLSnippetFn,
     (numBindings: number, set: number) =>
-      `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n          ')};`,
+      `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n          ')}`,
     numBindings,
     extraWGSL
   );
@@ -700,41 +700,62 @@ export class LimitTestsImpl extends GPUTestBase {
     }
   }
 
+  _createRenderPipelineDescriptor(module: GPUShaderModule): GPURenderPipelineDescriptor {
+    return {
+      layout: 'auto',
+      vertex: {
+        module,
+        entryPoint: 'mainVS',
+      },
+    };
+  }
+
+  _createRenderPipelineDescriptorWithFragmentShader(
+    module: GPUShaderModule
+  ): GPURenderPipelineDescriptor {
+    return {
+      layout: 'auto',
+      vertex: {
+        module,
+        entryPoint: 'mainVS',
+      },
+      fragment: {
+        module,
+        entryPoint: 'mainFS',
+        targets: [],
+      },
+      depthStencil: {
+        format: 'depth24plus-stencil8',
+        depthWriteEnabled: true,
+        depthCompare: 'always',
+      },
+    };
+  }
+
+  _createComputePipelineDescriptor(module: GPUShaderModule): GPUComputePipelineDescriptor {
+    return {
+      layout: 'auto',
+      compute: {
+        module,
+        entryPoint: 'main',
+      },
+    };
+  }
+
   createPipeline(createPipelineType: CreatePipelineType, module: GPUShaderModule) {
     const { device } = this;
 
     switch (createPipelineType) {
       case 'createRenderPipeline':
-        return device.createRenderPipeline({
-          layout: 'auto',
-          vertex: {
-            module,
-            entryPoint: 'mainVS',
-          },
-        });
+        return device.createRenderPipeline(this._createRenderPipelineDescriptor(module));
         break;
       case 'createRenderPipelineWithFragmentStage':
-        return device.createRenderPipeline({
-          layout: 'auto',
-          vertex: {
-            module,
-            entryPoint: 'mainVS',
-          },
-          fragment: {
-            module,
-            entryPoint: 'mainFS',
-            targets: [{ format: 'rgba8unorm', writeMask: 0 }],
-          },
-        });
+        return device.createRenderPipeline(
+          this._createRenderPipelineDescriptorWithFragmentShader(module)
+        );
         break;
       case 'createComputePipeline':
-        return device.createComputePipeline({
-          layout: 'auto',
-          compute: {
-            module,
-            entryPoint: 'main',
-          },
-        });
+        return device.createComputePipeline(this._createComputePipelineDescriptor(module));
         break;
     }
   }
@@ -744,34 +765,13 @@ export class LimitTestsImpl extends GPUTestBase {
 
     switch (createPipelineType) {
       case 'createRenderPipeline':
-        return device.createRenderPipelineAsync({
-          layout: 'auto',
-          vertex: {
-            module,
-            entryPoint: 'mainVS',
-          },
-        });
+        return device.createRenderPipelineAsync(this._createRenderPipelineDescriptor(module));
       case 'createRenderPipelineWithFragmentStage':
-        return device.createRenderPipelineAsync({
-          layout: 'auto',
-          vertex: {
-            module,
-            entryPoint: 'mainVS',
-          },
-          fragment: {
-            module,
-            entryPoint: 'mainFS',
-            targets: [{ format: 'rgba8unorm', writeMask: 0 }],
-          },
-        });
+        return device.createRenderPipelineAsync(
+          this._createRenderPipelineDescriptorWithFragmentShader(module)
+        );
       case 'createComputePipeline':
-        return device.createComputePipelineAsync({
-          layout: 'auto',
-          compute: {
-            module,
-            entryPoint: 'main',
-          },
-        });
+        return device.createComputePipelineAsync(this._createComputePipelineDescriptor(module));
     }
   }
 
@@ -783,17 +783,17 @@ export class LimitTestsImpl extends GPUTestBase {
     msg = ''
   ) {
     if (async) {
-      await this.expectValidationError(
-        () => {
-          this.createPipeline(createPipelineType, module);
-        },
+      await this.shouldRejectConditionally(
+        'GPUPipelineError',
+        this.createPipelineAsync(createPipelineType, module),
         shouldError,
         msg
       );
     } else {
-      await this.shouldRejectConditionally(
-        'GPUPipelineError',
-        this.createPipelineAsync(createPipelineType, module),
+      await this.expectValidationError(
+        () => {
+          this.createPipeline(createPipelineType, module);
+        },
         shouldError,
         msg
       );


### PR DESCRIPTION
* swapped incorrect async path in testCreatePipeline

* added shared pipeline descriptor creation so the code is more D.R.Y.

* changed the RenderPipelineWithFragmentShader to have no colorAttachments and just a depthStencilAttachment

* removed semicolon in getPerStageWGSLForBindingCombinationStorageTextures

Thanks to @haoxli for finding these issues

see: https://github.com/gpuweb/cts/pull/2471


Issue: none

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
