### PR TITLE
Add compatibility option

### DIFF
--- a/src/common/framework/test_config.ts
+++ b/src/common/framework/test_config.ts
@@ -16,6 +16,11 @@ export type TestConfig = {
    * MSL compiler is extremely slow to compile with loops rolled.
    */
   unrollConstEvalLoops: boolean;
+
+  /**
+   * Whether or not we're running in compatibility mode.
+   */
+  compatibility: boolean;
 };
 
 export const globalTestConfig: TestConfig = {
@@ -23,4 +28,5 @@ export const globalTestConfig: TestConfig = {
   testHeartbeatCallback: () => {},
   noRaceWithRejectOnTimeout: false,
   unrollConstEvalLoops: false,
+  compatibility: false,
 };

--- a/src/common/runtime/helper/options.ts
+++ b/src/common/runtime/helper/options.ts
@@ -21,26 +21,35 @@ export function optionString(
   return searchParams.get(opt) || '';
 }
 
-// The possible options for the tests.
+/**
+ * The possible options for the tests.
+ */
 export interface CTSOptions {
   worker: boolean;
   debug: boolean;
   compatibility: boolean;
   unrollConstEvalLoops: boolean;
-  powerPreference: GPUPowerPreference;
+  powerPreference?: GPUPowerPreference | '';
 }
 
-// Extra per option info.
+/**
+ * Extra per option info.
+ */
 export interface OptionInfo {
   description: string;
   parser?: (key: string, searchParams?: URLSearchParams) => boolean | string;
   selectValueDescriptions?: { value: string; description: string }[];
 }
 
-// Type for info for every option. This definition means adding an option
-// will generate a compile time error if no extra info is provided.
+/**
+ * Type for info for every option. This definition means adding an option
+ * will generate a compile time error if no extra info is provided.
+ */
 export type OptionsInfos<Type> = Record<keyof Type, OptionInfo>;
 
+/**
+ * Options to the CTS.
+ */
 export const kCTSOptionsInfo: OptionsInfos<CTSOptions> = {
   worker: { description: 'run in a worker' },
   debug: { description: 'show more info' },
@@ -90,14 +99,14 @@ function getOptionsInfoFromSearchString<Type extends CTSOptions>(
  * Given a test query string in the form of `suite:foo,bar,moo&opt1=val1&opt2=val2
  * returns the query and the options.
  */
-export function parseSearchPramLikeWithOptions<Type extends CTSOptions>(
+export function parseSearchParamLikeWithOptions<Type extends CTSOptions>(
   optionsInfos: OptionsInfos<Type>,
   query: string
 ): {
   queries: string[];
   options: Type;
 } {
-  const searchString = query.startsWith('q=') || query.startsWith('?') ? query : `q=${query}`;
+  const searchString = query.includes('q=') || query.startsWith('?') ? query : `q=${query}`;
   const queries = new URLSearchParams(searchString).getAll('q');
   const options = getOptionsInfoFromSearchString(optionsInfos, searchString);
   return { queries, options };
@@ -108,5 +117,5 @@ export function parseSearchPramLikeWithOptions<Type extends CTSOptions>(
  * returns the query and the common options.
  */
 export function parseSearchParamLikeWithCTSOptions(query: string) {
-  return parseSearchPramLikeWithOptions(kCTSOptionsInfo, query);
+  return parseSearchParamLikeWithOptions(kCTSOptionsInfo, query);
 }

--- a/src/common/runtime/helper/options.ts
+++ b/src/common/runtime/helper/options.ts
@@ -20,3 +20,93 @@ export function optionString(
 ): string {
   return searchParams.get(opt) || '';
 }
+
+// The possible options for the tests.
+export interface CTSOptions {
+  worker: boolean;
+  debug: boolean;
+  compatibility: boolean;
+  unrollConstEvalLoops: boolean;
+  powerPreference: GPUPowerPreference;
+}
+
+// Extra per option info.
+export interface OptionInfo {
+  description: string;
+  parser?: (key: string, searchParams?: URLSearchParams) => boolean | string;
+  selectValueDescriptions?: { value: string; description: string }[];
+}
+
+// Type for info for every option. This definition means adding an option
+// will generate a compile time error if no extra info is provided.
+export type OptionsInfos<Type> = Record<keyof Type, OptionInfo>;
+
+export const kCTSOptionsInfo: OptionsInfos<CTSOptions> = {
+  worker: { description: 'run in a worker' },
+  debug: { description: 'show more info' },
+  compatibility: { description: 'run in compatibility mode' },
+  unrollConstEvalLoops: { description: 'unroll const eval loops in WGSL' },
+  powerPreference: {
+    description: 'set default powerPreference for some tests',
+    parser: optionString,
+    selectValueDescriptions: [
+      { value: '', description: 'default' },
+      { value: 'low-power', description: 'low-power' },
+      { value: 'high-performance', description: 'high-performance' },
+    ],
+  },
+};
+
+/**
+ * Converts camel case to snake case.
+ * Examples:
+ *    fooBar -> foo_bar
+ *    parseHTMLFile -> parse_html_file
+ */
+export function camelCaseToSnakeCase(id: string) {
+  return id
+    .replace(/(.)([A-Z][a-z]+)/g, '$1_$2')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase();
+}
+
+/**
+ * Creates a Options from search parameters.
+ */
+function getOptionsInfoFromSearchString<Type extends CTSOptions>(
+  optionsInfos: OptionsInfos<Type>,
+  searchString: string
+): Type {
+  const searchParams = new URLSearchParams(searchString);
+  const optionValues: Record<string, boolean | string> = {};
+  for (const [optionName, info] of Object.entries(optionsInfos)) {
+    const parser = info.parser || optionEnabled;
+    optionValues[optionName] = parser(camelCaseToSnakeCase(optionName), searchParams);
+  }
+  return (optionValues as unknown) as Type;
+}
+
+/**
+ * Given a test query string in the form of `suite:foo,bar,moo&opt1=val1&opt2=val2
+ * returns the query and the options.
+ */
+export function parseSearchPramLikeWithOptions<Type extends CTSOptions>(
+  optionsInfos: OptionsInfos<Type>,
+  query: string
+): {
+  queries: string[];
+  options: Type;
+} {
+  const searchString = query.startsWith('q=') || query.startsWith('?') ? query : `q=${query}`;
+  const queries = new URLSearchParams(searchString).getAll('q');
+  const options = getOptionsInfoFromSearchString(optionsInfos, searchString);
+  return { queries, options };
+}
+
+/**
+ * Given a test query string in the form of `suite:foo,bar,moo&opt1=val1&opt2=val2
+ * returns the query and the common options.
+ */
+export function parseSearchParamLikeWithCTSOptions(query: string) {
+  return parseSearchPramLikeWithOptions(kCTSOptionsInfo, query);
+}

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -15,7 +15,7 @@ import { assert, ErrorWithExtra, unreachable } from '../util/util.js';
 
 import {
   kCTSOptionsInfo,
-  parseSearchPramLikeWithOptions,
+  parseSearchParamLikeWithOptions,
   CTSOptions,
   OptionInfo,
   OptionsInfos,
@@ -43,7 +43,7 @@ const kStandaloneOptionsInfos: OptionsInfos<StandaloneOptions> = {
   runnow: { description: 'run immediately on load' },
 };
 
-const { queries: qs, options } = parseSearchPramLikeWithOptions(
+const { queries: qs, options } = parseSearchParamLikeWithOptions(
   kStandaloneOptionsInfos,
   window.location.search || rootQuerySpec
 );

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -72,7 +72,7 @@ stopButtonElem.addEventListener('click', () => {
 
 if (powerPreference || compatibility) {
   setDefaultRequestAdapterOptions({
-    powerPreference,
+    ...(powerPreference && { powerPreference }),
     // MAINTENANCE_TODO: Change this to whatever the option ends up being
     ...(compatibility && { compatibilityMode: true }),
   });

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -13,12 +13,21 @@ import { TestTreeNode, TestSubtree, TestTreeLeaf, TestTree } from '../internal/t
 import { setDefaultRequestAdapterOptions } from '../util/navigator_gpu.js';
 import { assert, ErrorWithExtra, unreachable } from '../util/util.js';
 
-import { optionEnabled, optionString } from './helper/options.js';
+import {
+  kCTSOptionsInfo,
+  parseSearchPramLikeWithOptions,
+  CTSOptions,
+  OptionInfo,
+  OptionsInfos,
+  camelCaseToSnakeCase,
+} from './helper/options.js';
 import { TestWorker } from './helper/test_worker.js';
 
 const rootQuerySpec = 'webgpu:*';
 let promptBeforeReload = false;
 let isFullCTS = false;
+
+globalTestConfig.frameworkDebugLog = console.log;
 
 window.onbeforeunload = () => {
   // Prompt user before reloading if there are any results
@@ -27,79 +36,20 @@ window.onbeforeunload = () => {
 
 const kOpenTestLinkAltText = 'Open';
 
-// The possible options for the tests.
-interface StandaloneOptions {
-  runnow: boolean;
-  worker: boolean;
-  debug: boolean;
-  unrollConstEvalLoops: boolean;
-  powerPreference: string;
-}
+type StandaloneOptions = CTSOptions & { runnow: OptionInfo };
 
-// Extra per option info.
-interface StandaloneOptionInfo {
-  description: string;
-  parser?: (key: string) => boolean | string;
-  selectValueDescriptions?: { value: string; description: string }[];
-}
-
-// Type for info for every option. This definition means adding an option
-// will generate a compile time error if not extra info is provided.
-type StandaloneOptionsInfos = Record<keyof StandaloneOptions, StandaloneOptionInfo>;
-
-const optionsInfo: StandaloneOptionsInfos = {
+const kStandaloneOptionsInfos: OptionsInfos<StandaloneOptions> = {
+  ...kCTSOptionsInfo,
   runnow: { description: 'run immediately on load' },
-  worker: { description: 'run in a worker' },
-  debug: { description: 'show more info' },
-  unrollConstEvalLoops: { description: 'unroll const eval loops in WGSL' },
-  powerPreference: {
-    description: 'set default powerPreference for some tests',
-    parser: optionString,
-    selectValueDescriptions: [
-      { value: '', description: 'default' },
-      { value: 'low-power', description: 'low-power' },
-      { value: 'high-performance', description: 'high-performance' },
-    ],
-  },
 };
 
-/**
- * Converts camel case to snake case.
- * Examples:
- *    fooBar -> foo_bar
- *    parseHTMLFile -> parse_html_file
- */
-function camelCaseToSnakeCase(id: string) {
-  return id
-    .replace(/(.)([A-Z][a-z]+)/g, '$1_$2')
-    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-    .toLowerCase();
-}
-
-/**
- * Creates a StandaloneOptions from the current URL search parameters.
- */
-function getOptionsInfoFromSearchParameters(
-  optionsInfos: StandaloneOptionsInfos
-): StandaloneOptions {
-  const optionValues: Record<string, boolean | string> = {};
-  for (const [optionName, info] of Object.entries(optionsInfos)) {
-    const parser = info.parser || optionEnabled;
-    optionValues[optionName] = parser(camelCaseToSnakeCase(optionName));
-  }
-  return (optionValues as unknown) as StandaloneOptions;
-}
-
-// This is just a cast in one place.
-function optionsToRecord(options: StandaloneOptions) {
-  return (options as unknown) as Record<string, boolean | string>;
-}
-
-globalTestConfig.frameworkDebugLog = console.log;
-
-const options = getOptionsInfoFromSearchParameters(optionsInfo);
-const { runnow, debug, unrollConstEvalLoops, powerPreference } = options;
+const { queries: qs, options } = parseSearchPramLikeWithOptions(
+  kStandaloneOptionsInfos,
+  window.location.search || rootQuerySpec
+);
+const { runnow, debug, unrollConstEvalLoops, powerPreference, compatibility } = options;
 globalTestConfig.unrollConstEvalLoops = unrollConstEvalLoops;
+globalTestConfig.compatibility = compatibility;
 
 Logger.globalDebugMode = debug;
 const logger = new Logger();
@@ -120,8 +70,12 @@ stopButtonElem.addEventListener('click', () => {
   stopRequested = true;
 });
 
-if (powerPreference) {
-  setDefaultRequestAdapterOptions({ powerPreference: powerPreference as GPUPowerPreference });
+if (powerPreference || compatibility) {
+  setDefaultRequestAdapterOptions({
+    powerPreference,
+    // MAINTENANCE_TODO: Change this to whatever the option ends up being
+    ...(compatibility && { compatibilityMode: true }),
+  });
 }
 
 dataCache.setStore({
@@ -538,6 +492,11 @@ function prepareParams(params: Record<string, ParamValue>): string {
   return new URLSearchParams(pairs).toString();
 }
 
+// This is just a cast in one place.
+export function optionsToRecord(options: CTSOptions) {
+  return (options as unknown) as Record<string, boolean | string>;
+}
+
 /**
  * Given a search query, generates a search parameter string
  * @param queries array of queries
@@ -554,10 +513,6 @@ void (async () => {
   const loader = new DefaultTestFileLoader();
 
   // MAINTENANCE_TODO: start populating page before waiting for everything to load?
-  const qs = new URLSearchParams(window.location.search).getAll('q');
-  if (qs.length === 0) {
-    qs.push(rootQuerySpec);
-  }
   isFullCTS = qs.length === 1 && qs[0] === rootQuerySpec;
 
   // Update the URL bar to match the exact current options.
@@ -573,7 +528,10 @@ void (async () => {
     });
   };
 
-  const addOptionsToPage = (options: StandaloneOptions, optionsInfos: StandaloneOptionsInfos) => {
+  const addOptionsToPage = (
+    options: StandaloneOptions,
+    optionsInfos: typeof kStandaloneOptionsInfos
+  ) => {
     const optionsElem = $('table#options>tbody')[0];
     const optionValues = optionsToRecord(options);
 
@@ -587,7 +545,7 @@ void (async () => {
         });
     };
 
-    const createSelect = (optionName: string, info: StandaloneOptionInfo) => {
+    const createSelect = (optionName: string, info: OptionInfo) => {
       const select = $('<select>').on('change', function () {
         optionValues[optionName] = (this as HTMLInputElement).value;
         updateURLsWithCurrentOptions();
@@ -615,7 +573,7 @@ void (async () => {
         .appendTo(optionsElem);
     }
   };
-  addOptionsToPage(options, optionsInfo);
+  addOptionsToPage(options, kStandaloneOptionsInfos);
 
   assert(qs.length === 1, 'currently, there must be exactly one ?q=');
   const rootQuery = parseQuery(qs[0]);

--- a/src/common/util/navigator_gpu.ts
+++ b/src/common/util/navigator_gpu.ts
@@ -1,6 +1,7 @@
 /// <reference types="@webgpu/types" />
 
 import { TestCaseRecorder } from '../framework/fixture.js';
+
 import { ErrorWithExtra, assert, objectEquals } from './util.js';
 
 /**

--- a/src/common/util/navigator_gpu.ts
+++ b/src/common/util/navigator_gpu.ts
@@ -1,8 +1,7 @@
 /// <reference types="@webgpu/types" />
 
 import { TestCaseRecorder } from '../framework/fixture.js';
-
-import { ErrorWithExtra, assert } from './util.js';
+import { ErrorWithExtra, assert, objectEquals } from './util.js';
 
 /**
  * Finds and returns the `navigator.gpu` object (or equivalent, for non-browser implementations).
@@ -37,6 +36,10 @@ let impl: GPU | undefined = undefined;
 let defaultRequestAdapterOptions: GPURequestAdapterOptions | undefined;
 
 export function setDefaultRequestAdapterOptions(options: GPURequestAdapterOptions) {
+  // It's okay to call this if you don't change the options
+  if (objectEquals(options, defaultRequestAdapterOptions)) {
+    return;
+  }
   if (impl) {
     throw new Error('must call setDefaultRequestAdapterOptions before getGPU');
   }


### PR DESCRIPTION
This adds `compatibility=1` as an option.

It also tries to put some amount of option parsing in a shared place.
I didn't touch cmdline.js yet. I looked into it but there's disagreement
on the correct approach.

Is it is, running `q=compat:*` will fail. You must pass `q=compat:*&compatibility=1` where `compat:*` chooses which tests to run and `compatibility=1` makes the CTS as for a compat mode adapter.

I could hack something like "if (suite === 'compat') { enable compat }" but it seemed ... hacky and I didn't see a good way for tests to ask for adapters using the given test classes.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
