### PR TITLE
Execution tests for atomic builtins on workgroup atomic vars

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicAdd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicAdd.spec.ts
@@ -11,11 +11,16 @@ Returns the original value stored in the atomic object.
 import { makeTestGroup } from '../../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
 
-import { dispatchSizes, workgroupSizes, runTest } from './harness.js';
+import {
+  dispatchSizes,
+  workgroupSizes,
+  runStorageVariableTest,
+  runWorkgroupVariableTest,
+} from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('add')
+g.test('add_storage')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
@@ -28,6 +33,7 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
   .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
+    // Allocate one extra element to ensure it doesn't get modified
     const bufferNumElements = 2;
 
     const initValue = 0;
@@ -35,11 +41,46 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const expected = new Uint32Array(bufferNumElements);
     expected[0] = numInvocations;
 
-    runTest({
+    runStorageVariableTest({
       t,
       workgroupSize: t.params.workgroupSize,
       dispatchSize: t.params.dispatchSize,
       bufferNumElements,
+      initValue,
+      op,
+      expected,
+    });
+  });
+
+g.test('add_workgroup')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .fn(t => {
+    // Allocate one extra element to ensure it doesn't get modified
+    const wgNumElements = 2;
+
+    const initValue = 0;
+    const op = `atomicAdd(&wg[0], 1)`;
+
+    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize);
+    for (let d = 0; d < t.params.dispatchSize; ++d) {
+      const wg = expected.subarray(d * wgNumElements);
+      wg[0] = t.params.workgroupSize;
+    }
+
+    runWorkgroupVariableTest({
+      t,
+      workgroupSize: t.params.workgroupSize,
+      dispatchSize: t.params.dispatchSize,
+      wgNumElements,
       initValue,
       op,
       expected,

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMax.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMax.spec.ts
@@ -11,11 +11,16 @@ Returns the original value stored in the atomic object.
 import { makeTestGroup } from '../../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
 
-import { dispatchSizes, workgroupSizes, runTest } from './harness.js';
+import {
+  dispatchSizes,
+  workgroupSizes,
+  runStorageVariableTest,
+  runWorkgroupVariableTest,
+} from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('max')
+g.test('max_storage')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
@@ -28,6 +33,7 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
   .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
+    // Allocate one extra element to ensure it doesn't get modified
     const bufferNumElements = 2;
 
     const initValue = 0;
@@ -35,11 +41,46 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const expected = new Uint32Array(bufferNumElements);
     expected[0] = numInvocations - 1;
 
-    runTest({
+    runStorageVariableTest({
       t,
       workgroupSize: t.params.workgroupSize,
       dispatchSize: t.params.dispatchSize,
       bufferNumElements,
+      initValue,
+      op,
+      expected,
+    });
+  });
+
+g.test('max_workgroup')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .fn(t => {
+    // Allocate one extra element to ensure it doesn't get modified
+    const wgNumElements = 2;
+
+    const initValue = 0;
+    const op = `atomicMax(&wg[0], id)`;
+
+    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize).fill(initValue);
+    for (let d = 0; d < t.params.dispatchSize; ++d) {
+      const wg = expected.subarray(d * wgNumElements);
+      wg[0] = t.params.workgroupSize - 1;
+    }
+
+    runWorkgroupVariableTest({
+      t,
+      workgroupSize: t.params.workgroupSize,
+      dispatchSize: t.params.dispatchSize,
+      wgNumElements,
       initValue,
       op,
       expected,

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMin.spec.ts
@@ -11,11 +11,16 @@ Returns the original value stored in the atomic object.
 import { makeTestGroup } from '../../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
 
-import { dispatchSizes, workgroupSizes, runTest } from './harness.js';
+import {
+  dispatchSizes,
+  workgroupSizes,
+  runStorageVariableTest,
+  runWorkgroupVariableTest,
+} from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('min')
+g.test('min_storage')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
@@ -27,6 +32,7 @@ fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
   )
   .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
   .fn(t => {
+    // Allocate one extra element to ensure it doesn't get modified
     const bufferNumElements = 2;
 
     const initValue = 0xffffffff;
@@ -34,11 +40,46 @@ fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const expected = new Uint32Array(bufferNumElements).fill(initValue);
     expected[0] = 0;
 
-    runTest({
+    runStorageVariableTest({
       t,
       workgroupSize: t.params.workgroupSize,
       dispatchSize: t.params.dispatchSize,
       bufferNumElements,
+      initValue,
+      op,
+      expected,
+    });
+  });
+
+g.test('min_workgroup')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .fn(t => {
+    // Allocate one extra element to ensure it doesn't get modified
+    const wgNumElements = 2;
+
+    const initValue = 0xffffffff;
+    const op = `atomicMin(&wg[0], id)`;
+
+    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize).fill(initValue);
+    for (let d = 0; d < t.params.dispatchSize; ++d) {
+      const wg = expected.subarray(d * wgNumElements);
+      wg[0] = 0;
+    }
+
+    runWorkgroupVariableTest({
+      t,
+      workgroupSize: t.params.workgroupSize,
+      dispatchSize: t.params.dispatchSize,
+      wgNumElements,
       initValue,
       op,
       expected,

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicOr.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicOr.spec.ts
@@ -12,11 +12,17 @@ import { makeTestGroup } from '../../../../../../../common/framework/test_group.
 import { keysOf } from '../../../../../../../common/util/data_tables.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
 
-import { dispatchSizes, workgroupSizes, runTest, kMapId } from './harness.js';
+import {
+  dispatchSizes,
+  workgroupSizes,
+  runStorageVariableTest,
+  runWorkgroupVariableTest,
+  kMapId,
+} from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('or')
+g.test('or_storage')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
@@ -38,12 +44,12 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Allocate an output buffer with bitsize of max invocations plus 1 for validation
     const bufferNumElements = Math.max(1, numInvocations / 32) + 1;
 
-    const mapId = kMapId[t.params.mapId];
-    const extra = mapId.wgsl(numInvocations); // Defines map_id()
-
     // Start with all bits low, then using atomicOr to set mapped global id bit on.
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0;
+
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
       let i = map_id(id);
       atomicOr(&output[i / 32], 1u << i)
@@ -54,11 +60,64 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       expected[Math.floor(i / 32)] |= 1 << i;
     }
 
-    runTest({
+    runStorageVariableTest({
       t,
       workgroupSize: t.params.workgroupSize,
       dispatchSize: t.params.dispatchSize,
       bufferNumElements,
+      initValue,
+      op,
+      expected,
+      extra,
+    });
+  });
+
+g.test('or_workgroup')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+  )
+  .fn(t => {
+    const numInvocations = t.params.workgroupSize;
+
+    // Allocate workgroup array with bitsize of max invocations plus 1 for validation
+    const wgNumElements = Math.max(1, numInvocations / 32) + 1;
+
+    // Start with all bits low, then using atomicOr to set mapped local id bit on.
+    // Note: Both WGSL and JS will shift left 1 by id modulo 32.
+    const initValue = 0;
+
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations); // Defines map_id()
+    const op = `
+      let i = map_id(id);
+      atomicOr(&wg[i / 32], 1u << i)
+    `;
+    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize);
+    for (let d = 0; d < t.params.dispatchSize; ++d) {
+      for (let id = 0; id < numInvocations; ++id) {
+        const wg = expected.subarray(d * wgNumElements);
+        const i = mapId.f(id, numInvocations);
+        wg[Math.floor(i / 32)] |= 1 << i;
+      }
+    }
+
+    runWorkgroupVariableTest({
+      t,
+      workgroupSize: t.params.workgroupSize,
+      dispatchSize: t.params.dispatchSize,
+      wgNumElements,
       initValue,
       op,
       expected,

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
@@ -11,11 +11,16 @@ Returns the original value stored in the atomic object.
 import { makeTestGroup } from '../../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
 
-import { dispatchSizes, workgroupSizes, runTest } from './harness.js';
+import {
+  dispatchSizes,
+  workgroupSizes,
+  runStorageVariableTest,
+  runWorkgroupVariableTest,
+} from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('sub')
+g.test('sub_storage')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
@@ -28,6 +33,7 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
   .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
+    // Allocate one extra element to ensure it doesn't get modified
     const bufferNumElements = 2;
 
     const initValue = 0;
@@ -35,11 +41,46 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const expected = new Uint32Array(bufferNumElements);
     expected[0] = -1 * numInvocations;
 
-    runTest({
+    runStorageVariableTest({
       t,
       workgroupSize: t.params.workgroupSize,
       dispatchSize: t.params.dispatchSize,
       bufferNumElements,
+      initValue,
+      op,
+      expected,
+    });
+  });
+
+g.test('sub_workgroup')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .fn(t => {
+    // Allocate one extra element to ensure it doesn't get modified
+    const wgNumElements = 2;
+
+    const initValue = 0;
+    const op = `atomicSub(&wg[0], 1)`;
+
+    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize);
+    for (let d = 0; d < t.params.dispatchSize; ++d) {
+      const wg = expected.subarray(d * wgNumElements);
+      wg[0] = -1 * t.params.workgroupSize;
+    }
+
+    runWorkgroupVariableTest({
+      t,
+      workgroupSize: t.params.workgroupSize,
+      dispatchSize: t.params.dispatchSize,
+      wgNumElements,
       initValue,
       op,
       expected,

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicXor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicXor.spec.ts
@@ -12,11 +12,17 @@ import { makeTestGroup } from '../../../../../../../common/framework/test_group.
 import { keysOf } from '../../../../../../../common/util/data_tables.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
 
-import { dispatchSizes, workgroupSizes, runTest, kMapId } from './harness.js';
+import {
+  dispatchSizes,
+  workgroupSizes,
+  runStorageVariableTest,
+  runWorkgroupVariableTest,
+  kMapId,
+} from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('xor')
+g.test('xor_storage')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
@@ -55,11 +61,65 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       expected[Math.floor(i / 32)] ^= 1 << i;
     }
 
-    runTest({
+    runStorageVariableTest({
       t,
       workgroupSize: t.params.workgroupSize,
       dispatchSize: t.params.dispatchSize,
       bufferNumElements,
+      initValue,
+      op,
+      expected,
+      extra,
+    });
+  });
+
+g.test('xor_workgroup')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+  )
+  .fn(t => {
+    const numInvocations = t.params.workgroupSize;
+
+    // Allocate workgroup array with bitsize of max invocations plus 1 for validation
+    const wgNumElements = Math.max(1, numInvocations / 32) + 1;
+
+    // Start with all bits set to some random value for each u32 in the buffer, then atomicXor each mapped global id bit.
+    // Note: Both WGSL and JS will shift left 1 by id modulo 32.
+    const initValue = 0b11000011010110100000111100111100;
+
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations); // Defines map_id()
+    const op = `
+      let i = map_id(id);
+      atomicXor(&wg[i / 32], 1u << i)
+    `;
+
+    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize).fill(initValue);
+    for (let d = 0; d < t.params.dispatchSize; ++d) {
+      for (let id = 0; id < numInvocations; ++id) {
+        const wg = expected.subarray(d * wgNumElements);
+        const i = mapId.f(id, numInvocations);
+        wg[Math.floor(i / 32)] ^= 1 << i;
+      }
+    }
+
+    runWorkgroupVariableTest({
+      t,
+      workgroupSize: t.params.workgroupSize,
+      dispatchSize: t.params.dispatchSize,
+      wgNumElements,
       initValue,
       op,
       expected,

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/harness.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/harness.ts
@@ -1,4 +1,5 @@
-import { GPUTest } from '../../../../../../gpu_test';
+import { assert } from '../../../../../../../common/util/util.js';
+import { GPUTest } from '../../../../../../gpu_test.js';
 
 export const workgroupSizes = [1, 2, 32, 64];
 export const dispatchSizes = [1, 4, 8, 16];
@@ -14,13 +15,13 @@ export const kMapId = {
   },
 };
 
-export function runTest({
+export function runStorageVariableTest({
   t,
   workgroupSize, // Workgroup X-size
   dispatchSize, // Dispatch X-size
   bufferNumElements, // Number of 32-bit elements in output buffer
   initValue, // 32-bit initial value used to fill output buffer
-  op, // Atomic op source executed by the compute shader
+  op, // Atomic op source executed by the compute shader, NOTE: 'id' is global_invocation_id.x
   expected, // Expected values array to compare against output buffer
   extra, // Optional extra WGSL source
 }: {
@@ -33,6 +34,8 @@ export function runTest({
   expected: Uint32Array;
   extra?: string;
 }) {
+  assert(expected.length === bufferNumElements, "'expected' buffer size is incorrect");
+
   const wgsl = `
     @group(0) @binding(0)
     var<storage, read_write> output: array<atomic<u32>>;
@@ -57,6 +60,98 @@ export function runTest({
 
   const outputBuffer = t.device.createBuffer({
     size: bufferNumElements * Uint32Array.BYTES_PER_ELEMENT,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    mappedAtCreation: true,
+  });
+  // Fill with initial value
+  t.trackForCleanup(outputBuffer);
+  const data = new Uint32Array(outputBuffer.getMappedRange());
+  data.fill(initValue);
+  outputBuffer.unmap();
+
+  const bindGroup = t.device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [{ binding: 0, resource: { buffer: outputBuffer } }],
+  });
+
+  // Run the shader.
+  const encoder = t.device.createCommandEncoder();
+  const pass = encoder.beginComputePass();
+  pass.setPipeline(pipeline);
+  pass.setBindGroup(0, bindGroup);
+  pass.dispatchWorkgroups(dispatchSize);
+  pass.end();
+  t.queue.submit([encoder.finish()]);
+
+  t.expectGPUBufferValuesEqual(outputBuffer, expected);
+}
+
+export function runWorkgroupVariableTest({
+  t,
+  workgroupSize, // Workgroup X-size
+  dispatchSize, // Dispatch X-size
+  wgNumElements, // Number of 32-bit elements in 'wg' array. Output buffer is sized to wgNumElements * dispatchSize.
+  initValue, // 32-bit initial value used to fill 'wg' array
+  op, // Atomic op source executed by the compute shader, NOTE: 'id' is local_invocation_index
+  expected, // Expected values array to compare against output buffer
+  extra, // Optional extra WGSL source
+}: {
+  t: GPUTest;
+  workgroupSize: number;
+  dispatchSize: number;
+  wgNumElements: number;
+  initValue: number;
+  op: string;
+  expected: Uint32Array;
+  extra?: string;
+}) {
+  assert(expected.length === wgNumElements * dispatchSize, "'expected' buffer size is incorrect");
+
+  const wgsl = `
+    var<workgroup> wg: array<atomic<u32>, ${wgNumElements}>;
+
+    // Result of each workgroup is written to output[workgroup_id.x]
+    @group(0) @binding(0)
+    var<storage, read_write> output: array<u32, ${wgNumElements * dispatchSize}>;
+    
+    @compute @workgroup_size(${workgroupSize})
+    fn main(
+        @builtin(local_invocation_index) local_invocation_index: u32,
+        @builtin(workgroup_id) workgroup_id : vec3<u32>
+        ) {
+      let id = local_invocation_index;
+
+      // Initialize workgroup array
+      if (local_invocation_index == 0) {
+        for (var i = 0u; i < ${wgNumElements}; i++) {
+          atomicStore(&wg[i], ${initValue});
+        }
+      }
+      workgroupBarrier();
+
+      ${op};
+
+      // Copy results to output buffer
+      workgroupBarrier();
+      if (local_invocation_index == 0) {
+        for (var i = 0u; i < ${wgNumElements}; i++) {
+          output[(workgroup_id.x * ${wgNumElements}) + i] = atomicLoad(&wg[i]);
+        }
+      }
+    }
+    ${extra || ''}
+    `;
+
+  const pipeline = t.device.createComputePipeline({
+    layout: 'auto',
+    compute: {
+      module: t.device.createShaderModule({ code: wgsl }),
+      entryPoint: 'main',
+    },
+  });
+
+  const outputBuffer = t.device.createBuffer({
+    size: wgNumElements * dispatchSize * Uint32Array.BYTES_PER_ELEMENT,
     usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
     mappedAtCreation: true,
   });


### PR DESCRIPTION
For atomicAdd/Sub/Min/Max/And/Or/Xor, like https://github.com/gpuweb/cts/pull/2484 except on workgroup vars (former was on storage vars).

Issue: https://github.com/gpuweb/cts/issues/1275
Issue: https://github.com/gpuweb/cts/issues/1276
Issue: https://github.com/gpuweb/cts/issues/1277
Issue: https://github.com/gpuweb/cts/issues/1278
Issue: https://github.com/gpuweb/cts/issues/1279
Issue: https://github.com/gpuweb/cts/issues/1280
Issue: https://github.com/gpuweb/cts/issues/1281

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
