### PR TITLE
Migrate fundamental error interval tests

### DIFF
--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -14,7 +14,6 @@ import { objectEquals } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
 import {
   absoluteErrorInterval,
-  correctlyRoundedInterval,
   toF32Interval,
   toF32Matrix,
   toF32Vector,
@@ -24,7 +23,7 @@ import {
   spanF32Intervals,
 } from '../webgpu/util/f32_interval.js';
 import { FPInterval, IntervalBounds } from '../webgpu/util/floating_point.js';
-import { hexToF32, hexToF64, map2DArray, oneULPF32 } from '../webgpu/util/math.js';
+import { hexToF64, map2DArray, oneULPF32 } from '../webgpu/util/math.js';
 
 import { UnitTest } from './unit_test.js';
 
@@ -1636,62 +1635,6 @@ g.test('toF32Matrix')
     t.expect(
       objectEquals(got, expected),
       `toF32Matrix([${input}]) returned [${got}]. Expected [${expected}]`
-    );
-  });
-
-interface CorrectlyRoundedCase {
-  value: number;
-  expected: number | IntervalBounds;
-}
-
-g.test('correctlyRoundedInterval')
-  .paramsSubcasesOnly<CorrectlyRoundedCase>(
-    // prettier-ignore
-    [
-      // Edge Cases
-      { value: kValue.f32.infinity.positive, expected: kAnyBounds },
-      { value: kValue.f32.infinity.negative, expected: kAnyBounds },
-      { value: kValue.f32.positive.max, expected: kValue.f32.positive.max },
-      { value: kValue.f32.negative.min, expected: kValue.f32.negative.min },
-      { value: kValue.f32.positive.min, expected: kValue.f32.positive.min },
-      { value: kValue.f32.negative.max, expected: kValue.f32.negative.max },
-
-      // 32-bit subnormals
-      { value: kValue.f32.subnormal.positive.min, expected: [0, kValue.f32.subnormal.positive.min] },
-      { value: kValue.f32.subnormal.positive.max, expected: [0, kValue.f32.subnormal.positive.max] },
-      { value: kValue.f32.subnormal.negative.min, expected: [kValue.f32.subnormal.negative.min, 0] },
-      { value: kValue.f32.subnormal.negative.max, expected: [kValue.f32.subnormal.negative.max, 0] },
-
-      // 64-bit subnormals
-      { value: hexToF64(0x0000_0000_0000_0001n), expected: [0, kValue.f32.subnormal.positive.min] },
-      { value: hexToF64(0x0000_0000_0000_0002n), expected: [0, kValue.f32.subnormal.positive.min] },
-      { value: hexToF64(0x800f_ffff_ffff_ffffn), expected: [kValue.f32.subnormal.negative.max, 0] },
-      { value: hexToF64(0x800f_ffff_ffff_fffen), expected: [kValue.f32.subnormal.negative.max, 0] },
-
-      // 32-bit normals
-      { value: 0, expected: [0, 0] },
-      { value: hexToF32(0x03800000), expected: hexToF32(0x03800000) },
-      { value: hexToF32(0x03800001), expected: hexToF32(0x03800001) },
-      { value: hexToF32(0x83800000), expected: hexToF32(0x83800000) },
-      { value: hexToF32(0x83800001), expected: hexToF32(0x83800001) },
-
-      // 64-bit normals
-      { value: hexToF64(0x3ff0_0000_0000_0001n), expected: [hexToF32(0x3f800000), hexToF32(0x3f800001)] },
-      { value: hexToF64(0x3ff0_0000_0000_0002n), expected: [hexToF32(0x3f800000), hexToF32(0x3f800001)] },
-      { value: hexToF64(0x3ff0_0010_0000_0010n), expected: [hexToF32(0x3f800080), hexToF32(0x3f800081)] },
-      { value: hexToF64(0x3ff0_0020_0000_0020n), expected: [hexToF32(0x3f800100), hexToF32(0x3f800101)] },
-      { value: hexToF64(0xbff0_0000_0000_0001n), expected: [hexToF32(0xbf800001), hexToF32(0xbf800000)] },
-      { value: hexToF64(0xbff0_0000_0000_0002n), expected: [hexToF32(0xbf800001), hexToF32(0xbf800000)] },
-      { value: hexToF64(0xbff0_0010_0000_0010n), expected: [hexToF32(0xbf800081), hexToF32(0xbf800080)] },
-      { value: hexToF64(0xbff0_0020_0000_0020n), expected: [hexToF32(0xbf800101), hexToF32(0xbf800100)] },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = correctlyRoundedInterval(t.params.value);
-    t.expect(
-      objectEquals(expected, got),
-      `correctlyRoundedInterval(${t.params.value}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/f32_interval.spec.ts
+++ b/src/unittests/f32_interval.spec.ts
@@ -13,7 +13,6 @@ import { makeTestGroup } from '../common/framework/test_group.js';
 import { objectEquals } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
 import {
-  absoluteErrorInterval,
   toF32Interval,
   toF32Matrix,
   toF32Vector,
@@ -1635,79 +1634,6 @@ g.test('toF32Matrix')
     t.expect(
       objectEquals(got, expected),
       `toF32Matrix([${input}]) returned [${got}]. Expected [${expected}]`
-    );
-  });
-
-interface AbsoluteErrorCase {
-  value: number;
-  error: number;
-  expected: number | IntervalBounds;
-}
-
-g.test('absoluteErrorInterval')
-  .paramsSubcasesOnly<AbsoluteErrorCase>(
-    // prettier-ignore
-    [
-      // Edge Cases
-      { value: kValue.f32.infinity.positive, error: 0, expected: kAnyBounds },
-      { value: kValue.f32.infinity.positive, error: 2 ** -11, expected: kAnyBounds },
-      { value: kValue.f32.infinity.positive, error: 1, expected: kAnyBounds },
-      { value: kValue.f32.infinity.negative, error: 0, expected: kAnyBounds },
-      { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: kAnyBounds },
-      { value: kValue.f32.infinity.negative, error: 1, expected: kAnyBounds },
-      { value: kValue.f32.positive.max, error: 0, expected: kValue.f32.positive.max },
-      { value: kValue.f32.positive.max, error: 2 ** -11, expected: kValue.f32.positive.max },
-      { value: kValue.f32.positive.max, error: kValue.f32.positive.max, expected: kAnyBounds },
-      { value: kValue.f32.positive.min, error: 0, expected: kValue.f32.positive.min },
-      { value: kValue.f32.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: kValue.f32.positive.min, error: 1, expected: [-1, 1] },
-      { value: kValue.f32.negative.min, error: 0, expected: kValue.f32.negative.min },
-      { value: kValue.f32.negative.min, error: 2 ** -11, expected: kValue.f32.negative.min },
-      { value: kValue.f32.negative.min, error: kValue.f32.positive.max, expected: kAnyBounds },
-      { value: kValue.f32.negative.max, error: 0, expected: kValue.f32.negative.max },
-      { value: kValue.f32.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: kValue.f32.negative.max, error: 1, expected: [-1, 1] },
-
-      // 32-bit subnormals
-      { value: kValue.f32.subnormal.positive.max, error: 0, expected: [0, kValue.f32.subnormal.positive.max] },
-      { value: kValue.f32.subnormal.positive.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: kValue.f32.subnormal.positive.max, error: 1, expected: [-1, 1] },
-      { value: kValue.f32.subnormal.positive.min, error: 0, expected: [0, kValue.f32.subnormal.positive.min] },
-      { value: kValue.f32.subnormal.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: kValue.f32.subnormal.positive.min, error: 1, expected: [-1, 1] },
-      { value: kValue.f32.subnormal.negative.min, error: 0, expected: [kValue.f32.subnormal.negative.min, 0] },
-      { value: kValue.f32.subnormal.negative.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: kValue.f32.subnormal.negative.min, error: 1, expected: [-1, 1] },
-      { value: kValue.f32.subnormal.negative.max, error: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
-      { value: kValue.f32.subnormal.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: kValue.f32.subnormal.negative.max, error: 1, expected: [-1, 1] },
-
-      // 64-bit subnormals
-      { value: hexToF64(0x0000_0000_0000_0001n), error: 0, expected: [0, kValue.f32.subnormal.positive.min] },
-      { value: hexToF64(0x0000_0000_0000_0001n), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: hexToF64(0x0000_0000_0000_0001n), error: 1, expected: [-1, 1] },
-      { value: hexToF64(0x0000_0000_0000_0002n), error: 0, expected: [0, kValue.f32.subnormal.positive.min] },
-      { value: hexToF64(0x0000_0000_0000_0002n), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: hexToF64(0x0000_0000_0000_0002n), error: 1, expected: [-1, 1] },
-      { value: hexToF64(0x800f_ffff_ffff_ffffn), error: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
-      { value: hexToF64(0x800f_ffff_ffff_ffffn), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: hexToF64(0x800f_ffff_ffff_ffffn), error: 1, expected: [-1, 1] },
-      { value: hexToF64(0x800f_ffff_ffff_fffen), error: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
-      { value: hexToF64(0x800f_ffff_ffff_fffen), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: hexToF64(0x800f_ffff_ffff_fffen), error: 1, expected: [-1, 1] },
-
-      // Zero
-      { value: 0, error: 0, expected: 0 },
-      { value: 0, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
-      { value: 0, error: 1, expected: [-1, 1] },
-    ]
-  )
-  .fn(t => {
-    const expected = toF32Interval(t.params.expected);
-    const got = absoluteErrorInterval(t.params.value, t.params.error);
-    t.expect(
-      objectEquals(expected, got),
-      `absoluteErrorInterval(${t.params.value}, ${t.params.error}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -71,6 +71,66 @@ function applyError(
   return [begin, end];
 }
 
+// API - Fundamental Error Intervals
+
+interface CorrectlyRoundedCase {
+  value: number;
+  expected: number | IntervalBounds;
+}
+
+g.test('correctlyRoundedInterval_f32')
+  .paramsSubcasesOnly<CorrectlyRoundedCase>(
+    // prettier-ignore
+    [
+      // Edge Cases
+      { value: kValue.f32.infinity.positive, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, expected: kAnyBounds },
+      { value: kValue.f32.positive.max, expected: kValue.f32.positive.max },
+      { value: kValue.f32.negative.min, expected: kValue.f32.negative.min },
+      { value: kValue.f32.positive.min, expected: kValue.f32.positive.min },
+      { value: kValue.f32.negative.max, expected: kValue.f32.negative.max },
+
+      // 32-bit subnormals
+      { value: kValue.f32.subnormal.positive.min, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: kValue.f32.subnormal.positive.max, expected: [0, kValue.f32.subnormal.positive.max] },
+      { value: kValue.f32.subnormal.negative.min, expected: [kValue.f32.subnormal.negative.min, 0] },
+      { value: kValue.f32.subnormal.negative.max, expected: [kValue.f32.subnormal.negative.max, 0] },
+
+      // 64-bit subnormals
+      { value: hexToF64(0x0000_0000_0000_0001n), expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x0000_0000_0000_0002n), expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x800f_ffff_ffff_ffffn), expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800f_ffff_ffff_fffen), expected: [kValue.f32.subnormal.negative.max, 0] },
+
+      // 32-bit normals
+      { value: 0, expected: [0, 0] },
+      { value: hexToF32(0x03800000), expected: hexToF32(0x03800000) },
+      { value: hexToF32(0x03800001), expected: hexToF32(0x03800001) },
+      { value: hexToF32(0x83800000), expected: hexToF32(0x83800000) },
+      { value: hexToF32(0x83800001), expected: hexToF32(0x83800001) },
+
+      // 64-bit normals
+      { value: hexToF64(0x3ff0_0000_0000_0001n), expected: [hexToF32(0x3f800000), hexToF32(0x3f800001)] },
+      { value: hexToF64(0x3ff0_0000_0000_0002n), expected: [hexToF32(0x3f800000), hexToF32(0x3f800001)] },
+      { value: hexToF64(0x3ff0_0010_0000_0010n), expected: [hexToF32(0x3f800080), hexToF32(0x3f800081)] },
+      { value: hexToF64(0x3ff0_0020_0000_0020n), expected: [hexToF32(0x3f800100), hexToF32(0x3f800101)] },
+      { value: hexToF64(0xbff0_0000_0000_0001n), expected: [hexToF32(0xbf800001), hexToF32(0xbf800000)] },
+      { value: hexToF64(0xbff0_0000_0000_0002n), expected: [hexToF32(0xbf800001), hexToF32(0xbf800000)] },
+      { value: hexToF64(0xbff0_0010_0000_0010n), expected: [hexToF32(0xbf800081), hexToF32(0xbf800080)] },
+      { value: hexToF64(0xbff0_0020_0000_0020n), expected: [hexToF32(0xbf800101), hexToF32(0xbf800100)] },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.correctlyRoundedInterval(t.params.value);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.correctlyRoundedInterval(${t.params.value}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+// API - Acceptance Intervals
+
 interface ScalarToIntervalCase {
   input: number;
   expected: number | IntervalBounds;
@@ -4178,7 +4238,7 @@ g.test('multiplicationVectorMatrixInterval_f32')
     );
   });
 
-// Builtins with bespoke implementations
+// API - Acceptance Intervals w/ bespoke implementations
 
 interface FaceForwardCase {
   input: [number[], number[], number[]];

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -202,6 +202,79 @@ g.test('correctlyRoundedInterval_f32')
     );
   });
 
