### PR TITLE
Updated uses of timestampWrites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "gpuweb/types#e836ed695b7a8774da4cdee0787b24011992400d",
+        "@webgpu/types": "0.1.32",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1262,11 +1262,10 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.30",
-      "resolved": "git+ssh://git@github.com/gpuweb/types.git#e836ed695b7a8774da4cdee0787b24011992400d",
-      "integrity": "sha512-lGZhQ/p9NiD8u1LQQ/g5Xyj7Na1HPDO9xsJF3fsz8R5eJo8T4IyI7dRAygN6ePA1wmopZ4qzdltgEfUYPTJWpQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.32.tgz",
+      "integrity": "sha512-H6JRAvRonWxqREjxXMZgQmdgIFPe6mykLgdrHY7EQE7YihMKd/SjtSGilUmMKECVdUMg2IQB9vzaXDiTj1AxZg==",
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -9876,10 +9875,10 @@
       }
     },
     "@webgpu/types": {
-      "version": "git+ssh://git@github.com/gpuweb/types.git#e836ed695b7a8774da4cdee0787b24011992400d",
-      "integrity": "sha512-lGZhQ/p9NiD8u1LQQ/g5Xyj7Na1HPDO9xsJF3fsz8R5eJo8T4IyI7dRAygN6ePA1wmopZ4qzdltgEfUYPTJWpQ==",
-      "dev": true,
-      "from": "@webgpu/types@gpuweb/types#e836ed695b7a8774da4cdee0787b24011992400d"
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.32.tgz",
+      "integrity": "sha512-H6JRAvRonWxqREjxXMZgQmdgIFPe6mykLgdrHY7EQE7YihMKd/SjtSGilUmMKECVdUMg2IQB9vzaXDiTj1AxZg==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "gpuweb/types#e836ed695b7a8774da4cdee0787b24011992400d",
+    "@webgpu/types": "0.1.32",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -20,49 +20,6 @@ class F extends ValidationTest {
 
 export const g = makeTestGroup(F);
 
-g.test('timestampWrites,same_location')
-  .desc(
-    `
-  Test that entries in timestampWrites do not have the same location in GPUComputePassDescriptor.
-  `
-  )
-  .params(u =>
-    u //
-      .combine('locationA', ['beginning', 'end'] as const)
-      .combine('locationB', ['beginning', 'end'] as const)
-  )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase(['timestamp-query']);
-  })
-  .fn(t => {
-    const { locationA, locationB } = t.params;
-
-    const querySet = t.device.createQuerySet({
-      type: 'timestamp',
-      count: 2,
-    });
-
-    const timestampWriteA = {
-      querySet,
-      queryIndex: 0,
-      location: locationA,
-    };
-
-    const timestampWriteB = {
-      querySet,
-      queryIndex: 1,
-      location: locationB,
-    };
-
-    const isValid = locationA !== locationB;
-
-    const descriptor = {
-      timestampWrites: [timestampWriteA, timestampWriteB],
-    };
-
-    t.tryComputePass(isValid, descriptor);
-  });
-
 g.test('timestampWrites,query_set_type')
   .desc(
     `
@@ -72,35 +29,27 @@ g.test('timestampWrites,query_set_type')
   )
   .params(u =>
     u //
-      .combine('queryTypeA', kQueryTypes)
-      .combine('queryTypeB', kQueryTypes)
+      .combine('queryType', kQueryTypes)
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForQueryTypeOrSkipTestCase([
       'timestamp',
-      t.params.queryTypeA,
-      t.params.queryTypeB,
+      t.params.queryType,
     ]);
   })
   .fn(t => {
-    const { queryTypeA, queryTypeB } = t.params;
+    const { queryType } = t.params;
 
-    const timestampWriteA = {
-      querySet: t.device.createQuerySet({ type: queryTypeA, count: 1 }),
-      queryIndex: 0,
-      location: 'beginning' as const,
+    const isValid = queryType === 'timestamp';
+
+    const timestampWrites = {
+      querySet: t.device.createQuerySet({ type: queryType, count: 2 }),
+      beginningOfPassWriteIndex: 0,
+      endOfPassWriteIndex: 1,
     };
-
-    const timestampWriteB = {
-      querySet: t.device.createQuerySet({ type: queryTypeB, count: 1 }),
-      queryIndex: 0,
-      location: 'end' as const,
-    };
-
-    const isValid = queryTypeA === 'timestamp' && queryTypeB === 'timestamp';
 
     const descriptor = {
-      timestampWrites: [timestampWriteA, timestampWriteB],
+      timestampWrites,
     };
 
     t.tryComputePass(isValid, descriptor);
@@ -120,40 +69,46 @@ g.test('timestampWrites,invalid_query_set')
       count: 1,
     });
 
-    const timestampWrite = {
+    const timestampWrites = {
       querySet,
-      queryIndex: 0,
-      location: 'beginning' as const,
+      beginningOfPassWriteIndex: 0,
     };
 
     const descriptor = {
-      timestampWrites: [timestampWrite],
+      timestampWrites,
     };
 
     t.tryComputePass(querySetState === 'valid', descriptor);
   });
 
-g.test('timestampWrites,query_index_count')
-  .desc(`Test that querySet.count should be greater than timestampWrite.queryIndex.`)
-  .params(u => u.combine('queryIndex', [0, 1, 2, 3]))
+g.test('timestampWrites,query_index')
+  .desc(`Test that querySet.count should be greater than timestampWrite.queryIndex, and that the
+         query indexes are unique.`)
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('beginningOfPassWriteIndex', [undefined, 0, 1, 2, 3] as const)
+      .combine('endOfPassWriteIndex', [undefined, 0, 1, 2, 3] as const)
+  )
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase(['timestamp-query']);
   })
   .fn(t => {
-    const { queryIndex } = t.params;
+    const { beginningOfPassWriteIndex, endOfPassWriteIndex } = t.params;
 
     const querySetCount = 2;
 
-    const timestampWrite = {
+    const timestampWrites = {
       querySet: t.device.createQuerySet({ type: 'timestamp', count: querySetCount }),
-      queryIndex,
-      location: 'beginning' as const,
+      beginningOfPassWriteIndex,
+      endOfPassWriteIndex,
     };
 
-    const isValid = queryIndex < querySetCount;
+    const isValid = (beginningOfPassWriteIndex !== endOfPassWriteIndex) &&
+                    (beginningOfPassWriteIndex === undefined || beginningOfPassWriteIndex < querySetCount) &&
+                    (endOfPassWriteIndex === undefined || endOfPassWriteIndex < querySetCount)
 
     const descriptor = {
-      timestampWrites: [timestampWrite],
+      timestampWrites,
     };
 
     t.tryComputePass(isValid, descriptor);
@@ -179,14 +134,13 @@ g.test('timestamp_query_set,device_mismatch')
       count: 1,
     });
 
-    const timestampWrite = {
+    const timestampWrites = {
       querySet: timestampQuerySet,
-      queryIndex: 0,
-      location: 'beginning' as const,
+      beginningOfPassWriteIndex: 0,
     };
 
     const descriptor = {
-      timestampWrites: [timestampWrite],
+      timestampWrites,
     };
 
     t.tryComputePass(!mismatched, descriptor);

--- a/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginComputePass.spec.ts
@@ -32,10 +32,7 @@ g.test('timestampWrites,query_set_type')
       .combine('queryType', kQueryTypes)
   )
   .beforeAllSubcases(t => {
-    t.selectDeviceForQueryTypeOrSkipTestCase([
-      'timestamp',
-      t.params.queryType,
-    ]);
+    t.selectDeviceForQueryTypeOrSkipTestCase(['timestamp', t.params.queryType]);
   })
   .fn(t => {
     const { queryType } = t.params;
@@ -82,8 +79,10 @@ g.test('timestampWrites,invalid_query_set')
   });
 
 g.test('timestampWrites,query_index')
-  .desc(`Test that querySet.count should be greater than timestampWrite.queryIndex, and that the
-         query indexes are unique.`)
+  .desc(
+    `Test that querySet.count should be greater than timestampWrite.queryIndex, and that the
+         query indexes are unique.`
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('beginningOfPassWriteIndex', [undefined, 0, 1, 2, 3] as const)
@@ -103,9 +102,10 @@ g.test('timestampWrites,query_index')
       endOfPassWriteIndex,
     };
 
-    const isValid = (beginningOfPassWriteIndex !== endOfPassWriteIndex) &&
-                    (beginningOfPassWriteIndex === undefined || beginningOfPassWriteIndex < querySetCount) &&
-                    (endOfPassWriteIndex === undefined || endOfPassWriteIndex < querySetCount)
+    const isValid =
+      beginningOfPassWriteIndex !== endOfPassWriteIndex &&
+      (beginningOfPassWriteIndex === undefined || beginningOfPassWriteIndex < querySetCount) &&
+      (endOfPassWriteIndex === undefined || endOfPassWriteIndex < querySetCount);
 
     const descriptor = {
       timestampWrites,

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -22,7 +22,6 @@ Notes:
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { kQueryTypes } from '../../../capability_info.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);

--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -22,6 +22,7 @@ Notes:
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { kQueryTypes } from '../../../capability_info.js';
 import { ValidationTest } from '../validation_test.js';
 
 export const g = makeTestGroup(ValidationTest);
@@ -182,10 +183,14 @@ g.test('timestamp_query_set,device_mismatch')
     const { mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const timestampWrite = {
-      querySet: sourceDevice.createQuerySet({ type: 'timestamp', count: 1 }),
-      queryIndex: 0,
-      location: 'beginning' as const,
+    const timestampQuerySet = sourceDevice.createQuerySet({
+      type: 'timestamp',
+      count: 1,
+    });
+
+    const timestampWrites = {
+      querySet: timestampQuerySet,
+      beginningOfPassWriteIndex: 0,
     };
 
     const colorTexture = t.device.createTexture({
@@ -203,7 +208,7 @@ g.test('timestamp_query_set,device_mismatch')
           storeOp: 'store',
         },
       ],
-      timestampWrites: [timestampWrite],
+      timestampWrites,
     });
     pass.end();
 

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -979,7 +979,7 @@ g.test('timestampWrites,query_set_type')
   )
   .params(u =>
     u //
-    .combine('queryType', kQueryTypes)
+      .combine('queryType', kQueryTypes)
   )
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase(['timestamp-query']);
@@ -1005,8 +1005,10 @@ g.test('timestampWrites,query_set_type')
   });
 
 g.test('timestampWrite,query_index')
-  .desc(`Test that querySet.count should be greater than timestampWrite.queryIndex, and that the
-         query indexes are unique.`)
+  .desc(
+    `Test that querySet.count should be greater than timestampWrite.queryIndex, and that the
+         query indexes are unique.`
+  )
   .paramsSubcasesOnly(u =>
     u //
       .combine('beginningOfPassWriteIndex', [undefined, 0, 1, 2, 3] as const)
@@ -1026,9 +1028,10 @@ g.test('timestampWrite,query_index')
       endOfPassWriteIndex,
     };
 
-    const isValid = (beginningOfPassWriteIndex !== endOfPassWriteIndex) &&
-                    (beginningOfPassWriteIndex === undefined || beginningOfPassWriteIndex < querySetCount) &&
-                    (endOfPassWriteIndex === undefined || endOfPassWriteIndex < querySetCount)
+    const isValid =
+      beginningOfPassWriteIndex !== endOfPassWriteIndex &&
+      (beginningOfPassWriteIndex === undefined || beginningOfPassWriteIndex < querySetCount) &&
+      (endOfPassWriteIndex === undefined || endOfPassWriteIndex < querySetCount);
 
     const colorTexture = t.createTexture();
     const descriptor = {

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -979,147 +979,61 @@ g.test('timestampWrites,query_set_type')
   )
   .params(u =>
     u //
-      .combine('queryTypeA', kQueryTypes)
-      .combine('queryTypeB', kQueryTypes)
+    .combine('queryType', kQueryTypes)
   )
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase(['timestamp-query']);
   })
   .fn(t => {
-    const { queryTypeA, queryTypeB } = t.params;
+    const { queryType } = t.params;
 
-    const timestampWriteA = {
-      querySet: t.device.createQuerySet({ type: queryTypeA, count: 1 }),
-      queryIndex: 0,
-      location: 'beginning' as const,
+    const timestampWrites = {
+      querySet: t.device.createQuerySet({ type: queryType, count: 2 }),
+      beginningOfPassWriteIndex: 0,
+      endOfPassWriteIndex: 1,
     };
 
-    const timestampWriteB = {
-      querySet: t.device.createQuerySet({ type: queryTypeB, count: 1 }),
-      queryIndex: 0,
-      location: 'end' as const,
-    };
-
-    const isValid = queryTypeA === 'timestamp' && queryTypeB === 'timestamp';
+    const isValid = queryType === 'timestamp';
 
     const colorTexture = t.createTexture();
     const descriptor = {
       colorAttachments: [t.getColorAttachment(colorTexture)],
-      timestampWrites: [timestampWriteA, timestampWriteB],
-    };
-
-    t.tryRenderPass(isValid, descriptor);
-  });
-
-g.test('timestamp_writes_location')
-  .desc('Test that entries in timestampWrites do not have the same location.')
-  .params(u =>
-    u //
-      .combine('locationA', ['beginning', 'end'] as const)
-      .combine('locationB', ['beginning', 'end'] as const)
-  )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase(['timestamp-query']);
-  })
-  .fn(t => {
-    const { locationA, locationB } = t.params;
-
-    const querySet = t.device.createQuerySet({
-      type: 'timestamp',
-      count: 2,
-    });
-
-    const timestampWriteA = {
-      querySet,
-      queryIndex: 0,
-      location: locationA,
-    };
-
-    const timestampWriteB = {
-      querySet,
-      queryIndex: 1,
-      location: locationB,
-    };
-
-    const isValid = locationA !== locationB;
-
-    const colorTexture = t.createTexture({ format: 'rgba8unorm' });
-    const descriptor = {
-      colorAttachments: [t.getColorAttachment(colorTexture)],
-      timestampWrites: [timestampWriteA, timestampWriteB],
+      timestampWrites,
     };
 
     t.tryRenderPass(isValid, descriptor);
   });
 
 g.test('timestampWrite,query_index')
-  .desc(`Test that querySet.count should be greater than timestampWrite.queryIndex.`)
-  .params(u => u.combine('queryIndex', [0, 1, 2, 3]))
+  .desc(`Test that querySet.count should be greater than timestampWrite.queryIndex, and that the
+         query indexes are unique.`)
+  .paramsSubcasesOnly(u =>
+    u //
+      .combine('beginningOfPassWriteIndex', [undefined, 0, 1, 2, 3] as const)
+      .combine('endOfPassWriteIndex', [undefined, 0, 1, 2, 3] as const)
+  )
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase(['timestamp-query']);
   })
   .fn(t => {
-    const { queryIndex } = t.params;
+    const { beginningOfPassWriteIndex, endOfPassWriteIndex } = t.params;
 
     const querySetCount = 2;
 
-    const timestampWrite = {
+    const timestampWrites = {
       querySet: t.device.createQuerySet({ type: 'timestamp', count: querySetCount }),
-      queryIndex,
-      location: 'beginning' as const,
+      beginningOfPassWriteIndex,
+      endOfPassWriteIndex,
     };
 
-    const isValid = queryIndex < querySetCount;
+    const isValid = (beginningOfPassWriteIndex !== endOfPassWriteIndex) &&
+                    (beginningOfPassWriteIndex === undefined || beginningOfPassWriteIndex < querySetCount) &&
+                    (endOfPassWriteIndex === undefined || endOfPassWriteIndex < querySetCount)
 
     const colorTexture = t.createTexture();
     const descriptor = {
       colorAttachments: [t.getColorAttachment(colorTexture)],
-      timestampWrites: [timestampWrite],
-    };
-
-    t.tryRenderPass(isValid, descriptor);
-  });
-
-g.test('timestampWrite,same_query_index')
-  .desc(
-    `
-  Test that timestampWrites is invalid if each entry has the same queryIndex in the same querySet.
-  `
-  )
-  .params(u =>
-    u //
-      .combine('queryIndexA', [0, 1])
-      .combine('queryIndexB', [0, 1])
-  )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase(['timestamp-query']);
-  })
-  .fn(t => {
-    const { queryIndexA, queryIndexB } = t.params;
-
-    const querySet = t.device.createQuerySet({
-      type: 'timestamp',
-      count: 2,
-    });
-
-    const timestampWriteA = {
-      querySet,
-      queryIndex: queryIndexA,
-      location: 'beginning' as const,
-    };
-
-    const timestampWriteB = {
-      querySet,
-      queryIndex: queryIndexB,
-      location: 'end' as const,
-    };
-
-    const isValid = queryIndexA !== queryIndexB;
-
-    const colorTexture = t.createTexture();
-    const descriptor = {
-      colorAttachments: [t.getColorAttachment(colorTexture)],
-      timestampWrites: [timestampWriteA, timestampWriteB],
+      timestampWrites,
     };
 
     t.tryRenderPass(isValid, descriptor);


### PR DESCRIPTION
The API has changed, so this patch updates the CTS to match the behavior currently given in the spec.

Tests don't pass in any implementation yet, but will begin passing once https://chromium-review.googlesource.com/c/chromium/src/+/4507755 lands in Chrome.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
