### PR TITLE
Check for a device lost reason of 'unknown'

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -157,7 +157,7 @@ g.test('stale')
       kTimeoutMS,
       'adapter was not stale'
     );
-    t.expect(lost.reason === undefined);
+    t.expect(lost.reason === 'unknown');
 
     // Make sure to destroy the valid device after trying to get a second one. Otherwise, the second
     // device may fail because the adapter is put into an invalid state from the destroy.


### PR DESCRIPTION
The test was previously checking for undefined, which is not a valid return value for the lost reason. It can only be 'destroyed' or 'unknown'. This was likely just a misreading of the spec, as I know that I've confused 'unknown' and undefined in other cases before.

The test doesn't pass in Chrome yet, but will once a combination of https://dawn-review.googlesource.com/c/dawn/+/119140 and https://chromium-review.googlesource.com/c/chromium/src/+/4550020 land.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
