### PR TITLE
Make need for serialization of Comparators more obvious

### DIFF
--- a/src/unittests/serialization.spec.ts
+++ b/src/unittests/serialization.spec.ts
@@ -325,8 +325,8 @@ g.test('anyOf').fn(t => {
       const serialized = serializeComparator(c.comparator);
       const deserialized = deserializeComparator(serialized);
       for (const val of c.testCases) {
-        const got = deserialized.impl(val);
-        const expect = c.comparator.impl(val);
+        const got = deserialized.compare(val);
+        const expect = c.comparator.compare(val);
         t.expect(
           got.matched === expect.matched,
           `comparator(${val}): got: ${expect.matched}, expect: ${got.matched}`
@@ -351,8 +351,8 @@ g.test('skipUndefined').fn(t => {
       const serialized = serializeComparator(c.comparator);
       const deserialized = deserializeComparator(serialized);
       for (const val of c.testCases) {
-        const got = deserialized.impl(val);
-        const expect = c.comparator.impl(val);
+        const got = deserialized.compare(val);
+        const expect = c.comparator.compare(val);
         t.expect(
           got.matched === expect.matched,
           `comparator(${val}): got: ${expect.matched}, expect: ${got.matched}`

--- a/src/unittests/serialization.spec.ts
+++ b/src/unittests/serialization.spec.ts
@@ -10,7 +10,7 @@ import {
 import {
   anyOf,
   deserializeComparator,
-  SerializedComparator,
+  serializeComparator,
   skipUndefined,
 } from '../webgpu/util/compare.js';
 import { kValue } from '../webgpu/util/constants.js';
@@ -322,11 +322,11 @@ g.test('anyOf').fn(t => {
         testCases: [f32(0), f32(10), f32(122), f32(123), f32(124), f32(200)],
       },
     ]) {
-      const serialized = c.comparator as SerializedComparator;
+      const serialized = serializeComparator(c.comparator);
       const deserialized = deserializeComparator(serialized);
       for (const val of c.testCases) {
-        const got = deserialized(val);
-        const expect = c.comparator(val);
+        const got = deserialized.impl(val);
+        const expect = c.comparator.impl(val);
         t.expect(
           got.matched === expect.matched,
           `comparator(${val}): got: ${expect.matched}, expect: ${got.matched}`
@@ -348,11 +348,11 @@ g.test('skipUndefined').fn(t => {
         testCases: [f32(0), f32(10), f32(122), f32(123), f32(124), f32(200)],
       },
     ]) {
-      const serialized = c.comparator as SerializedComparator;
+      const serialized = serializeComparator(c.comparator);
       const deserialized = deserializeComparator(serialized);
       for (const val of c.testCases) {
-        const got = deserialized(val);
-        const expect = c.comparator(val);
+        const got = deserialized.impl(val);
+        const expect = c.comparator.impl(val);
         t.expect(
           got.matched === expect.matched,
           `comparator(${val}): got: ${expect.matched}, expect: ${got.matched}`

--- a/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
@@ -75,15 +75,15 @@ const f32RangeWithInfAndNaN: number[] = [
 ];
 
 const anyF32: Comparator = {
-  impl: v => ({ matched: true, got: `${v}`, expected: 'any f32' }),
+  compare: v => ({ matched: true, got: `${v}`, expected: 'any f32' }),
   kind: 'bitcast',
 };
 const anyI32: Comparator = {
-  impl: v => ({ matched: true, got: `${v}`, expected: 'any i32' }),
+  compare: v => ({ matched: true, got: `${v}`, expected: 'any i32' }),
   kind: 'bitcast',
 };
 const anyU32: Comparator = {
-  impl: v => ({ matched: true, got: `${v}`, expected: 'any u32' }),
+  compare: v => ({ matched: true, got: `${v}`, expected: 'any u32' }),
   kind: 'bitcast',
 };
 
@@ -106,7 +106,7 @@ function bitcastF32ToF32Comparator(f: number): Comparator {
   const acceptable: number[] = [f, ...(f32CanMapToZero(f) ? f32Zeros : [])];
   const match = (x: number): boolean => x === f || (f32CanMapToZero(f) && x === 0);
   return {
-    impl: (e: Value): Comparison => ({
+    compare: (e: Value): Comparison => ({
       matched: match((e as Scalar).value as number),
       got: `${e}`,
       expected: `${acceptable.join(' ')}`,
@@ -129,7 +129,7 @@ function bitcastF32ToU32Comparator(f: number): Comparator {
     x === reinterpretF32AsU32(f) ||
     (f32CanMapToZero(f) && (x === f32ZerosInU32[0] || x === f32ZerosInU32[1]));
   return {
-    impl: (e: Value): Comparison => ({
+    compare: (e: Value): Comparison => ({
       matched: match((e as Scalar).value as number),
       got: `${e}`,
       expected: `${acceptable.join(' ')}`,
@@ -152,7 +152,7 @@ function bitcastF32ToI32Comparator(f: number): Comparator {
     x === reinterpretF32AsI32(f) ||
     (f32CanMapToZero(f) && (x === f32ZerosInI32[0] || x === f32ZerosInI32[1]));
   return {
-    impl: (e: Value): Comparison => ({
+    compare: (e: Value): Comparison => ({
       matched: match((e as Scalar).value as number),
       got: `${e}`,
       expected: `${acceptable.join(' ')}`,

--- a/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
@@ -74,9 +74,18 @@ const f32RangeWithInfAndNaN: number[] = [
   ].map(u => reinterpretU32AsF32(u)),
 ];
 
-const anyF32: Comparator = v => ({ matched: true, got: `${v}`, expected: 'any f32' });
-const anyI32: Comparator = v => ({ matched: true, got: `${v}`, expected: 'any i32' });
-const anyU32: Comparator = v => ({ matched: true, got: `${v}`, expected: 'any u32' });
+const anyF32: Comparator = {
+  impl: v => ({ matched: true, got: `${v}`, expected: 'any f32' }),
+  kind: 'bitcast',
+};
+const anyI32: Comparator = {
+  impl: v => ({ matched: true, got: `${v}`, expected: 'any i32' }),
+  kind: 'bitcast',
+};
+const anyU32: Comparator = {
+  impl: v => ({ matched: true, got: `${v}`, expected: 'any u32' }),
+  kind: 'bitcast',
+};
 
 function f32CanMapToZero(f: number): boolean {
   return f === 0 || isSubnormalNumberF32(f);
@@ -96,11 +105,14 @@ function bitcastF32ToF32Comparator(f: number): Comparator {
   if (!isFinite(f)) return anyF32;
   const acceptable: number[] = [f, ...(f32CanMapToZero(f) ? f32Zeros : [])];
   const match = (x: number): boolean => x === f || (f32CanMapToZero(f) && x === 0);
-  return (e: Value): Comparison => ({
-    matched: match((e as Scalar).value as number),
-    got: `${e}`,
-    expected: `${acceptable.join(' ')}`,
-  });
+  return {
+    impl: (e: Value): Comparison => ({
+      matched: match((e as Scalar).value as number),
+      got: `${e}`,
+      expected: `${acceptable.join(' ')}`,
+    }),
+    kind: 'bitcast',
+  };
 }
 
 /**
@@ -116,11 +128,14 @@ function bitcastF32ToU32Comparator(f: number): Comparator {
   const match = (x: number): boolean =>
     x === reinterpretF32AsU32(f) ||
     (f32CanMapToZero(f) && (x === f32ZerosInU32[0] || x === f32ZerosInU32[1]));
-  return (e: Value): Comparison => ({
-    matched: match((e as Scalar).value as number),
-    got: `${e}`,
-    expected: `${acceptable.join(' ')}`,
-  });
+  return {
+    impl: (e: Value): Comparison => ({
+      matched: match((e as Scalar).value as number),
+      got: `${e}`,
+      expected: `${acceptable.join(' ')}`,
+    }),
+    kind: 'bitcast',
+  };
 }
 
 /**
@@ -136,11 +151,14 @@ function bitcastF32ToI32Comparator(f: number): Comparator {
   const match = (x: number): boolean =>
     x === reinterpretF32AsI32(f) ||
     (f32CanMapToZero(f) && (x === f32ZerosInI32[0] || x === f32ZerosInI32[1]));
-  return (e: Value): Comparison => ({
-    matched: match((e as Scalar).value as number),
-    got: `${e}`,
-    expected: `${acceptable.join(' ')}`,
-  });
+  return {
+    impl: (e: Value): Comparison => ({
+      matched: match((e as Scalar).value as number),
+      got: `${e}`,
+      expected: `${acceptable.join(' ')}`,
+    }),
+    kind: 'bitcast',
+  };
 }
 
 // Use of the CaseCache has been intentionally removed, because serialization

--- a/src/webgpu/shader/execution/expression/case_cache.ts
+++ b/src/webgpu/shader/execution/expression/case_cache.ts
@@ -1,5 +1,9 @@
 import { Cacheable, dataCache } from '../../../../common/framework/data_cache.js';
-import { SerializedComparator, deserializeComparator } from '../../../util/compare.js';
+import {
+  SerializedComparator,
+  deserializeComparator,
+  serializeComparator,
+} from '../../../util/compare.js';
 import {
   Scalar,
   Vector,
@@ -16,7 +20,7 @@ import {
 } from '../../../util/floating_point.js';
 import { flatten2DArray, unflatten2DArray } from '../../../util/math.js';
 
-import { Case, CaseList, Expectation } from './expression.js';
+import { Case, CaseList, Expectation, isComparator } from './expression.js';
 
 /**
  * SerializedExpectationValue holds the serialized form of an Expectation when
@@ -106,21 +110,10 @@ export function serializeExpectation(e: Expectation): SerializedExpectation {
       return { kind: 'intervals', value: e.map(serializeFPInterval) };
     }
   }
-  if (e instanceof Function) {
-    const comp = (e as unknown) as SerializedComparator;
-    if (comp !== undefined) {
-      // if blocks used to refine the type of comp.kind, otherwise it is
-      // actually the union of the string values
-      if (comp.kind === 'anyOf') {
-        return { kind: 'comparator', value: { kind: comp.kind, data: comp.data } };
-      }
-      if (comp.kind === 'skipUndefined') {
-        return { kind: 'comparator', value: { kind: comp.kind, data: comp.data } };
-      }
-    }
-    throw `cannot serialize comparator ${e}`;
+  if (isComparator(e)) {
+    return { kind: 'comparator', value: serializeComparator(e) };
   }
-  throw `cannot serialize expectation ${e}`;
+  throw `cannot serialize Expectation ${e}`;
 }
 
 /** deserializeExpectation() converts a SerializedExpectation to a Expectation */

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -1,7 +1,7 @@
 import { globalTestConfig } from '../../../../common/framework/test_config.js';
 import { objectEquals, unreachable } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { compare, Comparator } from '../../../util/compare.js';
+import { compare, Comparator, ComparatorImpl } from '../../../util/compare.js';
 import {
   ScalarType,
   Scalar,
@@ -28,8 +28,8 @@ import {
 
 export type Expectation = Value | FPInterval | FPInterval[] | FPInterval[][] | Comparator;
 
-/** Is this expectation actually a Comparator */
-function isComparator(e: Expectation): boolean {
+/** @returns if this Expectation actually a Comparator */
+export function isComparator(e: Expectation): e is Comparator {
   return !(
     e instanceof FPInterval ||
     e instanceof Scalar ||
@@ -39,12 +39,13 @@ function isComparator(e: Expectation): boolean {
   );
 }
 
-/** Helper for converting Values to Comparators */
+/** @returns the input if it is already a Comparator, otherwise wraps it in a 'value' comparator */
 export function toComparator(input: Expectation): Comparator {
-  if (!isComparator(input)) {
-    return got => compare(got, input as Value);
+  if (isComparator(input)) {
+    return input;
   }
-  return input as Comparator;
+
+  return { impl: got => compare(got, input as Value), kind: 'value' };
 }
 
 /** Case is a single expression test case. */
@@ -350,7 +351,7 @@ function submitBatch(
       for (let caseIdx = 0; caseIdx < cases.length; caseIdx++) {
         const c = cases[caseIdx];
         const got = outputs[caseIdx];
-        const cmp = toComparator(c.expected)(got);
+        const cmp = toComparator(c.expected).impl(got);
         if (!cmp.matched) {
           errs.push(`(${c.input instanceof Array ? c.input.join(', ') : c.input})
     returned: ${cmp.got}
@@ -776,29 +777,32 @@ function packScalarsToVector(
     }
 
     // Gather the comparators for the packed cases
-    const comparators = new Array<Comparator>(vectorWidth);
+    const cmp_impls = new Array<ComparatorImpl>(vectorWidth);
     for (let i = 0; i < vectorWidth; i++) {
-      comparators[i] = toComparator(cases[clampCaseIdx(caseIdx + i)].expected);
+      cmp_impls[i] = toComparator(cases[clampCaseIdx(caseIdx + i)].expected).impl;
     }
-    const packedComparator = (got: Value) => {
-      let matched = true;
-      const gElements = new Array<string>(vectorWidth);
-      const eElements = new Array<string>(vectorWidth);
-      for (let i = 0; i < vectorWidth; i++) {
-        const d = comparators[i]((got as Vector).elements[i]);
-        matched = matched && d.matched;
-        gElements[i] = d.got;
-        eElements[i] = d.expected;
-      }
-      return {
-        matched,
-        got: `${packedResultType}(${gElements.join(', ')})`,
-        expected: `${packedResultType}(${eElements.join(', ')})`,
-      };
+    const comparators: Comparator = {
+      impl: (got: Value) => {
+        let matched = true;
+        const gElements = new Array<string>(vectorWidth);
+        const eElements = new Array<string>(vectorWidth);
+        for (let i = 0; i < vectorWidth; i++) {
+          const d = cmp_impls[i]((got as Vector).elements[i]);
+          matched = matched && d.matched;
+          gElements[i] = d.got;
+          eElements[i] = d.expected;
+        }
+        return {
+          matched,
+          got: `${packedResultType}(${gElements.join(', ')})`,
+          expected: `${packedResultType}(${eElements.join(', ')})`,
+        };
+      },
+      kind: 'packed',
     };
 
     // Append the new packed case
-    packedCases.push({ input: packedInputs, expected: packedComparator });
+    packedCases.push({ input: packedInputs, expected: comparators });
     caseIdx += vectorWidth;
   }
 

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -45,7 +45,7 @@ export function toComparator(input: Expectation): Comparator {
     return input;
   }
 
-  return { impl: got => compare(got, input as Value), kind: 'value' };
+  return { compare: got => compare(got, input as Value), kind: 'value' };
 }
 
 /** Case is a single expression test case. */
@@ -351,7 +351,7 @@ function submitBatch(
       for (let caseIdx = 0; caseIdx < cases.length; caseIdx++) {
         const c = cases[caseIdx];
         const got = outputs[caseIdx];
-        const cmp = toComparator(c.expected).impl(got);
+        const cmp = toComparator(c.expected).compare(got);
         if (!cmp.matched) {
           errs.push(`(${c.input instanceof Array ? c.input.join(', ') : c.input})
     returned: ${cmp.got}
@@ -779,10 +779,10 @@ function packScalarsToVector(
     // Gather the comparators for the packed cases
     const cmp_impls = new Array<ComparatorImpl>(vectorWidth);
     for (let i = 0; i < vectorWidth; i++) {
-      cmp_impls[i] = toComparator(cases[clampCaseIdx(caseIdx + i)].expected).impl;
+      cmp_impls[i] = toComparator(cases[clampCaseIdx(caseIdx + i)].expected).compare;
     }
     const comparators: Comparator = {
-      impl: (got: Value) => {
+      compare: (got: Value) => {
         let matched = true;
         const gElements = new Array<string>(vectorWidth);
         const eElements = new Array<string>(vectorWidth);

--- a/src/webgpu/util/compare.ts
+++ b/src/webgpu/util/compare.ts
@@ -42,7 +42,7 @@ export type ComparatorImpl = (got: Value) => Comparison;
 
 /** Comparator is a function that compares whether the provided value matches an expectation. */
 export interface Comparator {
-  impl: ComparatorImpl;
+  compare: ComparatorImpl;
   kind: ComparatorKind;
   data?: Expectation | Expectation[];
 }
@@ -327,10 +327,10 @@ export function compare(
 /** @returns a Comparator that checks whether a test value matches any of the provided options */
 export function anyOf(...expectations: Expectation[]): Comparator {
   const c: Comparator = {
-    impl: (got: Value) => {
+    compare: (got: Value) => {
       const failed = new Set<string>();
       for (const e of expectations) {
-        const cmp = toComparator(e).impl(got);
+        const cmp = toComparator(e).compare(got);
         if (cmp.matched) {
           return cmp;
         }
@@ -352,9 +352,9 @@ export function anyOf(...expectations: Expectation[]): Comparator {
 /** @returns a Comparator that skips the test if the expectation is undefined */
 export function skipUndefined(expectation: Expectation | undefined): Comparator {
   const c: Comparator = {
-    impl: (got: Value) => {
+    compare: (got: Value) => {
       if (expectation !== undefined) {
-        return toComparator(expectation).impl(got);
+        return toComparator(expectation).compare(got);
       }
       return { matched: true, got: got.toString(), expected: `Treating 'undefined' as Any` };
     },


### PR DESCRIPTION
As-is the CTS framework just requires you to define a function to create a Comparator and pass it as a Expectation in a Case. This causes issues if the writer then attempts to implement using the CaseCache, since that requires the Comparator to have defined serialization and deserialization. There is no type level enforcement of this, so errors are not detected until runtime with the cache enabled.

This PR reworks the Comparator type to have an impl function and kind tag as required properties, along with optional data for serialization. This forces the user to actively bypass the type system to define a Comparator without serialization. Additional documentation has been added around the relevant definitions to point the user in the correct direction.

This PR doesn't change the entire type system to strictly require serialization/deserialization. This is because some of the internals of the testing framework use Comparators as part of building and running tests.

One could add in serialization/deserialization code to these Comparators, but this would allow silent errors when internal components leak out into the cache unintentionally. The other option is to split the current Case/Expectation system to have Serializable and non-Serializable implementations. This creates a bunch of duplicated code and significant amounts of type conversion for a bit of intellectual cleanliness.

This implementation chooses to make the framework user's error a type level error, so detectable by tooling, since there is likely to be many more changes to code defining tests and using the framework vs the framework itself. Issues in the framework will still cause runtime issues, and thus integration failures, but hopefully localize them to code that is changing less frequently.

The bitcast tests are given an explicit opt-out from the serialization. A follow up PR will rewrite them to properly define their Comparators and remove this legacy opt-out.

Issue #2593

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
