### PR TITLE
Migrate Scalar Pair -> Interval tests to use new numeric framework

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -22,7 +22,6 @@ import {
   dotInterval,
   faceForwardIntervals,
   fmaInterval,
-  minInterval,
   mixImpreciseInterval,
   mixPreciseInterval,
   modfInterval,
@@ -1876,64 +1875,6 @@ interface ScalarPairToIntervalCase {
   input: [number, number];
   expected: number | IntervalBounds;
 }
-
-g.test('minInterval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 0 },
-      { input: [1, 0], expected: 0 },
-      { input: [0, 1], expected: 0 },
-      { input: [-1, 0], expected: -1 },
-      { input: [0, -1], expected: -1 },
-      { input: [1, 1], expected: 1 },
-      { input: [1, -1], expected: -1 },
-      { input: [-1, 1], expected: -1 },
-      { input: [-1, -1], expected: -1 },
-
-      // 64-bit normals
-      { input: [0.1, 0], expected: 0 },
-      { input: [0, 0.1], expected: 0 },
-      { input: [-0.1, 0], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-      { input: [0, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-      { input: [0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-      { input: [-0.1, 0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-      { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-
-      // 32-bit subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [-1, kValue.f32.subnormal.positive.max], expected: -1 },
-      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
-
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [x, y] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = minInterval(x, y);
-    t.expect(
-      objectEquals(expected, got),
-      `minInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('powInterval')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -40,7 +40,6 @@ import {
   remainderInterval,
   smoothStepInterval,
   stepInterval,
-  subtractionInterval,
   subtractionMatrixInterval,
   toF32Interval,
   toF32Matrix,
@@ -2265,62 +2264,6 @@ g.test('stepInterval')
     t.expect(
       objectEquals(expected, got),
       `stepInterval(${edge}, ${x}) returned ${got}. Expected ${expected}`
-    );
-  });
-
-g.test('subtractionInterval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 0 },
-      { input: [1, 0], expected: 1 },
-      { input: [0, 1], expected: -1 },
-      { input: [-1, 0], expected: -1 },
-      { input: [0, -1], expected: 1 },
-      { input: [1, 1], expected: 0 },
-      { input: [1, -1], expected: 2 },
-      { input: [-1, 1], expected: -2 },
-      { input: [-1, -1], expected: 0 },
-
-      // 64-bit normals
-      { input: [0.1, 0], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [0, 0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-      { input: [-0.1, 0], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-      { input: [0, -0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULP(hexToF32(0x3dcccccd))] },  // ~0.0
-      { input: [0.1, -0.1], expected: [minusOneULP(hexToF32(0x3e4ccccd)), hexToF32(0x3e4ccccd)] }, // ~0.2
-      { input: [-0.1, 0.1], expected: [hexToF32(0xbe4ccccd), plusOneULP(hexToF32(0xbe4ccccd))] },  // ~-0.2
-      { input: [-0.1, -0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULP(hexToF32(0x3dcccccd))] }, // ~0
-
-      // // 32-bit normals
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [0, kValue.f32.subnormal.positive.max] },
-
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [x, y] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = subtractionInterval(x, y);
-    t.expect(
-      objectEquals(expected, got),
-      `subtractionInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -30,7 +30,6 @@ import {
   multiplicationMatrixVectorInterval,
   multiplicationVectorMatrixInterval,
   normalizeInterval,
-  powInterval,
   reflectInterval,
   refractInterval,
   smoothStepInterval,
@@ -1875,39 +1874,6 @@ interface ScalarPairToIntervalCase {
   input: [number, number];
   expected: number | IntervalBounds;
 }
-
-g.test('powInterval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      { input: [-1, 0], expected: kAnyBounds },
-      { input: [0, 0], expected: kAnyBounds },
-      { input: [1, 0], expected: [minusNULP(1, 3), hexToF64(0x3ff0_0000_3000_0000n)] },  // ~1
-      { input: [2, 0], expected: [minusNULP(1, 3), hexToF64(0x3ff0_0000_3000_0000n)] },  // ~1
-      { input: [kValue.f32.positive.max, 0], expected: [minusNULP(1, 3), hexToF64(0x3ff0_0000_3000_0000n)] },  // ~1
-      { input: [0, 1], expected: kAnyBounds },
-      { input: [1, 1], expected: [hexToF64(0x3fef_fffe_dfff_fe00n), hexToF64(0x3ff0_0000_c000_0200n)] },  // ~1
-      { input: [1, 100], expected: [hexToF64(0x3fef_ffba_3fff_3800n), hexToF64(0x3ff0_0023_2000_c800n)] },  // ~1
-      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
-      { input: [2, 1], expected: [hexToF64(0x3fff_fffe_a000_0200n), hexToF64(0x4000_0001_0000_0200n)] },  // ~2
-      { input: [2, 2], expected: [hexToF64(0x400f_fffd_a000_0400n), hexToF64(0x4010_0001_a000_0400n)] },  // ~4
-      { input: [10, 10], expected: [hexToF64(0x4202_a04f_51f7_7000n), hexToF64(0x4202_a070_ee08_e000n)] },  // ~10000000000
-      { input: [10, 1], expected: [hexToF64(0x4023_fffe_0b65_8b00n), hexToF64(0x4024_0002_149a_7c00n)] },  // ~10
-      { input: [kValue.f32.positive.max, 1], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [x, y] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = powInterval(x, y);
-    t.expect(
-      objectEquals(expected, got),
-      `powInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('stepInterval')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -28,7 +28,6 @@ import {
   mixImpreciseInterval,
   mixPreciseInterval,
   modfInterval,
-  multiplicationInterval,
   multiplicationMatrixMatrixInterval,
   multiplicationMatrixScalarInterval,
   multiplicationMatrixVectorInterval,
@@ -2043,68 +2042,6 @@ g.test('minInterval')
     t.expect(
       objectEquals(expected, got),
       `minInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
-    );
-  });
-
-g.test('multiplicationInterval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 0 },
-      { input: [1, 0], expected: 0 },
-      { input: [0, 1], expected: 0 },
-      { input: [-1, 0], expected: 0 },
-      { input: [0, -1], expected: 0 },
-      { input: [1, 1], expected: 1 },
-      { input: [1, -1], expected: -1 },
-      { input: [-1, 1], expected: -1 },
-      { input: [-1, -1], expected: 1 },
-      { input: [2, 1], expected: 2 },
-      { input: [1, -2], expected: -2 },
-      { input: [-2, 1], expected: -2 },
-      { input: [-2, -1], expected: 2 },
-      { input: [2, 2], expected: 4 },
-      { input: [2, -2], expected: -4 },
-      { input: [-2, 2], expected: -4 },
-      { input: [-2, -2], expected: 4 },
-
-      // 64-bit normals
-      { input: [0.1, 0], expected: 0 },
-      { input: [0, 0.1], expected: 0 },
-      { input: [-0.1, 0], expected: 0 },
-      { input: [0, -0.1], expected: 0 },
-      { input: [0.1, 0.1], expected: [minusNULP(hexToF32(0x3c23d70a), 2), plusOneULP(hexToF32(0x3c23d70a))] },  // ~0.01
-      { input: [0.1, -0.1], expected: [minusOneULP(hexToF32(0xbc23d70a)), plusNULP(hexToF32(0xbc23d70a), 2)] },  // ~-0.01
-      { input: [-0.1, 0.1], expected: [minusOneULP(hexToF32(0xbc23d70a)), plusNULP(hexToF32(0xbc23d70a), 2)] },  // ~-0.01
-      { input: [-0.1, -0.1], expected: [minusNULP(hexToF32(0x3c23d70a), 2), plusOneULP(hexToF32(0x3c23d70a))] },  // ~0.01
-
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [1, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [-1, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [1, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [-1, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-
-      // Edge of f32
-      { input: [kValue.f32.positive.max, kValue.f32.positive.max], expected: kAnyBounds },
-      { input: [kValue.f32.negative.min, kValue.f32.negative.min], expected: kAnyBounds },
-      { input: [kValue.f32.positive.max, kValue.f32.negative.min], expected: kAnyBounds },
-      { input: [kValue.f32.negative.min, kValue.f32.positive.max], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [x, y] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = multiplicationInterval(x, y);
-    t.expect(
-      objectEquals(expected, got),
-      `multiplicationInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -22,7 +22,6 @@ import {
   dotInterval,
   faceForwardIntervals,
   fmaInterval,
-  ldexpInterval,
   maxInterval,
   minInterval,
   mixImpreciseInterval,
@@ -1878,54 +1877,6 @@ interface ScalarPairToIntervalCase {
   input: [number, number];
   expected: number | IntervalBounds;
 }
-
-g.test('ldexpInterval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 0 },
-      { input: [0, 1], expected: 0 },
-      { input: [0, -1], expected: 0 },
-      { input: [1, 1], expected: 2 },
-      { input: [1, -1], expected: 0.5 },
-      { input: [-1, 1], expected: -2 },
-      { input: [-1, -1], expected: -0.5 },
-
-      // 64-bit normals
-      { input: [0, 0.1], expected: 0 },
-      { input: [0, -0.1], expected: 0 },
-      { input: [1.0000000001, 1], expected: [2, plusNULP(2, 2)] },  // ~2, additional ULP error due to first param not being f32 precise
-      { input: [-1.0000000001, 1], expected: [minusNULP(-2, 2), -2] },  // ~-2, additional ULP error due to first param not being f32 precise
-
-      // Edge Cases
-      { input: [1.9999998807907104, 127], expected: kValue.f32.positive.max },
-      { input: [1, -126], expected: kValue.f32.positive.min },
-      { input: [0.9999998807907104, -126], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [1.1920928955078125e-07, -126], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [-1.1920928955078125e-07, -126], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [-0.9999998807907104, -126], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [-1, -126], expected: kValue.f32.negative.max },
-      { input: [-1.9999998807907104, 127], expected: kValue.f32.negative.min },
-
-      // Out of Bounds
-      { input: [1, 128], expected: kAnyBounds },
-      { input: [-1, 128], expected: kAnyBounds },
-      { input: [100, 126], expected: kAnyBounds },
-      { input: [-100, 126], expected: kAnyBounds },
-      { input: [kValue.f32.positive.max, kValue.i32.positive.max], expected: kAnyBounds },
-      { input: [kValue.f32.negative.min, kValue.i32.positive.max], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [x, y] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = ldexpInterval(x, y);
-    t.expect(
-      objectEquals(expected, got),
-      `divisionInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('maxInterval')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -22,7 +22,6 @@ import {
   dotInterval,
   faceForwardIntervals,
   fmaInterval,
-  maxInterval,
   minInterval,
   mixImpreciseInterval,
   mixPreciseInterval,
@@ -1877,65 +1876,6 @@ interface ScalarPairToIntervalCase {
   input: [number, number];
   expected: number | IntervalBounds;
 }
-
-g.test('maxInterval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 0 },
-      { input: [1, 0], expected: 1 },
-      { input: [0, 1], expected: 1 },
-      { input: [-1, 0], expected: 0 },
-      { input: [0, -1], expected: 0 },
-      { input: [1, 1], expected: 1 },
-      { input: [1, -1], expected: 1 },
-      { input: [-1, 1], expected: 1 },
-      { input: [-1, -1], expected: -1 },
-
-      // 64-bit normals
-      { input: [0.1, 0], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [0, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, 0], expected: 0 },
-      { input: [0, -0.1], expected: 0 },
-      { input: [0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [0.1, -0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-
-      // 32-bit subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: 1 },
-      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
-
-
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [x, y] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = maxInterval(x, y);
-    t.expect(
-      objectEquals(expected, got),
-      `maxInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('minInterval')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -14,7 +14,6 @@ import { objectEquals } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
 import {
   absoluteErrorInterval,
-  additionInterval,
   additionMatrixInterval,
   atan2Interval,
   clampMedianInterval,
@@ -1902,62 +1901,6 @@ interface ScalarPairToIntervalCase {
   input: [number, number];
   expected: number | IntervalBounds;
 }
-
-g.test('additionInterval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 0 },
-      { input: [1, 0], expected: 1 },
-      { input: [0, 1], expected: 1 },
-      { input: [-1, 0], expected: -1 },
-      { input: [0, -1], expected: -1 },
-      { input: [1, 1], expected: 2 },
-      { input: [1, -1], expected: 0 },
-      { input: [-1, 1], expected: 0 },
-      { input: [-1, -1], expected: -2 },
-
-      // 64-bit normals
-      { input: [0.1, 0], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [0, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, 0], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-      { input: [0, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULP(hexToF32(0xbdcccccd))] },  // ~-0.1
-      { input: [0.1, 0.1], expected: [minusOneULP(hexToF32(0x3e4ccccd)), hexToF32(0x3e4ccccd)] },  // ~0.2
-      { input: [0.1, -0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULP(hexToF32(0x3dcccccd))] }, // ~0
-      { input: [-0.1, 0.1], expected: [minusOneULP(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULP(hexToF32(0x3dcccccd))] }, // ~0
-      { input: [-0.1, -0.1], expected: [hexToF32(0xbe4ccccd), plusOneULP(hexToF32(0xbe4ccccd))] },  // ~-0.2
-
-      // 32-bit subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
-
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [x, y] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = additionInterval(x, y);
-    t.expect(
-      objectEquals(expected, got),
-      `additionInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 // Note: atan2's parameters are labelled (y, x) instead of (x, y)
 g.test('atan2Interval')

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -19,7 +19,6 @@ import {
   clampMinMaxInterval,
   correctlyRoundedInterval,
   crossInterval,
-  distanceInterval,
   divisionInterval,
   dotInterval,
   faceForwardIntervals,
@@ -1901,56 +1900,6 @@ interface ScalarPairToIntervalCase {
   expected: number | IntervalBounds;
 }
 
-g.test('distanceIntervalScalar')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable  form due to the inherited nature
-      // of the errors.
-      //
-      // distance(x, y), where x - y = 0 has an acceptance interval of kAnyBounds,
-      // because distance(x, y) = length(x - y), and length(0) = kAnyBounds
-      { input: [0, 0], expected: kAnyBounds },
-      { input: [1.0, 0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [0.0, 1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [1.0, 1.0], expected: kAnyBounds },
-      { input: [-0.0, -1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [0.0, -1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [-1.0, -1.0], expected: kAnyBounds },
-      { input: [0.1, 0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-      { input: [0, 0.1], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-      { input: [-0.1, 0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-      { input: [0, -0.1], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-      { input: [10.0, 0], expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
-      { input: [0, 10.0], expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
-      { input: [-10.0, 0], expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
-      { input: [0, -10.0], expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
-
-      // Subnormal Cases
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: kAnyBounds },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: kAnyBounds },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: kAnyBounds },
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: kAnyBounds },
-
-      // Edge cases
-      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
-      { input: [kValue.f32.negative.min, 0], expected: kAnyBounds },
-      { input: [kValue.f32.negative.max, 0], expected: kAnyBounds },
-      { input: [kValue.f32.positive.min, 0], expected: kAnyBounds },
-      { input: [kValue.f32.positive.max, 0], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = distanceInterval(...t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `distanceInterval(${t.params.input[0]}, ${t.params.input[1]}) returned ${got}. Expected ${expected}`
-    );
-  });
-
 g.test('divisionInterval')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
@@ -2997,68 +2946,6 @@ interface VectorPairToIntervalCase {
   input: [number[], number[]];
   expected: number | IntervalBounds;
 }
-
-g.test('distanceIntervalVector')
-  .paramsSubcasesOnly<VectorPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      //
-      // distance(x, y), where x - y = 0 has an acceptance interval of kAnyBounds,
-      // because distance(x, y) = length(x - y), and length(0) = kAnyBounds
-
-      // vec2
-      { input: [[1.0, 0.0], [1.0, 0.0]], expected: kAnyBounds },
-      { input: [[1.0, 0.0], [0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0], [1.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[-1.0, 0.0], [0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0], [-1.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 1.0], [-1.0, 0.0]], expected: [hexToF64(0x3ff6_a09d_b000_0000n), hexToF64(0x3ff6_a09f_1000_0000n)] },  // ~√2
-      { input: [[0.1, 0.0], [0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-
-      // vec3
-      { input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: kAnyBounds },
-      { input: [[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 1.0, 0.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
-      { input: [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
-      { input: [[-1.0, -1.0, -1.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
-      { input: [[0.0, 0.0, 0.0], [-1.0, -1.0, -1.0]], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
-      { input: [[0.1, 0.0, 0.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-      { input: [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-
-      // vec4
-      { input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: kAnyBounds },
-      { input: [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [[1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
-      { input: [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
-      { input: [[-1.0, 1.0, -1.0, 1.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
-      { input: [[0.0, 0.0, 0.0, 0.0], [1.0, -1.0, 1.0, -1.0]], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
-      { input: [[0.1, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-      { input: [[0.0, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = distanceInterval(...t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `distanceInterval([${t.params.input[0]}, ${t.params.input[1]}]) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('dotInterval')
   .paramsSubcasesOnly<VectorPairToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -36,7 +36,6 @@ import {
   powInterval,
   reflectInterval,
   refractInterval,
-  remainderInterval,
   smoothStepInterval,
   stepInterval,
   subtractionMatrixInterval,
@@ -2042,56 +2041,6 @@ g.test('minInterval')
     t.expect(
       objectEquals(expected, got),
       `minInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
-    );
-  });
-
-g.test('remainderInterval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 1], expected: [0, 0] },
-      { input: [0, -1], expected: [0, 0] },
-      { input: [1, 1], expected: [0, 1] },
-      { input: [1, -1], expected: [0, 1] },
-      { input: [-1, 1], expected: [-1, 0] },
-      { input: [-1, -1], expected: [-1, 0] },
-      { input: [4, 2], expected: [0, 2] },
-      { input: [-4, 2], expected: [-2, 0] },
-      { input: [4, -2], expected: [0, 2] },
-      { input: [-4, -2], expected: [-2, 0] },
-      { input: [2, 4], expected: [2, 2] },
-      { input: [-2, 4], expected: [-2, -2] },
-      { input: [2, -4], expected: [2, 2] },
-      { input: [-2, -4], expected: [-2, -2] },
-
-      // 64-bit normals
-      { input: [0, 0.1], expected: [0, 0] },
-      { input: [0, -0.1], expected: [0, 0] },
-      { input: [1, 0.1], expected: [hexToF32(0xb4000000), hexToF32(0x3dccccd8)] }, // ~[0, 0.1]
-      { input: [-1, 0.1], expected: [hexToF32(0xbdccccd8), hexToF32(0x34000000)] }, // ~[-0.1, 0]
-      { input: [1, -0.1], expected: [hexToF32(0xb4000000), hexToF32(0x3dccccd8)] }, // ~[0, 0.1]
-      { input: [-1, -0.1], expected: [hexToF32(0xbdccccd8), hexToF32(0x34000000)] }, // ~[-0.1, 0]
-
-      // Denominator out of range
-      { input: [1, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [1, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
-      { input: [1, kValue.f32.negative.min], expected: kAnyBounds },
-      { input: [1, 0], expected: kAnyBounds },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [x, y] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = remainderInterval(x, y);
-    t.expect(
-      objectEquals(expected, got),
-      `remainderInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -15,7 +15,6 @@ import { kValue } from '../webgpu/util/constants.js';
 import {
   absoluteErrorInterval,
   additionMatrixInterval,
-  atan2Interval,
   clampMedianInterval,
   clampMinMaxInterval,
   correctlyRoundedInterval,
@@ -1901,79 +1900,6 @@ interface ScalarPairToIntervalCase {
   input: [number, number];
   expected: number | IntervalBounds;
 }
-
-// Note: atan2's parameters are labelled (y, x) instead of (x, y)
-g.test('atan2Interval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-      //
-      // The positive x & y quadrant is tested in more detail, and the other
-      // quadrants are spot checked that values are pointing in the right
-      // direction.
-      //
-      // Some of the intervals appear slightly asymmetric,
-      // i.e. [π/4 - 4097 * ULP(π/4), π/4 + 4096 * ULP(π/4)],
-      // this is because π/4 is not precisely expressible as a f32, so the
-      // higher precision value can be rounded up or down when converting to
-      // f32. Thus one option will be 1 ULP off of the constant value being
-      // used.
-
-      // positive y, positive x
-      { input: [1, hexToF32(0x3fddb3d7)], expected: [minusNULP(kValue.f32.positive.pi.sixth, 4097), plusNULP(kValue.f32.positive.pi.sixth, 4096)] },  // x = √3
-      { input: [1, 1], expected: [minusNULP(kValue.f32.positive.pi.quarter, 4097), plusNULP(kValue.f32.positive.pi.quarter, 4096)] },
-      // { input: [hexToF32(0x3fddb3d7), 1], expected: [hexToF64(0x3ff0_bf52_0000_0000n), hexToF64(0x3ff0_c352_6000_0000n)] },  // y = √3
-      { input: [Number.POSITIVE_INFINITY, 1], expected: kAnyBounds },
-
-      // positive y, negative x
-      { input: [1, -1], expected: [minusNULP(kValue.f32.positive.pi.three_quarters, 4096), plusNULP(kValue.f32.positive.pi.three_quarters, 4097)] },
-      { input: [Number.POSITIVE_INFINITY, -1], expected: kAnyBounds },
-
-      // negative y, negative x
-      { input: [-1, -1], expected: [minusNULP(kValue.f32.negative.pi.three_quarters, 4097), plusNULP(kValue.f32.negative.pi.three_quarters, 4096)] },
-      { input: [Number.NEGATIVE_INFINITY, -1], expected: kAnyBounds },
-
-      // negative y, positive x
-      { input: [-1, 1], expected: [minusNULP(kValue.f32.negative.pi.quarter, 4096), plusNULP(kValue.f32.negative.pi.quarter, 4097)] },
-      { input: [Number.NEGATIVE_INFINITY, 1], expected: kAnyBounds },
-
-      // Discontinuity @ origin (0,0)
-      { input: [0, 0], expected: kAnyBounds },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: kAnyBounds },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: kAnyBounds },
-      { input: [0, kValue.f32.positive.min], expected: kAnyBounds },
-      { input: [0, kValue.f32.negative.max], expected: kAnyBounds },
-      { input: [0, kValue.f32.positive.max], expected: kAnyBounds },
-      { input: [0, kValue.f32.negative.min], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [0, 1], expected: kAnyBounds },
-      { input: [kValue.f32.subnormal.positive.max, 1], expected: kAnyBounds },
-      { input: [kValue.f32.subnormal.negative.min, 1], expected: kAnyBounds },
-
-      // When atan(y/x) ~ 0, test that ULP applied to result of atan2, not the intermediate atan(y/x) value
-      {input: [hexToF32(0x80800000), hexToF32(0xbf800000)], expected: [minusNULP(kValue.f32.negative.pi.whole, 4096), plusNULP(kValue.f32.negative.pi.whole, 4096)] },
-      {input: [hexToF32(0x00800000), hexToF32(0xbf800000)], expected: [minusNULP(kValue.f32.positive.pi.whole, 4096), plusNULP(kValue.f32.positive.pi.whole, 4096)] },
-
-      // Very large |x| values should cause kAnyBounds to be returned, due to the restrictions on division
-      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
-      { input: [1, kValue.f32.positive.nearest_max], expected: kAnyBounds },
-      { input: [1, kValue.f32.negative.min], expected: kAnyBounds },
-      { input: [1, kValue.f32.negative.nearest_min], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [y, x] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = atan2Interval(y, x);
-    t.expect(
-      objectEquals(expected, got),
-      `atan2Interval(${y}, ${x}) returned ${got}. Expected ${expected}`
-    );
-  });
 
 g.test('distanceIntervalScalar')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -33,7 +33,6 @@ import {
   reflectInterval,
   refractInterval,
   smoothStepInterval,
-  stepInterval,
   subtractionMatrixInterval,
   toF32Interval,
   toF32Matrix,
@@ -1865,89 +1864,6 @@ g.test('ulpInterval')
     t.expect(
       objectEquals(expected, got),
       `ulpInterval(${t.params.value}, ${t.params.num_ulp}) returned ${got}. Expected ${expected}`
-    );
-  });
-
-interface ScalarPairToIntervalCase {
-  // input is a pair of independent values, not a range, so should not be
-  // converted to a FPInterval.
-  input: [number, number];
-  expected: number | IntervalBounds;
-}
-
-g.test('stepInterval')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 1 },
-      { input: [1, 1], expected: 1 },
-      { input: [0, 1], expected: 1 },
-      { input: [1, 0], expected: 0 },
-      { input: [-1, -1], expected: 1 },
-      { input: [0, -1], expected: 0 },
-      { input: [-1, 0], expected: 1 },
-      { input: [-1, 1], expected: 1 },
-      { input: [1, -1], expected: 0 },
-
-      // 64-bit normals
-      { input: [0.1, 0.1], expected: [0, 1] },
-      { input: [0, 0.1], expected: 1 },
-      { input: [0.1, 0], expected: 0 },
-      { input: [0.1, 1], expected: 1 },
-      { input: [1, 0.1], expected: 0 },
-      { input: [-0.1, -0.1], expected: [0, 1] },
-      { input: [0, -0.1], expected: 0 },
-      { input: [-0.1, 0], expected: 1 },
-      { input: [-0.1, -1], expected: 0 },
-      { input: [-1, -0.1], expected: 1 },
-
-      // Subnormals
-      { input: [0, kValue.f32.subnormal.positive.max], expected: 1 },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: 1 },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [0, 1] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [0, 1] },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: 0 },
-      { input: [1, kValue.f32.subnormal.positive.min], expected: 0 },
-      { input: [1, kValue.f32.subnormal.negative.max], expected: 0 },
-      { input: [1, kValue.f32.subnormal.negative.min], expected: 0 },
-      { input: [-1, kValue.f32.subnormal.positive.max], expected: 1 },
-      { input: [-1, kValue.f32.subnormal.positive.min], expected: 1 },
-      { input: [-1, kValue.f32.subnormal.negative.max], expected: 1 },
-      { input: [-1, kValue.f32.subnormal.negative.min], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, 1] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, 1] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: 1 },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.max, 1], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.min, 1], expected: 1 },
-      { input: [kValue.f32.subnormal.negative.max, 1], expected: 1 },
-      { input: [kValue.f32.subnormal.negative.min, 1], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.max, -1], expected: 0 },
-      { input: [kValue.f32.subnormal.positive.min, -1], expected: 0 },
-      { input: [kValue.f32.subnormal.negative.max, -1], expected: 0 },
-      { input: [kValue.f32.subnormal.negative.min, -1], expected: 0 },
-      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min], expected: [0, 1] },
-
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [edge, x] = t.params.input;
-    const expected = toF32Interval(t.params.expected);
-    const got = stepInterval(edge, x);
-    t.expect(
-      objectEquals(expected, got),
-      `stepInterval(${edge}, ${x}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1466,6 +1466,65 @@ g.test('multiplicationInterval_f32')
     );
   });
 
+g.test('maxInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: 0 },
+      { input: [1, 0], expected: 1 },
+      { input: [0, 1], expected: 1 },
+      { input: [-1, 0], expected: 0 },
+      { input: [0, -1], expected: 0 },
+      { input: [1, 1], expected: 1 },
+      { input: [1, -1], expected: 1 },
+      { input: [-1, 1], expected: 1 },
+      { input: [-1, -1], expected: -1 },
+
+      // 64-bit normals
+      { input: [0.1, 0], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [-0.1, 0], expected: 0 },
+      { input: [0, -0.1], expected: 0 },
+      { input: [0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0.1, -0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [-0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+
+      // 32-bit subnormals
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: 1 },
+      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
+
+
+      // Infinities
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.maxInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.maxInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 g.test('remainderInterval_f32')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1356,6 +1356,62 @@ g.test('divisionInterval_f32')
     );
   });
 
+g.test('subtractionInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: 0 },
+      { input: [1, 0], expected: 1 },
+      { input: [0, 1], expected: -1 },
+      { input: [-1, 0], expected: -1 },
+      { input: [0, -1], expected: 1 },
+      { input: [1, 1], expected: 0 },
+      { input: [1, -1], expected: 2 },
+      { input: [-1, 1], expected: -2 },
+      { input: [-1, -1], expected: 0 },
+
+      // 64-bit normals
+      { input: [0.1, 0], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0, 0.1], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [-0.1, 0], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [0, -0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULPF32(hexToF32(0x3dcccccd))] },  // ~0.0
+      { input: [0.1, -0.1], expected: [minusOneULPF32(hexToF32(0x3e4ccccd)), hexToF32(0x3e4ccccd)] }, // ~0.2
+      { input: [-0.1, 0.1], expected: [hexToF32(0xbe4ccccd), plusOneULPF32(hexToF32(0xbe4ccccd))] },  // ~-0.2
+      { input: [-0.1, -0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULPF32(hexToF32(0x3dcccccd))] }, // ~0
+
+      // // 32-bit normals
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [0, kValue.f32.subnormal.positive.max] },
+
+      // Infinities
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.subtractionInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.subtractionInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1254,6 +1254,56 @@ g.test('atan2Interval_f32')
     );
   });
 
+g.test('distanceIntervalScalar_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable  form due to the inherited nature
+      // of the errors.
+      //
+      // distance(x, y), where x - y = 0 has an acceptance interval of kAnyBounds,
+      // because distance(x, y) = length(x - y), and length(0) = kAnyBounds
+      { input: [0, 0], expected: kAnyBounds },
+      { input: [1.0, 0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [0.0, 1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [1.0, 1.0], expected: kAnyBounds },
+      { input: [-0.0, -1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [0.0, -1.0], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [-1.0, -1.0], expected: kAnyBounds },
+      { input: [0.1, 0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+      { input: [0, 0.1], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+      { input: [-0.1, 0], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+      { input: [0, -0.1], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+      { input: [10.0, 0], expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
+      { input: [0, 10.0], expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
+      { input: [-10.0, 0], expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
+      { input: [0, -10.0], expected: [hexToF64(0x4023_ffff_7000_0000n), hexToF64(0x4024_0000_b000_0000n)] },  // ~10
+
+      // Subnormal Cases
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: kAnyBounds },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: kAnyBounds },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: kAnyBounds },
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: kAnyBounds },
+
+      // Edge cases
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.negative.min, 0], expected: kAnyBounds },
+      { input: [kValue.f32.negative.max, 0], expected: kAnyBounds },
+      { input: [kValue.f32.positive.min, 0], expected: kAnyBounds },
+      { input: [kValue.f32.positive.max, 0], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.distanceInterval(...t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.distanceInterval(${t.params.input[0]}, ${t.params.input[1]}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;
@@ -1306,5 +1356,72 @@ g.test('lengthIntervalVector_f32')
     t.expect(
       objectEquals(expected, got),
       `f32.lengthInterval([${t.params.input}]) returned ${got}. Expected ${expected}`
+    );
+  });
+
+interface VectorPairToIntervalCase {
+  input: [number[], number[]];
+  expected: number | IntervalBounds;
+}
+
+g.test('distanceIntervalVector_f32')
+  .paramsSubcasesOnly<VectorPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+      //
+      // distance(x, y), where x - y = 0 has an acceptance interval of kAnyBounds,
+      // because distance(x, y) = length(x - y), and length(0) = kAnyBounds
+
+      // vec2
+      { input: [[1.0, 0.0], [1.0, 0.0]], expected: kAnyBounds },
+      { input: [[1.0, 0.0], [0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0], [1.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[-1.0, 0.0], [0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0], [-1.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 1.0], [-1.0, 0.0]], expected: [hexToF64(0x3ff6_a09d_b000_0000n), hexToF64(0x3ff6_a09f_1000_0000n)] },  // ~√2
+      { input: [[0.1, 0.0], [0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+
+      // vec3
+      { input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: kAnyBounds },
+      { input: [[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 1.0, 0.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
+      { input: [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
+      { input: [[-1.0, -1.0, -1.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
+      { input: [[0.0, 0.0, 0.0], [-1.0, -1.0, -1.0]], expected: [hexToF64(0x3ffb_b67a_1000_0000n), hexToF64(0x3ffb_b67b_b000_0000n)] },  // ~√3
+      { input: [[0.1, 0.0, 0.0], [0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+      { input: [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+
+      // vec4
+      { input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: kAnyBounds },
+      { input: [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]], expected: [hexToF64(0x3fef_ffff_7000_0000n), hexToF64(0x3ff0_0000_9000_0000n)] },  // ~1
+      { input: [[1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
+      { input: [[0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
+      { input: [[-1.0, 1.0, -1.0, 1.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
+      { input: [[0.0, 0.0, 0.0, 0.0], [1.0, -1.0, 1.0, -1.0]], expected: [hexToF64(0x3fff_ffff_7000_0000n), hexToF64(0x4000_0000_9000_0000n)] },  // ~2
+      { input: [[0.1, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+      { input: [[0.0, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0]], expected: [hexToF64(0x3fb9_9998_9000_0000n), hexToF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.distanceInterval(...t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.distanceInterval([${t.params.input[0]}, ${t.params.input[1]}]) returned ${got}. Expected ${expected}`
     );
   });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1356,6 +1356,68 @@ g.test('divisionInterval_f32')
     );
   });
 
+g.test('multiplicationInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: 0 },
+      { input: [1, 0], expected: 0 },
+      { input: [0, 1], expected: 0 },
+      { input: [-1, 0], expected: 0 },
+      { input: [0, -1], expected: 0 },
+      { input: [1, 1], expected: 1 },
+      { input: [1, -1], expected: -1 },
+      { input: [-1, 1], expected: -1 },
+      { input: [-1, -1], expected: 1 },
+      { input: [2, 1], expected: 2 },
+      { input: [1, -2], expected: -2 },
+      { input: [-2, 1], expected: -2 },
+      { input: [-2, -1], expected: 2 },
+      { input: [2, 2], expected: 4 },
+      { input: [2, -2], expected: -4 },
+      { input: [-2, 2], expected: -4 },
+      { input: [-2, -2], expected: 4 },
+
+      // 64-bit normals
+      { input: [0.1, 0], expected: 0 },
+      { input: [0, 0.1], expected: 0 },
+      { input: [-0.1, 0], expected: 0 },
+      { input: [0, -0.1], expected: 0 },
+      { input: [0.1, 0.1], expected: [minusNULPF32(hexToF32(0x3c23d70a), 2), plusOneULPF32(hexToF32(0x3c23d70a))] },  // ~0.01
+      { input: [0.1, -0.1], expected: [minusOneULPF32(hexToF32(0xbc23d70a)), plusNULPF32(hexToF32(0xbc23d70a), 2)] },  // ~-0.01
+      { input: [-0.1, 0.1], expected: [minusOneULPF32(hexToF32(0xbc23d70a)), plusNULPF32(hexToF32(0xbc23d70a), 2)] },  // ~-0.01
+      { input: [-0.1, -0.1], expected: [minusNULPF32(hexToF32(0x3c23d70a), 2), plusOneULPF32(hexToF32(0x3c23d70a))] },  // ~0.01
+
+      // Infinities
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [-1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [1, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [-1, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+
+      // Edge of f32
+      { input: [kValue.f32.positive.max, kValue.f32.positive.max], expected: kAnyBounds },
+      { input: [kValue.f32.negative.min, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [kValue.f32.positive.max, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [kValue.f32.negative.min, kValue.f32.positive.max], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.multiplicationInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.multiplicationInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 g.test('subtractionInterval_f32')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1665,6 +1665,82 @@ g.test('remainderInterval_f32')
     );
   });
 
+g.test('stepInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: 1 },
+      { input: [1, 1], expected: 1 },
+      { input: [0, 1], expected: 1 },
+      { input: [1, 0], expected: 0 },
+      { input: [-1, -1], expected: 1 },
+      { input: [0, -1], expected: 0 },
+      { input: [-1, 0], expected: 1 },
+      { input: [-1, 1], expected: 1 },
+      { input: [1, -1], expected: 0 },
+
+      // 64-bit normals
+      { input: [0.1, 0.1], expected: [0, 1] },
+      { input: [0, 0.1], expected: 1 },
+      { input: [0.1, 0], expected: 0 },
+      { input: [0.1, 1], expected: 1 },
+      { input: [1, 0.1], expected: 0 },
+      { input: [-0.1, -0.1], expected: [0, 1] },
+      { input: [0, -0.1], expected: 0 },
+      { input: [-0.1, 0], expected: 1 },
+      { input: [-0.1, -1], expected: 0 },
+      { input: [-1, -0.1], expected: 1 },
+
+      // Subnormals
+      { input: [0, kValue.f32.subnormal.positive.max], expected: 1 },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: 1 },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [0, 1] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [0, 1] },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: 0 },
+      { input: [1, kValue.f32.subnormal.positive.min], expected: 0 },
+      { input: [1, kValue.f32.subnormal.negative.max], expected: 0 },
+      { input: [1, kValue.f32.subnormal.negative.min], expected: 0 },
+      { input: [-1, kValue.f32.subnormal.positive.max], expected: 1 },
+      { input: [-1, kValue.f32.subnormal.positive.min], expected: 1 },
+      { input: [-1, kValue.f32.subnormal.negative.max], expected: 1 },
+      { input: [-1, kValue.f32.subnormal.negative.min], expected: 1 },
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, 1] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, 1] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: 1 },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: 1 },
+      { input: [kValue.f32.subnormal.positive.max, 1], expected: 1 },
+      { input: [kValue.f32.subnormal.positive.min, 1], expected: 1 },
+      { input: [kValue.f32.subnormal.negative.max, 1], expected: 1 },
+      { input: [kValue.f32.subnormal.negative.min, 1], expected: 1 },
+      { input: [kValue.f32.subnormal.positive.max, -1], expected: 0 },
+      { input: [kValue.f32.subnormal.positive.min, -1], expected: 0 },
+      { input: [kValue.f32.subnormal.negative.max, -1], expected: 0 },
+      { input: [kValue.f32.subnormal.negative.min, -1], expected: 0 },
+      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: 1 },
+      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min], expected: [0, 1] },
+
+      // Infinities
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [edge, x] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.stepInterval(edge, x);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.stepInterval(${edge}, ${x}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 g.test('subtractionInterval_f32')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1304,6 +1304,58 @@ g.test('distanceIntervalScalar_f32')
     );
   });
 
+g.test('divisionInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 1], expected: 0 },
+      { input: [0, -1], expected: 0 },
+      { input: [1, 1], expected: 1 },
+      { input: [1, -1], expected: -1 },
+      { input: [-1, 1], expected: -1 },
+      { input: [-1, -1], expected: 1 },
+      { input: [4, 2], expected: 2 },
+      { input: [-4, 2], expected: -2 },
+      { input: [4, -2], expected: -2 },
+      { input: [-4, -2], expected: 2 },
+
+      // 64-bit normals
+      { input: [0, 0.1], expected: 0 },
+      { input: [0, -0.1], expected: 0 },
+      { input: [1, 0.1], expected: [minusOneULPF32(10), plusOneULPF32(10)] },
+      { input: [-1, 0.1], expected: [minusOneULPF32(-10), plusOneULPF32(-10)] },
+      { input: [1, -0.1], expected: [minusOneULPF32(-10), plusOneULPF32(-10)] },
+      { input: [-1, -0.1], expected: [minusOneULPF32(10), plusOneULPF32(10)] },
+
+      // Denominator out of range
+      { input: [1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [1, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
+      { input: [1, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [1, 0], expected: kAnyBounds },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const error = (n: number): number => {
+      return 2.5 * oneULPF32(n);
+    };
+
+    const [x, y] = t.params.input;
+    t.params.expected = applyError(t.params.expected, error);
+    const expected = FP.f32.toInterval(t.params.expected);
+
+    const got = FP.f32.divisionInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.divisionInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1118,6 +1118,69 @@ g.test('truncInterval_f32')
     );
   });
 
+interface ScalarPairToIntervalCase {
+  // input is a pair of independent values, not a range, so should not be
+  // converted to a FPInterval.
+  input: [number, number];
+  expected: number | IntervalBounds;
+}
+
+g.test('additionInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: 0 },
+      { input: [1, 0], expected: 1 },
+      { input: [0, 1], expected: 1 },
+      { input: [-1, 0], expected: -1 },
+      { input: [0, -1], expected: -1 },
+      { input: [1, 1], expected: 2 },
+      { input: [1, -1], expected: 0 },
+      { input: [-1, 1], expected: 0 },
+      { input: [-1, -1], expected: -2 },
+
+      // 64-bit normals
+      { input: [0.1, 0], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [-0.1, 0], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [0, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3e4ccccd)), hexToF32(0x3e4ccccd)] },  // ~0.2
+      { input: [0.1, -0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULPF32(hexToF32(0x3dcccccd))] }, // ~0
+      { input: [-0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)) - hexToF32(0x3dcccccd), hexToF32(0x3dcccccd) - minusOneULPF32(hexToF32(0x3dcccccd))] }, // ~0
+      { input: [-0.1, -0.1], expected: [hexToF32(0xbe4ccccd), plusOneULPF32(hexToF32(0xbe4ccccd))] },  // ~-0.2
+
+      // 32-bit subnormals
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
+
+      // Infinities
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.additionInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.additionInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface VectorToIntervalCase {
   input: number[];
   expected: number | IntervalBounds;

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1356,6 +1356,54 @@ g.test('divisionInterval_f32')
     );
   });
 
+g.test('ldexpInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: 0 },
+      { input: [0, 1], expected: 0 },
+      { input: [0, -1], expected: 0 },
+      { input: [1, 1], expected: 2 },
+      { input: [1, -1], expected: 0.5 },
+      { input: [-1, 1], expected: -2 },
+      { input: [-1, -1], expected: -0.5 },
+
+      // 64-bit normals
+      { input: [0, 0.1], expected: 0 },
+      { input: [0, -0.1], expected: 0 },
+      { input: [1.0000000001, 1], expected: [2, plusNULPF32(2, 2)] },  // ~2, additional ULP error due to first param not being f32 precise
+      { input: [-1.0000000001, 1], expected: [minusNULPF32(-2, 2), -2] },  // ~-2, additional ULP error due to first param not being f32 precise
+
+      // Edge Cases
+      { input: [1.9999998807907104, 127], expected: kValue.f32.positive.max },
+      { input: [1, -126], expected: kValue.f32.positive.min },
+      { input: [0.9999998807907104, -126], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [1.1920928955078125e-07, -126], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [-1.1920928955078125e-07, -126], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [-0.9999998807907104, -126], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [-1, -126], expected: kValue.f32.negative.max },
+      { input: [-1.9999998807907104, 127], expected: kValue.f32.negative.min },
+
+      // Out of Bounds
+      { input: [1, 128], expected: kAnyBounds },
+      { input: [-1, 128], expected: kAnyBounds },
+      { input: [100, 126], expected: kAnyBounds },
+      { input: [-100, 126], expected: kAnyBounds },
+      { input: [kValue.f32.positive.max, kValue.i32.positive.max], expected: kAnyBounds },
+      { input: [kValue.f32.negative.min, kValue.i32.positive.max], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.ldexpInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.ldexpInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 g.test('multiplicationInterval_f32')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1418,6 +1418,56 @@ g.test('multiplicationInterval_f32')
     );
   });
 
+g.test('remainderInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 1], expected: [0, 0] },
+      { input: [0, -1], expected: [0, 0] },
+      { input: [1, 1], expected: [0, 1] },
+      { input: [1, -1], expected: [0, 1] },
+      { input: [-1, 1], expected: [-1, 0] },
+      { input: [-1, -1], expected: [-1, 0] },
+      { input: [4, 2], expected: [0, 2] },
+      { input: [-4, 2], expected: [-2, 0] },
+      { input: [4, -2], expected: [0, 2] },
+      { input: [-4, -2], expected: [-2, 0] },
+      { input: [2, 4], expected: [2, 2] },
+      { input: [-2, 4], expected: [-2, -2] },
+      { input: [2, -4], expected: [2, 2] },
+      { input: [-2, -4], expected: [-2, -2] },
+
+      // 64-bit normals
+      { input: [0, 0.1], expected: [0, 0] },
+      { input: [0, -0.1], expected: [0, 0] },
+      { input: [1, 0.1], expected: [hexToF32(0xb4000000), hexToF32(0x3dccccd8)] }, // ~[0, 0.1]
+      { input: [-1, 0.1], expected: [hexToF32(0xbdccccd8), hexToF32(0x34000000)] }, // ~[-0.1, 0]
+      { input: [1, -0.1], expected: [hexToF32(0xb4000000), hexToF32(0x3dccccd8)] }, // ~[0, 0.1]
+      { input: [-1, -0.1], expected: [hexToF32(0xbdccccd8), hexToF32(0x34000000)] }, // ~[-0.1, 0]
+
+      // Denominator out of range
+      { input: [1, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [1, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
+      { input: [1, kValue.f32.negative.min], expected: kAnyBounds },
+      { input: [1, 0], expected: kAnyBounds },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.remainderInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.remainderInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 g.test('subtractionInterval_f32')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1404,6 +1404,122 @@ g.test('ldexpInterval_f32')
     );
   });
 
+g.test('maxInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: 0 },
+      { input: [1, 0], expected: 1 },
+      { input: [0, 1], expected: 1 },
+      { input: [-1, 0], expected: 0 },
+      { input: [0, -1], expected: 0 },
+      { input: [1, 1], expected: 1 },
+      { input: [1, -1], expected: 1 },
+      { input: [-1, 1], expected: 1 },
+      { input: [-1, -1], expected: -1 },
+
+      // 64-bit normals
+      { input: [0.1, 0], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [-0.1, 0], expected: 0 },
+      { input: [0, -0.1], expected: 0 },
+      { input: [0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0.1, -0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [-0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+
+      // 32-bit subnormals
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: 1 },
+      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
+
+      // Infinities
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.maxInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.maxInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('minInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // 32-bit normals
+      { input: [0, 0], expected: 0 },
+      { input: [1, 0], expected: 0 },
+      { input: [0, 1], expected: 0 },
+      { input: [-1, 0], expected: -1 },
+      { input: [0, -1], expected: -1 },
+      { input: [1, 1], expected: 1 },
+      { input: [1, -1], expected: -1 },
+      { input: [-1, 1], expected: -1 },
+      { input: [-1, -1], expected: -1 },
+
+      // 64-bit normals
+      { input: [0.1, 0], expected: 0 },
+      { input: [0, 0.1], expected: 0 },
+      { input: [-0.1, 0], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [0, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
+      { input: [0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [-0.1, 0.1], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+      { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
+
+      // 32-bit subnormals
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
+      { input: [-1, kValue.f32.subnormal.positive.max], expected: -1 },
+      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
+
+      // Infinities
+      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.minInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.minInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 g.test('multiplicationInterval_f32')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore
@@ -1463,65 +1579,6 @@ g.test('multiplicationInterval_f32')
     t.expect(
       objectEquals(expected, got),
       `f32.multiplicationInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
-    );
-  });
-
-g.test('maxInterval_f32')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 0 },
-      { input: [1, 0], expected: 1 },
-      { input: [0, 1], expected: 1 },
-      { input: [-1, 0], expected: 0 },
-      { input: [0, -1], expected: 0 },
-      { input: [1, 1], expected: 1 },
-      { input: [1, -1], expected: 1 },
-      { input: [-1, 1], expected: 1 },
-      { input: [-1, -1], expected: -1 },
-
-      // 64-bit normals
-      { input: [0.1, 0], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [0, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, 0], expected: 0 },
-      { input: [0, -0.1], expected: 0 },
-      { input: [0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [0.1, -0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, 0.1], expected: [minusOneULPF32(hexToF32(0x3dcccccd)), hexToF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, -0.1], expected: [hexToF32(0xbdcccccd), plusOneULPF32(hexToF32(0xbdcccccd))] },  // ~-0.1
-
-      // 32-bit subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: 1 },
-      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
-
-
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-    ]
-  )
-  .fn(t => {
-    const [x, y] = t.params.input;
-    const expected = FP.f32.toInterval(t.params.expected);
-    const got = FP.f32.maxInterval(x, y);
-    t.expect(
-      objectEquals(expected, got),
-      `f32.maxInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -1582,6 +1582,39 @@ g.test('multiplicationInterval_f32')
     );
   });
 
+g.test('powInterval_f32')
+  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
+    // prettier-ignore
+    [
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+      { input: [-1, 0], expected: kAnyBounds },
+      { input: [0, 0], expected: kAnyBounds },
+      { input: [1, 0], expected: [minusNULPF32(1, 3), hexToF64(0x3ff0_0000_3000_0000n)] },  // ~1
+      { input: [2, 0], expected: [minusNULPF32(1, 3), hexToF64(0x3ff0_0000_3000_0000n)] },  // ~1
+      { input: [kValue.f32.positive.max, 0], expected: [minusNULPF32(1, 3), hexToF64(0x3ff0_0000_3000_0000n)] },  // ~1
+      { input: [0, 1], expected: kAnyBounds },
+      { input: [1, 1], expected: [hexToF64(0x3fef_fffe_dfff_fe00n), hexToF64(0x3ff0_0000_c000_0200n)] },  // ~1
+      { input: [1, 100], expected: [hexToF64(0x3fef_ffba_3fff_3800n), hexToF64(0x3ff0_0023_2000_c800n)] },  // ~1
+      { input: [1, kValue.f32.positive.max], expected: kAnyBounds },
+      { input: [2, 1], expected: [hexToF64(0x3fff_fffe_a000_0200n), hexToF64(0x4000_0001_0000_0200n)] },  // ~2
+      { input: [2, 2], expected: [hexToF64(0x400f_fffd_a000_0400n), hexToF64(0x4010_0001_a000_0400n)] },  // ~4
+      { input: [10, 10], expected: [hexToF64(0x4202_a04f_51f7_7000n), hexToF64(0x4202_a070_ee08_e000n)] },  // ~10000000000
+      { input: [10, 1], expected: [hexToF64(0x4023_fffe_0b65_8b00n), hexToF64(0x4024_0002_149a_7c00n)] },  // ~10
+      { input: [kValue.f32.positive.max, 1], expected: kAnyBounds },
+    ]
+  )
+  .fn(t => {
+    const [x, y] = t.params.input;
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.powInterval(x, y);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.powInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 g.test('remainderInterval_f32')
   .paramsSubcasesOnly<ScalarPairToIntervalCase>(
     // prettier-ignore

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -6,7 +6,6 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../util/conversion.js';
 import {
-  divisionInterval,
   F32Vector,
   multiplicationInterval,
   remainderInterval,
@@ -18,7 +17,6 @@ import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import {
   allInputSources,
-  generateBinaryToF32IntervalCases,
   generateF32VectorToVectorCases,
   generateVectorF32ToVectorCases,
   run,
@@ -28,12 +26,12 @@ import { binary, compoundBinary } from './binary.js';
 
 // Utility wrappers around the interval generators for the scalar-vector and
 // vector-scalar tests.
-const additionVectorScalarIntervalF32 = (v: number[], s: number): F32Vector => {
-  return toF32Vector(v.map(e => FP.f32.additionInterval(e, s)));
+const additionVectorScalarInterval = (v: number[], s: number): F32Vector => {
+  return FP.f32.toVector(v.map(e => FP.f32.additionInterval(e, s)));
 };
 
-const additionScalarVectorIntervalF32 = (s: number, v: number[]): F32Vector => {
-  return toF32Vector(v.map(e => FP.f32.additionInterval(s, e)));
+const additionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+  return FP.f32.toVector(v.map(e => FP.f32.additionInterval(s, e)));
 };
 
 const subtractionVectorScalarInterval = (v: number[], s: number): F32Vector => {
@@ -53,11 +51,11 @@ const multiplicationScalarVectorInterval = (s: number, v: number[]): F32Vector =
 };
 
 const divisionVectorScalarInterval = (v: number[], s: number): F32Vector => {
-  return toF32Vector(v.map(e => divisionInterval(e, s)));
+  return FP.f32.toVector(v.map(e => FP.f32.divisionInterval(e, s)));
 };
 
 const divisionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
-  return toF32Vector(v.map(e => divisionInterval(s, e)));
+  return FP.f32.toVector(v.map(e => FP.f32.divisionInterval(s, e)));
 };
 
 const remainderVectorScalarInterval = (v: number[], s: number): F32Vector => {
@@ -88,103 +86,103 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   addition_vec2_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'finite',
-      additionVectorScalarIntervalF32
+      additionVectorScalarInterval
     );
   },
   addition_vec2_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'unfiltered',
-      additionVectorScalarIntervalF32
+      additionVectorScalarInterval
     );
   },
   addition_vec3_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'finite',
-      additionVectorScalarIntervalF32
+      additionVectorScalarInterval
     );
   },
   addition_vec3_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'unfiltered',
-      additionVectorScalarIntervalF32
+      additionVectorScalarInterval
     );
   },
   addition_vec4_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'finite',
-      additionVectorScalarIntervalF32
+      additionVectorScalarInterval
     );
   },
   addition_vec4_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'unfiltered',
-      additionVectorScalarIntervalF32
+      additionVectorScalarInterval
     );
   },
   addition_scalar_vec2_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'finite',
-      additionScalarVectorIntervalF32
+      additionScalarVectorInterval
     );
   },
   addition_scalar_vec2_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
-      additionScalarVectorIntervalF32
+      additionScalarVectorInterval
     );
   },
   addition_scalar_vec3_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'finite',
-      additionScalarVectorIntervalF32
+      additionScalarVectorInterval
     );
   },
   addition_scalar_vec3_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
-      additionScalarVectorIntervalF32
+      additionScalarVectorInterval
     );
   },
   addition_scalar_vec4_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'finite',
-      additionScalarVectorIntervalF32
+      additionScalarVectorInterval
     );
   },
   addition_scalar_vec4_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
-      additionScalarVectorIntervalF32
+      additionScalarVectorInterval
     );
   },
   subtraction_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'finite',
@@ -192,7 +190,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_non_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
@@ -296,7 +294,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'finite',
@@ -304,7 +302,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_non_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
@@ -408,23 +406,23 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'finite',
-      divisionInterval
+      FP.f32.divisionInterval
     );
   },
   division_non_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
-      divisionInterval
+      FP.f32.divisionInterval
     );
   },
   division_vec2_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'finite',
@@ -432,7 +430,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_vec2_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'unfiltered',
@@ -440,7 +438,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_vec3_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'finite',
@@ -448,7 +446,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_vec3_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'unfiltered',
@@ -456,7 +454,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_vec4_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'finite',
@@ -464,7 +462,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_vec4_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'unfiltered',
@@ -472,7 +470,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_scalar_vec2_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'finite',
@@ -480,7 +478,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_scalar_vec2_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
@@ -488,7 +486,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_scalar_vec3_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'finite',
@@ -496,7 +494,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_scalar_vec3_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
@@ -504,7 +502,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_scalar_vec4_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'finite',
@@ -512,7 +510,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   division_scalar_vec4_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
@@ -520,7 +518,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'finite',
@@ -528,7 +526,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_non_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'unfiltered',

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -5,8 +5,7 @@ Execution Tests for the f32 arithmetic binary expression operations
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../util/conversion.js';
-import { F32Vector, remainderInterval, toF32Vector } from '../../../../util/f32_interval.js';
-import { FP } from '../../../../util/floating_point.js';
+import { FP, FPVector } from '../../../../util/floating_point.js';
 import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, run } from '../expression.js';
@@ -15,44 +14,44 @@ import { binary, compoundBinary } from './binary.js';
 
 // Utility wrappers around the interval generators for the scalar-vector and
 // vector-scalar tests.
-const additionVectorScalarInterval = (v: number[], s: number): F32Vector => {
+const additionVectorScalarInterval = (v: number[], s: number): FPVector => {
   return FP.f32.toVector(v.map(e => FP.f32.additionInterval(e, s)));
 };
 
-const additionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+const additionScalarVectorInterval = (s: number, v: number[]): FPVector => {
   return FP.f32.toVector(v.map(e => FP.f32.additionInterval(s, e)));
 };
 
-const subtractionVectorScalarInterval = (v: number[], s: number): F32Vector => {
+const subtractionVectorScalarInterval = (v: number[], s: number): FPVector => {
   return FP.f32.toVector(v.map(e => FP.f32.subtractionInterval(e, s)));
 };
 
-const subtractionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+const subtractionScalarVectorInterval = (s: number, v: number[]): FPVector => {
   return FP.f32.toVector(v.map(e => FP.f32.subtractionInterval(s, e)));
 };
 
-const multiplicationVectorScalarInterval = (v: number[], s: number): F32Vector => {
+const multiplicationVectorScalarInterval = (v: number[], s: number): FPVector => {
   return FP.f32.toVector(v.map(e => FP.f32.multiplicationInterval(e, s)));
 };
 
-const multiplicationScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+const multiplicationScalarVectorInterval = (s: number, v: number[]): FPVector => {
   return FP.f32.toVector(v.map(e => FP.f32.multiplicationInterval(s, e)));
 };
 
-const divisionVectorScalarInterval = (v: number[], s: number): F32Vector => {
+const divisionVectorScalarInterval = (v: number[], s: number): FPVector => {
   return FP.f32.toVector(v.map(e => FP.f32.divisionInterval(e, s)));
 };
 
-const divisionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
+const divisionScalarVectorInterval = (s: number, v: number[]): FPVector => {
   return FP.f32.toVector(v.map(e => FP.f32.divisionInterval(s, e)));
 };
 
-const remainderVectorScalarInterval = (v: number[], s: number): F32Vector => {
-  return toF32Vector(v.map(e => remainderInterval(e, s)));
+const remainderVectorScalarInterval = (v: number[], s: number): FPVector => {
+  return FP.f32.toVector(v.map(e => FP.f32.remainderInterval(e, s)));
 };
 
-const remainderScalarVectorInterval = (s: number, v: number[]): F32Vector => {
-  return toF32Vector(v.map(e => remainderInterval(s, e)));
+const remainderScalarVectorInterval = (s: number, v: number[]): FPVector => {
+  return FP.f32.toVector(v.map(e => FP.f32.remainderInterval(s, e)));
 };
 
 export const g = makeTestGroup(GPUTest);
@@ -511,7 +510,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       fullF32Range(),
       'finite',
-      remainderInterval
+      FP.f32.remainderInterval
     );
   },
   remainder_non_const: () => {
@@ -519,7 +518,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
-      remainderInterval
+      FP.f32.remainderInterval
     );
   },
   remainder_vec2_scalar_const: () => {

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -6,7 +6,6 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../util/conversion.js';
 import {
-  additionInterval,
   divisionInterval,
   F32Vector,
   multiplicationInterval,
@@ -14,6 +13,7 @@ import {
   subtractionInterval,
   toF32Vector,
 } from '../../../../util/f32_interval.js';
+import { FP } from '../../../../util/floating_point.js';
 import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import {
@@ -28,12 +28,12 @@ import { binary, compoundBinary } from './binary.js';
 
 // Utility wrappers around the interval generators for the scalar-vector and
 // vector-scalar tests.
-const additionVectorScalarInterval = (v: number[], s: number): F32Vector => {
-  return toF32Vector(v.map(e => additionInterval(e, s)));
+const additionVectorScalarIntervalF32 = (v: number[], s: number): F32Vector => {
+  return toF32Vector(v.map(e => FP.f32.additionInterval(e, s)));
 };
 
-const additionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
-  return toF32Vector(v.map(e => additionInterval(s, e)));
+const additionScalarVectorIntervalF32 = (s: number, v: number[]): F32Vector => {
+  return toF32Vector(v.map(e => FP.f32.additionInterval(s, e)));
 };
 
 const subtractionVectorScalarInterval = (v: number[], s: number): F32Vector => {
@@ -72,19 +72,19 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('binary/f32_arithmetic', {
   addition_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'finite',
-      additionInterval
+      FP.f32.additionInterval
     );
   },
   addition_non_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
-      additionInterval
+      FP.f32.additionInterval
     );
   },
   addition_vec2_scalar_const: () => {
@@ -92,7 +92,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       sparseVectorF32Range(2),
       fullF32Range(),
       'finite',
-      additionVectorScalarInterval
+      additionVectorScalarIntervalF32
     );
   },
   addition_vec2_scalar_non_const: () => {
@@ -100,7 +100,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       sparseVectorF32Range(2),
       fullF32Range(),
       'unfiltered',
-      additionVectorScalarInterval
+      additionVectorScalarIntervalF32
     );
   },
   addition_vec3_scalar_const: () => {
@@ -108,7 +108,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       sparseVectorF32Range(3),
       fullF32Range(),
       'finite',
-      additionVectorScalarInterval
+      additionVectorScalarIntervalF32
     );
   },
   addition_vec3_scalar_non_const: () => {
@@ -116,7 +116,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       sparseVectorF32Range(3),
       fullF32Range(),
       'unfiltered',
-      additionVectorScalarInterval
+      additionVectorScalarIntervalF32
     );
   },
   addition_vec4_scalar_const: () => {
@@ -124,7 +124,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       sparseVectorF32Range(4),
       fullF32Range(),
       'finite',
-      additionVectorScalarInterval
+      additionVectorScalarIntervalF32
     );
   },
   addition_vec4_scalar_non_const: () => {
@@ -132,7 +132,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       sparseVectorF32Range(4),
       fullF32Range(),
       'unfiltered',
-      additionVectorScalarInterval
+      additionVectorScalarIntervalF32
     );
   },
   addition_scalar_vec2_const: () => {
@@ -140,7 +140,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       sparseVectorF32Range(2),
       'finite',
-      additionScalarVectorInterval
+      additionScalarVectorIntervalF32
     );
   },
   addition_scalar_vec2_non_const: () => {
@@ -148,7 +148,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
-      additionScalarVectorInterval
+      additionScalarVectorIntervalF32
     );
   },
   addition_scalar_vec3_const: () => {
@@ -156,7 +156,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       sparseVectorF32Range(3),
       'finite',
-      additionScalarVectorInterval
+      additionScalarVectorIntervalF32
     );
   },
   addition_scalar_vec3_non_const: () => {
@@ -164,7 +164,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
-      additionScalarVectorInterval
+      additionScalarVectorIntervalF32
     );
   },
   addition_scalar_vec4_const: () => {
@@ -172,7 +172,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       sparseVectorF32Range(4),
       'finite',
-      additionScalarVectorInterval
+      additionScalarVectorIntervalF32
     );
   },
   addition_scalar_vec4_non_const: () => {
@@ -180,7 +180,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
-      additionScalarVectorInterval
+      additionScalarVectorIntervalF32
     );
   },
   subtraction_const: () => {

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -9,18 +9,12 @@ import {
   F32Vector,
   multiplicationInterval,
   remainderInterval,
-  subtractionInterval,
   toF32Vector,
 } from '../../../../util/f32_interval.js';
 import { FP } from '../../../../util/floating_point.js';
 import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import {
-  allInputSources,
-  generateF32VectorToVectorCases,
-  generateVectorF32ToVectorCases,
-  run,
-} from '../expression.js';
+import { allInputSources, run } from '../expression.js';
 
 import { binary, compoundBinary } from './binary.js';
 
@@ -35,11 +29,11 @@ const additionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
 };
 
 const subtractionVectorScalarInterval = (v: number[], s: number): F32Vector => {
-  return toF32Vector(v.map(e => subtractionInterval(e, s)));
+  return FP.f32.toVector(v.map(e => FP.f32.subtractionInterval(e, s)));
 };
 
 const subtractionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
-  return toF32Vector(v.map(e => subtractionInterval(s, e)));
+  return FP.f32.toVector(v.map(e => FP.f32.subtractionInterval(s, e)));
 };
 
 const multiplicationVectorScalarInterval = (v: number[], s: number): F32Vector => {
@@ -186,7 +180,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       fullF32Range(),
       'finite',
-      subtractionInterval
+      FP.f32.subtractionInterval
     );
   },
   subtraction_non_const: () => {
@@ -194,11 +188,11 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
-      subtractionInterval
+      FP.f32.subtractionInterval
     );
   },
   subtraction_vec2_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'finite',
@@ -206,7 +200,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_vec2_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'unfiltered',
@@ -214,7 +208,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_vec3_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'finite',
@@ -222,7 +216,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_vec3_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'unfiltered',
@@ -230,7 +224,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_vec4_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'finite',
@@ -238,7 +232,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_vec4_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'unfiltered',
@@ -246,7 +240,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_scalar_vec2_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'finite',
@@ -254,7 +248,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_scalar_vec2_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
@@ -262,7 +256,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_scalar_vec3_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'finite',
@@ -270,7 +264,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_scalar_vec3_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
@@ -278,7 +272,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_scalar_vec4_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'finite',
@@ -286,7 +280,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   subtraction_scalar_vec4_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
@@ -310,7 +304,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_vec2_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'finite',
@@ -318,7 +312,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_vec2_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'unfiltered',
@@ -326,7 +320,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_vec3_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'finite',
@@ -334,7 +328,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_vec3_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'unfiltered',
@@ -342,7 +336,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_vec4_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'finite',
@@ -350,7 +344,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_vec4_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'unfiltered',
@@ -358,7 +352,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_scalar_vec2_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'finite',
@@ -366,7 +360,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_scalar_vec2_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
@@ -374,7 +368,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_scalar_vec3_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'finite',
@@ -382,7 +376,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_scalar_vec3_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
@@ -390,7 +384,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_scalar_vec4_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'finite',
@@ -398,7 +392,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   multiplication_scalar_vec4_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
@@ -534,7 +528,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_vec2_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'finite',
@@ -542,7 +536,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_vec2_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
       fullF32Range(),
       'unfiltered',
@@ -550,7 +544,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_vec3_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'finite',
@@ -558,7 +552,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_vec3_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
       fullF32Range(),
       'unfiltered',
@@ -566,7 +560,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_vec4_scalar_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'finite',
@@ -574,7 +568,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_vec4_scalar_non_const: () => {
-    return generateVectorF32ToVectorCases(
+    return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
       fullF32Range(),
       'unfiltered',
@@ -582,7 +576,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_scalar_vec2_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'finite',
@@ -590,7 +584,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_scalar_vec2_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
@@ -598,7 +592,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_scalar_vec3_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'finite',
@@ -606,7 +600,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_scalar_vec3_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
@@ -614,7 +608,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_scalar_vec4_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'finite',
@@ -622,7 +616,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
     );
   },
   remainder_scalar_vec4_non_const: () => {
-    return generateF32VectorToVectorCases(
+    return FP.f32.generateScalarVectorToVectorCases(
       fullF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',

--- a/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_arithmetic.spec.ts
@@ -5,12 +5,7 @@ Execution Tests for the f32 arithmetic binary expression operations
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../util/conversion.js';
-import {
-  F32Vector,
-  multiplicationInterval,
-  remainderInterval,
-  toF32Vector,
-} from '../../../../util/f32_interval.js';
+import { F32Vector, remainderInterval, toF32Vector } from '../../../../util/f32_interval.js';
 import { FP } from '../../../../util/floating_point.js';
 import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
@@ -37,11 +32,11 @@ const subtractionScalarVectorInterval = (s: number, v: number[]): F32Vector => {
 };
 
 const multiplicationVectorScalarInterval = (v: number[], s: number): F32Vector => {
-  return toF32Vector(v.map(e => multiplicationInterval(e, s)));
+  return FP.f32.toVector(v.map(e => FP.f32.multiplicationInterval(e, s)));
 };
 
 const multiplicationScalarVectorInterval = (s: number, v: number[]): F32Vector => {
-  return toF32Vector(v.map(e => multiplicationInterval(s, e)));
+  return FP.f32.toVector(v.map(e => FP.f32.multiplicationInterval(s, e)));
 };
 
 const divisionVectorScalarInterval = (v: number[], s: number): F32Vector => {
@@ -292,7 +287,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       fullF32Range(),
       'finite',
-      multiplicationInterval
+      FP.f32.multiplicationInterval
     );
   },
   multiplication_non_const: () => {
@@ -300,7 +295,7 @@ export const d = makeCaseCache('binary/f32_arithmetic', {
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
-      multiplicationInterval
+      FP.f32.multiplicationInterval
     );
   },
   multiplication_vec2_scalar_const: () => {

--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -11,10 +11,10 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { atan2Interval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { linearRange, sparseF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateBinaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -28,11 +28,11 @@ export const d = makeCaseCache('atan2', {
       ...sparseF32Range(),
       ...linearRange(kValue.f32.negative.max, kValue.f32.positive.min, 10),
     ];
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       numeric_range,
       numeric_range,
       'unfiltered',
-      atan2Interval
+      FP.f32.atan2Interval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/distance.spec.ts
@@ -11,15 +11,10 @@ Returns the distance between e1 and e2 (e.g. length(e1-e2)).
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../../util/conversion.js';
-import { distanceInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range, sparseVectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import {
-  allInputSources,
-  generateBinaryToF32IntervalCases,
-  generateVectorPairToF32IntervalCases,
-  run,
-} from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -27,67 +22,67 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('distance', {
   f32_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'finite',
-      distanceInterval
+      FP.f32.distanceInterval
     );
   },
   f32_non_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
-      distanceInterval
+      FP.f32.distanceInterval
     );
   },
   f32_vec2_const: () => {
-    return generateVectorPairToF32IntervalCases(
+    return FP.f32.generateVectorPairToIntervalCases(
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
       'finite',
-      distanceInterval
+      FP.f32.distanceInterval
     );
   },
   f32_vec2_non_const: () => {
-    return generateVectorPairToF32IntervalCases(
+    return FP.f32.generateVectorPairToIntervalCases(
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
       'unfiltered',
-      distanceInterval
+      FP.f32.distanceInterval
     );
   },
   f32_vec3_const: () => {
-    return generateVectorPairToF32IntervalCases(
+    return FP.f32.generateVectorPairToIntervalCases(
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
       'finite',
-      distanceInterval
+      FP.f32.distanceInterval
     );
   },
   f32_vec3_non_const: () => {
-    return generateVectorPairToF32IntervalCases(
+    return FP.f32.generateVectorPairToIntervalCases(
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
       'unfiltered',
-      distanceInterval
+      FP.f32.distanceInterval
     );
   },
   f32_vec4_const: () => {
-    return generateVectorPairToF32IntervalCases(
+    return FP.f32.generateVectorPairToIntervalCases(
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
       'finite',
-      distanceInterval
+      FP.f32.distanceInterval
     );
   },
   f32_vec4_non_const: () => {
-    return generateVectorPairToF32IntervalCases(
+    return FP.f32.generateVectorPairToIntervalCases(
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
       'unfiltered',
-      distanceInterval
+      FP.f32.distanceInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ldexp.spec.ts
@@ -14,14 +14,12 @@ Returns e1 * 2^e2. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { kValue } from '../../../../../util/constants.js';
-import { f32, i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
-import { ldexpInterval } from '../../../../../util/f32_interval.js';
+import { i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
+import { FP } from '../../../../../util/floating_point.js';
 import {
   biasedRange,
   fullF32Range,
   fullI32Range,
-  quantizeToF32,
   quantizeToI32,
 } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
@@ -31,21 +29,21 @@ import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
-const makeCase = (e1: number, e2: number): Case => {
+function makeCaseF32(e1: number, e2: number): Case {
   // Due to the heterogeneous types of the params to ldexp (f32 & i32),
   // makeBinaryToF32IntervalCase cannot be used here.
-  e1 = quantizeToF32(e1);
+  e1 = FP.f32.quantize(e1);
   e2 = quantizeToI32(e2);
-  const expected = ldexpInterval(e1, e2);
-  return { input: [f32(e1), i32(e2)], expected };
-};
+  const expected = FP.f32.ldexpInterval(e1, e2);
+  return { input: [FP.f32.scalarBuilder(e1), i32(e2)], expected };
+}
 
 export const d = makeCaseCache('ldexp', {
   f32_non_const: () => {
     const cases: Array<Case> = [];
     fullF32Range().forEach(e1 => {
       fullI32Range().forEach(e2 => {
-        cases.push(makeCase(e1, e2));
+        cases.push(makeCaseF32(e1, e2));
       });
     });
     return cases;
@@ -54,9 +52,8 @@ export const d = makeCaseCache('ldexp', {
     const cases: Array<Case> = [];
     fullF32Range().forEach(e1 => {
       biasedRange(-128, 128, 10).forEach(e2 => {
-        const val = e1 * Math.pow(2, e2);
-        if (val >= kValue.f32.negative.min && val <= kValue.f32.positive.max) {
-          cases.push(makeCase(e1, e2));
+        if (FP.f32.isFinite(e1 * Math.pow(2, e2))) {
+          cases.push(makeCaseF32(e1, e2));
         }
       });
     });

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -19,10 +19,10 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
-import { maxInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, generateBinaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -44,11 +44,11 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('max', {
   f32: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
-      maxInterval
+      FP.f32.maxInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -18,10 +18,10 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
-import { minInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, generateBinaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, Case, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -29,11 +29,11 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('min', {
   f32: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
-      minInterval
+      FP.f32.minInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/pow.spec.ts
@@ -10,10 +10,10 @@ Returns e1 raised to the power e2. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeF32 } from '../../../../../util/conversion.js';
-import { powInterval } from '../../../../../util/f32_interval.js';
+import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, generateBinaryToF32IntervalCases, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
 
@@ -21,14 +21,19 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('pow', {
   f32_const: () => {
-    return generateBinaryToF32IntervalCases(fullF32Range(), fullF32Range(), 'finite', powInterval);
+    return FP.f32.generateScalarPairToIntervalCases(
+      fullF32Range(),
+      fullF32Range(),
+      'finite',
+      FP.f32.powInterval
+    );
   },
   f32_non_const: () => {
-    return generateBinaryToF32IntervalCases(
+    return FP.f32.generateScalarPairToIntervalCases(
       fullF32Range(),
       fullF32Range(),
       'unfiltered',
-      powInterval
+      FP.f32.powInterval
     );
   },
 });

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -10,9 +10,9 @@ Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf } from '../../../../../util/compare.js';
-import { f32, TypeF32 } from '../../../../../util/conversion.js';
-import { stepInterval, toF32Interval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, quantizeToF32 } from '../../../../../util/math.js';
+import { TypeF32 } from '../../../../../util/conversion.js';
+import { FP } from '../../../../../util/floating_point.js';
+import { fullF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
@@ -22,25 +22,25 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('step', {
   f32: () => {
-    const zeroInterval = toF32Interval(0);
-    const oneInterval = toF32Interval(1);
+    const zeroInterval = FP.f32.toInterval(0);
+    const oneInterval = FP.f32.toInterval(1);
 
     // stepInterval's return value isn't always interpreted as an acceptance
     // interval, so makeBinaryToF32IntervalCase cannot be used here.
     // See the comment block on stepInterval for more details
     const makeCase = (edge: number, x: number): Case => {
-      edge = quantizeToF32(edge);
-      x = quantizeToF32(x);
-      const expected = stepInterval(edge, x);
+      edge = FP.f32.quantize(edge);
+      x = FP.f32.quantize(x);
+      const expected = FP.f32.stepInterval(edge, x);
 
       // [0, 0], [1, 1], or [-∞, +∞] cases
       if (expected.isPoint() || !expected.isFinite()) {
-        return { input: [f32(edge), f32(x)], expected };
+        return { input: [FP.f32.scalarBuilder(edge), FP.f32.scalarBuilder(x)], expected };
       }
 
       // [0, 1] case
       return {
-        input: [f32(edge), f32(x)],
+        input: [FP.f32.scalarBuilder(edge), FP.f32.scalarBuilder(x)],
         expected: anyOf(zeroInterval, oneInterval),
       };
     };

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -19,7 +19,6 @@ import {
   ScalarBuilder,
 } from '../../../util/conversion.js';
 import {
-  ScalarPairToInterval,
   MatrixPairToMatrix,
   MatrixScalarToMatrix,
   MatrixToMatrix,
@@ -819,54 +818,6 @@ function packScalarsToVector(
 export type IntervalFilter =
   | 'finite' // Expected to be finite in the interval numeric space
   | 'unfiltered'; // No expectations
-
-/**
- * @returns a Case for the params and binary interval generator provided
- * The Case will use use an interval comparator for matching results.
- * @param param0 the first param or left hand side to pass in
- * @param param1 the second param or rhs hand side to pass in
- * @param filter what interval filtering to apply
- * @param ops callbacks that implement generating an acceptance interval for a
- *            binary operation
- */
-function makeBinaryToF32IntervalCase(
-  param0: number,
-  param1: number,
-  filter: IntervalFilter,
-  ...ops: ScalarPairToInterval[]
-): Case | undefined {
-  param0 = quantizeToF32(param0);
-  param1 = quantizeToF32(param1);
-
-  const intervals = ops.map(o => o(param0, param1));
-  if (filter === 'finite' && intervals.some(i => !i.isFinite())) {
-    return undefined;
-  }
-  return { input: [f32(param0), f32(param1)], expected: anyOf(...intervals) };
-}
-
-/**
- * @returns an array of Cases for operations over a range of inputs
- * @param param0s array of inputs to try for the first param
- * @param param1s array of inputs to try for the second param
- * @param filter what interval filtering to apply
- * @param ops callbacks that implement generating an acceptance interval for a
- *            binary operation
- */
-export function generateBinaryToF32IntervalCases(
-  param0s: number[],
-  param1s: number[],
-  filter: IntervalFilter,
-  ...ops: ScalarPairToInterval[]
-): Case[] {
-  return cartesianProduct(param0s, param1s).reduce((cases, e) => {
-    const c = makeBinaryToF32IntervalCase(e[0], e[1], filter, ...ops);
-    if (c !== undefined) {
-      cases.push(c);
-    }
-    return cases;
-  }, new Array<Case>());
-}
 
 /**
  * @returns a Case for the params and ternary interval generator provided

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -220,10 +220,6 @@ export function smoothStepInterval(low: number, high: number, x: number): FPInte
   return FP.f32.smoothStepInterval(low, high, x);
 }
 
-export function stepInterval(edge: number, x: number): FPInterval {
-  return FP.f32.stepInterval(edge, x);
-}
-
 export function subtractionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
   return FP.f32.subtractionMatrixInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -124,10 +124,6 @@ export function additionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
   return FP.f32.additionMatrixInterval(x, y);
 }
 
-export function atan2Interval(y: number | FPInterval, x: number | FPInterval): FPInterval {
-  return FP.f32.atan2Interval(y, x);
-}
-
 export const clampIntervals = FP.f32.clampIntervals;
 
 export function clampMedianInterval(

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -120,10 +120,6 @@ export function ulpInterval(n: number, numULP: number): FPInterval {
   return FP.f32.ulpInterval(n, numULP);
 }
 
-export function additionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return FP.f32.additionInterval(x, y);
-}
-
 export function additionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
   return FP.f32.additionMatrixInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -248,10 +248,6 @@ export function stepInterval(edge: number, x: number): FPInterval {
   return FP.f32.stepInterval(edge, x);
 }
 
-export function subtractionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return FP.f32.subtractionInterval(x, y);
-}
-
 export function subtractionMatrixInterval(x: number[][], y: number[][]): FPMatrix {
   return FP.f32.subtractionMatrixInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -170,10 +170,6 @@ export function lengthInterval(n: number | FPInterval | number[] | FPVector): FP
   return FP.f32.lengthInterval(n);
 }
 
-export function minInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return FP.f32.minInterval(x, y);
-}
-
 export const mixIntervals = FP.f32.mixIntervals;
 
 export function mixImpreciseInterval(x: number, y: number, z: number): FPInterval {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -150,10 +150,6 @@ export function determinantInterval(m: number[][]): FPInterval {
   return FP.f32.determinantInterval(m);
 }
 
-export function divisionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return FP.f32.divisionInterval(x, y);
-}
-
 export function dotInterval(x: number[] | FPInterval[], y: number[] | FPInterval[]): FPInterval {
   return FP.f32.dotInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -150,10 +150,6 @@ export function determinantInterval(m: number[][]): FPInterval {
   return FP.f32.determinantInterval(m);
 }
 
-export function distanceInterval(x: number | number[], y: number | number[]): FPInterval {
-  return FP.f32.distanceInterval(x, y);
-}
-
 export function divisionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
   return FP.f32.divisionInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -232,10 +232,6 @@ export function refractInterval(i: number[], s: number[], r: number): FPVector {
   return FP.f32.refractInterval(i, s, r);
 }
 
-export function remainderInterval(x: number, y: number): FPInterval {
-  return FP.f32.remainderInterval(x, y);
-}
-
 export function smoothStepInterval(low: number, high: number, x: number): FPInterval {
   return FP.f32.smoothStepInterval(low, high, x);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -6,10 +6,6 @@ import { FPInterval, FPMatrix, FPVector, IntervalBounds, FP } from './floating_p
 
 // Interfaces
 
-export interface ScalarPairToInterval {
-  (x: number, y: number): FPInterval;
-}
-
 export interface ScalarTripleToInterval {
   (x: number, y: number, z: number): FPInterval;
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -170,10 +170,6 @@ export function lengthInterval(n: number | FPInterval | number[] | FPVector): FP
   return FP.f32.lengthInterval(n);
 }
 
-export function maxInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return FP.f32.maxInterval(x, y);
-}
-
 export function minInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
   return FP.f32.minInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -208,10 +208,6 @@ export function normalizeInterval(n: number[]): FPVector {
   return FP.f32.normalizeInterval(n);
 }
 
-export function powInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return FP.f32.powInterval(x, y);
-}
-
 export function reflectInterval(x: number[], y: number[]): FPVector {
   return FP.f32.reflectInterval(x, y);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -196,10 +196,6 @@ export function modfInterval(n: number): { fract: FPInterval; whole: FPInterval 
   return FP.f32.modfInterval(n);
 }
 
-export function multiplicationInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
-  return FP.f32.multiplicationInterval(x, y);
-}
-
 export function multiplicationMatrixScalarInterval(mat: number[][], scalar: number): FPMatrix {
   return FP.f32.multiplicationMatrixScalarInterval(mat, scalar);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -166,10 +166,6 @@ export function fmaInterval(x: number, y: number, z: number): FPInterval {
   return FP.f32.fmaInterval(x, y, z);
 }
 
-export function ldexpInterval(e1: number, e2: number): FPInterval {
-  return FP.f32.ldexpInterval(e1, e2);
-}
-
 export function lengthInterval(n: number | FPInterval | number[] | FPVector): FPInterval {
   return FP.f32.lengthInterval(n);
 }

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -1782,14 +1782,19 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of atan2(y, x) */
-  public atan2Interval(y: number | FPInterval, x: number | FPInterval): FPInterval {
+  protected atan2IntervalImpl(y: number | FPInterval, x: number | FPInterval): FPInterval {
     return this.runScalarPairToIntervalOp(
       this.toInterval(y),
       this.toInterval(x),
       this.Atan2IntervalOp
     );
   }
+
+  /** Calculate an acceptance interval of atan2(y, x) */
+  public abstract readonly atan2Interval: (
+    y: number | FPInterval,
+    x: number | FPInterval
+  ) => FPInterval;
 
   private readonly AtanhIntervalOp: ScalarToIntervalOp = {
     impl: (n: number) => {
@@ -3331,6 +3336,7 @@ class F32Traits extends FPTraits {
   public readonly asinInterval = this.asinIntervalImpl.bind(this);
   public readonly asinhInterval = this.asinhIntervalImpl.bind(this);
   public readonly atanInterval = this.atanIntervalImpl.bind(this);
+  public readonly atan2Interval = this.atan2IntervalImpl.bind(this);
   public readonly atanhInterval = this.atanhIntervalImpl.bind(this);
   public readonly ceilInterval = this.ceilIntervalImpl.bind(this);
   public readonly cosInterval = this.cosIntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2989,13 +2989,16 @@ abstract class FPTraits {
   };
 
   /** Calculate an acceptance interval for x % y */
-  public remainderInterval(x: number, y: number): FPInterval {
+  protected remainderIntervalImpl(x: number, y: number): FPInterval {
     return this.runScalarPairToIntervalOp(
       this.toInterval(x),
       this.toInterval(y),
       this.RemainderIntervalOp
     );
   }
+
+  /** Calculate an acceptance interval for x % y */
+  public abstract readonly remainderInterval: (x: number, y: number) => FPInterval;
 
   private readonly RoundIntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3535,6 +3538,7 @@ class F32Traits extends FPTraits {
   public readonly negationInterval = this.negationIntervalImpl.bind(this);
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);
   public readonly radiansInterval = this.radiansIntervalImpl.bind(this);
+  public readonly remainderInterval = this.remainderIntervalImpl.bind(this);
   public readonly roundInterval = this.roundIntervalImpl.bind(this);
   public readonly saturateInterval = this.saturateIntervalImpl.bind(this);
   public readonly signInterval = this.signIntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2872,14 +2872,16 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of pow(x, y) */
-  public powInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  protected powIntervalImpl(x: number | FPInterval, y: number | FPInterval): FPInterval {
     return this.runScalarPairToIntervalOp(
       this.toInterval(x),
       this.toInterval(y),
       this.PowIntervalOp
     );
   }
+
+  /** Calculate an acceptance interval of pow(x, y) */
+  public abstract readonly powInterval: (x: number | FPInterval, y: number | FPInterval) => FPInterval;
 
   // Once a full implementation of F16Interval exists, the correctlyRounded for
   // that can potentially be used instead of having a bespoke operation
@@ -3551,6 +3553,7 @@ class F32Traits extends FPTraits {
   public readonly minInterval = this.minIntervalImpl.bind(this);
   public readonly multiplicationInterval = this.multiplicationIntervalImpl.bind(this);
   public readonly negationInterval = this.negationIntervalImpl.bind(this);
+  public readonly powInterval = this.powIntervalImpl.bind(this);
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);
   public readonly radiansInterval = this.radiansIntervalImpl.bind(this);
   public readonly remainderInterval = this.remainderIntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2679,14 +2679,19 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of min(x, y) */
-  public minInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  protected minIntervalImpl(x: number | FPInterval, y: number | FPInterval): FPInterval {
     return this.runScalarPairToIntervalOp(
       this.toInterval(x),
       this.toInterval(y),
       this.MinIntervalOp
     );
   }
+
+  /** Calculate an acceptance interval of min(x, y) */
+  public abstract readonly minInterval: (
+    x: number | FPInterval,
+    y: number | FPInterval
+  ) => FPInterval;
 
   /** All acceptance interval functions for mix(x, y, z) */
   public readonly mixIntervals: ScalarTripleToInterval[] = [
@@ -3543,6 +3548,7 @@ class F32Traits extends FPTraits {
   public readonly logInterval = this.logIntervalImpl.bind(this);
   public readonly log2Interval = this.log2IntervalImpl.bind(this);
   public readonly maxInterval = this.maxIntervalImpl.bind(this);
+  public readonly minInterval = this.minIntervalImpl.bind(this);
   public readonly multiplicationInterval = this.multiplicationIntervalImpl.bind(this);
   public readonly negationInterval = this.negationIntervalImpl.bind(this);
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2569,10 +2569,12 @@ abstract class FPTraits {
     ),
   };
 
-  /** Calculate an acceptance interval of ldexp(e1, e2) */
-  public ldexpInterval(e1: number, e2: number): FPInterval {
+  protected ldexpIntervalImpl(e1: number, e2: number): FPInterval {
     return this.roundAndFlushScalarPairToInterval(e1, e2, this.LdexpIntervalOp);
   }
+
+  /** Calculate an acceptance interval of ldexp(e1, e2) */
+  public abstract readonly ldexpInterval: (e1: number, e2: number) => FPInterval;
 
   private readonly LengthIntervalScalarOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -3531,6 +3533,7 @@ class F32Traits extends FPTraits {
   public readonly floorInterval = this.floorIntervalImpl.bind(this);
   public readonly fractInterval = this.fractIntervalImpl.bind(this);
   public readonly inverseSqrtInterval = this.inverseSqrtIntervalImpl.bind(this);
+  public readonly ldexpInterval = this.ldexpIntervalImpl.bind(this);
   public readonly lengthInterval = this.lengthIntervalImpl.bind(this);
   public readonly logInterval = this.logIntervalImpl.bind(this);
   public readonly log2Interval = this.log2IntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2652,14 +2652,19 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of max(x, y) */
-  public maxInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  protected maxIntervalImpl(x: number | FPInterval, y: number | FPInterval): FPInterval {
     return this.runScalarPairToIntervalOp(
       this.toInterval(x),
       this.toInterval(y),
       this.MaxIntervalOp
     );
   }
+
+  /** Calculate an acceptance interval of max(x, y) */
+  public abstract readonly maxInterval: (
+    x: number | FPInterval,
+    y: number | FPInterval
+  ) => FPInterval;
 
   private readonly MinIntervalOp: ScalarPairToIntervalOp = {
     impl: (x: number, y: number): FPInterval => {
@@ -3537,6 +3542,7 @@ class F32Traits extends FPTraits {
   public readonly lengthInterval = this.lengthIntervalImpl.bind(this);
   public readonly logInterval = this.logIntervalImpl.bind(this);
   public readonly log2Interval = this.log2IntervalImpl.bind(this);
+  public readonly maxInterval = this.maxIntervalImpl.bind(this);
   public readonly multiplicationInterval = this.multiplicationIntervalImpl.bind(this);
   public readonly negationInterval = this.negationIntervalImpl.bind(this);
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -3169,14 +3169,19 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of x - y */
-  public subtractionInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  protected subtractionIntervalImpl(x: number | FPInterval, y: number | FPInterval): FPInterval {
     return this.runScalarPairToIntervalOp(
       this.toInterval(x),
       this.toInterval(y),
       this.SubtractionIntervalOp
     );
   }
+
+  /** Calculate an acceptance interval of x - y */
+  public abstract readonly subtractionInterval: (
+    x: number | FPInterval,
+    y: number | FPInterval
+  ) => FPInterval;
 
   /** Calculate an acceptance interval of x - y, when x and y are matrices */
   public subtractionMatrixInterval(x: Matrix<number>, y: Matrix<number>): FPMatrix {
@@ -3530,6 +3535,7 @@ class F32Traits extends FPTraits {
   public readonly sinInterval = this.sinIntervalImpl.bind(this);
   public readonly sinhInterval = this.sinhIntervalImpl.bind(this);
   public readonly sqrtInterval = this.sqrtIntervalImpl.bind(this);
+  public readonly subtractionInterval = this.subtractionIntervalImpl.bind(this);
   public readonly tanInterval = this.tanIntervalImpl.bind(this);
   public readonly tanhInterval = this.tanhIntervalImpl.bind(this);
   public readonly truncInterval = this.truncIntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2745,14 +2745,19 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance interval of x * y */
-  public multiplicationInterval(x: number | FPInterval, y: number | FPInterval): FPInterval {
+  protected multiplicationIntervalImpl(x: number | FPInterval, y: number | FPInterval): FPInterval {
     return this.runScalarPairToIntervalOp(
       this.toInterval(x),
       this.toInterval(y),
       this.MultiplicationIntervalOp
     );
   }
+
+  /** Calculate an acceptance interval of x * y */
+  public abstract readonly multiplicationInterval: (
+    x: number | FPInterval,
+    y: number | FPInterval
+  ) => FPInterval;
 
   /**
    * @returns the vector result of multiplying the given vector by the given
@@ -3526,6 +3531,7 @@ class F32Traits extends FPTraits {
   public readonly lengthInterval = this.lengthIntervalImpl.bind(this);
   public readonly logInterval = this.logIntervalImpl.bind(this);
   public readonly log2Interval = this.log2IntervalImpl.bind(this);
+  public readonly multiplicationInterval = this.multiplicationIntervalImpl.bind(this);
   public readonly negationInterval = this.negationIntervalImpl.bind(this);
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);
   public readonly radiansInterval = this.radiansIntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2881,7 +2881,10 @@ abstract class FPTraits {
   }
 
   /** Calculate an acceptance interval of pow(x, y) */
-  public abstract readonly powInterval: (x: number | FPInterval, y: number | FPInterval) => FPInterval;
+  public abstract readonly powInterval: (
+    x: number | FPInterval,
+    y: number | FPInterval
+  ) => FPInterval;
 
   // Once a full implementation of F16Interval exists, the correctlyRounded for
   // that can potentially be used instead of having a bespoke operation
@@ -3166,7 +3169,16 @@ abstract class FPTraits {
     },
   };
 
-  /** Calculate an acceptance 'interval' for step(edge, x)
+  protected stepIntervalImpl(edge: number, x: number): FPInterval {
+    return this.runScalarPairToIntervalOp(
+      this.toInterval(edge),
+      this.toInterval(x),
+      this.StepIntervalOp
+    );
+  }
+
+  /**
+   * Calculate an acceptance 'interval' for step(edge, x)
    *
    * step only returns two possible values, so its interval requires special
    * interpretation in CTS tests.
@@ -3177,13 +3189,7 @@ abstract class FPTraits {
    * [-∞, +∞] is treated as any interval, since an undefined or infinite value
    * was passed in.
    */
-  public stepInterval(edge: number, x: number): FPInterval {
-    return this.runScalarPairToIntervalOp(
-      this.toInterval(edge),
-      this.toInterval(x),
-      this.StepIntervalOp
-    );
-  }
+  public abstract readonly stepInterval: (edge: number, x: number) => FPInterval;
 
   private readonly SubtractionIntervalOp: ScalarPairToIntervalOp = {
     impl: (x: number, y: number): FPInterval => {
@@ -3563,6 +3569,7 @@ class F32Traits extends FPTraits {
   public readonly sinInterval = this.sinIntervalImpl.bind(this);
   public readonly sinhInterval = this.sinhIntervalImpl.bind(this);
   public readonly sqrtInterval = this.sqrtIntervalImpl.bind(this);
+  public readonly stepInterval = this.stepIntervalImpl.bind(this);
   public readonly subtractionInterval = this.subtractionIntervalImpl.bind(this);
   public readonly tanInterval = this.tanIntervalImpl.bind(this);
   public readonly tanhInterval = this.tanhIntervalImpl.bind(this);


### PR DESCRIPTION
Same basic changes as the Scalar -> Interval patch (#2474), except                                                                                                             
covering Scalar Pair -> Interval tests.                                                                                                                                     
                                                                                                                                                                            
All tests now use the FPTraits implementations directly, and all                                                                                                            
of the old code is removed. Some infra for Vector Pair ->                                                                                                                   
Interval is included, since it is needed for distance. 

Issue: #2416

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
