### PR TITLE
[WGSL] Fulfill F16 traits (step 1) and add fundamental interval unit tests

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -133,7 +133,7 @@ interface ConstructorCase {
   expected: IntervalBounds;
 }
 
-g.test('constructor_f32f16af')
+g.test('constructor')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16', 'abstract'] as const)
@@ -194,7 +194,7 @@ interface ContainsNumberCase {
   expected: boolean;
 }
 
-g.test('contains_number_f32f16af')
+g.test('contains_number')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16', 'abstract'] as const)
@@ -333,7 +333,7 @@ interface ContainsIntervalCase {
   expected: boolean;
 }
 
-g.test('contains_interval_f32f16af')
+g.test('contains_interval')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16', 'abstract'] as const)
@@ -445,7 +445,7 @@ interface SpanIntervalsCase {
   expected: number | IntervalBounds;
 }
 
-g.test('spanIntervals_f32f16af')
+g.test('spanIntervals')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16', 'abstract'] as const)
@@ -499,7 +499,7 @@ interface isVectorCase {
   expected: boolean;
 }
 
-g.test('isVector_f32f16af')
+g.test('isVector')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16', 'abstract'] as const)
@@ -610,7 +610,7 @@ interface toVectorCase {
   expected: (number | IntervalBounds)[];
 }
 
-g.test('toVector_f32f16af')
+g.test('toVector')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16', 'abstract'] as const)
@@ -737,7 +737,7 @@ interface isMatrixCase {
   expected: boolean;
 }
 
-g.test('isMatrix_f32f16af')
+g.test('isMatrix')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16', 'abstract'] as const)
@@ -1187,7 +1187,7 @@ interface toMatrixCase {
   expected: (number | IntervalBounds)[][];
 }
 
-g.test('toMatrix_f32f16af')
+g.test('toMatrix')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16', 'abstract'] as const)
@@ -1886,7 +1886,7 @@ const kSubnormalAbsoluteErrorValue = {
   f16: 2 ** -20, // f16 0x0010
 } as const;
 
-g.test('absoluteErrorInterval_f32f16')
+g.test('absoluteErrorInterval')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16'] as const)
@@ -2065,7 +2065,7 @@ const kCorrectlyRoundedF64NormalCases = [
   },
 ] as const;
 
-g.test('correctlyRoundedInterval_f32f16')
+g.test('correctlyRoundedInterval')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16'] as const)
@@ -2124,7 +2124,7 @@ const kULPErrorValue = {
   f16: 5, // 5 ULP is required for atan accuracy on f16
 };
 
-g.test('ulpInterval_f32f16')
+g.test('ulpInterval')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16'] as const)

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -7,10 +7,12 @@ import { objectEquals, unreachable } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
 import { FP, FPInterval, IntervalBounds } from '../webgpu/util/floating_point.js';
 import {
+  reinterpretU16AsF16,
   reinterpretU32AsF32,
   reinterpretU64AsF64,
   map2DArray,
   oneULPF32,
+  oneULPF16,
 } from '../webgpu/util/math.js';
 
 import { UnitTest } from './unit_test.js';
