### PR TITLE
Check exception type for Webgpu getCurrentTexture test

### DIFF
--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -58,8 +58,8 @@ g.test('configured')
     const ctx = canvas.getContext('webgpu');
     assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
-    // Calling getCurrentTexture prior to configuration should throw an exception.
-    t.shouldThrow(true, () => {
+    // Calling getCurrentTexture prior to configuration should throw an InvalidStateError exception.
+    t.shouldThrow('InvalidStateError', () => {
       ctx.getCurrentTexture();
     });
 
@@ -91,10 +91,10 @@ g.test('configured')
     t.expect(prevTexture !== currentTexture);
     prevTexture = currentTexture;
 
-    // Calling getCurrentTexture after calling unconfigure should throw an exception.
+    // Calling getCurrentTexture after calling unconfigure should throw an InvalidStateError exception.
     ctx.unconfigure();
 
-    t.shouldThrow(true, () => {
+    t.shouldThrow('InvalidStateError', () => {
       ctx.getCurrentTexture();
     });
   });


### PR DESCRIPTION
Currently WebGPU getCurrentTexture test doesn't check exception type for a failure test so the test can
unexpectedly pass even if implmentations raise a wrong type exception.

This PR fixes this problem by letting the test check the exception type.

Issue: #2518 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
