### PR TITLE
Remove using CaseCache in bitcast tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
@@ -45,7 +45,6 @@ import {
   linearRange,
   isSubnormalNumberF32,
 } from '../../../../../util/math.js';
-import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, run, CaseList, InputSource, ShaderBuilder } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -75,9 +74,9 @@ const f32RangeWithInfAndNaN: number[] = [
   ].map(u => reinterpretU32AsF32(u)),
 ];
 
-const anyF32: Comparator = v => ({ matched: true, got: `$v`, expected: 'any f32' });
-const anyI32: Comparator = v => ({ matched: true, got: `$v`, expected: 'any i32' });
-const anyU32: Comparator = v => ({ matched: true, got: `$v`, expected: 'any u32' });
+const anyF32: Comparator = v => ({ matched: true, got: `${v}`, expected: 'any f32' });
+const anyI32: Comparator = v => ({ matched: true, got: `${v}`, expected: 'any i32' });
+const anyU32: Comparator = v => ({ matched: true, got: `${v}`, expected: 'any u32' });
 
 function f32CanMapToZero(f: number): boolean {
   return f === 0 || isSubnormalNumberF32(f);
@@ -144,26 +143,59 @@ function bitcastF32ToI32Comparator(f: number): Comparator {
   });
 }
 
-const TODO_CASES: CaseList = [];
-export const d = makeCaseCache('bitcast', {
-  // Identity cases
-  i32_to_i32: () => fullI32Range().map(e => ({ input: i32(e), expected: i32(e) })),
-  u32_to_u32: () => fullU32Range().map(e => ({ input: u32(e), expected: u32(e) })),
-  f32_inf_nan_to_f32: () =>
-    f32RangeWithInfAndNaN.map(e => ({ input: f32(e), expected: bitcastF32ToF32Comparator(e) })),
-  f32_to_f32: () => f32Range.map(e => ({ input: f32(e), expected: bitcastF32ToF32Comparator(e) })),
-  // i32,u32,f32 to different i32,u32,f32
-  i32_to_u32: () => fullI32Range().map(e => ({ input: i32(e), expected: u32(e) })),
-  i32_to_f32: () => TODO_CASES,
-  u32_to_i32: () => fullU32Range().map(e => ({ input: u32(e), expected: i32(e) })),
-  u32_to_f32: () => TODO_CASES,
-  f32_inf_nan_to_i32: () =>
-    f32RangeWithInfAndNaN.map(e => ({ input: f32(e), expected: bitcastF32ToI32Comparator(e) })),
-  f32_to_i32: () => f32Range.map(e => ({ input: f32(e), expected: bitcastF32ToI32Comparator(e) })),
-  f32_inf_nan_to_u32: () =>
-    f32RangeWithInfAndNaN.map(e => ({ input: f32(e), expected: bitcastF32ToU32Comparator(e) })),
-  f32_to_u32: () => f32Range.map(e => ({ input: f32(e), expected: bitcastF32ToU32Comparator(e) })),
-});
+// Use of the CaseCache has been intentionally removed, because serialization
+// does not exist for these custom comparators, so they break the cache.
+
+// const TODO_CASES: CaseList = [];
+
+// Identity Cases
+function i32_to_i32() {
+  return fullI32Range().map(e => ({ input: i32(e), expected: i32(e) }));
+}
+function u32_to_u32() {
+  return fullU32Range().map(e => ({ input: u32(e), expected: u32(e) }));
+}
+function f32_inf_nan_to_f32() {
+  return f32RangeWithInfAndNaN.map(e => ({
+    input: f32(e),
+    expected: bitcastF32ToF32Comparator(e),
+  }));
+}
+function f32_to_f32() {
+  return f32Range.map(e => ({ input: f32(e), expected: bitcastF32ToF32Comparator(e) }));
+}
+
+// i32,u32,f32 to different i32,u32,f32
+function i32_to_u32() {
+  return fullI32Range().map(e => ({ input: i32(e), expected: u32(e) }));
+}
+// function i32_to_f32() {
+//   return TODO_CASES;
+// }
+function u32_to_i32() {
+  return fullU32Range().map(e => ({ input: u32(e), expected: i32(e) }));
+}
+// function u32_to_f32() {
+//   return TODO_CASES;
+// }
+function f32_inf_nan_to_i32() {
+  return f32RangeWithInfAndNaN.map(e => ({
+    input: f32(e),
+    expected: bitcastF32ToI32Comparator(e),
+  }));
+}
+function f32_to_i32() {
+  return f32Range.map(e => ({ input: f32(e), expected: bitcastF32ToI32Comparator(e) }));
+}
+function f32_inf_nan_to_u32() {
+  return f32RangeWithInfAndNaN.map(e => ({
+    input: f32(e),
+    expected: bitcastF32ToU32Comparator(e),
+  }));
+}
+function f32_to_u32() {
+  return f32Range.map(e => ({ input: f32(e), expected: bitcastF32ToU32Comparator(e) }));
+}
 
 /**
  * @returns a ShaderBuilder that generates a call to bitcast,
@@ -199,7 +231,7 @@ g.test('i32_to_i32')
       .combine('alias', [false, true])
   )
   .fn(async t => {
-    const cases = await d.get('i32_to_i32');
+    const cases = i32_to_i32();
     await run(t, bitcastBuilder('i32', t.params), [TypeI32], TypeI32, t.params, cases);
   });
 
@@ -213,7 +245,7 @@ g.test('u32_to_u32')
       .combine('alias', [false, true])
   )
   .fn(async t => {
-    const cases = await d.get('u32_to_u32');
+    const cases = u32_to_u32();
     await run(t, bitcastBuilder('u32', t.params), [TypeU32], TypeU32, t.params, cases);
   });
 
@@ -227,10 +259,8 @@ g.test('f32_to_f32')
       .combine('alias', [false, true])
   )
   .fn(async t => {
-    const cases = await d.get(
-      // Infinities and NaNs are errors in const-eval.
-      t.params.inputSource === 'const' ? 'f32_to_f32' : 'f32_inf_nan_to_f32'
-    );
+    // Infinities and NaNs are errors in const-eval.
+    const cases = t.params.inputSource === 'const' ? f32_to_f32() : f32_inf_nan_to_f32();
     await run(t, bitcastBuilder('f32', t.params), [TypeF32], TypeF32, t.params, cases);
   });
 
@@ -245,7 +275,7 @@ g.test('u32_to_i32')
       .combine('alias', [false, true])
   )
   .fn(async t => {
-    const cases = await d.get('u32_to_i32');
+    const cases = u32_to_i32();
     await run(t, bitcastBuilder('i32', t.params), [TypeU32], TypeI32, t.params, cases);
   });
 
@@ -259,10 +289,8 @@ g.test('f32_to_i32')
       .combine('alias', [false, true])
   )
   .fn(async t => {
-    const cases = await d.get(
-      // Infinities and NaNs are errors in const-eval.
-      t.params.inputSource === 'const' ? 'f32_to_i32' : 'f32_inf_nan_to_i32'
-    );
+    // Infinities and NaNs are errors in const-eval.
+    const cases = t.params.inputSource === 'const' ? f32_to_i32() : f32_inf_nan_to_i32();
     await run(t, bitcastBuilder('i32', t.params), [TypeF32], TypeI32, t.params, cases);
   });
 
@@ -277,7 +305,7 @@ g.test('i32_to_u32')
       .combine('alias', [false, true])
   )
   .fn(async t => {
-    const cases = await d.get('i32_to_u32');
+    const cases = i32_to_u32();
     await run(t, bitcastBuilder('u32', t.params), [TypeI32], TypeU32, t.params, cases);
   });
 
@@ -291,10 +319,8 @@ g.test('f32_to_u32')
       .combine('alias', [false, true])
   )
   .fn(async t => {
-    const cases = await d.get(
-      // Infinities and NaNs are errors in const-eval.
-      t.params.inputSource === 'const' ? 'f32_to_u32' : 'f32_inf_nan_to_u32'
-    );
+    // Infinities and NaNs are errors in const-eval.
+    const cases = t.params.inputSource === 'const' ? f32_to_u32() : f32_inf_nan_to_u32();
     await run(t, bitcastBuilder('u32', t.params), [TypeF32], TypeU32, t.params, cases);
   });
 

--- a/src/webgpu/shader/execution/expression/case_cache.ts
+++ b/src/webgpu/shader/execution/expression/case_cache.ts
@@ -118,9 +118,9 @@ export function serializeExpectation(e: Expectation): SerializedExpectation {
         return { kind: 'comparator', value: { kind: comp.kind, data: comp.data } };
       }
     }
-    throw 'cannot serialize comparator';
+    throw `cannot serialize comparator ${e}`;
   }
-  throw 'cannot serialize expectation';
+  throw `cannot serialize expectation ${e}`;
 }
 
 /** deserializeExpectation() converts a SerializedExpectation to a Expectation */


### PR DESCRIPTION
Currently these tests use custom Comparators that don't have serialization methods, so cannot be put in the cache.

Issue #2593

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