@@ -23,6 +25,7 @@ const kAnyBounds: IntervalBounds = [Number.NEGATIVE_INFINITY, Number.POSITIVE_IN
 /** Interval from kAnyBounds */
 const kAnyInterval = {
   f32: FP.f32.toInterval(kAnyBounds),
+  f16: FP.f16.toInterval(kAnyBounds),
   abstract: FP.abstract.toInterval(kAnyBounds),
 };
 
@@ -46,21 +49,45 @@ function minusOneULPF32(x: number): number {
   return minusNULPF32(x, 1);
 }
 
+/** @returns a number N * ULP greater than the provided number, treats input as f16 */
+function plusNULPF16(x: number, n: number): number {
+  return x + n * oneULPF16(x);
+}
+
+/** @returns a number one ULP greater than the provided number, treats input as f16 */
+function plusOneULPF16(x: number): number {
+  return plusNULPF16(x, 1);
+}
+
+/** @returns a number N * ULP less than the provided number, treats input as f16 */
+function minusNULPF16(x: number, n: number): number {
+  return x - n * oneULPF16(x);
+}
+
+/** @returns a number one ULP less than the provided number, treats input as f16 */
+function minusOneULPF16(x: number): number {
+  return minusNULPF16(x, 1);
+}
+
 /** Group ULP functions of different FP traits */
 const plusNULPFunctions = {
   f32: plusNULPF32,
+  f16: plusNULPF16,
 };
 
 const plusOneULPFunctions = {
   f32: plusOneULPF32,
+  f16: plusOneULPF16,
 };
 
 const minusNULPFunctions = {
   f32: minusNULPF32,
+  f16: minusNULPF16,
 };
 
 const minusOneULPFunctions = {
   f32: minusOneULPF32,
+  f16: minusOneULPF16,
 };
 
 /** @returns the expected IntervalBounds adjusted by the given error function
@@ -106,10 +133,10 @@ interface ConstructorCase {
   expected: IntervalBounds;
 }
 
-g.test('constructor_f32af')
+g.test('constructor_f32f16af')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<ConstructorCase>(p => {
         const constants = FP[p.trait].constants();
@@ -167,10 +194,10 @@ interface ContainsNumberCase {
   expected: boolean;
 }
 
-g.test('contains_number_f32af')
+g.test('contains_number_f32f16af')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<ContainsNumberCase>(p => {
         const constants = FP[p.trait].constants();
@@ -306,10 +333,10 @@ interface ContainsIntervalCase {
   expected: boolean;
 }
 
-g.test('contains_interval_f32af')
+g.test('contains_interval_f32f16af')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<ContainsIntervalCase>(p => {
         const constants = FP[p.trait].constants();
@@ -418,10 +445,10 @@ interface SpanIntervalsCase {
   expected: number | IntervalBounds;
 }
 
-g.test('spanIntervals_f32af')
+g.test('spanIntervals_f32f16af')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<SpanIntervalsCase>(p => {
         const constants = FP[p.trait].constants();
@@ -472,10 +499,10 @@ interface isVectorCase {
   expected: boolean;
 }
 
-g.test('isVector_f32af')
+g.test('isVector_f32f16af')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<isVectorCase>(p => {
         const trait = FP[p.trait];
@@ -583,10 +610,10 @@ interface toVectorCase {
   expected: (number | IntervalBounds)[];
 }
 
-g.test('toVector_f32af')
+g.test('toVector_f32f16af')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<toVectorCase>(p => {
         const trait = FP[p.trait];
@@ -710,10 +737,10 @@ interface isMatrixCase {
   expected: boolean;
 }
 
-g.test('isMatrix_f32af')
+g.test('isMatrix_f32f16af')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<isMatrixCase>(p => {
         const trait = FP[p.trait];
@@ -1160,10 +1187,10 @@ interface toMatrixCase {
   expected: (number | IntervalBounds)[][];
 }
 
-g.test('toMatrix_f32af')
+g.test('toMatrix_f32f16af')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<toMatrixCase>(p => {
         const trait = FP[p.trait];
@@ -1844,22 +1871,25 @@ interface AbsoluteErrorCase {
 // but 1.0 +/- x is still exactly representable.
 const kSmallAbsoluteErrorValue = {
   f32: 2 ** -11, // Builtin cos and sin has a absolute error 2**-11 for f32
+  f16: 2 ** -7, // Builtin cos and sin has a absolute error 2**-7 for f16
 } as const;
 // A large absolute error value is a representable value x that much smaller than maximum
 // positive, but positive.max - x is still exactly representable.
 const kLargeAbsoluteErrorValue = {
   f32: 2 ** 110, // f32.positive.max - 2**110 = 3.4028104e+38 = 0x7f7fffbf in f32
+  f16: 2 ** 10, // f16.positive.max - 2**10 = 64480 = 0x7bdf in f16
 } as const;
 // A subnormal absolute error value is a subnormal representable value x of kind, which ensures
 // that positive.subnormal.min +/- x is still exactly representable.
 const kSubnormalAbsoluteErrorValue = {
   f32: 2 ** -140, // f32 0x00000200
+  f16: 2 ** -20, // f16 0x0010
 } as const;
 
-g.test('absoluteErrorInterval_f32')
+g.test('absoluteErrorInterval_f32f16')
   .params(u =>
     u
-      .combine('trait', ['f32'] as const)
+      .combine('trait', ['f32', 'f16'] as const)
       .beginSubcases()
       .expandWithParams<AbsoluteErrorCase>(p => {
         const trait = FP[p.trait];
@@ -1966,48 +1996,79 @@ const kCorrectlyRoundedNormalCases = {
     { value: reinterpretU32AsF32(0x83800000), expected: reinterpretU32AsF32(0x83800000) },
     { value: reinterpretU32AsF32(0x83800001), expected: reinterpretU32AsF32(0x83800001) },
   ] as CorrectlyRoundedCase[],
-};
+  f16: [
+    { value: 0, expected: [0, 0] },
+    { value: reinterpretU16AsF16(0x0c00), expected: reinterpretU16AsF16(0x0c00) },
+    { value: reinterpretU16AsF16(0x0c01), expected: reinterpretU16AsF16(0x0c01) },
+    { value: reinterpretU16AsF16(0x8c00), expected: reinterpretU16AsF16(0x8c00) },
+    { value: reinterpretU16AsF16(0x8c01), expected: reinterpretU16AsF16(0x8c01) },
+  ] as CorrectlyRoundedCase[],
+} as const;
 
 // 64-bit normals that fall between two conjunction normal values in target type
 const kCorrectlyRoundedF64NormalCases = [
   {
     value: reinterpretU64AsF64(0x3ff0_0000_0000_0001n),
-    expected: { f32: [reinterpretU32AsF32(0x3f800000), reinterpretU32AsF32(0x3f800001)] },
+    expected: {
+      f32: [reinterpretU32AsF32(0x3f800000), reinterpretU32AsF32(0x3f800001)],
+      f16: [reinterpretU16AsF16(0x3c00), reinterpretU16AsF16(0x3c01)],
+    },
   },
   {
     value: reinterpretU64AsF64(0x3ff0_0000_0000_0002n),
-    expected: { f32: [reinterpretU32AsF32(0x3f800000), reinterpretU32AsF32(0x3f800001)] },
+    expected: {
+      f32: [reinterpretU32AsF32(0x3f800000), reinterpretU32AsF32(0x3f800001)],
+      f16: [reinterpretU16AsF16(0x3c00), reinterpretU16AsF16(0x3c01)],
+    },
   },
   {
     value: reinterpretU64AsF64(0x3ff0_0800_0000_0010n),
-    expected: { f32: [reinterpretU32AsF32(0x3f804000), reinterpretU32AsF32(0x3f804001)] },
+    expected: {
+      f32: [reinterpretU32AsF32(0x3f804000), reinterpretU32AsF32(0x3f804001)],
+      f16: [reinterpretU16AsF16(0x3c02), reinterpretU16AsF16(0x3c03)],
+    },
   },
   {
     value: reinterpretU64AsF64(0x3ff0_1000_0000_0020n),
-    expected: { f32: [reinterpretU32AsF32(0x3f808000), reinterpretU32AsF32(0x3f808001)] },
+    expected: {
+      f32: [reinterpretU32AsF32(0x3f808000), reinterpretU32AsF32(0x3f808001)],
+      f16: [reinterpretU16AsF16(0x3c04), reinterpretU16AsF16(0x3c05)],
+    },
   },
   {
     value: reinterpretU64AsF64(0xbff0_0000_0000_0001n),
-    expected: { f32: [reinterpretU32AsF32(0xbf800001), reinterpretU32AsF32(0xbf800000)] },
+    expected: {
+      f32: [reinterpretU32AsF32(0xbf800001), reinterpretU32AsF32(0xbf800000)],
+      f16: [reinterpretU16AsF16(0xbc01), reinterpretU16AsF16(0xbc00)],
+    },
   },
   {
     value: reinterpretU64AsF64(0xbff0_0000_0000_0002n),
-    expected: { f32: [reinterpretU32AsF32(0xbf800001), reinterpretU32AsF32(0xbf800000)] },
+    expected: {
+      f32: [reinterpretU32AsF32(0xbf800001), reinterpretU32AsF32(0xbf800000)],
+      f16: [reinterpretU16AsF16(0xbc01), reinterpretU16AsF16(0xbc00)],
+    },
   },
   {
     value: reinterpretU64AsF64(0xbff0_0800_0000_0010n),
-    expected: { f32: [reinterpretU32AsF32(0xbf804001), reinterpretU32AsF32(0xbf804000)] },
+    expected: {
+      f32: [reinterpretU32AsF32(0xbf804001), reinterpretU32AsF32(0xbf804000)],
+      f16: [reinterpretU16AsF16(0xbc03), reinterpretU16AsF16(0xbc02)],
+    },
   },
   {
     value: reinterpretU64AsF64(0xbff0_1000_0000_0020n),
-    expected: { f32: [reinterpretU32AsF32(0xbf808001), reinterpretU32AsF32(0xbf808000)] },
+    expected: {
+      f32: [reinterpretU32AsF32(0xbf808001), reinterpretU32AsF32(0xbf808000)],
+      f16: [reinterpretU16AsF16(0xbc05), reinterpretU16AsF16(0xbc04)],
+    },
   },
 ] as const;
 
-g.test('correctlyRoundedInterval_f32')
+g.test('correctlyRoundedInterval_f32f16')
   .params(u =>
     u
-      .combine('trait', ['f32'] as const)
+      .combine('trait', ['f32', 'f16'] as const)
       .beginSubcases()
       .expandWithParams<CorrectlyRoundedCase>(p => {
         const constants = FP[p.trait].constants();
@@ -2060,12 +2121,13 @@ interface ULPCase {
 // Special values used for testing ULP error interval
 const kULPErrorValue = {
   f32: 4096, // 4096 ULP is required for atan accuracy on f32
+  f16: 5, // 5 ULP is required for atan accuracy on f16
 };
 
-g.test('ulpInterval_f32')
+g.test('ulpInterval_f32f16')
   .params(u =>
     u
-      .combine('trait', ['f32'] as const)
+      .combine('trait', ['f32', 'f16'] as const)
       .beginSubcases()
       .expandWithParams<ULPCase>(p => {
         const constants = FP[p.trait].constants();

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -34,6 +34,7 @@ import {
   nextAfterF32,
   nextAfterF64,
   NextDirection,
+  oneULPF16,
   oneULPF32,
   oneULPF64,
   lerpBigInt,
@@ -778,6 +779,153 @@ g.test('oneULPF32')
     t.expect(
       got === expect || (Number.isNaN(got) && Number.isNaN(expect)),
       `oneULPF32(${target}) returned ${got}. Expected ${expect}`
+    );
+  });
+
+g.test('oneULPF16FlushToZero')
+  .paramsSubcasesOnly<OneULPCase>([
+    // Edge Cases
+    { target: Number.NaN, expect: Number.NaN },
+    { target: Number.POSITIVE_INFINITY, expect: reinterpretU16AsF16(0x5000) },
+    { target: Number.NEGATIVE_INFINITY, expect: reinterpretU16AsF16(0x5000) },
+
+    // Zeroes, expect positive.min in flush mode
+    { target: +0, expect: reinterpretU16AsF16(0x0400) },
+    { target: -0, expect: reinterpretU16AsF16(0x0400) },
+
+    // Subnormals
+    { target: kValue.f16.subnormal.positive.min, expect: reinterpretU16AsF16(0x0400) },
+    { target: 1.91e-6, expect: reinterpretU16AsF16(0x0400) }, // positive subnormal
+    { target: kValue.f16.subnormal.positive.max, expect: reinterpretU16AsF16(0x0400) },
+    { target: kValue.f16.subnormal.negative.min, expect: reinterpretU16AsF16(0x0400) },
+    { target: -1.91e-6, expect: reinterpretU16AsF16(0x0400) }, // negative subnormal
+    { target: kValue.f16.subnormal.negative.max, expect: reinterpretU16AsF16(0x0400) },
+
+    // Normals
+    { target: kValue.f16.positive.min, expect: reinterpretU16AsF16(0x0001) },
+    { target: 1, expect: reinterpretU16AsF16(0x1000) },
+    { target: 2, expect: reinterpretU16AsF16(0x1400) },
+    { target: 4, expect: reinterpretU16AsF16(0x1800) },
+    { target: 1000, expect: reinterpretU16AsF16(0x3800) },
+    { target: kValue.f16.positive.max, expect: reinterpretU16AsF16(0x5000) },
+    { target: kValue.f16.negative.max, expect: reinterpretU16AsF16(0x0001) },
+    { target: -1, expect: reinterpretU16AsF16(0x1000) },
+    { target: -2, expect: reinterpretU16AsF16(0x1400) },
+    { target: -4, expect: reinterpretU16AsF16(0x1800) },
+    { target: -1000, expect: reinterpretU16AsF16(0x3800) },
+    { target: kValue.f16.negative.min, expect: reinterpretU16AsF16(0x5000) },
+
+    // No precise f16 value
+    { target: 0.001, expect: reinterpretU16AsF16(0x0010) }, // positive normal
+    { target: -0.001, expect: reinterpretU16AsF16(0x0010) }, // negative normal
+    { target: 1e8, expect: reinterpretU16AsF16(0x5000) }, // positive out of range
+    { target: -1e8, expect: reinterpretU16AsF16(0x5000) }, // negative out of range
+  ])
+  .fn(t => {
+    const target = t.params.target;
+    const got = oneULPF16(target, 'flush');
+    const expect = t.params.expect;
+    t.expect(
+      got === expect || (Number.isNaN(got) && Number.isNaN(expect)),
+      `oneULPF16(${target}, 'flush') returned ${got}. Expected ${expect}`
+    );
+  });
+
+g.test('oneULPF16NoFlush')
+  .paramsSubcasesOnly<OneULPCase>([
+    // Edge Cases
+    { target: Number.NaN, expect: Number.NaN },
+    { target: Number.POSITIVE_INFINITY, expect: reinterpretU16AsF16(0x5000) },
+    { target: Number.NEGATIVE_INFINITY, expect: reinterpretU16AsF16(0x5000) },
+
+    // Zeroes, expect positive.min in flush mode
+    { target: +0, expect: reinterpretU16AsF16(0x0001) },
+    { target: -0, expect: reinterpretU16AsF16(0x0001) },
+
+    // Subnormals
+    { target: kValue.f16.subnormal.positive.min, expect: reinterpretU16AsF16(0x0001) },
+    { target: 1.91e-6, expect: reinterpretU16AsF16(0x0001) }, // positive subnormal
+    { target: kValue.f16.subnormal.positive.max, expect: reinterpretU16AsF16(0x0001) },
+    { target: kValue.f16.subnormal.negative.min, expect: reinterpretU16AsF16(0x0001) },
+    { target: -1.91e-6, expect: reinterpretU16AsF16(0x0001) }, // negative subnormal
+    { target: kValue.f16.subnormal.negative.max, expect: reinterpretU16AsF16(0x0001) },
+
+    // Normals
+    { target: kValue.f16.positive.min, expect: reinterpretU16AsF16(0x0001) },
+    { target: 1, expect: reinterpretU16AsF16(0x1000) },
+    { target: 2, expect: reinterpretU16AsF16(0x1400) },
+    { target: 4, expect: reinterpretU16AsF16(0x1800) },
+    { target: 1000, expect: reinterpretU16AsF16(0x3800) },
+    { target: kValue.f16.positive.max, expect: reinterpretU16AsF16(0x5000) },
+    { target: kValue.f16.negative.max, expect: reinterpretU16AsF16(0x0001) },
+    { target: -1, expect: reinterpretU16AsF16(0x1000) },
+    { target: -2, expect: reinterpretU16AsF16(0x1400) },
+    { target: -4, expect: reinterpretU16AsF16(0x1800) },
+    { target: -1000, expect: reinterpretU16AsF16(0x3800) },
+    { target: kValue.f16.negative.min, expect: reinterpretU16AsF16(0x5000) },
+
+    // No precise f16 value
+    { target: 0.001, expect: reinterpretU16AsF16(0x0010) }, // positive normal
+    { target: -0.001, expect: reinterpretU16AsF16(0x0010) }, // negative normal
+    { target: 1e8, expect: reinterpretU16AsF16(0x5000) }, // positive out of range
+    { target: -1e8, expect: reinterpretU16AsF16(0x5000) }, // negative out of range
+  ])
+  .fn(t => {
+    const target = t.params.target;
+    const got = oneULPF16(target, 'no-flush');
+    const expect = t.params.expect;
+    t.expect(
+      got === expect || (Number.isNaN(got) && Number.isNaN(expect)),
+      `oneULPF16(${target}, no-flush) returned ${got}. Expected ${expect}`
+    );
+  });
+
+g.test('oneULPF16')
+  .paramsSubcasesOnly<OneULPCase>([
+    // Edge Cases
+    { target: Number.NaN, expect: Number.NaN },
+    { target: Number.POSITIVE_INFINITY, expect: reinterpretU16AsF16(0x5000) },
+    { target: Number.NEGATIVE_INFINITY, expect: reinterpretU16AsF16(0x5000) },
+
+    // Zeroes, expect positive.min in flush mode
+    { target: +0, expect: reinterpretU16AsF16(0x0400) },
+    { target: -0, expect: reinterpretU16AsF16(0x0400) },
+
+    // Subnormals
+    { target: kValue.f16.subnormal.positive.min, expect: reinterpretU16AsF16(0x0400) },
+    { target: 1.91e-6, expect: reinterpretU16AsF16(0x0400) }, // positive subnormal
+    { target: kValue.f16.subnormal.positive.max, expect: reinterpretU16AsF16(0x0400) },
+    { target: kValue.f16.subnormal.negative.min, expect: reinterpretU16AsF16(0x0400) },
+    { target: -1.91e-6, expect: reinterpretU16AsF16(0x0400) }, // negative subnormal
+    { target: kValue.f16.subnormal.negative.max, expect: reinterpretU16AsF16(0x0400) },
+
+    // Normals
+    { target: kValue.f16.positive.min, expect: reinterpretU16AsF16(0x0001) },
+    { target: 1, expect: reinterpretU16AsF16(0x1000) },
+    { target: 2, expect: reinterpretU16AsF16(0x1400) },
+    { target: 4, expect: reinterpretU16AsF16(0x1800) },
+    { target: 1000, expect: reinterpretU16AsF16(0x3800) },
+    { target: kValue.f16.positive.max, expect: reinterpretU16AsF16(0x5000) },
+    { target: kValue.f16.negative.max, expect: reinterpretU16AsF16(0x0001) },
+    { target: -1, expect: reinterpretU16AsF16(0x1000) },
+    { target: -2, expect: reinterpretU16AsF16(0x1400) },
+    { target: -4, expect: reinterpretU16AsF16(0x1800) },
+    { target: -1000, expect: reinterpretU16AsF16(0x3800) },
+    { target: kValue.f16.negative.min, expect: reinterpretU16AsF16(0x5000) },
+
+    // No precise f16 value
+    { target: 0.001, expect: reinterpretU16AsF16(0x0010) }, // positive normal
+    { target: -0.001, expect: reinterpretU16AsF16(0x0010) }, // negative normal
+    { target: 1e8, expect: reinterpretU16AsF16(0x5000) }, // positive out of range
+    { target: -1e8, expect: reinterpretU16AsF16(0x5000) }, // negative out of range
+  ])
+  .fn(t => {
+    const target = t.params.target;
+    const got = oneULPF16(target, 'flush');
+    const expect = t.params.expect;
+    t.expect(
+      got === expect || (Number.isNaN(got) && Number.isNaN(expect)),
+      `oneULPF16(${target}, 'flush') returned ${got}. Expected ${expect}`
     );
   });
 

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -125,11 +125,32 @@ export const kBit = {
       min: 0x0400,
       max: 0x7bff,
       zero: 0x0000,
+      nearest_max: 0x7bfe,
+      less_than_one: 0x3bff,
+      pi: {
+        whole: 0x4248,
+        three_quarters: 0x40b6,
+        half: 0x3e48,
+        third: 0x3c30,
+        quarter: 0x3a48,
+        sixth: 0x3830,
+      },
+      e: 0x416f,
     },
     negative: {
       max: 0x8400,
       min: 0xfbff,
       zero: 0x8000,
+      nearest_min: 0xfbfe,
+      less_than_one: 0xbbff,
+      pi: {
+        whole: 0xc248,
+        three_quarters: 0xc0b6,
+        half: 0xbe48,
+        third: 0xbc30,
+        quarter: 0xba48,
+        sixth: 0xb830,
+      },
     },
     subnormal: {
       positive: {
@@ -492,6 +513,17 @@ export const kValue = {
       min: reinterpretU16AsF16(kBit.f16.positive.min),
       max: reinterpretU16AsF16(kBit.f16.positive.max),
       zero: reinterpretU16AsF16(kBit.f16.positive.zero),
+      nearest_max: reinterpretU16AsF16(kBit.f16.positive.nearest_max),
+      less_than_one: reinterpretU16AsF16(kBit.f16.positive.less_than_one),
+      pi: {
+        whole: reinterpretU16AsF16(kBit.f16.positive.pi.whole),
+        three_quarters: reinterpretU16AsF16(kBit.f16.positive.pi.three_quarters),
+        half: reinterpretU16AsF16(kBit.f16.positive.pi.half),
+        third: reinterpretU16AsF16(kBit.f16.positive.pi.third),
+        quarter: reinterpretU16AsF16(kBit.f16.positive.pi.quarter),
+        sixth: reinterpretU16AsF16(kBit.f16.positive.pi.sixth),
+      },
+      e: reinterpretU16AsF16(kBit.f16.positive.e),
       // The positive pipeline-overridable constant with the smallest magnitude
       // which when cast to f16 will produce infinity. This comes from WGSL
       // conversion rules and the rounding rules of WebIDL.
@@ -508,6 +540,16 @@ export const kValue = {
       max: reinterpretU16AsF16(kBit.f16.negative.max),
       min: reinterpretU16AsF16(kBit.f16.negative.min),
       zero: reinterpretU16AsF16(kBit.f16.negative.zero),
+      nearest_min: reinterpretU16AsF16(kBit.f16.negative.nearest_min),
+      less_than_one: reinterpretU16AsF16(kBit.f16.negative.less_than_one), // -0.9996
+      pi: {
+        whole: reinterpretU16AsF16(kBit.f16.negative.pi.whole),
+        three_quarters: reinterpretU16AsF16(kBit.f16.negative.pi.three_quarters),
+        half: reinterpretU16AsF16(kBit.f16.negative.pi.half),
+        third: reinterpretU16AsF16(kBit.f16.negative.pi.third),
+        quarter: reinterpretU16AsF16(kBit.f16.negative.pi.quarter),
+        sixth: reinterpretU16AsF16(kBit.f16.negative.pi.sixth),
+      },
       // The negative pipeline-overridable constant with the smallest magnitude
       // which when cast to f16 will produce infinity. This comes from WGSL
       // conversion rules and the rounding rules of WebIDL.

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -967,16 +967,6 @@ export function reinterpretU32sAsF64(u32s: [number, number]): number {
 }
 
 /**
- * @returns a number representing the u16 interpretation
- * of the bits of a number assumed to be an f16 value.
- */
-export function reinterpretF16AsU16(f16: number): number {
-  const array = new Float16Array(1);
-  array[0] = f16;
-  return new Uint16Array(array.buffer)[0];
-}
-
-/**
  * @returns a number representing the u32 interpretation
  * of the bits of a number assumed to be an f32 value.
  */
@@ -1024,6 +1014,26 @@ export function reinterpretI32AsU32(i32: number): number {
   const array = new Int32Array(1);
   array[0] = i32;
   return new Uint32Array(array.buffer)[0];
+}
+
+/**
+ * @returns a number representing the u16 interpretation
+ * of the bits of a number assumed to be an f16 value.
+ */
+export function reinterpretF16AsU16(f16: number): number {
+  const array = new Float16Array(1);
+  array[0] = f16;
+  return new Uint16Array(array.buffer)[0];
+}
+
+/**
+ * @returns a number representing the f16 interpretation
+ * of the bits of a number assumed to be an u16 value.
+ */
+export function reinterpretU16AsF16(u16: number): number {
+  const array = new Uint16Array(1);
+  array[0] = u16;
+  return new Float16Array(array.buffer)[0];
 }
 
 /**

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -2,7 +2,15 @@ import { assert } from '../../common/util/util.js';
 import { Float16Array } from '../../external/petamoriken/float16/float16.js';
 
 import { kBit, kValue } from './constants.js';
-import { f32, floatBitsToNumber, i32, kFloat16Format, kFloat32Format, u32 } from './conversion.js';
+import {
+  f32,
+  f16,
+  floatBitsToNumber,
+  i32,
+  kFloat16Format,
+  kFloat32Format,
+  u32,
+} from './conversion.js';
 
 /**
  * A multiple of 8 guaranteed to be way too large to allocate (just under 8 pebibytes).
@@ -386,12 +394,55 @@ export function oneULPF32(target: number, mode: FlushMode = 'flush'): number {
   //     before and after are f32 representable
   const before = nextAfterF32(target, 'negative', mode);
   const after = nextAfterF32(target, 'positive', mode);
-  const converted: number = new Float32Array([target])[0];
+  const converted: number = quantizeToF32(target);
   if (converted === target) {
     // |target| is f32 representable, so either before or after will be x
     return Math.min(target - before, after - target);
   } else {
     // |target| is not f32 representable so taking distance of neighbouring f32s.
+    return after - before;
+  }
+}
+
+/**
+ * @returns ulp(x), the unit of least precision for a specific number as a 32-bit float
+ *
+ * ulp(x) is the distance between the two floating point numbers nearest x.
+ * This value is also called unit of last place, ULP, and 1 ULP.
+ * See the WGSL spec and http://www.ens-lyon.fr/LIP/Pub/Rapports/RR/RR2005/RR2005-09.pdf
+ * for a more detailed/nuanced discussion of the definition of ulp(x).
+ *
+ * @param target number to calculate ULP for
+ * @param mode should FTZ occurring during calculation or not
+ */
+export function oneULPF16(target: number, mode: FlushMode = 'flush'): number {
+  if (Number.isNaN(target)) {
+    return Number.NaN;
+  }
+
+  target = mode === 'flush' ? flushSubnormalNumberF16(target) : target;
+
+  // For values at the edge of the range or beyond ulp(x) is defined as the
+  // distance between the two nearest f16 representable numbers to the
+  // appropriate edge.
+  if (target === Number.POSITIVE_INFINITY || target >= kValue.f16.positive.max) {
+    return kValue.f16.positive.max - kValue.f16.positive.nearest_max;
+  } else if (target === Number.NEGATIVE_INFINITY || target <= kValue.f16.negative.min) {
+    return kValue.f16.negative.nearest_min - kValue.f16.negative.min;
+  }
+
+  // ulp(x) is min(after - before), where
+  //     before <= x <= after
+  //     before =/= after
+  //     before and after are f16 representable
+  const before = nextAfterF16(target, 'negative', mode);
+  const after = nextAfterF16(target, 'positive', mode);
+  const converted: number = quantizeToF16(target);
+  if (converted === target) {
+    // |target| is f16 representable, so either before or after will be x
+    return Math.min(target - before, after - target);
+  } else {
+    // |target| is not f16 representable so taking distance of neighbouring f16s.
     return after - before;
   }
 }
@@ -1571,6 +1622,11 @@ export interface QuantizeFunc {
 /** @returns the closest 32-bit floating point value to the input */
 export function quantizeToF32(num: number): number {
   return f32(num).value as number;
+}
+
+/** @returns the closest 16-bit floating point value to the input */
+export function quantizeToF16(num: number): number {
+  return f16(num).value as number;
 }
 
 /** @returns the closest 32-bit signed integer value to the input */


### PR DESCRIPTION
This PR fulfill f16 traits (as the step 1, most interval ops are left unimplemented) and implement the fundamental interval unit tests for f16.

Issue: #2499 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
