### PR TITLE
Convert integer arithmetic tests to use sparse inputs

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/i32_arithmetic.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { kValue } from '../../../../util/constants.js';
 import { TypeI32, TypeVec } from '../../../../util/conversion.js';
-import { fullI32Range, sparseI32Range, vectorI32Range } from '../../../../util/math.js';
+import { sparseI32Range, vectorI32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import {
   allInputSources,
@@ -74,25 +74,25 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('binary/i32_arithmetic', {
   addition: () => {
-    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), i32_add);
+    return generateBinaryToI32Cases(sparseI32Range(), sparseI32Range(), i32_add);
   },
   subtraction: () => {
-    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), i32_subtract);
+    return generateBinaryToI32Cases(sparseI32Range(), sparseI32Range(), i32_subtract);
   },
   multiplication: () => {
-    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), i32_multiply);
+    return generateBinaryToI32Cases(sparseI32Range(), sparseI32Range(), i32_multiply);
   },
   division_non_const: () => {
-    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), i32_divide_non_const);
+    return generateBinaryToI32Cases(sparseI32Range(), sparseI32Range(), i32_divide_non_const);
   },
   division_const: () => {
-    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), i32_divide_const);
+    return generateBinaryToI32Cases(sparseI32Range(), sparseI32Range(), i32_divide_const);
   },
   remainder_non_const: () => {
-    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), i32_remainder_non_const);
+    return generateBinaryToI32Cases(sparseI32Range(), sparseI32Range(), i32_remainder_non_const);
   },
   remainder_const: () => {
-    return generateBinaryToI32Cases(fullI32Range(), fullI32Range(), i32_remainder_const);
+    return generateBinaryToI32Cases(sparseI32Range(), sparseI32Range(), i32_remainder_const);
   },
   addition_scalar_vector2: () => {
     return generateI32VectorBinaryToVectorCases(sparseI32Range(), vectorI32Range(2), i32_add);

--- a/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/u32_arithmetic.spec.ts
@@ -5,7 +5,7 @@ Execution Tests for the u32 arithmetic binary expression operations
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
 import { TypeU32, TypeVec } from '../../../../util/conversion.js';
-import { fullU32Range, sparseU32Range, vectorU32Range } from '../../../../util/math.js';
+import { sparseU32Range, vectorU32Range } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
 import {
   allInputSources,
@@ -61,25 +61,25 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('binary/u32_arithmetic', {
   addition: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_add);
+    return generateBinaryToU32Cases(sparseU32Range(), sparseU32Range(), u32_add);
   },
   subtraction: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_subtract);
+    return generateBinaryToU32Cases(sparseU32Range(), sparseU32Range(), u32_subtract);
   },
   multiplication: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_multiply);
+    return generateBinaryToU32Cases(sparseU32Range(), sparseU32Range(), u32_multiply);
   },
   division_non_const: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_divide_non_const);
+    return generateBinaryToU32Cases(sparseU32Range(), sparseU32Range(), u32_divide_non_const);
   },
   division_const: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_divide_const);
+    return generateBinaryToU32Cases(sparseU32Range(), sparseU32Range(), u32_divide_const);
   },
   remainder_non_const: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_remainder_non_const);
+    return generateBinaryToU32Cases(sparseU32Range(), sparseU32Range(), u32_remainder_non_const);
   },
   remainder_const: () => {
-    return generateBinaryToU32Cases(fullU32Range(), fullU32Range(), u32_remainder_const);
+    return generateBinaryToU32Cases(sparseU32Range(), sparseU32Range(), u32_remainder_const);
   },
   addition_scalar_vector2: () => {
     return generateU32VectorBinaryToVectorCases(sparseU32Range(), vectorU32Range(2), u32_add);

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -919,11 +919,15 @@ export function filteredF64Range(
 /** Short list of i32 values of interest to test against */
 const kInterestingI32Values: number[] = [
   kValue.i32.negative.max,
-  kValue.i32.negative.max / 2,
+  Math.trunc(kValue.i32.negative.max / 2),
+  -256,
+  -10,
   -1,
   0,
   1,
-  kValue.i32.positive.max / 2,
+  10,
+  256,
+  Math.trunc(kValue.i32.positive.max / 2),
   kValue.i32.positive.max,
 ];
 
@@ -1005,7 +1009,14 @@ export function fullI32Range(
 }
 
 /** Short list of u32 values of interest to test against */
-const kInterestingU32Values: number[] = [0, 1, kValue.u32.max / 2, kValue.u32.max];
+const kInterestingU32Values: number[] = [
+  0,
+  1,
+  10,
+  256,
+  Math.trunc(kValue.u32.max / 2),
+  kValue.u32.max,
+];
 
 /** @returns minimal u32 values that cover the entire range of u32 behaviours
  *


### PR DESCRIPTION
This reduces the number of test cases substantially, since these will be generating N^2 cases per operation.

Fixes #2623

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
