### PR TITLE
Switch to using sparseF32Range in f32 arithmetic tests

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/f32_addition.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_addition.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../util/conversion.js';
 import { FP, FPVector } from '../../../../util/floating_point.js';
-import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
+import { sparseF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, run } from '../expression.js';
 
@@ -25,16 +25,16 @@ export const g = makeTestGroup(GPUTest);
 export const d = makeCaseCache('binary/f32_addition', {
   scalar_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'finite',
       FP.f32.additionInterval
     );
   },
   scalar_non_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'unfiltered',
       FP.f32.additionInterval
     );
@@ -42,7 +42,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   vec2_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       additionVectorScalarInterval
     );
@@ -50,7 +50,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   vec2_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       additionVectorScalarInterval
     );
@@ -58,7 +58,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   vec3_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       additionVectorScalarInterval
     );
@@ -66,7 +66,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   vec3_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       additionVectorScalarInterval
     );
@@ -74,7 +74,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   vec4_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       additionVectorScalarInterval
     );
@@ -82,14 +82,14 @@ export const d = makeCaseCache('binary/f32_addition', {
   vec4_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       additionVectorScalarInterval
     );
   },
   scalar_vec2_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'finite',
       additionScalarVectorInterval
@@ -97,7 +97,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   },
   scalar_vec2_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
       additionScalarVectorInterval
@@ -105,7 +105,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   },
   scalar_vec3_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'finite',
       additionScalarVectorInterval
@@ -113,7 +113,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   },
   scalar_vec3_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
       additionScalarVectorInterval
@@ -121,7 +121,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   },
   scalar_vec4_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'finite',
       additionScalarVectorInterval
@@ -129,7 +129,7 @@ export const d = makeCaseCache('binary/f32_addition', {
   },
   scalar_vec4_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
       additionScalarVectorInterval
@@ -137,8 +137,8 @@ export const d = makeCaseCache('binary/f32_addition', {
   },
   subtraction_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'finite',
       FP.f32.subtractionInterval
     );

--- a/src/webgpu/shader/execution/expression/binary/f32_division.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_division.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../util/conversion.js';
 import { FP, FPVector } from '../../../../util/floating_point.js';
-import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
+import { sparseF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, run } from '../expression.js';
 
@@ -25,16 +25,16 @@ export const g = makeTestGroup(GPUTest);
 export const d = makeCaseCache('binary/f32_division', {
   scalar_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'finite',
       FP.f32.divisionInterval
     );
   },
   scalar_non_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'unfiltered',
       FP.f32.divisionInterval
     );
@@ -42,7 +42,7 @@ export const d = makeCaseCache('binary/f32_division', {
   vec2_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       divisionVectorScalarInterval
     );
@@ -50,7 +50,7 @@ export const d = makeCaseCache('binary/f32_division', {
   vec2_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       divisionVectorScalarInterval
     );
@@ -58,7 +58,7 @@ export const d = makeCaseCache('binary/f32_division', {
   vec3_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       divisionVectorScalarInterval
     );
@@ -66,7 +66,7 @@ export const d = makeCaseCache('binary/f32_division', {
   vec3_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       divisionVectorScalarInterval
     );
@@ -74,7 +74,7 @@ export const d = makeCaseCache('binary/f32_division', {
   vec4_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       divisionVectorScalarInterval
     );
@@ -82,14 +82,14 @@ export const d = makeCaseCache('binary/f32_division', {
   vec4_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       divisionVectorScalarInterval
     );
   },
   scalar_vec2_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'finite',
       divisionScalarVectorInterval
@@ -97,7 +97,7 @@ export const d = makeCaseCache('binary/f32_division', {
   },
   scalar_vec2_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
       divisionScalarVectorInterval
@@ -105,7 +105,7 @@ export const d = makeCaseCache('binary/f32_division', {
   },
   scalar_vec3_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'finite',
       divisionScalarVectorInterval
@@ -113,7 +113,7 @@ export const d = makeCaseCache('binary/f32_division', {
   },
   scalar_vec3_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
       divisionScalarVectorInterval
@@ -121,7 +121,7 @@ export const d = makeCaseCache('binary/f32_division', {
   },
   scalar_vec4_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'finite',
       divisionScalarVectorInterval
@@ -129,7 +129,7 @@ export const d = makeCaseCache('binary/f32_division', {
   },
   scalar_vec4_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
       divisionScalarVectorInterval

--- a/src/webgpu/shader/execution/expression/binary/f32_multiplication.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_multiplication.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../util/conversion.js';
 import { FP, FPVector } from '../../../../util/floating_point.js';
-import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
+import { sparseF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, run } from '../expression.js';
 
@@ -25,16 +25,16 @@ export const g = makeTestGroup(GPUTest);
 export const d = makeCaseCache('binary/f32_multiplication', {
   scalar_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'finite',
       FP.f32.multiplicationInterval
     );
   },
   scalar_non_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'unfiltered',
       FP.f32.multiplicationInterval
     );
@@ -42,7 +42,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   vec2_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       multiplicationVectorScalarInterval
     );
@@ -50,7 +50,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   vec2_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       multiplicationVectorScalarInterval
     );
@@ -58,7 +58,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   vec3_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       multiplicationVectorScalarInterval
     );
@@ -66,7 +66,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   vec3_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       multiplicationVectorScalarInterval
     );
@@ -74,7 +74,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   vec4_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       multiplicationVectorScalarInterval
     );
@@ -82,14 +82,14 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   vec4_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       multiplicationVectorScalarInterval
     );
   },
   scalar_vec2_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'finite',
       multiplicationScalarVectorInterval
@@ -97,7 +97,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   },
   scalar_vec2_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
       multiplicationScalarVectorInterval
@@ -105,7 +105,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   },
   scalar_vec3_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'finite',
       multiplicationScalarVectorInterval
