### PR TITLE
Implement core abstract float support

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -95,6 +95,9 @@ g.test('constructor_f32')
       { input: [0], expected: [0] },
       { input: [10], expected: [10] },
       { input: [-5], expected: [-5] },
+      { input: [2.5], expected: [2.5] },
+      { input: [-1.375], expected: [-1.375] },
+      { input: [-1.375, 2.5], expected: [-1.375, 2.5] },
 
       // Edges
       { input: [0, kValue.f32.positive.max], expected: [0, kValue.f32.positive.max] },
@@ -131,6 +134,9 @@ g.test('constructor_abstract')
       { input: [0], expected: [0] },
       { input: [10], expected: [10] },
       { input: [-5], expected: [-5] },
+      { input: [2.5], expected: [2.5] },
+      { input: [-1.375], expected: [-1.375] },
+      { input: [-1.375, 2.5], expected: [-1.375, 2.5] },
 
       // Edges
       { input: [0, kValue.f64.positive.max], expected: [0, kValue.f64.positive.max] },
@@ -142,8 +148,10 @@ g.test('constructor_abstract')
       { input: [kValue.f64.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, 0] },
       { input: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], expected: kAnyBounds },
 
-      // Note: Out of range values are infinities for abstract float, due to abstract float and 'number' both being f64.
-      // So there is no seperate OOR tests, the testing framework considers them duplicates.
+      // Note: Out of range values are limited to infinities for abstract float,
+      // due to abstract float and 'number' both being f64.
+      // So there is no  separate OOR tests, the testing framework considers
+      // them duplicates.
     ]
   )
   .fn(t => {
@@ -178,6 +186,9 @@ g.test('contains_number_f32')
       { bounds: [-5, 10], value: -6, expected: false },
       { bounds: [-5, 10], value: 50, expected: false },
       { bounds: [-5, 10], value: -10, expected: false },
+      { bounds: [-1.375, 2.5], value: -10, expected: false },
+      { bounds: [-1.375, 2.5], value: 0.5, expected: true },
+      { bounds: [-1.375, 2.5], value: 10, expected: false },
 
       // Point
       { bounds: 0, value: 0, expected: true },
@@ -291,6 +302,9 @@ g.test('contains_number_abstract')
       { bounds: [-5, 10], value: -6, expected: false },
       { bounds: [-5, 10], value: 50, expected: false },
       { bounds: [-5, 10], value: -10, expected: false },
+      { bounds: [-1.375, 2.5], value: -10, expected: false },
+      { bounds: [-1.375, 2.5], value: 0.5, expected: true },
+      { bounds: [-1.375, 2.5], value: 10, expected: false },
 
       // Point
       { bounds: 0, value: 0, expected: true },
@@ -342,8 +356,10 @@ g.test('contains_number_abstract')
       { bounds: [kValue.f64.negative.min, 0], value: kValue.f64.negative.max, expected: true },
       { bounds: [kValue.f64.negative.min, 0], value: kValue.f64.infinity.negative, expected: false },
 
-      // Note: Out of range values are infinities for abstract float, due to abstract float and 'number' both being f64.
-      // So there is no separate OOR tests, the testing framework considers them duplicates.
+      // Note: Out of range values are limited to infinities for abstract float,
+      // due to abstract float and 'number' both being f64.
+      // So there is no separate OOR tests, the testing framework considers them
+      // duplicates.
 
       // Subnormals
       { bounds: [0, kValue.f64.positive.min], value: kValue.f64.subnormal.positive.min, expected: true },
@@ -527,8 +543,10 @@ g.test('contains_interval_abstract')
       { lhs: [kValue.f64.negative.min, 0], rhs: [kValue.f64.infinity.negative, -100 ], expected: false },
       { lhs: [kValue.f64.negative.min, 0], rhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], expected: false },
 
-      // Note: Out of range values are infinities for abstract float, due to abstract float and 'number' both being f64.
-      // So there is no separate OOR tests, the testing framework considers them duplicates.
+      // Note: Out of range values are limited to infinities for abstract float,
+      // due to abstract float and 'number' both being f64.
+      // So there is no separate OOR tests, the testing framework considers them
+      // duplicates.
     ]
   )
   .fn(t => {

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -18,6 +18,9 @@ const kAnyBounds: IntervalBounds = [Number.NEGATIVE_INFINITY, Number.POSITIVE_IN
 /** Interval from kAnyBounds for f32 */
 const kAnyIntervalF32: FPInterval = FP.f32.toInterval(kAnyBounds);
 
+/** Interval from kAnyBounds for abstract floats */
+const kAnyIntervalAbstract: FPInterval = FP.abstract.toInterval(kAnyBounds);
+
 /** @returns a number N * ULP greater than the provided number, treats input as f32 */
 function plusNULPF32(x: number, n: number): number {
   return x + n * oneULPF32(x);
@@ -114,6 +117,40 @@ g.test('constructor_f32')
     t.expect(
       objectEquals(i.bounds(), t.params.expected),
       `new FPInterval('f32', [${t.params.input}]) returned ${i}. Expected [${t.params.expected}]`
+    );
+  });
+
+g.test('constructor_abstract')
+  .paramsSubcasesOnly<ConstructorCase>(
+    // prettier-ignore
+    [
+      // Common cases
+      { input: [0, 10], expected: [0, 10] },
+      { input: [-5, 0], expected: [-5, 0] },
+      { input: [-5, 10], expected: [-5, 10] },
+      { input: [0], expected: [0] },
+      { input: [10], expected: [10] },
+      { input: [-5], expected: [-5] },
+
+      // Edges
+      { input: [0, kValue.f64.positive.max], expected: [0, kValue.f64.positive.max] },
+      { input: [kValue.f64.negative.min, 0], expected: [kValue.f64.negative.min, 0] },
+      { input: [kValue.f64.negative.min, kValue.f64.positive.max], expected: [kValue.f64.negative.min, kValue.f64.positive.max] },
+
+      // Infinities
+      { input: [0, kValue.f64.infinity.positive], expected: [0, Number.POSITIVE_INFINITY] },
+      { input: [kValue.f64.infinity.negative, 0], expected: [Number.NEGATIVE_INFINITY, 0] },
+      { input: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], expected: kAnyBounds },
+
+      // Note: Out of range values are infinities for abstract float, due to abstract float and 'number' both being f64.
+      // So there is no seperate OOR tests, the testing framework considers them duplicates.
+    ]
+  )
+  .fn(t => {
+    const i = new FPInterval('abstract', ...t.params.input);
+    t.expect(
+      objectEquals(i.bounds(), t.params.expected),
+      `new FPInterval('abstract', [${t.params.input}]) returned ${i}. Expected [${t.params.expected}]`
     );
   });
 
@@ -236,6 +273,106 @@ g.test('contains_number_f32')
     t.expect(expected === got, `${i}.contains(${value}) returned ${got}. Expected ${expected}`);
   });
 
