### PR TITLE
Migrate existing `abs` tests over to use FP.f32 directly

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -13,7 +13,6 @@ import { makeTestGroup } from '../common/framework/test_group.js';
 import { objectEquals } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
 import {
-  absInterval,
   absoluteErrorInterval,
   acosInterval,
   acoshAlternativeInterval,
@@ -1932,47 +1931,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('absInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Common usages
-      { input: 1, expected: 1 },
-      { input: -1, expected: 1 },
-      { input: 0.1, expected: [hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)] },
-      { input: -0.1, expected: [hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)] },
-
-      // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
-      { input: kValue.f32.positive.min, expected: kValue.f32.positive.min },
-      { input: kValue.f32.negative.min, expected: kValue.f32.positive.max },
-      { input: kValue.f32.negative.max, expected: kValue.f32.positive.min },
-
-      // 32-bit subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: kValue.f32.subnormal.positive.min, expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: kValue.f32.subnormal.negative.min, expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: kValue.f32.subnormal.negative.max, expected: [0, kValue.f32.subnormal.positive.min] },
-
-      // 64-bit subnormals
-      { input: hexToF64(0x0000_0000_0000_0001n), expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: hexToF64(0x800f_ffff_ffff_ffffn), expected: [0, kValue.f32.subnormal.positive.min] },
-
-      // Zero
-      { input: 0, expected: 0 },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = absInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `absInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('acosInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -1928,13 +1928,13 @@ g.test('ulpInterval')
     );
   });
 
-interface PointToIntervalCase {
+interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
 
 g.test('absInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Common usages
@@ -1975,7 +1975,7 @@ g.test('absInterval')
   });
 
 g.test('acosInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2010,7 +2010,7 @@ g.test('acosInterval')
   });
 
 g.test('acoshAlternativeInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2037,7 +2037,7 @@ g.test('acoshAlternativeInterval')
   });
 
 g.test('acoshPrimaryInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2064,7 +2064,7 @@ g.test('acoshPrimaryInterval')
   });
 
 g.test('asinInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2099,7 +2099,7 @@ g.test('asinInterval')
   });
 
 g.test('asinhInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2124,7 +2124,7 @@ g.test('asinhInterval')
   });
 
 g.test('atanInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2154,7 +2154,7 @@ g.test('atanInterval')
   });
 
 g.test('atanhInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2180,7 +2180,7 @@ g.test('atanhInterval')
   });
 
 g.test('ceilInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2222,7 +2222,7 @@ g.test('ceilInterval')
   });
 
 g.test('cosInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // This test does not include some common cases. i.e. f(x = π/2) = 0,
@@ -2258,7 +2258,7 @@ g.test('cosInterval')
   });
 
 g.test('coshInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2284,7 +2284,7 @@ g.test('coshInterval')
   });
 
 g.test('degreesInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2316,7 +2316,7 @@ g.test('degreesInterval')
   });
 
 g.test('expInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2342,7 +2342,7 @@ g.test('expInterval')
   });
 
 g.test('exp2Interval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2368,7 +2368,7 @@ g.test('exp2Interval')
   });
 
 g.test('floorInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2410,7 +2410,7 @@ g.test('floorInterval')
   });
 
 g.test('fractInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2442,7 +2442,7 @@ g.test('fractInterval')
   });
 
 g.test('inverseSqrtInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: -1, expected: kAnyBounds },
@@ -2470,7 +2470,7 @@ g.test('inverseSqrtInterval')
   });
 
 g.test('lengthIntervalScalar')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2511,7 +2511,7 @@ g.test('lengthIntervalScalar')
   });
 
 g.test('logInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: -1, expected: kAnyBounds },
@@ -2540,7 +2540,7 @@ g.test('logInterval')
   });
 
 g.test('log2Interval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: -1, expected: kAnyBounds },
@@ -2569,7 +2569,7 @@ g.test('log2Interval')
   });
 
 g.test('negationInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2605,7 +2605,7 @@ g.test('negationInterval')
   });
 
 g.test('quantizeToF16Interval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2640,7 +2640,7 @@ g.test('quantizeToF16Interval')
   });
 
 g.test('radiansInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2670,7 +2670,7 @@ g.test('radiansInterval')
   });
 
 g.test('roundInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2716,7 +2716,7 @@ g.test('roundInterval')
   });
 
 g.test('saturateInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Normals
@@ -2754,7 +2754,7 @@ g.test('saturateInterval')
   });
 
 g.test('signInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: kValue.f32.infinity.negative, expected: kAnyBounds },
@@ -2786,7 +2786,7 @@ g.test('signInterval')
   });
 
 g.test('sinInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // This test does not include some common cases, i.e. f(x = -π|π) = 0,
@@ -2820,7 +2820,7 @@ g.test('sinInterval')
   });
 
 g.test('sinhInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2845,7 +2845,7 @@ g.test('sinhInterval')
   });
 
 g.test('sqrtInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2870,7 +2870,7 @@ g.test('sqrtInterval')
   });
 
 g.test('tanInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // All of these are hard coded, since the error intervals are difficult to
@@ -2911,7 +2911,7 @@ g.test('tanInterval')
   });
 
 g.test('tanhInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -2936,7 +2936,7 @@ g.test('tanhInterval')
   });
 
 g.test('truncInterval')
-  .paramsSubcasesOnly<PointToIntervalCase>(
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
       { input: 0, expected: 0 },
@@ -2975,7 +2975,7 @@ g.test('truncInterval')
     );
   });
 
-interface BinaryToIntervalCase {
+interface ScalarPairToIntervalCase {
   // input is a pair of independent values, not a range, so should not be
   // converted to a FPInterval.
   input: [number, number];
@@ -2983,7 +2983,7 @@ interface BinaryToIntervalCase {
 }
 
 g.test('additionInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3040,7 +3040,7 @@ g.test('additionInterval')
 
 // Note: atan2's parameters are labelled (y, x) instead of (x, y)
 g.test('atan2Interval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3112,7 +3112,7 @@ g.test('atan2Interval')
   });
 
 g.test('distanceIntervalScalar')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3162,7 +3162,7 @@ g.test('distanceIntervalScalar')
   });
 
 g.test('divisionInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3214,7 +3214,7 @@ g.test('divisionInterval')
   });
 
 g.test('ldexpInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3262,7 +3262,7 @@ g.test('ldexpInterval')
   });
 
 g.test('maxInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3321,7 +3321,7 @@ g.test('maxInterval')
   });
 
 g.test('minInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3379,7 +3379,7 @@ g.test('minInterval')
   });
 
 g.test('multiplicationInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3441,7 +3441,7 @@ g.test('multiplicationInterval')
   });
 
 g.test('remainderInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3491,7 +3491,7 @@ g.test('remainderInterval')
   });
 
 g.test('powInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3524,7 +3524,7 @@ g.test('powInterval')
   });
 
 g.test('stepInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3600,7 +3600,7 @@ g.test('stepInterval')
   });
 
 g.test('subtractionInterval')
-  .paramsSubcasesOnly<BinaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
     [
       // 32-bit normals
@@ -3655,13 +3655,13 @@ g.test('subtractionInterval')
     );
   });
 
-interface TernaryToIntervalCase {
+interface ScalarTripleToIntervalCase {
   input: [number, number, number];
   expected: number | IntervalBounds;
 }
 
 g.test('clampMedianInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Normals
@@ -3711,7 +3711,7 @@ g.test('clampMedianInterval')
   });
 
 g.test('clampMinMaxInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Normals
@@ -3761,7 +3761,7 @@ g.test('clampMinMaxInterval')
   });
 
 g.test('fmaInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Normals
@@ -3810,7 +3810,7 @@ g.test('fmaInterval')
   });
 
 g.test('mixImpreciseInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3889,7 +3889,7 @@ g.test('mixImpreciseInterval')
   });
 
 g.test('mixPreciseInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -3968,7 +3968,7 @@ g.test('mixPreciseInterval')
   });
 
 g.test('smoothStepInterval')
-  .paramsSubcasesOnly<TernaryToIntervalCase>(
+  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
     // prettier-ignore
     [
       // Some of these are hard coded, since the error intervals are difficult
@@ -4022,7 +4022,7 @@ g.test('smoothStepInterval')
     );
   });
 
-interface PointToVectorCase {
+interface ScalarToVectorCase {
   input: number;
   expected: (number | IntervalBounds)[];
 }
@@ -4054,7 +4054,7 @@ interface PointToVectorCase {
   ]; // ~-0.5..., due to lack of precision in i16
 
   g.test('unpack2x16snormInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds] },
@@ -4076,7 +4076,7 @@ interface PointToVectorCase {
     });
 
   g.test('unpack2x16floatInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
         // f16 normals
@@ -4115,7 +4115,7 @@ interface PointToVectorCase {
   ]; // ~0.5..., due to lack of precision in u16
 
   g.test('unpack2x16unormInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
       { input: 0x00000000, expected: [kZeroBounds, kZeroBounds] },
@@ -4144,7 +4144,7 @@ interface PointToVectorCase {
   ]; // ~-0.49606..., due to lack of precision in i8
 
   g.test('unpack4x8snormInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
@@ -4177,7 +4177,7 @@ interface PointToVectorCase {
   ]; // ~0.50196..., due to lack of precision in u8
 
   g.test('unpack4x8unormInterval')
-    .paramsSubcasesOnly<PointToVectorCase>(
+    .paramsSubcasesOnly<ScalarToVectorCase>(
       // prettier-ignore
       [
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kZeroBounds] },

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -75,7 +75,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateBinaryToF32IntervalCases(
       fullF32Range(),
       fullF32Range(),
-      'f32-only',
+      'finite',
       additionInterval
     );
   },
@@ -91,7 +91,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
-      'f32-only',
+      'finite',
       additionVectorScalarInterval
     );
   },
@@ -107,7 +107,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
-      'f32-only',
+      'finite',
       additionVectorScalarInterval
     );
   },
@@ -123,7 +123,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
-      'f32-only',
+      'finite',
       additionVectorScalarInterval
     );
   },
@@ -139,7 +139,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       additionScalarVectorInterval
     );
   },
@@ -155,7 +155,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       additionScalarVectorInterval
     );
   },
@@ -171,7 +171,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       additionScalarVectorInterval
     );
   },
@@ -187,7 +187,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateBinaryToF32IntervalCases(
       fullF32Range(),
       fullF32Range(),
-      'f32-only',
+      'finite',
       subtractionInterval
     );
   },
@@ -203,7 +203,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
-      'f32-only',
+      'finite',
       subtractionVectorScalarInterval
     );
   },
@@ -219,7 +219,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
-      'f32-only',
+      'finite',
       subtractionVectorScalarInterval
     );
   },
@@ -235,7 +235,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
-      'f32-only',
+      'finite',
       subtractionVectorScalarInterval
     );
   },
@@ -251,7 +251,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       subtractionScalarVectorInterval
     );
   },
@@ -267,7 +267,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       subtractionScalarVectorInterval
     );
   },
@@ -283,7 +283,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       subtractionScalarVectorInterval
     );
   },
@@ -299,7 +299,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateBinaryToF32IntervalCases(
       fullF32Range(),
       fullF32Range(),
-      'f32-only',
+      'finite',
       multiplicationInterval
     );
   },
@@ -315,7 +315,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
-      'f32-only',
+      'finite',
       multiplicationVectorScalarInterval
     );
   },
@@ -331,7 +331,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
-      'f32-only',
+      'finite',
       multiplicationVectorScalarInterval
     );
   },
@@ -347,7 +347,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
-      'f32-only',
+      'finite',
       multiplicationVectorScalarInterval
     );
   },
@@ -363,7 +363,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       multiplicationScalarVectorInterval
     );
   },
@@ -379,7 +379,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       multiplicationScalarVectorInterval
     );
   },
@@ -395,7 +395,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       multiplicationScalarVectorInterval
     );
   },
@@ -411,7 +411,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateBinaryToF32IntervalCases(
       fullF32Range(),
       fullF32Range(),
-      'f32-only',
+      'finite',
       divisionInterval
     );
   },
@@ -427,7 +427,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
-      'f32-only',
+      'finite',
       divisionVectorScalarInterval
     );
   },
@@ -443,7 +443,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
-      'f32-only',
+      'finite',
       divisionVectorScalarInterval
     );
   },
@@ -459,7 +459,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
-      'f32-only',
+      'finite',
       divisionVectorScalarInterval
     );
   },
@@ -475,7 +475,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       divisionScalarVectorInterval
     );
   },
@@ -491,7 +491,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       divisionScalarVectorInterval
     );
   },
@@ -507,7 +507,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       divisionScalarVectorInterval
     );
   },
@@ -523,7 +523,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateBinaryToF32IntervalCases(
       fullF32Range(),
       fullF32Range(),
-      'f32-only',
+      'finite',
       remainderInterval
     );
   },
@@ -539,7 +539,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
-      'f32-only',
+      'finite',
       remainderVectorScalarInterval
     );
   },
@@ -555,7 +555,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
-      'f32-only',
+      'finite',
       remainderVectorScalarInterval
     );
   },
@@ -571,7 +571,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateVectorF32ToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
-      'f32-only',
+      'finite',
       remainderVectorScalarInterval
     );
   },
@@ -587,7 +587,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       remainderScalarVectorInterval
     );
   },
@@ -603,7 +603,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       remainderScalarVectorInterval
     );
   },
@@ -619,7 +619,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     return generateF32VectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       remainderScalarVectorInterval
     );
   },

--- a/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_matrix_arithmetic.spec.ts
@@ -39,7 +39,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 2),
       sparseMatrixF32Range(2, 2),
-      'f32-only',
+      'finite',
       additionMatrixInterval
     );
   },
@@ -55,7 +55,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 3),
       sparseMatrixF32Range(2, 3),
-      'f32-only',
+      'finite',
       additionMatrixInterval
     );
   },
@@ -71,7 +71,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 4),
       sparseMatrixF32Range(2, 4),
-      'f32-only',
+      'finite',
       additionMatrixInterval
     );
   },
@@ -87,7 +87,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 2),
       sparseMatrixF32Range(3, 2),
-      'f32-only',
+      'finite',
       additionMatrixInterval
     );
   },
@@ -103,7 +103,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 3),
       sparseMatrixF32Range(3, 3),
-      'f32-only',
+      'finite',
       additionMatrixInterval
     );
   },
@@ -119,7 +119,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 4),
       sparseMatrixF32Range(3, 4),
-      'f32-only',
+      'finite',
       additionMatrixInterval
     );
   },
@@ -135,7 +135,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 2),
       sparseMatrixF32Range(4, 2),
-      'f32-only',
+      'finite',
       additionMatrixInterval
     );
   },
@@ -151,7 +151,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 3),
       sparseMatrixF32Range(4, 3),
-      'f32-only',
+      'finite',
       additionMatrixInterval
     );
   },
@@ -167,7 +167,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 4),
       sparseMatrixF32Range(4, 4),
-      'f32-only',
+      'finite',
       additionMatrixInterval
     );
   },
@@ -183,7 +183,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 2),
       sparseMatrixF32Range(2, 2),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -199,7 +199,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 3),
       sparseMatrixF32Range(2, 2),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -215,7 +215,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 2),
       sparseMatrixF32Range(3, 2),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -231,7 +231,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 3),
       sparseMatrixF32Range(3, 2),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -247,7 +247,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 4),
       sparseMatrixF32Range(2, 2),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -263,7 +263,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 2),
       sparseMatrixF32Range(4, 2),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -279,7 +279,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 4),
       sparseMatrixF32Range(4, 2),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -295,7 +295,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 3),
       sparseMatrixF32Range(4, 2),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -311,7 +311,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 4),
       sparseMatrixF32Range(3, 2),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -327,7 +327,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 3),
       sparseMatrixF32Range(3, 3),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -343,7 +343,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 2),
       sparseMatrixF32Range(3, 3),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -359,7 +359,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 3),
       sparseMatrixF32Range(2, 3),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -375,7 +375,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 2),
       sparseMatrixF32Range(2, 3),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -391,7 +391,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 4),
       sparseMatrixF32Range(3, 3),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -407,7 +407,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 3),
       sparseMatrixF32Range(4, 3),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -423,7 +423,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 4),
       sparseMatrixF32Range(4, 3),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -439,7 +439,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 2),
       sparseMatrixF32Range(4, 3),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -455,7 +455,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 4),
       sparseMatrixF32Range(2, 3),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -471,7 +471,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 4),
       sparseMatrixF32Range(4, 4),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -487,7 +487,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 2),
       sparseMatrixF32Range(4, 4),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -503,7 +503,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 4),
       sparseMatrixF32Range(2, 4),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -519,7 +519,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 2),
       sparseMatrixF32Range(2, 4),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -535,7 +535,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 3),
       sparseMatrixF32Range(4, 4),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -551,7 +551,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 4),
       sparseMatrixF32Range(3, 4),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -567,7 +567,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 3),
       sparseMatrixF32Range(3, 4),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -583,7 +583,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 2),
       sparseMatrixF32Range(3, 4),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -599,7 +599,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 3),
       sparseMatrixF32Range(2, 4),
-      'f32-only',
+      'finite',
       multiplicationMatrixMatrixInterval
     );
   },
@@ -615,7 +615,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixScalarToMatrixCases(
       sparseMatrixF32Range(2, 2),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       multiplicationMatrixScalarInterval
     );
   },
@@ -631,7 +631,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixScalarToMatrixCases(
       sparseMatrixF32Range(2, 3),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       multiplicationMatrixScalarInterval
     );
   },
@@ -647,7 +647,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixScalarToMatrixCases(
       sparseMatrixF32Range(2, 4),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       multiplicationMatrixScalarInterval
     );
   },
@@ -663,7 +663,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixScalarToMatrixCases(
       sparseMatrixF32Range(3, 2),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       multiplicationMatrixScalarInterval
     );
   },
@@ -679,7 +679,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixScalarToMatrixCases(
       sparseMatrixF32Range(3, 3),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       multiplicationMatrixScalarInterval
     );
   },
@@ -695,7 +695,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixScalarToMatrixCases(
       sparseMatrixF32Range(3, 4),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       multiplicationMatrixScalarInterval
     );
   },
@@ -711,7 +711,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixScalarToMatrixCases(
       sparseMatrixF32Range(4, 2),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       multiplicationMatrixScalarInterval
     );
   },
@@ -727,7 +727,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixScalarToMatrixCases(
       sparseMatrixF32Range(4, 3),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       multiplicationMatrixScalarInterval
     );
   },
@@ -743,7 +743,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixScalarToMatrixCases(
       sparseMatrixF32Range(4, 4),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       multiplicationMatrixScalarInterval
     );
   },
@@ -759,7 +759,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateScalarMatrixToMatrixCases(
       sparseF32Range(),
       sparseMatrixF32Range(2, 2),
-      'f32-only',
+      'finite',
       multiplicationScalarMatrixInterval
     );
   },
@@ -775,7 +775,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateScalarMatrixToMatrixCases(
       sparseF32Range(),
       sparseMatrixF32Range(2, 3),
-      'f32-only',
+      'finite',
       multiplicationScalarMatrixInterval
     );
   },
@@ -791,7 +791,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateScalarMatrixToMatrixCases(
       sparseF32Range(),
       sparseMatrixF32Range(2, 4),
-      'f32-only',
+      'finite',
       multiplicationScalarMatrixInterval
     );
   },
@@ -807,7 +807,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateScalarMatrixToMatrixCases(
       sparseF32Range(),
       sparseMatrixF32Range(3, 2),
-      'f32-only',
+      'finite',
       multiplicationScalarMatrixInterval
     );
   },
@@ -823,7 +823,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateScalarMatrixToMatrixCases(
       sparseF32Range(),
       sparseMatrixF32Range(3, 3),
-      'f32-only',
+      'finite',
       multiplicationScalarMatrixInterval
     );
   },
@@ -839,7 +839,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateScalarMatrixToMatrixCases(
       sparseF32Range(),
       sparseMatrixF32Range(3, 4),
-      'f32-only',
+      'finite',
       multiplicationScalarMatrixInterval
     );
   },
@@ -855,7 +855,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateScalarMatrixToMatrixCases(
       sparseF32Range(),
       sparseMatrixF32Range(4, 2),
-      'f32-only',
+      'finite',
       multiplicationScalarMatrixInterval
     );
   },
@@ -871,7 +871,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateScalarMatrixToMatrixCases(
       sparseF32Range(),
       sparseMatrixF32Range(4, 3),
-      'f32-only',
+      'finite',
       multiplicationScalarMatrixInterval
     );
   },
@@ -887,7 +887,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateScalarMatrixToMatrixCases(
       sparseF32Range(),
       sparseMatrixF32Range(4, 4),
-      'f32-only',
+      'finite',
       multiplicationScalarMatrixInterval
     );
   },
@@ -903,7 +903,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixVectorToVectorCases(
       sparseMatrixF32Range(2, 2),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       multiplicationMatrixVectorInterval
     );
   },
@@ -919,7 +919,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixVectorToVectorCases(
       sparseMatrixF32Range(2, 3),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       multiplicationMatrixVectorInterval
     );
   },
@@ -935,7 +935,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixVectorToVectorCases(
       sparseMatrixF32Range(2, 4),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       multiplicationMatrixVectorInterval
     );
   },
@@ -951,7 +951,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixVectorToVectorCases(
       sparseMatrixF32Range(3, 2),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       multiplicationMatrixVectorInterval
     );
   },
@@ -967,7 +967,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixVectorToVectorCases(
       sparseMatrixF32Range(3, 3),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       multiplicationMatrixVectorInterval
     );
   },
@@ -983,7 +983,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixVectorToVectorCases(
       sparseMatrixF32Range(3, 4),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       multiplicationMatrixVectorInterval
     );
   },
@@ -999,7 +999,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixVectorToVectorCases(
       sparseMatrixF32Range(4, 2),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       multiplicationMatrixVectorInterval
     );
   },
@@ -1015,7 +1015,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixVectorToVectorCases(
       sparseMatrixF32Range(4, 3),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       multiplicationMatrixVectorInterval
     );
   },
@@ -1031,7 +1031,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixVectorToVectorCases(
       sparseMatrixF32Range(4, 4),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       multiplicationMatrixVectorInterval
     );
   },
@@ -1047,7 +1047,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateVectorMatrixToVectorCases(
       sparseVectorF32Range(2),
       sparseMatrixF32Range(2, 2),
-      'f32-only',
+      'finite',
       multiplicationVectorMatrixInterval
     );
   },
@@ -1063,7 +1063,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateVectorMatrixToVectorCases(
       sparseVectorF32Range(2),
       sparseMatrixF32Range(3, 2),
-      'f32-only',
+      'finite',
       multiplicationVectorMatrixInterval
     );
   },
@@ -1079,7 +1079,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateVectorMatrixToVectorCases(
       sparseVectorF32Range(2),
       sparseMatrixF32Range(4, 2),
-      'f32-only',
+      'finite',
       multiplicationVectorMatrixInterval
     );
   },
@@ -1095,7 +1095,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateVectorMatrixToVectorCases(
       sparseVectorF32Range(3),
       sparseMatrixF32Range(2, 3),
-      'f32-only',
+      'finite',
       multiplicationVectorMatrixInterval
     );
   },
@@ -1111,7 +1111,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateVectorMatrixToVectorCases(
       sparseVectorF32Range(3),
       sparseMatrixF32Range(3, 3),
-      'f32-only',
+      'finite',
       multiplicationVectorMatrixInterval
     );
   },
@@ -1127,7 +1127,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateVectorMatrixToVectorCases(
       sparseVectorF32Range(3),
       sparseMatrixF32Range(4, 3),
-      'f32-only',
+      'finite',
       multiplicationVectorMatrixInterval
     );
   },
@@ -1143,7 +1143,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateVectorMatrixToVectorCases(
       sparseVectorF32Range(4),
       sparseMatrixF32Range(2, 4),
-      'f32-only',
+      'finite',
       multiplicationVectorMatrixInterval
     );
   },
@@ -1159,7 +1159,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateVectorMatrixToVectorCases(
       sparseVectorF32Range(4),
       sparseMatrixF32Range(3, 4),
-      'f32-only',
+      'finite',
       multiplicationVectorMatrixInterval
     );
   },
@@ -1175,7 +1175,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateVectorMatrixToVectorCases(
       sparseVectorF32Range(4),
       sparseMatrixF32Range(4, 4),
-      'f32-only',
+      'finite',
       multiplicationVectorMatrixInterval
     );
   },
@@ -1191,7 +1191,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 2),
       sparseMatrixF32Range(2, 2),
-      'f32-only',
+      'finite',
       subtractionMatrixInterval
     );
   },
@@ -1207,7 +1207,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 3),
       sparseMatrixF32Range(2, 3),
-      'f32-only',
+      'finite',
       subtractionMatrixInterval
     );
   },
@@ -1223,7 +1223,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(2, 4),
       sparseMatrixF32Range(2, 4),
-      'f32-only',
+      'finite',
       subtractionMatrixInterval
     );
   },
@@ -1239,7 +1239,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 2),
       sparseMatrixF32Range(3, 2),
-      'f32-only',
+      'finite',
       subtractionMatrixInterval
     );
   },
@@ -1255,7 +1255,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 3),
       sparseMatrixF32Range(3, 3),
-      'f32-only',
+      'finite',
       subtractionMatrixInterval
     );
   },
@@ -1271,7 +1271,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(3, 4),
       sparseMatrixF32Range(3, 4),
-      'f32-only',
+      'finite',
       subtractionMatrixInterval
     );
   },
@@ -1287,7 +1287,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 2),
       sparseMatrixF32Range(4, 2),
-      'f32-only',
+      'finite',
       subtractionMatrixInterval
     );
   },
@@ -1303,7 +1303,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 3),
       sparseMatrixF32Range(4, 3),
-      'f32-only',
+      'finite',
       subtractionMatrixInterval
     );
   },
@@ -1319,7 +1319,7 @@ export const d = makeCaseCache('binary/f32_matrix_arithmetic', {
     return generateMatrixPairToMatrixCases(
       sparseMatrixF32Range(4, 4),
       sparseMatrixF32Range(4, 4),
-      'f32-only',
+      'finite',
       subtractionMatrixInterval
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -19,10 +19,10 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kBit } from '../../../../../util/constants.js';
 import { i32Bits, TypeF32, TypeI32, TypeU32, u32Bits } from '../../../../../util/conversion.js';
-import { absInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -30,7 +30,11 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('abs', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', absInterval);
+    return FP.f32.generateScalarToIntervalCases(
+      fullF32Range(),
+      'unfiltered',
+      FP.f32.absInterval.bind(FP.f32)
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -26,7 +26,7 @@ const inputs = [
 
 export const d = makeCaseCache('acos', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'f32-only', acosInterval);
+    return generateUnaryToF32IntervalCases(inputs, 'finite', acosInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(inputs, 'unfiltered', acosInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -30,7 +30,7 @@ const inputs = [
 
 export const d = makeCaseCache('acosh', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'f32-only', ...acoshIntervals);
+    return generateUnaryToF32IntervalCases(inputs, 'finite', ...acoshIntervals);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(inputs, 'unfiltered', ...acoshIntervals);

--- a/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
@@ -26,7 +26,7 @@ const inputs = [
 
 export const d = makeCaseCache('asin', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'f32-only', asinInterval);
+    return generateUnaryToF32IntervalCases(inputs, 'finite', asinInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(inputs, 'unfiltered', asinInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -35,7 +35,7 @@ const inputs = [
 
 export const d = makeCaseCache('atan', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'f32-only', atanInterval);
+    return generateUnaryToF32IntervalCases(inputs, 'finite', atanInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(inputs, 'unfiltered', atanInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -33,7 +33,7 @@ const inputs = [
 
 export const d = makeCaseCache('atanh', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'f32-only', atanhInterval);
+    return generateUnaryToF32IntervalCases(inputs, 'finite', atanhInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(inputs, 'unfiltered', atanhInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -71,7 +71,7 @@ export const d = makeCaseCache('clamp', {
       sparseF32Range(),
       sparseF32Range(),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       ...clampIntervals
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -21,7 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('cosh', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'f32-only', coshInterval);
+    return generateUnaryToF32IntervalCases(fullF32Range(), 'finite', coshInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', coshInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cross.spec.ts
@@ -23,7 +23,7 @@ export const d = makeCaseCache('cross', {
     return generateVectorPairToVectorCases(
       vectorF32Range(3),
       vectorF32Range(3),
-      'f32-only',
+      'finite',
       crossInterval
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -21,7 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('degrees', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'f32-only', degreesInterval);
+    return generateUnaryToF32IntervalCases(fullF32Range(), 'finite', degreesInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', degreesInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/determinant.spec.ts
@@ -68,7 +68,7 @@ export const d = makeCaseCache('determinant', {
   f32_mat2x2_const: () => {
     return generateMatrixToScalarCases(
       kDeterminantMatrixF32Values[2],
-      'f32-only',
+      'finite',
       determinantInterval
     );
   },
@@ -82,7 +82,7 @@ export const d = makeCaseCache('determinant', {
   f32_mat3x3_const: () => {
     return generateMatrixToScalarCases(
       kDeterminantMatrixF32Values[3],
-      'f32-only',
+      'finite',
       determinantInterval
     );
   },
@@ -96,7 +96,7 @@ export const d = makeCaseCache('determinant', {
   f32_mat4x4_const: () => {
     return generateMatrixToScalarCases(
       kDeterminantMatrixF32Values[4],
-      'f32-only',
+      'finite',
       determinantInterval
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
@@ -30,7 +30,7 @@ export const d = makeCaseCache('distance', {
     return generateBinaryToF32IntervalCases(
       fullF32Range(),
       fullF32Range(),
-      'f32-only',
+      'finite',
       distanceInterval
     );
   },
@@ -46,7 +46,7 @@ export const d = makeCaseCache('distance', {
     return generateVectorPairToF32IntervalCases(
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       distanceInterval
     );
   },
@@ -62,7 +62,7 @@ export const d = makeCaseCache('distance', {
     return generateVectorPairToF32IntervalCases(
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       distanceInterval
     );
   },
@@ -78,7 +78,7 @@ export const d = makeCaseCache('distance', {
     return generateVectorPairToF32IntervalCases(
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       distanceInterval
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot.spec.ts
@@ -25,7 +25,7 @@ export const d = makeCaseCache('dot', {
     return generateVectorPairToF32IntervalCases(
       vectorF32Range(2),
       vectorF32Range(2),
-      'f32-only',
+      'finite',
       dotInterval
     );
   },
@@ -41,7 +41,7 @@ export const d = makeCaseCache('dot', {
     return generateVectorPairToF32IntervalCases(
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       dotInterval
     );
   },
@@ -57,7 +57,7 @@ export const d = makeCaseCache('dot', {
     return generateVectorPairToF32IntervalCases(
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       dotInterval
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -33,7 +33,7 @@ const inputs = [
 
 export const d = makeCaseCache('exp', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'f32-only', expInterval);
+    return generateUnaryToF32IntervalCases(inputs, 'finite', expInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(inputs, 'unfiltered', expInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -33,7 +33,7 @@ const inputs = [
 
 export const d = makeCaseCache('exp2', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'f32-only', exp2Interval);
+    return generateUnaryToF32IntervalCases(inputs, 'finite', exp2Interval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(inputs, 'unfiltered', exp2Interval);

--- a/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
@@ -49,7 +49,7 @@ function makeCaseF32(
   const z_f32 = z.map(f32);
 
   const results = faceForwardIntervals(x, y, z);
-  if (check === 'f32-only' && results.some(r => r === undefined)) {
+  if (check === 'finite' && results.some(r => r === undefined)) {
     return undefined;
   }
 
@@ -89,7 +89,7 @@ export const d = makeCaseCache('faceForward', {
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
-      'f32-only'
+      'finite'
     );
   },
   f32_vec2_non_const: () => {
@@ -105,7 +105,7 @@ export const d = makeCaseCache('faceForward', {
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
-      'f32-only'
+      'finite'
     );
   },
   f32_vec3_non_const: () => {
@@ -121,7 +121,7 @@ export const d = makeCaseCache('faceForward', {
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
-      'f32-only'
+      'finite'
     );
   },
   f32_vec4_non_const: () => {

--- a/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
@@ -25,7 +25,7 @@ export const d = makeCaseCache('fma', {
       sparseF32Range(),
       sparseF32Range(),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       fmaInterval
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -29,19 +29,19 @@ export const d = makeCaseCache('length', {
     return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', lengthInterval);
   },
   f32_vec2_const: () => {
-    return generateVectorToF32IntervalCases(vectorF32Range(2), 'f32-only', lengthInterval);
+    return generateVectorToF32IntervalCases(vectorF32Range(2), 'finite', lengthInterval);
   },
   f32_vec2_non_const: () => {
     return generateVectorToF32IntervalCases(vectorF32Range(2), 'unfiltered', lengthInterval);
   },
   f32_vec3_const: () => {
-    return generateVectorToF32IntervalCases(vectorF32Range(3), 'f32-only', lengthInterval);
+    return generateVectorToF32IntervalCases(vectorF32Range(3), 'finite', lengthInterval);
   },
   f32_vec3_non_const: () => {
     return generateVectorToF32IntervalCases(vectorF32Range(3), 'unfiltered', lengthInterval);
   },
   f32_vec4_const: () => {
-    return generateVectorToF32IntervalCases(vectorF32Range(4), 'f32-only', lengthInterval);
+    return generateVectorToF32IntervalCases(vectorF32Range(4), 'finite', lengthInterval);
   },
   f32_vec4_non_const: () => {
     return generateVectorToF32IntervalCases(vectorF32Range(4), 'unfiltered', lengthInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -30,7 +30,7 @@ const inputs = [
 
 export const d = makeCaseCache('log', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'f32-only', logInterval);
+    return generateUnaryToF32IntervalCases(inputs, 'finite', logInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(inputs, 'unfiltered', logInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -30,7 +30,7 @@ const inputs = [
 
 export const d = makeCaseCache('log2', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'f32-only', log2Interval);
+    return generateUnaryToF32IntervalCases(inputs, 'finite', log2Interval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(inputs, 'unfiltered', log2Interval);

--- a/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/mix.spec.ts
@@ -32,7 +32,7 @@ export const d = makeCaseCache('mix', {
       sparseF32Range(),
       sparseF32Range(),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       ...mixIntervals
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/normalize.spec.ts
@@ -20,19 +20,19 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('normalize', {
   f32_vec2_const: () => {
-    return generateVectorToVectorCases(vectorF32Range(2), 'f32-only', normalizeInterval);
+    return generateVectorToVectorCases(vectorF32Range(2), 'finite', normalizeInterval);
   },
   f32_vec2_non_const: () => {
     return generateVectorToVectorCases(vectorF32Range(2), 'unfiltered', normalizeInterval);
   },
   f32_vec3_const: () => {
-    return generateVectorToVectorCases(vectorF32Range(3), 'f32-only', normalizeInterval);
+    return generateVectorToVectorCases(vectorF32Range(3), 'finite', normalizeInterval);
   },
   f32_vec3_non_const: () => {
     return generateVectorToVectorCases(vectorF32Range(3), 'unfiltered', normalizeInterval);
   },
   f32_vec4_const: () => {
-    return generateVectorToVectorCases(vectorF32Range(4), 'f32-only', normalizeInterval);
+    return generateVectorToVectorCases(vectorF32Range(4), 'finite', normalizeInterval);
   },
   f32_vec4_non_const: () => {
     return generateVectorToVectorCases(vectorF32Range(4), 'unfiltered', normalizeInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -21,12 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('pow', {
   f32_const: () => {
-    return generateBinaryToF32IntervalCases(
-      fullF32Range(),
-      fullF32Range(),
-      'f32-only',
-      powInterval
-    );
+    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), 'finite', powInterval);
   },
   f32_non_const: () => {
     return generateBinaryToF32IntervalCases(

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -35,7 +35,7 @@ export const d = makeCaseCache('quantizeToF16', {
         kValue.f16.positive.max,
         ...fullF16Range(),
       ],
-      'f32-only',
+      'finite',
       quantizeToF16Interval
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/reflect.spec.ts
@@ -24,7 +24,7 @@ export const d = makeCaseCache('reflect', {
     return generateVectorPairToVectorCases(
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
-      'f32-only',
+      'finite',
       reflectInterval
     );
   },
@@ -40,7 +40,7 @@ export const d = makeCaseCache('reflect', {
     return generateVectorPairToVectorCases(
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
-      'f32-only',
+      'finite',
       reflectInterval
     );
   },
@@ -56,7 +56,7 @@ export const d = makeCaseCache('reflect', {
     return generateVectorPairToVectorCases(
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
-      'f32-only',
+      'finite',
       reflectInterval
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
@@ -43,7 +43,7 @@ function makeCaseF32(i: number[], s: number[], r: number, check: IntervalFilter)
   const r_f32 = f32(r);
 
   const vectors = refractInterval(i, s, r);
-  if (check === 'f32-only' && vectors.some(e => !e.isFinite())) {
+  if (check === 'finite' && vectors.some(e => !e.isFinite())) {
     return undefined;
   }
 
@@ -84,7 +84,7 @@ export const d = makeCaseCache('refract', {
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
       sparseF32Range(),
-      'f32-only'
+      'finite'
     );
   },
   f32_vec2_non_const: () => {
@@ -100,7 +100,7 @@ export const d = makeCaseCache('refract', {
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
       sparseF32Range(),
-      'f32-only'
+      'finite'
     );
   },
   f32_vec3_non_const: () => {
@@ -116,7 +116,7 @@ export const d = makeCaseCache('refract', {
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
       sparseF32Range(),
-      'f32-only'
+      'finite'
     );
   },
   f32_vec4_non_const: () => {

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -21,7 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sinh', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'f32-only', sinhInterval);
+    return generateUnaryToF32IntervalCases(fullF32Range(), 'finite', sinhInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', sinhInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -27,7 +27,7 @@ export const d = makeCaseCache('smoothstep', {
       sparseF32Range(),
       sparseF32Range(),
       sparseF32Range(),
-      'f32-only',
+      'finite',
       smoothStepInterval
     );
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -21,7 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sqrt', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'f32-only', sqrtInterval);
+    return generateUnaryToF32IntervalCases(fullF32Range(), 'finite', sqrtInterval);
   },
   f32_non_const: () => {
     return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', sqrtInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/transpose.spec.ts
@@ -20,55 +20,55 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('transpose', {
   f32_mat2x2_const: () => {
-    return generateMatrixToMatrixCases(sparseMatrixF32Range(2, 2), 'f32-only', transposeInterval);
+    return generateMatrixToMatrixCases(sparseMatrixF32Range(2, 2), 'finite', transposeInterval);
   },
   f32_mat2x2_non_const: () => {
     return generateMatrixToMatrixCases(sparseMatrixF32Range(2, 2), 'unfiltered', transposeInterval);
   },
   f32_mat2x3_const: () => {
-    return generateMatrixToMatrixCases(sparseMatrixF32Range(2, 3), 'f32-only', transposeInterval);
+    return generateMatrixToMatrixCases(sparseMatrixF32Range(2, 3), 'finite', transposeInterval);
   },
   f32_mat2x3_non_const: () => {
     return generateMatrixToMatrixCases(sparseMatrixF32Range(2, 3), 'unfiltered', transposeInterval);
   },
   f32_mat2x4_const: () => {
-    return generateMatrixToMatrixCases(sparseMatrixF32Range(2, 4), 'f32-only', transposeInterval);
+    return generateMatrixToMatrixCases(sparseMatrixF32Range(2, 4), 'finite', transposeInterval);
   },
   f32_mat2x4_non_const: () => {
     return generateMatrixToMatrixCases(sparseMatrixF32Range(2, 4), 'unfiltered', transposeInterval);
   },
   f32_mat3x2_const: () => {
-    return generateMatrixToMatrixCases(sparseMatrixF32Range(3, 2), 'f32-only', transposeInterval);
+    return generateMatrixToMatrixCases(sparseMatrixF32Range(3, 2), 'finite', transposeInterval);
   },
   f32_mat3x2_non_const: () => {
     return generateMatrixToMatrixCases(sparseMatrixF32Range(3, 2), 'unfiltered', transposeInterval);
   },
   f32_mat3x3_const: () => {
-    return generateMatrixToMatrixCases(sparseMatrixF32Range(3, 3), 'f32-only', transposeInterval);
+    return generateMatrixToMatrixCases(sparseMatrixF32Range(3, 3), 'finite', transposeInterval);
   },
   f32_mat3x3_non_const: () => {
     return generateMatrixToMatrixCases(sparseMatrixF32Range(3, 3), 'unfiltered', transposeInterval);
   },
   f32_mat3x4_const: () => {
-    return generateMatrixToMatrixCases(sparseMatrixF32Range(3, 4), 'f32-only', transposeInterval);
+    return generateMatrixToMatrixCases(sparseMatrixF32Range(3, 4), 'finite', transposeInterval);
   },
   f32_mat3x4_non_const: () => {
     return generateMatrixToMatrixCases(sparseMatrixF32Range(3, 4), 'unfiltered', transposeInterval);
   },
   f32_mat4x2_const: () => {
-    return generateMatrixToMatrixCases(sparseMatrixF32Range(4, 2), 'f32-only', transposeInterval);
+    return generateMatrixToMatrixCases(sparseMatrixF32Range(4, 2), 'finite', transposeInterval);
   },
   f32_mat4x2_non_const: () => {
     return generateMatrixToMatrixCases(sparseMatrixF32Range(4, 2), 'unfiltered', transposeInterval);
   },
   f32_mat4x3_const: () => {
-    return generateMatrixToMatrixCases(sparseMatrixF32Range(4, 3), 'f32-only', transposeInterval);
+    return generateMatrixToMatrixCases(sparseMatrixF32Range(4, 3), 'finite', transposeInterval);
   },
   f32_mat4x3_non_const: () => {
     return generateMatrixToMatrixCases(sparseMatrixF32Range(4, 3), 'unfiltered', transposeInterval);
   },
   f32_mat4x4_const: () => {
-    return generateMatrixToMatrixCases(sparseMatrixF32Range(4, 4), 'f32-only', transposeInterval);
+    return generateMatrixToMatrixCases(sparseMatrixF32Range(4, 4), 'finite', transposeInterval);
   },
   f32_mat4x4_non_const: () => {
     return generateMatrixToMatrixCases(sparseMatrixF32Range(4, 4), 'unfiltered', transposeInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16float.spec.ts
@@ -19,7 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack2x16float', {
   u32_const: () => {
-    return generateU32ToVectorCases(fullU32Range(), 'f32-only', unpack2x16floatInterval);
+    return generateU32ToVectorCases(fullU32Range(), 'finite', unpack2x16floatInterval);
   },
   u32_non_const: () => {
     return generateU32ToVectorCases(fullU32Range(), 'unfiltered', unpack2x16floatInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16snorm.spec.ts
@@ -19,7 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack2x16snorm', {
   u32_const: () => {
-    return generateU32ToVectorCases(fullU32Range(), 'f32-only', unpack2x16snormInterval);
+    return generateU32ToVectorCases(fullU32Range(), 'finite', unpack2x16snormInterval);
   },
   u32_non_const: () => {
     return generateU32ToVectorCases(fullU32Range(), 'unfiltered', unpack2x16snormInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -19,7 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack2x16unorm', {
   u32_const: () => {
-    return generateU32ToVectorCases(fullU32Range(), 'f32-only', unpack2x16unormInterval);
+    return generateU32ToVectorCases(fullU32Range(), 'finite', unpack2x16unormInterval);
   },
   u32_non_const: () => {
     return generateU32ToVectorCases(fullU32Range(), 'unfiltered', unpack2x16unormInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8snorm.spec.ts
@@ -19,7 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack4x8snorm', {
   u32_const: () => {
-    return generateU32ToVectorCases(fullU32Range(), 'f32-only', unpack4x8snormInterval);
+    return generateU32ToVectorCases(fullU32Range(), 'finite', unpack4x8snormInterval);
   },
   u32_non_const: () => {
     return generateU32ToVectorCases(fullU32Range(), 'unfiltered', unpack4x8snormInterval);

--- a/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/unpack4x8unorm.spec.ts
@@ -19,7 +19,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unpack4x8unorm', {
   u32_const: () => {
-    return generateU32ToVectorCases(fullU32Range(), 'f32-only', unpack4x8unormInterval);
+    return generateU32ToVectorCases(fullU32Range(), 'finite', unpack4x8unormInterval);
   },
   u32_non_const: () => {
     return generateU32ToVectorCases(fullU32Range(), 'unfiltered', unpack4x8unormInterval);

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -19,17 +19,17 @@ import {
   ScalarBuilder,
 } from '../../../util/conversion.js';
 import {
-  BinaryToInterval,
+  ScalarPairToInterval,
   MatrixPairToMatrix,
   MatrixScalarToMatrix,
   MatrixToMatrix,
   MatrixToScalar,
   MatrixVectorToVector,
-  PointToInterval,
-  PointToVector,
+  ScalarToInterval,
+  ScalarToVector,
   ScalarMatrixToMatrix,
   ScalarVectorToVector,
-  TernaryToInterval,
+  ScalarTripleToInterval,
   VectorMatrixToVector,
   VectorPairToInterval,
   VectorPairToVector,
@@ -832,7 +832,7 @@ export type IntervalFilter =
 function makeUnaryToF32IntervalCase(
   param: number,
   filter: IntervalFilter,
-  ...ops: PointToInterval[]
+  ...ops: ScalarToInterval[]
 ): Case | undefined {
   param = quantizeToF32(param);
 
@@ -853,7 +853,7 @@ function makeUnaryToF32IntervalCase(
 export function generateUnaryToF32IntervalCases(
   params: number[],
   filter: IntervalFilter,
-  ...ops: PointToInterval[]
+  ...ops: ScalarToInterval[]
 ): Case[] {
   return params.reduce((cases, e) => {
     const c = makeUnaryToF32IntervalCase(e, filter, ...ops);
@@ -877,7 +877,7 @@ function makeBinaryToF32IntervalCase(
   param0: number,
   param1: number,
   filter: IntervalFilter,
-  ...ops: BinaryToInterval[]
+  ...ops: ScalarPairToInterval[]
 ): Case | undefined {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
@@ -901,7 +901,7 @@ export function generateBinaryToF32IntervalCases(
   param0s: number[],
   param1s: number[],
   filter: IntervalFilter,
-  ...ops: BinaryToInterval[]
+  ...ops: ScalarPairToInterval[]
 ): Case[] {
   return cartesianProduct(param0s, param1s).reduce((cases, e) => {
     const c = makeBinaryToF32IntervalCase(e[0], e[1], filter, ...ops);
@@ -927,7 +927,7 @@ function makeTernaryToF32IntervalCase(
   param1: number,
   param2: number,
   filter: IntervalFilter,
-  ...ops: TernaryToInterval[]
+  ...ops: ScalarTripleToInterval[]
 ): Case | undefined {
   param0 = quantizeToF32(param0);
   param1 = quantizeToF32(param1);
@@ -957,7 +957,7 @@ export function generateTernaryToF32IntervalCases(
   param1s: number[],
   param2s: number[],
   filter: IntervalFilter,
-  ...ops: TernaryToInterval[]
+  ...ops: ScalarTripleToInterval[]
 ): Case[] {
   return cartesianProduct(param0s, param1s, param2s).reduce((cases, e) => {
     const c = makeTernaryToF32IntervalCase(e[0], e[1], e[2], filter, ...ops);
@@ -1657,7 +1657,7 @@ export function generateVectorMatrixToVectorCases(
 function makeU32ToVectorCase(
   param: number,
   filter: IntervalFilter,
-  ...ops: PointToVector[]
+  ...ops: ScalarToVector[]
 ): Case | undefined {
   param = Math.trunc(param);
   const param_u32 = u32(param);
@@ -1683,7 +1683,7 @@ function makeU32ToVectorCase(
 export function generateU32ToVectorCases(
   params: number[],
   filter: IntervalFilter,
-  ...ops: PointToVector[]
+  ...ops: ScalarToVector[]
 ): Case[] {
   return params.reduce((cases, e) => {
     const c = makeU32ToVectorCase(e, filter, ...ops);

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -818,7 +818,7 @@ function packScalarsToVector(
  * cause a validation error not an execution error.
  */
 export type IntervalFilter =
-  | 'f32-only' // Expected to be f32 finite
+  | 'finite' // Expected to be finite in the interval numeric space
   | 'unfiltered'; // No expectations
 
 /**
@@ -837,7 +837,7 @@ function makeUnaryToF32IntervalCase(
   param = quantizeToF32(param);
 
   const intervals = ops.map(o => o(param));
-  if (filter === 'f32-only' && intervals.some(i => !i.isFinite())) {
+  if (filter === 'finite' && intervals.some(i => !i.isFinite())) {
     return undefined;
   }
   return { input: [f32(param)], expected: anyOf(...intervals) };
@@ -883,7 +883,7 @@ function makeBinaryToF32IntervalCase(
   param1 = quantizeToF32(param1);
 
   const intervals = ops.map(o => o(param0, param1));
-  if (filter === 'f32-only' && intervals.some(i => !i.isFinite())) {
+  if (filter === 'finite' && intervals.some(i => !i.isFinite())) {
     return undefined;
   }
   return { input: [f32(param0), f32(param1)], expected: anyOf(...intervals) };
@@ -934,7 +934,7 @@ function makeTernaryToF32IntervalCase(
   param2 = quantizeToF32(param2);
 
   const intervals = ops.map(o => o(param0, param1, param2));
-  if (filter === 'f32-only' && intervals.some(i => !i.isFinite())) {
+  if (filter === 'finite' && intervals.some(i => !i.isFinite())) {
     return undefined;
   }
   return {
@@ -984,7 +984,7 @@ function makeVectorToF32IntervalCase(
   const param_f32 = param.map(f32);
 
   const intervals = ops.map(o => o(param));
-  if (filter === 'f32-only' && intervals.some(i => !i.isFinite())) {
+  if (filter === 'finite' && intervals.some(i => !i.isFinite())) {
     return undefined;
   }
   return {
@@ -1034,7 +1034,7 @@ function makeVectorPairToF32IntervalCase(
   const param1_f32 = param1.map(f32);
 
   const intervals = ops.map(o => o(param0, param1));
-  if (filter === 'f32-only' && intervals.some(i => !i.isFinite())) {
+  if (filter === 'finite' && intervals.some(i => !i.isFinite())) {
     return undefined;
   }
   return {
@@ -1082,7 +1082,7 @@ function makeVectorToVectorCase(
   const param_f32 = param.map(f32);
 
   const vectors = ops.map(o => o(param));
-  if (filter === 'f32-only' && vectors.some(v => v.some(e => !e.isFinite()))) {
+  if (filter === 'finite' && vectors.some(v => v.some(e => !e.isFinite()))) {
     return undefined;
   }
   return {
@@ -1132,7 +1132,7 @@ function makeVectorPairToVectorCase(
   const param1_f32 = param1.map(f32);
 
   const vectors = ops.map(o => o(param0, param1));
-  if (filter === 'f32-only' && vectors.some(v => v.some(e => !e.isFinite()))) {
+  if (filter === 'finite' && vectors.some(v => v.some(e => !e.isFinite()))) {
     return undefined;
   }
   return {
@@ -1184,7 +1184,7 @@ function makeVectorF32ToVectorCase(
   const scalar_f32 = f32(scalar);
 
   const results = ops.map(o => o(vec, scalar));
-  if (filter === 'f32-only' && results.some(r => r.some(e => !e.isFinite()))) {
+  if (filter === 'finite' && results.some(r => r.some(e => !e.isFinite()))) {
     return undefined;
   }
   return {
@@ -1240,7 +1240,7 @@ function makeF32VectorToVectorCase(
   const vec_f32 = vec.map(f32);
 
   const results = ops.map(o => o(scalar, vec));
-  if (filter === 'f32-only' && results.some(r => r.some(e => !e.isFinite()))) {
+  if (filter === 'finite' && results.some(r => r.some(e => !e.isFinite()))) {
     return undefined;
   }
   return {
@@ -1292,7 +1292,7 @@ function makeMatrixToScalarCase(
   const param_f32 = map2DArray(param, f32);
 
   const results = ops.map(o => o(param));
-  if (filter === 'f32-only' && results.some(e => !e.isFinite())) {
+  if (filter === 'finite' && results.some(e => !e.isFinite())) {
     return undefined;
   }
 
@@ -1339,7 +1339,7 @@ function makeMatrixToMatrixCase(
   const param_f32 = map2DArray(param, f32);
 
   const results = ops.map(o => o(param));
-  if (filter === 'f32-only' && results.some(m => m.some(c => c.some(r => !r.isFinite())))) {
+  if (filter === 'finite' && results.some(m => m.some(c => c.some(r => !r.isFinite())))) {
     return undefined;
   }
 
@@ -1390,7 +1390,7 @@ function makeMatrixPairToMatrixCase(
   const param1_f32 = map2DArray(param1, f32);
 
   const results = ops.map(o => o(param0, param1));
-  if (filter === 'f32-only' && results.some(m => m.some(c => c.some(r => !r.isFinite())))) {
+  if (filter === 'finite' && results.some(m => m.some(c => c.some(r => !r.isFinite())))) {
     return undefined;
   }
   return {
@@ -1442,7 +1442,7 @@ function makeMatrixScalarToMatrixCase(
   const scalar_f32 = f32(scalar);
 
   const results = ops.map(o => o(mat, scalar));
-  if (filter === 'f32-only' && results.some(m => m.some(c => c.some(r => !r.isFinite())))) {
+  if (filter === 'finite' && results.some(m => m.some(c => c.some(r => !r.isFinite())))) {
     return undefined;
   }
   return {
@@ -1498,7 +1498,7 @@ function makeScalarMatrixToMatrixCase(
   const scalar_f32 = f32(scalar);
 
   const results = ops.map(o => o(scalar, mat));
-  if (filter === 'f32-only' && results.some(m => m.some(c => c.some(r => !r.isFinite())))) {
+  if (filter === 'finite' && results.some(m => m.some(c => c.some(r => !r.isFinite())))) {
     return undefined;
   }
   return {
@@ -1554,7 +1554,7 @@ function makeMatrixVectorToVectorCase(
   const vec_f32 = vec.map(f32);
 
   const results = ops.map(o => o(mat, vec));
-  if (filter === 'f32-only' && results.some(v => v.some(e => !e.isFinite()))) {
+  if (filter === 'finite' && results.some(v => v.some(e => !e.isFinite()))) {
     return undefined;
   }
   return {
@@ -1610,7 +1610,7 @@ function makeVectorMatrixToVectorCase(
   const mat_f32 = map2DArray(mat, f32);
 
   const results = ops.map(o => o(vec, mat));
-  if (filter === 'f32-only' && results.some(v => v.some(e => !e.isFinite()))) {
+  if (filter === 'finite' && results.some(v => v.some(e => !e.isFinite()))) {
     return undefined;
   }
   return {
@@ -1663,7 +1663,7 @@ function makeU32ToVectorCase(
   const param_u32 = u32(param);
 
   const vectors = ops.map(o => o(param));
-  if (filter === 'f32-only' && vectors.some(v => !v.every(e => e.isFinite()))) {
+  if (filter === 'finite' && vectors.some(v => !v.every(e => e.isFinite()))) {
     return undefined;
   }
   return {

--- a/src/webgpu/shader/execution/expression/unary/f32_conversion.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_conversion.spec.ts
@@ -54,7 +54,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   f32_mat2x2_const: () => {
     return generateMatrixToMatrixCases(
       sparseMatrixF32Range(2, 2),
-      'f32-only',
+      'finite',
       correctlyRoundedMatrix
     );
   },
@@ -68,7 +68,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   f32_mat2x3_const: () => {
     return generateMatrixToMatrixCases(
       sparseMatrixF32Range(2, 3),
-      'f32-only',
+      'finite',
       correctlyRoundedMatrix
     );
   },
@@ -82,7 +82,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   f32_mat2x4_const: () => {
     return generateMatrixToMatrixCases(
       sparseMatrixF32Range(2, 4),
-      'f32-only',
+      'finite',
       correctlyRoundedMatrix
     );
   },
@@ -96,7 +96,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   f32_mat3x2_const: () => {
     return generateMatrixToMatrixCases(
       sparseMatrixF32Range(3, 2),
-      'f32-only',
+      'finite',
       correctlyRoundedMatrix
     );
   },
@@ -110,7 +110,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   f32_mat3x3_const: () => {
     return generateMatrixToMatrixCases(
       sparseMatrixF32Range(3, 3),
-      'f32-only',
+      'finite',
       correctlyRoundedMatrix
     );
   },
@@ -124,7 +124,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   f32_mat3x4_const: () => {
     return generateMatrixToMatrixCases(
       sparseMatrixF32Range(3, 4),
-      'f32-only',
+      'finite',
       correctlyRoundedMatrix
     );
   },
@@ -138,7 +138,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   f32_mat4x2_const: () => {
     return generateMatrixToMatrixCases(
       sparseMatrixF32Range(4, 2),
-      'f32-only',
+      'finite',
       correctlyRoundedMatrix
     );
   },
@@ -152,7 +152,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   f32_mat4x3_const: () => {
     return generateMatrixToMatrixCases(
       sparseMatrixF32Range(4, 3),
-      'f32-only',
+      'finite',
       correctlyRoundedMatrix
     );
   },
@@ -166,7 +166,7 @@ export const d = makeCaseCache('unary/f32_conversion', {
   f32_mat4x4_const: () => {
     return generateMatrixToMatrixCases(
       sparseMatrixF32Range(4, 4),
-      'f32-only',
+      'finite',
       correctlyRoundedMatrix
     );
   },

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -6,19 +6,19 @@ import { FPInterval, FPMatrix, FPVector, IntervalBounds, FP } from './floating_p
 
 // Interfaces
 
-export interface PointToInterval {
+export interface ScalarToInterval {
   (x: number): FPInterval;
 }
 
-export interface BinaryToInterval {
+export interface ScalarPairToInterval {
   (x: number, y: number): FPInterval;
 }
 
-export interface TernaryToInterval {
+export interface ScalarTripleToInterval {
   (x: number, y: number, z: number): FPInterval;
 }
 
-export interface PointToVector {
+export interface ScalarToVector {
   (n: number): FPVector;
 }
 

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -124,10 +124,6 @@ export function ulpInterval(n: number, numULP: number): FPInterval {
   return FP.f32.ulpInterval(n, numULP);
 }
 
-export function absInterval(n: number): FPInterval {
-  return FP.f32.absInterval(n);
-}
-
 export function acosInterval(n: number): FPInterval {
   return FP.f32.acosInterval(n);
 }


### PR DESCRIPTION
Also renames the filter type 'f32-only' to 'finite'

Issue #2416

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
