### PR TITLE
Add VideoFrame tests for copyExternalImageToTexture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "0.1.32",
+        "@webgpu/types": "gpuweb/types#ecce0c39ff3cd735612c30ad71b346a577263cfb",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1263,9 +1263,10 @@
     },
     "node_modules/@webgpu/types": {
       "version": "0.1.32",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.32.tgz",
-      "integrity": "sha512-H6JRAvRonWxqREjxXMZgQmdgIFPe6mykLgdrHY7EQE7YihMKd/SjtSGilUmMKECVdUMg2IQB9vzaXDiTj1AxZg==",
-      "dev": true
+      "resolved": "git+ssh://git@github.com/gpuweb/types.git#ecce0c39ff3cd735612c30ad71b346a577263cfb",
+      "integrity": "sha512-t3GASruyOksOhCvPqjDDKH4806EpdANF09qRML7hd5C5dw8x6fPoxBBTgm6lxnSiopTjdMSkBEkSJRMtdc4OHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -9883,10 +9884,10 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.32",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.32.tgz",
-      "integrity": "sha512-H6JRAvRonWxqREjxXMZgQmdgIFPe6mykLgdrHY7EQE7YihMKd/SjtSGilUmMKECVdUMg2IQB9vzaXDiTj1AxZg==",
-      "dev": true
+      "version": "git+ssh://git@github.com/gpuweb/types.git#ecce0c39ff3cd735612c30ad71b346a577263cfb",
+      "integrity": "sha512-t3GASruyOksOhCvPqjDDKH4806EpdANF09qRML7hd5C5dw8x6fPoxBBTgm6lxnSiopTjdMSkBEkSJRMtdc4OHQ==",
+      "dev": true,
+      "from": "@webgpu/types@gpuweb/types#ecce0c39ff3cd735612c30ad71b346a577263cfb"
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "0.1.32",
+    "@webgpu/types": "gpuweb/types#ecce0c39ff3cd735612c30ad71b346a577263cfb",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/web_platform/copyToTexture/video.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/video.spec.ts
@@ -55,18 +55,17 @@ It creates HTMLVideoElement with videos under Resource folder.
     const videoElement = getVideoElement(t, videoName);
 
     await startPlayingAndWaitForVideo(videoElement, async () => {
-      const source =
-        sourceType === 'VideoFrame'
-          ? await getVideoFrameFromVideoElement(t, videoElement)
-          : videoElement;
-      const width =
-        sourceType === 'VideoFrame'
-          ? (source as VideoFrame).codedWidth
-          : (source as HTMLVideoElement).videoWidth;
-      const height =
-        sourceType === 'VideoFrame'
-          ? (source as VideoFrame).codedHeight
-          : (source as HTMLVideoElement).videoHeight;
+      let source, width, height;
+      if (sourceType === 'VideoFrame') {
+        source = await getVideoFrameFromVideoElement(t, videoElement);
+        width = source.codedWidth;
+        height = source.codedHeight;
+      } else {
+        source = videoElement;
+        width = source.videoWidth;
+        height = source.videoHeight;
+      }
+
       const dstTexture = t.device.createTexture({
         format: kFormat,
         size: { width, height, depthOrArrayLayers: 1 },
@@ -113,6 +112,8 @@ It creates HTMLVideoElement with videos under Resource folder.
         ]);
       }
 
-      if (sourceType === 'VideoFrame') (source as VideoFrame).close();
+      if (source instanceof VideoFrame) {
+        source.close();
+      }
     });
   });


### PR DESCRIPTION
Here's a screenshot of tests passing of a Chromium build with the appropriate patch:
![image](https://github.com/gpuweb/cts/assets/634478/b5663d2b-078e-44b2-af9c-61b29b41d88d)


Issue: https://github.com/gpuweb/gpuweb/pull/4178/

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
