### PR TITLE
Fix throws/rejections of non-Error types, and add lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,9 +17,11 @@
     // Core rules
     "linebreak-style": ["warn", "unix"],
     "no-console": "warn",
+    "no-throw-literal": "warn",
     "no-undef": "off",
     "no-useless-rename": "warn",
     "object-shorthand": "warn",
+    "prefer-promise-reject-errors": "warn",
     "quotes": ["warn", "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
 
     // All test TODOs must be tracked inside file/test descriptions or READMEs.

--- a/src/webgpu/shader/execution/expression/case_cache.ts
+++ b/src/webgpu/shader/execution/expression/case_cache.ts
@@ -1,4 +1,5 @@
 import { Cacheable, dataCache } from '../../../../common/framework/data_cache.js';
+import { unreachable } from '../../../../common/util/util.js';
 import {
   SerializedComparator,
   deserializeComparator,
@@ -113,7 +114,7 @@ export function serializeExpectation(e: Expectation): SerializedExpectation {
   if (isComparator(e)) {
     return { kind: 'comparator', value: serializeComparator(e) };
   }
-  throw `cannot serialize Expectation ${e}`;
+  unreachable(`cannot serialize Expectation ${e}`);
 }
 
 /** deserializeExpectation() converts a SerializedExpectation to a Expectation */

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -140,7 +140,7 @@ export function startPlayingAndWaitForVideo(
             await callback();
             resolve();
           } catch (ex) {
-            reject();
+            reject(ex);
           }
         })();
       if (video.error) {


### PR DESCRIPTION
Throwing non-Error types makes things a bit difficult to debug, because no error stack is captured.

Issue: None

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] ~Tests are properly located in the test tree.~
- [ ] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