+g.test('contains_number_abstract')
+  .paramsSubcasesOnly<ContainsNumberCase>(
+    // prettier-ignore
+    [
+      // Common usage
+      { bounds: [0, 10], value: 0, expected: true },
+      { bounds: [0, 10], value: 10, expected: true },
+      { bounds: [0, 10], value: 5, expected: true },
+      { bounds: [0, 10], value: -5, expected: false },
+      { bounds: [0, 10], value: 50, expected: false },
+      { bounds: [0, 10], value: Number.NaN, expected: false },
+      { bounds: [-5, 10], value: 0, expected: true },
+      { bounds: [-5, 10], value: 10, expected: true },
+      { bounds: [-5, 10], value: 5, expected: true },
+      { bounds: [-5, 10], value: -5, expected: true },
+      { bounds: [-5, 10], value: -6, expected: false },
+      { bounds: [-5, 10], value: 50, expected: false },
+      { bounds: [-5, 10], value: -10, expected: false },
+
+      // Point
+      { bounds: 0, value: 0, expected: true },
+      { bounds: 0, value: 10, expected: false },
+      { bounds: 0, value: -1000, expected: false },
+      { bounds: 10, value: 10, expected: true },
+      { bounds: 10, value: 0, expected: false },
+      { bounds: 10, value: -10, expected: false },
+      { bounds: 10, value: 11, expected: false },
+
+      // Upper infinity
+      { bounds: [0, kValue.f64.infinity.positive], value: kValue.f64.positive.min, expected: true },
+      { bounds: [0, kValue.f64.infinity.positive], value: kValue.f64.positive.max, expected: true },
+      { bounds: [0, kValue.f64.infinity.positive], value: kValue.f64.infinity.positive, expected: true },
+      { bounds: [0, kValue.f64.infinity.positive], value: kValue.f64.negative.min, expected: false },
+      { bounds: [0, kValue.f64.infinity.positive], value: kValue.f64.negative.max, expected: false },
+      { bounds: [0, kValue.f64.infinity.positive], value: kValue.f64.infinity.negative, expected: false },
+
+      // Lower infinity
+      { bounds: [kValue.f64.infinity.negative, 0], value: kValue.f64.positive.min, expected: false },
+      { bounds: [kValue.f64.infinity.negative, 0], value: kValue.f64.positive.max, expected: false },
+      { bounds: [kValue.f64.infinity.negative, 0], value: kValue.f64.infinity.positive, expected: false },
+      { bounds: [kValue.f64.infinity.negative, 0], value: kValue.f64.negative.min, expected: true },
+      { bounds: [kValue.f64.infinity.negative, 0], value: kValue.f64.negative.max, expected: true },
+      { bounds: [kValue.f64.infinity.negative, 0], value: kValue.f64.infinity.negative, expected: true },
+
+      // Full infinity
+      { bounds: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], value: kValue.f64.positive.min, expected: true },
+      { bounds: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], value: kValue.f64.positive.max, expected: true },
+      { bounds: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], value: kValue.f64.infinity.positive, expected: true },
+      { bounds: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], value: kValue.f64.negative.min, expected: true },
+      { bounds: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], value: kValue.f64.negative.max, expected: true },
+      { bounds: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], value: kValue.f64.infinity.negative, expected: true },
+      { bounds: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], value: Number.NaN, expected: true },
+
+      // Maximum abstract boundary
+      { bounds: [0, kValue.f64.positive.max], value: kValue.f64.positive.min, expected: true },
+      { bounds: [0, kValue.f64.positive.max], value: kValue.f64.positive.max, expected: true },
+      { bounds: [0, kValue.f64.positive.max], value: kValue.f64.infinity.positive, expected: false },
+      { bounds: [0, kValue.f64.positive.max], value: kValue.f64.negative.min, expected: false },
+      { bounds: [0, kValue.f64.positive.max], value: kValue.f64.negative.max, expected: false },
+      { bounds: [0, kValue.f64.positive.max], value: kValue.f64.infinity.negative, expected: false },
+
+      // Minimum abstract boundary
+      { bounds: [kValue.f64.negative.min, 0], value: kValue.f64.positive.min, expected: false },
+      { bounds: [kValue.f64.negative.min, 0], value: kValue.f64.positive.max, expected: false },
+      { bounds: [kValue.f64.negative.min, 0], value: kValue.f64.infinity.positive, expected: false },
+      { bounds: [kValue.f64.negative.min, 0], value: kValue.f64.negative.min, expected: true },
+      { bounds: [kValue.f64.negative.min, 0], value: kValue.f64.negative.max, expected: true },
+      { bounds: [kValue.f64.negative.min, 0], value: kValue.f64.infinity.negative, expected: false },
+
+      // Note: Out of range values are infinities for abstract float, due to abstract float and 'number' both being f64.
+      // So there is no separate OOR tests, the testing framework considers them duplicates.
+
+      // Subnormals
+      { bounds: [0, kValue.f64.positive.min], value: kValue.f64.subnormal.positive.min, expected: true },
+      { bounds: [0, kValue.f64.positive.min], value: kValue.f64.subnormal.positive.max, expected: true },
+      { bounds: [0, kValue.f64.positive.min], value: kValue.f64.subnormal.negative.min, expected: false },
+      { bounds: [0, kValue.f64.positive.min], value: kValue.f64.subnormal.negative.max, expected: false },
+      { bounds: [kValue.f64.negative.max, 0], value: kValue.f64.subnormal.positive.min, expected: false },
+      { bounds: [kValue.f64.negative.max, 0], value: kValue.f64.subnormal.positive.max, expected: false },
+      { bounds: [kValue.f64.negative.max, 0], value: kValue.f64.subnormal.negative.min, expected: true },
+      { bounds: [kValue.f64.negative.max, 0], value: kValue.f64.subnormal.negative.max, expected: true },
+      { bounds: [0, kValue.f64.subnormal.positive.min], value: kValue.f64.subnormal.positive.min, expected: true },
+      { bounds: [0, kValue.f64.subnormal.positive.min], value: kValue.f64.subnormal.positive.max, expected: false },
+      { bounds: [0, kValue.f64.subnormal.positive.min], value: kValue.f64.subnormal.negative.min, expected: false },
+      { bounds: [0, kValue.f64.subnormal.positive.min], value: kValue.f64.subnormal.negative.max, expected: false },
+      { bounds: [kValue.f64.subnormal.negative.max, 0], value: kValue.f64.subnormal.positive.min, expected: false },
+      { bounds: [kValue.f64.subnormal.negative.max, 0], value: kValue.f64.subnormal.positive.max, expected: false },
+      { bounds: [kValue.f64.subnormal.negative.max, 0], value: kValue.f64.subnormal.negative.min, expected: false },
+      { bounds: [kValue.f64.subnormal.negative.max, 0], value: kValue.f64.subnormal.negative.max, expected: true },
+    ]
+  )
+  .fn(t => {
+    const i = FP.abstract.toInterval(t.params.bounds);
+    const value = t.params.value;
+    const expected = t.params.expected;
+
+    const got = i.contains(value);
+    t.expect(expected === got, `${i}.contains(${value}) returned ${got}. Expected ${expected}`);
+  });
+
 interface ContainsIntervalCase {
   lhs: number | IntervalBounds;
   rhs: number | IntervalBounds;
@@ -330,6 +467,79 @@ g.test('contains_interval_f32')
     t.expect(expected === got, `${lhs}.contains(${rhs}) returned ${got}. Expected ${expected}`);
   });
 
