### PR TITLE
Add missing toStorage() when assigning values to outputs

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -514,7 +514,7 @@ export function basicExpressionBuilder(expressionBuilder: ExpressionBuilder): Sh
       } else {
         body = `
   for (var i = 0u; i < ${cases.length}; i++) {
-    outputs[i].value = values[i];
+    outputs[i].value = ${toStorage(resultType, `values[i]`)};
   }`;
       }
 


### PR DESCRIPTION
This patch adds the missing call of toStorage() when assigning values to outputs so that values can be correctly transformed to be assigned to outputs.value.

This patch fixes the bugs when values are boolean values. In this case outputs.value are uint values, so the missing of toStorage() on values will cause WGSL compilation errors about type mismatch.

With this patch the below CTS tests can pass:
- webgpu:shader,execution,expression,binary,bool_logical:*


Issue: #

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
