### PR TITLE
Fix large limit value rounding error

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -255,7 +255,8 @@ export function getLimitValue(
     case 'underDefault':
       return defaultLimit - 1;
     case 'betweenDefaultAndMaximum':
-      return ((defaultLimit + maximumLimit) / 2) | 0;
+      // The result can be larger than maximum i32.
+      return Math.floor((defaultLimit + maximumLimit) / 2);
     case 'atMaximum':
       return maximumLimit;
     case 'overMaximum':

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
@@ -50,7 +50,7 @@ function getDeviceLimitToRequest(
     case 'betweenDefaultAndMaximum':
       return Math.min(
         defaultLimit,
-        roundDown(((defaultLimit + maximumLimit) / 2) | 0, kMinAttributeStride)
+        roundDown(Math.floor((defaultLimit + maximumLimit) / 2), kMinAttributeStride)
       );
     case 'atMaximum':
       return maximumLimit;


### PR DESCRIPTION
This PR fix the rounding error for number value larger than maximum i32 when calculating the limit value.


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
