### PR TITLE
Add max_ulp entries to constants

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -1589,47 +1589,40 @@ interface limitsBigIntBitsF64Case {
   value: number;
 }
 
-// Have to indirectly reference the test cases, because the testing framework
-// creates case names from the parameters of the case via JSON.stringify.
-// For compatibility reason JSON.stringify does not handle BigInts, so directly
-// referencing the cases will cause a failure when it tries to build the case
-// name from the bits value
-const kF64LimitsEquivalencyCases: limitsBigIntBitsF64Case[] = [
-  { bits: kBit.f64.positive.max, value: kValue.f64.positive.max },
-  { bits: kBit.f64.positive.min, value: kValue.f64.positive.min },
-  { bits: kBit.f64.positive.nearest_max, value: kValue.f64.positive.nearest_max },
-  { bits: kBit.f64.positive.less_than_one, value: kValue.f64.positive.less_than_one },
-  { bits: kBit.f64.positive.pi.whole, value: kValue.f64.positive.pi.whole },
-  { bits: kBit.f64.positive.pi.three_quarters, value: kValue.f64.positive.pi.three_quarters },
-  { bits: kBit.f64.positive.pi.half, value: kValue.f64.positive.pi.half },
-  { bits: kBit.f64.positive.pi.third, value: kValue.f64.positive.pi.third },
-  { bits: kBit.f64.positive.pi.quarter, value: kValue.f64.positive.pi.quarter },
-  { bits: kBit.f64.positive.pi.sixth, value: kValue.f64.positive.pi.sixth },
-  { bits: kBit.f64.positive.e, value: kValue.f64.positive.e },
-  { bits: kBit.f64.negative.max, value: kValue.f64.negative.max },
-  { bits: kBit.f64.negative.min, value: kValue.f64.negative.min },
-  { bits: kBit.f64.negative.nearest_min, value: kValue.f64.negative.nearest_min },
-  { bits: kBit.f64.negative.pi.whole, value: kValue.f64.negative.pi.whole },
-  { bits: kBit.f64.negative.pi.three_quarters, value: kValue.f64.negative.pi.three_quarters },
-  { bits: kBit.f64.negative.pi.half, value: kValue.f64.negative.pi.half },
-  { bits: kBit.f64.negative.pi.third, value: kValue.f64.negative.pi.third },
-  { bits: kBit.f64.negative.pi.quarter, value: kValue.f64.negative.pi.quarter },
-  { bits: kBit.f64.negative.pi.sixth, value: kValue.f64.negative.pi.sixth },
-  { bits: kBit.f64.subnormal.positive.max, value: kValue.f64.subnormal.positive.max },
-  { bits: kBit.f64.subnormal.positive.min, value: kValue.f64.subnormal.positive.min },
-  { bits: kBit.f64.subnormal.negative.max, value: kValue.f64.subnormal.negative.max },
-  { bits: kBit.f64.subnormal.negative.min, value: kValue.f64.subnormal.negative.min },
-  { bits: kBit.f64.infinity.positive, value: kValue.f64.infinity.positive },
-  { bits: kBit.f64.infinity.negative, value: kValue.f64.infinity.negative },
-];
-
 // Test to confirm kBit and kValue constants are equivalent for f64
 g.test('f64LimitsEquivalency')
