### PR TITLE
Set `?q=` as default args prefix

### DIFF
--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -46,7 +46,7 @@ const [
 ] = process.argv;
 
 (async () => {
-  let argsPrefixes = [''];
+  let argsPrefixes = ['?q='];
   let expectationLines = new Set<string>();
 
   if (process.argv.length >= 7) {


### PR DESCRIPTION
This fixes one of wpt lint errors.

Issue: #2622

<hr>

**Requirements for PR author:**

- [ ] ~~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~~
- [ ] ~~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~~
- [ ] ~~Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)~~

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
