### PR TITLE
Migrate bespoke floating point tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -15,7 +15,6 @@ import { kValue } from '../webgpu/util/constants.js';
 import {
   absoluteErrorInterval,
   correctlyRoundedInterval,
-  modfInterval,
   refractInterval,
   toF32Interval,
   toF32Matrix,
@@ -1908,50 +1907,3 @@ interface RefractCase {
       );
     });
 }
-
-interface ModfCase {
-  input: number;
-  fract: number | IntervalBounds;
-  whole: number | IntervalBounds;
-}
-
-g.test('modfInterval')
-  .paramsSubcasesOnly<ModfCase>(
-    // prettier-ignore
-    [
-      // Normals
-      { input: 0, fract: 0, whole: 0 },
-      { input: 1, fract: 0, whole: 1 },
-      { input: -1, fract: 0, whole: -1 },
-      { input: 0.5, fract: 0.5, whole: 0 },
-      { input: -0.5, fract: -0.5, whole: 0 },
-      { input: 2.5, fract: 0.5, whole: 2 },
-      { input: -2.5, fract: -0.5, whole: -2 },
-      { input: 10.0, fract: 0, whole: 10 },
-      { input: -10.0, fract: 0, whole: -10 },
-
-      // Subnormals
-      { input: kValue.f32.subnormal.negative.min, fract: [kValue.f32.subnormal.negative.min, 0], whole: 0 },
-      { input: kValue.f32.subnormal.negative.max, fract: [kValue.f32.subnormal.negative.max, 0], whole: 0 },
-      { input: kValue.f32.subnormal.positive.min, fract: [0, kValue.f32.subnormal.positive.min], whole: 0 },
-      { input: kValue.f32.subnormal.positive.max, fract: [0, kValue.f32.subnormal.positive.max], whole: 0 },
-
-      // Boundaries
-      { input: kValue.f32.negative.min, fract: 0, whole: kValue.f32.negative.min },
-      { input: kValue.f32.negative.max, fract: kValue.f32.negative.max, whole: 0 },
-      { input: kValue.f32.positive.min, fract: kValue.f32.positive.min, whole: 0 },
-      { input: kValue.f32.positive.max, fract: 0, whole: kValue.f32.positive.max },
-    ]
-  )
-  .fn(t => {
-    const expected = {
-      fract: toF32Interval(t.params.fract),
-      whole: toF32Interval(t.params.whole),
-    };
-
-    const got = modfInterval(t.params.input);
-    t.expect(
-      objectEquals(expected, got),
-      `modfInterval([${t.params.input}) returned { fract: [${got.fract}], whole: [${got.whole}] }. Expected { fract: [${expected.fract}], whole: [${expected.whole}] }`
-    );
-  });

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -15,7 +15,6 @@ import { kValue } from '../webgpu/util/constants.js';
 import {
   absoluteErrorInterval,
   correctlyRoundedInterval,
-  faceForwardIntervals,
   modfInterval,
   refractInterval,
   toF32Interval,
@@ -1841,78 +1840,6 @@ g.test('ulpInterval')
     t.expect(
       objectEquals(expected, got),
       `ulpInterval(${t.params.value}, ${t.params.num_ulp}) returned ${got}. Expected ${expected}`
-    );
-  });
-
-interface FaceForwardCase {
-  input: [number[], number[], number[]];
-  expected: ((number | IntervalBounds)[] | undefined)[];
-}
-
-g.test('faceForwardIntervals')
-  .paramsSubcasesOnly<FaceForwardCase>(
-    // prettier-ignore
-    [
-      // vec2
-      { input: [[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]], expected: [[-1.0, 0.0]] },
-      { input: [[-1.0, 0.0], [1.0, 0.0], [1.0, 0.0]], expected: [[1.0, 0.0]] },
-      { input: [[1.0, 0.0], [-1.0, 1.0], [1.0, -1.0]], expected: [[1.0, 0.0]] },
-      { input: [[-1.0, 0.0], [-1.0, 1.0], [1.0, -1.0]], expected: [[-1.0, 0.0]] },
-      { input: [[10.0, 0.0], [10.0, 0.0], [10.0, 0.0]], expected: [[-10.0, 0.0]] },
-      { input: [[-10.0, 0.0], [10.0, 0.0], [10.0, 0.0]], expected: [[10.0, 0.0]] },
-      { input: [[10.0, 0.0], [-10.0, 10.0], [10.0, -10.0]], expected: [[10.0, 0.0]] },
-      { input: [[-10.0, 0.0], [-10.0, 10.0], [10.0, -10.0]], expected: [[-10.0, 0.0]] },
-      { input: [[0.1, 0.0], [0.1, 0.0], [0.1, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0]] },
-      { input: [[-0.1, 0.0], [0.1, 0.0], [0.1, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0]] },
-      { input: [[0.1, 0.0], [-0.1, 0.1], [0.1, -0.1]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0]] },
-      { input: [[-0.1, 0.0], [-0.1, 0.1], [0.1, -0.1]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0]] },
-
-      // vec3
-      { input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [[-1.0, 0.0, 0.0]] },
-      { input: [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [[1.0, 0.0, 0.0]] },
-      { input: [[1.0, 0.0, 0.0], [-1.0, 1.0, 0.0], [1.0, -1.0, 0.0]], expected: [[1.0, 0.0, 0.0]] },
-      { input: [[-1.0, 0.0, 0.0], [-1.0, 1.0, 0.0], [1.0, -1.0, 0.0]], expected: [[-1.0, 0.0, 0.0]] },
-      { input: [[10.0, 0.0, 0.0], [10.0, 0.0, 0.0], [10.0, 0.0, 0.0]], expected: [[-10.0, 0.0, 0.0]] },
-      { input: [[-10.0, 0.0, 0.0], [10.0, 0.0, 0.0], [10.0, 0.0, 0.0]], expected: [[10.0, 0.0, 0.0]] },
-      { input: [[10.0, 0.0, 0.0], [-10.0, 10.0, 0.0], [10.0, -10.0, 0.0]], expected: [[10.0, 0.0, 0.0]] },
-      { input: [[-10.0, 0.0, 0.0], [-10.0, 10.0, 0.0], [10.0, -10.0, 0.0]], expected: [[-10.0, 0.0, 0.0]] },
-      { input: [[0.1, 0.0, 0.0], [0.1, 0.0, 0.0], [0.1, 0.0, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0, 0.0]] },
-      { input: [[-0.1, 0.0, 0.0], [0.1, 0.0, 0.0], [0.1, 0.0, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0, 0.0]] },
-      { input: [[0.1, 0.0, 0.0], [-0.1, 0.0, 0.0], [0.1, -0.0, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0, 0.0]] },
-      { input: [[-0.1, 0.0, 0.0], [-0.1, 0.0, 0.0], [0.1, -0.0, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0, 0.0]] },
-
-      // vec4
-      { input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [[-1.0, 0.0, 0.0, 0.0]] },
-      { input: [[-1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [[1.0, 0.0, 0.0, 0.0]] },
-      { input: [[1.0, 0.0, 0.0, 0.0], [-1.0, 1.0, 0.0, 0.0], [1.0, -1.0, 0.0, 0.0]], expected: [[1.0, 0.0, 0.0, 0.0]] },
-      { input: [[-1.0, 0.0, 0.0, 0.0], [-1.0, 1.0, 0.0, 0.0], [1.0, -1.0, 0.0, 0.0]], expected: [[-1.0, 0.0, 0.0, 0.0]] },
-      { input: [[10.0, 0.0, 0.0, 0.0], [10.0, 0.0, 0.0, 0.0], [10.0, 0.0, 0.0, 0.0]], expected: [[-10.0, 0.0, 0.0, 0.0]] },
-      { input: [[-10.0, 0.0, 0.0, 0.0], [10.0, 0.0, 0.0, 0.0], [10.0, 0.0, 0.0, 0.0]], expected: [[10.0, 0.0, 0.0, 0.0]] },
-      { input: [[10.0, 0.0, 0.0, 0.0], [-10.0, 10.0, 0.0, 0.0], [10.0, -10.0, 0.0, 0.0]], expected: [[10.0, 0.0, 0.0, 0.0]] },
-      { input: [[-10.0, 0.0, 0.0, 0.0], [-10.0, 10.0, 0.0, 0.0], [10.0, -10.0, 0.0, 0.0]], expected: [[-10.0, 0.0, 0.0, 0.0]] },
-      { input: [[0.1, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0, 0.0, 0.0]] },
-      { input: [[-0.1, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0, 0.0, 0.0]] },
-      { input: [[0.1, 0.0, 0.0, 0.0], [-0.1, 0.0, 0.0, 0.0], [0.1, -0.0, 0.0, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0, 0.0, 0.0]] },
-      { input: [[-0.1, 0.0, 0.0, 0.0], [-0.1, 0.0, 0.0, 0.0], [0.1, -0.0, 0.0, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0, 0.0, 0.0]] },
-
-      // dot(y, z) === 0
-      { input: [[1.0, 1.0], [1.0, 0.0], [0.0, 1.0]], expected:  [[-1.0, -1.0]] },
-
-      // subnormals, also dot(y, z) spans 0
-      { input: [[kValue.f32.subnormal.positive.max, 0.0], [kValue.f32.subnormal.positive.min, 0.0], [kValue.f32.subnormal.negative.min, 0.0]], expected:  [[[0.0, kValue.f32.subnormal.positive.max], 0.0], [[kValue.f32.subnormal.negative.min, 0], 0.0]] },
-
-      // dot going OOB returns [undefined, x, -x]
-      { input: [[1.0, 1.0], [kValue.f32.positive.max, kValue.f32.positive.max], [kValue.f32.positive.max, kValue.f32.positive.max]], expected: [undefined, [1, 1], [-1, -1]] },
-
-    ]
-  )
-  .fn(t => {
-    const [x, y, z] = t.params.input;
-    const expected = t.params.expected.map(e => (e !== undefined ? toF32Vector(e) : undefined));
-    const got = faceForwardIntervals(x, y, z);
-    t.expect(
-      objectEquals(expected, got),
-      `faceForwardInterval([${x}], [${y}], [${z}]) returned [${got}]. Expected [${expected}]`
     );
   });
 

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -15,7 +15,6 @@ import { kValue } from '../webgpu/util/constants.js';
 import {
   absoluteErrorInterval,
   correctlyRoundedInterval,
-  refractInterval,
   toF32Interval,
   toF32Matrix,
   toF32Vector,
@@ -1841,69 +1840,3 @@ g.test('ulpInterval')
       `ulpInterval(${t.params.value}, ${t.params.num_ulp}) returned ${got}. Expected ${expected}`
     );
   });
