### PR TITLE
Execution atomic builtins: add tests for i32 workgroup/storage vars

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicAdd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicAdd.spec.ts
@@ -16,6 +16,7 @@ import {
   workgroupSizes,
   runStorageVariableTest,
   runWorkgroupVariableTest,
+  typedArrayCtor,
 } from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -30,7 +31,12 @@ T is i32 or u32
 fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
-  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('scalarKind', ['u32', 'i32'])
+  )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
     // Allocate one extra element to ensure it doesn't get modified
@@ -38,7 +44,7 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
     const initValue = 0;
     const op = `atomicAdd(&output[0], 1)`;
-    const expected = new Uint32Array(bufferNumElements);
+    const expected = new (typedArrayCtor(t.params.scalarKind))(bufferNumElements);
     expected[0] = numInvocations;
 
     runStorageVariableTest({
@@ -62,7 +68,12 @@ T is i32 or u32
 fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
-  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('scalarKind', ['u32', 'i32'])
+  )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
     const wgNumElements = 2;
@@ -70,7 +81,9 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const initValue = 0;
     const op = `atomicAdd(&wg[0], 1)`;
 
-    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize);
+    const expected = new (typedArrayCtor(t.params.scalarKind))(
+      wgNumElements * t.params.dispatchSize
+    );
     for (let d = 0; d < t.params.dispatchSize; ++d) {
       const wg = expected.subarray(d * wgNumElements);
       wg[0] = t.params.workgroupSize;

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMax.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMax.spec.ts
@@ -16,6 +16,7 @@ import {
   workgroupSizes,
   runStorageVariableTest,
   runWorkgroupVariableTest,
+  typedArrayCtor,
 } from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -30,7 +31,12 @@ T is i32 or u32
 fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
-  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('scalarKind', ['u32', 'i32'])
+  )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
     // Allocate one extra element to ensure it doesn't get modified
@@ -38,7 +44,7 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
     const initValue = 0;
     const op = `atomicMax(&output[0], id)`;
-    const expected = new Uint32Array(bufferNumElements);
+    const expected = new (typedArrayCtor(t.params.scalarKind))(bufferNumElements);
     expected[0] = numInvocations - 1;
 
     runStorageVariableTest({
@@ -62,7 +68,12 @@ T is i32 or u32
 fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
-  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('scalarKind', ['u32', 'i32'])
+  )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
     const wgNumElements = 2;
@@ -70,7 +81,9 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const initValue = 0;
     const op = `atomicMax(&wg[0], id)`;
 
-    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize).fill(initValue);
+    const expected = new (typedArrayCtor(t.params.scalarKind))(
+      wgNumElements * t.params.dispatchSize
+    ).fill(initValue);
     for (let d = 0; d < t.params.dispatchSize; ++d) {
       const wg = expected.subarray(d * wgNumElements);
       wg[0] = t.params.workgroupSize - 1;

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMin.spec.ts
@@ -16,6 +16,7 @@ import {
   workgroupSizes,
   runStorageVariableTest,
   runWorkgroupVariableTest,
+  typedArrayCtor,
 } from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -30,14 +31,19 @@ T is i32 or u32
 fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
-  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('scalarKind', ['u32', 'i32'])
+  )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
     const bufferNumElements = 2;
 
-    const initValue = 0xffffffff;
+    const initValue = t.params.scalarKind === 'u32' ? 0xffffffff : 0x7fffffff;
     const op = `atomicMin(&output[0], id)`;
