### PR TITLE
Add negative zeroes to kValue

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
@@ -22,7 +22,7 @@ import { TestParams } from '../../../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { Comparator, alwaysPass, anyOf } from '../../../../../util/compare.js';
-import { kBit } from '../../../../../util/constants.js';
+import { kBit, kValue } from '../../../../../util/constants.js';
 import {
   reinterpretI32AsF32,
   reinterpretF32AsI32,
@@ -72,7 +72,9 @@ const f32ZerosInU32 = [0, kBit.f32.negative.zero];
 const f32ZerosInF32 = f32ZerosInU32.map(u => reinterpretU32AsF32(u));
 const f32ZerosInI32 = f32ZerosInU32.map(u => reinterpretU32AsI32(u));
 
-const f32FiniteRange: number[] = [...fullF32Range(), ...f32ZerosInF32];
+// f32FiniteRange is a list of finite f32s. fullF32Range() already
+// has +0, we only need to add -0.
+const f32FiniteRange: number[] = [...fullF32Range(), kValue.f32.negative.zero];
 const f32RangeWithInfAndNaN: number[] = [...f32FiniteRange, ...f32InfAndNaNInF32];
 
 const anyF32 = alwaysPass('any f32');

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -376,6 +376,7 @@ export const kValue = {
     positive: {
       min: reinterpretU64AsF64(kBit.f64.positive.min),
       max: reinterpretU64AsF64(kBit.f64.positive.max),
+      zero: reinterpretU64AsF64(kBit.f64.positive.zero),
       nearest_max: reinterpretU64AsF64(kBit.f64.positive.nearest_max),
       less_than_one: reinterpretU64AsF64(kBit.f64.positive.less_than_one),
       pi: {
@@ -391,6 +392,7 @@ export const kValue = {
     negative: {
       max: reinterpretU64AsF64(kBit.f64.negative.max),
       min: reinterpretU64AsF64(kBit.f64.negative.min),
+      zero: reinterpretU64AsF64(kBit.f64.negative.zero),
       nearest_min: reinterpretU64AsF64(kBit.f64.negative.nearest_min),
       less_than_one: reinterpretU64AsF64(kBit.f64.negative.less_than_one), // -0.999999940395
       pi: {
@@ -423,6 +425,7 @@ export const kValue = {
     positive: {
       min: reinterpretU32AsF32(kBit.f32.positive.min),
       max: reinterpretU32AsF32(kBit.f32.positive.max),
+      zero: reinterpretU32AsF32(kBit.f32.positive.zero),
       nearest_max: reinterpretU32AsF32(kBit.f32.positive.nearest_max),
       less_than_one: reinterpretU32AsF32(kBit.f32.positive.less_than_one),
       pi: {
@@ -449,6 +452,7 @@ export const kValue = {
     negative: {
       max: reinterpretU32AsF32(kBit.f32.negative.max),
       min: reinterpretU32AsF32(kBit.f32.negative.min),
+      zero: reinterpretU32AsF32(kBit.f32.negative.zero),
       nearest_min: reinterpretU32AsF32(kBit.f32.negative.nearest_min),
       less_than_one: reinterpretU32AsF32(kBit.f32.negative.less_than_one), // -0.999999940395
       pi: {


### PR DESCRIPTION
And remove the duplicated +0 value from the bitcast tests


Addresses feedback in https://github.com/gpuweb/cts/pull/2751#discussion_r1223078111 

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