+interface ULPCase {
+  value: number;
+  num_ulp: number;
+  expected: number | IntervalBounds;
+}
+
+g.test('ulpInterval_f32')
+  .paramsSubcasesOnly<ULPCase>(
+    // prettier-ignore
+    [
+      // Edge Cases
+      { value: kValue.f32.infinity.positive, num_ulp: 0, expected: kAnyBounds },
+      { value: kValue.f32.infinity.positive, num_ulp: 1, expected: kAnyBounds },
+      { value: kValue.f32.infinity.positive, num_ulp: 4096, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, num_ulp: 0, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, num_ulp: 1, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, num_ulp: 4096, expected: kAnyBounds },
+      { value: kValue.f32.positive.max, num_ulp: 0, expected: kValue.f32.positive.max },
+      { value: kValue.f32.positive.max, num_ulp: 1, expected: kAnyBounds },
+      { value: kValue.f32.positive.max, num_ulp: 4096, expected: kAnyBounds },
+      { value: kValue.f32.positive.min, num_ulp: 0, expected: kValue.f32.positive.min },
+      { value: kValue.f32.positive.min, num_ulp: 1, expected: [0, plusOneULPF32(kValue.f32.positive.min)] },
+      { value: kValue.f32.positive.min, num_ulp: 4096, expected: [0, plusNULPF32(kValue.f32.positive.min, 4096)] },
+      { value: kValue.f32.negative.min, num_ulp: 0, expected: kValue.f32.negative.min },
+      { value: kValue.f32.negative.min, num_ulp: 1, expected: kAnyBounds },
+      { value: kValue.f32.negative.min, num_ulp: 4096, expected: kAnyBounds },
+      { value: kValue.f32.negative.max, num_ulp: 0, expected: kValue.f32.negative.max },
+      { value: kValue.f32.negative.max, num_ulp: 1, expected: [minusOneULPF32(kValue.f32.negative.max), 0] },
+      { value: kValue.f32.negative.max, num_ulp: 4096, expected: [minusNULPF32(kValue.f32.negative.max, 4096), 0] },
+
+      // 32-bit subnormals
+      { value: kValue.f32.subnormal.positive.max, num_ulp: 0, expected: [0, kValue.f32.subnormal.positive.max] },
+      { value: kValue.f32.subnormal.positive.max, num_ulp: 1, expected: [minusOneULPF32(0), plusOneULPF32(kValue.f32.subnormal.positive.max)] },
+      { value: kValue.f32.subnormal.positive.max, num_ulp: 4096, expected: [minusNULPF32(0, 4096), plusNULPF32(kValue.f32.subnormal.positive.max, 4096)] },
+      { value: kValue.f32.subnormal.positive.min, num_ulp: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: kValue.f32.subnormal.positive.min, num_ulp: 1, expected: [minusOneULPF32(0), plusOneULPF32(kValue.f32.subnormal.positive.min)] },
+      { value: kValue.f32.subnormal.positive.min, num_ulp: 4096, expected: [minusNULPF32(0, 4096), plusNULPF32(kValue.f32.subnormal.positive.min, 4096)] },
+      { value: kValue.f32.subnormal.negative.min, num_ulp: 0, expected: [kValue.f32.subnormal.negative.min, 0] },
+      { value: kValue.f32.subnormal.negative.min, num_ulp: 1, expected: [minusOneULPF32(kValue.f32.subnormal.negative.min), plusOneULPF32(0)] },
+      { value: kValue.f32.subnormal.negative.min, num_ulp: 4096, expected: [minusNULPF32(kValue.f32.subnormal.negative.min, 4096), plusNULPF32(0, 4096)] },
+      { value: kValue.f32.subnormal.negative.max, num_ulp: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: kValue.f32.subnormal.negative.max, num_ulp: 1, expected: [minusOneULPF32(kValue.f32.subnormal.negative.max), plusOneULPF32(0)] },
+      { value: kValue.f32.subnormal.negative.max, num_ulp: 4096, expected: [minusNULPF32(kValue.f32.subnormal.negative.max, 4096), plusNULPF32(0, 4096)] },
+
+      // 64-bit subnormals
+      { value: hexToF64(0x0000_0000_0000_0001n), num_ulp: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x0000_0000_0000_0001n), num_ulp: 1, expected: [minusOneULPF32(0), plusOneULPF32(kValue.f32.subnormal.positive.min)] },
+      { value: hexToF64(0x0000_0000_0000_0001n), num_ulp: 4096, expected: [minusNULPF32(0, 4096), plusNULPF32(kValue.f32.subnormal.positive.min, 4096)] },
+      { value: hexToF64(0x0000_0000_0000_0002n), num_ulp: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x0000_0000_0000_0002n), num_ulp: 1, expected: [minusOneULPF32(0), plusOneULPF32(kValue.f32.subnormal.positive.min)] },
+      { value: hexToF64(0x0000_0000_0000_0002n), num_ulp: 4096, expected: [minusNULPF32(0, 4096), plusNULPF32(kValue.f32.subnormal.positive.min, 4096)] },
+      { value: hexToF64(0x800f_ffff_ffff_ffffn), num_ulp: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800f_ffff_ffff_ffffn), num_ulp: 1, expected: [minusOneULPF32(kValue.f32.subnormal.negative.max), plusOneULPF32(0)] },
+      { value: hexToF64(0x800f_ffff_ffff_ffffn), num_ulp: 4096, expected: [minusNULPF32(kValue.f32.subnormal.negative.max, 4096), plusNULPF32(0, 4096)] },
+      { value: hexToF64(0x800f_ffff_ffff_fffen), num_ulp: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800f_ffff_ffff_fffen), num_ulp: 1, expected: [minusOneULPF32(kValue.f32.subnormal.negative.max), plusOneULPF32(0)] },
+      { value: hexToF64(0x800f_ffff_ffff_fffen), num_ulp: 4096, expected: [minusNULPF32(kValue.f32.subnormal.negative.max, 4096), plusNULPF32(0, 4096)] },
+
+      // Zero
+      { value: 0, num_ulp: 0, expected: 0 },
+      { value: 0, num_ulp: 1, expected: [minusOneULPF32(0), plusOneULPF32(0)] },
+      { value: 0, num_ulp: 4096, expected: [minusNULPF32(0, 4096), plusNULPF32(0, 4096)] },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.ulpInterval(t.params.value, t.params.num_ulp);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.ulpInterval(${t.params.value}, ${t.params.num_ulp}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 // API - Acceptance Intervals
 
 interface ScalarToIntervalCase {

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -73,6 +73,79 @@ function applyError(
 
 // API - Fundamental Error Intervals
 
+interface AbsoluteErrorCase {
+  value: number;
+  error: number;
+  expected: number | IntervalBounds;
+}
+
+g.test('absoluteErrorInterval_f32')
+  .paramsSubcasesOnly<AbsoluteErrorCase>(
+    // prettier-ignore
+    [
+      // Edge Cases
+      { value: kValue.f32.infinity.positive, error: 0, expected: kAnyBounds },
+      { value: kValue.f32.infinity.positive, error: 2 ** -11, expected: kAnyBounds },
+      { value: kValue.f32.infinity.positive, error: 1, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, error: 0, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, error: 2 ** -11, expected: kAnyBounds },
+      { value: kValue.f32.infinity.negative, error: 1, expected: kAnyBounds },
+      { value: kValue.f32.positive.max, error: 0, expected: kValue.f32.positive.max },
+      { value: kValue.f32.positive.max, error: 2 ** -11, expected: kValue.f32.positive.max },
+      { value: kValue.f32.positive.max, error: kValue.f32.positive.max, expected: kAnyBounds },
+      { value: kValue.f32.positive.min, error: 0, expected: kValue.f32.positive.min },
+      { value: kValue.f32.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.positive.min, error: 1, expected: [-1, 1] },
+      { value: kValue.f32.negative.min, error: 0, expected: kValue.f32.negative.min },
+      { value: kValue.f32.negative.min, error: 2 ** -11, expected: kValue.f32.negative.min },
+      { value: kValue.f32.negative.min, error: kValue.f32.positive.max, expected: kAnyBounds },
+      { value: kValue.f32.negative.max, error: 0, expected: kValue.f32.negative.max },
+      { value: kValue.f32.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.negative.max, error: 1, expected: [-1, 1] },
+
+      // 32-bit subnormals
+      { value: kValue.f32.subnormal.positive.max, error: 0, expected: [0, kValue.f32.subnormal.positive.max] },
+      { value: kValue.f32.subnormal.positive.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.subnormal.positive.max, error: 1, expected: [-1, 1] },
+      { value: kValue.f32.subnormal.positive.min, error: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: kValue.f32.subnormal.positive.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.subnormal.positive.min, error: 1, expected: [-1, 1] },
+      { value: kValue.f32.subnormal.negative.min, error: 0, expected: [kValue.f32.subnormal.negative.min, 0] },
+      { value: kValue.f32.subnormal.negative.min, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.subnormal.negative.min, error: 1, expected: [-1, 1] },
+      { value: kValue.f32.subnormal.negative.max, error: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: kValue.f32.subnormal.negative.max, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: kValue.f32.subnormal.negative.max, error: 1, expected: [-1, 1] },
+
+      // 64-bit subnormals
+      { value: hexToF64(0x0000_0000_0000_0001n), error: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x0000_0000_0000_0001n), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: hexToF64(0x0000_0000_0000_0001n), error: 1, expected: [-1, 1] },
+      { value: hexToF64(0x0000_0000_0000_0002n), error: 0, expected: [0, kValue.f32.subnormal.positive.min] },
+      { value: hexToF64(0x0000_0000_0000_0002n), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: hexToF64(0x0000_0000_0000_0002n), error: 1, expected: [-1, 1] },
+      { value: hexToF64(0x800f_ffff_ffff_ffffn), error: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800f_ffff_ffff_ffffn), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: hexToF64(0x800f_ffff_ffff_ffffn), error: 1, expected: [-1, 1] },
+      { value: hexToF64(0x800f_ffff_ffff_fffen), error: 0, expected: [kValue.f32.subnormal.negative.max, 0] },
+      { value: hexToF64(0x800f_ffff_ffff_fffen), error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: hexToF64(0x800f_ffff_ffff_fffen), error: 1, expected: [-1, 1] },
+
+      // Zero
+      { value: 0, error: 0, expected: 0 },
+      { value: 0, error: 2 ** -11, expected: [-(2 ** -11), 2 ** -11] },
+      { value: 0, error: 1, expected: [-1, 1] },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toInterval(t.params.expected);
+    const got = FP.f32.absoluteErrorInterval(t.params.value, t.params.error);
+    t.expect(
+      objectEquals(expected, got),
+      `f32.absoluteErrorInterval(${t.params.value}, ${t.params.error}) returned ${got}. Expected ${expected}`
+    );
+  });
+
 interface CorrectlyRoundedCase {
   value: number;
   expected: number | IntervalBounds;

--- a/src/webgpu/shader/execution/expression/unary/f32_conversion.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f32_conversion.spec.ts
@@ -15,7 +15,6 @@ import {
   TypeU32,
   u32,
 } from '../../../../util/conversion.js';
-import { correctlyRoundedInterval } from '../../../../util/f32_interval.js';
 import { FP } from '../../../../util/floating_point.js';
 import {
   fullF32Range,
@@ -39,17 +38,17 @@ export const d = makeCaseCache('unary/f32_conversion', {
   },
   u32: () => {
     return fullU32Range().map(u => {
-      return { input: u32(u), expected: correctlyRoundedInterval(u) };
+      return { input: u32(u), expected: FP.f32.correctlyRoundedInterval(u) };
     });
   },
   i32: () => {
     return fullI32Range().map(i => {
-      return { input: i32(i), expected: correctlyRoundedInterval(i) };
+      return { input: i32(i), expected: FP.f32.correctlyRoundedInterval(i) };
     });
   },
   f32: () => {
     return fullF32Range().map(f => {
-      return { input: f32(f), expected: correctlyRoundedInterval(f) };
+      return { input: f32(f), expected: FP.f32.correctlyRoundedInterval(f) };
     });
   },
   f32_mat2x2_const: () => {

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -38,10 +38,6 @@ export function toF32Matrix(m: (number | IntervalBounds | FPInterval)[][] | FPVe
 
 // Accuracy Interval
 
-export function absoluteErrorInterval(n: number, error_range: number): FPInterval {
-  return FP.f32.absoluteErrorInterval(n, error_range);
-}
-
 export function ulpInterval(n: number, numULP: number): FPInterval {
   return FP.f32.ulpInterval(n, numULP);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -38,10 +38,6 @@ export function toF32Matrix(m: (number | IntervalBounds | FPInterval)[][] | FPVe
 
 // Accuracy Interval
 
-export function correctlyRoundedInterval(n: number | FPInterval): FPInterval {
-  return FP.f32.correctlyRoundedInterval(n);
-}
-
 export function absoluteErrorInterval(n: number, error_range: number): FPInterval {
   return FP.f32.absoluteErrorInterval(n, error_range);
 }

--- a/src/webgpu/util/f32_interval.ts
+++ b/src/webgpu/util/f32_interval.ts
@@ -35,9 +35,3 @@ export function isF32Matrix(
 export function toF32Matrix(m: (number | IntervalBounds | FPInterval)[][] | FPVector[]): FPMatrix {
   return FP.f32.toMatrix(m);
 }
-
-// Accuracy Interval
-
-export function ulpInterval(n: number, numULP: number): FPInterval {
-  return FP.f32.ulpInterval(n, numULP);
-}

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2257,11 +2257,13 @@ abstract class FPTraits {
     return op;
   }
 
-  /** @returns an interval of N * ULP around the point */
-  public ulpInterval(n: number, numULP: number): FPInterval {
+  protected ulpIntervalImpl(n: number, numULP: number): FPInterval {
     numULP = Math.abs(numULP);
     return this.runScalarToIntervalOp(this.toInterval(n), this.ULPIntervalOp(numULP));
   }
+
+  /** @returns an interval of N * ULP around the point */
+  public abstract readonly ulpInterval: (n: number, numULP: number) => FPInterval;
 
   // API - Acceptance Intervals
 
@@ -4011,6 +4013,7 @@ class F32Traits extends FPTraits {
   public readonly absoluteErrorInterval = this.absoluteErrorIntervalImpl.bind(this);
   public readonly correctlyRoundedInterval = this.correctlyRoundedIntervalImpl.bind(this);
   public readonly correctlyRoundedMatrix = this.correctlyRoundedMatrixImpl.bind(this);
+  public readonly ulpInterval = this.ulpIntervalImpl.bind(this);
 
   // Framework - API - Overrides
   public readonly absInterval = this.absIntervalImpl.bind(this);

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2177,6 +2177,35 @@ abstract class FPTraits {
 
   // API - Fundamental Error Intervals
 
+  /** @returns a ScalarToIntervalOp for [n - error_range, n + error_range] */
+  private AbsoluteErrorIntervalOp(error_range: number): ScalarToIntervalOp {
+    const op: ScalarToIntervalOp = {
+      impl: (_: number) => {
+        return this.constants().anyInterval;
+      },
+    };
+
+    if (isFiniteF32(error_range)) {
+      op.impl = (n: number) => {
+        assert(!Number.isNaN(n), `absolute error not defined for NaN`);
+        return this.toInterval([n - error_range, n + error_range]);
+      };
+    }
+
+    return op;
+  }
+
+  protected absoluteErrorIntervalImpl(n: number, error_range: number): FPInterval {
+    error_range = Math.abs(error_range);
+    return this.runScalarToIntervalOp(
+      this.toInterval(n),
+      this.AbsoluteErrorIntervalOp(error_range)
+    );
+  }
+
+  /** @returns an interval of the absolute error around the point */
+  public abstract readonly absoluteErrorInterval: (n: number, error_range: number) => FPInterval;
+
   /**
    * Defines a ScalarToIntervalOp for an interval of the correctly rounded values
    * around the point
@@ -2201,33 +2230,6 @@ abstract class FPTraits {
 
   /** @returns a matrix of correctly rounded intervals for the provided matrix */
   public abstract readonly correctlyRoundedMatrix: (m: Array2D<number>) => FPMatrix;
-
-  /** @returns a ScalarToIntervalOp for [n - error_range, n + error_range] */
-  private AbsoluteErrorIntervalOp(error_range: number): ScalarToIntervalOp {
-    const op: ScalarToIntervalOp = {
-      impl: (_: number) => {
-        return this.constants().anyInterval;
-      },
-    };
-
-    if (isFiniteF32(error_range)) {
-      op.impl = (n: number) => {
-        assert(!Number.isNaN(n), `absolute error not defined for NaN`);
-        return this.toInterval([n - error_range, n + error_range]);
-      };
-    }
-
-    return op;
-  }
-
-  /** @returns an interval of the absolute error around the point */
-  public absoluteErrorInterval(n: number, error_range: number): FPInterval {
-    error_range = Math.abs(error_range);
-    return this.runScalarToIntervalOp(
-      this.toInterval(n),
-      this.AbsoluteErrorIntervalOp(error_range)
-    );
-  }
 
   /** @returns a ScalarToIntervalOp for [n - numULP * ULP(n), n + numULP * ULP(n)] */
   private ULPIntervalOp(numULP: number): ScalarToIntervalOp {
@@ -4005,6 +4007,11 @@ class F32Traits extends FPTraits {
   public readonly oneULP = oneULPF32;
   public readonly scalarBuilder = f32;
 
+  // Framework - Fundamental Error Intervals - Overrides
+  public readonly absoluteErrorInterval = this.absoluteErrorIntervalImpl.bind(this);
+  public readonly correctlyRoundedInterval = this.correctlyRoundedIntervalImpl.bind(this);
+  public readonly correctlyRoundedMatrix = this.correctlyRoundedMatrixImpl.bind(this);
+
   // Framework - API - Overrides
   public readonly absInterval = this.absIntervalImpl.bind(this);
   public readonly acosInterval = this.acosIntervalImpl.bind(this);
@@ -4022,8 +4029,6 @@ class F32Traits extends FPTraits {
   public readonly clampMedianInterval = this.clampMedianIntervalImpl.bind(this);
   public readonly clampMinMaxInterval = this.clampMinMaxIntervalImpl.bind(this);
   public readonly clampIntervals = [this.clampMedianInterval, this.clampMinMaxInterval];
-  public readonly correctlyRoundedInterval = this.correctlyRoundedIntervalImpl.bind(this);
-  public readonly correctlyRoundedMatrix = this.correctlyRoundedMatrixImpl.bind(this);
   public readonly cosInterval = this.cosIntervalImpl.bind(this);
   public readonly coshInterval = this.coshIntervalImpl.bind(this);
   public readonly crossInterval = this.crossIntervalImpl.bind(this);


### PR DESCRIPTION
This covers migrating absoluteError, correctlyRounded, and ULP to the
new numeric framework.

Issue: #2416

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
