### PR TITLE
[wgsl] Validation tests for `enable`

### DIFF
--- a/src/webgpu/shader/validation/parse/enable.spec.ts
+++ b/src/webgpu/shader/validation/parse/enable.spec.ts
@@ -1,0 +1,70 @@
+export const description = `Parser validation tests for enable`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kCases = {
+  f16: { code: `enable f16;`, pass: true },
+  decl_before: {
+    code: `alias i = i32;
+enable f16;`,
+    pass: false,
+  },
+  after_decl: {
+    code: `enable f16;
+alias i = i32;`,
+    pass: true,
+  },
+  const_assert_before: {
+    code: `const_assert 1 == 1;
+enable f16;`,
+    pass: false,
+  },
+  const_assert_after: {
+    code: `enable f16;
+const_assert 1 == 1;`,
+    pass: true,
+  },
+  embedded_comment: {
+    code: `/* comment
+
+*/enable f16;`,
+    pass: true,
+  },
+  parens: {
+    code: `enable(f16);`,
+    pass: false,
+  },
+  multi_line: {
+    code: `enable
+f16;`,
+    pass: true,
+  },
+  multiple_enables: {
+    code: `enable f16;
+enable f16;`,
+    pass: true,
+  },
+  multipe_entries: {
+    code: `enable f16, f16, f16;`,
+    pass: true,
+  },
+  unknown: {
+    code: `enable unknown;`,
+    pass: false,
+  },
+};
+
+g.test('enable')
+  .desc(`Tests that enables are validated correctly`)
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .params(u => u.combine('case', keysOf(kCases)))
+  .fn(t => {
+    const c = kCases[t.params.case];
+    t.expectCompileResult(c.pass, c.code);
+  });


### PR DESCRIPTION
This CL adds validation tests for the `enable` directive.

Fixes #1708

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
