### PR TITLE
Check exception type for Webgpu context configure test

### DIFF
--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -71,15 +71,15 @@ g.test('device')
     const ctx = canvas.getContext('webgpu');
     assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
-    // Calling configure without a device should throw.
-    t.shouldThrow(true, () => {
+    // Calling configure without a device should throw a TypeError.
+    t.shouldThrow('TypeError', () => {
       ctx.configure({
         format: 'rgba8unorm',
       } as GPUCanvasConfiguration);
     });
 
-    // Device is not configured, so getCurrentTexture will throw.
-    t.shouldThrow(true, () => {
+    // Device is not configured, so getCurrentTexture will throw an InvalidStateError.
+    t.shouldThrow('InvalidStateError', () => {
       ctx.getCurrentTexture();
     });
 
@@ -94,7 +94,7 @@ g.test('device')
 
     // Unconfiguring should cause the device to be cleared.
     ctx.unconfigure();
-    t.shouldThrow(true, () => {
+    t.shouldThrow('InvalidStateError', () => {
       ctx.getCurrentTexture();
     });
 


### PR DESCRIPTION
Issue: #2574 <!-- Fill in the issue number here. See docs/intro/life_of.md -->

Currently WebGPU canvas context configure tests don't check exception type for a failure test so the tests can unexpectedly pass even if implmentations raise a wrong type exception.

This PR fixes this problem by letting the test check the exception type.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