-
-interface RefractCase {
-  input: [number[], number[], number];
-  expected: (number | IntervalBounds)[];
-}
-
-// Scope for refractInterval tests so that they can have constants for magic
-// numbers that don't pollute the global namespace or have unwieldy long names.
-{
-  const kNegativeOneBounds: IntervalBounds = [
-    hexToF64(0xbff0_0000_c000_0000n),
-    hexToF64(0xbfef_ffff_4000_0000n),
-  ];
-
-  g.test('refractInterval')
-    .paramsSubcasesOnly<RefractCase>(
-      // Some of these are hard coded, since the error intervals are difficult
-      // to express in a closed human-readable form due to the inherited nature
-      // of the errors.
-
-      // prettier-ignore
-      [
-      // k < 0
-      { input: [[1, 1], [0.1, 0], 10], expected: [0, 0] },
-
-      // k contains 0
-      { input: [[1, 1], [0.1, 0], 1.005038], expected: [kAnyBounds, kAnyBounds] },
-
-      // k > 0
-      // vec2
-      { input: [[1, 1], [1, 0], 1], expected: [kNegativeOneBounds, 1] },
-      { input: [[1, -2], [3, 4], 5], expected: [[hexToF32(0x40ce87a4), hexToF32(0x40ce8840)],  // ~6.454...
-                                                [hexToF32(0xc100fae8), hexToF32(0xc100fa80)]] },  // ~-8.061...
-
-      // vec3
-      { input: [[1, 1, 1], [1, 0, 0], 1], expected: [kNegativeOneBounds, 1, 1] },
-      { input: [[1, -2, 3], [-4, 5, -6], 7], expected: [[hexToF32(0x40d24480), hexToF32(0x40d24c00)],  // ~6.571...
-                                                        [hexToF32(0xc1576f80), hexToF32(0xc1576ad0)],  // ~-13.464...
-                                                        [hexToF32(0x41a2d9b0), hexToF32(0x41a2dc80)]] },  // ~20.356...
-
-      // vec4
-      { input: [[1, 1, 1, 1], [1, 0, 0, 0], 1], expected: [kNegativeOneBounds, 1, 1, 1] },
-      { input: [[1, -2, 3,-4], [-5, 6, -7, 8], 9], expected: [[hexToF32(0x410ae480), hexToF32(0x410af240)],  // ~8.680...
-                                                              [hexToF32(0xc18cf7c0), hexToF32(0xc18cef80)],  // ~-17.620...
-                                                              [hexToF32(0x41d46cc0), hexToF32(0x41d47660)],  // ~26.553...
-                                                              [hexToF32(0xc20dfa80), hexToF32(0xc20df500)]] },  // ~-35.494...
-
-      // Test that dot going OOB bounds in the intermediate calculations propagates
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
-      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
-      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
-    ]
-    )
-    .fn(t => {
-      const [i, s, r] = t.params.input;
-      const expected = toF32Vector(t.params.expected);
-      const got = refractInterval(i, s, r);
-      t.expect(
-        objectEquals(expected, got),
-        `refractIntervals([${i}], [${s}], ${r}) returned [${got}]. Expected [${expected}]`
-      );
-    });
-}

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -4298,3 +4298,69 @@ g.test('modfInterval_f32')
       `f32.modfInterval([${t.params.input}) returned { fract: [${got.fract}], whole: [${got.whole}] }. Expected { fract: [${expected.fract}], whole: [${expected.whole}] }`
     );
   });