@@ -113,7 +113,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   },
   scalar_vec3_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
       multiplicationScalarVectorInterval
@@ -121,7 +121,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   },
   scalar_vec4_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'finite',
       multiplicationScalarVectorInterval
@@ -129,7 +129,7 @@ export const d = makeCaseCache('binary/f32_multiplication', {
   },
   scalar_vec4_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
       multiplicationScalarVectorInterval

--- a/src/webgpu/shader/execution/expression/binary/f32_remainder.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_remainder.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../util/conversion.js';
 import { FP, FPVector } from '../../../../util/floating_point.js';
-import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
+import { sparseF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, run } from '../expression.js';
 
@@ -25,16 +25,16 @@ export const g = makeTestGroup(GPUTest);
 export const d = makeCaseCache('binary/f32_remainder', {
   scalar_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'finite',
       FP.f32.remainderInterval
     );
   },
   scalar_non_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'unfiltered',
       FP.f32.remainderInterval
     );
@@ -42,7 +42,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   vec2_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       remainderVectorScalarInterval
     );
@@ -50,7 +50,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   vec2_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       remainderVectorScalarInterval
     );
@@ -58,7 +58,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   vec3_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       remainderVectorScalarInterval
     );
@@ -66,7 +66,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   vec3_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       remainderVectorScalarInterval
     );
@@ -74,7 +74,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   vec4_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       remainderVectorScalarInterval
     );
@@ -82,14 +82,14 @@ export const d = makeCaseCache('binary/f32_remainder', {
   vec4_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       remainderVectorScalarInterval
     );
   },
   scalar_vec2_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'finite',
       remainderScalarVectorInterval
@@ -97,7 +97,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   },
   scalar_vec2_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
       remainderScalarVectorInterval
@@ -105,7 +105,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   },
   scalar_vec3_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'finite',
       remainderScalarVectorInterval
@@ -113,7 +113,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   },
   scalar_vec3_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
       remainderScalarVectorInterval
@@ -121,7 +121,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   },
   scalar_vec4_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'finite',
       remainderScalarVectorInterval
@@ -129,7 +129,7 @@ export const d = makeCaseCache('binary/f32_remainder', {
   },
   scalar_vec4_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
       remainderScalarVectorInterval

--- a/src/webgpu/shader/execution/expression/binary/f32_subtraction.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/f32_subtraction.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeF32, TypeVec } from '../../../../util/conversion.js';
 import { FP, FPVector } from '../../../../util/floating_point.js';
-import { fullF32Range, sparseVectorF32Range } from '../../../../util/math.js';
+import { sparseF32Range, sparseVectorF32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import { allInputSources, run } from '../expression.js';
 
@@ -25,16 +25,16 @@ export const g = makeTestGroup(GPUTest);
 export const d = makeCaseCache('binary/f32_subtraction', {
   scalar_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'finite',
       FP.f32.subtractionInterval
     );
   },
   scalar_non_const: () => {
     return FP.f32.generateScalarPairToIntervalCases(
-      fullF32Range(),
-      fullF32Range(),
+      sparseF32Range(),
+      sparseF32Range(),
       'unfiltered',
       FP.f32.subtractionInterval
     );
@@ -42,7 +42,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   vec2_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       subtractionVectorScalarInterval
     );
@@ -50,7 +50,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   vec2_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(2),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       subtractionVectorScalarInterval
     );
@@ -58,7 +58,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   vec3_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       subtractionVectorScalarInterval
     );
@@ -66,7 +66,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   vec3_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(3),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       subtractionVectorScalarInterval
     );
@@ -74,7 +74,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   vec4_scalar_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'finite',
       subtractionVectorScalarInterval
     );
@@ -82,14 +82,14 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   vec4_scalar_non_const: () => {
     return FP.f32.generateVectorScalarToVectorCases(
       sparseVectorF32Range(4),
-      fullF32Range(),
+      sparseF32Range(),
       'unfiltered',
       subtractionVectorScalarInterval
     );
   },
   scalar_vec2_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'finite',
       subtractionScalarVectorInterval
@@ -97,7 +97,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   },
   scalar_vec2_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(2),
       'unfiltered',
       subtractionScalarVectorInterval
@@ -105,7 +105,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   },
   scalar_vec3_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'finite',
       subtractionScalarVectorInterval
@@ -113,7 +113,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   },
   scalar_vec3_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(3),
       'unfiltered',
       subtractionScalarVectorInterval
@@ -121,7 +121,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   },
   scalar_vec4_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'finite',
       subtractionScalarVectorInterval
@@ -129,7 +129,7 @@ export const d = makeCaseCache('binary/f32_subtraction', {
   },
   scalar_vec4_non_const: () => {
     return FP.f32.generateScalarVectorToVectorCases(
-      fullF32Range(),
+      sparseF32Range(),
       sparseVectorF32Range(4),
       'unfiltered',
       subtractionScalarVectorInterval


### PR DESCRIPTION
Fixes #2613

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
