### PR TITLE
Update `unpack2x16snorm` acceptance intervals

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -4303,23 +4303,57 @@ interface ScalarToVectorCase {
   expected: (number | IntervalBounds)[];
 }
 
-// Scope for unpack* tests so that they can have constants for magic numbers
-// that don't pollute the global namespace or have unwieldy long names.
+g.test('unpack2x16floatInterval')
+  .paramsSubcasesOnly<ScalarToVectorCase>(
+    // prettier-ignore
+    [
+      // f16 normals
+      { input: 0x00000000, expected: [0, 0] },
+      { input: 0x80000000, expected: [0, 0] },
+      { input: 0x00008000, expected: [0, 0] },
+      { input: 0x80008000, expected: [0, 0] },
+      { input: 0x00003c00, expected: [1, 0] },
+      { input: 0x3c000000, expected: [0, 1] },
+      { input: 0x3c003c00, expected: [1, 1] },
+      { input: 0xbc00bc00, expected: [-1, -1] },
+      { input: 0x49004900, expected: [10, 10] },
+      { input: 0xc900c900, expected: [-10, -10] },
+
+      // f16 subnormals
+      { input: 0x000003ff, expected: [[0, kValue.f16.subnormal.positive.max], 0] },
+      { input: 0x000083ff, expected: [[kValue.f16.subnormal.negative.min, 0], 0] },
+
+      // f16 out of bounds
+      { input: 0x7c000000, expected: [kAnyBounds, kAnyBounds] },
+      { input: 0xffff0000, expected: [kAnyBounds, kAnyBounds] },
+    ]
+  )
+  .fn(t => {
+    const expected = FP.f32.toVector(t.params.expected);
+    const got = FP.f32.unpack2x16floatInterval(t.params.input);
+    t.expect(
+      objectEquals(expected, got),
+      `unpack2x16floatInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
+    );
+  });
+
+// Scope for unpack2x16snormInterval tests so that they can have constants for
+// magic numbers that don't pollute the global namespace or have unwieldy long
+// names.
+//
+// unpack2x16snormInterval has a seperate scope from below, because its accuracy
+// is currently different.
 {
   const kZeroBounds: IntervalBounds = [
-    reinterpretU32AsF32(0x81200000),
-    reinterpretU32AsF32(0x01200000),
+    reinterpretU32AsF32(0x81400000),
+    reinterpretU32AsF32(0x01400000),
   ];
   const kOneBoundsSnorm: IntervalBounds = [
     reinterpretU64AsF64(0x3fef_ffff_a000_0000n),
-    reinterpretU64AsF64(0x3ff0_0000_4000_0000n),
-  ];
-  const kOneBoundsUnorm: IntervalBounds = [
-    reinterpretU64AsF64(0x3fef_ffff_b000_0000n),
-    reinterpretU64AsF64(0x3ff0_0000_2800_0000n),
+    reinterpretU64AsF64(0x3ff0_0000_3000_0000n),
   ];
   const kNegOneBoundsSnorm: IntervalBounds = [
-    reinterpretU64AsF64(0xbff0_0000_0000_0000n),
+    reinterpretU64AsF64(0xbff0_0000_3000_0000n),
     reinterpretU64AsF64(0xbfef_ffff_a000_0000n),
   ];
 
@@ -4353,41 +4387,27 @@ interface ScalarToVectorCase {
         `unpack2x16snormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
       );
     });
+}
 
