### PR TITLE
Include testharness.js in exposed interface tests

### DIFF
--- a/src/webgpu/idl/exposed.http.html
+++ b/src/webgpu/idl/exposed.http.html
@@ -5,6 +5,8 @@
     <title>WebGPU exposed items (non-HTTPS)</title>
     <meta name=assert content="WebGPU should not be exposed on a non-[SecureContext]">
     <link rel=help href='https://gpuweb.github.io/gpuweb/'>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
     <script type=module src=exposed.html.js></script>
   </head>
   <body></body>

--- a/src/webgpu/idl/exposed.https.html
+++ b/src/webgpu/idl/exposed.https.html
@@ -1,10 +1,12 @@
 <!doctype html>
 <html>
   <head>
-    <title>WebGPU exposed items (HTTPS)</title>
     <meta charset=utf-8>
+    <title>WebGPU exposed items (HTTPS)</title>
     <meta name=assert content="All specified WebGPU items/interfaces should be exposed, on a [SecureContext]">
     <link rel=help href='https://gpuweb.github.io/gpuweb/'>
+    <script src=/resources/testharness.js></script>
+    <script src=/resources/testharnessreport.js></script>
     <script type=module src=exposed.html.js></script>
   </head>
   <body></body>


### PR DESCRIPTION
These tests should be run as testharness.js tests, even though they don't actually use any of testharness.js. Include testharness.js anyway to make `wpt lint` not misidentify these as "visual" tests.

Initially I was going to rewrite these as vanilla testharness.js files, but I'm pretty sure I verified these tests worked in the past, and that testharness.js will catch plain exceptions thrown at the toplevel (of an imported module, in this case).

Issue #2628