### PR TITLE
Test async pipeline creation before/after device destroy

### DIFF
--- a/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
+++ b/src/webgpu/api/validation/state/device_lost/destroy.spec.ts
@@ -482,18 +482,11 @@ Tests creating compute pipeline asynchronously on destroyed device.
       t.expect(lostInfo.reason === 'destroyed');
     }
 
-    // After device destroy, expect a GPUPipelineError with "validation" reason.
-    t.shouldReject(
-      'GPUPipelineError',
+    // After device destroy, creation should still resolve successfully.
+    t.shouldResolve(
       (async () => {
-        try {
-          await fn();
-        } catch (ex) {
-          if (ex instanceof GPUPipelineError) {
-            t.expect(ex.reason === 'validation');
-          }
-          throw ex;
-        }
+        const pipeline = await fn();
+        t.expect(pipeline instanceof GPUComputePipeline);
       })()
     );
   });
@@ -532,18 +525,11 @@ Tests creating render pipeline asynchronously on destroyed device.
       t.expect(lostInfo.reason === 'destroyed');
     }
 
-    // After device destroy, expect a GPUPipelineError with "validation" reason.
-    t.shouldReject(
-      'GPUPipelineError',
+    // After device destroy, creation should still resolve successfully.
+    t.shouldResolve(
       (async () => {
-        try {
-          await fn();
-        } catch (ex) {
-          if (ex instanceof GPUPipelineError) {
-            t.expect(ex.reason === 'validation');
-          }
-          throw ex;
-        }
+        const pipeline = await fn();
+        t.expect(pipeline instanceof GPURenderPipeline);
       })()
     );
   });


### PR DESCRIPTION
Fixes #2265

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
