### PR TITLE
Migrate Scalar -> Interval tests to use new numeric framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -39,7 +39,6 @@ import {
   multiplicationVectorMatrixInterval,
   normalizeInterval,
   powInterval,
-  radiansInterval,
   reflectInterval,
   refractInterval,
   remainderInterval,
@@ -1910,36 +1909,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('radiansInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: -180, expected: [minusOneULP(kValue.f32.negative.pi.whole), plusOneULP(kValue.f32.negative.pi.whole)] },
-      { input: -135, expected: [minusOneULP(kValue.f32.negative.pi.three_quarters), plusOneULP(kValue.f32.negative.pi.three_quarters)] },
-      { input: -90, expected: [minusOneULP(kValue.f32.negative.pi.half), plusOneULP(kValue.f32.negative.pi.half)] },
-      { input: -60, expected: [minusOneULP(kValue.f32.negative.pi.third), plusOneULP(kValue.f32.negative.pi.third)] },
-      { input: -45, expected: [minusOneULP(kValue.f32.negative.pi.quarter), plusOneULP(kValue.f32.negative.pi.quarter)] },
-      { input: -30, expected: [minusOneULP(kValue.f32.negative.pi.sixth), plusOneULP(kValue.f32.negative.pi.sixth)] },
-      { input: 0, expected: 0 },
-      { input: 30, expected: [minusOneULP(kValue.f32.positive.pi.sixth), plusOneULP(kValue.f32.positive.pi.sixth)] },
-      { input: 45, expected: [minusOneULP(kValue.f32.positive.pi.quarter), plusOneULP(kValue.f32.positive.pi.quarter)] },
-      { input: 60, expected: [minusOneULP(kValue.f32.positive.pi.third), plusOneULP(kValue.f32.positive.pi.third)] },
-      { input: 90, expected: [minusOneULP(kValue.f32.positive.pi.half), plusOneULP(kValue.f32.positive.pi.half)] },
-      { input: 135, expected: [minusOneULP(kValue.f32.positive.pi.three_quarters), plusOneULP(kValue.f32.positive.pi.three_quarters)] },
-      { input: 180, expected: [minusOneULP(kValue.f32.positive.pi.whole), plusOneULP(kValue.f32.positive.pi.whole)] },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = radiansInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `radiansInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('roundInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -24,7 +24,6 @@ import {
   distanceInterval,
   divisionInterval,
   dotInterval,
-  expInterval,
   exp2Interval,
   faceForwardIntervals,
   floorInterval,
@@ -1920,32 +1919,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('expInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: 0, expected: 1 },
-      { input: 1, expected: [kValue.f32.positive.e, plusOneULP(kValue.f32.positive.e)] },
-      { input: 89, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const error = (x: number): number => {
-      const n = 3 + 2 * Math.abs(t.params.input);
-      return n * oneULPF32(x);
-    };
-
-    t.params.expected = applyError(t.params.expected, error);
-    const expected = toF32Interval(t.params.expected);
-
-    const got = expInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `expInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('exp2Interval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -25,7 +25,6 @@ import {
   divisionInterval,
   dotInterval,
   faceForwardIntervals,
-  floorInterval,
   fmaInterval,
   fractInterval,
   inverseSqrtInterval,
@@ -1918,48 +1917,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('floorInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: 0, expected: 0 },
-      { input: 0.1, expected: 0 },
-      { input: 0.9, expected: 0 },
-      { input: 1.0, expected: 1 },
-      { input: 1.1, expected: 1 },
-      { input: 1.9, expected: 1 },
-      { input: -0.1, expected: -1 },
-      { input: -0.9, expected: -1 },
-      { input: -1.0, expected: -1 },
-      { input: -1.1, expected: -2 },
-      { input: -1.9, expected: -2 },
-
-      // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
-      { input: kValue.f32.positive.min, expected: 0 },
-      { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
-      { input: kValue.f32.negative.max, expected: -1 },
-      { input: kValue.powTwo.to30, expected: kValue.powTwo.to30 },
-      { input: -kValue.powTwo.to30, expected: -kValue.powTwo.to30 },
-
-      // 32-bit subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: 0 },
-      { input: kValue.f32.subnormal.positive.min, expected: 0 },
-      { input: kValue.f32.subnormal.negative.min, expected: [-1, 0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [-1, 0] },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = floorInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `floorInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('fractInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -14,7 +14,6 @@ import { objectEquals } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
 import {
   absoluteErrorInterval,
-  acosInterval,
   acoshAlternativeInterval,
   acoshPrimaryInterval,
   additionInterval,
@@ -1931,41 +1930,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('acosInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the complexity of
-      // their derivation.
-      //
-      // The acceptance interval @ x = -1 and 1 is kAnyBounds, because
-      // sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inverseqrt
-      // The acceptance interval @ x = 0 is kAnyBounds, because atan2 is not
-      // well-defined/implemented at 0.
-      // Near 1, the absolute error should be larger and, away from 1 the atan2
-      // inherited error should be larger.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: -1, expected: kAnyBounds },
-      { input: -1/2, expected: [hexToF32(0x4005fa91), hexToF32(0x40061a94)] },  // ~2π/3
-      { input: 0, expected: kAnyBounds },
-      { input: 1/2, expected: [hexToF32(0x3f85fa8f), hexToF32(0x3f861a94)] },  // ~π/3
-      { input: minusOneULP(1), expected: [hexToF64(0x3f2f_fdff_6000_0000n), hexToF64(0x3f3b_106f_c933_4fb9n)] },  // ~0.0003
-      { input: 1, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = acosInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `acosInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('acoshAlternativeInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -24,7 +24,6 @@ import {
   distanceInterval,
   divisionInterval,
   dotInterval,
-  exp2Interval,
   faceForwardIntervals,
   floorInterval,
   fmaInterval,
@@ -1919,32 +1918,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('exp2Interval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: 0, expected: 1 },
-      { input: 1, expected: 2 },
-      { input: 128, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const error = (x: number): number => {
-      const n = 3 + 2 * Math.abs(t.params.input);
-      return n * oneULPF32(x);
-    };
-
-    t.params.expected = applyError(t.params.expected, error);
-    const expected = toF32Interval(t.params.expected);
-
-    const got = exp2Interval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `exp2Interval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('floorInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -20,7 +20,6 @@ import {
   clampMedianInterval,
   clampMinMaxInterval,
   correctlyRoundedInterval,
-  coshInterval,
   crossInterval,
   degreesInterval,
   distanceInterval,
@@ -1922,32 +1921,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('coshInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: -1, expected: [ hexToF32(0x3fc583a4), hexToF32(0x3fc583b1)] },  // ~1.1543...
-      { input: 0, expected: [hexToF32(0x3f7ffffd), hexToF32(0x3f800002)] },  // ~1
-      { input: 1, expected: [ hexToF32(0x3fc583a4), hexToF32(0x3fc583b1)] },  // ~1.1543...
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-
-    const got = coshInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `coshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('degreesInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -14,8 +14,6 @@ import { objectEquals } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
 import {
   absoluteErrorInterval,
-  acoshAlternativeInterval,
-  acoshPrimaryInterval,
   additionInterval,
   additionMatrixInterval,
   asinInterval,
@@ -1930,60 +1928,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('acoshAlternativeInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: -1, expected: kAnyBounds },
-      { input: 0, expected: kAnyBounds },
-      { input: 1, expected: kAnyBounds },  // 1/0 occurs in inverseSqrt in this formulation
-      { input: 1.1, expected: [hexToF64(0x3fdc_6368_8000_0000n), hexToF64(0x3fdc_636f_2000_0000n)] },  // ~0.443..., differs from the primary in the later digits
-      { input: 10, expected: [hexToF64(0x4007_f21e_4000_0000n), hexToF64(0x4007_f21f_6000_0000n)] },  // ~2.993...
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = acoshAlternativeInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `acoshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
-
-g.test('acoshPrimaryInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: -1, expected: kAnyBounds },
-      { input: 0, expected: kAnyBounds },
-      { input: 1, expected: kAnyBounds },  // 1/0 occurs in inverseSqrt in this formulation
-      { input: 1.1, expected: [hexToF64(0x3fdc_6368_2000_0000n), hexToF64(0x3fdc_636f_8000_0000n)] }, // ~0.443..., differs from the alternative in the later digits
-      { input: 10, expected: [hexToF64(0x4007_f21e_4000_0000n), hexToF64(0x4007_f21f_6000_0000n)] },  // ~2.993...
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = acoshPrimaryInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `acoshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('asinInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -27,7 +27,6 @@ import {
   faceForwardIntervals,
   fmaInterval,
   ldexpInterval,
-  log2Interval,
   maxInterval,
   minInterval,
   mixImpreciseInterval,
@@ -1913,35 +1912,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('log2Interval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: -1, expected: kAnyBounds },
-      { input: 0, expected: kAnyBounds },
-      { input: 1, expected: 0 },
-      { input: 2, expected: 1 },
-      { input: kValue.f32.positive.max, expected: [minusOneULP(128), 128] },
-    ]
-  )
-  .fn(t => {
-    const error = (n: number): number => {
-      if (t.params.input >= 0.5 && t.params.input <= 2.0) {
-        return 2 ** -21;
-      }
-      return 3 * oneULPF32(n);
-    };
-
-    t.params.expected = applyError(t.params.expected, error);
-    const expected = toF32Interval(t.params.expected);
-
-    const got = log2Interval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `log2Interval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('negationInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -16,7 +16,6 @@ import {
   absoluteErrorInterval,
   additionInterval,
   additionMatrixInterval,
-  atanInterval,
   atan2Interval,
   atanhInterval,
   ceilInterval,
@@ -1926,36 +1925,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('atanInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: hexToF32(0xbfddb3d7), expected: [kValue.f32.negative.pi.third, plusOneULP(kValue.f32.negative.pi.third)] }, // x = -√3
-      { input: -1, expected: [kValue.f32.negative.pi.quarter, plusOneULP(kValue.f32.negative.pi.quarter)] },
-      { input: hexToF32(0xbf13cd3a), expected: [kValue.f32.negative.pi.sixth, plusOneULP(kValue.f32.negative.pi.sixth)] },  // x = -1/√3
-      { input: 0, expected: 0 },
-      { input: hexToF32(0x3f13cd3a), expected: [minusOneULP(kValue.f32.positive.pi.sixth), kValue.f32.positive.pi.sixth] },  // x = 1/√3
-      { input: 1, expected: [minusOneULP(kValue.f32.positive.pi.quarter), kValue.f32.positive.pi.quarter] },
-      { input: hexToF32(0x3fddb3d7), expected: [minusOneULP(kValue.f32.positive.pi.third), kValue.f32.positive.pi.third] }, // x = √3
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const error = (n: number): number => {
-      return 4096 * oneULPF32(n);
-    };
-
-    t.params.expected = applyError(t.params.expected, error);
-    const expected = toF32Interval(t.params.expected);
-
-    const got = atanInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `atanInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('atanhInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -46,7 +46,6 @@ import {
   stepInterval,
   subtractionInterval,
   subtractionMatrixInterval,
-  tanInterval,
   tanhInterval,
   toF32Interval,
   toF32Matrix,
@@ -1903,47 +1902,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('tanInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // All of these are hard coded, since the error intervals are difficult to
-      // express in a closed human--readable form.
-      // Some easy looking cases like f(x = -π|π) = 0 are actually quite
-      // difficult. This is because the interval is calculated from the results
-      // of sin(x)/cos(x), which becomes very messy at x = -π|π, since π is
-      // irrational, thus does not have an exact representation as a f32.
-      //
-      // Even at 0, which has a precise f32 value, there is still the problem
-      // that result of sin(0) and cos(0) will be intervals due to the inherited
-      // nature of errors, so the proper interval will be an interval calculated
-      // from dividing an interval by another interval and applying an error
-      // function to that.
-      //
-      // This complexity is why the entire interval framework was developed.
-      //
-      // The examples here have been manually traced to confirm the expectation
-      // values are correct.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: kValue.f32.negative.pi.whole, expected: [hexToF64(0xbf40_02bc_9000_0000n), hexToF64(0x3f40_0144_f000_0000n)] },  // ~0.0
-      { input: kValue.f32.negative.pi.half, expected: kAnyBounds },
-      { input: 0, expected: [hexToF64(0xbf40_0200_b000_0000n), hexToF64(0x3f40_0200_b000_0000n)] },  // ~0.0
-      { input: kValue.f32.positive.pi.half, expected: kAnyBounds },
-      { input: kValue.f32.positive.pi.whole, expected: [hexToF64(0xbf40_0144_f000_0000n), hexToF64(0x3f40_02bc_9000_0000n)] },  // ~0.0
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = tanInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `tanInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('tanhInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -42,7 +42,6 @@ import {
   reflectInterval,
   refractInterval,
   remainderInterval,
-  signInterval,
   sinInterval,
   sinhInterval,
   smoothStepInterval,
@@ -1907,38 +1906,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('signInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: -1 },
-      { input: -10, expected: -1 },
-      { input: -1, expected: -1 },
-      { input: -0.1, expected: -1 },
-      { input: kValue.f32.negative.max, expected:  -1 },
-      { input: kValue.f32.subnormal.negative.min, expected: [-1, 0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [-1, 0] },
-      { input: 0, expected: 0 },
-      { input: kValue.f32.subnormal.positive.max, expected: [0, 1] },
-      { input: kValue.f32.subnormal.positive.min, expected: [0, 1] },
-      { input: kValue.f32.positive.min, expected: 1 },
-      { input: 0.1, expected: 1 },
-      { input: 1, expected: 1 },
-      { input: 10, expected: 1 },
-      { input: kValue.f32.positive.max, expected: 1 },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = signInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `signInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('sinInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -43,7 +43,6 @@ import {
   refractInterval,
   remainderInterval,
   smoothStepInterval,
-  sqrtInterval,
   stepInterval,
   subtractionInterval,
   subtractionMatrixInterval,
@@ -1904,31 +1903,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('sqrtInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      { input: -1, expected: kAnyBounds },
-      { input: 0, expected: kAnyBounds },
-      { input: 0.01, expected: [hexToF64(0x3fb9_9998_b000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-      { input: 1, expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: 4, expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
-      { input: 100, expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = sqrtInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `sqrtInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('tanInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -46,7 +46,6 @@ import {
   stepInterval,
   subtractionInterval,
   subtractionMatrixInterval,
-  tanhInterval,
   toF32Interval,
   toF32Matrix,
   toF32Vector,
@@ -1902,31 +1901,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('tanhInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: -1, expected: [hexToF64(0xbfe8_5efd_1000_0000n), hexToF64(0xbfe8_5ef8_9000_0000n)] },  // ~-0.7615...
-      { input: 0, expected: [hexToF64(0xbe8c_0000_b000_0000n), hexToF64(0x3e8c_0000_b000_0000n)] },  // ~0
-      { input: 1, expected: [hexToF64(0x3fe8_5ef8_9000_0000n), hexToF64(0x3fe8_5efd_1000_0000n)] },  // ~0.7615...
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = tanhInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `tanhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('truncInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -37,7 +37,6 @@ import {
   multiplicationMatrixScalarInterval,
   multiplicationMatrixVectorInterval,
   multiplicationVectorMatrixInterval,
-  negationInterval,
   normalizeInterval,
   powInterval,
   quantizeToF16Interval,
@@ -1912,42 +1911,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('negationInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: 0, expected: 0 },
-      { input: 0.1, expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] }, // ~-0.1
-      { input: 1.0, expected: -1.0 },
-      { input: 1.9, expected: [hexToF32(0xbff33334), plusOneULP(hexToF32(0xbff33334))] },  // ~-1.9
-      { input: -0.1, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] }, // ~0.1
-      { input: -1.0, expected: 1 },
-      { input: -1.9, expected: [minusOneULP(hexToF32(0x3ff33334)), hexToF32(0x3ff33334)] },  // ~1.9
-
-      // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: kValue.f32.negative.min },
-      { input: kValue.f32.positive.min, expected: kValue.f32.negative.max },
-      { input: kValue.f32.negative.min, expected: kValue.f32.positive.max },
-      { input: kValue.f32.negative.max, expected: kValue.f32.positive.min },
-
-      // 32-bit subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: kValue.f32.subnormal.positive.min, expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: kValue.f32.subnormal.negative.min, expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: kValue.f32.subnormal.negative.max, expected: [0, kValue.f32.subnormal.positive.min] },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = negationInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `negationInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('quantizeToF16Interval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -27,7 +27,6 @@ import {
   faceForwardIntervals,
   fmaInterval,
   ldexpInterval,
-  logInterval,
   log2Interval,
   maxInterval,
   minInterval,
@@ -1914,35 +1913,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('logInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: -1, expected: kAnyBounds },
-      { input: 0, expected: kAnyBounds },
-      { input: 1, expected: 0 },
-      { input: kValue.f32.positive.e, expected: [minusOneULP(1), 1] },
-      { input: kValue.f32.positive.max, expected: [minusOneULP(hexToF32(0x42b17218)), hexToF32(0x42b17218)] },  // ~88.72...
-    ]
-  )
-  .fn(t => {
-    const error = (n: number): number => {
-      if (t.params.input >= 0.5 && t.params.input <= 2.0) {
-        return 2 ** -21;
-      }
-      return 3 * oneULPF32(n);
-    };
-
-    t.params.expected = applyError(t.params.expected, error);
-    const expected = toF32Interval(t.params.expected);
-
-    const got = logInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `logInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('log2Interval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -17,7 +17,6 @@ import {
   additionInterval,
   additionMatrixInterval,
   atan2Interval,
-  atanhInterval,
   ceilInterval,
   clampMedianInterval,
   clampMinMaxInterval,
@@ -1925,32 +1924,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('atanhInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: -1, expected: kAnyBounds },
-      { input: -0.1, expected: [hexToF64(0xbfb9_af9a_6000_0000n), hexToF64(0xbfb9_af8c_c000_0000n)] },  // ~-0.1003...
-      { input: 0, expected: [hexToF64(0xbe96_0000_2000_0000n), hexToF64(0x3e98_0000_0000_0000n)] },  // ~0
-      { input: 0.1, expected: [hexToF64(0x3fb9_af8b_8000_0000n), hexToF64(0x3fb9_af9b_0000_0000n)] },  // ~0.1003...
-      { input: 1, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = atanhInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `atanhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('ceilInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -21,7 +21,6 @@ import {
   clampMinMaxInterval,
   correctlyRoundedInterval,
   crossInterval,
-  degreesInterval,
   distanceInterval,
   divisionInterval,
   dotInterval,
@@ -1921,38 +1920,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('degreesInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: kValue.f32.negative.pi.whole, expected: [minusOneULP(-180), plusOneULP(-180)] },
-      { input: kValue.f32.negative.pi.three_quarters, expected: [minusOneULP(-135), plusOneULP(-135)] },
-      { input: kValue.f32.negative.pi.half, expected: [minusOneULP(-90), plusOneULP(-90)] },
-      { input: kValue.f32.negative.pi.third, expected: [minusOneULP(-60), plusOneULP(-60)] },
-      { input: kValue.f32.negative.pi.quarter, expected: [minusOneULP(-45), plusOneULP(-45)] },
-      { input: kValue.f32.negative.pi.sixth, expected: [minusOneULP(-30), plusOneULP(-30)] },
-      { input: 0, expected: 0 },
-      { input: kValue.f32.positive.pi.sixth, expected: [minusOneULP(30), plusOneULP(30)] },
-      { input: kValue.f32.positive.pi.quarter, expected: [minusOneULP(45), plusOneULP(45)] },
-      { input: kValue.f32.positive.pi.third, expected: [minusOneULP(60), plusOneULP(60)] },
-      { input: kValue.f32.positive.pi.half, expected: [minusOneULP(90), plusOneULP(90)] },
-      { input: kValue.f32.positive.pi.three_quarters, expected: [minusOneULP(135), plusOneULP(135)] },
-      { input: kValue.f32.positive.pi.whole, expected: [minusOneULP(180), plusOneULP(180)] },
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = degreesInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `degreesInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('expInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -26,7 +26,6 @@ import {
   dotInterval,
   faceForwardIntervals,
   fmaInterval,
-  inverseSqrtInterval,
   ldexpInterval,
   lengthInterval,
   logInterval,
@@ -1916,34 +1915,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('inverseSqrtInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: -1, expected: kAnyBounds },
-      { input: 0, expected: kAnyBounds },
-      { input: 0.04, expected: [minusOneULP(5), plusOneULP(5)] },
-      { input: 1, expected: 1 },
-      { input: 100, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: kValue.f32.positive.max, expected: [hexToF32(0x1f800000), plusNULP(hexToF32(0x1f800000), 2)] },  // ~5.421...e-20, i.e. 1/√max f32
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const error = (n: number): number => {
-      return 2 * oneULPF32(n);
-    };
-
-    t.params.expected = applyError(t.params.expected, error);
-    const expected = toF32Interval(t.params.expected);
-
-    const got = inverseSqrtInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `inverseSqrtInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('lengthIntervalScalar')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -42,7 +42,6 @@ import {
   reflectInterval,
   refractInterval,
   remainderInterval,
-  sinhInterval,
   smoothStepInterval,
   sqrtInterval,
   stepInterval,
@@ -1905,31 +1904,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('sinhInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: -1, expected: [ hexToF32(0xbf966d05), hexToF32(0xbf966cf8)] },  // ~-1.175...
-      { input: 0, expected: [hexToF32(0xb4600000), hexToF32(0x34600000)] },  // ~0
-      { input: 1, expected: [ hexToF32(0x3f966cf8), hexToF32(0x3f966d05)] },  // ~1.175...
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = sinhInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `sinhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('sqrtInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -39,7 +39,6 @@ import {
   multiplicationVectorMatrixInterval,
   normalizeInterval,
   powInterval,
-  quantizeToF16Interval,
   radiansInterval,
   reflectInterval,
   refractInterval,
@@ -1911,41 +1910,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('quantizeToF16Interval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: kValue.f16.negative.min, expected: kValue.f16.negative.min },
-      { input: -1, expected: -1 },
-      { input: -0.1, expected: [hexToF32(0xbdcce000), hexToF32(0xbdccc000)] },  // ~-0.1
-      { input: kValue.f16.negative.max, expected: kValue.f16.negative.max },
-      { input: kValue.f16.subnormal.negative.min, expected: [kValue.f16.subnormal.negative.min, 0] },
-      { input: kValue.f16.subnormal.negative.max, expected: [kValue.f16.subnormal.negative.max, 0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [kValue.f16.subnormal.negative.max, 0] },
-      { input: 0, expected: 0 },
-      { input: kValue.f32.subnormal.positive.min, expected: [0, kValue.f16.subnormal.positive.min] },
-      { input: kValue.f16.subnormal.positive.min, expected: [0, kValue.f16.subnormal.positive.min] },
-      { input: kValue.f16.subnormal.positive.max, expected: [0, kValue.f16.subnormal.positive.max] },
-      { input: kValue.f16.positive.min, expected: kValue.f16.positive.min },
-      { input: 0.1, expected: [hexToF32(0x3dccc000), hexToF32(0x3dcce000)] },  // ~0.1
-      { input: 1, expected: 1 },
-      { input: kValue.f16.positive.max, expected: kValue.f16.positive.max },
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-
-    const got = quantizeToF16Interval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `quantizeToF16Interval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('radiansInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -42,7 +42,6 @@ import {
   reflectInterval,
   refractInterval,
   remainderInterval,
-  sinInterval,
   sinhInterval,
   smoothStepInterval,
   sqrtInterval,
@@ -1906,40 +1905,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('sinInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // This test does not include some common cases, i.e. f(x = -π|π) = 0,
-      // because the difference between true x and x as a f32 is sufficiently
-      // large, such that the high slope of f @ x causes the results to be
-      // substantially different, so instead of getting 0 you get a value on the
-      // order of 10^-8 away from it, thus difficult to express in a
-      // human-readable manner.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: kValue.f32.negative.pi.half, expected: [-1, plusOneULP(-1)] },
-      { input: 0, expected: 0 },
-      { input: kValue.f32.positive.pi.half, expected: [minusOneULP(1), 1] },
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const error = (_: number): number => {
-      return 2 ** -11;
-    };
-
-    t.params.expected = applyError(t.params.expected, error);
-    const expected = toF32Interval(t.params.expected);
-
-    const got = sinInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `sinInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('sinhInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -42,7 +42,6 @@ import {
   reflectInterval,
   refractInterval,
   remainderInterval,
-  saturateInterval,
   signInterval,
   sinInterval,
   sinhInterval,
@@ -1908,44 +1907,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('saturateInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Normals
-      { input: 0, expected: 0 },
-      { input: 1, expected: 1.0 },
-      { input: -0.1, expected: 0 },
-      { input: -1, expected: 0 },
-      { input: -10, expected: 0 },
-      { input: 0.1, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: 10, expected: 1.0 },
-      { input: 11.1, expected: 1.0 },
-      { input: kValue.f32.positive.max, expected: 1.0 },
-      { input: kValue.f32.positive.min, expected: kValue.f32.positive.min },
-      { input: kValue.f32.negative.max, expected: 0.0 },
-      { input: kValue.f32.negative.min, expected: 0.0 },
-
-      // Subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: [0.0, kValue.f32.subnormal.positive.max] },
-      { input: kValue.f32.subnormal.positive.min, expected: [0.0, kValue.f32.subnormal.positive.min] },
-      { input: kValue.f32.subnormal.negative.min, expected: [kValue.f32.subnormal.negative.min, 0.0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [kValue.f32.subnormal.negative.max, 0.0] },
-
-      // Infinities
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = saturateInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `saturationInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('signInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -17,7 +17,6 @@ import {
   additionInterval,
   additionMatrixInterval,
   atan2Interval,
-  ceilInterval,
   clampMedianInterval,
   clampMinMaxInterval,
   correctlyRoundedInterval,
@@ -1924,48 +1923,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('ceilInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: 0, expected: 0 },
-      { input: 0.1, expected: 1 },
-      { input: 0.9, expected: 1 },
-      { input: 1.0, expected: 1 },
-      { input: 1.1, expected: 2 },
-      { input: 1.9, expected: 2 },
-      { input: -0.1, expected: 0 },
-      { input: -0.9, expected: 0 },
-      { input: -1.0, expected: -1 },
-      { input: -1.1, expected: -1 },
-      { input: -1.9, expected: -1 },
-
-      // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
-      { input: kValue.f32.positive.min, expected: 1 },
-      { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
-      { input: kValue.f32.negative.max, expected: 0 },
-      { input: kValue.powTwo.to30, expected: kValue.powTwo.to30 },
-      { input: -kValue.powTwo.to30, expected: -kValue.powTwo.to30 },
-
-      // 32-bit subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: [0, 1] },
-      { input: kValue.f32.subnormal.positive.min, expected: [0, 1] },
-      { input: kValue.f32.subnormal.negative.min, expected: 0 },
-      { input: kValue.f32.subnormal.negative.max, expected: 0 },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = ceilInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `ceilInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('cosInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -16,7 +16,6 @@ import {
   absoluteErrorInterval,
   additionInterval,
   additionMatrixInterval,
-  asinInterval,
   asinhInterval,
   atanInterval,
   atan2Interval,
@@ -1928,41 +1927,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('asinInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a simple human-readable form due to the complexity of their derivation.
-      //
-      // The acceptance interval @ x = -1 and 1 is kAnyBounds, because
-      // sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inversqrt.
-      // The acceptance interval @ x = 0 is kAnyBounds, because atan2 is not
-      // well-defined/implemented at 0.
-      // Near 0, but not subnormal the absolute error should be larger, so will
-      // be +/- 6.77e-5, away from 0 the atan2 inherited error should be larger.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: -1, expected: kAnyBounds },
-      { input: -1/2, expected: [hexToF64(0xbfe0_c352_c000_0000n), hexToF64(0xbfe0_bf51_c000_0000n)] },  // ~-π/6
-      { input: kValue.f32.negative.max, expected: [-6.77e-5, 6.77e-5] },  // ~0
-      { input: 0, expected: kAnyBounds },
-      { input: kValue.f32.positive.min, expected: [-6.77e-5, 6.77e-5] },  // ~0
-      { input: 1/2, expected: [hexToF64(0x3fe0_bf51_c000_0000n), hexToF64(0x3fe0_c352_c000_0000n)] },  // ~π/6
-      { input: 1, expected: kAnyBounds },  // ~π/2
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = asinInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `asinInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('asinhInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -26,7 +26,6 @@ import {
   dotInterval,
   faceForwardIntervals,
   fmaInterval,
-  fractInterval,
   inverseSqrtInterval,
   ldexpInterval,
   lengthInterval,
@@ -1917,38 +1916,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('fractInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: 0, expected: 0 },
-      { input: 0.1, expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] }, // ~0.1
-      { input: 0.9, expected: [hexToF32(0x3f666666), plusOneULP(hexToF32(0x3f666666))] },  // ~0.9
-      { input: 1.0, expected: 0 },
-      { input: 1.1, expected: [hexToF64(0x3fb9_9998_0000_0000n), hexToF64(0x3fb9_999a_0000_0000n)] }, // ~0.1
-      { input: -0.1, expected: [hexToF32(0x3f666666), plusOneULP(hexToF32(0x3f666666))] },  // ~0.9
-      { input: -0.9, expected: [hexToF64(0x3fb9_9999_0000_0000n), hexToF64(0x3fb9_999a_0000_0000n)] }, // ~0.1
-      { input: -1.0, expected: 0 },
-      { input: -1.1, expected: [hexToF64(0x3fec_cccc_c000_0000n), hexToF64(0x3fec_cccd_0000_0000n), ] }, // ~0.9
-
-      // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: 0 },
-      { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
-      { input: kValue.f32.negative.min, expected: 0 },
-      { input: kValue.f32.negative.max, expected: [kValue.f32.positive.less_than_one, 1.0] },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = fractInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `fractInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('inverseSqrtInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -20,7 +20,6 @@ import {
   clampMedianInterval,
   clampMinMaxInterval,
   correctlyRoundedInterval,
-  cosInterval,
   coshInterval,
   crossInterval,
   degreesInterval,
@@ -1923,42 +1922,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('cosInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // This test does not include some common cases. i.e. f(x = π/2) = 0,
-      // because the difference between true x and x as a f32 is sufficiently
-      // large, such that the high slope of f @ x causes the results to be
-      // substantially different, so instead of getting 0 you get a value on the
-      // order of 10^-8 away from 0, thus difficult to express in a
-      // human-readable manner.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: kValue.f32.negative.pi.whole, expected: [-1, plusOneULP(-1)] },
-      { input: kValue.f32.negative.pi.third, expected: [minusOneULP(1/2), 1/2] },
-      { input: 0, expected: [1, 1] },
-      { input: kValue.f32.positive.pi.third, expected: [minusOneULP(1/2), 1/2] },
-      { input: kValue.f32.positive.pi.whole, expected: [-1, plusOneULP(-1)] },
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const error = (_: number): number => {
-      return 2 ** -11;
-    };
-
-    t.params.expected = applyError(t.params.expected, error);
-    const expected = toF32Interval(t.params.expected);
-
-    const got = cosInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `cosInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('coshInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -42,7 +42,6 @@ import {
   reflectInterval,
   refractInterval,
   remainderInterval,
-  roundInterval,
   saturateInterval,
   signInterval,
   sinInterval,
@@ -1909,52 +1908,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('roundInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: 0, expected: 0 },
-      { input: 0.1, expected: 0 },
-      { input: 0.5, expected: 0 },  // Testing tie breaking
-      { input: 0.9, expected: 1 },
-      { input: 1.0, expected: 1 },
-      { input: 1.1, expected: 1 },
-      { input: 1.5, expected: 2 },  // Testing tie breaking
-      { input: 1.9, expected: 2 },
-      { input: -0.1, expected: 0 },
-      { input: -0.5, expected: 0 },  // Testing tie breaking
-      { input: -0.9, expected: -1 },
-      { input: -1.0, expected: -1 },
-      { input: -1.1, expected: -1 },
-      { input: -1.5, expected: -2 },  // Testing tie breaking
-      { input: -1.9, expected: -2 },
-
-      // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
-      { input: kValue.f32.positive.min, expected: 0 },
-      { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
-      { input: kValue.f32.negative.max, expected: 0 },
-      { input: kValue.powTwo.to30, expected: kValue.powTwo.to30 },
-      { input: -kValue.powTwo.to30, expected: -kValue.powTwo.to30 },
-
-      // 32-bit subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: 0 },
-      { input: kValue.f32.subnormal.positive.min, expected: 0 },
-      { input: kValue.f32.subnormal.negative.min, expected: 0 },
-      { input: kValue.f32.subnormal.negative.max, expected: 0 },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = roundInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `roundInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('saturateInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -50,7 +50,6 @@ import {
   toF32Matrix,
   toF32Vector,
   transposeInterval,
-  truncInterval,
   ulpInterval,
   unpack2x16floatInterval,
   unpack2x16snormInterval,
@@ -1894,51 +1893,6 @@ g.test('ulpInterval')
     t.expect(
       objectEquals(expected, got),
       `ulpInterval(${t.params.value}, ${t.params.num_ulp}) returned ${got}. Expected ${expected}`
-    );
-  });
-
-interface ScalarToIntervalCase {
-  input: number;
-  expected: number | IntervalBounds;
-}
-
-g.test('truncInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: 0, expected: 0 },
-      { input: 0.1, expected: 0 },
-      { input: 0.9, expected: 0 },
-      { input: 1.0, expected: 1 },
-      { input: 1.1, expected: 1 },
-      { input: 1.9, expected: 1 },
-      { input: -0.1, expected: 0 },
-      { input: -0.9, expected: 0 },
-      { input: -1.0, expected: -1 },
-      { input: -1.1, expected: -1 },
-      { input: -1.9, expected: -1 },
-
-      // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
-      { input: kValue.f32.positive.min, expected: 0 },
-      { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
-      { input: kValue.f32.negative.max, expected: 0 },
-
-      // 32-bit subnormals
-      { input: kValue.f32.subnormal.positive.max, expected: 0 },
-      { input: kValue.f32.subnormal.positive.min, expected: 0 },
-      { input: kValue.f32.subnormal.negative.min, expected: 0 },
-      { input: kValue.f32.subnormal.negative.max, expected: 0 },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = truncInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `truncInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -27,7 +27,6 @@ import {
   faceForwardIntervals,
   fmaInterval,
   ldexpInterval,
-  lengthInterval,
   logInterval,
   log2Interval,
   maxInterval,
@@ -1916,47 +1915,6 @@ interface ScalarToIntervalCase {
   expected: number | IntervalBounds;
 }
 
-g.test('lengthIntervalScalar')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      //
-      // length(0) = kAnyBounds, because length uses sqrt, which is defined as 1/inversesqrt
-      {input: 0, expected: kAnyBounds },
-      {input: 1.0, expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: -1.0, expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: 0.1, expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-      {input: -0.1, expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-      {input: 10.0, expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
-      {input: -10.0, expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
-
-      // Subnormal Cases
-      { input: kValue.f32.subnormal.negative.min, expected: kAnyBounds },
-      { input: kValue.f32.subnormal.negative.max, expected: kAnyBounds },
-      { input: kValue.f32.subnormal.positive.min, expected: kAnyBounds },
-      { input: kValue.f32.subnormal.positive.max, expected: kAnyBounds },
-
-      // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: kValue.f32.negative.max, expected: kAnyBounds },
-      { input: kValue.f32.positive.min, expected: kAnyBounds },
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = lengthInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `lengthInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
-
 g.test('logInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
@@ -3649,61 +3607,6 @@ interface ScalarToVectorCase {
       );
     });
 }
-
-interface VectorToIntervalCase {
-  input: number[];
-  expected: number | IntervalBounds;
-}
-
-g.test('lengthIntervalVector')
-  .paramsSubcasesOnly<VectorToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-
-      // vec2
-      {input: [1.0, 0.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: [0.0, 1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: [1.0, 1.0], expected: [hexToF64(0x3ff6_a09d_b000_0000n), hexToF64(0x3ff6_a09f_1000_0000n)] },  // ~√2
-      {input: [-1.0, -1.0], expected: [hexToF64(0x3ff6_a09d_b000_0000n), hexToF64(0x3ff6_a09f_1000_0000n)] },  // ~√2
-      {input: [-1.0, 1.0], expected: [hexToF64(0x3ff6_a09d_b000_0000n), hexToF64(0x3ff6_a09f_1000_0000n)] },  // ~√2
-      {input: [0.1, 0.0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-
-      // vec3
-      {input: [1.0, 0.0, 0.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: [0.0, 1.0, 0.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: [0.0, 0.0, 1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: [1.0, 1.0, 1.0], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
-      {input: [-1.0, -1.0, -1.0], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
-      {input: [1.0, -1.0, -1.0], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
-      {input: [0.1, 0.0, 0.0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-
-      // vec4
-      {input: [1.0, 0.0, 0.0, 0.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: [0.0, 1.0, 0.0, 0.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: [0.0, 0.0, 1.0, 0.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: [0.0, 0.0, 0.0, 1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      {input: [1.0, 1.0, 1.0, 1.0], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
-      {input: [-1.0, -1.0, -1.0, -1.0], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
-      {input: [-1.0, 1.0, -1.0, 1.0], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
-      {input: [0.1, 0.0, 0.0, 0.0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-
-      // Test that dot going OOB bounds in the intermediate calculations propagates
-      { input: [kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], expected: kAnyBounds },
-      { input: [kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], expected: kAnyBounds },
-      { input: [kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = lengthInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `lengthInterval([${t.params.input}]) returned ${got}. Expected ${expected}`
-    );
-  });
 
 interface VectorPairToIntervalCase {
   input: [number[], number[]];

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -16,7 +16,6 @@ import {
   absoluteErrorInterval,
   additionInterval,
   additionMatrixInterval,
-  asinhInterval,
   atanInterval,
   atan2Interval,
   atanhInterval,
@@ -1927,31 +1926,6 @@ interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
 }
-
-g.test('asinhInterval')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { input: kValue.f32.negative.min, expected: kAnyBounds },
-      { input: -1, expected: [hexToF64(0xbfec_343a_8000_0000n), hexToF64(0xbfec_3432_8000_0000n)] },  // ~-0.88137...
-      { input: 0, expected: [hexToF64(0xbeaa_0000_2000_0000n), hexToF64(0x3eb1_ffff_d000_0000n)] },  // ~0
-      { input: 1, expected: [hexToF64(0x3fec_3435_4000_0000n), hexToF64(0x3fec_3437_8000_0000n)] },  // ~0.88137...
-      { input: kValue.f32.positive.max, expected: kAnyBounds },
-      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = asinhInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `asinhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('atanInterval')
   .paramsSubcasesOnly<ScalarToIntervalCase>(

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -987,6 +987,31 @@ g.test('sinhInterval_f32')
     );
   });
 
+g.test('sqrtInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
+      { input: 0.01, expected: [hexToF64(0x3fb9_9998_b000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+      { input: 1, expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: 4, expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
+      { input: 100, expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.sqrtInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.sqrtInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -399,3 +399,29 @@ g.test('cosInterval_f32')
       `f32.cosInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('coshInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: [ hexToF32(0x3fc583a4), hexToF32(0x3fc583b1)] },  // ~1.1543...
+      { input: 0, expected: [hexToF32(0x3f7ffffd), hexToF32(0x3f800002)] },  // ~1
+      { input: 1, expected: [ hexToF32(0x3fc583a4), hexToF32(0x3fc583b1)] },  // ~1.1543...
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.coshInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.coshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -858,6 +858,44 @@ g.test('roundInterval_f32')
     );
   });
 
+g.test('saturateInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Normals
+      { input: 0, expected: 0 },
+      { input: 1, expected: 1.0 },
+      { input: -0.1, expected: 0 },
+      { input: -1, expected: 0 },
+      { input: -10, expected: 0 },
+      { input: 0.1, expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: 10, expected: 1.0 },
+      { input: 11.1, expected: 1.0 },
+      { input: kValue.f32.positive.max, expected: 1.0 },
+      { input: kValue.f32.positive.min, expected: kValue.f32.positive.min },
+      { input: kValue.f32.negative.max, expected: 0.0 },
+      { input: kValue.f32.negative.min, expected: 0.0 },
+
+      // Subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: [0.0, kValue.f32.subnormal.positive.max] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0.0, kValue.f32.subnormal.positive.min] },
+      { input: kValue.f32.subnormal.negative.min, expected: [kValue.f32.subnormal.negative.min, 0.0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [kValue.f32.subnormal.negative.max, 0.0] },
+
+      // Infinities
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.saturateInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.saturationInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -583,3 +583,31 @@ g.test('fractInterval_f32')
       `f32.fractInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('inverseSqrtInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
+      { input: 0.04, expected: [minusOneULPF32(5), plusOneULPF32(5)] },
+      { input: 1, expected: 1 },
+      { input: 100, expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: kValue.f32.positive.max, expected: [hexToF32(0x1f800000), plusNULPF32(hexToF32(0x1f800000), 2)] },  // ~5.421...e-20, i.e. 1/√max f32
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const error = (n: number): number => {
+      return 2 * oneULPF32(n);
+    };
+
+    t.params.expected = applyError(t.params.expected, error);
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.inverseSqrtInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.inverseSqrtInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1078,6 +1078,46 @@ g.test('tanhInterval_f32')
     );
   });
 
+g.test('truncInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: 0 },
+      { input: 0.1, expected: 0 },
+      { input: 0.9, expected: 0 },
+      { input: 1.0, expected: 1 },
+      { input: 1.1, expected: 1 },
+      { input: 1.9, expected: 1 },
+      { input: -0.1, expected: 0 },
+      { input: -0.9, expected: 0 },
+      { input: -1.0, expected: -1 },
+      { input: -1.1, expected: -1 },
+      { input: -1.9, expected: -1 },
+
+      // Edge cases
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
+      { input: kValue.f32.positive.min, expected: 0 },
+      { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
+      { input: kValue.f32.negative.max, expected: 0 },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: 0 },
+      { input: kValue.f32.subnormal.positive.min, expected: 0 },
+      { input: kValue.f32.subnormal.negative.min, expected: 0 },
+      { input: kValue.f32.subnormal.negative.max, expected: 0 },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.truncInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.truncInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -551,3 +551,35 @@ g.test('floorInterval_f32')
       `f32.floorInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('fractInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: 0 },
+      { input: 0.1, expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] }, // ~0.1
+      { input: 0.9, expected: [hexToF32(0x3f666666), plusOneULPF32(hexToF32(0x3f666666))] },  // ~0.9
+      { input: 1.0, expected: 0 },
+      { input: 1.1, expected: [hexToF64(0x3fb9_9998_0000_0000n), hexToF64(0x3fb9_999a_0000_0000n)] }, // ~0.1
+      { input: -0.1, expected: [hexToF32(0x3f666666), plusOneULPF32(hexToF32(0x3f666666))] },  // ~0.9
+      { input: -0.9, expected: [hexToF64(0x3fb9_9999_0000_0000n), hexToF64(0x3fb9_999a_0000_0000n)] }, // ~0.1
+      { input: -1.0, expected: 0 },
+      { input: -1.1, expected: [hexToF64(0x3fec_cccc_c000_0000n), hexToF64(0x3fec_cccd_0000_0000n), ] }, // ~0.9
+
+      // Edge cases
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: 0 },
+      { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
+      { input: kValue.f32.negative.min, expected: 0 },
+      { input: kValue.f32.negative.max, expected: [kValue.f32.positive.less_than_one, 1.0] },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.fractInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.fractInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -105,3 +105,57 @@ g.test('acosInterval_f32')
       `f32.acosInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('acoshAlternativeInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
+      { input: 1, expected: kAnyBounds },  // 1/0 occurs in inverseSqrt in this formulation
+      { input: 1.1, expected: [hexToF64(0x3fdc_6368_8000_0000n), hexToF64(0x3fdc_636f_2000_0000n)] },  // ~0.443..., differs from the primary in the later digits
+      { input: 10, expected: [hexToF64(0x4007_f21e_4000_0000n), hexToF64(0x4007_f21f_6000_0000n)] },  // ~2.993...
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.acoshAlternativeInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.acoshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('acoshPrimaryInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
+      { input: 1, expected: kAnyBounds },  // 1/0 occurs in inverseSqrt in this formulation
+      { input: 1.1, expected: [hexToF64(0x3fdc_6368_2000_0000n), hexToF64(0x3fdc_636f_8000_0000n)] }, // ~0.443..., differs from the alternative in the later digits
+      { input: 10, expected: [hexToF64(0x4007_f21e_4000_0000n), hexToF64(0x4007_f21f_6000_0000n)] },  // ~2.993...
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.acoshPrimaryInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.acoshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -321,3 +321,45 @@ g.test('atanhInterval_f32')
       `f32.atanhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('ceilInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: 0 },
+      { input: 0.1, expected: 1 },
+      { input: 0.9, expected: 1 },
+      { input: 1.0, expected: 1 },
+      { input: 1.1, expected: 2 },
+      { input: 1.9, expected: 2 },
+      { input: -0.1, expected: 0 },
+      { input: -0.9, expected: 0 },
+      { input: -1.0, expected: -1 },
+      { input: -1.1, expected: -1 },
+      { input: -1.9, expected: -1 },
+
+      // Edge cases
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
+      { input: kValue.f32.positive.min, expected: 1 },
+      { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
+      { input: kValue.f32.negative.max, expected: 0 },
+      { input: kValue.powTwo.to30, expected: kValue.powTwo.to30 },
+      { input: -kValue.powTwo.to30, expected: -kValue.powTwo.to30 },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: [0, 1] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0, 1] },
+      { input: kValue.f32.subnormal.negative.min, expected: 0 },
+      { input: kValue.f32.subnormal.negative.max, expected: 0 },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.ceilInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.ceilInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -962,6 +962,31 @@ g.test('sinInterval_f32')
     );
   });
 
+g.test('sinhInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: [ hexToF32(0xbf966d05), hexToF32(0xbf966cf8)] },  // ~-1.175...
+      { input: 0, expected: [hexToF32(0xb4600000), hexToF32(0x34600000)] },  // ~0
+      { input: 1, expected: [ hexToF32(0x3f966cf8), hexToF32(0x3f966d05)] },  // ~1.175...
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.sinhInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.sinhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -747,6 +747,41 @@ g.test('negationInterval_f32')
     );
   });
 
+g.test('quantizeToF16Interval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: kValue.f16.negative.min, expected: kValue.f16.negative.min },
+      { input: -1, expected: -1 },
+      { input: -0.1, expected: [hexToF32(0xbdcce000), hexToF32(0xbdccc000)] },  // ~-0.1
+      { input: kValue.f16.negative.max, expected: kValue.f16.negative.max },
+      { input: kValue.f16.subnormal.negative.min, expected: [kValue.f16.subnormal.negative.min, 0] },
+      { input: kValue.f16.subnormal.negative.max, expected: [kValue.f16.subnormal.negative.max, 0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [kValue.f16.subnormal.negative.max, 0] },
+      { input: 0, expected: 0 },
+      { input: kValue.f32.subnormal.positive.min, expected: [0, kValue.f16.subnormal.positive.min] },
+      { input: kValue.f16.subnormal.positive.min, expected: [0, kValue.f16.subnormal.positive.min] },
+      { input: kValue.f16.subnormal.positive.max, expected: [0, kValue.f16.subnormal.positive.max] },
+      { input: kValue.f16.positive.min, expected: kValue.f16.positive.min },
+      { input: 0.1, expected: [hexToF32(0x3dccc000), hexToF32(0x3dcce000)] },  // ~0.1
+      { input: 1, expected: 1 },
+      { input: kValue.f16.positive.max, expected: kValue.f16.positive.max },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.quantizeToF16Interval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.quantizeToF16Interval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -194,3 +194,28 @@ g.test('asinInterval_f32')
       `f32.asinInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('asinhInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: [hexToF64(0xbfec_343a_8000_0000n), hexToF64(0xbfec_3432_8000_0000n)] },  // ~-0.88137...
+      { input: 0, expected: [hexToF64(0xbeaa_0000_2000_0000n), hexToF64(0x3eb1_ffff_d000_0000n)] },  // ~0
+      { input: 1, expected: [hexToF64(0x3fec_3435_4000_0000n), hexToF64(0x3fec_3437_8000_0000n)] },  // ~0.88137...
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.asinhInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.asinhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -896,6 +896,38 @@ g.test('saturateInterval_f32')
     );
   });
 
+g.test('signInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: -1 },
+      { input: -10, expected: -1 },
+      { input: -1, expected: -1 },
+      { input: -0.1, expected: -1 },
+      { input: kValue.f32.negative.max, expected:  -1 },
+      { input: kValue.f32.subnormal.negative.min, expected: [-1, 0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [-1, 0] },
+      { input: 0, expected: 0 },
+      { input: kValue.f32.subnormal.positive.max, expected: [0, 1] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0, 1] },
+      { input: kValue.f32.positive.min, expected: 1 },
+      { input: 0.1, expected: 1 },
+      { input: 1, expected: 1 },
+      { input: 10, expected: 1 },
+      { input: kValue.f32.positive.max, expected: 1 },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.signInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.signInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -483,3 +483,29 @@ g.test('expInterval_f32')
       `f32.expInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('exp2Interval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: 0, expected: 1 },
+      { input: 1, expected: 2 },
+      { input: 128, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const error = (x: number): number => {
+      const n = 3 + 2 * Math.abs(t.params.input);
+      return n * oneULPF32(x);
+    };
+
+    t.params.expected = applyError(t.params.expected, error);
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.exp2Interval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.exp2Interval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1012,6 +1012,47 @@ g.test('sqrtInterval_f32')
     );
   });
 
+g.test('tanInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // All of these are hard coded, since the error intervals are difficult to
+      // express in a closed human--readable form.
+      // Some easy looking cases like f(x = -π|π) = 0 are actually quite
+      // difficult. This is because the interval is calculated from the results
+      // of sin(x)/cos(x), which becomes very messy at x = -π|π, since π is
+      // irrational, thus does not have an exact representation as a f32.
+      //
+      // Even at 0, which has a precise f32 value, there is still the problem
+      // that result of sin(0) and cos(0) will be intervals due to the inherited
+      // nature of errors, so the proper interval will be an interval calculated
+      // from dividing an interval by another interval and applying an error
+      // function to that.
+      //
+      // This complexity is why the entire interval framework was developed.
+      //
+      // The examples here have been manually traced to confirm the expectation
+      // values are correct.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: kValue.f32.negative.pi.whole, expected: [hexToF64(0xbf40_02bc_9000_0000n), hexToF64(0x3f40_0144_f000_0000n)] },  // ~0.0
+      { input: kValue.f32.negative.pi.half, expected: kAnyBounds },
+      { input: 0, expected: [hexToF64(0xbf40_0200_b000_0000n), hexToF64(0x3f40_0200_b000_0000n)] },  // ~0.0
+      { input: kValue.f32.positive.pi.half, expected: kAnyBounds },
+      { input: kValue.f32.positive.pi.whole, expected: [hexToF64(0xbf40_0144_f000_0000n), hexToF64(0x3f40_02bc_9000_0000n)] },  // ~0.0
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.tanInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.tanInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1,0 +1,62 @@
+export const description = `
+Floating Point unit tests.
+`;
+
+import { makeTestGroup } from '../common/framework/test_group.js';
+import { objectEquals } from '../common/util/util.js';
+import { kValue } from '../webgpu/util/constants.js';
+import { FP, IntervalBounds } from '../webgpu/util/floating_point.js';
+import { hexToF32, hexToF64 } from '../webgpu/util/math.js';
+
+import { UnitTest } from './unit_test.js';
+
+export const g = makeTestGroup(UnitTest);
+
+/** Bounds indicating an expectation of an interval of all possible values */
+const kAnyBounds: IntervalBounds = [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY];
+
+interface ScalarToIntervalCase {
+  input: number;
+  expected: number | IntervalBounds;
+}
+
+g.test('absInterval')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Common usages
+      { input: 1, expected: 1 },
+      { input: -1, expected: 1 },
+      { input: 0.1, expected: [hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)] },
+      { input: -0.1, expected: [hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)] },
+
+      // Edge cases
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
+      { input: kValue.f32.positive.min, expected: kValue.f32.positive.min },
+      { input: kValue.f32.negative.min, expected: kValue.f32.positive.max },
+      { input: kValue.f32.negative.max, expected: kValue.f32.positive.min },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: kValue.f32.subnormal.positive.min, expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: kValue.f32.subnormal.negative.min, expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: kValue.f32.subnormal.negative.max, expected: [0, kValue.f32.subnormal.positive.min] },
+
+      // 64-bit subnormals
+      { input: hexToF64(0x0000_0000_0000_0001n), expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: hexToF64(0x800f_ffff_ffff_ffffn), expected: [0, kValue.f32.subnormal.positive.min] },
+
+      // Zero
+      { input: 0, expected: 0 },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.absInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.absInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -812,6 +812,52 @@ g.test('radiansInterval_f32')
     );
   });
 
+g.test('roundInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: 0 },
+      { input: 0.1, expected: 0 },
+      { input: 0.5, expected: 0 },  // Testing tie breaking
+      { input: 0.9, expected: 1 },
+      { input: 1.0, expected: 1 },
+      { input: 1.1, expected: 1 },
+      { input: 1.5, expected: 2 },  // Testing tie breaking
+      { input: 1.9, expected: 2 },
+      { input: -0.1, expected: 0 },
+      { input: -0.5, expected: 0 },  // Testing tie breaking
+      { input: -0.9, expected: -1 },
+      { input: -1.0, expected: -1 },
+      { input: -1.1, expected: -1 },
+      { input: -1.5, expected: -2 },  // Testing tie breaking
+      { input: -1.9, expected: -2 },
+
+      // Edge cases
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
+      { input: kValue.f32.positive.min, expected: 0 },
+      { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
+      { input: kValue.f32.negative.max, expected: 0 },
+      { input: kValue.powTwo.to30, expected: kValue.powTwo.to30 },
+      { input: -kValue.powTwo.to30, expected: -kValue.powTwo.to30 },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: 0 },
+      { input: kValue.f32.subnormal.positive.min, expected: 0 },
+      { input: kValue.f32.subnormal.negative.min, expected: 0 },
+      { input: kValue.f32.subnormal.negative.max, expected: 0 },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.roundInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.roundInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -295,3 +295,29 @@ g.test('atanInterval_f32')
       `f32.atanInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('atanhInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature of the errors.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: kAnyBounds },
+      { input: -0.1, expected: [hexToF64(0xbfb9_af9a_6000_0000n), hexToF64(0xbfb9_af8c_c000_0000n)] },  // ~-0.1003...
+      { input: 0, expected: [hexToF64(0xbe96_0000_2000_0000n), hexToF64(0x3e98_0000_0000_0000n)] },  // ~0
+      { input: 0.1, expected: [hexToF64(0x3fb9_af8b_8000_0000n), hexToF64(0x3fb9_af9b_0000_0000n)] },  // ~0.1003...
+      { input: 1, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.atanhInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.atanhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -509,3 +509,45 @@ g.test('exp2Interval_f32')
       `f32.exp2Interval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('floorInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: 0 },
+      { input: 0.1, expected: 0 },
+      { input: 0.9, expected: 0 },
+      { input: 1.0, expected: 1 },
+      { input: 1.1, expected: 1 },
+      { input: 1.9, expected: 1 },
+      { input: -0.1, expected: -1 },
+      { input: -0.9, expected: -1 },
+      { input: -1.0, expected: -1 },
+      { input: -1.1, expected: -2 },
+      { input: -1.9, expected: -2 },
+
+      // Edge cases
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
+      { input: kValue.f32.positive.min, expected: 0 },
+      { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
+      { input: kValue.f32.negative.max, expected: -1 },
+      { input: kValue.powTwo.to30, expected: kValue.powTwo.to30 },
+      { input: -kValue.powTwo.to30, expected: -kValue.powTwo.to30 },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: 0 },
+      { input: kValue.f32.subnormal.positive.min, expected: 0 },
+      { input: kValue.f32.subnormal.negative.min, expected: [-1, 0] },
+      { input: kValue.f32.subnormal.negative.max, expected: [-1, 0] },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.floorInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.floorInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -159,3 +159,38 @@ g.test('acoshPrimaryInterval_f32')
       `f32.acoshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('asinInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a simple human-readable form due to the complexity of their derivation.
+      //
+      // The acceptance interval @ x = -1 and 1 is kAnyBounds, because
+      // sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inversqrt.
+      // The acceptance interval @ x = 0 is kAnyBounds, because atan2 is not
+      // well-defined/implemented at 0.
+      // Near 0, but not subnormal the absolute error should be larger, so will
+      // be +/- 6.77e-5, away from 0 the atan2 inherited error should be larger.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: kAnyBounds },
+      { input: -1/2, expected: [hexToF64(0xbfe0_c352_c000_0000n), hexToF64(0xbfe0_bf51_c000_0000n)] },  // ~-π/6
+      { input: kValue.f32.negative.max, expected: [-6.77e-5, 6.77e-5] },  // ~0
+      { input: 0, expected: kAnyBounds },
+      { input: kValue.f32.positive.min, expected: [-6.77e-5, 6.77e-5] },  // ~0
+      { input: 1/2, expected: [hexToF64(0x3fe0_bf51_c000_0000n), hexToF64(0x3fe0_c352_c000_0000n)] },  // ~π/6
+      { input: 1, expected: kAnyBounds },  // ~π/2
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.asinInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.asinInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -928,6 +928,40 @@ g.test('signInterval_f32')
     );
   });
 
+g.test('sinInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // This test does not include some common cases, i.e. f(x = -π|π) = 0,
+      // because the difference between true x and x as a f32 is sufficiently
+      // large, such that the high slope of f @ x causes the results to be
+      // substantially different, so instead of getting 0 you get a value on the
+      // order of 10^-8 away from it, thus difficult to express in a
+      // human-readable manner.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: kValue.f32.negative.pi.half, expected: [-1, plusOneULPF32(-1)] },
+      { input: 0, expected: 0 },
+      { input: kValue.f32.positive.pi.half, expected: [minusOneULPF32(1), 1] },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const error = (_: number): number => {
+      return 2 ** -11;
+    };
+
+    t.params.expected = applyError(t.params.expected, error);
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.sinInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.sinInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -363,3 +363,39 @@ g.test('ceilInterval_f32')
       `f32.ceilInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('cosInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // This test does not include some common cases. i.e. f(x = π/2) = 0,
+      // because the difference between true x and x as a f32 is sufficiently
+      // large, such that the high slope of f @ x causes the results to be
+      // substantially different, so instead of getting 0 you get a value on the
+      // order of 10^-8 away from 0, thus difficult to express in a
+      // human-readable manner.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: kValue.f32.negative.pi.whole, expected: [-1, plusOneULPF32(-1)] },
+      { input: kValue.f32.negative.pi.third, expected: [minusOneULPF32(1/2), 1/2] },
+      { input: 0, expected: [1, 1] },
+      { input: kValue.f32.positive.pi.third, expected: [minusOneULPF32(1/2), 1/2] },
+      { input: kValue.f32.positive.pi.whole, expected: [-1, plusOneULPF32(-1)] },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const error = (_: number): number => {
+      return 2 ** -11;
+    };
+
+    t.params.expected = applyError(t.params.expected, error);
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.cosInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.cosInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1,3 +1,5 @@
+import { logInterval, toF32Interval } from '../webgpu/util/f32_interval';
+
 export const description = `
 Floating Point unit tests.
 `;
@@ -650,6 +652,35 @@ g.test('lengthIntervalScalar_f32')
     t.expect(
       objectEquals(expected, got),
       `f32.lengthInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('logInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
+      { input: 1, expected: 0 },
+      { input: kValue.f32.positive.e, expected: [minusOneULPF32(1), 1] },
+      { input: kValue.f32.positive.max, expected: [minusOneULPF32(hexToF32(0x42b17218)), hexToF32(0x42b17218)] },  // ~88.72...
+    ]
+  )
+  .fn(t => {
+    const error = (n: number): number => {
+      if (t.params.input >= 0.5 && t.params.input <= 2.0) {
+        return 2 ** -21;
+      }
+      return 3 * oneULPF32(n);
+    };
+
+    t.params.expected = applyError(t.params.expected, error);
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.logInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.logInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -782,6 +782,36 @@ g.test('quantizeToF16Interval_f32')
     );
   });
 
+g.test('radiansInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: -180, expected: [minusOneULPF32(kValue.f32.negative.pi.whole), plusOneULPF32(kValue.f32.negative.pi.whole)] },
+      { input: -135, expected: [minusOneULPF32(kValue.f32.negative.pi.three_quarters), plusOneULPF32(kValue.f32.negative.pi.three_quarters)] },
+      { input: -90, expected: [minusOneULPF32(kValue.f32.negative.pi.half), plusOneULPF32(kValue.f32.negative.pi.half)] },
+      { input: -60, expected: [minusOneULPF32(kValue.f32.negative.pi.third), plusOneULPF32(kValue.f32.negative.pi.third)] },
+      { input: -45, expected: [minusOneULPF32(kValue.f32.negative.pi.quarter), plusOneULPF32(kValue.f32.negative.pi.quarter)] },
+      { input: -30, expected: [minusOneULPF32(kValue.f32.negative.pi.sixth), plusOneULPF32(kValue.f32.negative.pi.sixth)] },
+      { input: 0, expected: 0 },
+      { input: 30, expected: [minusOneULPF32(kValue.f32.positive.pi.sixth), plusOneULPF32(kValue.f32.positive.pi.sixth)] },
+      { input: 45, expected: [minusOneULPF32(kValue.f32.positive.pi.quarter), plusOneULPF32(kValue.f32.positive.pi.quarter)] },
+      { input: 60, expected: [minusOneULPF32(kValue.f32.positive.pi.third), plusOneULPF32(kValue.f32.positive.pi.third)] },
+      { input: 90, expected: [minusOneULPF32(kValue.f32.positive.pi.half), plusOneULPF32(kValue.f32.positive.pi.half)] },
+      { input: 135, expected: [minusOneULPF32(kValue.f32.positive.pi.three_quarters), plusOneULPF32(kValue.f32.positive.pi.three_quarters)] },
+      { input: 180, expected: [minusOneULPF32(kValue.f32.positive.pi.whole), plusOneULPF32(kValue.f32.positive.pi.whole)] },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.radiansInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.radiansInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1053,6 +1053,31 @@ g.test('tanInterval_f32')
     );
   });
 
+g.test('tanhInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: -1, expected: [hexToF64(0xbfe8_5efd_1000_0000n), hexToF64(0xbfe8_5ef8_9000_0000n)] },  // ~-0.7615...
+      { input: 0, expected: [hexToF64(0xbe8c_0000_b000_0000n), hexToF64(0x3e8c_0000_b000_0000n)] },  // ~0
+      { input: 1, expected: [hexToF64(0x3fe8_5ef8_9000_0000n), hexToF64(0x3fe8_5efd_1000_0000n)] },  // ~0.7615...
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.tanhInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.tanhInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1,5 +1,3 @@
-import { logInterval, toF32Interval } from '../webgpu/util/f32_interval';
-
 export const description = `
 Floating Point unit tests.
 `;
@@ -681,6 +679,35 @@ g.test('logInterval_f32')
     t.expect(
       objectEquals(expected, got),
       `f32.logInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('log2Interval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: -1, expected: kAnyBounds },
+      { input: 0, expected: kAnyBounds },
+      { input: 1, expected: 0 },
+      { input: 2, expected: 1 },
+      { input: kValue.f32.positive.max, expected: [minusOneULPF32(128), 128] },
+    ]
+  )
+  .fn(t => {
+    const error = (n: number): number => {
+      if (t.params.input >= 0.5 && t.params.input <= 2.0) {
+        return 2 ** -21;
+      }
+      return 3 * oneULPF32(n);
+    };
+
+    t.params.expected = applyError(t.params.expected, error);
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.log2Interval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.log2Interval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -711,6 +711,42 @@ g.test('log2Interval_f32')
     );
   });
 
+g.test('negationInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: 0, expected: 0 },
+      { input: 0.1, expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] }, // ~-0.1
+      { input: 1.0, expected: -1.0 },
+      { input: 1.9, expected: [hexToF32(0xbff33334), plusOneULPF32(hexToF32(0xbff33334))] },  // ~-1.9
+      { input: -0.1, expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] }, // ~0.1
+      { input: -1.0, expected: 1 },
+      { input: -1.9, expected: [minusOneULPF32(hexToF32(0x3ff33334)), hexToF32(0x3ff33334)] },  // ~1.9
+
+      // Edge cases
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.positive.max, expected: kValue.f32.negative.min },
+      { input: kValue.f32.positive.min, expected: kValue.f32.negative.max },
+      { input: kValue.f32.negative.min, expected: kValue.f32.positive.max },
+      { input: kValue.f32.negative.max, expected: kValue.f32.positive.min },
+
+      // 32-bit subnormals
+      { input: kValue.f32.subnormal.positive.max, expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: kValue.f32.subnormal.positive.min, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: kValue.f32.subnormal.negative.min, expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: kValue.f32.subnormal.negative.max, expected: [0, kValue.f32.subnormal.positive.min] },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.negationInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.negationInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -457,3 +457,29 @@ g.test('degreesInterval_f32')
       `f32.degreesInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('expInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: 0, expected: 1 },
+      { input: 1, expected: [kValue.f32.positive.e, plusOneULPF32(kValue.f32.positive.e)] },
+      { input: 89, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const error = (x: number): number => {
+      const n = 3 + 2 * Math.abs(t.params.input);
+      return n * oneULPF32(x);
+    };
+
+    t.params.expected = applyError(t.params.expected, error);
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.expInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.expInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -425,3 +425,35 @@ g.test('coshInterval_f32')
       `f32.coshInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
+
+g.test('degreesInterval_f32')
+  .paramsSubcasesOnly<ScalarToIntervalCase>(
+    // prettier-ignore
+    [
+      { input: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { input: kValue.f32.negative.min, expected: kAnyBounds },
+      { input: kValue.f32.negative.pi.whole, expected: [minusOneULPF32(-180), plusOneULPF32(-180)] },
+      { input: kValue.f32.negative.pi.three_quarters, expected: [minusOneULPF32(-135), plusOneULPF32(-135)] },
+      { input: kValue.f32.negative.pi.half, expected: [minusOneULPF32(-90), plusOneULPF32(-90)] },
+      { input: kValue.f32.negative.pi.third, expected: [minusOneULPF32(-60), plusOneULPF32(-60)] },
+      { input: kValue.f32.negative.pi.quarter, expected: [minusOneULPF32(-45), plusOneULPF32(-45)] },
+      { input: kValue.f32.negative.pi.sixth, expected: [minusOneULPF32(-30), plusOneULPF32(-30)] },
+      { input: 0, expected: 0 },
+      { input: kValue.f32.positive.pi.sixth, expected: [minusOneULPF32(30), plusOneULPF32(30)] },
+      { input: kValue.f32.positive.pi.quarter, expected: [minusOneULPF32(45), plusOneULPF32(45)] },
+      { input: kValue.f32.positive.pi.third, expected: [minusOneULPF32(60), plusOneULPF32(60)] },
+      { input: kValue.f32.positive.pi.half, expected: [minusOneULPF32(90), plusOneULPF32(90)] },
+      { input: kValue.f32.positive.pi.three_quarters, expected: [minusOneULPF32(135), plusOneULPF32(135)] },
+      { input: kValue.f32.positive.pi.whole, expected: [minusOneULPF32(180), plusOneULPF32(180)] },
+      { input: kValue.f32.positive.max, expected: kAnyBounds },
+      { input: kValue.f32.infinity.positive, expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.degreesInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.degreesInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+    );
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/abs.spec.ts
@@ -30,11 +30,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('abs', {
   f32: () => {
-    return FP.f32.generateScalarToIntervalCases(
-      fullF32Range(),
-      'unfiltered',
-      FP.f32.absInterval.bind(FP.f32)
-    );
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.absInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acos.spec.ts
@@ -10,10 +10,10 @@ Returns the arc cosine of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { acosInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { linearRange, fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -26,10 +26,10 @@ const inputs = [
 
 export const d = makeCaseCache('acos', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'finite', acosInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'finite', FP.f32.acosInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'unfiltered', acosInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'unfiltered', FP.f32.acosInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/acosh.spec.ts
@@ -14,10 +14,10 @@ Note: The result is not mathematically meaningful when e < 1.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { acoshIntervals } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { biasedRange, fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -30,10 +30,10 @@ const inputs = [
 
 export const d = makeCaseCache('acosh', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'finite', ...acoshIntervals);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'finite', ...FP.f32.acoshIntervals);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'unfiltered', ...acoshIntervals);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'unfiltered', ...FP.f32.acoshIntervals);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asin.spec.ts
@@ -10,10 +10,10 @@ Returns the arc sine of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { asinInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { linearRange, fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -26,10 +26,10 @@ const inputs = [
 
 export const d = makeCaseCache('asin', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'finite', asinInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'finite', FP.f32.asinInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'unfiltered', asinInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'unfiltered', FP.f32.asinInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/asinh.spec.ts
@@ -13,10 +13,10 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { asinhInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -24,7 +24,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('asinh', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', asinhInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.asinhInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan.spec.ts
@@ -11,10 +11,10 @@ Returns the arc tangent of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { atanInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -35,10 +35,10 @@ const inputs = [
 
 export const d = makeCaseCache('atan', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'finite', atanInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'finite', FP.f32.atanInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'unfiltered', atanInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'unfiltered', FP.f32.atanInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atanh.spec.ts
@@ -14,10 +14,10 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { atanhInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { biasedRange, fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -33,10 +33,10 @@ const inputs = [
 
 export const d = makeCaseCache('atanh', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'finite', atanhInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'finite', FP.f32.atanhInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'unfiltered', atanhInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'unfiltered', FP.f32.atanhInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -11,10 +11,10 @@ Returns the ceiling of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { ceilInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,7 +22,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('ceil', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
         // Small positive numbers
         0.1,
@@ -39,7 +39,7 @@ export const d = makeCaseCache('ceil', {
         ...fullF32Range(),
       ],
       'unfiltered',
-      ceilInterval
+      FP.f32.ceilInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -11,10 +11,10 @@ Returns the cosine of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { cosInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,14 +22,14 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('cos', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
-        // Well defined accuracy range
+        // Well-defined accuracy range
         ...linearRange(-Math.PI, Math.PI, 1000),
         ...fullF32Range(),
       ],
       'unfiltered',
-      cosInterval
+      FP.f32.cosInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cosh.spec.ts
@@ -10,10 +10,10 @@ Returns the hyperbolic cosine of e. Component-wise when T is a vector
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { coshInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,10 +21,10 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('cosh', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'finite', coshInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'finite', FP.f32.coshInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', coshInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.coshInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/degrees.spec.ts
@@ -10,10 +10,10 @@ Converts radians to degrees, approximating e1 × 180 ÷ π. Component-wise when 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { degreesInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,10 +21,14 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('degrees', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'finite', degreesInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'finite', FP.f32.degreesInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', degreesInterval);
+    return FP.f32.generateScalarToIntervalCases(
+      fullF32Range(),
+      'unfiltered',
+      FP.f32.degreesInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp.spec.ts
@@ -11,10 +11,10 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { expInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -33,10 +33,10 @@ const inputs = [
 
 export const d = makeCaseCache('exp', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'finite', expInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'finite', FP.f32.expInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'unfiltered', expInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'unfiltered', FP.f32.expInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/exp2.spec.ts
@@ -11,10 +11,10 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { exp2Interval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -33,10 +33,10 @@ const inputs = [
 
 export const d = makeCaseCache('exp2', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'finite', exp2Interval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'finite', FP.f32.exp2Interval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'unfiltered', exp2Interval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'unfiltered', FP.f32.exp2Interval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -10,10 +10,10 @@ Returns the floor of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { floorInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,7 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('floor', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
         // Small positive numbers
         0.1,
@@ -38,7 +38,7 @@ export const d = makeCaseCache('floor', {
         ...fullF32Range(),
       ],
       'unfiltered',
-      floorInterval
+      FP.f32.floorInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -11,10 +11,10 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { fractInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,7 +22,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('fract', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
         0.5, // 0.5 -> 0.5
         0.9, // ~0.9 -> ~0.9
@@ -40,7 +40,7 @@ export const d = makeCaseCache('fract', {
         ...fullF32Range(),
       ],
       'unfiltered',
-      fractInterval
+      FP.f32.fractInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/inversesqrt.spec.ts
@@ -11,10 +11,10 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { inverseSqrtInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { biasedRange, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,7 +22,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('inverseSqrt', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
         // 0 < x <= 1 linearly spread
         ...linearRange(kValue.f32.positive.min, 1, 100),
@@ -30,7 +30,7 @@ export const d = makeCaseCache('inverseSqrt', {
         ...biasedRange(1, 2 ** 32, 1000),
       ],
       'unfiltered',
-      inverseSqrtInterval
+      FP.f32.inverseSqrtInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/length.spec.ts
@@ -10,15 +10,10 @@ Returns the length of e (e.g. abs(e) if T is a scalar, or sqrt(e[0]^2 + e[1]^2 +
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
-import { lengthInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range, vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import {
-  allInputSources,
-  generateUnaryToF32IntervalCases,
-  generateVectorToF32IntervalCases,
-  run,
-} from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -26,25 +21,41 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('length', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', lengthInterval);
+    return FP.f32.generateScalarToIntervalCases(
+      fullF32Range(),
+      'unfiltered',
+      FP.f32.lengthInterval
+    );
   },
   f32_vec2_const: () => {
-    return generateVectorToF32IntervalCases(vectorF32Range(2), 'finite', lengthInterval);
+    return FP.f32.generateVectorToIntervalCases(vectorF32Range(2), 'finite', FP.f32.lengthInterval);
   },
   f32_vec2_non_const: () => {
-    return generateVectorToF32IntervalCases(vectorF32Range(2), 'unfiltered', lengthInterval);
+    return FP.f32.generateVectorToIntervalCases(
+      vectorF32Range(2),
+      'unfiltered',
+      FP.f32.lengthInterval
+    );
   },
   f32_vec3_const: () => {
-    return generateVectorToF32IntervalCases(vectorF32Range(3), 'finite', lengthInterval);
+    return FP.f32.generateVectorToIntervalCases(vectorF32Range(3), 'finite', FP.f32.lengthInterval);
   },
   f32_vec3_non_const: () => {
-    return generateVectorToF32IntervalCases(vectorF32Range(3), 'unfiltered', lengthInterval);
+    return FP.f32.generateVectorToIntervalCases(
+      vectorF32Range(3),
+      'unfiltered',
+      FP.f32.lengthInterval
+    );
   },
   f32_vec4_const: () => {
-    return generateVectorToF32IntervalCases(vectorF32Range(4), 'finite', lengthInterval);
+    return FP.f32.generateVectorToIntervalCases(vectorF32Range(4), 'finite', FP.f32.lengthInterval);
   },
   f32_vec4_non_const: () => {
-    return generateVectorToF32IntervalCases(vectorF32Range(4), 'unfiltered', lengthInterval);
+    return FP.f32.generateVectorToIntervalCases(
+      vectorF32Range(4),
+      'unfiltered',
+      FP.f32.lengthInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log.spec.ts
@@ -11,10 +11,10 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { logInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -30,10 +30,10 @@ const inputs = [
 
 export const d = makeCaseCache('log', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'finite', logInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'finite', FP.f32.logInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'unfiltered', logInterval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'unfiltered', FP.f32.logInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/log2.spec.ts
@@ -11,10 +11,10 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { log2Interval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { biasedRange, fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -30,10 +30,10 @@ const inputs = [
 
 export const d = makeCaseCache('log2', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'finite', log2Interval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'finite', FP.f32.log2Interval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(inputs, 'unfiltered', log2Interval);
+    return FP.f32.generateScalarToIntervalCases(inputs, 'unfiltered', FP.f32.log2Interval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quantizeToF16.spec.ts
@@ -12,10 +12,10 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { quantizeToF16Interval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF16Range, fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -23,7 +23,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('quantizeToF16', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
         kValue.f16.negative.min,
         kValue.f16.negative.max,
@@ -36,11 +36,11 @@ export const d = makeCaseCache('quantizeToF16', {
         ...fullF16Range(),
       ],
       'finite',
-      quantizeToF16Interval
+      FP.f32.quantizeToF16Interval
     );
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
         kValue.f16.negative.min,
         kValue.f16.negative.max,
@@ -53,7 +53,7 @@ export const d = makeCaseCache('quantizeToF16', {
         ...fullF32Range(),
       ],
       'unfiltered',
-      quantizeToF16Interval
+      FP.f32.quantizeToF16Interval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/radians.spec.ts
@@ -11,10 +11,10 @@ Component-wise when T is a vector
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { radiansInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,7 +22,11 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('radians', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', radiansInterval);
+    return FP.f32.generateScalarToIntervalCases(
+      fullF32Range(),
+      'unfiltered',
+      FP.f32.radiansInterval
+    );
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -13,10 +13,10 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { roundInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -24,7 +24,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('round', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', roundInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.roundInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
@@ -10,10 +10,10 @@ Returns clamp(e, 0.0, 1.0). Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { saturateInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,14 +21,14 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('saturate', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
         // Non-clamped values
         ...linearRange(0.0, 1.0, 100),
         ...fullF32Range(),
       ],
       'unfiltered',
-      saturateInterval
+      FP.f32.saturateInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -10,10 +10,10 @@ Returns the sign of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
-import { signInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range, fullI32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,7 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sign', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', signInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.signInterval);
   },
   i32: () =>
     fullI32Range().map(i => {

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -10,10 +10,10 @@ Returns the sine of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { sinInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,14 +21,14 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sin', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
-        // Well defined accuracy range
+        // Well-defined accuracy range
         ...linearRange(-Math.PI, Math.PI, 1000),
         ...fullF32Range(),
       ],
       'unfiltered',
-      sinInterval
+      FP.f32.sinInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sinh.spec.ts
@@ -10,10 +10,10 @@ Returns the hyperbolic sine of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { sinhInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,10 +21,10 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sinh', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'finite', sinhInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'finite', FP.f32.sinhInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', sinhInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.sinhInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sqrt.spec.ts
@@ -10,10 +10,10 @@ Returns the square root of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { sqrtInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,10 +21,10 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('sqrt', {
   f32_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'finite', sqrtInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'finite', FP.f32.sqrtInterval);
   },
   f32_non_const: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', sqrtInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.sqrtInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tan.spec.ts
@@ -10,10 +10,10 @@ Returns the tangent of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { tanInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,14 +21,14 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('tan', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       [
         // Defined accuracy range
         ...linearRange(-Math.PI, Math.PI, 100),
         ...fullF32Range(),
       ],
       'unfiltered',
-      tanInterval
+      FP.f32.tanInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/tanh.spec.ts
@@ -10,10 +10,10 @@ Returns the hyperbolic tangent of e. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { tanhInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,7 +21,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('tanh', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', tanhInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.tanhInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -11,10 +11,10 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { truncInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -22,7 +22,7 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('trunc', {
   f32: () => {
-    return generateUnaryToF32IntervalCases(fullF32Range(), 'unfiltered', truncInterval);
+    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.truncInterval);
   },
 });
 

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -25,7 +25,6 @@ import {
   MatrixToMatrix,
   MatrixToScalar,
   MatrixVectorToVector,
-  ScalarToInterval,
   ScalarToVector,
   ScalarMatrixToMatrix,
   ScalarVectorToVector,
@@ -820,49 +819,6 @@ function packScalarsToVector(
 export type IntervalFilter =
   | 'finite' // Expected to be finite in the interval numeric space
   | 'unfiltered'; // No expectations
-
-/**
- * @returns a Case for the param and unary interval generator provided
- * The Case will use an interval comparator for matching results.
- * @param param the param to pass in
- * @param filter what interval filtering to apply
- * @param ops callbacks that implement generating an acceptance interval for an
- *            unary operation
- */
-function makeUnaryToF32IntervalCase(
-  param: number,
-  filter: IntervalFilter,
-  ...ops: ScalarToInterval[]
-): Case | undefined {
-  param = quantizeToF32(param);
-
-  const intervals = ops.map(o => o(param));
-  if (filter === 'finite' && intervals.some(i => !i.isFinite())) {
-    return undefined;
-  }
-  return { input: [f32(param)], expected: anyOf(...intervals) };
-}
-
-/**
- * @returns an array of Cases for operations over a range of inputs
- * @param params array of inputs to try
- * @param filter what interval filtering to apply
- * @param ops callbacks that implement generating an acceptance interval for an
- *            unary operation
- */
-export function generateUnaryToF32IntervalCases(
-  params: number[],
-  filter: IntervalFilter,
-  ...ops: ScalarToInterval[]
-): Case[] {
-  return params.reduce((cases, e) => {
-    const c = makeUnaryToF32IntervalCase(e, filter, ...ops);
-    if (c !== undefined) {
-      cases.push(c);
-    }
-    return cases;
-  }, new Array<Case>());
-}
 
 /**
  * @returns a Case for the params and binary interval generator provided

--- a/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_arithmetic.spec.ts
@@ -5,10 +5,10 @@ Execution Tests for the f32 arithmetic unary expression operations
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32 } from '../../../../util/conversion.js';
-import { negationInterval } from '../../../../util/f32_interval.js';
+import { FP } from '../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, generateUnaryToF32IntervalCases, run } from '../expression.js';
+import { allInputSources, run } from '../expression.js';
 
 import { unary } from './unary.js';
 
@@ -16,10 +16,10 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('unary/f32_arithmetic', {
   negation: () => {
-    return generateUnaryToF32IntervalCases(
+    return FP.f32.generateScalarToIntervalCases(
       fullF32Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }),
       'unfiltered',
-      negationInterval
+      FP.f32.negationInterval
     );
   },
 });

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -260,10 +260,6 @@ export function remainderInterval(x: number, y: number): FPInterval {
   return FP.f32.remainderInterval(x, y);
 }
 
-export function roundInterval(n: number): FPInterval {
-  return FP.f32.roundInterval(n);
-}
-
 export function saturateInterval(n: number): FPInterval {
   return FP.f32.saturateInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -260,10 +260,6 @@ export function remainderInterval(x: number, y: number): FPInterval {
   return FP.f32.remainderInterval(x, y);
 }
 
-export function sinInterval(n: number): FPInterval {
-  return FP.f32.sinInterval(n);
-}
-
 export function sinhInterval(n: number): FPInterval {
   return FP.f32.sinhInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -174,10 +174,6 @@ export function dotInterval(x: number[] | FPInterval[], y: number[] | FPInterval
   return FP.f32.dotInterval(x, y);
 }
 
-export function expInterval(x: number | FPInterval): FPInterval {
-  return FP.f32.expInterval(x);
-}
-
 export function exp2Interval(x: number | FPInterval): FPInterval {
   return FP.f32.exp2Interval(x);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -186,10 +186,6 @@ export function fmaInterval(x: number, y: number, z: number): FPInterval {
   return FP.f32.fmaInterval(x, y, z);
 }
 
-export function inverseSqrtInterval(n: number | FPInterval): FPInterval {
-  return FP.f32.inverseSqrtInterval(n);
-}
-
 export function ldexpInterval(e1: number, e2: number): FPInterval {
   return FP.f32.ldexpInterval(e1, e2);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -260,10 +260,6 @@ export function remainderInterval(x: number, y: number): FPInterval {
   return FP.f32.remainderInterval(x, y);
 }
 
-export function signInterval(n: number): FPInterval {
-  return FP.f32.signInterval(n);
-}
-
 export function sinInterval(n: number): FPInterval {
   return FP.f32.sinInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -276,10 +276,6 @@ export function subtractionMatrixInterval(x: number[][], y: number[][]): FPMatri
   return FP.f32.subtractionMatrixInterval(x, y);
 }
 
-export function tanInterval(n: number): FPInterval {
-  return FP.f32.tanInterval(n);
-}
-
 export function tanhInterval(n: number): FPInterval {
   return FP.f32.tanhInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -136,10 +136,6 @@ export function atan2Interval(y: number | FPInterval, x: number | FPInterval): F
   return FP.f32.atan2Interval(y, x);
 }
 
-export function ceilInterval(n: number): FPInterval {
-  return FP.f32.ceilInterval(n);
-}
-
 export const clampIntervals = FP.f32.clampIntervals;
 
 export function clampMedianInterval(

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -174,20 +174,12 @@ export function dotInterval(x: number[] | FPInterval[], y: number[] | FPInterval
   return FP.f32.dotInterval(x, y);
 }
 
-export function exp2Interval(x: number | FPInterval): FPInterval {
-  return FP.f32.exp2Interval(x);
-}
-
 export function faceForwardIntervals(
   x: number[],
   y: number[],
   z: number[]
 ): (FPVector | undefined)[] {
   return FP.f32.faceForwardIntervals(x, y, z);
-}
-
-export function floorInterval(n: number): FPInterval {
-  return FP.f32.floorInterval(n);
 }
 
 export function fmaInterval(x: number, y: number, z: number): FPInterval {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -136,10 +136,6 @@ export function atan2Interval(y: number | FPInterval, x: number | FPInterval): F
   return FP.f32.atan2Interval(y, x);
 }
 
-export function atanhInterval(n: number): FPInterval {
-  return FP.f32.atanhInterval(n);
-}
-
 export function ceilInterval(n: number): FPInterval {
   return FP.f32.ceilInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -194,14 +194,6 @@ export function lengthInterval(n: number | FPInterval | number[] | FPVector): FP
   return FP.f32.lengthInterval(n);
 }
 
-export function logInterval(x: number | FPInterval): FPInterval {
-  return FP.f32.logInterval(x);
-}
-
-export function log2Interval(x: number | FPInterval): FPInterval {
-  return FP.f32.log2Interval(x);
-}
-
 export function maxInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
   return FP.f32.maxInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -158,10 +158,6 @@ export function crossInterval(x: number[], y: number[]): FPVector {
   return FP.f32.crossInterval(x, y);
 }
 
-export function degreesInterval(n: number): FPInterval {
-  return FP.f32.degreesInterval(n);
-}
-
 export function determinantInterval(m: number[][]): FPInterval {
   return FP.f32.determinantInterval(m);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -132,10 +132,6 @@ export function additionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
   return FP.f32.additionMatrixInterval(x, y);
 }
 
-export function asinhInterval(n: number): FPInterval {
-  return FP.f32.asinhInterval(n);
-}
-
 export function atanInterval(n: number | FPInterval): FPInterval {
   return FP.f32.atanInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -240,10 +240,6 @@ export function multiplicationVectorMatrixInterval(x: number[], y: number[][]): 
   return FP.f32.multiplicationVectorMatrixInterval(x, y);
 }
 
-export function negationInterval(n: number): FPInterval {
-  return FP.f32.negationInterval(n);
-}
-
 export function normalizeInterval(n: number[]): FPVector {
   return FP.f32.normalizeInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -264,10 +264,6 @@ export function smoothStepInterval(low: number, high: number, x: number): FPInte
   return FP.f32.smoothStepInterval(low, high, x);
 }
 
-export function sqrtInterval(n: number | FPInterval): FPInterval {
-  return FP.f32.sqrtInterval(n);
-}
-
 export function stepInterval(edge: number, x: number): FPInterval {
   return FP.f32.stepInterval(edge, x);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -260,10 +260,6 @@ export function remainderInterval(x: number, y: number): FPInterval {
   return FP.f32.remainderInterval(x, y);
 }
 
-export function sinhInterval(n: number): FPInterval {
-  return FP.f32.sinhInterval(n);
-}
-
 export function smoothStepInterval(low: number, high: number, x: number): FPInterval {
   return FP.f32.smoothStepInterval(low, high, x);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -124,10 +124,6 @@ export function ulpInterval(n: number, numULP: number): FPInterval {
   return FP.f32.ulpInterval(n, numULP);
 }
 
-export function acosInterval(n: number): FPInterval {
-  return FP.f32.acosInterval(n);
-}
-
 export const acoshIntervals = FP.f32.acoshIntervals;
 
 export function acoshAlternativeInterval(x: number | FPInterval): FPInterval {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -132,10 +132,6 @@ export function additionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
   return FP.f32.additionMatrixInterval(x, y);
 }
 
-export function atanInterval(n: number | FPInterval): FPInterval {
-  return FP.f32.atanInterval(n);
-}
-
 export function atan2Interval(y: number | FPInterval, x: number | FPInterval): FPInterval {
   return FP.f32.atan2Interval(y, x);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -124,16 +124,6 @@ export function ulpInterval(n: number, numULP: number): FPInterval {
   return FP.f32.ulpInterval(n, numULP);
 }
 
-export const acoshIntervals = FP.f32.acoshIntervals;
-
-export function acoshAlternativeInterval(x: number | FPInterval): FPInterval {
-  return FP.f32.acoshAlternativeInterval(x);
-}
-
-export function acoshPrimaryInterval(x: number | FPInterval): FPInterval {
-  return FP.f32.acoshPrimaryInterval(x);
-}
-
 export function additionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
   return FP.f32.additionInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -154,14 +154,6 @@ export function clampMinMaxInterval(
   return FP.f32.clampMinMaxInterval(x, y, z);
 }
 
-export function cosInterval(n: number): FPInterval {
-  return FP.f32.cosInterval(n);
-}
-
-export function coshInterval(n: number): FPInterval {
-  return FP.f32.coshInterval(n);
-}
-
 export function crossInterval(x: number[], y: number[]): FPVector {
   return FP.f32.crossInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -248,10 +248,6 @@ export function powInterval(x: number | FPInterval, y: number | FPInterval): FPI
   return FP.f32.powInterval(x, y);
 }
 
-export function quantizeToF16Interval(n: number): FPInterval {
-  return FP.f32.quantizeToF16Interval(n);
-}
-
 export function radiansInterval(n: number): FPInterval {
   return FP.f32.radiansInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -248,10 +248,6 @@ export function powInterval(x: number | FPInterval, y: number | FPInterval): FPI
   return FP.f32.powInterval(x, y);
 }
 
-export function radiansInterval(n: number): FPInterval {
-  return FP.f32.radiansInterval(n);
-}
-
 export function reflectInterval(x: number[], y: number[]): FPVector {
   return FP.f32.reflectInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -6,10 +6,6 @@ import { FPInterval, FPMatrix, FPVector, IntervalBounds, FP } from './floating_p
 
 // Interfaces
 
-export interface ScalarToInterval {
-  (x: number): FPInterval;
-}
-
 export interface ScalarPairToInterval {
   (x: number, y: number): FPInterval;
 }
@@ -278,10 +274,6 @@ export function subtractionMatrixInterval(x: number[][], y: number[][]): FPMatri
 
 export function transposeInterval(m: number[][]): FPMatrix {
   return FP.f32.transposeInterval(m);
-}
-
-export function truncInterval(n: number | FPInterval): FPInterval {
-  return FP.f32.truncInterval(n);
 }
 
 export function unpack2x16floatInterval(n: number): FPVector {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -186,10 +186,6 @@ export function fmaInterval(x: number, y: number, z: number): FPInterval {
   return FP.f32.fmaInterval(x, y, z);
 }
 
-export function fractInterval(n: number): FPInterval {
-  return FP.f32.fractInterval(n);
-}
-
 export function inverseSqrtInterval(n: number | FPInterval): FPInterval {
   return FP.f32.inverseSqrtInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -276,10 +276,6 @@ export function subtractionMatrixInterval(x: number[][], y: number[][]): FPMatri
   return FP.f32.subtractionMatrixInterval(x, y);
 }
 
-export function tanhInterval(n: number): FPInterval {
-  return FP.f32.tanhInterval(n);
-}
-
 export function transposeInterval(m: number[][]): FPMatrix {
   return FP.f32.transposeInterval(m);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -132,10 +132,6 @@ export function additionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
   return FP.f32.additionMatrixInterval(x, y);
 }
 
-export function asinInterval(n: number): FPInterval {
-  return FP.f32.asinInterval(n);
-}
-
 export function asinhInterval(n: number): FPInterval {
   return FP.f32.asinhInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -260,10 +260,6 @@ export function remainderInterval(x: number, y: number): FPInterval {
   return FP.f32.remainderInterval(x, y);
 }
 
-export function saturateInterval(n: number): FPInterval {
-  return FP.f32.saturateInterval(n);
-}
-
 export function signInterval(n: number): FPInterval {
   return FP.f32.signInterval(n);
 }

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2405,10 +2405,12 @@ abstract class FPTraits {
     ),
   };
 
-  /** Calculate an acceptance interval of log2(x) */
-  public log2Interval(x: number | FPInterval): FPInterval {
+  protected log2IntervalImpl(x: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(x), this.Log2IntervalOp);
   }
+
+  /** Calculate an acceptance interval of log2(x) */
+  public abstract readonly log2Interval: (x: number | FPInterval) => FPInterval;
 
   private readonly MaxIntervalOp: ScalarPairToIntervalOp = {
     impl: (x: number, y: number): FPInterval => {
@@ -3266,6 +3268,7 @@ class F32Traits extends FPTraits {
   public readonly inverseSqrtInterval = this.inverseSqrtIntervalImpl.bind(this);
   public readonly lengthInterval = this.lengthIntervalImpl.bind(this);
   public readonly logInterval = this.logIntervalImpl.bind(this);
+  public readonly log2Interval = this.log2IntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2268,10 +2268,12 @@ abstract class FPTraits {
     ),
   };
 
-  /** Calculate an acceptance interval of inverseSqrt(x) */
-  public inverseSqrtInterval(n: number | FPInterval): FPInterval {
+  protected inverseSqrtIntervalImpl(n: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.InverseSqrtIntervalOp);
   }
+
+  /** Calculate an acceptance interval of inverseSqrt(x) */
+  public abstract readonly inverseSqrtInterval: (n: number | FPInterval) => FPInterval;
 
   private readonly LdexpIntervalOp: ScalarPairToIntervalOp = {
     impl: this.limitScalarPairToIntervalDomain(
@@ -3211,6 +3213,7 @@ class F32Traits extends FPTraits {
   public readonly exp2Interval = this.exp2IntervalImpl.bind(this);
   public readonly floorInterval = this.floorIntervalImpl.bind(this);
   public readonly fractInterval = this.fractIntervalImpl.bind(this);
+  public readonly inverseSqrtInterval = this.inverseSqrtIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -3014,10 +3014,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of trunc(x) */
-  public truncInterval(n: number | FPInterval): FPInterval {
+  protected truncIntervalImpl(n: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.TruncIntervalOp);
   }
+
+  /** Calculate an acceptance interval of trunc(x) */
+  public abstract readonly truncInterval: (n: number | FPInterval) => FPInterval;
 
   /**
    * Once-allocated ArrayBuffer/views to avoid overhead of allocation when
@@ -3301,6 +3303,7 @@ class F32Traits extends FPTraits {
   public readonly sqrtInterval = this.sqrtIntervalImpl.bind(this);
   public readonly tanInterval = this.tanIntervalImpl.bind(this);
   public readonly tanhInterval = this.tanhIntervalImpl.bind(this);
+  public readonly truncInterval = this.truncIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2787,10 +2787,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of round(x) */
-  public roundInterval(n: number): FPInterval {
+  protected roundIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.RoundIntervalOp);
   }
+
+  /** Calculate an acceptance interval of round(x) */
+  public abstract readonly roundInterval: (n: number) => FPInterval;
 
   /**
    * Calculate an acceptance interval of saturate(n) as clamp(n, 0.0, 1.0)
@@ -3278,6 +3280,7 @@ class F32Traits extends FPTraits {
   public readonly negationInterval = this.negationIntervalImpl.bind(this);
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);
   public readonly radiansInterval = this.radiansIntervalImpl.bind(this);
+  public readonly roundInterval = this.roundIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2650,10 +2650,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of quantizeToF16(x) */
-  public quantizeToF16Interval(n: number): FPInterval {
+  protected quantizeToF16IntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.QuantizeToF16IntervalOp);
   }
+
+  /** Calculate an acceptance interval of quantizeToF16(x) */
+  public abstract readonly quantizeToF16Interval: (n: number) => FPInterval;
 
   private readonly RadiansIntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3272,6 +3274,7 @@ class F32Traits extends FPTraits {
   public readonly logInterval = this.logIntervalImpl.bind(this);
   public readonly log2Interval = this.log2IntervalImpl.bind(this);
   public readonly negationInterval = this.negationIntervalImpl.bind(this);
+  public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2968,10 +2968,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of tan(x) */
-  public tanInterval(n: number): FPInterval {
+  protected tanIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.TanIntervalOp);
   }
+
+  /** Calculate an acceptance interval of tan(x) */
+  public abstract readonly tanInterval: (n: number) => FPInterval;
 
   private readonly TanhIntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3295,6 +3297,7 @@ class F32Traits extends FPTraits {
   public readonly sinInterval = this.sinIntervalImpl.bind(this);
   public readonly sinhInterval = this.sinhIntervalImpl.bind(this);
   public readonly sqrtInterval = this.sqrtIntervalImpl.bind(this);
+  public readonly tanInterval = this.tanIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2602,10 +2602,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of -x */
-  public negationInterval(n: number): FPInterval {
+  protected negationIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.NegationIntervalOp);
   }
+
+  /** Calculate an acceptance interval of -x */
+  public abstract readonly negationInterval: (n: number) => FPInterval;
 
   private readonly NormalizeIntervalOp: VectorToVectorOp = {
     impl: (n: number[]): FPVector => {
@@ -3269,6 +3271,7 @@ class F32Traits extends FPTraits {
   public readonly lengthInterval = this.lengthIntervalImpl.bind(this);
   public readonly logInterval = this.logIntervalImpl.bind(this);
   public readonly log2Interval = this.log2IntervalImpl.bind(this);
+  public readonly negationInterval = this.negationIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2981,10 +2981,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of tanh(x) */
-  public tanhInterval(n: number): FPInterval {
+  protected tanhIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.TanhIntervalOp);
   }
+
+  /** Calculate an acceptance interval of tanh(x) */
+  public abstract readonly tanhInterval: (n: number) => FPInterval;
 
   private readonly TransposeIntervalOp: MatrixToMatrixOp = {
     impl: (m: Matrix<number>): FPMatrix => {
@@ -3298,6 +3300,7 @@ class F32Traits extends FPTraits {
   public readonly sinhInterval = this.sinhIntervalImpl.bind(this);
   public readonly sqrtInterval = this.sqrtIntervalImpl.bind(this);
   public readonly tanInterval = this.tanIntervalImpl.bind(this);
+  public readonly tanhInterval = this.tanhIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1627,10 +1627,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of asinh(x) */
-  public asinhInterval(n: number): FPInterval {
+  protected asinhIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.AsinhIntervalOp);
   }
+
+  /** Calculate an acceptance interval of asinh(x) */
+  public abstract readonly asinhInterval: (n: number) => FPInterval;
 
   private readonly AtanIntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3177,6 +3179,7 @@ class F32Traits extends FPTraits {
     this.acoshPrimaryInterval.bind(this),
   ];
   public asinInterval = this.asinIntervalImpl.bind(this);
+  public asinhInterval = this.asinhIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -776,7 +776,7 @@ abstract class FPTraits {
   public abstract readonly isSubnormal: (n: number) => boolean;
   /** @returns 0 if the provided number is subnormal, otherwise returns the proved number */
   public abstract readonly flushSubnormal: (n: number) => number;
-  /** @returns 1 * ULP(number) */
+  /** @returns 1 * ULP: (number) */
   public abstract readonly oneULP: (target: number, mode?: FlushMode) => number;
   /** @returns a builder for converting numbers to Scalars */
   public abstract readonly scalarBuilder: (n: number) => Scalar;
@@ -1512,10 +1512,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval for abs(n) */
-  public absInterval(n: number): FPInterval {
+  protected absIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.AbsIntervalOp);
   }
+
+  /** Calculate an acceptance interval for abs(n) */
+  public abstract readonly absInterval: (n: number) => FPInterval;
 
   private readonly AcosIntervalOp: ScalarToIntervalOp = {
     impl: this.limitScalarToIntervalDomain(this.toInterval([-1.0, 1.0]), (n: number) => {
@@ -1528,10 +1530,12 @@ abstract class FPTraits {
     }),
   };
 
-  /** Calculate an acceptance interval for acos(n) */
-  public acosInterval(n: number): FPInterval {
+  protected acosIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.AcosIntervalOp);
   }
+
+  /** Calculate an acceptance interval for acos(n) */
+  public abstract readonly acosInterval: (n: number) => FPInterval;
 
   /** All acceptance interval functions for acosh(x) */
   public readonly acoshIntervals: ScalarToInterval[] = [
@@ -3158,6 +3162,10 @@ class F32Traits extends FPTraits {
   public readonly flushSubnormal = flushSubnormalNumberF32;
   public readonly oneULP = oneULPF32;
   public readonly scalarBuilder = f32;
+
+  // Overrides - API
+  public absInterval = this.absIntervalImpl.bind(this);
+  public acosInterval = this.acosIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1856,10 +1856,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of degrees(x) */
-  public degreesInterval(n: number): FPInterval {
+  protected degreesIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.DegreesIntervalOp);
   }
+
+  /** Calculate an acceptance interval of degrees(x) */
+  public abstract readonly degreesInterval: (n: number) => FPInterval;
 
   /**
    * Calculate the minor of a NxN matrix.
@@ -3196,6 +3198,7 @@ class F32Traits extends FPTraits {
   public readonly ceilInterval = this.ceilIntervalImpl.bind(this);
   public readonly cosInterval = this.cosIntervalImpl.bind(this);
   public readonly coshInterval = this.coshIntervalImpl.bind(this);
+  public readonly degreesInterval = this.degreesIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2126,10 +2126,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval for exp(x) */
-  public expInterval(x: number | FPInterval): FPInterval {
+  protected expIntervalImpl(x: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(x), this.ExpIntervalOp);
   }
+
+  /** Calculate an acceptance interval for exp(x) */
+  public abstract readonly expInterval: (x: number | FPInterval) => FPInterval;
 
   private readonly Exp2IntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3199,6 +3201,7 @@ class F32Traits extends FPTraits {
   public readonly cosInterval = this.cosIntervalImpl.bind(this);
   public readonly coshInterval = this.coshIntervalImpl.bind(this);
   public readonly degreesInterval = this.degreesIntervalImpl.bind(this);
+  public readonly expInterval = this.expIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2386,10 +2386,12 @@ abstract class FPTraits {
     ),
   };
 
-  /** Calculate an acceptance interval of log(x) */
-  public logInterval(x: number | FPInterval): FPInterval {
+  protected logIntervalImpl(x: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(x), this.LogIntervalOp);
   }
+
+  /** Calculate an acceptance interval of log(x) */
+  public abstract readonly logInterval: (x: number | FPInterval) => FPInterval;
 
   private readonly Log2IntervalOp: ScalarToIntervalOp = {
     impl: this.limitScalarToIntervalDomain(
@@ -3263,6 +3265,7 @@ class F32Traits extends FPTraits {
   public readonly fractInterval = this.fractIntervalImpl.bind(this);
   public readonly inverseSqrtInterval = this.inverseSqrtIntervalImpl.bind(this);
   public readonly lengthInterval = this.lengthIntervalImpl.bind(this);
+  public readonly logInterval = this.logIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2840,10 +2840,12 @@ abstract class FPTraits {
     ),
   };
 
-  /** Calculate an acceptance interval of sin(x) */
-  public sinInterval(n: number): FPInterval {
+  protected sinIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.SinIntervalOp);
   }
+
+  /** Calculate an acceptance interval of sin(x) */
+  public abstract readonly sinInterval: (n: number) => FPInterval;
 
   private readonly SinhIntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3286,6 +3288,7 @@ class F32Traits extends FPTraits {
   public readonly roundInterval = this.roundIntervalImpl.bind(this);
   public readonly saturateInterval = this.saturateIntervalImpl.bind(this);
   public readonly signInterval = this.signIntervalImpl.bind(this);
+  public readonly sinInterval = this.sinIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1706,10 +1706,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of atanh(x) */
-  public atanhInterval(n: number): FPInterval {
+  protected atanhIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.AtanhIntervalOp);
   }
+
+  /** Calculate an acceptance interval of atanh(x) */
+  public abstract readonly atanhInterval: (n: number) => FPInterval;
 
   private readonly CeilIntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3184,6 +3186,7 @@ class F32Traits extends FPTraits {
   public asinInterval = this.asinIntervalImpl.bind(this);
   public asinhInterval = this.asinhIntervalImpl.bind(this);
   public atanInterval = this.atanIntervalImpl.bind(this);
+  public atanhInterval = this.atanhIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1537,12 +1537,6 @@ abstract class FPTraits {
   /** Calculate an acceptance interval for acos(n) */
   public abstract readonly acosInterval: (n: number) => FPInterval;
 
-  /** All acceptance interval functions for acosh(x) */
-  public readonly acoshIntervals: ScalarToInterval[] = [
-    this.acoshAlternativeInterval.bind(this),
-    this.acoshPrimaryInterval.bind(this),
-  ];
-
   private readonly AcoshAlternativeIntervalOp: ScalarToIntervalOp = {
     impl: (x: number): FPInterval => {
       // acosh(x) = log(x + sqrt((x + 1.0f) * (x - 1.0)))
@@ -1555,10 +1549,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of acosh(x) using log(x + sqrt((x + 1.0f) * (x - 1.0))) */
-  public acoshAlternativeInterval(x: number | FPInterval): FPInterval {
+  protected acoshAlternativeIntervalImpl(x: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(x), this.AcoshAlternativeIntervalOp);
   }
+
+  /** Calculate an acceptance interval of acosh(x) using log(x + sqrt((x + 1.0f) * (x - 1.0))) */
+  public abstract readonly acoshAlternativeInterval: (x: number | FPInterval) => FPInterval;
 
   private readonly AcoshPrimaryIntervalOp: ScalarToIntervalOp = {
     impl: (x: number): FPInterval => {
@@ -1569,10 +1565,15 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of acosh(x) using log(x + sqrt(x * x - 1.0)) */
-  public acoshPrimaryInterval(x: number | FPInterval): FPInterval {
+  protected acoshPrimaryIntervalImpl(x: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(x), this.AcoshPrimaryIntervalOp);
   }
+
+  /** Calculate an acceptance interval of acosh(x) using log(x + sqrt(x * x - 1.0)) */
+  protected abstract acoshPrimaryInterval: (x: number | FPInterval) => FPInterval;
+
+  /** All acceptance interval functions for acosh(x) */
+  public abstract readonly acoshIntervals: ScalarToInterval[];
 
   private readonly AdditionIntervalOp: ScalarPairToIntervalOp = {
     impl: (x: number, y: number): FPInterval => {
@@ -3166,6 +3167,12 @@ class F32Traits extends FPTraits {
   // Overrides - API
   public absInterval = this.absIntervalImpl.bind(this);
   public acosInterval = this.acosIntervalImpl.bind(this);
+  public acoshAlternativeInterval = this.acoshAlternativeIntervalImpl.bind(this);
+  public acoshPrimaryInterval = this.acoshPrimaryIntervalImpl.bind(this);
+  public acoshIntervals = [
+    this.acoshAlternativeInterval.bind(this),
+    this.acoshPrimaryInterval.bind(this),
+  ];
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1719,10 +1719,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of ceil(x) */
-  public ceilInterval(n: number): FPInterval {
+  protected ceilIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.CeilIntervalOp);
   }
+
+  /** Calculate an acceptance interval of ceil(x) */
+  public abstract readonly ceilInterval: (n: number) => FPInterval;
 
   /** All acceptance interval functions for clamp(x, y, z) */
   public readonly clampIntervals: ScalarTripleToInterval[] = [
@@ -3175,18 +3177,19 @@ class F32Traits extends FPTraits {
   public readonly scalarBuilder = f32;
 
   // Overrides - API
-  public absInterval = this.absIntervalImpl.bind(this);
-  public acosInterval = this.acosIntervalImpl.bind(this);
-  public acoshAlternativeInterval = this.acoshAlternativeIntervalImpl.bind(this);
-  public acoshPrimaryInterval = this.acoshPrimaryIntervalImpl.bind(this);
-  public acoshIntervals = [
+  public readonly absInterval = this.absIntervalImpl.bind(this);
+  public readonly acosInterval = this.acosIntervalImpl.bind(this);
+  public readonly acoshAlternativeInterval = this.acoshAlternativeIntervalImpl.bind(this);
+  public readonly acoshPrimaryInterval = this.acoshPrimaryIntervalImpl.bind(this);
+  public readonly acoshIntervals = [
     this.acoshAlternativeInterval.bind(this),
     this.acoshPrimaryInterval.bind(this),
   ];
-  public asinInterval = this.asinIntervalImpl.bind(this);
-  public asinhInterval = this.asinhIntervalImpl.bind(this);
-  public atanInterval = this.atanIntervalImpl.bind(this);
-  public atanhInterval = this.atanhIntervalImpl.bind(this);
+  public readonly asinInterval = this.asinIntervalImpl.bind(this);
+  public readonly asinhInterval = this.asinhIntervalImpl.bind(this);
+  public readonly atanInterval = this.atanIntervalImpl.bind(this);
+  public readonly atanhInterval = this.atanhIntervalImpl.bind(this);
+  public readonly ceilInterval = this.ceilIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2903,10 +2903,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of sqrt(x) */
-  public sqrtInterval(n: number | FPInterval): FPInterval {
+  protected sqrtIntervalImpl(n: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.SqrtIntervalOp);
   }
+
+  /** Calculate an acceptance interval of sqrt(x) */
+  public abstract readonly sqrtInterval: (n: number | FPInterval) => FPInterval;
 
   private readonly StepIntervalOp: ScalarPairToIntervalOp = {
     impl: (edge: number, x: number): FPInterval => {
@@ -3292,6 +3294,7 @@ class F32Traits extends FPTraits {
   public readonly signInterval = this.signIntervalImpl.bind(this);
   public readonly sinInterval = this.sinIntervalImpl.bind(this);
   public readonly sinhInterval = this.sinhIntervalImpl.bind(this);
+  public readonly sqrtInterval = this.sqrtIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2858,10 +2858,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of sinh(x) */
-  public sinhInterval(n: number): FPInterval {
+  protected sinhIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.SinhIntervalOp);
   }
+
+  /** Calculate an acceptance interval of sinh(x) */
+  public abstract readonly sinhInterval: (n: number) => FPInterval;
 
   private readonly SmoothStepOp: ScalarTripleToIntervalOp = {
     impl: (low: number, high: number, x: number): FPInterval => {
@@ -3289,6 +3291,7 @@ class F32Traits extends FPTraits {
   public readonly saturateInterval = this.saturateIntervalImpl.bind(this);
   public readonly signInterval = this.signIntervalImpl.bind(this);
   public readonly sinInterval = this.sinIntervalImpl.bind(this);
+  public readonly sinhInterval = this.sinhIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1641,9 +1641,12 @@ abstract class FPTraits {
   };
 
   /** Calculate an acceptance interval of atan(x) */
-  public atanInterval(n: number | FPInterval): FPInterval {
+  protected atanIntervalImpl(n: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.AtanIntervalOp);
   }
+
+  /** Calculate an acceptance interval of atan(x) */
+  public abstract readonly atanInterval: (n: number | FPInterval) => FPInterval;
 
   private readonly Atan2IntervalOp: ScalarPairToIntervalOp = {
     impl: this.limitScalarPairToIntervalDomain(
@@ -3180,6 +3183,7 @@ class F32Traits extends FPTraits {
   ];
   public asinInterval = this.asinIntervalImpl.bind(this);
   public asinhInterval = this.asinhIntervalImpl.bind(this);
+  public atanInterval = this.atanIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2824,10 +2824,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of sign(x) */
-  public signInterval(n: number): FPInterval {
+  protected signIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.SignIntervalOp);
   }
+
+  /** Calculate an acceptance interval of sign(x) */
+  public abstract readonly signInterval: (n: number) => FPInterval;
 
   private readonly SinIntervalOp: ScalarToIntervalOp = {
     impl: this.limitScalarToIntervalDomain(
@@ -3283,6 +3285,7 @@ class F32Traits extends FPTraits {
   public readonly radiansInterval = this.radiansIntervalImpl.bind(this);
   public readonly roundInterval = this.roundIntervalImpl.bind(this);
   public readonly saturateInterval = this.saturateIntervalImpl.bind(this);
+  public readonly signInterval = this.signIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1793,10 +1793,12 @@ abstract class FPTraits {
     ),
   };
 
-  /** Calculate an acceptance interval of cos(x) */
-  public cosInterval(n: number): FPInterval {
+  protected cosIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.CosIntervalOp);
   }
+
+  /** Calculate an acceptance interval of cos(x) */
+  public abstract readonly cosInterval: (n: number) => FPInterval;
 
   private readonly CoshIntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3190,6 +3192,7 @@ class F32Traits extends FPTraits {
   public readonly atanInterval = this.atanIntervalImpl.bind(this);
   public readonly atanhInterval = this.atanhIntervalImpl.bind(this);
   public readonly ceilInterval = this.ceilIntervalImpl.bind(this);
+  public readonly cosInterval = this.cosIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1611,9 +1611,12 @@ abstract class FPTraits {
   };
 
   /** Calculate an acceptance interval for asin(n) */
-  public asinInterval(n: number): FPInterval {
+  protected asinIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.AsinIntervalOp);
   }
+
+  /** Calculate an acceptance interval for asin(n) */
+  public abstract readonly asinInterval: (n: number) => FPInterval;
 
   private readonly AsinhIntervalOp: ScalarToIntervalOp = {
     impl: (x: number): FPInterval => {
@@ -3173,6 +3176,7 @@ class F32Traits extends FPTraits {
     this.acoshAlternativeInterval.bind(this),
     this.acoshPrimaryInterval.bind(this),
   ];
+  public asinInterval = this.asinIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2209,10 +2209,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of floor(x) */
-  public floorInterval(n: number): FPInterval {
+  protected floorIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.FloorIntervalOp);
   }
+
+  /** Calculate an acceptance interval of floor(x) */
+  public abstract readonly floorInterval: (n: number) => FPInterval;
 
   private readonly FmaIntervalOp: ScalarTripleToIntervalOp = {
     impl: (x: number, y: number, z: number): FPInterval => {
@@ -3205,6 +3207,7 @@ class F32Traits extends FPTraits {
   public readonly degreesInterval = this.degreesIntervalImpl.bind(this);
   public readonly expInterval = this.expIntervalImpl.bind(this);
   public readonly exp2Interval = this.exp2IntervalImpl.bind(this);
+  public readonly floorInterval = this.floorIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2139,10 +2139,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval for exp2(x) */
-  public exp2Interval(x: number | FPInterval): FPInterval {
+  protected exp2IntervalImpl(x: number | FPInterval): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(x), this.Exp2IntervalOp);
   }
+
+  /** Calculate an acceptance interval for exp2(x) */
+  public abstract readonly exp2Interval: (x: number | FPInterval) => FPInterval;
 
   /**
    * Calculate the acceptance intervals for faceForward(x, y, z)
@@ -3202,6 +3204,7 @@ class F32Traits extends FPTraits {
   public readonly coshInterval = this.coshIntervalImpl.bind(this);
   public readonly degreesInterval = this.degreesIntervalImpl.bind(this);
   public readonly expInterval = this.expIntervalImpl.bind(this);
+  public readonly exp2Interval = this.exp2IntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2252,10 +2252,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of fract(x) */
-  public fractInterval(n: number): FPInterval {
+  protected fractIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.FractIntervalOp);
   }
+
+  /** Calculate an acceptance interval of fract(x) */
+  public abstract readonly fractInterval: (n: number) => FPInterval;
 
   private readonly InverseSqrtIntervalOp: ScalarToIntervalOp = {
     impl: this.limitScalarToIntervalDomain(
@@ -3208,6 +3210,7 @@ class F32Traits extends FPTraits {
   public readonly expInterval = this.expIntervalImpl.bind(this);
   public readonly exp2Interval = this.exp2IntervalImpl.bind(this);
   public readonly floorInterval = this.floorIntervalImpl.bind(this);
+  public readonly fractInterval = this.fractIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1811,10 +1811,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of cosh(x) */
-  public coshInterval(n: number): FPInterval {
+  protected coshIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.CoshIntervalOp);
   }
+
+  /** Calculate an acceptance interval of cosh(x) */
+  public abstract readonly coshInterval: (n: number) => FPInterval;
 
   private readonly CrossIntervalOp: VectorPairToVectorOp = {
     impl: (x: number[], y: number[]): FPVector => {
@@ -3193,6 +3195,7 @@ class F32Traits extends FPTraits {
   public readonly atanhInterval = this.atanhIntervalImpl.bind(this);
   public readonly ceilInterval = this.ceilIntervalImpl.bind(this);
   public readonly cosInterval = this.cosIntervalImpl.bind(this);
+  public readonly coshInterval = this.coshIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2795,13 +2795,11 @@ abstract class FPTraits {
   public abstract readonly roundInterval: (n: number) => FPInterval;
 
   /**
-   * Calculate an acceptance interval of saturate(n) as clamp(n, 0.0, 1.0)
-   *
    * The definition of saturate does not specify which version of clamp to use.
    * Using min-max here, since it has wider acceptance intervals, that include
    * all of median's.
    */
-  public saturateInterval(n: number): FPInterval {
+  protected saturateIntervalImpl(n: number): FPInterval {
     return this.runScalarTripleToIntervalOp(
       this.toInterval(n),
       this.toInterval(0.0),
@@ -2809,6 +2807,9 @@ abstract class FPTraits {
       this.ClampMinMaxIntervalOp
     );
   }
+
+  /*** Calculate an acceptance interval of saturate(n) as clamp(n, 0.0, 1.0) */
+  public abstract readonly saturateInterval: (n: number) => FPInterval;
 
   private readonly SignIntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3281,6 +3282,7 @@ class F32Traits extends FPTraits {
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);
   public readonly radiansInterval = this.radiansIntervalImpl.bind(this);
   public readonly roundInterval = this.roundIntervalImpl.bind(this);
+  public readonly saturateInterval = this.saturateIntervalImpl.bind(this);
 }
 
 export const FP = {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2663,10 +2663,12 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of radians(x) */
-  public radiansInterval(n: number): FPInterval {
+  protected radiansIntervalImpl(n: number): FPInterval {
     return this.runScalarToIntervalOp(this.toInterval(n), this.RadiansIntervalOp);
   }
+
+  /** Calculate an acceptance interval of radians(x) */
+  public abstract readonly radiansInterval: (n: number) => FPInterval;
 
   private readonly ReflectIntervalOp: VectorPairToVectorOp = {
     impl: (x: number[], y: number[]): FPVector => {
@@ -3275,6 +3277,7 @@ class F32Traits extends FPTraits {
   public readonly log2Interval = this.log2IntervalImpl.bind(this);
   public readonly negationInterval = this.negationIntervalImpl.bind(this);
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);
+  public readonly radiansInterval = this.radiansIntervalImpl.bind(this);
 }
 
 export const FP = {


### PR DESCRIPTION
All of the existing floating point tests for operations that take                                                                                                           
in Scalar values and output intervals are converted to using the                                                                                                            
new FPTrait based framework directly.                                                                                                                                       
                                                                                                                                                                            
Generic Case generation for these tests is moved from free                                                                                                                  
function in expression.ts to members in FPTraits to reduce the                                                                                                              
amount of information that needed to be threaded through calls.                                                                                                             
                                                                                                                                                                            
Some infra for Vector -> Interval is implemented also to support                                                                                                            
'length' tests, since the API for the builtin takes both Scalars                                                                                                            
and Vectors.                                                                                                                                                                
                                                                                                                                                                            
All of the old code and shims for this class of builtins is                                                                                                                 
removed. 

Issue: #2416

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
