### PR TITLE
Replace calling Vector/Matrix constructors directly

### DIFF
--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -6,12 +6,12 @@ import { anyOf } from './compare.js';
 import { kValue } from './constants.js';
 import {
   f32,
-  Matrix,
   reinterpretF32AsU32,
   reinterpretU32AsF32,
   Scalar,
+  toMatrix,
+  toVector,
   u32,
-  Vector,
 } from './conversion.js';
 import {
   calculatePermutations,
@@ -949,7 +949,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [new Vector(param.map(this.scalarBuilder))],
+      input: [toVector(param, this.scalarBuilder)],
       expected: anyOf(...intervals),
     };
   }
@@ -996,10 +996,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [
-        new Vector(param0.map(this.scalarBuilder)),
-        new Vector(param1.map(this.scalarBuilder)),
-      ],
+      input: [toVector(param0, this.scalarBuilder), toVector(param1, this.scalarBuilder)],
       expected: anyOf(...intervals),
     };
   }
@@ -1045,7 +1042,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [new Vector(param.map(this.scalarBuilder))],
+      input: [toVector(param, this.scalarBuilder)],
       expected: anyOf(...vectors),
     };
   }
@@ -1093,7 +1090,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [this.scalarBuilder(scalar), new Vector(vector.map(this.scalarBuilder))],
+      input: [this.scalarBuilder(scalar), toVector(vector, this.scalarBuilder)],
       expected: anyOf(...results),
     };
   }
@@ -1146,7 +1143,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [new Vector(vector.map(this.scalarBuilder)), this.scalarBuilder(scalar)],
+      input: [toVector(vector, this.scalarBuilder), this.scalarBuilder(scalar)],
       expected: anyOf(...results),
     };
   }
@@ -1198,10 +1195,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [
-        new Vector(param0.map(this.scalarBuilder)),
-        new Vector(param1.map(this.scalarBuilder)),
-      ],
+      input: [toVector(param0, this.scalarBuilder), toVector(param1, this.scalarBuilder)],
       expected: anyOf(...vectors),
     };
   }
@@ -1248,7 +1242,7 @@ abstract class FPTraits {
     }
 
     return {
-      input: [new Matrix(map2DArray(param, this.scalarBuilder))],
+      input: [toMatrix(param, this.scalarBuilder)],
       expected: anyOf(...results),
     };
   }
@@ -1293,7 +1287,7 @@ abstract class FPTraits {
     }
 
     return {
-      input: [new Matrix(map2DArray(param, this.scalarBuilder))],
+      input: [toMatrix(param, this.scalarBuilder)],
       expected: anyOf(...results),
     };
   }
@@ -1341,10 +1335,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [
-        new Matrix(map2DArray(param0, this.scalarBuilder)),
-        new Matrix(map2DArray(param1, this.scalarBuilder)),
-      ],
+      input: [toMatrix(param0, this.scalarBuilder), toMatrix(param1, this.scalarBuilder)],
       expected: anyOf(...results),
     };
   }
@@ -1394,7 +1385,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [new Matrix(map2DArray(mat, this.scalarBuilder)), this.scalarBuilder(scalar)],
+      input: [toMatrix(mat, this.scalarBuilder), this.scalarBuilder(scalar)],
       expected: anyOf(...results),
     };
   }
@@ -1448,7 +1439,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [this.scalarBuilder(scalar), new Matrix(map2DArray(mat, this.scalarBuilder))],
+      input: [this.scalarBuilder(scalar), toMatrix(mat, this.scalarBuilder)],
       expected: anyOf(...results),
     };
   }
@@ -1502,10 +1493,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [
-        new Matrix(map2DArray(mat, this.scalarBuilder)),
-        new Vector(vec.map(this.scalarBuilder)),
-      ],
+      input: [toMatrix(mat, this.scalarBuilder), toVector(vec, this.scalarBuilder)],
       expected: anyOf(...results),
     };
   }
@@ -1559,10 +1547,7 @@ abstract class FPTraits {
       return undefined;
     }
     return {
-      input: [
-        new Vector(vec.map(this.scalarBuilder)),
-        new Matrix(map2DArray(mat, this.scalarBuilder)),
-      ],
+      input: [toVector(vec, this.scalarBuilder), toMatrix(mat, this.scalarBuilder)],
       expected: anyOf(...results),
     };
   }


### PR DESCRIPTION
Use provided toFoo utilities, which handle iteratively applying the builder.
This leads to slightly shorter/cleaner code.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
