### PR TITLE
Remove console.log from a file exported to wpt

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -18,19 +18,11 @@ type DestroyableObject =
   | { getExtension(extensionName: 'WEBGL_lose_context'): WEBGL_lose_context };
 
 export class SubcaseBatchState {
-  private _params: TestParams;
-
-  constructor(params: TestParams) {
-    this._params = params;
-  }
-
-  /**
-   * Returns the case parameters for this test fixture shared state. Subcase params
-   * are not included.
-   */
-  get params(): TestParams {
-    return this._params;
-  }
+  constructor(
+    protected readonly recorder: TestCaseRecorder,
+    /** The case parameters for this test fixture shared state. Subcase params are not included. */
+    public readonly params: TestParams
+  ) {}
 
   /**
    * Runs before the `.before()` function.
@@ -62,13 +54,13 @@ export class Fixture<S extends SubcaseBatchState = SubcaseBatchState> {
    *
    * @internal
    */
-  protected rec: TestCaseRecorder;
+  readonly rec: TestCaseRecorder;
   private eventualExpectations: Array<Promise<unknown>> = [];
   private numOutstandingAsyncExpectations = 0;
   private objectsToCleanUp: DestroyableObject[] = [];
 
-  public static MakeSharedState(params: TestParams): SubcaseBatchState {
-    return new SubcaseBatchState(params);
+  public static MakeSharedState(recorder: TestCaseRecorder, params: TestParams): SubcaseBatchState {
+    return new SubcaseBatchState(recorder, params);
   }
 
   /** @internal */
@@ -340,12 +332,12 @@ export type SubcaseBatchStateFromFixture<F> = F extends Fixture<infer S> ? S : n
  */
 export type FixtureClass<F extends Fixture = Fixture> = {
   new (sharedState: SubcaseBatchStateFromFixture<F>, log: TestCaseRecorder, params: TestParams): F;
-  MakeSharedState(params: TestParams): SubcaseBatchStateFromFixture<F>;
+  MakeSharedState(recorder: TestCaseRecorder, params: TestParams): SubcaseBatchStateFromFixture<F>;
 };
 export type FixtureClassInterface<F extends Fixture = Fixture> = {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   new (...args: any[]): F;
-  MakeSharedState(params: TestParams): SubcaseBatchStateFromFixture<F>;
+  MakeSharedState(recorder: TestCaseRecorder, params: TestParams): SubcaseBatchStateFromFixture<F>;
 };
 export type FixtureClassWithMixin<FC, M> = FC extends FixtureClass<infer F>
   ? FixtureClass<F & M>

--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -479,7 +479,7 @@ class RunCaseSpecific implements RunCase {
     const { testHeartbeatCallback, maxSubcasesInFlight } = globalTestConfig;
     try {
       rec.start();
-      const sharedState = this.fixture.MakeSharedState(this.params);
+      const sharedState = this.fixture.MakeSharedState(rec, this.params);
       try {
         await sharedState.init();
         if (this.beforeFn) {

--- a/src/common/runtime/helper/test_worker-worker.ts
+++ b/src/common/runtime/helper/test_worker-worker.ts
@@ -3,6 +3,7 @@ import { DefaultTestFileLoader } from '../../internal/file_loader.js';
 import { Logger } from '../../internal/logging/logger.js';
 import { parseQuery } from '../../internal/query/parseQuery.js';
 import { TestQueryWithExpectation } from '../../internal/query/query.js';
+import { setDefaultRequestAdapterOptions } from '../../util/navigator_gpu.js';
 import { assert } from '../../util/util.js';
 
 // Should be DedicatedWorkerGlobalScope, but importing lib "webworker" conflicts with lib "dom".
@@ -16,7 +17,11 @@ setBaseResourcePath('../../../resources');
 self.onmessage = async (ev: MessageEvent) => {
   const query: string = ev.data.query;
   const expectations: TestQueryWithExpectation[] = ev.data.expectations;
+  const defaultRequestAdapterOptions: GPURequestAdapterOptions =
+    ev.data.defaultRequestAdapterOptions;
   const debug: boolean = ev.data.debug;
+
+  setDefaultRequestAdapterOptions(defaultRequestAdapterOptions);
 
   Logger.globalDebugMode = debug;
   const log = new Logger();

--- a/src/common/runtime/helper/test_worker.ts
+++ b/src/common/runtime/helper/test_worker.ts
@@ -2,6 +2,7 @@ import { LogMessageWithStack } from '../../internal/logging/log_message.js';
 import { TransferredTestCaseResult, LiveTestCaseResult } from '../../internal/logging/result.js';
 import { TestCaseRecorder } from '../../internal/logging/test_case_recorder.js';
 import { TestQueryWithExpectation } from '../../internal/query/query.js';
+import { getDefaultRequestAdapterOptions } from '../../util/navigator_gpu.js';
 
 export class TestWorker {
   private readonly debug: boolean;
@@ -35,7 +36,12 @@ export class TestWorker {
     query: string,
     expectations: TestQueryWithExpectation[] = []
   ): Promise<void> {
-    this.worker.postMessage({ query, expectations, debug: this.debug });
+    this.worker.postMessage({
+      query,
+      expectations,
+      debug: this.debug,
+      defaultRequestAdapterOptions: getDefaultRequestAdapterOptions(),
+    });
     const workerResult = await new Promise<LiveTestCaseResult>(resolve => {
       this.resolvers.set(query, resolve);
     });

--- a/src/common/util/navigator_gpu.ts
+++ b/src/common/util/navigator_gpu.ts
@@ -1,6 +1,8 @@
 /// <reference types="@webgpu/types" />
 
-import { assert } from './util.js';
+import { TestCaseRecorder } from '../framework/fixture.js';
+
+import { ErrorWithExtra, assert } from './util.js';
 
 /**
  * Finds and returns the `navigator.gpu` object (or equivalent, for non-browser implementations).
@@ -45,7 +47,7 @@ export function setDefaultRequestAdapterOptions(options: GPURequestAdapterOption
  * Finds and returns the `navigator.gpu` object (or equivalent, for non-browser implementations).
  * Throws an exception if not found.
  */
-export function getGPU(): GPU {
+export function getGPU(recorder: TestCaseRecorder): GPU {
   if (impl) {
     return impl;
   }
@@ -62,8 +64,8 @@ export function getGPU(): GPU {
       void promise.then(async adapter => {
         if (adapter) {
           const info = await adapter.requestAdapterInfo();
-          // eslint-disable-next-line no-console
-          console.log(info);
+          const infoString = `Adapter: ${info.vendor} / ${info.architecture} / ${info.device}`;
+          recorder.debug(new ErrorWithExtra(infoString, () => ({ adapterInfo: info })));
         }
       });
       return promise;

--- a/src/common/util/navigator_gpu.ts
+++ b/src/common/util/navigator_gpu.ts
@@ -43,11 +43,15 @@ export function setDefaultRequestAdapterOptions(options: GPURequestAdapterOption
   defaultRequestAdapterOptions = { ...options };
 }
 
+export function getDefaultRequestAdapterOptions() {
+  return defaultRequestAdapterOptions;
+}
+
 /**
  * Finds and returns the `navigator.gpu` object (or equivalent, for non-browser implementations).
  * Throws an exception if not found.
  */
-export function getGPU(recorder: TestCaseRecorder): GPU {
+export function getGPU(recorder: TestCaseRecorder | null): GPU {
   if (impl) {
     return impl;
   }
@@ -60,14 +64,16 @@ export function getGPU(recorder: TestCaseRecorder): GPU {
     impl.requestAdapter = function (
       options?: GPURequestAdapterOptions
     ): Promise<GPUAdapter | null> {
-      const promise = oldFn.call(this, { ...defaultRequestAdapterOptions, ...(options || {}) });
-      void promise.then(async adapter => {
-        if (adapter) {
-          const info = await adapter.requestAdapterInfo();
-          const infoString = `Adapter: ${info.vendor} / ${info.architecture} / ${info.device}`;
-          recorder.debug(new ErrorWithExtra(infoString, () => ({ adapterInfo: info })));
-        }
-      });
+      const promise = oldFn.call(this, { ...defaultRequestAdapterOptions, ...options });
+      if (recorder) {
+        void promise.then(async adapter => {
+          if (adapter) {
+            const info = await adapter.requestAdapterInfo();
+            const infoString = `Adapter: ${info.vendor} / ${info.architecture} / ${info.device}`;
+            recorder.debug(new ErrorWithExtra(infoString, () => ({ adapterInfo: info })));
+          }
+        });
+      }
       return promise;
     };
   }

--- a/src/stress/adapter/device_allocation.spec.ts
+++ b/src/stress/adapter/device_allocation.spec.ts
@@ -219,7 +219,7 @@ g.test('coexisting')
   .params(u => u.combine('adapterType', kAdapterTypes))
   .fn(async t => {
     const { adapterType } = t.params;
-    const adapter = await getGPU().requestAdapter(kAdapterTypeOptions[adapterType]);
+    const adapter = await getGPU(t.rec).requestAdapter(kAdapterTypeOptions[adapterType]);
     assert(adapter !== null, 'Failed to get adapter.');
 
     // Based on Vulkan conformance test requirement to be able to create multiple devices.
@@ -242,7 +242,7 @@ objects are recycled over a very large number of iterations.`
   .params(u => u.combine('adapterType', kAdapterTypes))
   .fn(async t => {
     const { adapterType } = t.params;
-    const adapter = await getGPU().requestAdapter(kAdapterTypeOptions[adapterType]);
+    const adapter = await getGPU(t.rec).requestAdapter(kAdapterTypeOptions[adapterType]);
     assert(adapter !== null, 'Failed to get adapter.');
 
     // Since devices are being destroyed, we should be able to create many devices.
@@ -274,7 +274,7 @@ implicitly keep the device in scope.`
   .params(u => u.combine('adapterType', kAdapterTypes))
   .fn(async t => {
     const { adapterType } = t.params;
-    const adapter = await getGPU().requestAdapter(kAdapterTypeOptions[adapterType]);
+    const adapter = await getGPU(t.rec).requestAdapter(kAdapterTypeOptions[adapterType]);
     assert(adapter !== null, 'Failed to get adapter.');
 
     const kNumDevices = 10_000;

--- a/src/webgpu/api/operation/adapter/requestAdapter.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestAdapter.spec.ts
@@ -102,7 +102,7 @@ g.test('requestAdapter')
   )
   .fn(async t => {
     const { powerPreference, forceFallbackAdapter } = t.params;
-    const adapter = await getGPU().requestAdapter({
+    const adapter = await getGPU(t.rec).requestAdapter({
       ...(powerPreference !== undefined && { powerPreference }),
       ...(forceFallbackAdapter !== undefined && { forceFallbackAdapter }),
     });
@@ -118,7 +118,7 @@ g.test('requestAdapter')
 
 g.test('requestAdapter_no_parameters')
   .desc(`request adapter with no parameters`)
-  .fn(async () => {
-    const adapter = await getGPU().requestAdapter();
+  .fn(async t => {
+    const adapter = await getGPU(t.rec).requestAdapter();
     await testAdapter(adapter);
   });

--- a/src/webgpu/api/operation/adapter/requestAdapterInfo.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestAdapterInfo.spec.ts
@@ -22,7 +22,7 @@ g.test('adapter_info')
     - Every member in the structure except description is properly formatted`
   )
   .fn(async t => {
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 

--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -31,7 +31,7 @@ g.test('default')
   )
   .fn(async t => {
     const { args } = t.params;
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
     const device = await adapter.requestDevice(...args);
@@ -61,7 +61,7 @@ g.test('invalid')
     `
   )
   .fn(async t => {
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
@@ -99,7 +99,7 @@ g.test('stale')
       )
   )
   .fn(async t => {
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
@@ -172,7 +172,7 @@ g.test('features,unknown')
     Test requesting device with an unknown feature.`
   )
   .fn(async t => {
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
@@ -193,7 +193,7 @@ g.test('features,known')
   .fn(async t => {
     const { feature } = t.params;
 
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
@@ -213,7 +213,7 @@ g.test('limits,unknown')
     requestDevice to reject.`
   )
   .fn(async t => {
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
@@ -235,7 +235,7 @@ g.test('limits,supported')
   .fn(async t => {
     const { limit, limitValue } = t.params;
 
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
@@ -289,7 +289,7 @@ g.test('limit,better_than_supported')
   .fn(async t => {
     const { limit, mul, add } = t.params;
 
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
@@ -332,7 +332,7 @@ g.test('limit,worse_than_default')
   .fn(async t => {
     const { limit, mul, add } = t.params;
 
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 

--- a/src/webgpu/api/operation/buffers/map_detach.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_detach.spec.ts
@@ -48,7 +48,7 @@ g.test('while_mapped')
 
     let device: GPUDevice = t.device;
     if (deviceDestroy) {
-      const adapter = await getGPU().requestAdapter();
+      const adapter = await getGPU(t.rec).requestAdapter();
       assert(adapter !== null);
       device = await adapter.requestDevice();
     }

--- a/src/webgpu/api/operation/device/lost.spec.ts
+++ b/src/webgpu/api/operation/device/lost.spec.ts
@@ -43,7 +43,7 @@ g.test('not_lost_on_gc')
     // Wraps a lost promise object creation in a function scope so that the device has the best
     // chance of being gone and ready for GC before trying to resolve the lost promise.
     const { lost } = await (async () => {
-      const adapter = await getGPU().requestAdapter();
+      const adapter = await getGPU(t.rec).requestAdapter();
       assert(adapter !== null);
       const lost = (await adapter.requestDevice()).lost;
       return { lost };
@@ -56,7 +56,7 @@ g.test('not_lost_on_gc')
 g.test('lost_on_destroy')
   .desc(`'lost' is resolved, with reason='destroyed', on GPUDevice.destroy().`)
   .fn(async t => {
-    const adapter = await getGPU().requestAdapter();
+    const adapter = await getGPU(t.rec).requestAdapter();
     assert(adapter !== null);
     const device: GPUDevice = await adapter.requestDevice();
     t.expectDeviceDestroyed(device);
@@ -66,7 +66,7 @@ g.test('lost_on_destroy')
 g.test('same_object')
   .desc(`'lost' provides the same Promise and GPUDeviceLostInfo objects each time it's accessed.`)
   .fn(async t => {
-    const adapter = await getGPU().requestAdapter();
+    const adapter = await getGPU(t.rec).requestAdapter();
     assert(adapter !== null);
     const device: GPUDevice = await adapter.requestDevice();
 

--- a/src/webgpu/api/operation/labels.spec.ts
+++ b/src/webgpu/api/operation/labels.spec.ts
@@ -19,7 +19,7 @@ const kTestFunctions: { [name: string]: TestFunction } = {
   },
 
   requestDevice: async (t: GPUTest, label: string) => {
-    const gpu = getGPU();
+    const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     t.expect(!!adapter);
     const device = await adapter!.requestDevice({ label });

--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -318,7 +318,7 @@ export class LimitTestsImpl extends GPUTestBase {
 
   async init() {
     await super.init();
-    const gpu = getGPU();
+    const gpu = getGPU(this.rec);
     this._adapter = await gpu.requestAdapter();
     const limit = this.limit;
     this.defaultLimit = getDefaultLimit(limit);

--- a/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension2D.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxTextureDimension2D.spec.ts
@@ -68,7 +68,7 @@ g.test('configure,at_over')
               () => {
                 context.configure({
                   device,
-                  format: getGPU().getPreferredCanvasFormat(),
+                  format: getGPU(t.rec).getPreferredCanvasFormat(),
                 });
               },
               shouldError,
@@ -103,7 +103,7 @@ g.test('getCurrentTexture,at_over')
 
             context.configure({
               device,
-              format: getGPU().getPreferredCanvasFormat(),
+              format: getGPU(t.rec).getPreferredCanvasFormat(),
             });
 
             if (canvas) {

--- a/src/webgpu/api/validation/error_scope.spec.ts
+++ b/src/webgpu/api/validation/error_scope.spec.ts
@@ -23,7 +23,7 @@ class ErrorScopeTests extends Fixture {
 
   async init(): Promise<void> {
     await super.init();
-    const gpu = getGPU();
+    const gpu = getGPU(this.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
     const device = await adapter.requestDevice();

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -4,6 +4,7 @@ import {
   FixtureClassInterface,
   FixtureClassWithMixin,
   SubcaseBatchState,
+  TestCaseRecorder,
   TestParams,
 } from '../common/framework/fixture.js';
 import {
@@ -114,7 +115,10 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
    */
   selectDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
     assert(this.provider === undefined, "Can't selectDeviceOrSkipTestCase() multiple times");
-    this.provider = devicePool.acquire(initUncanonicalizedDeviceDescriptor(descriptor));
+    this.provider = devicePool.acquire(
+      this.recorder,
+      initUncanonicalizedDeviceDescriptor(descriptor)
+    );
     // Suppress uncaught promise rejection (we'll catch it later).
     this.provider.catch(() => {});
   }
@@ -172,6 +176,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     );
 
     this.mismatchedProvider = mismatchedDevicePool.acquire(
+      this.recorder,
       initUncanonicalizedDeviceDescriptor(descriptor)
     );
     // Suppress uncaught promise rejection (we'll catch it later).
@@ -186,8 +191,11 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
  * as well as helpers that use that device.
  */
 export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
-  public static MakeSharedState(params: TestParams): GPUTestSubcaseBatchState {
-    return new GPUTestSubcaseBatchState(params);
+  public static MakeSharedState(
+    recorder: TestCaseRecorder,
+    params: TestParams
+  ): GPUTestSubcaseBatchState {
+    return new GPUTestSubcaseBatchState(recorder, params);
   }
 
   // This must be overridden in derived classes

--- a/src/webgpu/idl/idl_test.ts
+++ b/src/webgpu/idl/idl_test.ts
@@ -12,7 +12,7 @@ interface UnknownObject {
 export class IDLTest extends Fixture {
   init(): Promise<void> {
     // Ensure the GPU provider is initialized
-    getGPU();
+    getGPU(this.rec);
     return Promise.resolve();
   }
 

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -1,4 +1,4 @@
-import { SkipTestCase } from '../../common/framework/fixture.js';
+import { SkipTestCase, TestCaseRecorder } from '../../common/framework/fixture.js';
 import { attemptGarbageCollection } from '../../common/util/collect_garbage.js';
 import { getGPU } from '../../common/util/navigator_gpu.js';
 import {
@@ -22,12 +22,15 @@ export class DevicePool {
   private holders: 'uninitialized' | 'failed' | DescriptorToHolderMap = 'uninitialized';
 
   /** Acquire a device from the pool and begin the error scopes. */
-  async acquire(descriptor?: UncanonicalizedDeviceDescriptor): Promise<DeviceProvider> {
+  async acquire(
+    recorder: TestCaseRecorder,
+    descriptor?: UncanonicalizedDeviceDescriptor
+  ): Promise<DeviceProvider> {
     let errorMessage = '';
     if (this.holders === 'uninitialized') {
       this.holders = new DescriptorToHolderMap();
       try {
-        await this.holders.getOrCreate(undefined);
+        await this.holders.getOrCreate(recorder, undefined);
       } catch (ex) {
         this.holders = 'failed';
         if (ex instanceof Error) {
@@ -41,7 +44,7 @@ export class DevicePool {
       `WebGPU device failed to initialize${errorMessage}; not retrying`
     );
 
-    const holder = await this.holders.getOrCreate(descriptor);
+    const holder = await this.holders.getOrCreate(recorder, descriptor);
 
     assert(holder.state === 'free', 'Device was in use on DevicePool.acquire');
     holder.state = 'acquired';
@@ -132,6 +135,7 @@ class DescriptorToHolderMap {
    * Throws SkipTestCase if devices with this descriptor are unsupported.
    */
   async getOrCreate(
+    recorder: TestCaseRecorder,
     uncanonicalizedDescriptor: UncanonicalizedDeviceDescriptor | undefined
   ): Promise<DeviceHolder> {
     const [descriptor, key] = canonicalizeDescriptor(uncanonicalizedDescriptor);
@@ -156,7 +160,7 @@ class DescriptorToHolderMap {
     // No existing item was found; add a new one.
     let value;
     try {
-      value = await DeviceHolder.create(descriptor);
+      value = await DeviceHolder.create(recorder, descriptor);
     } catch (ex) {
       if (ex instanceof FeaturesNotSupported) {
         this.unsupported.add(key);
@@ -284,8 +288,11 @@ class DeviceHolder implements DeviceProvider {
 
   // Gets a device and creates a DeviceHolder.
   // If the device is lost, DeviceHolder.lost gets set.
-  static async create(descriptor: CanonicalDeviceDescriptor | undefined): Promise<DeviceHolder> {
-    const gpu = getGPU();
+  static async create(
+    recorder: TestCaseRecorder,
+    descriptor: CanonicalDeviceDescriptor | undefined
+  ): Promise<DeviceHolder> {
+    const gpu = getGPU(recorder);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null, 'requestAdapter returned null');
     if (!supportsFeature(adapter, descriptor)) {

--- a/src/webgpu/web_platform/worker/worker.ts
+++ b/src/webgpu/web_platform/worker/worker.ts
@@ -1,7 +1,8 @@
+import { getGPU, setDefaultRequestAdapterOptions } from '../../../common/util/navigator_gpu.js';
 import { assert, objectEquals, iterRange } from '../../../common/util/util.js';
 
 async function basicTest() {
-  const adapter = await navigator.gpu.requestAdapter();
+  const adapter = await getGPU(null).requestAdapter();
   assert(adapter !== null, 'Failed to get adapter.');
 
   const device = await adapter.requestDevice();
@@ -68,6 +69,10 @@ async function basicTest() {
 }
 
 self.onmessage = async (ev: MessageEvent) => {
+  const defaultRequestAdapterOptions: GPURequestAdapterOptions =
+    ev.data.defaultRequestAdapterOptions;
+  setDefaultRequestAdapterOptions(defaultRequestAdapterOptions);
+
   let error = undefined;
   try {
     await basicTest();

--- a/src/webgpu/web_platform/worker/worker.ts
+++ b/src/webgpu/web_platform/worker/worker.ts
@@ -1,8 +1,7 @@
-import { getGPU } from '../../../common/util/navigator_gpu.js';
 import { assert, objectEquals, iterRange } from '../../../common/util/util.js';
 
 async function basicTest() {
-  const adapter = await getGPU().requestAdapter();
+  const adapter = await navigator.gpu.requestAdapter();
   assert(adapter !== null, 'Failed to get adapter.');
 
   const device = await adapter.requestDevice();

--- a/src/webgpu/web_platform/worker/worker_launcher.ts
+++ b/src/webgpu/web_platform/worker/worker_launcher.ts
@@ -1,3 +1,5 @@
+import { getDefaultRequestAdapterOptions } from '../../../common/util/navigator_gpu.js';
+
 export type TestResult = {
   error: String | undefined;
 };
@@ -11,6 +13,6 @@ export async function launchWorker() {
   const promise = new Promise<TestResult>(resolve => {
     worker.addEventListener('message', ev => resolve(ev.data as TestResult), { once: true });
   });
-  worker.postMessage({});
+  worker.postMessage({ defaultRequestAdapterOptions: getDefaultRequestAdapterOptions() });
   return await promise;
 }


### PR DESCRIPTION
WPT has a lint that disallows console.log. This print is somewhat useful for debugging but seems generally unnecessary. I would keep it, but I'm not sure how other than doing shenanigans in the WPT build process (can't suppress the lint because the suppression file lives outside the webgpu directory).

Issue: #2628