### PR TITLE
Add missing files to out-wpt/ build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,13 +58,18 @@ module.exports = function (grunt) {
           '--delete-dir-on-start',
           '--out-dir=out-wpt/',
           'src/',
-          '--only=src/common/framework/',
-          '--only=src/common/runtime/helper/',
-          '--only=src/common/runtime/wpt.ts',
+          '--only=src/common/',
+          '--only=src/external/',
           '--only=src/webgpu/',
           // These files will be generated, instead of compiled from TypeScript.
           '--ignore=src/common/internal/version.ts',
           '--ignore=src/webgpu/listing.ts',
+          // These files are only used by non-WPT builds.
+          '--ignore=src/common/runtime/cmdline.ts',
+          '--ignore=src/common/runtime/server.ts',
+          '--ignore=src/common/runtime/standalone.ts',
+          '--ignore=src/common/runtime/helper/sys.ts',
+          '--ignore=src/common/tools',
         ],
       },
       'build-out-node': {


### PR DESCRIPTION
Issue: fixes #1092 (hopefully, I can't easily test this)

<hr>

**Requirements for PR author:**

- [ ] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [ ] ~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] ~Tests are properly located in the test tree.~
- [ ] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] ~Helpers and types promote readability and maintainability.~

When landing this PR, be sure to make any necessary issue status updates.
