### PR TITLE
Uniformity validation tests for function variable values

### DIFF
--- a/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
+++ b/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
@@ -557,6 +557,16 @@ const kFuncVarCases = {
     cond: `x > 0`,
     uniform: `never`,
   },
+  if_nonescaping_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      x = nonuniform_value[0];
+      return;
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
   loop_body_depends_on_continuing_uniform: {
     typename: `u32`,
     typedecl: ``,

--- a/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
+++ b/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
@@ -1,6 +1,7 @@
 export const description = `Validation tests for uniformity analysis`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { unreachable } from '../../../../common/util/util.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
@@ -353,4 +354,901 @@ fn main(@builtin(${t.params.builtin}) p : ${t.params.type}) {
 `;
 
     t.expectCompileResult(t.params.uniform, code);
+  });
+
+function expectedUniformity(uniform: string, init: string): boolean {
+  switch (uniform) {
+    case `always`: {
+      return true;
+    }
+    case `never`: {
+      return false;
+    }
+    case `init`: {
+      switch (init) {
+        case `none`:
+        case `uniform`: {
+          return true;
+        }
+        case `nonuniform`: {
+          return false;
+        }
+        default: {
+          break;
+        }
+      }
+      unreachable(`Unhandled init`);
+      break;
+    }
+    default: {
+      unreachable(`Unhandled uniform`);
+    }
+  }
+}
+
+function generateFunctionVarInit(init: string): string {
+  switch (init) {
+    case `none`: {
+      return ``;
+    }
+    case `uniform`: {
+      return `= uniform_value[3]`;
+    }
+    case `nonuniform`: {
+      return `= nonuniform_value[3]`;
+    }
+    default: {
+      unreachable(`Unhandled init`);
+    }
+  }
+}
+
+const kFuncVarCases = {
+  no_assign: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: ``,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  simple_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `x = uniform_value[0];`,
+    cond: `x > 0`,
+    uniform: `always`,
+  },
+  simple_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `x = nonuniform_value[0];`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  compound_assign_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `x += uniform_value[0];`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  compound_assign_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `x -= nonuniform_value[0];`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  unreachable_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      break;
+      x = uniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  unreachable_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      break;
+      x = nonuniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  if_no_else_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      x = uniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  if_no_else_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      x = nonuniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  if_no_then_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+    } else {
+      x = uniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  if_no_then_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+    } else {
+      x = nonuniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  if_else_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      x = uniform_value[0];
+    } else {
+      x = uniform_value[1];
+    }`,
+    cond: `x > 0`,
+    uniform: `always`,
+  },
+  if_else_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      x = nonuniform_value[0];
+    } else {
+      x = nonuniform_value[1];
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  if_else_split: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      x = uniform_value[0];
+    } else {
+      x = nonuniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  if_unreachable_else_none: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+    } else {
+      return;
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  if_unreachable_else_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      x = uniform_value[0];
+    } else {
+      return;
+    }`,
+    cond: `x > 0`,
+    uniform: `always`,
+  },
+  if_unreachable_else_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      x = nonuniform_value[0];
+    } else {
+      return;
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  if_unreachable_then_none: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      return;
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  if_unreachable_then_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      return;
+    } else {
+      x = uniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `always`,
+  },
+  if_unreachable_then_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `if uniform_cond {
+      return;
+    } else {
+      x = nonuniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  loop_body_depends_on_continuing_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if x > 0 {
+        let tmp = textureSample(t, s, vec2f(0,0));
+      }
+      continuing {
+        x = uniform_value[0];
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `init`,
+  },
+  loop_body_depends_on_continuing_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if x > 0 {
+        let tmp = textureSample(t, s, vec2f(0,0));
+      }
+      continuing {
+        x = nonuniform_value[0];
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `never`,
+  },
+  loop_body_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      x = uniform_value[0];
+      continuing {
+        break if uniform_cond;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `always`,
+  },
+  loop_body_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      x = nonuniform_value[0];
+      continuing {
+        break if uniform_cond;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  loop_body_nonuniform_cond: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      // The analysis doesn't recognize the content of the value.
+      x = uniform_value[0];
+      continuing {
+        break if nonuniform_cond;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  loop_unreachable_continuing: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      break;
+      continuing {
+        break if uniform_cond;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  loop_continuing_from_body_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      x = uniform_value[0];
+      continuing  {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `always`,
+  },
+  loop_continuing_from_body_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      x = nonuniform_value[0];
+      continuing  {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `never`,
+  },
+  loop_continuing_from_body_split1: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if uniform_cond {
+        x = uniform_value[0];
+      }
+      continuing {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `init`,
+  },
+  loop_continuing_from_body_split2: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if uniform_cond {
+        x = nonuniform_value[0];
+      }
+      continuing {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `never`,
+  },
+  loop_continuing_from_body_split3: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if uniform_cond {
+        x = uniform_value[0];
+      } else {
+        x = uniform_value[1];
+      }
+      continuing {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `always`,
+  },
+  loop_continuing_from_body_split4: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if nonuniform_cond {
+        x = uniform_value[0];
+      } else {
+        x = uniform_value[1];
+      }
+      continuing {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `never`,
+  },
+  loop_continuing_from_body_split5: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if nonuniform_cond {
+        x = uniform_value[0];
+      } else {
+        x = uniform_value[0];
+      }
+      continuing {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    // The analysis doesn't recognize that uniform_value[0] is assignment on all paths.
+    uniform: `never`,
+  },
+  loop_in_loop_with_continue_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      loop {
+        x = nonuniform_value[0];
+        if nonuniform_cond {
+          break;
+        }
+        continue;
+      }
+      x = uniform_value[0];
+      continuing {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `always`,
+  },
+  loop_in_loop_with_continue_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      loop {
+        x = uniform_value[0];
+        if uniform_cond {
+          break;
+        }
+        continue;
+      }
+      x = nonuniform_value[0];
+      continuing {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+        break if uniform_cond;
+      }
+    }`,
+    cond: `true`, // override the standard check
+    uniform: `never`,
+  },
+  after_loop_with_uniform_break_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if uniform_cond {
+        x = uniform_value[0];
+        break;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `always`,
+  },
+  after_loop_with_uniform_break_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if uniform_cond {
+        x = nonuniform_value[0];
+        break;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  after_loop_with_nonuniform_break: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if nonuniform_cond {
+        x = uniform_value[0];
+        break;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  after_loop_with_uniform_breaks: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `loop {
+      if uniform_cond {
+        x = uniform_value[0];
+        break;
+      } else {
+        break;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  switch_uniform_case: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `switch uniform_val {
+      case 0 {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+      }
+      default {
+      }
+    }`,
+    cond: `true`, // override default check
+    uniform: `init`,
+  },
+  switch_nonuniform_case: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `switch nonuniform_val {
+      case 0 {
+        if x > 0 {
+          let tmp = textureSample(t, s, vec2f(0,0));
+        }
+      }
+      default {
+      }
+    }`,
+    cond: `true`, // override default check
+    uniform: `never`,
+  },
+  after_switch_all_uniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `switch uniform_val {
+      case 0 {
+        x = uniform_value[0];
+      }
+      case 1,2 {
+        x = uniform_value[1];
+      }
+      default {
+        x = uniform_value[2];
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `always`,
+  },
+  after_switch_some_assign: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `switch uniform_val {
+      case 0 {
+        x = uniform_value[0];
+      }
+      case 1,2 {
+        x = uniform_value[1];
+      }
+      default {
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  after_switch_nonuniform: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `switch uniform_val {
+      case 0 {
+        x = uniform_value[0];
+      }
+      case 1,2 {
+        x = uniform_value[1];
+      }
+      default {
+        x = nonuniform_value[0];
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  after_switch_with_break_nonuniform1: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `switch uniform_val {
+      default {
+        if uniform_cond {
+          x = uniform_value[0];
+          break;
+        }
+        x = nonuniform_value[0];
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  after_switch_with_break_nonuniform2: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `switch uniform_val {
+      default {
+        x = uniform_value[0];
+        if uniform_cond {
+          x = nonuniform_value[0];
+          break;
+        }
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  for_loop_uniform_body: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `for (var i = 0; i < 10; i += 1) {
+      x = uniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  for_loop_nonuniform_body: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `for (var i = 0; i < 10; i += 1) {
+      x = nonuniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  for_loop_uniform_body_no_condition: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `for (var i = 0; ; i += 1) {
+      x = uniform_value[0];
+      if uniform_cond {
+        break;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `always`,
+  },
+  for_loop_nonuniform_body_no_condition: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `for (var i = 0; ; i += 1) {
+      x = nonuniform_value[0];
+      if uniform_cond {
+        break;
+      }
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  for_loop_uniform_increment: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `for (; uniform_cond; x += uniform_value[0]) {
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  for_loop_nonuniform_increment: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `for (; uniform_cond; x += nonuniform_value[0]) {
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  for_loop_uniform_init: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `for (x = uniform_value[0]; uniform_cond; ) {
+    }`,
+    cond: `x > 0`,
+    uniform: `always`,
+  },
+  for_loop_nonuniform_init: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `for (x = nonuniform_value[0]; uniform_cond;) {
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  while_loop_uniform_body: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `while uniform_cond {
+      x = uniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `init`,
+  },
+  while_loop_nonuniform_body: {
+    typename: `u32`,
+    typedecl: ``,
+    assignment: `while uniform_cond {
+      x = nonuniform_value[0];
+    }`,
+    cond: `x > 0`,
+    uniform: `never`,
+  },
+  partial_assignment_uniform: {
+    typename: `block`,
+    typedecl: `struct block {
+      x : u32,
+      y : u32
+    }`,
+    assignment: `x.x = uniform_value[0].x;`,
+    cond: `x.x > 0`,
+    uniform: `init`,
+  },
+  partial_assignment_nonuniform: {
+    typename: `block`,
+    typedecl: `struct block {
+      x : u32,
+      y : u32
+    }`,
+    assignment: `x.x = nonuniform_value[0].x;`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
+  partial_assignment_all_members_uniform: {
+    typename: `block`,
+    typedecl: `struct block {
+      x : u32,
+      y : u32
+    }`,
+    assignment: `x.x = uniform_value[0].x;
+    x.y = uniform_value[1].y;`,
+    cond: `x.x > 0`,
+    uniform: `init`,
+  },
+  partial_assignment_all_members_nonuniform: {
+    typename: `block`,
+    typedecl: `struct block {
+      x : u32,
+      y : u32
+    }`,
+    assignment: `x.x = nonuniform_value[0].x;
+    x.y = uniform_value[0].x;`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
+  partial_assignment_single_element_struct_uniform: {
+    typename: `block`,
+    typedecl: `struct block {
+      x : u32
+    }`,
+    assignment: `x.x = uniform_value[0].x;`,
+    cond: `x.x > 0`,
+    uniform: `init`,
+  },
+  partial_assignment_single_element_struct_nonuniform: {
+    typename: `block`,
+    typedecl: `struct block {
+      x : u32
+    }`,
+    assignment: `x.x = nonuniform_value[0].x;`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
+  partial_assignment_single_element_array_uniform: {
+    typename: `array<u32, 1>`,
+    typedecl: ``,
+    assignment: `x[0] = uniform_value[0][0];`,
+    cond: `x[0] > 0`,
+    uniform: `init`,
+  },
+  partial_assignment_single_element_array_nonuniform: {
+    typename: `array<u32, 1>`,
+    typedecl: ``,
+    assignment: `x[0] = nonuniform_value[0][0];`,
+    cond: `x[0] > 0`,
+    uniform: `never`,
+  },
+  nested1: {
+    typename: `block`,
+    typedecl: `struct block {
+      x : u32,
+      y : u32
+    }`,
+    assignment: `for (; uniform_cond; ) {
+      if uniform_cond {
+        x = uniform_value[0];
+        break;
+        x.y = nonuniform_value[0].y;
+      } else {
+        if uniform_cond {
+          continue;
+        }
+        x = uniform_value[1];
+      }
+    }`,
+    cond: `x.x > 0`,
+    uniform: `init`,
+  },
+  nested2: {
+    typename: `block`,
+    typedecl: `struct block {
+      x : u32,
+      y : u32
+    }`,
+    assignment: `for (; uniform_cond; ) {
+      if uniform_cond {
+        x = uniform_value[0];
+        break;
+        x.y = nonuniform_value[0].y;
+      } else {
+        if nonuniform_cond {
+          continue;
+        }
+        x = uniform_value[1];
+      }
+    }`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
+};
+
+g.test('function_variables')
+  .desc(`Test uniformity of function variables`)
+  .params(u =>
+    u
+      .combine('case', keysOf(kFuncVarCases))
+      .combine('init', ['none', 'uniform', 'nonuniform'] as const)
+  )
+  .fn(t => {
+    const code = `
+${kFuncVarCases[t.params.case].typedecl}
+
+@group(0) @binding(0)
+var<storage> uniform_value : array<${kFuncVarCases[t.params.case].typename}, 4>;
+@group(0) @binding(1)
+var<storage, read_write> nonuniform_value : array<${kFuncVarCases[t.params.case].typename}, 4>;
+
+@group(1) @binding(0)
+var t : texture_2d<f32>;
+@group(1) @binding(1)
+var s : sampler;
+
+var<private> nonuniform_cond : bool = true;
+const uniform_cond : bool = true;
+var<private> nonuniform_val : u32 = 0;
+const uniform_val : u32 = 0;
+
+@fragment
+fn main() {
+  var x : ${kFuncVarCases[t.params.case].typename} ${generateFunctionVarInit(t.params.init)};
+
+  ${kFuncVarCases[t.params.case].assignment}
+
+  if ${kFuncVarCases[t.params.case].cond} {
+    let tmp = textureSample(t, s, vec2f(0,0));
+  }
+}
+`;
+
+    const result = expectedUniformity(kFuncVarCases[t.params.case].uniform, t.params.init);
+    if (!result) {
+      t.expectCompileResult(true, `diagnostic(off, derivative_uniformity);\n` + code);
+    }
+    t.expectCompileResult(result, code);
   });


### PR DESCRIPTION
* Add validation tests to cover Function-scope Variable Value Analysis
* Pointers are deferred to a subsequent set of tests (i.e. not let decls of pointers)




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