+
+interface RefractCase {
+  input: [number[], number[], number];
+  expected: (number | IntervalBounds)[];
+}
+
+// Scope for refractInterval tests so that they can have constants for magic
+// numbers that don't pollute the global namespace or have unwieldy long names.
+{
+  const kNegativeOneBounds: IntervalBounds = [
+    hexToF64(0xbff0_0000_c000_0000n),
+    hexToF64(0xbfef_ffff_4000_0000n),
+  ];
+
+  g.test('refractInterval_f32')
+    .paramsSubcasesOnly<RefractCase>(
+      // Some of these are hard coded, since the error intervals are difficult
+      // to express in a closed human-readable form due to the inherited nature
+      // of the errors.
+
+      // prettier-ignore
+      [
+        // k < 0
+        { input: [[1, 1], [0.1, 0], 10], expected: [0, 0] },
+
+        // k contains 0
+        { input: [[1, 1], [0.1, 0], 1.005038], expected: [kAnyBounds, kAnyBounds] },
+
+        // k > 0
+        // vec2
+        { input: [[1, 1], [1, 0], 1], expected: [kNegativeOneBounds, 1] },
+        { input: [[1, -2], [3, 4], 5], expected: [[hexToF32(0x40ce87a4), hexToF32(0x40ce8840)],  // ~6.454...
+            [hexToF32(0xc100fae8), hexToF32(0xc100fa80)]] },  // ~-8.061...
+
+        // vec3
+        { input: [[1, 1, 1], [1, 0, 0], 1], expected: [kNegativeOneBounds, 1, 1] },
+        { input: [[1, -2, 3], [-4, 5, -6], 7], expected: [[hexToF32(0x40d24480), hexToF32(0x40d24c00)],  // ~6.571...
+            [hexToF32(0xc1576f80), hexToF32(0xc1576ad0)],  // ~-13.464...
+            [hexToF32(0x41a2d9b0), hexToF32(0x41a2dc80)]] },  // ~20.356...
+
+        // vec4
+        { input: [[1, 1, 1, 1], [1, 0, 0, 0], 1], expected: [kNegativeOneBounds, 1, 1, 1] },
+        { input: [[1, -2, 3,-4], [-5, 6, -7, 8], 9], expected: [[hexToF32(0x410ae480), hexToF32(0x410af240)],  // ~8.680...
+            [hexToF32(0xc18cf7c0), hexToF32(0xc18cef80)],  // ~-17.620...
+            [hexToF32(0x41d46cc0), hexToF32(0x41d47660)],  // ~26.553...
+            [hexToF32(0xc20dfa80), hexToF32(0xc20df500)]] },  // ~-35.494...
+
+        // Test that dot going OOB bounds in the intermediate calculations propagates
+        { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+        { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+        { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+        { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+        { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+        { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kAnyBounds, kAnyBounds, kAnyBounds] },
+      ]
+    )
+    .fn(t => {
+      const [i, s, r] = t.params.input;
+      const expected = FP.f32.toVector(t.params.expected);
+      const got = FP.f32.refractInterval(i, s, r);
+      t.expect(
+        objectEquals(expected, got),
+        `refractIntervals([${i}], [${s}], ${r}) returned [${got}]. Expected [${expected}]`
+      );
+    });
+}

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -4177,3 +4177,75 @@ g.test('multiplicationVectorMatrixInterval_f32')
       )}]) returned '[${JSON.stringify(got)}]'. Expected '[${JSON.stringify(expected)}]'`
     );
   });
+
+interface FaceForwardCase {
+  input: [number[], number[], number[]];
+  expected: ((number | IntervalBounds)[] | undefined)[];
+}
+
+g.test('faceForwardIntervals_f32')
+  .paramsSubcasesOnly<FaceForwardCase>(
+    // prettier-ignore
+    [
+      // vec2
+      { input: [[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]], expected: [[-1.0, 0.0]] },
+      { input: [[-1.0, 0.0], [1.0, 0.0], [1.0, 0.0]], expected: [[1.0, 0.0]] },
+      { input: [[1.0, 0.0], [-1.0, 1.0], [1.0, -1.0]], expected: [[1.0, 0.0]] },
+      { input: [[-1.0, 0.0], [-1.0, 1.0], [1.0, -1.0]], expected: [[-1.0, 0.0]] },
+      { input: [[10.0, 0.0], [10.0, 0.0], [10.0, 0.0]], expected: [[-10.0, 0.0]] },
+      { input: [[-10.0, 0.0], [10.0, 0.0], [10.0, 0.0]], expected: [[10.0, 0.0]] },
+      { input: [[10.0, 0.0], [-10.0, 10.0], [10.0, -10.0]], expected: [[10.0, 0.0]] },
+      { input: [[-10.0, 0.0], [-10.0, 10.0], [10.0, -10.0]], expected: [[-10.0, 0.0]] },
+      { input: [[0.1, 0.0], [0.1, 0.0], [0.1, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0]] },
+      { input: [[-0.1, 0.0], [0.1, 0.0], [0.1, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0]] },
+      { input: [[0.1, 0.0], [-0.1, 0.1], [0.1, -0.1]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0]] },
+      { input: [[-0.1, 0.0], [-0.1, 0.1], [0.1, -0.1]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0]] },
+
+      // vec3
+      { input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [[-1.0, 0.0, 0.0]] },
+      { input: [[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: [[1.0, 0.0, 0.0]] },
+      { input: [[1.0, 0.0, 0.0], [-1.0, 1.0, 0.0], [1.0, -1.0, 0.0]], expected: [[1.0, 0.0, 0.0]] },
+      { input: [[-1.0, 0.0, 0.0], [-1.0, 1.0, 0.0], [1.0, -1.0, 0.0]], expected: [[-1.0, 0.0, 0.0]] },
+      { input: [[10.0, 0.0, 0.0], [10.0, 0.0, 0.0], [10.0, 0.0, 0.0]], expected: [[-10.0, 0.0, 0.0]] },
+      { input: [[-10.0, 0.0, 0.0], [10.0, 0.0, 0.0], [10.0, 0.0, 0.0]], expected: [[10.0, 0.0, 0.0]] },
+      { input: [[10.0, 0.0, 0.0], [-10.0, 10.0, 0.0], [10.0, -10.0, 0.0]], expected: [[10.0, 0.0, 0.0]] },
+      { input: [[-10.0, 0.0, 0.0], [-10.0, 10.0, 0.0], [10.0, -10.0, 0.0]], expected: [[-10.0, 0.0, 0.0]] },
+      { input: [[0.1, 0.0, 0.0], [0.1, 0.0, 0.0], [0.1, 0.0, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0, 0.0]] },
+      { input: [[-0.1, 0.0, 0.0], [0.1, 0.0, 0.0], [0.1, 0.0, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0, 0.0]] },
+      { input: [[0.1, 0.0, 0.0], [-0.1, 0.0, 0.0], [0.1, -0.0, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0, 0.0]] },
+      { input: [[-0.1, 0.0, 0.0], [-0.1, 0.0, 0.0], [0.1, -0.0, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0, 0.0]] },
+
+      // vec4
+      { input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [[-1.0, 0.0, 0.0, 0.0]] },
+      { input: [[-1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [[1.0, 0.0, 0.0, 0.0]] },
+      { input: [[1.0, 0.0, 0.0, 0.0], [-1.0, 1.0, 0.0, 0.0], [1.0, -1.0, 0.0, 0.0]], expected: [[1.0, 0.0, 0.0, 0.0]] },
+      { input: [[-1.0, 0.0, 0.0, 0.0], [-1.0, 1.0, 0.0, 0.0], [1.0, -1.0, 0.0, 0.0]], expected: [[-1.0, 0.0, 0.0, 0.0]] },
+      { input: [[10.0, 0.0, 0.0, 0.0], [10.0, 0.0, 0.0, 0.0], [10.0, 0.0, 0.0, 0.0]], expected: [[-10.0, 0.0, 0.0, 0.0]] },
+      { input: [[-10.0, 0.0, 0.0, 0.0], [10.0, 0.0, 0.0, 0.0], [10.0, 0.0, 0.0, 0.0]], expected: [[10.0, 0.0, 0.0, 0.0]] },
+      { input: [[10.0, 0.0, 0.0, 0.0], [-10.0, 10.0, 0.0, 0.0], [10.0, -10.0, 0.0, 0.0]], expected: [[10.0, 0.0, 0.0, 0.0]] },
+      { input: [[-10.0, 0.0, 0.0, 0.0], [-10.0, 10.0, 0.0, 0.0], [10.0, -10.0, 0.0, 0.0]], expected: [[-10.0, 0.0, 0.0, 0.0]] },
+      { input: [[0.1, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0, 0.0, 0.0]] },
+      { input: [[-0.1, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0], [0.1, 0.0, 0.0, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0, 0.0, 0.0]] },
+      { input: [[0.1, 0.0, 0.0, 0.0], [-0.1, 0.0, 0.0, 0.0], [0.1, -0.0, 0.0, 0.0]], expected: [[[hexToF32(0x3dcccccc), hexToF32(0x3dcccccd)], 0.0, 0.0, 0.0]] },
+      { input: [[-0.1, 0.0, 0.0, 0.0], [-0.1, 0.0, 0.0, 0.0], [0.1, -0.0, 0.0, 0.0]], expected: [[[hexToF32(0xbdcccccd), hexToF32(0xbdcccccc)], 0.0, 0.0, 0.0]] },
+
+      // dot(y, z) === 0
+      { input: [[1.0, 1.0], [1.0, 0.0], [0.0, 1.0]], expected:  [[-1.0, -1.0]] },
+
+      // subnormals, also dot(y, z) spans 0
+      { input: [[kValue.f32.subnormal.positive.max, 0.0], [kValue.f32.subnormal.positive.min, 0.0], [kValue.f32.subnormal.negative.min, 0.0]], expected:  [[[0.0, kValue.f32.subnormal.positive.max], 0.0], [[kValue.f32.subnormal.negative.min, 0], 0.0]] },
+
+      // dot going OOB returns [undefined, x, -x]
+      { input: [[1.0, 1.0], [kValue.f32.positive.max, kValue.f32.positive.max], [kValue.f32.positive.max, kValue.f32.positive.max]], expected: [undefined, [1, 1], [-1, -1]] },
+
+    ]
+  )
+  .fn(t => {
+    const [x, y, z] = t.params.input;
+    const expected = t.params.expected.map(e => (e !== undefined ? FP.f32.toVector(e) : undefined));
+    const got = FP.f32.faceForwardIntervals(x, y, z);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.faceForwardInterval([${x}], [${y}], [${z}]) returned [${got}]. Expected [${expected}]`
+    );
+  });

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -4178,6 +4178,8 @@ g.test('multiplicationVectorMatrixInterval_f32')
     );
   });
 
