### PR TITLE
Adds validation tests for float32-filterable

### DIFF
--- a/src/webgpu/api/validation/texture/float32_filterable.spec.ts
+++ b/src/webgpu/api/validation/texture/float32_filterable.spec.ts
@@ -1,0 +1,58 @@
+export const description = `
+Tests for capabilities added by float32-filterable flag.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { kTextureSampleTypes } from '../../../capability_info.js';
+import { ValidationTest } from '../validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+const kFloat32Formats: GPUTextureFormat[] = ['r32float', 'rg32float', 'rgba32float'];
+
+g.test('create_bind_group')
+  .desc(
+    `
+Test that it is valid to bind a float32 texture format to a 'float' sampled texture iff
+float32-filterable is enabled.
+`
+  )
+  .params(u =>
+    u
+      .combine('enabled', [true, false] as const)
+      .beginSubcases()
+      .combine('format', kFloat32Formats)
+      .combine('sampleType', kTextureSampleTypes)
+  )
+  .beforeAllSubcases(t => {
+    if (t.params.enabled) {
+      t.selectDeviceOrSkipTestCase('float32-filterable');
+    }
+  })
+  .fn(t => {
+    const { enabled, format, sampleType } = t.params;
+    const layout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          texture: { sampleType },
+        },
+      ],
+    });
+    const textureDesc = {
+      size: { width: 4, height: 4 },
+      format,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
+    };
+    const shouldError = !(
+      (enabled && sampleType === 'float') ||
+      sampleType === 'unfilterable-float'
+    );
+    t.expectValidationError(() => {
+      t.device.createBindGroup({
+        entries: [{ binding: 0, resource: t.device.createTexture(textureDesc).createView() }],
+        layout,
+      });
+    }, shouldError);
+  });


### PR DESCRIPTION
**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.