-  .params(u => u.combine('idx', Array.from(Array(kF64LimitsEquivalencyCases.length).keys())))
+  .paramsSimple<limitsBigIntBitsF64Case>([
+    { bits: kBit.f64.positive.max, value: kValue.f64.positive.max },
+    { bits: kBit.f64.positive.min, value: kValue.f64.positive.min },
+    { bits: kBit.f64.positive.nearest_max, value: kValue.f64.positive.nearest_max },
+    { bits: kBit.f64.positive.less_than_one, value: kValue.f64.positive.less_than_one },
+    { bits: kBit.f64.positive.pi.whole, value: kValue.f64.positive.pi.whole },
+    { bits: kBit.f64.positive.pi.three_quarters, value: kValue.f64.positive.pi.three_quarters },
+    { bits: kBit.f64.positive.pi.half, value: kValue.f64.positive.pi.half },
+    { bits: kBit.f64.positive.pi.third, value: kValue.f64.positive.pi.third },
+    { bits: kBit.f64.positive.pi.quarter, value: kValue.f64.positive.pi.quarter },
+    { bits: kBit.f64.positive.pi.sixth, value: kValue.f64.positive.pi.sixth },
+    { bits: kBit.f64.positive.e, value: kValue.f64.positive.e },
+    { bits: kBit.f64.positive.max_ulp, value: kValue.f64.positive.max_ulp },
+    { bits: kBit.f64.negative.max, value: kValue.f64.negative.max },
+    { bits: kBit.f64.negative.min, value: kValue.f64.negative.min },
+    { bits: kBit.f64.negative.nearest_min, value: kValue.f64.negative.nearest_min },
+    { bits: kBit.f64.negative.pi.whole, value: kValue.f64.negative.pi.whole },
+    { bits: kBit.f64.negative.pi.three_quarters, value: kValue.f64.negative.pi.three_quarters },
+    { bits: kBit.f64.negative.pi.half, value: kValue.f64.negative.pi.half },
+    { bits: kBit.f64.negative.pi.third, value: kValue.f64.negative.pi.third },
+    { bits: kBit.f64.negative.pi.quarter, value: kValue.f64.negative.pi.quarter },
+    { bits: kBit.f64.negative.pi.sixth, value: kValue.f64.negative.pi.sixth },
+    { bits: kBit.f64.subnormal.positive.max, value: kValue.f64.subnormal.positive.max },
+    { bits: kBit.f64.subnormal.positive.min, value: kValue.f64.subnormal.positive.min },
+    { bits: kBit.f64.subnormal.negative.max, value: kValue.f64.subnormal.negative.max },
+    { bits: kBit.f64.subnormal.negative.min, value: kValue.f64.subnormal.negative.min },
+    { bits: kBit.f64.infinity.positive, value: kValue.f64.infinity.positive },
+    { bits: kBit.f64.infinity.negative, value: kValue.f64.infinity.negative },
+  ])
   .fn(test => {
-    const idx = test.params.idx;
-    const bits = kF64LimitsEquivalencyCases[idx].bits;
-    const value = kF64LimitsEquivalencyCases[idx].value;
+    const bits = test.params.bits;
+    const value = test.params.value;
 
     const val_to_bits = bits === float64ToUint64(value);
     const bits_to_val = value === uint64ToFloat64(bits);
@@ -1658,6 +1651,7 @@ g.test('f32LimitsEquivalency')
     { bits: kBit.f32.positive.pi.quarter, value: kValue.f32.positive.pi.quarter },
     { bits: kBit.f32.positive.pi.sixth, value: kValue.f32.positive.pi.sixth },
     { bits: kBit.f32.positive.e, value: kValue.f32.positive.e },
+    { bits: kBit.f32.positive.max_ulp, value: kValue.f32.positive.max_ulp },
     { bits: kBit.f32.negative.max, value: kValue.f32.negative.max },
     { bits: kBit.f32.negative.min, value: kValue.f32.negative.min },
     { bits: kBit.f32.negative.nearest_min, value: kValue.f32.negative.nearest_min },
@@ -1691,8 +1685,25 @@ g.test('f16LimitsEquivalency')
   .paramsSimple<limitsNumberBitsCase>([
     { bits: kBit.f16.positive.max, value: kValue.f16.positive.max },
     { bits: kBit.f16.positive.min, value: kValue.f16.positive.min },
+    { bits: kBit.f16.positive.nearest_max, value: kValue.f16.positive.nearest_max },
+    { bits: kBit.f16.positive.less_than_one, value: kValue.f16.positive.less_than_one },
+    { bits: kBit.f16.positive.pi.whole, value: kValue.f16.positive.pi.whole },
+    { bits: kBit.f16.positive.pi.three_quarters, value: kValue.f16.positive.pi.three_quarters },
+    { bits: kBit.f16.positive.pi.half, value: kValue.f16.positive.pi.half },
+    { bits: kBit.f16.positive.pi.third, value: kValue.f16.positive.pi.third },
+    { bits: kBit.f16.positive.pi.quarter, value: kValue.f16.positive.pi.quarter },
+    { bits: kBit.f16.positive.pi.sixth, value: kValue.f16.positive.pi.sixth },
+    { bits: kBit.f16.positive.e, value: kValue.f16.positive.e },
+    { bits: kBit.f16.positive.max_ulp, value: kValue.f16.positive.max_ulp },
     { bits: kBit.f16.negative.max, value: kValue.f16.negative.max },
     { bits: kBit.f16.negative.min, value: kValue.f16.negative.min },
+    { bits: kBit.f16.negative.nearest_min, value: kValue.f16.negative.nearest_min },
+    { bits: kBit.f16.negative.pi.whole, value: kValue.f16.negative.pi.whole },
+    { bits: kBit.f16.negative.pi.three_quarters, value: kValue.f16.negative.pi.three_quarters },
+    { bits: kBit.f16.negative.pi.half, value: kValue.f16.negative.pi.half },
+    { bits: kBit.f16.negative.pi.third, value: kValue.f16.negative.pi.third },
+    { bits: kBit.f16.negative.pi.quarter, value: kValue.f16.negative.pi.quarter },
+    { bits: kBit.f16.negative.pi.sixth, value: kValue.f16.negative.pi.sixth },
     { bits: kBit.f16.subnormal.positive.max, value: kValue.f16.subnormal.positive.max },
     { bits: kBit.f16.subnormal.positive.min, value: kValue.f16.subnormal.positive.min },
     { bits: kBit.f16.subnormal.negative.max, value: kValue.f16.subnormal.negative.max },

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -38,6 +38,7 @@ export const kBit = {
         sixth: BigInt(0x3fe0_c152_382d_7366n),
       },
       e: BigInt(0x4005_bf0a_8b14_5769n),
+      max_ulp: BigInt(0x7ca0_0000_0000_0000n),
     },
     negative: {
       max: BigInt(0x8010_0000_0000_0000n),
@@ -87,6 +88,7 @@ export const kBit = {
         sixth: 0x3f06_0a92,
       },
       e: 0x402d_f854,
+      max_ulp: 0x7380_0000,
     },
     negative: {
       max: 0x8080_0000,
@@ -136,6 +138,7 @@ export const kBit = {
         sixth: 0x3830,
       },
       e: 0x416f,
+      max_ulp: 0x5000,
     },
     negative: {
       max: 0x8400,
@@ -388,6 +391,7 @@ export const kValue = {
         sixth: reinterpretU64AsF64(kBit.f64.positive.pi.sixth),
       },
       e: reinterpretU64AsF64(kBit.f64.positive.e),
+      max_ulp: reinterpretU64AsF64(kBit.f64.positive.max_ulp),
     },
     negative: {
       max: reinterpretU64AsF64(kBit.f64.negative.max),
@@ -437,6 +441,7 @@ export const kValue = {
         sixth: reinterpretU32AsF32(kBit.f32.positive.pi.sixth),
       },
       e: reinterpretU32AsF32(kBit.f32.positive.e),
+      max_ulp: reinterpretU32AsF32(kBit.f32.positive.max_ulp),
       // The positive pipeline-overridable constant with the smallest magnitude
       // which when cast to f32 will produce infinity. This comes from WGSL
       // conversion rules and the rounding rules of WebIDL.
@@ -528,6 +533,7 @@ export const kValue = {
         sixth: reinterpretU16AsF16(kBit.f16.positive.pi.sixth),
       },
       e: reinterpretU16AsF16(kBit.f16.positive.e),
+      max_ulp: reinterpretU16AsF16(kBit.f16.positive.max_ulp),
       // The positive pipeline-overridable constant with the smallest magnitude
       // which when cast to f16 will produce infinity. This comes from WGSL
       // conversion rules and the rounding rules of WebIDL.

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -341,13 +341,16 @@ export function oneULPF64(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF64(target) : target;
 
-  // For values at the edge of the range or beyond ulp(x) is defined as the
+  // For values out of bounds for f64 ulp(x) is defined as the
   // distance between the two nearest f64 representable numbers to the
-  // appropriate edge.
-  if (target === Number.POSITIVE_INFINITY || target >= kValue.f64.positive.max) {
-    return kValue.f64.positive.max - kValue.f64.positive.nearest_max;
-  } else if (target === Number.NEGATIVE_INFINITY || target <= kValue.f64.negative.min) {
-    return kValue.f64.negative.nearest_min - kValue.f64.negative.min;
+  // appropriate edge, which also happens to be the maximum possible ULP.
+  if (
+    target === Number.POSITIVE_INFINITY ||
+    target >= kValue.f64.positive.max ||
+    target === Number.NEGATIVE_INFINITY ||
+    target <= kValue.f64.negative.min
+  ) {
+    return kValue.f64.positive.max_ulp;
   }
 
   // ulp(x) is min(after - before), where
@@ -379,13 +382,16 @@ export function oneULPF32(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF32(target) : target;
 
-  // For values at the edge of the range or beyond ulp(x) is defined as the
+  // For values out of bounds for f32 ulp(x) is defined as the
   // distance between the two nearest f32 representable numbers to the
-  // appropriate edge.
-  if (target === Number.POSITIVE_INFINITY || target >= kValue.f32.positive.max) {
-    return kValue.f32.positive.max - kValue.f32.positive.nearest_max;
-  } else if (target === Number.NEGATIVE_INFINITY || target <= kValue.f32.negative.min) {
-    return kValue.f32.negative.nearest_min - kValue.f32.negative.min;
+  // appropriate edge, which also happens to be the maximum possible ULP.
+  if (
+    target === Number.POSITIVE_INFINITY ||
+    target >= kValue.f32.positive.max ||
+    target === Number.NEGATIVE_INFINITY ||
+    target <= kValue.f32.negative.min
+  ) {
+    return kValue.f32.positive.max_ulp;
   }
 
   // ulp(x) is min(after - before), where
@@ -422,13 +428,16 @@ export function oneULPF16(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF16(target) : target;
 
-  // For values at the edge of the range or beyond ulp(x) is defined as the
+  // For values out of bounds for f16 ulp(x) is defined as the
   // distance between the two nearest f16 representable numbers to the
-  // appropriate edge.
-  if (target === Number.POSITIVE_INFINITY || target >= kValue.f16.positive.max) {
-    return kValue.f16.positive.max - kValue.f16.positive.nearest_max;
-  } else if (target === Number.NEGATIVE_INFINITY || target <= kValue.f16.negative.min) {
-    return kValue.f16.negative.nearest_min - kValue.f16.negative.min;
+  // appropriate edge, which also happens to be the maximum possible ULP.
+  if (
+    target === Number.POSITIVE_INFINITY ||
+    target >= kValue.f16.positive.max ||
+    target === Number.NEGATIVE_INFINITY ||
+    target <= kValue.f16.negative.min
+  ) {
+    return kValue.f16.positive.max_ulp;
   }
 
   // ulp(x) is min(after - before), where


### PR DESCRIPTION
These are used as in ULP calculations, though there should be no functional changes from this patch.

Also refactors the f64 constant tests to no longer need to index into an indirect case array, since BigInt's are now directly supported.

Fixes #2775

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
