### PR TITLE
Disable test if compat

### DIFF
--- a/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
@@ -267,6 +267,10 @@ class F extends TextureTestMixin(GPUTest) {
 
   async init() {
     await super.init();
+    if (this.isCompatibility) {
+      this.skip('WGSL sample_mask is not supported in compatibility mode');
+      return;
+    }
     // Create a 2x2 color texture to sample from
     // texel 0 - Red
     // texel 1 - Green

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -7,6 +7,7 @@ import {
   TestCaseRecorder,
   TestParams,
 } from '../common/framework/fixture.js';
+import { globalTestConfig } from '../common/framework/test_config.js';
 import {
   assert,
   range,
@@ -207,6 +208,10 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
   /** GPUQueue for the test to use. (Same as `t.device.queue`.) */
   get queue(): GPUQueue {
     return this.device.queue;
+  }
+
+  get isCompatibility() {
+    return globalTestConfig.compatibility;
   }
 
   /** Snapshot a GPUBuffer's contents, returning a new GPUBuffer with the `MAP_READ` usage. */


### PR DESCRIPTION
Here's a test that is skipped if compat. It's dependant on https://github.com/gpuweb/cts/pull/2757


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