+g.test('contains_interval_abstract')
+  .paramsSubcasesOnly<ContainsIntervalCase>(
+    // prettier-ignore
+    [
+      // Common usage
+      { lhs: [-10, 10], rhs: 0, expected: true },
+      { lhs: [-10, 10], rhs: [-1, 0], expected: true },
+      { lhs: [-10, 10], rhs: [0, 2], expected: true },
+      { lhs: [-10, 10], rhs: [-1, 2], expected: true },
+      { lhs: [-10, 10], rhs: [0, 10], expected: true },
+      { lhs: [-10, 10], rhs: [-10, 2], expected: true },
+      { lhs: [-10, 10], rhs: [-10, 10], expected: true },
+      { lhs: [-10, 10], rhs: [-100, 10], expected: false },
+
+      // Upper infinity
+      { lhs: [0, kValue.f64.infinity.positive], rhs: 0, expected: true },
+      { lhs: [0, kValue.f64.infinity.positive], rhs: [-1, 0], expected: false },
+      { lhs: [0, kValue.f64.infinity.positive], rhs: [0, 1], expected: true },
+      { lhs: [0, kValue.f64.infinity.positive], rhs: [0, kValue.f64.positive.max], expected: true },
+      { lhs: [0, kValue.f64.infinity.positive], rhs: [0, kValue.f64.infinity.positive], expected: true },
+      { lhs: [0, kValue.f64.infinity.positive], rhs: [100, kValue.f64.infinity.positive], expected: true },
+      { lhs: [0, kValue.f64.infinity.positive], rhs: [Number.NEGATIVE_INFINITY, kValue.f64.infinity.positive], expected: false },
+
+      // Lower infinity
+      { lhs: [kValue.f64.infinity.negative, 0], rhs: 0, expected: true },
+      { lhs: [kValue.f64.infinity.negative, 0], rhs: [-1, 0], expected: true },
+      { lhs: [kValue.f64.infinity.negative, 0], rhs: [kValue.f64.negative.min, 0], expected: true },
+      { lhs: [kValue.f64.infinity.negative, 0], rhs: [0, 1], expected: false },
+      { lhs: [kValue.f64.infinity.negative, 0], rhs: [kValue.f64.infinity.negative, 0], expected: true },
+      { lhs: [kValue.f64.infinity.negative, 0], rhs: [kValue.f64.infinity.negative, -100 ], expected: true },
+      { lhs: [kValue.f64.infinity.negative, 0], rhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], expected: false },
+
+      // Full infinity
+      { lhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], rhs: 0, expected: true },
+      { lhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], rhs: [-1, 0], expected: true },
+      { lhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], rhs: [0, 1], expected: true },
+      { lhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], rhs: [0, kValue.f64.infinity.positive], expected: true },
+      { lhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], rhs: [100, kValue.f64.infinity.positive], expected: true },
+      { lhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], rhs: [kValue.f64.infinity.negative, 0], expected: true },
+      { lhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], rhs: [kValue.f64.infinity.negative, -100 ], expected: true },
+      { lhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], rhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], expected: true },
+
+      // Maximum abstract boundary
+      { lhs: [0, kValue.f64.positive.max], rhs: 0, expected: true },
+      { lhs: [0, kValue.f64.positive.max], rhs: [-1, 0], expected: false },
+      { lhs: [0, kValue.f64.positive.max], rhs: [0, 1], expected: true },
+      { lhs: [0, kValue.f64.positive.max], rhs: [0, kValue.f64.positive.max], expected: true },
+      { lhs: [0, kValue.f64.positive.max], rhs: [0, kValue.f64.infinity.positive], expected: false },
+      { lhs: [0, kValue.f64.positive.max], rhs: [100, kValue.f64.infinity.positive], expected: false },
+      { lhs: [0, kValue.f64.positive.max], rhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], expected: false },
+
+      // Minimum abstract boundary
+      { lhs: [kValue.f64.negative.min, 0], rhs: [0, 0], expected: true },
+      { lhs: [kValue.f64.negative.min, 0], rhs: [-1, 0], expected: true },
+      { lhs: [kValue.f64.negative.min, 0], rhs: [kValue.f64.negative.min, 0], expected: true },
+      { lhs: [kValue.f64.negative.min, 0], rhs: [0, 1], expected: false },
+      { lhs: [kValue.f64.negative.min, 0], rhs: [kValue.f64.infinity.negative, 0], expected: false },
+      { lhs: [kValue.f64.negative.min, 0], rhs: [kValue.f64.infinity.negative, -100 ], expected: false },
+      { lhs: [kValue.f64.negative.min, 0], rhs: [kValue.f64.infinity.negative, kValue.f64.infinity.positive], expected: false },
+
+      // Note: Out of range values are infinities for abstract float, due to abstract float and 'number' both being f64.
+      // So there is no separate OOR tests, the testing framework considers them duplicates.
+    ]
+  )
+  .fn(t => {
+    const lhs = FP.abstract.toInterval(t.params.lhs);
+    const rhs = FP.abstract.toInterval(t.params.rhs);
+    const expected = t.params.expected;
+
+    const got = lhs.contains(rhs);
+    t.expect(expected === got, `${lhs}.contains(${rhs}) returned ${got}. Expected ${expected}`);
+  });
+
 // Utilities
 
 interface SpanIntervalsCase {
@@ -376,6 +586,48 @@ g.test('spanIntervals_f32')
     t.expect(
       objectEquals(got, expected),
       `f32.span({${intervals}}) returned ${got}. Expected ${expected}`
+    );
+  });
+
+g.test('spanIntervals_abstract')
+  .paramsSubcasesOnly<SpanIntervalsCase>(
+    // prettier-ignore
+    [
+      // Single Intervals
+      { intervals: [[0, 10]], expected: [0, 10] },
+      { intervals: [[0, kValue.f64.positive.max]], expected: [0, kValue.f64.positive.max] },
+      { intervals: [[0, kValue.f64.positive.nearest_max]], expected: [0, kValue.f64.positive.nearest_max] },
+      { intervals: [[0, kValue.f64.infinity.positive]], expected: [0, Number.POSITIVE_INFINITY] },
+      { intervals: [[kValue.f64.negative.min, 0]], expected: [kValue.f64.negative.min, 0] },
+      { intervals: [[kValue.f64.negative.nearest_min, 0]], expected: [kValue.f64.negative.nearest_min, 0] },
+      { intervals: [[kValue.f64.infinity.negative, 0]], expected: [Number.NEGATIVE_INFINITY, 0] },
+
+      // Double Intervals
+      { intervals: [[0, 1], [2, 5]], expected: [0, 5] },
+      { intervals: [[2, 5], [0, 1]], expected: [0, 5] },
+      { intervals: [[0, 2], [1, 5]], expected: [0, 5] },
+      { intervals: [[0, 5], [1, 2]], expected: [0, 5] },
+      { intervals: [[kValue.f64.infinity.negative, 0], [0, kValue.f64.infinity.positive]], expected: kAnyBounds },
+
+      // Multiple Intervals
+      { intervals: [[0, 1], [2, 3], [4, 5]], expected: [0, 5] },
+      { intervals: [[0, 1], [4, 5], [2, 3]], expected: [0, 5] },
+      { intervals: [[0, 1], [0, 1], [0, 1]], expected: [0, 1] },
+
+      // Point Intervals
+      { intervals: [1], expected: 1 },
+      { intervals: [1, 2], expected: [1, 2] },
+      { intervals: [-10, 2], expected: [-10, 2] },
+    ]
+  )
+  .fn(t => {
+    const intervals = t.params.intervals.map(i => FP.abstract.toInterval(i));
+    const expected = FP.abstract.toInterval(t.params.expected);
+
+    const got = FP.abstract.spanIntervals(...intervals);
+    t.expect(
+      objectEquals(got, expected),
+      `abstract.span({${intervals}}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -476,6 +728,111 @@ g.test('isVector_f32')
 
     const got = FP.f32.isVector(input);
     t.expect(got === expected, `f32.isVector([${input}]) returned ${got}. Expected ${expected}`);
+  });
+
+g.test('isVector_abstract')
+  .paramsSubcasesOnly<isVectorCase>([
+    // numbers
+    { input: [1, 2], expected: false },
+    { input: [1, 2, 3], expected: false },
+    { input: [1, 2, 3, 4], expected: false },
+
+    // IntervalBounds
+    { input: [[1], [2]], expected: false },
+    { input: [[1], [2], [3]], expected: false },
+    { input: [[1], [2], [3], [4]], expected: false },
+    {
+      input: [
+        [1, 2],
+        [2, 3],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+        [4, 5],
+      ],
+      expected: false,
+    },
+
+    // abstractInterval, valid dimensions
+    { input: [FP.abstract.toInterval([1]), FP.abstract.toInterval([2])], expected: true },
+    { input: [FP.abstract.toInterval([1, 2]), FP.abstract.toInterval([2, 3])], expected: true },
+    {
+      input: [
+        FP.abstract.toInterval([1]),
+        FP.abstract.toInterval([2]),
+        FP.abstract.toInterval([3]),
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        FP.abstract.toInterval([1, 2]),
+        FP.abstract.toInterval([2, 3]),
+        FP.abstract.toInterval([3, 4]),
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        FP.abstract.toInterval([1]),
+        FP.abstract.toInterval([2]),
+        FP.abstract.toInterval([3]),
+        FP.abstract.toInterval([4]),
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        FP.abstract.toInterval([1, 2]),
+        FP.abstract.toInterval([2, 3]),
+        FP.abstract.toInterval([3, 4]),
+        FP.abstract.toInterval([4, 5]),
+      ],
+      expected: true,
+    },
+
+    // FPInterval, invalid dimensions
+    { input: [FP.abstract.toInterval([1])], expected: false },
+    {
+      input: [
+        FP.abstract.toInterval([1]),
+        FP.abstract.toInterval([2]),
+        FP.abstract.toInterval([3]),
+        FP.abstract.toInterval([4]),
+        FP.abstract.toInterval([5]),
+      ],
+      expected: false,
+    },
+
+    // Mixed
+    { input: [1, [2]], expected: false },
+    { input: [1, [2], FP.abstract.toInterval([3])], expected: false },
+    { input: [1, FP.abstract.toInterval([2]), [3], 4], expected: false },
+    { input: [FP.abstract.toInterval(1), 2], expected: false },
+    { input: [FP.abstract.toInterval(1), [2]], expected: false },
+  ])
+  .fn(t => {
+    const input = t.params.input;
+    const expected = t.params.expected;
+
+    const got = FP.abstract.isVector(input);
+    t.expect(
+      got === expected,
+      `abstract.isVector([${input}]) returned ${got}. Expected ${expected}`
+    );
   });
 
 interface toVectorCase {
@@ -593,6 +950,127 @@ g.test('toVector_f32')
     t.expect(
       objectEquals(got, expected),
       `f32.toVector([${input}]) returned [${got}]. Expected [${expected}]`
+    );
+  });
+
+g.test('toVector_abstract')
+  .paramsSubcasesOnly<toVectorCase>([
+    // numbers
+    { input: [1, 2], expected: [1, 2] },
+    { input: [1, 2, 3], expected: [1, 2, 3] },
+    { input: [1, 2, 3, 4], expected: [1, 2, 3, 4] },
+
+    // IntervalBounds
+    { input: [[1], [2]], expected: [1, 2] },
+    { input: [[1], [2], [3]], expected: [1, 2, 3] },
+    { input: [[1], [2], [3], [4]], expected: [1, 2, 3, 4] },
+    {
+      input: [
+        [1, 2],
+        [2, 3],
+      ],
+      expected: [
+        [1, 2],
+        [2, 3],
+      ],
+    },
+    {
+      input: [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+      ],
+      expected: [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+      ],
+    },
+    {
+      input: [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+        [4, 5],
+      ],
+      expected: [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+        [4, 5],
+      ],
+    },
+
+    // abstractInterval
+    { input: [FP.abstract.toInterval([1]), FP.abstract.toInterval([2])], expected: [1, 2] },
+    {
+      input: [FP.abstract.toInterval([1, 2]), FP.abstract.toInterval([2, 3])],
+      expected: [
+        [1, 2],
+        [2, 3],
+      ],
+    },
+    {
+      input: [
+        FP.abstract.toInterval([1]),
+        FP.abstract.toInterval([2]),
+        FP.abstract.toInterval([3]),
+      ],
+      expected: [1, 2, 3],
+    },
+    {
+      input: [
+        FP.abstract.toInterval([1, 2]),
+        FP.abstract.toInterval([2, 3]),
+        FP.abstract.toInterval([3, 4]),
+      ],
+      expected: [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+      ],
+    },
+    {
+      input: [
+        FP.abstract.toInterval([1]),
+        FP.abstract.toInterval([2]),
+        FP.abstract.toInterval([3]),
+        FP.abstract.toInterval([4]),
+      ],
+      expected: [1, 2, 3, 4],
+    },
+    {
+      input: [
+        FP.abstract.toInterval([1, 2]),
+        FP.abstract.toInterval([2, 3]),
+        FP.abstract.toInterval([3, 4]),
+        FP.abstract.toInterval([4, 5]),
+      ],
+      expected: [
+        [1, 2],
+        [2, 3],
+        [3, 4],
+        [4, 5],
+      ],
+    },
+
+    // Mixed
+    { input: [1, [2]], expected: [1, 2] },
+    { input: [1, [2], FP.abstract.toInterval([3])], expected: [1, 2, 3] },
+    { input: [1, FP.abstract.toInterval([2]), [3], 4], expected: [1, 2, 3, 4] },
+    {
+      input: [1, [2], [2, 3], kAnyIntervalAbstract],
+      expected: [1, 2, [2, 3], kAnyBounds],
+    },
+  ])
+  .fn(t => {
+    const input = t.params.input;
+    const expected = t.params.expected.map(e => FP.abstract.toInterval(e));
+
+    const got = FP.abstract.toVector(input);
+    t.expect(
+      objectEquals(got, expected),
+      `abstract.toVector([${input}]) returned [${got}]. Expected [${expected}]`
     );
   });
 
@@ -1022,6 +1500,508 @@ g.test('isMatrix_f32')
 
     const got = FP.f32.isMatrix(input);
     t.expect(got === expected, `f32.isMatrix([${input}]) returned ${got}. Expected ${expected}`);
+  });
+
+g.test('isMatrix_abstract')
+  .paramsSubcasesOnly<isMatrixCase>([
+    // numbers
+    {
+      input: [
+        [1, 2],
+        [3, 4],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [7, 8],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [10, 11, 12],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+      ],
+      expected: false,
+    },
+
+    // IntervalBounds
+    {
+      input: [
+        [[1], [2]],
+        [[3], [4]],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], [2]],
+        [[3], [4]],
+        [[5], [6]],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], [2]],
+        [[3], [4]],
+        [[5], [6]],
+        [[7], [8]],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], [2], [3]],
+        [[4], [5], [6]],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], [2], [3]],
+        [[4], [5], [6]],
+        [[7], [8], [9]],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], [2], [3]],
+        [[4], [5], [6]],
+        [[7], [8], [9]],
+        [[10], [11], [12]],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], [2], [3], [4]],
+        [[5], [6], [7], [8]],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], [2], [3], [4]],
+        [[5], [6], [7], [8]],
+        [[9], [10], [11], [12]],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], [2], [3], [4]],
+        [[5], [6], [7], [8]],
+        [[9], [10], [11], [12]],
+        [[13], [14], [15], [16]],
+      ],
+      expected: false,
+    },
+
+    // FPInterval, valid dimensions
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2)],
+        [FP.abstract.toInterval(3), FP.abstract.toInterval(4)],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2)],
+        [FP.abstract.toInterval(3), FP.abstract.toInterval(4)],
+        [FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2)],
+        [FP.abstract.toInterval(3), FP.abstract.toInterval(4)],
+        [FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+        [FP.abstract.toInterval(7), FP.abstract.toInterval(8)],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2), FP.abstract.toInterval(3)],
+        [FP.abstract.toInterval(4), FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2), FP.abstract.toInterval(3)],
+        [FP.abstract.toInterval(4), FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+        [FP.abstract.toInterval(7), FP.abstract.toInterval(8), FP.abstract.toInterval(9)],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2), FP.abstract.toInterval(3)],
+        [FP.abstract.toInterval(4), FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+        [FP.abstract.toInterval(7), FP.abstract.toInterval(8), FP.abstract.toInterval(9)],
+        [FP.abstract.toInterval(10), FP.abstract.toInterval(11), FP.abstract.toInterval(12)],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval(1),
+          FP.abstract.toInterval(2),
+          FP.abstract.toInterval(3),
+          FP.abstract.toInterval(4),
+        ],
+        [
+          FP.abstract.toInterval(5),
+          FP.abstract.toInterval(6),
+          FP.abstract.toInterval(7),
+          FP.abstract.toInterval(8),
+        ],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval(1),
+          FP.abstract.toInterval(2),
+          FP.abstract.toInterval(3),
+          FP.abstract.toInterval(4),
+        ],
+        [
+          FP.abstract.toInterval(5),
+          FP.abstract.toInterval(6),
+          FP.abstract.toInterval(7),
+          FP.abstract.toInterval(8),
+        ],
+        [
+          FP.abstract.toInterval(9),
+          FP.abstract.toInterval(10),
+          FP.abstract.toInterval(11),
+          FP.abstract.toInterval(12),
+        ],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval(1),
+          FP.abstract.toInterval(2),
+          FP.abstract.toInterval(3),
+          FP.abstract.toInterval(4),
+        ],
+        [
+          FP.abstract.toInterval(5),
+          FP.abstract.toInterval(6),
+          FP.abstract.toInterval(7),
+          FP.abstract.toInterval(8),
+        ],
+        [
+          FP.abstract.toInterval(9),
+          FP.abstract.toInterval(10),
+          FP.abstract.toInterval(11),
+          FP.abstract.toInterval(12),
+        ],
+        [
+          FP.abstract.toInterval(13),
+          FP.abstract.toInterval(14),
+          FP.abstract.toInterval(15),
+          FP.abstract.toInterval(16),
+        ],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval([1, 2]), FP.abstract.toInterval([2, 3])],
+        [FP.abstract.toInterval([3, 4]), FP.abstract.toInterval([4, 5])],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval([1, 2]), FP.abstract.toInterval([2, 3])],
+        [FP.abstract.toInterval([3, 4]), FP.abstract.toInterval([4, 5])],
+        [FP.abstract.toInterval([5, 6]), FP.abstract.toInterval([6, 7])],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval([1, 2]), FP.abstract.toInterval([2, 3])],
+        [FP.abstract.toInterval([3, 4]), FP.abstract.toInterval([4, 5])],
+        [FP.abstract.toInterval([5, 6]), FP.abstract.toInterval([6, 7])],
+        [FP.abstract.toInterval([7, 8]), FP.abstract.toInterval([8, 9])],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+        ],
+        [
+          FP.abstract.toInterval([4, 5]),
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+        ],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+        ],
+        [
+          FP.abstract.toInterval([4, 5]),
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+        ],
+        [
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+          FP.abstract.toInterval([9, 10]),
+        ],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+        ],
+        [
+          FP.abstract.toInterval([4, 5]),
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+        ],
+        [
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+          FP.abstract.toInterval([9, 10]),
+        ],
+        [
+          FP.abstract.toInterval([10, 11]),
+          FP.abstract.toInterval([11, 12]),
+          FP.abstract.toInterval([12, 13]),
+        ],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+          FP.abstract.toInterval([4, 5]),
+        ],
+        [
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+        ],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+          FP.abstract.toInterval([4, 5]),
+        ],
+        [
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+        ],
+        [
+          FP.abstract.toInterval([9, 10]),
+          FP.abstract.toInterval([10, 11]),
+          FP.abstract.toInterval([11, 12]),
+          FP.abstract.toInterval([12, 13]),
+        ],
+      ],
+      expected: true,
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+          FP.abstract.toInterval([4, 5]),
+        ],
+        [
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+        ],
+        [
+          FP.abstract.toInterval([9, 10]),
+          FP.abstract.toInterval([10, 11]),
+          FP.abstract.toInterval([11, 12]),
+          FP.abstract.toInterval([12, 13]),
+        ],
+        [
+          FP.abstract.toInterval([13, 14]),
+          FP.abstract.toInterval([14, 15]),
+          FP.abstract.toInterval([15, 16]),
+          FP.abstract.toInterval([16, 17]),
+        ],
+      ],
+      expected: true,
+    },
+
+    // FPInterval, invalid dimensions
+    { input: [[FP.abstract.toInterval(1)]], expected: false },
+    {
+      input: [[FP.abstract.toInterval(1)], [FP.abstract.toInterval(3), FP.abstract.toInterval(4)]],
+      expected: false,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2)],
+        [FP.abstract.toInterval(3), FP.abstract.toInterval(4), FP.abstract.toInterval(5)],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2)],
+        [FP.abstract.toInterval(3), FP.abstract.toInterval(4)],
+        [FP.abstract.toInterval(5)],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2)],
+        [FP.abstract.toInterval(3), FP.abstract.toInterval(4)],
+        [FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+        [FP.abstract.toInterval(7), FP.abstract.toInterval(8)],
+        [FP.abstract.toInterval(9), FP.abstract.toInterval(10)],
+      ],
+      expected: false,
+    },
+
+    // Mixed
+    {
+      input: [
+        [1, [2]],
+        [3, 4],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], [2]],
+        [[3], 4],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [1, 2],
+        [FP.abstract.toInterval([3]), 4],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [[1], FP.abstract.toInterval([2])],
+        [FP.abstract.toInterval([3]), FP.abstract.toInterval([4])],
+      ],
+      expected: false,
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), [2]],
+        [3, 4],
+      ],
+      expected: false,
+    },
+  ])
+  .fn(t => {
+    const input = t.params.input;
+    const expected = t.params.expected;
+
+    const got = FP.abstract.isMatrix(input);
+    t.expect(
+      got === expected,
+      `abstract.isMatrix([${input}]) returned ${got}. Expected ${expected}`
+    );
   });
 
 interface toMatrixCase {
@@ -1678,6 +2658,734 @@ g.test('toMatrix_f32')
     t.expect(
       objectEquals(got, expected),
       `f32.toMatrix([${input}]) returned [${got}]. Expected [${expected}]`
+    );
+  });
+
+g.test('toMatrix_abstract')
+  .paramsSubcasesOnly<toMatrixCase>([
+    // numbers
+    {
+      input: [
+        [1, 2],
+        [3, 4],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+      ],
+    },
+    {
+      input: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+    },
+    {
+      input: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [7, 8],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [7, 8],
+      ],
+    },
+    {
+      input: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+      expected: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+    },
+    {
+      input: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      expected: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+    },
+    {
+      input: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [10, 11, 12],
+      ],
+      expected: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [10, 11, 12],
+      ],
+    },
+    {
+      input: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ],
+      expected: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ],
+    },
+    {
+      input: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+      ],
+      expected: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+      ],
+    },
+    {
+      input: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+      ],
+      expected: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+      ],
+    },
+
+    // IntervalBounds
+    {
+      input: [
+        [[1], [2]],
+        [[3], [4]],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+      ],
+    },
+    {
+      input: [
+        [[1], [2]],
+        [[3], [4]],
+        [[5], [6]],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+    },
+    {
+      input: [
+        [[1], [2]],
+        [[3], [4]],
+        [[5], [6]],
+        [[7], [8]],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [7, 8],
+      ],
+    },
+    {
+      input: [
+        [[1], [2], [3]],
+        [[4], [5], [6]],
+      ],
+      expected: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+    },
+    {
+      input: [
+        [[1], [2], [3]],
+        [[4], [5], [6]],
+        [[7], [8], [9]],
+      ],
+      expected: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+    },
+    {
+      input: [
+        [[1], [2], [3]],
+        [[4], [5], [6]],
+        [[7], [8], [9]],
+        [[10], [11], [12]],
+      ],
+      expected: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [10, 11, 12],
+      ],
+    },
+    {
+      input: [
+        [[1], [2], [3], [4]],
+        [[5], [6], [7], [8]],
+      ],
+      expected: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ],
+    },
+    {
+      input: [
+        [[1], [2], [3], [4]],
+        [[5], [6], [7], [8]],
+        [[9], [10], [11], [12]],
+      ],
+      expected: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+      ],
+    },
+    {
+      input: [
+        [[1], [2], [3], [4]],
+        [[5], [6], [7], [8]],
+        [[9], [10], [11], [12]],
+        [[13], [14], [15], [16]],
+      ],
+      expected: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+      ],
+    },
+
+    // FPInterval
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2)],
+        [FP.abstract.toInterval(3), FP.abstract.toInterval(4)],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+      ],
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2)],
+        [FP.abstract.toInterval(3), FP.abstract.toInterval(4)],
+        [FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+      ],
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2)],
+        [FP.abstract.toInterval(3), FP.abstract.toInterval(4)],
+        [FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+        [FP.abstract.toInterval(7), FP.abstract.toInterval(8)],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [7, 8],
+      ],
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2), FP.abstract.toInterval(3)],
+        [FP.abstract.toInterval(4), FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+      ],
+      expected: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2), FP.abstract.toInterval(3)],
+        [FP.abstract.toInterval(4), FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+        [FP.abstract.toInterval(7), FP.abstract.toInterval(8), FP.abstract.toInterval(9)],
+      ],
+      expected: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+    },
+    {
+      input: [
+        [FP.abstract.toInterval(1), FP.abstract.toInterval(2), FP.abstract.toInterval(3)],
+        [FP.abstract.toInterval(4), FP.abstract.toInterval(5), FP.abstract.toInterval(6)],
+        [FP.abstract.toInterval(7), FP.abstract.toInterval(8), FP.abstract.toInterval(9)],
+        [FP.abstract.toInterval(10), FP.abstract.toInterval(11), FP.abstract.toInterval(12)],
+      ],
+      expected: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+        [10, 11, 12],
+      ],
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval(1),
+          FP.abstract.toInterval(2),
+          FP.abstract.toInterval(3),
+          FP.abstract.toInterval(4),
+        ],
+        [
+          FP.abstract.toInterval(5),
+          FP.abstract.toInterval(6),
+          FP.abstract.toInterval(7),
+          FP.abstract.toInterval(8),
+        ],
+      ],
+      expected: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+      ],
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval(1),
+          FP.abstract.toInterval(2),
+          FP.abstract.toInterval(3),
+          FP.abstract.toInterval(4),
+        ],
+        [
+          FP.abstract.toInterval(5),
+          FP.abstract.toInterval(6),
+          FP.abstract.toInterval(7),
+          FP.abstract.toInterval(8),
+        ],
+        [
+          FP.abstract.toInterval(9),
+          FP.abstract.toInterval(10),
+          FP.abstract.toInterval(11),
+          FP.abstract.toInterval(12),
+        ],
+      ],
+      expected: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+      ],
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval(1),
+          FP.abstract.toInterval(2),
+          FP.abstract.toInterval(3),
+          FP.abstract.toInterval(4),
+        ],
+        [
+          FP.abstract.toInterval(5),
+          FP.abstract.toInterval(6),
+          FP.abstract.toInterval(7),
+          FP.abstract.toInterval(8),
+        ],
+        [
+          FP.abstract.toInterval(9),
+          FP.abstract.toInterval(10),
+          FP.abstract.toInterval(11),
+          FP.abstract.toInterval(12),
+        ],
+        [
+          FP.abstract.toInterval(13),
+          FP.abstract.toInterval(14),
+          FP.abstract.toInterval(15),
+          FP.abstract.toInterval(16),
+        ],
+      ],
+      expected: [
+        [1, 2, 3, 4],
+        [5, 6, 7, 8],
+        [9, 10, 11, 12],
+        [13, 14, 15, 16],
+      ],
+    },
+
+    {
+      input: [
+        [FP.abstract.toInterval([1, 2]), FP.abstract.toInterval([2, 3])],
+        [FP.abstract.toInterval([3, 4]), FP.abstract.toInterval([4, 5])],
+      ],
+      expected: [
+        [
+          [1, 2],
+          [2, 3],
+        ],
+        [
+          [3, 4],
+          [4, 5],
+        ],
+      ],
+    },
+    {
+      input: [
+        [FP.abstract.toInterval([1, 2]), FP.abstract.toInterval([2, 3])],
+        [FP.abstract.toInterval([3, 4]), FP.abstract.toInterval([4, 5])],
+        [FP.abstract.toInterval([5, 6]), FP.abstract.toInterval([6, 7])],
+      ],
+      expected: [
+        [
+          [1, 2],
+          [2, 3],
+        ],
+        [
+          [3, 4],
+          [4, 5],
+        ],
+        [
+          [5, 6],
+          [6, 7],
+        ],
+      ],
+    },
+    {
+      input: [
+        [FP.abstract.toInterval([1, 2]), FP.abstract.toInterval([2, 3])],
+        [FP.abstract.toInterval([3, 4]), FP.abstract.toInterval([4, 5])],
+        [FP.abstract.toInterval([5, 6]), FP.abstract.toInterval([6, 7])],
+        [FP.abstract.toInterval([7, 8]), FP.abstract.toInterval([8, 9])],
+      ],
+      expected: [
+        [
+          [1, 2],
+          [2, 3],
+        ],
+        [
+          [3, 4],
+          [4, 5],
+        ],
+        [
+          [5, 6],
+          [6, 7],
+        ],
+        [
+          [7, 8],
+          [8, 9],
+        ],
+      ],
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+        ],
+        [
+          FP.abstract.toInterval([4, 5]),
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+        ],
+      ],
+      expected: [
+        [
+          [1, 2],
+          [2, 3],
+          [3, 4],
+        ],
+        [
+          [4, 5],
+          [5, 6],
+          [6, 7],
+        ],
+      ],
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+        ],
+        [
+          FP.abstract.toInterval([4, 5]),
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+        ],
+        [
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+          FP.abstract.toInterval([9, 10]),
+        ],
+      ],
+      expected: [
+        [
+          [1, 2],
+          [2, 3],
+          [3, 4],
+        ],
+        [
+          [4, 5],
+          [5, 6],
+          [6, 7],
+        ],
+        [
+          [7, 8],
+          [8, 9],
+          [9, 10],
+        ],
+      ],
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+        ],
+        [
+          FP.abstract.toInterval([4, 5]),
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+        ],
+        [
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+          FP.abstract.toInterval([9, 10]),
+        ],
+        [
+          FP.abstract.toInterval([10, 11]),
+          FP.abstract.toInterval([11, 12]),
+          FP.abstract.toInterval([12, 13]),
+        ],
+      ],
+      expected: [
+        [
+          [1, 2],
+          [2, 3],
+          [3, 4],
+        ],
+        [
+          [4, 5],
+          [5, 6],
+          [6, 7],
+        ],
+        [
+          [7, 8],
+          [8, 9],
+          [9, 10],
+        ],
+        [
+          [10, 11],
+          [11, 12],
+          [12, 13],
+        ],
+      ],
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+          FP.abstract.toInterval([4, 5]),
+        ],
+        [
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+        ],
+      ],
+      expected: [
+        [
+          [1, 2],
+          [2, 3],
+          [3, 4],
+          [4, 5],
+        ],
+        [
+          [5, 6],
+          [6, 7],
+          [7, 8],
+          [8, 9],
+        ],
+      ],
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+          FP.abstract.toInterval([4, 5]),
+        ],
+        [
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+        ],
+        [
+          FP.abstract.toInterval([9, 10]),
+          FP.abstract.toInterval([10, 11]),
+          FP.abstract.toInterval([11, 12]),
+          FP.abstract.toInterval([12, 13]),
+        ],
+      ],
+      expected: [
+        [
+          [1, 2],
+          [2, 3],
+          [3, 4],
+          [4, 5],
+        ],
+        [
+          [5, 6],
+          [6, 7],
+          [7, 8],
+          [8, 9],
+        ],
+        [
+          [9, 10],
+          [10, 11],
+          [11, 12],
+          [12, 13],
+        ],
+      ],
+    },
+    {
+      input: [
+        [
+          FP.abstract.toInterval([1, 2]),
+          FP.abstract.toInterval([2, 3]),
+          FP.abstract.toInterval([3, 4]),
+          FP.abstract.toInterval([4, 5]),
+        ],
+        [
+          FP.abstract.toInterval([5, 6]),
+          FP.abstract.toInterval([6, 7]),
+          FP.abstract.toInterval([7, 8]),
+          FP.abstract.toInterval([8, 9]),
+        ],
+        [
+          FP.abstract.toInterval([9, 10]),
+          FP.abstract.toInterval([10, 11]),
+          FP.abstract.toInterval([11, 12]),
+          FP.abstract.toInterval([12, 13]),
+        ],
+        [
+          FP.abstract.toInterval([13, 14]),
+          FP.abstract.toInterval([14, 15]),
+          FP.abstract.toInterval([15, 16]),
+          FP.abstract.toInterval([16, 17]),
+        ],
+      ],
+      expected: [
+        [
+          [1, 2],
+          [2, 3],
+          [3, 4],
+          [4, 5],
+        ],
+        [
+          [5, 6],
+          [6, 7],
+          [7, 8],
+          [8, 9],
+        ],
+        [
+          [9, 10],
+          [10, 11],
+          [11, 12],
+          [12, 13],
+        ],
+        [
+          [13, 14],
+          [14, 15],
+          [15, 16],
+          [16, 17],
+        ],
+      ],
+    },
+
+    // Mixed
+    {
+      input: [
+        [1, [2]],
+        [3, 4],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+      ],
+    },
+    {
+      input: [
+        [[1], [2]],
+        [[3], 4],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+      ],
+    },
+    {
+      input: [
+        [1, 2],
+        [FP.abstract.toInterval([3]), 4],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+      ],
+    },
+    {
+      input: [
+        [[1], FP.abstract.toInterval([2])],
+        [FP.abstract.toInterval([3]), FP.abstract.toInterval([4])],
+      ],
+      expected: [
+        [1, 2],
+        [3, 4],
+      ],
+    },
+  ])
+  .fn(t => {
+    const input = t.params.input;
+    const expected = map2DArray(t.params.expected, e => FP.abstract.toInterval(e));
+
+    const got = FP.abstract.toMatrix(input);
+    t.expect(
+      objectEquals(got, expected),
+      `abstract.toMatrix([${input}]) returned [${got}]. Expected [${expected}]`
     );
   });
 

--- a/src/unittests/serialization.spec.ts
+++ b/src/unittests/serialization.spec.ts
@@ -215,7 +215,7 @@ g.test('value').fn(t => {
   }
 });
 
-g.test('f32_interval').fn(t => {
+g.test('fpinterval_f32').fn(t => {
   for (const interval of [
     FP.f32.toInterval(0),
     FP.f32.toInterval(-0),
@@ -239,6 +239,40 @@ g.test('f32_interval').fn(t => {
     FP.f32.toInterval([kValue.f32.subnormal.positive.min, kValue.f32.subnormal.positive.max]),
     FP.f32.toInterval([kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max]),
     FP.f32.toInterval([kValue.f32.infinity.negative, kValue.f32.infinity.positive]),
+  ]) {
+    const serialized = serializeFPInterval(interval);
+    const deserialized = deserializeFPInterval(serialized);
+    t.expect(
+      objectEquals(interval, deserialized),
+      `interval ${interval} -> serialize -> deserialize -> ${deserialized}`
+    );
+  }
+});
+
+g.test('fpinterval_abstract').fn(t => {
+  for (const interval of [
+    FP.abstract.toInterval(0),
+    FP.abstract.toInterval(-0),
+    FP.abstract.toInterval(1),
+    FP.abstract.toInterval(-1),
+    FP.abstract.toInterval(0.5),
+    FP.abstract.toInterval(-0.5),
+    FP.abstract.toInterval(kValue.f64.positive.max),
+    FP.abstract.toInterval(kValue.f64.positive.min),
+    FP.abstract.toInterval(kValue.f64.subnormal.positive.max),
+    FP.abstract.toInterval(kValue.f64.subnormal.positive.min),
+    FP.abstract.toInterval(kValue.f64.subnormal.negative.max),
+    FP.abstract.toInterval(kValue.f64.subnormal.negative.min),
+    FP.abstract.toInterval(kValue.f64.infinity.positive),
+    FP.abstract.toInterval(kValue.f64.infinity.negative),
+
+    FP.abstract.toInterval([-0, 0]),
+    FP.abstract.toInterval([-1, 1]),
+    FP.abstract.toInterval([-0.5, 0.5]),
+    FP.abstract.toInterval([kValue.f64.positive.min, kValue.f64.positive.max]),
+    FP.abstract.toInterval([kValue.f64.subnormal.positive.min, kValue.f64.subnormal.positive.max]),
+    FP.abstract.toInterval([kValue.f64.subnormal.negative.min, kValue.f64.subnormal.negative.max]),
+    FP.abstract.toInterval([kValue.f64.infinity.negative, kValue.f64.infinity.positive]),
   ]) {
     const serialized = serializeFPInterval(interval);
     const deserialized = deserializeFPInterval(serialized);

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -24,6 +24,67 @@ export const kBit = {
     max: 0xffff_ffff,
   },
 
+  // Limits of f64
+  // Have to be stored as a BigInt hex value, since number is a f64 internally,
+  // so 64-bit hex values are not guaranteed to be precisely representable.
+  f64: {
+    positive: {
+      min: BigInt(0x0010_0000_0000_0000n),
+      max: BigInt(0x7fef_ffff_ffff_ffffn),
+      zero: BigInt(0x0000_0000_0000_0000n),
+      nearest_max: BigInt(0x7fef_ffff_ffff_fffen),
+      less_than_one: BigInt(0x3fef_ffff_ffff_ffffn),
+      pi: {
+        whole: BigInt(0x4009_21fb_5444_2d18n),
+        three_quarters: BigInt(0x4002_d97c_7f33_21d2n),
+        half: BigInt(0x3ff9_21fb_5444_2d18n),
+        third: BigInt(0x3ff0_c152_382d_7366n),
+        quarter: BigInt(0x3fe9_21fb_5444_2d18n),
+        sixth: BigInt(0x3fe0_c152_382d_7366n),
+      },
+      e: BigInt(0x4005_bf0a_8b14_5769n),
+    },
+    negative: {
+      max: BigInt(0x8010_0000_0000_0000n),
+      min: BigInt(0xffef_ffff_ffff_ffffn),
+      zero: BigInt(0x8000_0000_0000_0000n),
+      nearest_min: BigInt(0xffef_ffff_ffff_fffen),
+      less_than_one: BigInt(0xbfef_ffff_ffff_ffffn),
+      pi: {
+        whole: BigInt(0xc009_21fb_5444_2d18n),
+        three_quarters: BigInt(0xc002_d97c_7f33_21d2n),
+        half: BigInt(0xbff9_21fb_5444_2d18n),
+        third: BigInt(0xbff0_c152_382d_7366n),
+        quarter: BigInt(0xbfe9_21fb_5444_2d18n),
+        sixth: BigInt(0xbfe0_c152_382d_7366n),
+      },
+    },
+    subnormal: {
+      positive: {
+        min: BigInt(0x0000_0000_0000_0001n),
+        max: BigInt(0x000f_ffff_ffff_ffffn),
+      },
+      negative: {
+        max: BigInt(0x8000_0000_0000_0001n),
+        min: BigInt(0x800f_ffff_ffff_ffffn),
+      },
+    },
+    nan: {
+      negative: {
+        s: BigInt(0xfff0_0000_0000_0001n),
+        q: BigInt(0xfff8_0000_0000_0001n),
+      },
+      positive: {
+        s: BigInt(0x7ff0_0000_0000_0001n),
+        q: BigInt(0x7ff8_0000_0000_0001n),
+      },
+    },
+    infinity: {
+      positive: BigInt(0x7ff0_0000_0000_0000n),
+      negative: BigInt(0xfff0_0000_0000_0000n),
+    },
+  },
+
   // Limits of f32
   f32: {
     positive: {
@@ -33,7 +94,7 @@ export const kBit = {
       nearest_max: 0x7f7f_fffe,
       less_than_one: 0x3f7f_ffff,
       pi: {
-        whole: 0x404_90fdb,
+        whole: 0x4049_0fdb,
         three_quarters: 0x4016_cbe4,
         half: 0x3fc9_0fdb,
         third: 0x3f86_0a92,
@@ -51,8 +112,8 @@ export const kBit = {
       pi: {
         whole: 0xc04_90fdb,
         three_quarters: 0xc016_cbe4,
-        half: 0xbfc90fdb,
-        third: 0xbf860a92,
+        half: 0xbfc9_0fdb,
+        third: 0xbf86_0a92,
         quarter: 0xbf49_0fdb,
         sixth: 0xbf06_0a92,
       },
@@ -273,16 +334,6 @@ function hexToF64(hex: bigint): number {
 }
 
 /**
- * Converts a 64-bit float value to a 64-bit hex value
- *
- * Using a locally defined function here to avoid compile time dependency
- * issues.
- * */
-function f64ToHex(number: number): bigint {
-  return new BigUint64Array(new Float64Array([number]).buffer)[0];
-}
-
-/**
  * Converts a 32-bit hex value to a 32-bit float value
  *
  * Using a locally defined function here to avoid compile time dependency
@@ -321,6 +372,53 @@ export const kValue = {
     max: 4294967295,
   },
 
+  // Limits of f64
+  f64: {
+    positive: {
+      min: hexToF64(kBit.f64.positive.min),
+      max: hexToF64(kBit.f64.positive.max),
+      nearest_max: hexToF64(kBit.f64.positive.nearest_max),
+      less_than_one: hexToF64(kBit.f64.positive.less_than_one),
+      pi: {
+        whole: hexToF64(kBit.f64.positive.pi.whole),
+        three_quarters: hexToF64(kBit.f64.positive.pi.three_quarters),
+        half: hexToF64(kBit.f64.positive.pi.half),
+        third: hexToF64(kBit.f64.positive.pi.third),
+        quarter: hexToF64(kBit.f64.positive.pi.quarter),
+        sixth: hexToF64(kBit.f64.positive.pi.sixth),
+      },
+      e: hexToF64(kBit.f64.positive.e),
+    },
+    negative: {
+      max: hexToF64(kBit.f64.negative.max),
+      min: hexToF64(kBit.f64.negative.min),
+      nearest_min: hexToF64(kBit.f64.negative.nearest_min),
+      less_than_one: hexToF64(kBit.f64.negative.less_than_one), // -0.999999940395
+      pi: {
+        whole: hexToF64(kBit.f64.negative.pi.whole),
+        three_quarters: hexToF64(kBit.f64.negative.pi.three_quarters),
+        half: hexToF64(kBit.f64.negative.pi.half),
+        third: hexToF64(kBit.f64.negative.pi.third),
+        quarter: hexToF64(kBit.f64.negative.pi.quarter),
+        sixth: hexToF64(kBit.f64.negative.pi.sixth),
+      },
+    },
+    subnormal: {
+      positive: {
+        min: hexToF64(kBit.f64.subnormal.positive.min),
+        max: hexToF64(kBit.f64.subnormal.positive.max),
+      },
+      negative: {
+        max: hexToF64(kBit.f64.subnormal.negative.max),
+        min: hexToF64(kBit.f64.subnormal.negative.min),
+      },
+    },
+    infinity: {
+      positive: hexToF64(kBit.f64.infinity.positive),
+      negative: hexToF64(kBit.f64.infinity.negative),
+    },
+  },
+
   // Limits of f32
   f32: {
     positive: {
@@ -339,7 +437,7 @@ export const kValue = {
       e: hexToF32(kBit.f32.positive.e),
       first_f64_not_castable: hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127, // mid point of 2**128 and largest f32
       last_f64_castable: hexToF64(
-        f64ToHex(hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
+        BigInt(hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
       ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     negative: {
@@ -357,7 +455,7 @@ export const kValue = {
       },
       first_f64_not_castable: -(hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127), // mid point of -2**128 and largest f32
       last_f64_castable: -hexToF64(
-        f64ToHex(hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
+        BigInt(hexToF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
       ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     subnormal: {
@@ -402,7 +500,7 @@ export const kValue = {
       zero: hexToF16(kBit.f16.positive.zero),
       first_f64_not_castable: hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16, // mid point of 2**16 and largest f16
       last_f64_castable: hexToF64(
-        f64ToHex(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
+        BigInt(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
       ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     negative: {
@@ -411,7 +509,7 @@ export const kValue = {
       zero: hexToF16(kBit.f16.negative.zero),
       first_f64_not_castable: -(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16), // mid point of -2**16 and largest f16
       last_f64_castable: -hexToF64(
-        f64ToHex(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
+        BigInt(hexToF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
       ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     subnormal: {

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -1,10 +1,5 @@
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 
-// MAINTENANCE_TODO(sarahM0): Perhaps instead of kBit and kValue tables we could have one table
-// where every value is a Scalar instead of either bits or value?
-// Then tests wouldn't need most of the Scalar.fromX calls,
-// and you would probably need fewer table entries in total
-// (since each Scalar has both bits and value).
 export const kBit = {
   // Limits of int32
   i32: {
@@ -69,16 +64,6 @@ export const kBit = {
         min: BigInt(0x800f_ffff_ffff_ffffn),
       },
     },
-    nan: {
-      negative: {
-        s: BigInt(0xfff0_0000_0000_0001n),
-        q: BigInt(0xfff8_0000_0000_0001n),
-      },
-      positive: {
-        s: BigInt(0x7ff0_0000_0000_0001n),
-        q: BigInt(0x7ff8_0000_0000_0001n),
-      },
-    },
     infinity: {
       positive: BigInt(0x7ff0_0000_0000_0000n),
       negative: BigInt(0xfff0_0000_0000_0000n),
@@ -128,16 +113,6 @@ export const kBit = {
         min: 0x807f_ffff,
       },
     },
-    nan: {
-      negative: {
-        s: 0xff80_0001,
-        q: 0xffc0_0001,
-      },
-      positive: {
-        s: 0x7f80_0001,
-        q: 0x7fc0_0001,
-      },
-    },
     infinity: {
       positive: 0x7f80_0000,
       negative: 0xff80_0000,
@@ -164,16 +139,6 @@ export const kBit = {
       negative: {
         max: 0x8001,
         min: 0x83ff,
-      },
-    },
-    nan: {
-      negative: {
-        s: 0xfc01,
-        q: 0xfe01,
-      },
-      positive: {
-        s: 0x7c01,
-        q: 0x7e01,
       },
     },
     infinity: {

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -933,6 +933,22 @@ export const True = bool(true);
 /** A 'false' literal value */
 export const False = bool(false);
 
+// Encoding to u32s, instead of BigInt, for serialization
+export function reinterpretF64AsU32s(f64: number): [number, number] {
+  const array = new Float64Array(1);
+  array[0] = f64;
+  const u32s = new Uint32Array(array.buffer);
+  return [u32s[0], u32s[1]];
+}
+
+// De-encoding from u32s, instead of BigInt, for serialization
+export function reinterpretU32sAsF64(u32s: [number, number]): number {
+  const array = new Uint32Array(2);
+  array[0] = u32s[0];
+  array[1] = u32s[1];
+  return new Float64Array(array.buffer)[0];
+}
+
 export function reinterpretF32AsU32(f32: number): number {
   const array = new Float32Array(1);
   array[0] = f32;

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -88,7 +88,7 @@ export type NextDirection = 'positive' | 'negative';
  * so cannot call itself directly or indirectly.
  */
 const nextAfterF64Data = new ArrayBuffer(8);
-const nextAfterF64Hex = new BigUint64Array(nextAfterF64Data);
+const nextAfterF64Int = new BigUint64Array(nextAfterF64Data);
 const nextAfterF64Float = new Float64Array(nextAfterF64Data);
 
 /**
@@ -134,15 +134,15 @@ export function nextAfterF64(val: number, dir: NextDirection, mode: FlushMode): 
   }
 
   nextAfterF64Float[0] = val;
-  const is_positive = (nextAfterF64Hex[0] & 0x8000_0000_0000_0000n) === 0n;
+  const is_positive = (nextAfterF64Int[0] & 0x8000_0000_0000_0000n) === 0n;
   if (is_positive === (dir === 'positive')) {
-    nextAfterF64Hex[0] += 1n;
+    nextAfterF64Int[0] += 1n;
   } else {
-    nextAfterF64Hex[0] -= 1n;
+    nextAfterF64Int[0] -= 1n;
   }
 
   // Checking for overflow
-  if ((nextAfterF64Hex[0] & 0x7ff0_0000_0000_0000n) === 0x7ff0_0000_0000_0000n) {
+  if ((nextAfterF64Int[0] & 0x7ff0_0000_0000_0000n) === 0x7ff0_0000_0000_0000n) {
     if (dir === 'positive') {
       return kValue.f64.infinity.positive;
     } else {
@@ -161,7 +161,7 @@ export function nextAfterF64(val: number, dir: NextDirection, mode: FlushMode): 
  * so cannot call itself directly or indirectly.
  */
 const nextAfterF32Data = new ArrayBuffer(4);
-const nextAfterF32Hex = new Uint32Array(nextAfterF32Data);
+const nextAfterF32Int = new Uint32Array(nextAfterF32Data);
 const nextAfterF32Float = new Float32Array(nextAfterF32Data);
 
 /**
@@ -214,16 +214,16 @@ export function nextAfterF32(val: number, dir: NextDirection, mode: FlushMode): 
     // val is either f32 precise or quantizing rounded in the opposite direction
     // from what is needed, so need to calculate the value in the correct
     // direction.
-    const is_positive = (nextAfterF32Hex[0] & 0x80000000) === 0;
+    const is_positive = (nextAfterF32Int[0] & 0x80000000) === 0;
     if (is_positive === (dir === 'positive')) {
-      nextAfterF32Hex[0] += 1;
+      nextAfterF32Int[0] += 1;
     } else {
-      nextAfterF32Hex[0] -= 1;
+      nextAfterF32Int[0] -= 1;
     }
   }
 
   // Checking for overflow
-  if ((nextAfterF32Hex[0] & 0x7f800000) === 0x7f800000) {
+  if ((nextAfterF32Int[0] & 0x7f800000) === 0x7f800000) {
     if (dir === 'positive') {
       return kValue.f32.infinity.positive;
     } else {

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -34,6 +34,16 @@ export function clamp(n: number, { min, max }: { min: number; max: number }): nu
   return Math.min(Math.max(n, min), max);
 }
 
+/** @returns 0 if |val| is a subnormal f64 number, otherwise returns |val| */
+export function flushSubnormalNumberF64(val: number): number {
+  return isSubnormalNumberF64(val) ? 0 : val;
+}
+
+/** @returns if number is within subnormal range of f64 */
+export function isSubnormalNumberF64(n: number): boolean {
+  return n > kValue.f64.negative.max && n < kValue.f64.positive.min;
+}
+
 /** @returns 0 if |val| is a subnormal f32 number, otherwise returns |val| */
 export function flushSubnormalNumberF32(val: number): number {
   return isSubnormalNumberF32(val) ? 0 : val;
@@ -69,6 +79,79 @@ export type FlushMode = 'flush' | 'no-flush';
 
 /** Should nextAfter calculate towards positive infinity or negative infinity */
 export type NextDirection = 'positive' | 'negative';
+
+/**
+ * Once-allocated ArrayBuffer/views to avoid overhead of allocation when
+ * converting between numeric formats
+ *
+ * Usage of a once-allocated pattern like this makes nextAfterF64 non-reentrant,
+ * so cannot call itself directly or indirectly.
+ */
+const nextAfterF64Data = new ArrayBuffer(8);
+const nextAfterF64Hex = new BigUint64Array(nextAfterF64Data);
+const nextAfterF64Float = new Float64Array(nextAfterF64Data);
+
+/**
+ * @returns the next f64 value after |val|, towards +inf or -inf as specified by |dir|.
+
+ * If |mode| is 'flush', all subnormal values will be flushed to 0,
+ * before processing and for -/+0 the nextAfterF64 will be the closest normal in
+ * the correct direction.
+
+ * If |mode| is 'no-flush', the next subnormal will be calculated when appropriate,
+ * and for -/+0 the nextAfterF64 will be the closest subnormal in the correct
+ * direction.
+ *
+ * val needs to be in [min f64, max f64]
+ */
+export function nextAfterF64(val: number, dir: NextDirection, mode: FlushMode): number {
+  if (Number.isNaN(val)) {
+    return val;
+  }
+
+  if (val === Number.POSITIVE_INFINITY) {
+    return kValue.f64.infinity.positive;
+  }
+
+  if (val === Number.NEGATIVE_INFINITY) {
+    return kValue.f64.infinity.negative;
+  }
+
+  assert(
+    val <= kValue.f64.positive.max && val >= kValue.f64.negative.min,
+    `${val} is not in the range of f64`
+  );
+
+  val = mode === 'flush' ? flushSubnormalNumberF64(val) : val;
+
+  // -/+0 === 0 returns true
+  if (val === 0) {
+    if (dir === 'positive') {
+      return mode === 'flush' ? kValue.f64.positive.min : kValue.f64.subnormal.positive.min;
+    } else {
+      return mode === 'flush' ? kValue.f64.negative.max : kValue.f64.subnormal.negative.max;
+    }
+  }
+
+  nextAfterF64Float[0] = val;
+  const is_positive = (nextAfterF64Hex[0] & 0x8000_0000_0000_0000n) === 0n;
+  if (is_positive === (dir === 'positive')) {
+    nextAfterF64Hex[0] += 1n;
+  } else {
+    nextAfterF64Hex[0] -= 1n;
+  }
+
+  // Checking for overflow
+  if ((nextAfterF64Hex[0] & 0x7ff0_0000_0000_0000n) === 0x7ff0_0000_0000_0000n) {
+    if (dir === 'positive') {
+      return kValue.f64.infinity.positive;
+    } else {
+      return kValue.f64.infinity.negative;
+    }
+  }
+
+  return mode === 'flush' ? flushSubnormalNumberF64(nextAfterF64Float[0]) : nextAfterF64Float[0];
+}
 
 /**
  * Once-allocated ArrayBuffer/views to avoid overhead of allocation when
@@ -233,6 +316,44 @@ export function nextAfterF16(val: number, dir: NextDirection, mode: FlushMode): 
 }
 
 /**
+ * @returns ulp(x), the unit of least precision for a specific number as a 64-bit float
+ *
+ * ulp(x) is the distance between the two floating point numbers nearest x.
+ * This value is also called unit of last place, ULP, and 1 ULP.
+ * See the WGSL spec and http://www.ens-lyon.fr/LIP/Pub/Rapports/RR/RR2005/RR2005-09.pdf
+ * for a more detailed/nuanced discussion of the definition of ulp(x).
+ *
+ * @param target number to calculate ULP for
+ * @param mode should FTZ occurring during calculation or not
+ */
+export function oneULPF64(target: number, mode: FlushMode = 'flush'): number {
+  if (Number.isNaN(target)) {
+    return Number.NaN;
+  }
+
+  target = mode === 'flush' ? flushSubnormalNumberF64(target) : target;
+
+  // For values at the edge of the range or beyond ulp(x) is defined as the
+  // distance between the two nearest f64 representable numbers to the
+  // appropriate edge.
+  if (target === Number.POSITIVE_INFINITY || target >= kValue.f64.positive.max) {
+    return kValue.f64.positive.max - kValue.f64.positive.nearest_max;
+  } else if (target === Number.NEGATIVE_INFINITY || target <= kValue.f64.negative.min) {
+    return kValue.f64.negative.nearest_min - kValue.f64.negative.min;
+  }
+
+  // ulp(x) is min(after - before), where
+  //     before <= x <= after
+  //     before =/= after
+  //     before and after are f64 representable
+  const before = nextAfterF64(target, 'negative', mode);
+  const after = nextAfterF64(target, 'positive', mode);
+  // Since number is internally a f64, |target| is always f64 representable, so
+  // either before or after will be x
+  return Math.min(target - before, after - target);
+}
+
+/**
  * @returns ulp(x), the unit of least precision for a specific number as a 32-bit float
  *
  * ulp(x) is the distance between the two floating point numbers nearest x.
@@ -241,7 +362,7 @@ export function nextAfterF16(val: number, dir: NextDirection, mode: FlushMode): 
  * for a more detailed/nuanced discussion of the definition of ulp(x).
  *
  * @param target number to calculate ULP for
- * @param mode should FTZ occuring during calculation or not
+ * @param mode should FTZ occurring during calculation or not
  */
 export function oneULPF32(target: number, mode: FlushMode = 'flush'): number {
   if (Number.isNaN(target)) {
@@ -250,8 +371,9 @@ export function oneULPF32(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF32(target) : target;
 
-  // For values at the edge of the range or beyond ulp(x) is defined as the distance between the two nearest
-  // f32 representable numbers to the appropriate edge.
+  // For values at the edge of the range or beyond ulp(x) is defined as the
+  // distance between the two nearest f32 representable numbers to the
+  // appropriate edge.
   if (target === Number.POSITIVE_INFINITY || target >= kValue.f32.positive.max) {
     return kValue.f32.positive.max - kValue.f32.positive.nearest_max;
   } else if (target === Number.NEGATIVE_INFINITY || target <= kValue.f32.negative.min) {
@@ -272,6 +394,33 @@ export function oneULPF32(target: number, mode: FlushMode = 'flush'): number {
     // |target| is not f32 representable so taking distance of neighbouring f32s.
     return after - before;
   }
+}
+
+/**
+ * Calculate the valid roundings when quantizing to 64-bit floats
+ *
+ * TS/JS's number type is internally a f64, so the supplied value will be
+ * quanitized by definition. The only corner cases occur if a non-finite value
+ * is provided, since the valid roundings include the appropriate min or max
+ * value.
+ *
+ * @param n number to be quantized
+ * @returns all of the acceptable roundings for quantizing to 64-bits in
+ *          ascending order.
+ */
+export function correctlyRoundedF64(n: number): number[] {
+  assert(!Number.isNaN(n), `correctlyRoundedF32 not defined for NaN`);
+  // Above f64 range
+  if (n === Number.POSITIVE_INFINITY) {
+    return [kValue.f64.positive.max, Number.POSITIVE_INFINITY];
+  }
+
+  // Below f64 range
+  if (n === Number.NEGATIVE_INFINITY) {
+    return [Number.NEGATIVE_INFINITY, kValue.f64.negative.min];
+  }
+
+  return [n];
 }
 
 /**


### PR DESCRIPTION
This PR adds in the various utilities needed for abstract float (f64), i.e. nextAfter, ULP, serialize/deserialize interval.

An implementation FPTraits, FPAbstractTraits is implemented to use these utiliites.

Test coverage is added for all of this new code.

The interval generators are roughed in enough to instantiate the FPTraits object, but not tested or used. Further PRs will implement testing for this code and add it being used.

Fixes #2416

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