-    const expected = new Uint32Array(bufferNumElements).fill(initValue);
+    const expected = new (typedArrayCtor(t.params.scalarKind))(bufferNumElements).fill(initValue);
     expected[0] = 0;
 
     runStorageVariableTest({
@@ -61,15 +67,22 @@ T is i32 or u32
 fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
-  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('scalarKind', ['u32', 'i32'])
+  )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
     const wgNumElements = 2;
 
-    const initValue = 0xffffffff;
+    const initValue = t.params.scalarKind === 'u32' ? 0xffffffff : 0x7fffffff;
     const op = `atomicMin(&wg[0], id)`;
 
-    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize).fill(initValue);
+    const expected = new (typedArrayCtor(t.params.scalarKind))(
+      wgNumElements * t.params.dispatchSize
+    ).fill(initValue);
     for (let d = 0; d < t.params.dispatchSize; ++d) {
       const wg = expected.subarray(d * wgNumElements);
       wg[0] = 0;

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicOr.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicOr.spec.ts
@@ -18,6 +18,7 @@ import {
   runStorageVariableTest,
   runWorkgroupVariableTest,
   kMapId,
+  typedArrayCtor,
 } from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -37,6 +38,7 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
+      .combine('scalarKind', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
@@ -48,13 +50,14 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0;
 
+    const scalarKind = t.params.scalarKind;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
-      let i = map_id(id);
-      atomicOr(&output[i / 32], 1u << i)
+    let i = map_id(u32(id));
+      atomicOr(&output[i / 32], ${scalarKind}(1) << i)
     `;
-    const expected = new Uint32Array(bufferNumElements);
+    const expected = new (typedArrayCtor(scalarKind))(bufferNumElements);
     for (let id = 0; id < numInvocations; ++id) {
       const i = mapId.f(id, numInvocations);
       expected[Math.floor(i / 32)] |= 1 << i;
@@ -87,6 +90,7 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
+      .combine('scalarKind', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize;
@@ -98,13 +102,14 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0;
 
+    const scalarKind = t.params.scalarKind;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
-      let i = map_id(id);
-      atomicOr(&wg[i / 32], 1u << i)
+    let i = map_id(u32(id));
+      atomicOr(&wg[i / 32], ${scalarKind}(1) << i)
     `;
-    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize);
+    const expected = new (typedArrayCtor(scalarKind))(wgNumElements * t.params.dispatchSize);
     for (let d = 0; d < t.params.dispatchSize; ++d) {
       for (let id = 0; id < numInvocations; ++id) {
         const wg = expected.subarray(d * wgNumElements);

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
@@ -16,6 +16,7 @@ import {
   workgroupSizes,
   runStorageVariableTest,
   runWorkgroupVariableTest,
+  typedArrayCtor,
 } from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -30,7 +31,12 @@ T is i32 or u32
 fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
-  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('scalarKind', ['u32', 'i32'])
+  )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
     // Allocate one extra element to ensure it doesn't get modified
@@ -38,7 +44,7 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
     const initValue = 0;
     const op = `atomicSub(&output[0], 1)`;
-    const expected = new Uint32Array(bufferNumElements);
+    const expected = new (typedArrayCtor(t.params.scalarKind))(bufferNumElements);
     expected[0] = -1 * numInvocations;
 
     runStorageVariableTest({
@@ -62,7 +68,12 @@ T is i32 or u32
 fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
-  .params(u => u.combine('workgroupSize', workgroupSizes).combine('dispatchSize', dispatchSizes))
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('scalarKind', ['u32', 'i32'])
+  )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
     const wgNumElements = 2;
@@ -70,7 +81,9 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const initValue = 0;
     const op = `atomicSub(&wg[0], 1)`;
 
-    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize);
+    const expected = new (typedArrayCtor(t.params.scalarKind))(
+      wgNumElements * t.params.dispatchSize
+    );
     for (let d = 0; d < t.params.dispatchSize; ++d) {
       const wg = expected.subarray(d * wgNumElements);
       wg[0] = -1 * t.params.workgroupSize;

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicXor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicXor.spec.ts
@@ -18,6 +18,7 @@ import {
   runStorageVariableTest,
   runWorkgroupVariableTest,
   kMapId,
+  typedArrayCtor,
 } from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
@@ -37,6 +38,7 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
+      .combine('scalarKind', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
@@ -48,14 +50,15 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0b11000011010110100000111100111100;
 
+    const scalarKind = t.params.scalarKind;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
-      let i = map_id(id);
-      atomicXor(&output[i / 32], 1u << i)
+    let i = map_id(u32(id));
+      atomicXor(&output[i / 32], ${scalarKind}(1) << i)
     `;
 
-    const expected = new Uint32Array(bufferNumElements).fill(initValue);
+    const expected = new (typedArrayCtor(scalarKind))(bufferNumElements).fill(initValue);
     for (let id = 0; id < numInvocations; ++id) {
       const i = mapId.f(id, numInvocations);
       expected[Math.floor(i / 32)] ^= 1 << i;
@@ -88,6 +91,7 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
+      .combine('scalarKind', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize;
@@ -99,14 +103,17 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0b11000011010110100000111100111100;
 
+    const scalarKind = t.params.scalarKind;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
-      let i = map_id(id);
-      atomicXor(&wg[i / 32], 1u << i)
+      let i = map_id(u32(id));
+      atomicXor(&wg[i / 32], ${scalarKind}(1) << i)
     `;
 
-    const expected = new Uint32Array(wgNumElements * t.params.dispatchSize).fill(initValue);
+    const expected = new (typedArrayCtor(scalarKind))(wgNumElements * t.params.dispatchSize).fill(
+      initValue
+    );
     for (let d = 0; d < t.params.dispatchSize; ++d) {
       for (let id = 0; id < numInvocations; ++id) {
         const wg = expected.subarray(d * wgNumElements);

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/harness.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/harness.ts
@@ -1,4 +1,8 @@
-import { assert } from '../../../../../../../common/util/util.js';
+import {
+  assert,
+  TypedArrayBufferView,
+  TypedArrayBufferViewConstructor,
+} from '../../../../../../../common/util/util.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
 
 export const workgroupSizes = [1, 2, 32, 64];
@@ -14,6 +18,18 @@ export const kMapId = {
       `fn map_id(id: u32) -> u32 { return ((id * 14957) ^ ((id * 26561) >> 2)) % ${max}; }`,
   },
 };
+
+export function typedArrayCtor(scalarType: string): TypedArrayBufferViewConstructor {
+  switch (scalarType) {
+    case 'u32':
+      return Uint32Array;
+    case 'i32':
+      return Int32Array;
+    default:
+      assert(false, 'Atomic variables can only by u32 or i32');
+      return Uint8Array;
+  }
+}
 
 export function runStorageVariableTest({
   t,
@@ -31,20 +47,23 @@ export function runStorageVariableTest({
   bufferNumElements: number;
   initValue: number;
   op: string;
-  expected: Uint32Array;
+  expected: TypedArrayBufferView;
   extra?: string;
 }) {
   assert(expected.length === bufferNumElements, "'expected' buffer size is incorrect");
 
+  const scalarType = expected instanceof Uint32Array ? 'u32' : 'i32';
+  const arrayType = typedArrayCtor(scalarType);
+
   const wgsl = `
     @group(0) @binding(0)
-    var<storage, read_write> output: array<atomic<u32>>;
+    var<storage, read_write> output: array<atomic<${scalarType}>>;
     
     @compute @workgroup_size(${workgroupSize})
     fn main(
         @builtin(global_invocation_id) global_invocation_id : vec3<u32>,
         ) {
-      let id = global_invocation_id[0];
+      let id = ${scalarType}(global_invocation_id[0]);
       ${op};
     }
     ${extra || ''}
@@ -59,13 +78,13 @@ export function runStorageVariableTest({
   });
 
   const outputBuffer = t.device.createBuffer({
-    size: bufferNumElements * Uint32Array.BYTES_PER_ELEMENT,
+    size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
     usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
     mappedAtCreation: true,
   });
   // Fill with initial value
   t.trackForCleanup(outputBuffer);
-  const data = new Uint32Array(outputBuffer.getMappedRange());
+  const data = new arrayType(outputBuffer.getMappedRange());
   data.fill(initValue);
   outputBuffer.unmap();
 
@@ -102,29 +121,32 @@ export function runWorkgroupVariableTest({
   wgNumElements: number;
   initValue: number;
   op: string;
-  expected: Uint32Array;
+  expected: TypedArrayBufferView;
   extra?: string;
 }) {
   assert(expected.length === wgNumElements * dispatchSize, "'expected' buffer size is incorrect");
 
+  const scalarType = expected instanceof Uint32Array ? 'u32' : 'i32';
+  const arrayType = typedArrayCtor(scalarType);
+
   const wgsl = `
-    var<workgroup> wg: array<atomic<u32>, ${wgNumElements}>;
+    var<workgroup> wg: array<atomic<${scalarType}>, ${wgNumElements}>;
 
     // Result of each workgroup is written to output[workgroup_id.x]
     @group(0) @binding(0)
-    var<storage, read_write> output: array<u32, ${wgNumElements * dispatchSize}>;
+    var<storage, read_write> output: array<${scalarType}, ${wgNumElements * dispatchSize}>;
     
     @compute @workgroup_size(${workgroupSize})
     fn main(
         @builtin(local_invocation_index) local_invocation_index: u32,
         @builtin(workgroup_id) workgroup_id : vec3<u32>
         ) {
-      let id = local_invocation_index;
+      let id = ${scalarType}(local_invocation_index);
 
       // Initialize workgroup array
       if (local_invocation_index == 0) {
         for (var i = 0u; i < ${wgNumElements}; i++) {
-          atomicStore(&wg[i], ${initValue});
+          atomicStore(&wg[i], bitcast<${scalarType}>(${initValue}u));
         }
       }
       workgroupBarrier();
@@ -151,15 +173,9 @@ export function runWorkgroupVariableTest({
   });
 
   const outputBuffer = t.device.createBuffer({
-    size: wgNumElements * dispatchSize * Uint32Array.BYTES_PER_ELEMENT,
+    size: wgNumElements * dispatchSize * arrayType.BYTES_PER_ELEMENT,
     usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
-    mappedAtCreation: true,
   });
-  // Fill with initial value
-  t.trackForCleanup(outputBuffer);
-  const data = new Uint32Array(outputBuffer.getMappedRange());
-  data.fill(initValue);
-  outputBuffer.unmap();
 
   const bindGroup = t.device.createBindGroup({
     layout: pipeline.getBindGroupLayout(0),


### PR DESCRIPTION
Issue: #1275
Issue: #1276
Issue: #1277
Issue: #1278
Issue: #1279
Issue: #1280
Issue: #1281
<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
