### PR TITLE
[wgsl] Add test for BOM.

### DIFF
--- a/src/webgpu/shader/validation/parse/blankspace.spec.ts
+++ b/src/webgpu/shader/validation/parse/blankspace.spec.ts
@@ -50,7 +50,14 @@ g.test('blankspace')
   });
 
 g.test('bom')
-  .desc(`Tests that including a BOM causes a shader compile error`)
+  .desc(
+    `Tests that including a BOM causes a shader compile error.
+
+Note, per RFC 2632, for protocols which forbit the use of U+FEFF then the BOM is treated as a
+"ZERO WIDTH NO-BREAK SPACE". The "ZERO WIDTH NO-BREAK SPACE" is not a valid WGSL blankspace code
+point, so the BOM ends up as a shader compilation error.
+    `
+  )
   .params(u => u.combine('include_bom', [true, false]))
   .fn(t => {
     const code = `${t.params.include_bom ? '\uFEFF' : ''}const name : i32 = 0;`;

--- a/src/webgpu/shader/validation/parse/blankspace.spec.ts
+++ b/src/webgpu/shader/validation/parse/blankspace.spec.ts
@@ -48,3 +48,11 @@ g.test('blankspace')
     const code = `const${t.params.blankspace[0]}ident : i32 = 0;`;
     t.expectCompileResult(true, code);
   });
+
+g.test('bom')
+  .desc(`Tests that including a BOM causes a shader compile error`)
+  .params(u => u.combine('include_bom', [true, false]))
+  .fn(t => {
+    const code = `${t.params.include_bom ? '\uFEFF' : ''}const name : i32 = 0;`;
+    t.expectCompileResult(!t.params.include_bom, code);
+  });


### PR DESCRIPTION
This CL adds a test that a shader with a BOM will be rejected. The BOM is not permitted in WGSL source.

Fixes: #1949

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
