### PR TITLE
Update acceptance intervals for unpack* to 'correctly rounded'

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -4478,26 +4478,14 @@ g.test('unpack2x16floatInterval')
 // Scope for remaining unpack* tests so that they can have constants for magic
 // numbers that don't pollute the global namespace or have unwieldy long names.
 {
-  const kZeroBounds: IntervalBounds = [
-    reinterpretU32AsF32(0x81200000),
-    reinterpretU32AsF32(0x01200000),
-  ];
-  const kOneBoundsSnorm: IntervalBounds = [
-    reinterpretU64AsF64(0x3fef_ffff_a000_0000n),
-    reinterpretU64AsF64(0x3ff0_0000_4000_0000n),
-  ];
-  const kOneBoundsUnorm: IntervalBounds = [
-    reinterpretU64AsF64(0x3fef_ffff_b000_0000n),
-    reinterpretU64AsF64(0x3ff0_0000_2800_0000n),
-  ];
-  const kNegOneBoundsSnorm: IntervalBounds = [
-    reinterpretU64AsF64(0xbff0_0000_0000_0000n),
-    reinterpretU64AsF64(0xbfef_ffff_a000_0000n),
-  ];
+  const kZeroBounds: IntervalBounds = [0.0];
+  const kOneBoundsSnorm: IntervalBounds = [1.0];
+  const kOneBoundsUnorm: IntervalBounds = [1.0];
+  const kNegOneBoundsSnorm: IntervalBounds = [-1.0];
   const kHalfBounds2x16unorm: IntervalBounds = [
-    reinterpretU64AsF64(0x3fe0_000f_b000_0000n),
-    reinterpretU64AsF64(0x3fe0_0010_7000_0000n),
-  ]; // ~0.5..., due to lack of precision in u16
+    reinterpretU32AsF32(0x3f000080),
+    reinterpretU32AsF32(0x3f000081),
+  ]; // ~0.5..., due to the lack of accuracy in u16
 
   g.test('unpack2x16unormInterval')
     .paramsSubcasesOnly<ScalarToVectorCase>(
@@ -4515,17 +4503,17 @@ g.test('unpack2x16floatInterval')
       const got = FP.f32.unpack2x16unormInterval(t.params.input);
       t.expect(
         objectEquals(expected, got),
-        `unpack2x16unormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
+        `unpack2x16unormInterval(${t.params.input})\n\tReturned [${got}]\n\tExpected [${expected}]`
       );
     });
 
   const kHalfBounds4x8snorm: IntervalBounds = [
-    reinterpretU64AsF64(0x3fe0_2040_2000_0000n),
-    reinterpretU64AsF64(0x3fe0_2041_0000_0000n),
+    reinterpretU32AsF32(0x3f010204),
+    reinterpretU32AsF32(0x3f010205),
   ]; // ~0.50196..., due to lack of precision in i8
   const kNegHalfBounds4x8snorm: IntervalBounds = [
-    reinterpretU64AsF64(0xbfdf_bf7f_6000_0000n),
-    reinterpretU64AsF64(0xbfdf_bf7e_8000_0000n),
+    reinterpretU32AsF32(0xbefdfbf8),
+    reinterpretU32AsF32(0xbefdfbf7),
   ]; // ~-0.49606..., due to lack of precision in i8
 
   g.test('unpack4x8snormInterval')
@@ -4561,13 +4549,13 @@ g.test('unpack2x16floatInterval')
       const got = FP.f32.unpack4x8snormInterval(t.params.input);
       t.expect(
         objectEquals(expected, got),
-        `unpack4x8snormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
+        `unpack4x8snormInterval(${t.params.input})\n\tReturned [${got}]\n\tExpected [${expected}]`
       );
     });
 
   const kHalfBounds4x8unorm: IntervalBounds = [
-    reinterpretU64AsF64(0x3fe0_100f_b000_0000n),
-    reinterpretU64AsF64(0x3fe0_1010_7000_0000n),
+    reinterpretU32AsF32(0x3f008080),
+    reinterpretU32AsF32(0x3f008081),
   ]; // ~0.50196..., due to lack of precision in u8
 
   g.test('unpack4x8unormInterval')
@@ -4595,7 +4583,7 @@ g.test('unpack2x16floatInterval')
       const got = FP.f32.unpack4x8unormInterval(t.params.input);
       t.expect(
         objectEquals(expected, got),
-        `unpack4x8unormInterval(${t.params.input}) returned [${got}]. Expected [${expected}]`
+        `unpack4x8unormInterval(${t.params.input})\n\tReturned [${got}]\n\tExpected [${expected}]`
       );
     });
 }

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -4410,7 +4410,7 @@ class F32Traits extends FPTraits {
       'unpack2x16unormInterval only accepts values on the bounds of u32'
     );
     const op = (n: number): FPInterval => {
-      return this.divisionInterval(n, 65535);
+      return this.correctlyRoundedInterval(n / 65535);
     };
 
     this.unpackDataU32[0] = n;
@@ -4426,7 +4426,7 @@ class F32Traits extends FPTraits {
       'unpack4x8snormInterval only accepts values on the bounds of u32'
     );
     const op = (n: number): FPInterval => {
-      return this.maxInterval(this.divisionInterval(n, 127), -1);
+      return this.correctlyRoundedInterval(Math.max(n / 127, -1));
     };
     this.unpackDataU32[0] = n;
     return [
@@ -4446,7 +4446,7 @@ class F32Traits extends FPTraits {
       'unpack4x8unormInterval only accepts values on the bounds of u32'
     );
     const op = (n: number): FPInterval => {
-      return this.divisionInterval(n, 255);
+      return this.correctlyRoundedInterval(n / 255);
     };
 
     this.unpackDataU32[0] = n;


### PR DESCRIPTION
This does not include unpack2x16snorm, which has an error 3 ULP

Fixes https://github.com/gpuweb/cts/issues/2485

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