-  g.test('unpack2x16floatInterval')
-    .paramsSubcasesOnly<ScalarToVectorCase>(
-      // prettier-ignore
-      [
-        // f16 normals
-        { input: 0x00000000, expected: [0, 0] },
-        { input: 0x80000000, expected: [0, 0] },
-        { input: 0x00008000, expected: [0, 0] },
-        { input: 0x80008000, expected: [0, 0] },
-        { input: 0x00003c00, expected: [1, 0] },
-        { input: 0x3c000000, expected: [0, 1] },
-        { input: 0x3c003c00, expected: [1, 1] },
-        { input: 0xbc00bc00, expected: [-1, -1] },
-        { input: 0x49004900, expected: [10, 10] },
-        { input: 0xc900c900, expected: [-10, -10] },
-
-        // f16 subnormals
-        { input: 0x000003ff, expected: [[0, kValue.f16.subnormal.positive.max], 0] },
-        { input: 0x000083ff, expected: [[kValue.f16.subnormal.negative.min, 0], 0] },
-
-        // f16 out of bounds
-        { input: 0x7c000000, expected: [kAnyBounds, kAnyBounds] },
-        { input: 0xffff0000, expected: [kAnyBounds, kAnyBounds] },
-      ]
-    )
-    .fn(t => {
-      const expected = FP.f32.toVector(t.params.expected);
-      const got = FP.f32.unpack2x16floatInterval(t.params.input);
-      t.expect(
-        objectEquals(expected, got),
-        `unpack2x16floatInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
-      );
-    });
-
+// Scope for remaining unpack* tests so that they can have constants for magic
+// numbers that don't pollute the global namespace or have unwieldy long names.
+{
+  const kZeroBounds: IntervalBounds = [
+    reinterpretU32AsF32(0x81200000),
+    reinterpretU32AsF32(0x01200000),
+  ];
+  const kOneBoundsSnorm: IntervalBounds = [
+    reinterpretU64AsF64(0x3fef_ffff_a000_0000n),
+    reinterpretU64AsF64(0x3ff0_0000_4000_0000n),
+  ];
+  const kOneBoundsUnorm: IntervalBounds = [
+    reinterpretU64AsF64(0x3fef_ffff_b000_0000n),
+    reinterpretU64AsF64(0x3ff0_0000_2800_0000n),
+  ];
+  const kNegOneBoundsSnorm: IntervalBounds = [
+    reinterpretU64AsF64(0xbff0_0000_0000_0000n),
+    reinterpretU64AsF64(0xbfef_ffff_a000_0000n),
+  ];
   const kHalfBounds2x16unorm: IntervalBounds = [
     reinterpretU64AsF64(0x3fe0_000f_b000_0000n),
     reinterpretU64AsF64(0x3fe0_0010_7000_0000n),
@@ -4436,9 +4456,18 @@ interface ScalarToVectorCase {
         { input: 0x7f007f00, expected: [kZeroBounds, kOneBoundsSnorm, kZeroBounds, kOneBoundsSnorm] },
         { input: 0x007f007f, expected: [kOneBoundsSnorm, kZeroBounds, kOneBoundsSnorm, kZeroBounds] },
         { input: 0x7f7f7f7f, expected: [kOneBoundsSnorm, kOneBoundsSnorm, kOneBoundsSnorm, kOneBoundsSnorm] },
-        { input: 0x81818181, expected: [kNegOneBoundsSnorm, kNegOneBoundsSnorm, kNegOneBoundsSnorm, kNegOneBoundsSnorm] },
-        { input: 0x40404040, expected: [kHalfBounds4x8snorm, kHalfBounds4x8snorm, kHalfBounds4x8snorm, kHalfBounds4x8snorm] },
-        { input: 0xc1c1c1c1, expected: [kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm] },
+        {
+          input: 0x81818181,
+          expected: [kNegOneBoundsSnorm, kNegOneBoundsSnorm, kNegOneBoundsSnorm, kNegOneBoundsSnorm]
+        },
+        {
+          input: 0x40404040,
+          expected: [kHalfBounds4x8snorm, kHalfBounds4x8snorm, kHalfBounds4x8snorm, kHalfBounds4x8snorm]
+        },
+        {
+          input: 0xc1c1c1c1,
+          expected: [kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm]
+        },
       ]
     )
     .fn(t => {
@@ -4469,7 +4498,10 @@ interface ScalarToVectorCase {
         { input: 0xff00ff00, expected: [kZeroBounds, kOneBoundsUnorm, kZeroBounds, kOneBoundsUnorm] },
         { input: 0x00ff00ff, expected: [kOneBoundsUnorm, kZeroBounds, kOneBoundsUnorm, kZeroBounds] },
         { input: 0xffffffff, expected: [kOneBoundsUnorm, kOneBoundsUnorm, kOneBoundsUnorm, kOneBoundsUnorm] },
-        { input: 0x80808080, expected: [kHalfBounds4x8unorm, kHalfBounds4x8unorm, kHalfBounds4x8unorm, kHalfBounds4x8unorm] },
+        {
+          input: 0x80808080,
+          expected: [kHalfBounds4x8unorm, kHalfBounds4x8unorm, kHalfBounds4x8unorm, kHalfBounds4x8unorm]
+        },
       ]
     )
     .fn(t => {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -4388,7 +4388,7 @@ class F32Traits extends FPTraits {
       'unpack2x16snormInterval only accepts values on the bounds of u32'
     );
     const op = (n: number): FPInterval => {
-      return this.maxInterval(this.divisionInterval(n, 32767), -1);
+      return this.ulpInterval(Math.max(n / 32767, -1), 3);
     };
 
     this.unpackDataU32[0] = n;


### PR DESCRIPTION
This has changed to 3 ULP

Fixes #2451

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
