### PR TITLE
Adding 0x80000000/0x8000 cases to `ceil`, `fract`, `floor` & `round`

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -2690,10 +2690,12 @@ const kFloorIntervalCases = {
   f32: [
     { input: 2 ** 30, expected: 2 ** 30 },
     { input: -(2 ** 30), expected: -(2 ** 30) },
+    { input: 0x80000000, expected: 0x80000000 }, // https://github.com/gpuweb/cts/issues/2766
   ],
   f16: [
-    { input: 2 ** 15, expected: 2 ** 15 },
-    { input: -(2 ** 15), expected: -(2 ** 15) },
+    { input: 2 ** 14, expected: 2 ** 14 },
+    { input: -(2 ** 14), expected: -(2 ** 14) },
+    { input: 0x8000, expected: 0x8000 }, // https://github.com/gpuweb/cts/issues/2766
   ],
 } as const;
 
@@ -2766,7 +2768,10 @@ g.test('fractInterval_f32')
       { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
       { input: kValue.f32.negative.min, expected: 0 },
       { input: kValue.f32.negative.max, expected: [kValue.f32.positive.less_than_one, 1.0] },
-    ]
+
+      // https://github.com/gpuweb/cts/issues/2766
+      { input: 0x80000000, expected: 0 },
+]
   )
   .fn(t => {
     const expected = FP.f32.toInterval(t.params.expected);

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -2484,10 +2484,12 @@ const kCeilIntervalCases = {
   f32: [
     { input: 2 ** 30, expected: 2 ** 30 },
     { input: -(2 ** 30), expected: -(2 ** 30) },
+    { input: 0x80000000, expected: 0x80000000 }, // https://github.com/gpuweb/cts/issues/2766
   ],
   f16: [
-    { input: 2 ** 15, expected: 2 ** 15 },
-    { input: -(2 ** 15), expected: -(2 ** 15) },
+    { input: 2 ** 14, expected: 2 ** 14 },
+    { input: -(2 ** 14), expected: -(2 ** 14) },
+    { input: 0x8000, expected: 0x8000 }, // https://github.com/gpuweb/cts/issues/2766
   ],
 } as const;
 
@@ -3015,10 +3017,12 @@ const kRoundIntervalCases = {
   f32: [
     { input: 2 ** 30, expected: 2 ** 30 },
     { input: -(2 ** 30), expected: -(2 ** 30) },
+    { input: 0x80000000, expected: 0x80000000 }, // https://github.com/gpuweb/cts/issues/2766
   ],
   f16: [
-    { input: 2 ** 15, expected: 2 ** 15 },
-    { input: -(2 ** 15), expected: -(2 ** 15) },
+    { input: 2 ** 14, expected: 2 ** 14 },
+    { input: -(2 ** 14), expected: -(2 ** 14) },
+    { input: 0x8000, expected: 0x8000 }, // https://github.com/gpuweb/cts/issues/2766
   ],
 } as const;
 

--- a/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/ceil.spec.ts
@@ -36,6 +36,7 @@ export const d = makeCaseCache('ceil', {
         -1.0,
         -1.1,
         -1.9,
+        0x80000000, // https://github.com/gpuweb/cts/issues/2766
         ...fullF32Range(),
       ],
       'unfiltered',
@@ -57,6 +58,7 @@ export const d = makeCaseCache('ceil', {
         -1.0,
         -1.1,
         -1.9,
+        0x8000, // https://github.com/gpuweb/cts/issues/2766
         ...fullF16Range(),
       ],
       'unfiltered',

--- a/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/floor.spec.ts
@@ -35,6 +35,7 @@ export const d = makeCaseCache('floor', {
         -1.0,
         -1.1,
         -1.9,
+        0x80000000, // https://github.com/gpuweb/cts/issues/2766
         ...fullF32Range(),
       ],
       'unfiltered',
@@ -56,6 +57,7 @@ export const d = makeCaseCache('floor', {
         -1.0,
         -1.1,
         -1.9,
+        0x8000, // https://github.com/gpuweb/cts/issues/2766
         ...fullF16Range(),
       ],
       'unfiltered',

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.spec.ts
@@ -37,6 +37,7 @@ export const d = makeCaseCache('fract', {
         -2, // -2 -> 0
         -1.11, // ~-1.11 -> ~0.89
         -10.0001, // -10.0001 -> ~0.9999
+        0x80000000, // https://github.com/gpuweb/cts/issues/2766
         ...fullF32Range(),
       ],
       'unfiltered',

--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -24,10 +24,24 @@ export const g = makeTestGroup(GPUTest);
 
 export const d = makeCaseCache('round', {
   f32: () => {
-    return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.roundInterval);
+    return FP.f32.generateScalarToIntervalCases(
+      [
+        0x80000000, // https://github.com/gpuweb/cts/issues/2766,
+        ...fullF32Range(),
+      ],
+      'unfiltered',
+      FP.f32.roundInterval
+    );
   },
   f16: () => {
-    return FP.f16.generateScalarToIntervalCases(fullF16Range(), 'unfiltered', FP.f16.roundInterval);
+    return FP.f16.generateScalarToIntervalCases(
+      [
+        0x8000, // https://github.com/gpuweb/cts/issues/2766
+        ...fullF16Range(),
+      ],
+      'unfiltered',
+      FP.f16.roundInterval
+    );
   },
 });
 

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -3270,12 +3270,18 @@ abstract class FPTraits {
       // This is how other shading languages operate and allows for a desirable
       // wrap around in graphics programming.
       const result = this.subtractionInterval(n, this.floorInterval(n));
+      assert(
+        // negative.subnormal.min instead of 0, because FTZ can occur
+        // selectively during the calculation
+        this.toInterval([this.constants().negative.subnormal.min, 1.0]).contains(result),
+        `fract(${n}) interval [${result}] unexpectedly extends beyond [~0.0, 1.0]`
+      );
       if (result.contains(1)) {
         // Very small negative numbers can lead to catastrophic cancellation,
         // thus calculating a fract of 1.0, which is technically not a
         // fractional part, so some implementations clamp the result to next
         // nearest number.
-        return this.spanIntervals(result, this.toInterval(kValue.f32.positive.less_than_one));
+        return this.spanIntervals(result, this.toInterval(this.constants().positive.less_than_one));
       }
       return result;
     },


### PR DESCRIPTION
This should detect if an implementation is doing something like fract(x) = x - floor(i32(x)), or floor(x) = i32(x), etc, which
will fail to conform to the spec.

Fixes #2766

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
