### PR TITLE
Update Expiration cts for GPUExternalTexture imported from VideoFrame

### DIFF
--- a/src/webgpu/api/validation/gpu_external_texture_expiration.spec.ts
+++ b/src/webgpu/api/validation/gpu_external_texture_expiration.spec.ts
@@ -232,12 +232,12 @@ g.test('use_import_to_refresh')
     });
 
     await waitForNextTask(() => {
-      const maydBeTheSameExternalTexture = t.device.importExternalTexture({
+      const mayBeTheSameExternalTexture = t.device.importExternalTexture({
         /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
         source: source as any,
       });
 
-      if (externalTexture === maydBeTheSameExternalTexture) {
+      if (externalTexture === mayBeTheSameExternalTexture) {
         // ImportExternalTexture should refresh expired GPUExternalTexture.
         t.submitCommandBuffer(bindGroup, true);
       } else {


### PR DESCRIPTION
According to WebGPU spec, GPUExternalTexture from VideoFrame expires when, and only when, the source VideoFrame is closed (https://www.w3.org/TR/webgpu/#external-texture-creation).

Update related cts to follow the spec




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
