### PR TITLE
WebGPU GPUBuffer.mapState MAP_READ mode

### DIFF
--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -367,16 +367,16 @@ g.test('mappedAtCreation,mapState')
   .desc('Test that exposed map state of buffer created with mappedAtCreation has expected values.')
   .params(u =>
     u
-      .combine('usageType', ['invalid', 'MAP_READ', 'MAP_WRITE'])
+      .combine('usageType', ['invalid', 'read', 'write'])
       .combine('afterUnmap', [false, true])
       .combine('afterDestroy', [false, true])
   )
   .fn(t => {
     const { usageType, afterUnmap, afterDestroy } = t.params;
     const usage =
-      usageType === 'MAP_READ'
+      usageType === 'read'
         ? GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-        : usageType === 'MAP_WRITE'
+        : usageType === 'write'
         ? GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
         : 0;
     const validationError = usage === 0;
@@ -414,8 +414,8 @@ g.test('mapAsync,mapState')
   .desc('Test that exposed map state of buffer mapped with mapAsync has expected values.')
   .params(u =>
     u
-      .combine('usageType', ['invalid', 'MAP_READ', 'MAP_WRITE'])
-      .combine('mapModeType', ['READ', 'WRITE'])
+      .combine('usageType', ['invalid', 'read', 'write'])
+      .combine('mapModeType', ['READ', 'WRITE'] as const)
       .combine('beforeUnmap', [false, true])
       .combine('beforeDestroy', [false, true])
       .combine('afterUnmap', [false, true])
@@ -433,9 +433,9 @@ g.test('mapAsync,mapState')
     const size = 8;
     const range = [0, 8];
     const usage =
-      usageType === 'MAP_READ'
+      usageType === 'read'
         ? GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
-        : usageType === 'MAP_WRITE'
+        : usageType === 'write'
         ? GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
         : 0;
     const bufferCreationValidationError = usage === 0;

--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -439,7 +439,7 @@ g.test('mapAsync,mapState')
         ? GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
         : 0;
     const bufferCreationValidationError = usage === 0;
-    const mapMode = mapModeType === 'READ' ? GPUMapMode.READ : GPUMapMode.WRITE;
+    const mapMode = GPUMapMode[mapModeType];
 
     let buffer: GPUBuffer;
     t.expectValidationError(() => {

--- a/src/webgpu/api/operation/buffers/map.spec.ts
+++ b/src/webgpu/api/operation/buffers/map.spec.ts
@@ -367,12 +367,19 @@ g.test('mappedAtCreation,mapState')
   .desc('Test that exposed map state of buffer created with mappedAtCreation has expected values.')
   .params(u =>
     u
-      .combine('validationError', [false, true])
+      .combine('usageType', ['invalid', 'MAP_READ', 'MAP_WRITE'])
       .combine('afterUnmap', [false, true])
       .combine('afterDestroy', [false, true])
   )
   .fn(t => {
-    const { validationError, afterUnmap, afterDestroy } = t.params;
+    const { usageType, afterUnmap, afterDestroy } = t.params;
+    const usage =
+      usageType === 'MAP_READ'
+        ? GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+        : usageType === 'MAP_WRITE'
+        ? GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+        : 0;
+    const validationError = usage === 0;
     const size = 8;
     const range = [0, 8];
 
@@ -381,7 +388,7 @@ g.test('mappedAtCreation,mapState')
       buffer = t.device.createBuffer({
         mappedAtCreation: true,
         size,
-        usage: validationError ? 0 : GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+        usage,
       });
     }, validationError);
 
@@ -407,8 +414,8 @@ g.test('mapAsync,mapState')
   .desc('Test that exposed map state of buffer mapped with mapAsync has expected values.')
   .params(u =>
     u
-      .combine('bufferCreationValidationError', [false, true])
-      .combine('mapAsyncValidationError', [false, true])
+      .combine('usageType', ['invalid', 'MAP_READ', 'MAP_WRITE'])
+      .combine('mapModeType', ['READ', 'WRITE'])
       .combine('beforeUnmap', [false, true])
       .combine('beforeDestroy', [false, true])
       .combine('afterUnmap', [false, true])
@@ -416,8 +423,8 @@ g.test('mapAsync,mapState')
   )
   .fn(async t => {
     const {
-      bufferCreationValidationError,
-      mapAsyncValidationError,
+      usageType,
+      mapModeType,
       beforeUnmap,
       beforeDestroy,
       afterUnmap,
@@ -425,25 +432,35 @@ g.test('mapAsync,mapState')
     } = t.params;
     const size = 8;
     const range = [0, 8];
+    const usage =
+      usageType === 'MAP_READ'
+        ? GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+        : usageType === 'MAP_WRITE'
+        ? GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE
+        : 0;
+    const bufferCreationValidationError = usage === 0;
+    const mapMode = mapModeType === 'READ' ? GPUMapMode.READ : GPUMapMode.WRITE;
 
     let buffer: GPUBuffer;
     t.expectValidationError(() => {
       buffer = t.device.createBuffer({
         mappedAtCreation: false,
         size,
-        usage: bufferCreationValidationError
-          ? 0
-          : GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE,
+        usage,
       });
     }, bufferCreationValidationError);
 
     t.expect(buffer!.mapState === 'unmapped');
 
     {
+      const mapAsyncValidationError =
+        bufferCreationValidationError ||
+        (mapMode === GPUMapMode.READ && !(usage & GPUBufferUsage.MAP_READ)) ||
+        (mapMode === GPUMapMode.WRITE && !(usage & GPUBufferUsage.MAP_WRITE));
       let promise: Promise<void>;
       t.expectValidationError(() => {
-        promise = buffer!.mapAsync(mapAsyncValidationError ? 0 : GPUMapMode.WRITE);
-      }, bufferCreationValidationError || mapAsyncValidationError);
+        promise = buffer!.mapAsync(mapMode);
+      }, mapAsyncValidationError);
       t.expect(buffer!.mapState === 'pending');
 
       try {


### PR DESCRIPTION
This PR adds a missing `GPUBuffer.mapState` test case with MAP_READ mode.

Issue: #2124 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