+// Builtins with bespoke implementations
+
 interface FaceForwardCase {
   input: [number[], number[], number[]];
   expected: ((number | IntervalBounds)[] | undefined)[];
@@ -4247,5 +4249,52 @@ g.test('faceForwardIntervals_f32')
     t.expect(
       objectEquals(expected, got),
       `f32.faceForwardInterval([${x}], [${y}], [${z}]) returned [${got}]. Expected [${expected}]`
+    );
+  });
+
+interface ModfCase {
+  input: number;
+  fract: number | IntervalBounds;
+  whole: number | IntervalBounds;
+}
+
+g.test('modfInterval_f32')
+  .paramsSubcasesOnly<ModfCase>(
+    // prettier-ignore
+    [
+      // Normals
+      { input: 0, fract: 0, whole: 0 },
+      { input: 1, fract: 0, whole: 1 },
+      { input: -1, fract: 0, whole: -1 },
+      { input: 0.5, fract: 0.5, whole: 0 },
+      { input: -0.5, fract: -0.5, whole: 0 },
+      { input: 2.5, fract: 0.5, whole: 2 },
+      { input: -2.5, fract: -0.5, whole: -2 },
+      { input: 10.0, fract: 0, whole: 10 },
+      { input: -10.0, fract: 0, whole: -10 },
+
+      // Subnormals
+      { input: kValue.f32.subnormal.negative.min, fract: [kValue.f32.subnormal.negative.min, 0], whole: 0 },
+      { input: kValue.f32.subnormal.negative.max, fract: [kValue.f32.subnormal.negative.max, 0], whole: 0 },
+      { input: kValue.f32.subnormal.positive.min, fract: [0, kValue.f32.subnormal.positive.min], whole: 0 },
+      { input: kValue.f32.subnormal.positive.max, fract: [0, kValue.f32.subnormal.positive.max], whole: 0 },
+
+      // Boundaries
+      { input: kValue.f32.negative.min, fract: 0, whole: kValue.f32.negative.min },
+      { input: kValue.f32.negative.max, fract: kValue.f32.negative.max, whole: 0 },
+      { input: kValue.f32.positive.min, fract: kValue.f32.positive.min, whole: 0 },
+      { input: kValue.f32.positive.max, fract: 0, whole: kValue.f32.positive.max },
+    ]
+  )
+  .fn(t => {
+    const expected = {
+      fract: FP.f32.toInterval(t.params.fract),
+      whole: FP.f32.toInterval(t.params.whole),
+    };
+
+    const got = FP.f32.modfInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.modfInterval([${t.params.input}) returned { fract: [${got.fract}], whole: [${got.whole}] }. Expected { fract: [${expected.fract}], whole: [${expected.whole}] }`
     );
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
@@ -9,7 +9,7 @@ Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf } from '../../../../../util/compare.js';
-import { TypeF32, TypeVec, Vector } from '../../../../../util/conversion.js';
+import { toVector, TypeF32, TypeVec } from '../../../../../util/conversion.js';
 import { F32Vector } from '../../../../../util/f32_interval.js';
 import { FP, FPKind } from '../../../../../util/floating_point.js';
 import { cartesianProduct, sparseVectorF32Range } from '../../../../../util/math.js';
@@ -60,9 +60,9 @@ function makeCase(
 
   return {
     input: [
-      new Vector(x.map(fp.scalarBuilder)),
-      new Vector(y.map(fp.scalarBuilder)),
-      new Vector(z.map(fp.scalarBuilder)),
+      toVector(x, fp.scalarBuilder),
+      toVector(y, fp.scalarBuilder),
+      toVector(z, fp.scalarBuilder),
     ],
     expected: anyOf(...define_results),
   };

--- a/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/faceForward.spec.ts
@@ -9,9 +9,10 @@ Returns e1 if dot(e2,e3) is negative, and -e1 otherwise.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf } from '../../../../../util/compare.js';
-import { f32, TypeF32, TypeVec, Vector } from '../../../../../util/conversion.js';
-import { F32Vector, faceForwardIntervals } from '../../../../../util/f32_interval.js';
-import { cartesianProduct, quantizeToF32, sparseVectorF32Range } from '../../../../../util/math.js';
+import { TypeF32, TypeVec, Vector } from '../../../../../util/conversion.js';
+import { F32Vector } from '../../../../../util/f32_interval.js';
+import { FP, FPKind } from '../../../../../util/floating_point.js';
+import { cartesianProduct, sparseVectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, IntervalFilter, run } from '../../expression.js';
 
@@ -29,26 +30,25 @@ export const g = makeTestGroup(GPUTest);
 
 /**
  * @returns a Case for `faceForward`
+ * @param kind what kind of floating point numbers being operated on
  * @param x the `x` param for the case
  * @param y the `y` param for the case
  * @param z the `z` param for the case
  * @param check what interval checking to apply
  * */
-function makeCaseF32(
+function makeCase(
+  kind: FPKind,
   x: number[],
   y: number[],
   z: number[],
   check: IntervalFilter
 ): Case | undefined {
-  x = x.map(quantizeToF32);
-  y = y.map(quantizeToF32);
-  z = z.map(quantizeToF32);
+  const fp = FP[kind];
+  x = x.map(fp.quantize);
+  y = y.map(fp.quantize);
+  z = z.map(fp.quantize);
 
-  const x_f32 = x.map(f32);
-  const y_f32 = y.map(f32);
-  const z_f32 = z.map(f32);
-
-  const results = faceForwardIntervals(x, y, z);
+  const results = FP.f32.faceForwardIntervals(x, y, z);
   if (check === 'finite' && results.some(r => r === undefined)) {
     return undefined;
   }
@@ -59,19 +59,25 @@ function makeCaseF32(
   const define_results = results.filter((r): r is F32Vector => r !== undefined);
 
   return {
-    input: [new Vector(x_f32), new Vector(y_f32), new Vector(z_f32)],
+    input: [
+      new Vector(x.map(fp.scalarBuilder)),
+      new Vector(y.map(fp.scalarBuilder)),
+      new Vector(z.map(fp.scalarBuilder)),
+    ],
     expected: anyOf(...define_results),
   };
 }
 
 /**
  * @returns an array of Cases for `faceForward`
+ * @param kind what kind of floating point numbers being operated on
  * @param xs array of inputs to try for the `x` param
  * @param ys array of inputs to try for the `y` param
  * @param zs array of inputs to try for the `z` param
  * @param check what interval checking to apply
  */
-function generateCasesF32(
+function generateCases(
+  kind: FPKind,
   xs: number[][],
   ys: number[][],
   zs: number[][],
@@ -79,13 +85,14 @@ function generateCasesF32(
 ): Case[] {
   // Cannot use `cartesianProduct` here due to heterogeneous param types
   return cartesianProduct(xs, ys, zs)
-    .map(e => makeCaseF32(e[0], e[1], e[2], check))
+    .map(e => makeCase('f32', e[0], e[1], e[2], check))
     .filter((c): c is Case => c !== undefined);
 }
 
 export const d = makeCaseCache('faceForward', {
   f32_vec2_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
@@ -93,7 +100,8 @@ export const d = makeCaseCache('faceForward', {
     );
   },
   f32_vec2_non_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
@@ -101,7 +109,8 @@ export const d = makeCaseCache('faceForward', {
     );
   },
   f32_vec3_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
@@ -109,7 +118,8 @@ export const d = makeCaseCache('faceForward', {
     );
   },
   f32_vec3_non_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
@@ -117,7 +127,8 @@ export const d = makeCaseCache('faceForward', {
     );
   },
   f32_vec4_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
@@ -125,7 +136,8 @@ export const d = makeCaseCache('faceForward', {
     );
   },
   f32_vec4_non_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -66,18 +66,16 @@ function makeVectorCaseWhole(kind: FPKind, v: number[]): Case {
 
 export const d = makeCaseCache('modf', {
   f32_fract: () => {
-    const fp = FP.f32;
     const makeCase = (n: number): Case => {
-      n = fp.quantize(n);
-      return { input: fp.scalarBuilder(n), expected: fp.modfInterval(n).fract };
+      n = FP.f32.quantize(n);
+      return { input: FP.f32.scalarBuilder(n), expected: FP.f32.modfInterval(n).fract };
     };
     return fullF32Range().map(makeCase);
   },
   f32_whole: () => {
-    const fp = FP.f32;
     const makeCase = (n: number): Case => {
-      n = fp.quantize(n);
-      return { input: fp.scalarBuilder(n), expected: fp.modfInterval(n).whole };
+      n = FP.f32.quantize(n);
+      return { input: FP.f32.scalarBuilder(n), expected: FP.f32.modfInterval(n).whole };
     };
     return fullF32Range().map(makeCase);
   },

--- a/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/modf.spec.ts
@@ -18,9 +18,9 @@ Returns the result_struct for the given type.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { f32, toVector, TypeF32, TypeVec } from '../../../../../util/conversion.js';
-import { modfInterval } from '../../../../../util/f32_interval.js';
-import { fullF32Range, quantizeToF32, vectorF32Range } from '../../../../../util/math.js';
+import { toVector, TypeF32, TypeVec } from '../../../../../util/conversion.js';
+import { FP, FPKind } from '../../../../../util/floating_point.js';
+import { fullF32Range, vectorF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import {
   allInputSources,
@@ -32,68 +32,72 @@ import {
 
 export const g = makeTestGroup(GPUTest);
 
-/* @returns an ShaderBuilder that evaluates modf and returns .whole from the result structure */
+/** @returns an ShaderBuilder that evaluates modf and returns .whole from the result structure */
 function wholeBuilder(): ShaderBuilder {
   return basicExpressionBuilder(value => `modf(${value}).whole`);
 }
 
-/* @returns an ShaderBuilder that evaluates modf and returns .fract from the result structure */
+/** @returns an ShaderBuilder that evaluates modf and returns .fract from the result structure */
 function fractBuilder(): ShaderBuilder {
   return basicExpressionBuilder(value => `modf(${value}).fract`);
 }
 
-/* @returns a fract Case for a given vector input */
-function makeVectorCaseFract(v: number[]): Case {
-  v = v.map(quantizeToF32);
+/** @returns a fract Case for a given vector input */
+function makeVectorCaseFract(kind: FPKind, v: number[]): Case {
+  const fp = FP[kind];
+  v = v.map(fp.quantize);
   const fs = v.map(e => {
-    return modfInterval(e).fract;
+    return fp.modfInterval(e).fract;
   });
 
-  return { input: toVector(v, f32), expected: fs };
+  return { input: toVector(v, fp.scalarBuilder), expected: fs };
 }
 
-/* @returns a whole Case for a given vector input */
-function makeVectorCaseWhole(v: number[]): Case {
-  v = v.map(quantizeToF32);
+/** @returns a whole Case for a given vector input */
+function makeVectorCaseWhole(kind: FPKind, v: number[]): Case {
+  const fp = FP[kind];
+  v = v.map(fp.quantize);
   const ws = v.map(e => {
-    return modfInterval(e).whole;
+    return fp.modfInterval(e).whole;
   });
 
-  return { input: toVector(v, f32), expected: ws };
+  return { input: toVector(v, fp.scalarBuilder), expected: ws };
 }
 
 export const d = makeCaseCache('modf', {
   f32_fract: () => {
+    const fp = FP.f32;
     const makeCase = (n: number): Case => {
-      n = quantizeToF32(n);
-      return { input: f32(n), expected: modfInterval(n).fract };
+      n = fp.quantize(n);
+      return { input: fp.scalarBuilder(n), expected: fp.modfInterval(n).fract };
     };
     return fullF32Range().map(makeCase);
   },
   f32_whole: () => {
+    const fp = FP.f32;
     const makeCase = (n: number): Case => {
-      n = quantizeToF32(n);
-      return { input: f32(n), expected: modfInterval(n).whole };
+      n = fp.quantize(n);
+      return { input: fp.scalarBuilder(n), expected: fp.modfInterval(n).whole };
     };
     return fullF32Range().map(makeCase);
   },
   f32_vec2_fract: () => {
-    return vectorF32Range(2).map(makeVectorCaseFract);
+    return vectorF32Range(2).map(makeVectorCaseFract.bind(null, 'f32'));
   },
   f32_vec2_whole: () => {
-    return vectorF32Range(2).map(makeVectorCaseWhole);
+    return vectorF32Range(2).map(makeVectorCaseWhole.bind(null, 'f32'));
   },
   f32_vec3_fract: () => {
-    return vectorF32Range(3).map(makeVectorCaseFract);
+    return vectorF32Range(3).map(makeVectorCaseFract.bind(null, 'f32'));
   },
   f32_vec3_whole: () => {
-    return vectorF32Range(3).map(makeVectorCaseWhole);
+    return vectorF32Range(3).map(makeVectorCaseWhole.bind(null, 'f32'));
   },
   f32_vec4_fract: () => {
-    return vectorF32Range(4).map(makeVectorCaseFract);
+    return vectorF32Range(4).map(makeVectorCaseFract.bind(null, 'f32'));
   },
   f32_vec4_whole: () => {
-    return vectorF32Range(4).map(makeVectorCaseWhole);
+    return vectorF32Range(4).map(makeVectorCaseWhole.bind(null, 'f32'));
   },
 });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/refract.spec.ts
@@ -12,9 +12,9 @@ vector e3*e1- (e3* dot(e2,e1) + sqrt(k)) *e2.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { f32, TypeF32, TypeVec, Vector } from '../../../../../util/conversion.js';
-import { refractInterval } from '../../../../../util/f32_interval.js';
-import { sparseVectorF32Range, quantizeToF32, sparseF32Range } from '../../../../../util/math.js';
+import { toVector, TypeF32, TypeVec } from '../../../../../util/conversion.js';
+import { FP, FPKind } from '../../../../../util/floating_point.js';
+import { sparseVectorF32Range, sparseF32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, IntervalFilter, run } from '../../expression.js';
 
@@ -28,39 +28,45 @@ export const g = makeTestGroup(GPUTest);
 
 /**
  * @returns a Case for `refract`
+ * @param kind what type of floating point numbers to operate on
  * @param i the `i` param for the case
  * @param s the `s` param for the case
  * @param r the `r` param for the case
  * @param check what interval checking to apply
  * */
-function makeCaseF32(i: number[], s: number[], r: number, check: IntervalFilter): Case | undefined {
-  i = i.map(quantizeToF32);
-  s = s.map(quantizeToF32);
-  r = quantizeToF32(r);
+function makeCase(
+  kind: FPKind,
+  i: number[],
+  s: number[],
+  r: number,
+  check: IntervalFilter
+): Case | undefined {
+  const fp = FP[kind];
+  i = i.map(fp.quantize);
+  s = s.map(fp.quantize);
+  r = fp.quantize(r);
 
-  const i_f32 = i.map(f32);
-  const s_f32 = s.map(f32);
-  const r_f32 = f32(r);
-
-  const vectors = refractInterval(i, s, r);
+  const vectors = fp.refractInterval(i, s, r);
   if (check === 'finite' && vectors.some(e => !e.isFinite())) {
     return undefined;
   }
 
   return {
-    input: [new Vector(i_f32), new Vector(s_f32), r_f32],
-    expected: refractInterval(i, s, r),
+    input: [toVector(i, fp.scalarBuilder), toVector(s, fp.scalarBuilder), fp.scalarBuilder(r)],
+    expected: fp.refractInterval(i, s, r),
   };
 }
 
 /**
  * @returns an array of Cases for `refract`
+ * @param kind what type of floating point numbers to operate on
  * @param param_is array of inputs to try for the `i` param
  * @param param_ss array of inputs to try for the `s` param
  * @param param_rs array of inputs to try for the `r` param
  * @param check what interval checking to apply
  */
-function generateCasesF32(
+function generateCases(
+  kind: FPKind,
   param_is: number[][],
   param_ss: number[][],
   param_rs: number[],
@@ -71,7 +77,7 @@ function generateCasesF32(
     .flatMap(i => {
       return param_ss.flatMap(s => {
         return param_rs.map(r => {
-          return makeCaseF32(i, s, r, check);
+          return makeCase('f32', i, s, r, check);
         });
       });
     })
@@ -80,7 +86,8 @@ function generateCasesF32(
 
 export const d = makeCaseCache('refract', {
   f32_vec2_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
       sparseF32Range(),
@@ -88,7 +95,8 @@ export const d = makeCaseCache('refract', {
     );
   },
   f32_vec2_non_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(2),
       sparseVectorF32Range(2),
       sparseF32Range(),
@@ -96,7 +104,8 @@ export const d = makeCaseCache('refract', {
     );
   },
   f32_vec3_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
       sparseF32Range(),
@@ -104,7 +113,8 @@ export const d = makeCaseCache('refract', {
     );
   },
   f32_vec3_non_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(3),
       sparseVectorF32Range(3),
       sparseF32Range(),
@@ -112,7 +122,8 @@ export const d = makeCaseCache('refract', {
     );
   },
   f32_vec4_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
       sparseF32Range(),
@@ -120,7 +131,8 @@ export const d = makeCaseCache('refract', {
     );
   },
   f32_vec4_non_const: () => {
-    return generateCasesF32(
+    return generateCases(
+      'f32',
       sparseVectorF32Range(4),
       sparseVectorF32Range(4),
       sparseF32Range(),

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -50,10 +50,6 @@ export function ulpInterval(n: number, numULP: number): FPInterval {
   return FP.f32.ulpInterval(n, numULP);
 }
 
-export function modfInterval(n: number): { fract: FPInterval; whole: FPInterval } {
-  return FP.f32.modfInterval(n);
-}
-
 export function refractInterval(i: number[], s: number[], r: number): FPVector {
   return FP.f32.refractInterval(i, s, r);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -50,14 +50,6 @@ export function ulpInterval(n: number, numULP: number): FPInterval {
   return FP.f32.ulpInterval(n, numULP);
 }
 
-export function faceForwardIntervals(
-  x: number[],
-  y: number[],
-  z: number[]
-): (FPVector | undefined)[] {
-  return FP.f32.faceForwardIntervals(x, y, z);
-}
-
 export function modfInterval(n: number): { fract: FPInterval; whole: FPInterval } {
   return FP.f32.modfInterval(n);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -49,7 +49,3 @@ export function absoluteErrorInterval(n: number, error_range: number): FPInterva
 export function ulpInterval(n: number, numULP: number): FPInterval {
   return FP.f32.ulpInterval(n, numULP);
 }
-
-export function refractInterval(i: number[], s: number[], r: number): FPVector {
-  return FP.f32.refractInterval(i, s, r);
-}

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -3297,12 +3297,14 @@ abstract class FPTraits {
   /** All acceptance interval functions for mix(x, y, z) */
   public abstract readonly mixIntervals: ScalarTripleToInterval[];
 
-  /** Calculate an acceptance interval of modf(x) */
-  public modfInterval(n: number): { fract: FPInterval; whole: FPInterval } {
+  protected modfIntervalImpl(n: number): { fract: FPInterval; whole: FPInterval } {
     const fract = this.correctlyRoundedInterval(n % 1.0);
     const whole = this.correctlyRoundedInterval(n - (n % 1.0));
     return { fract, whole };
   }
+
+  /** Calculate an acceptance interval of modf(x) */
+  public abstract readonly modfInterval: (n: number) => { fract: FPInterval; whole: FPInterval };
 
   private readonly MultiplicationInnerOp = {
     impl: (x: number, y: number): FPInterval => {
@@ -4060,6 +4062,7 @@ class F32Traits extends FPTraits {
   public readonly mixImpreciseInterval = this.mixImpreciseIntervalImpl.bind(this);
   public readonly mixPreciseInterval = this.mixPreciseIntervalImpl.bind(this);
   public readonly mixIntervals = [this.mixImpreciseInterval, this.mixPreciseInterval];
+  public readonly modfInterval = this.modfIntervalImpl.bind(this);
   public readonly multiplicationInterval = this.multiplicationIntervalImpl.bind(this);
   public readonly multiplicationMatrixMatrixInterval = this.multiplicationMatrixMatrixIntervalImpl.bind(
     this

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2963,8 +2963,6 @@ abstract class FPTraits {
   public abstract readonly exp2Interval: (x: number | FPInterval) => FPInterval;
 
   /**
-   * Calculate the acceptance intervals for faceForward(x, y, z)
-   *
    * faceForward(x, y, z) = select(-x, x, dot(z, y) < 0.0)
    *
    * This builtin selects from two discrete results (delta rounding/flushing),
@@ -2974,7 +2972,11 @@ abstract class FPTraits {
    * Thus, a bespoke implementation is used instead of
    * defining an Op and running that through the framework.
    */
-  public faceForwardIntervals(x: number[], y: number[], z: number[]): (FPVector | undefined)[] {
+  protected faceForwardIntervalsImpl(
+    x: number[],
+    y: number[],
+    z: number[]
+  ): (FPVector | undefined)[] {
     const x_vec = this.toVector(x);
     // Running vector through this.runScalarToIntervalOpComponentWise to make
     // sure that flushing/rounding is handled, since toVector does not perform
@@ -3018,6 +3020,13 @@ abstract class FPTraits {
     );
     return results;
   }
+
+  /** Calculate the acceptance intervals for faceForward(x, y, z) */
+  public abstract readonly faceForwardIntervals: (
+    x: number[],
+    y: number[],
+    z: number[]
+  ) => (FPVector | undefined)[];
 
   private readonly FloorIntervalOp: ScalarToIntervalOp = {
     impl: (n: number): FPInterval => {
@@ -4037,6 +4046,7 @@ class F32Traits extends FPTraits {
   public readonly dotInterval = this.dotIntervalImpl.bind(this);
   public readonly expInterval = this.expIntervalImpl.bind(this);
   public readonly exp2Interval = this.exp2IntervalImpl.bind(this);
+  public readonly faceForwardIntervals = this.faceForwardIntervalsImpl.bind(this);
   public readonly floorInterval = this.floorIntervalImpl.bind(this);
   public readonly fmaInterval = this.fmaIntervalImpl.bind(this);
   public readonly fractInterval = this.fractIntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -3537,8 +3537,6 @@ abstract class FPTraits {
   public abstract readonly reflectInterval: (x: number[], y: number[]) => FPVector;
 
   /**
-   * Calculate acceptance interval vectors of reflect(i, s, r)
-   *
    * refract is a singular function in the sense that it is the only builtin that
    * takes in (FPVector, FPVector, F32) and returns FPVector and is basically
    * defined in terms of other functions.
@@ -3547,7 +3545,7 @@ abstract class FPTraits {
    * own operation type, etc, it instead has a bespoke implementation that is a
    * composition of other builtin functions that use the framework.
    */
-  public refractInterval(i: number[], s: number[], r: number): FPVector {
+  protected refractIntervalImpl(i: number[], s: number[], r: number): FPVector {
     assert(
       i.length === s.length,
       `refract is only defined for vectors with the same number of elements`
@@ -3582,6 +3580,9 @@ abstract class FPTraits {
       this.SubtractionIntervalOp
     ); // (i * r) - (s * t)
   }
+
+  /** Calculate acceptance interval vectors of reflect(i, s, r) */
+  public abstract readonly refractInterval: (i: number[], s: number[], r: number) => FPVector;
 
   private readonly RemainderIntervalOp: ScalarPairToIntervalOp = {
     impl: (x: number, y: number): FPInterval => {
@@ -4085,6 +4086,7 @@ class F32Traits extends FPTraits {
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalImpl.bind(this);
   public readonly radiansInterval = this.radiansIntervalImpl.bind(this);
   public readonly reflectInterval = this.reflectIntervalImpl.bind(this);
+  public readonly refractInterval = this.refractIntervalImpl.bind(this);
   public readonly remainderInterval = this.remainderIntervalImpl.bind(this);
   public readonly roundInterval = this.roundIntervalImpl.bind(this);
   public readonly saturateInterval = this.saturateIntervalImpl.bind(this);


### PR DESCRIPTION
This covers migrating faceForward, modf and refract to the new testing
framework.

Issue: #2416

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
