### PR TITLE
Clarify that f64 castable constants are about WebIDL casting

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -432,9 +432,9 @@ TODO(#2060): test with last_f64_castable.
         { constants: { ci: kValue.i32.positive.max }, _success: true },
         { constants: { ci: kValue.i32.positive.max + 1 }, _success: false },
         { constants: { cf: kValue.f32.negative.min }, _success: true },
-        { constants: { cf: kValue.f32.negative.first_f64_not_castable }, _success: false },
+        { constants: { cf: kValue.f32.negative.first_webidl_not_castable }, _success: false },
         { constants: { cf: kValue.f32.positive.max }, _success: true },
-        { constants: { cf: kValue.f32.positive.first_f64_not_castable }, _success: false },
+        { constants: { cf: kValue.f32.positive.first_webidl_not_castable }, _success: false },
         // Conversion to boolean can't fail
         { constants: { cb: Number.MAX_VALUE }, _success: true },
         { constants: { cb: kValue.i32.negative.min - 1 }, _success: true },
@@ -481,13 +481,13 @@ clarity on whether values like f16.positive.last_f64_castable would be valid. Se
       .combine('isAsync', [true, false])
       .combineWithParams([
         { constants: { cf16: kValue.f16.negative.min }, _success: true },
-        { constants: { cf16: kValue.f16.negative.first_f64_not_castable }, _success: false },
+        { constants: { cf16: kValue.f16.negative.first_webidl_not_castable }, _success: false },
         { constants: { cf16: kValue.f16.positive.max }, _success: true },
-        { constants: { cf16: kValue.f16.positive.first_f64_not_castable }, _success: false },
+        { constants: { cf16: kValue.f16.positive.first_webidl_not_castable }, _success: false },
         { constants: { cf16: kValue.f32.negative.min }, _success: false },
         { constants: { cf16: kValue.f32.positive.max }, _success: false },
-        { constants: { cf16: kValue.f32.negative.first_f64_not_castable }, _success: false },
-        { constants: { cf16: kValue.f32.positive.first_f64_not_castable }, _success: false },
+        { constants: { cf16: kValue.f32.negative.first_webidl_not_castable }, _success: false },
+        { constants: { cf16: kValue.f32.positive.first_webidl_not_castable }, _success: false },
       ] as const)
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -416,7 +416,7 @@ g.test('overrides,value,validation_error')
     `
 Tests calling createComputePipeline(Async) validation for unrepresentable constant values in compute stage.
 
-TODO(#2060): test with last_f64_castable.
+TODO(#2060): test with last_castable_pipeline_override.
 `
   )
   .params(u =>
@@ -432,9 +432,15 @@ TODO(#2060): test with last_f64_castable.
         { constants: { ci: kValue.i32.positive.max }, _success: true },
         { constants: { ci: kValue.i32.positive.max + 1 }, _success: false },
         { constants: { cf: kValue.f32.negative.min }, _success: true },
-        { constants: { cf: kValue.f32.negative.first_webidl_not_castable }, _success: false },
+        {
+          constants: { cf: kValue.f32.negative.first_non_castable_pipeline_override },
+          _success: false,
+        },
         { constants: { cf: kValue.f32.positive.max }, _success: true },
-        { constants: { cf: kValue.f32.positive.first_webidl_not_castable }, _success: false },
+        {
+          constants: { cf: kValue.f32.positive.first_non_castable_pipeline_override },
+          _success: false,
+        },
         // Conversion to boolean can't fail
         { constants: { cb: Number.MAX_VALUE }, _success: true },
         { constants: { cb: kValue.i32.negative.min - 1 }, _success: true },
@@ -442,7 +448,6 @@ TODO(#2060): test with last_f64_castable.
   )
   .fn(t => {
     const { isAsync, constants, _success } = t.params;
-
     const descriptor = {
       layout: 'auto' as const,
       compute: {
@@ -473,7 +478,7 @@ g.test('overrides,value,validation_error,f16')
 Tests calling createComputePipeline(Async) validation for unrepresentable f16 constant values in compute stage.
 
 TODO(#2060): Tighten the cases around the valid/invalid boundary once we have WGSL spec
-clarity on whether values like f16.positive.last_f64_castable would be valid. See issue.
+clarity on whether values like f16.positive.last_castable_pipeline_override would be valid. See issue.
 `
   )
   .params(u =>
@@ -481,13 +486,25 @@ clarity on whether values like f16.positive.last_f64_castable would be valid. Se
       .combine('isAsync', [true, false])
       .combineWithParams([
         { constants: { cf16: kValue.f16.negative.min }, _success: true },
-        { constants: { cf16: kValue.f16.negative.first_webidl_not_castable }, _success: false },
+        {
+          constants: { cf16: kValue.f16.negative.first_non_castable_pipeline_override },
+          _success: false,
+        },
         { constants: { cf16: kValue.f16.positive.max }, _success: true },
-        { constants: { cf16: kValue.f16.positive.first_webidl_not_castable }, _success: false },
+        {
+          constants: { cf16: kValue.f16.positive.first_non_castable_pipeline_override },
+          _success: false,
+        },
         { constants: { cf16: kValue.f32.negative.min }, _success: false },
         { constants: { cf16: kValue.f32.positive.max }, _success: false },
-        { constants: { cf16: kValue.f32.negative.first_webidl_not_castable }, _success: false },
-        { constants: { cf16: kValue.f32.positive.first_webidl_not_castable }, _success: false },
+        {
+          constants: { cf16: kValue.f32.negative.first_non_castable_pipeline_override },
+          _success: false,
+        },
+        {
+          constants: { cf16: kValue.f32.positive.first_non_castable_pipeline_override },
+          _success: false,
+        },
       ] as const)
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -299,9 +299,15 @@ TODO(#2060): test with last_f64_castable.
         { vertexConstants: { ci: kValue.i32.positive.max }, _success: true },
         { vertexConstants: { ci: kValue.i32.positive.max + 1 }, _success: false },
         { vertexConstants: { cf: kValue.f32.negative.min }, _success: true },
-        { vertexConstants: { cf: kValue.f32.negative.first_webidl_not_castable }, _success: false },
+        {
+          vertexConstants: { cf: kValue.f32.negative.first_non_castable_pipeline_override },
+          _success: false,
+        },
         { vertexConstants: { cf: kValue.f32.positive.max }, _success: true },
-        { vertexConstants: { cf: kValue.f32.positive.first_webidl_not_castable }, _success: false },
+        {
+          vertexConstants: { cf: kValue.f32.positive.first_non_castable_pipeline_override },
+          _success: false,
+        },
         // Conversion to boolean can't fail
         { vertexConstants: { cb: Number.MAX_VALUE }, _success: true },
         { vertexConstants: { cb: kValue.i32.negative.min - 1 }, _success: true },
@@ -364,12 +370,12 @@ TODO(#2060): test with last_f64_castable.
         { fragmentConstants: { ci: kValue.i32.positive.max + 1 }, _success: false },
         { fragmentConstants: { cf: kValue.f32.negative.min }, _success: true },
         {
-          fragmentConstants: { cf: kValue.f32.negative.first_webidl_not_castable },
+          fragmentConstants: { cf: kValue.f32.negative.first_non_castable_pipeline_override },
           _success: false,
         },
         { fragmentConstants: { cf: kValue.f32.positive.max }, _success: true },
         {
-          fragmentConstants: { cf: kValue.f32.positive.first_webidl_not_castable },
+          fragmentConstants: { cf: kValue.f32.positive.first_non_castable_pipeline_override },
           _success: false,
         },
         // Conversion to boolean can't fail
@@ -416,22 +422,22 @@ clarity on whether values like f16.positive.last_f64_castable would be valid. Se
       .combineWithParams([
         { vertexConstants: { cf16: kValue.f16.negative.min }, _success: true },
         {
-          vertexConstants: { cf16: kValue.f16.negative.first_webidl_not_castable },
+          vertexConstants: { cf16: kValue.f16.negative.first_non_castable_pipeline_override },
           _success: false,
         },
         { vertexConstants: { cf16: kValue.f16.positive.max }, _success: true },
         {
-          vertexConstants: { cf16: kValue.f16.positive.first_webidl_not_castable },
+          vertexConstants: { cf16: kValue.f16.positive.first_non_castable_pipeline_override },
           _success: false,
         },
         { vertexConstants: { cf16: kValue.f32.negative.min }, _success: false },
         { vertexConstants: { cf16: kValue.f32.positive.max }, _success: false },
         {
-          vertexConstants: { cf16: kValue.f32.negative.first_webidl_not_castable },
+          vertexConstants: { cf16: kValue.f32.negative.first_non_castable_pipeline_override },
           _success: false,
         },
         {
-          vertexConstants: { cf16: kValue.f32.positive.first_webidl_not_castable },
+          vertexConstants: { cf16: kValue.f32.positive.first_non_castable_pipeline_override },
           _success: false,
         },
       ] as const)
@@ -488,22 +494,22 @@ clarity on whether values like f16.positive.last_f64_castable would be valid. Se
       .combineWithParams([
         { fragmentConstants: { cf16: kValue.f16.negative.min }, _success: true },
         {
-          fragmentConstants: { cf16: kValue.f16.negative.first_webidl_not_castable },
+          fragmentConstants: { cf16: kValue.f16.negative.first_non_castable_pipeline_override },
           _success: false,
         },
         { fragmentConstants: { cf16: kValue.f16.positive.max }, _success: true },
         {
-          fragmentConstants: { cf16: kValue.f16.positive.first_webidl_not_castable },
+          fragmentConstants: { cf16: kValue.f16.positive.first_non_castable_pipeline_override },
           _success: false,
         },
         { fragmentConstants: { cf16: kValue.f32.negative.min }, _success: false },
         { fragmentConstants: { cf16: kValue.f32.positive.max }, _success: false },
         {
-          fragmentConstants: { cf16: kValue.f32.negative.first_webidl_not_castable },
+          fragmentConstants: { cf16: kValue.f32.negative.first_non_castable_pipeline_override },
           _success: false,
         },
         {
-          fragmentConstants: { cf16: kValue.f32.positive.first_webidl_not_castable },
+          fragmentConstants: { cf16: kValue.f32.positive.first_non_castable_pipeline_override },
           _success: false,
         },
       ] as const)

--- a/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/overrides.spec.ts
@@ -299,9 +299,9 @@ TODO(#2060): test with last_f64_castable.
         { vertexConstants: { ci: kValue.i32.positive.max }, _success: true },
         { vertexConstants: { ci: kValue.i32.positive.max + 1 }, _success: false },
         { vertexConstants: { cf: kValue.f32.negative.min }, _success: true },
-        { vertexConstants: { cf: kValue.f32.negative.first_f64_not_castable }, _success: false },
+        { vertexConstants: { cf: kValue.f32.negative.first_webidl_not_castable }, _success: false },
         { vertexConstants: { cf: kValue.f32.positive.max }, _success: true },
-        { vertexConstants: { cf: kValue.f32.positive.first_f64_not_castable }, _success: false },
+        { vertexConstants: { cf: kValue.f32.positive.first_webidl_not_castable }, _success: false },
         // Conversion to boolean can't fail
         { vertexConstants: { cb: Number.MAX_VALUE }, _success: true },
         { vertexConstants: { cb: kValue.i32.negative.min - 1 }, _success: true },
@@ -363,9 +363,15 @@ TODO(#2060): test with last_f64_castable.
         { fragmentConstants: { ci: kValue.i32.positive.max }, _success: true },
         { fragmentConstants: { ci: kValue.i32.positive.max + 1 }, _success: false },
         { fragmentConstants: { cf: kValue.f32.negative.min }, _success: true },
-        { fragmentConstants: { cf: kValue.f32.negative.first_f64_not_castable }, _success: false },
+        {
+          fragmentConstants: { cf: kValue.f32.negative.first_webidl_not_castable },
+          _success: false,
+        },
         { fragmentConstants: { cf: kValue.f32.positive.max }, _success: true },
-        { fragmentConstants: { cf: kValue.f32.positive.first_f64_not_castable }, _success: false },
+        {
+          fragmentConstants: { cf: kValue.f32.positive.first_webidl_not_castable },
+          _success: false,
+        },
         // Conversion to boolean can't fail
         { fragmentConstants: { cb: Number.MAX_VALUE }, _success: true },
         { fragmentConstants: { cb: kValue.i32.negative.min - 1 }, _success: true },
@@ -409,13 +415,25 @@ clarity on whether values like f16.positive.last_f64_castable would be valid. Se
       .combine('isAsync', [true, false])
       .combineWithParams([
         { vertexConstants: { cf16: kValue.f16.negative.min }, _success: true },
-        { vertexConstants: { cf16: kValue.f16.negative.first_f64_not_castable }, _success: false },
+        {
+          vertexConstants: { cf16: kValue.f16.negative.first_webidl_not_castable },
+          _success: false,
+        },
         { vertexConstants: { cf16: kValue.f16.positive.max }, _success: true },
-        { vertexConstants: { cf16: kValue.f16.positive.first_f64_not_castable }, _success: false },
+        {
+          vertexConstants: { cf16: kValue.f16.positive.first_webidl_not_castable },
+          _success: false,
+        },
         { vertexConstants: { cf16: kValue.f32.negative.min }, _success: false },
         { vertexConstants: { cf16: kValue.f32.positive.max }, _success: false },
-        { vertexConstants: { cf16: kValue.f32.negative.first_f64_not_castable }, _success: false },
-        { vertexConstants: { cf16: kValue.f32.positive.first_f64_not_castable }, _success: false },
+        {
+          vertexConstants: { cf16: kValue.f32.negative.first_webidl_not_castable },
+          _success: false,
+        },
+        {
+          vertexConstants: { cf16: kValue.f32.positive.first_webidl_not_castable },
+          _success: false,
+        },
       ] as const)
   )
   .beforeAllSubcases(t => {
@@ -470,22 +488,22 @@ clarity on whether values like f16.positive.last_f64_castable would be valid. Se
       .combineWithParams([
         { fragmentConstants: { cf16: kValue.f16.negative.min }, _success: true },
         {
-          fragmentConstants: { cf16: kValue.f16.negative.first_f64_not_castable },
+          fragmentConstants: { cf16: kValue.f16.negative.first_webidl_not_castable },
           _success: false,
         },
         { fragmentConstants: { cf16: kValue.f16.positive.max }, _success: true },
         {
-          fragmentConstants: { cf16: kValue.f16.positive.first_f64_not_castable },
+          fragmentConstants: { cf16: kValue.f16.positive.first_webidl_not_castable },
           _success: false,
         },
         { fragmentConstants: { cf16: kValue.f32.negative.min }, _success: false },
         { fragmentConstants: { cf16: kValue.f32.positive.max }, _success: false },
         {
-          fragmentConstants: { cf16: kValue.f32.negative.first_f64_not_castable },
+          fragmentConstants: { cf16: kValue.f32.negative.first_webidl_not_castable },
           _success: false,
         },
         {
-          fragmentConstants: { cf16: kValue.f32.positive.first_f64_not_castable },
+          fragmentConstants: { cf16: kValue.f32.positive.first_webidl_not_castable },
           _success: false,
         },
       ] as const)

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -403,10 +403,15 @@ export const kValue = {
         sixth: reinterpretU32AsF32(kBit.f32.positive.pi.sixth),
       },
       e: reinterpretU32AsF32(kBit.f32.positive.e),
-      first_f64_not_castable: reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127, // mid point of 2**128 and largest f32
-      last_f64_castable: reinterpretU64AsF64(
+      // The positive number/f64 with the smallest magnitude which when cast to
+      // f32 will produce infinity, per the rounding rules of WebIDL.
+      first_webidl_not_castable: reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127,
+      // The positive number/f64 with the largest magnitude which when cast to
+      // f32 will not produce infinity, instead rounding to FLT_MAX, per
+      // the rounding rules of WebIDL
+      last_webidl_castable: reinterpretU64AsF64(
         BigInt(reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
-      ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
+      ),
     },
     negative: {
       max: reinterpretU32AsF32(kBit.f32.negative.max),
@@ -421,10 +426,15 @@ export const kValue = {
         quarter: reinterpretU32AsF32(kBit.f32.negative.pi.quarter),
         sixth: reinterpretU32AsF32(kBit.f32.negative.pi.sixth),
       },
-      first_f64_not_castable: -(reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127), // mid point of -2**128 and largest f32
-      last_f64_castable: -reinterpretU64AsF64(
+      // The negative number/f64 with the smallest magnitude which when cast to
+      // f32 will produce infinity, per the rounding rules of WebIDL.
+      first_webidl_not_castable: -(reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127),
+      // The negative number/f64 with the largest magnitude which when cast to
+      // f32 will not produce infinity, instead rounding to FLT_MIN, per
+      // the rounding rules of WebIDL.
+      last_webidl_castable: -reinterpretU64AsF64(
         BigInt(reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
-      ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
+      ),
     },
     subnormal: {
       positive: {
@@ -466,8 +476,8 @@ export const kValue = {
       min: reinterpretU16AsF16(kBit.f16.positive.min),
       max: reinterpretU16AsF16(kBit.f16.positive.max),
       zero: reinterpretU16AsF16(kBit.f16.positive.zero),
-      first_f64_not_castable: reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16, // mid point of 2**16 and largest f16
-      last_f64_castable: reinterpretU64AsF64(
+      first_webidl_not_castable: reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16, // mid point of 2**16 and largest f16
+      last_webidl_castable: reinterpretU64AsF64(
         BigInt(reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
       ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
@@ -475,8 +485,8 @@ export const kValue = {
       max: reinterpretU16AsF16(kBit.f16.negative.max),
       min: reinterpretU16AsF16(kBit.f16.negative.min),
       zero: reinterpretU16AsF16(kBit.f16.negative.zero),
-      first_f64_not_castable: -(reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16), // mid point of -2**16 and largest f16
-      last_f64_castable: -reinterpretU64AsF64(
+      first_webidl_not_castable: -(reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16), // mid point of -2**16 and largest f16
+      last_webidl_castable: -reinterpretU64AsF64(
         BigInt(reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
       ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -294,9 +294,19 @@ export const kBit = {
  *
  * Using a locally defined function here to avoid compile time dependency
  * issues.
- * */
+ */
 function reinterpretU64AsF64(input: bigint): number {
   return new Float64Array(new BigInt64Array([input]).buffer)[0];
+}
+
+/**
+ * @returns the 64-bit integer bit representation of 64-bit float value
+ *
+ * Using a locally defined function here to avoid compile time dependency
+ * issues.
+ */
+function reinterpretF64AsU64(input: number): bigint {
+  return new BigInt64Array(new Float64Array([input]).buffer)[0];
 }
 
 /**
@@ -305,7 +315,7 @@ function reinterpretU64AsF64(input: bigint): number {
  *
  * Using a locally defined function here to avoid compile time dependency
  * issues.
- * */
+ */
 function reinterpretU32AsF32(input: number): number {
   return new Float32Array(new Uint32Array([input]).buffer)[0];
 }
@@ -316,7 +326,7 @@ function reinterpretU32AsF32(input: number): number {
  *
  * Using a locally defined function here to avoid compile time dependency
  * issues.
- * */
+ */
 function reinterpretU16AsF16(input: number): number {
   return new Float16Array(new Uint16Array([input]).buffer)[0];
 }
@@ -403,14 +413,16 @@ export const kValue = {
         sixth: reinterpretU32AsF32(kBit.f32.positive.pi.sixth),
       },
       e: reinterpretU32AsF32(kBit.f32.positive.e),
-      // The positive number/f64 with the smallest magnitude which when cast to
-      // f32 will produce infinity, per the rounding rules of WebIDL.
-      first_webidl_not_castable: reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127,
-      // The positive number/f64 with the largest magnitude which when cast to
-      // f32 will not produce infinity, instead rounding to FLT_MAX, per
-      // the rounding rules of WebIDL
-      last_webidl_castable: reinterpretU64AsF64(
-        BigInt(reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
+      // The positive pipeline-overridable constant with the smallest magnitude
+      // which when cast to f32 will produce infinity. This comes from WGSL
+      // conversion rules and the rounding rules of WebIDL.
+      first_non_castable_pipeline_override:
+        reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127,
+      // The positive pipeline-overridable constant with the largest magnitude
+      // which when cast to f32 will not produce infinity. This comes from WGSL
+      // conversion rules and the rounding rules of WebIDL
+      last_castable_pipeline_override: reinterpretU64AsF64(
+        reinterpretF64AsU64(reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
       ),
     },
     negative: {
@@ -426,14 +438,18 @@ export const kValue = {
         quarter: reinterpretU32AsF32(kBit.f32.negative.pi.quarter),
         sixth: reinterpretU32AsF32(kBit.f32.negative.pi.sixth),
       },
-      // The negative number/f64 with the smallest magnitude which when cast to
-      // f32 will produce infinity, per the rounding rules of WebIDL.
-      first_webidl_not_castable: -(reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127),
-      // The negative number/f64 with the largest magnitude which when cast to
-      // f32 will not produce infinity, instead rounding to FLT_MIN, per
-      // the rounding rules of WebIDL.
-      last_webidl_castable: -reinterpretU64AsF64(
-        BigInt(reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
+      // The negative pipeline-overridable constant with the smallest magnitude
+      // which when cast to f32 will produce infinity. This comes from WGSL
+      // conversion rules and the rounding rules of WebIDL.
+      first_non_castable_pipeline_override: -(
+        reinterpretU32AsF32(kBit.f32.positive.max) / 2 +
+        2 ** 127
+      ),
+      // The negative pipeline-overridable constant with the largest magnitude
+      // which when cast to f32 will not produce infinity. This comes from WGSL
+      // conversion rules and the rounding rules of WebIDL.
+      last_castable_pipeline_override: -reinterpretU64AsF64(
+        reinterpretF64AsU64(reinterpretU32AsF32(kBit.f32.positive.max) / 2 + 2 ** 127) - BigInt(1)
       ),
     },
     subnormal: {
@@ -476,11 +492,35 @@ export const kValue = {
       min: reinterpretU16AsF16(kBit.f16.positive.min),
       max: reinterpretU16AsF16(kBit.f16.positive.max),
       zero: reinterpretU16AsF16(kBit.f16.positive.zero),
+      // The positive pipeline-overridable constant with the smallest magnitude
+      // which when cast to f16 will produce infinity. This comes from WGSL
+      // conversion rules and the rounding rules of WebIDL.
+      first_non_castable_pipeline_override:
+        reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 15,
+      // The positive pipeline-overridable constant with the largest magnitude
+      // which when cast to f16 will not produce infinity. This comes from WGSL
+      // conversion rules and the rounding rules of WebIDL
+      last_castable_pipeline_override: reinterpretU64AsF64(
+        reinterpretF64AsU64(reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 15) - BigInt(1)
+      ),
     },
     negative: {
       max: reinterpretU16AsF16(kBit.f16.negative.max),
       min: reinterpretU16AsF16(kBit.f16.negative.min),
       zero: reinterpretU16AsF16(kBit.f16.negative.zero),
+      // The negative pipeline-overridable constant with the smallest magnitude
+      // which when cast to f16 will produce infinity. This comes from WGSL
+      // conversion rules and the rounding rules of WebIDL.
+      first_non_castable_pipeline_override: -(
+        reinterpretU16AsF16(kBit.f16.positive.max) / 2 +
+        2 ** 15
+      ),
+      // The negative pipeline-overridable constant with the largest magnitude
+      // which when cast to f16 will not produce infinity. This comes from WGSL
+      // conversion rules and the rounding rules of WebIDL.
+      last_castable_pipeline_override: -reinterpretU64AsF64(
+        reinterpretF64AsU64(reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 15) - BigInt(1)
+      ),
     },
     subnormal: {
       positive: {

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -476,19 +476,11 @@ export const kValue = {
       min: reinterpretU16AsF16(kBit.f16.positive.min),
       max: reinterpretU16AsF16(kBit.f16.positive.max),
       zero: reinterpretU16AsF16(kBit.f16.positive.zero),
-      first_webidl_not_castable: reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16, // mid point of 2**16 and largest f16
-      last_webidl_castable: reinterpretU64AsF64(
-        BigInt(reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
-      ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     negative: {
       max: reinterpretU16AsF16(kBit.f16.negative.max),
       min: reinterpretU16AsF16(kBit.f16.negative.min),
       zero: reinterpretU16AsF16(kBit.f16.negative.zero),
-      first_webidl_not_castable: -(reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16), // mid point of -2**16 and largest f16
-      last_webidl_castable: -reinterpretU64AsF64(
-        BigInt(reinterpretU16AsF16(kBit.f16.positive.max) / 2 + 2 ** 16) - BigInt(1)
-      ), // first_f64_not_castable minus one fraction bit of the 64 bit float representation
     },
     subnormal: {
       positive: {


### PR DESCRIPTION
Adds comments clarifying what the values are, and changes the name to be more explicit.

The f16 versions were removed because a) there are not currently used, and b) looking at 
the WebIDL spec, I don't think conversion to half float is actually specified, just to single 
float.

Fixes #2501

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
