### PR TITLE
Add support for overflow domains to correctly rounded

### DIFF
--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -939,10 +939,16 @@ g.test('correctlyRoundedF32')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f32.infinity.positive, expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
-      { value: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
       { value: kValue.f32.positive.max, expected: [kValue.f32.positive.max] },
       { value: kValue.f32.negative.min, expected: [kValue.f32.negative.min] },
+      { value: kValue.f32.positive.max + oneULPF64(kValue.f32.positive.max), expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.negative.min - oneULPF64(kValue.f32.negative.min), expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: 2 ** (kValue.f32.emax + 1) - oneULPF64(kValue.f32.positive.max), expected: [kValue.f32.positive.max, Number.POSITIVE_INFINITY] },
+      { value: -(2 ** (kValue.f32.emax + 1)) + oneULPF64(kValue.f32.positive.max), expected: [Number.NEGATIVE_INFINITY, kValue.f32.negative.min] },
+      { value: 2 ** (kValue.f32.emax + 1), expected: [Number.POSITIVE_INFINITY] },
+      { value: -(2 ** (kValue.f32.emax + 1)), expected: [Number.NEGATIVE_INFINITY] },
+      { value: kValue.f32.infinity.positive, expected: [Number.POSITIVE_INFINITY] },
+      { value: kValue.f32.infinity.negative, expected: [Number.NEGATIVE_INFINITY] },
 
       // 32-bit subnormals
       { value: kValue.f32.subnormal.positive.min, expected: [kValue.f32.subnormal.positive.min] },
@@ -994,10 +1000,16 @@ g.test('correctlyRoundedF16')
     // prettier-ignore
     [
       // Edge Cases
-      { value: kValue.f16.infinity.positive, expected: [kValue.f16.positive.max, Number.POSITIVE_INFINITY] },
-      { value: kValue.f16.infinity.negative, expected: [Number.NEGATIVE_INFINITY, kValue.f16.negative.min] },
       { value: kValue.f16.positive.max, expected: [kValue.f16.positive.max] },
       { value: kValue.f16.negative.min, expected: [kValue.f16.negative.min] },
+      { value: kValue.f16.positive.max + oneULPF64(kValue.f16.positive.max), expected: [kValue.f16.positive.max, Number.POSITIVE_INFINITY] },
+      { value: kValue.f16.negative.min - oneULPF64(kValue.f16.negative.min), expected: [Number.NEGATIVE_INFINITY, kValue.f16.negative.min] },
+      { value: 2 ** (kValue.f16.emax + 1) - oneULPF64(kValue.f16.positive.max), expected: [kValue.f16.positive.max, Number.POSITIVE_INFINITY] },
+      { value: -(2 ** (kValue.f16.emax + 1)) + oneULPF64(kValue.f16.positive.max), expected: [Number.NEGATIVE_INFINITY, kValue.f16.negative.min] },
+      { value: 2 ** (kValue.f16.emax + 1), expected: [Number.POSITIVE_INFINITY] },
+      { value: -(2 ** (kValue.f16.emax + 1)), expected: [Number.NEGATIVE_INFINITY] },
+      { value: kValue.f16.infinity.positive, expected: [Number.POSITIVE_INFINITY] },
+      { value: kValue.f16.infinity.negative, expected: [Number.NEGATIVE_INFINITY] },
 
       // 16-bit subnormals
       { value: kValue.f16.subnormal.positive.min, expected: [kValue.f16.subnormal.positive.min] },
@@ -1603,7 +1615,7 @@ g.test('f64LimitsEquivalency')
     { bits: kBit.f64.positive.pi.quarter, value: kValue.f64.positive.pi.quarter },
     { bits: kBit.f64.positive.pi.sixth, value: kValue.f64.positive.pi.sixth },
     { bits: kBit.f64.positive.e, value: kValue.f64.positive.e },
-    { bits: kBit.f64.positive.max_ulp, value: kValue.f64.positive.max_ulp },
+    { bits: kBit.f64.max_ulp, value: kValue.f64.max_ulp },
     { bits: kBit.f64.negative.max, value: kValue.f64.negative.max },
     { bits: kBit.f64.negative.min, value: kValue.f64.negative.min },
     { bits: kBit.f64.negative.nearest_min, value: kValue.f64.negative.nearest_min },
@@ -1651,7 +1663,7 @@ g.test('f32LimitsEquivalency')
     { bits: kBit.f32.positive.pi.quarter, value: kValue.f32.positive.pi.quarter },
     { bits: kBit.f32.positive.pi.sixth, value: kValue.f32.positive.pi.sixth },
     { bits: kBit.f32.positive.e, value: kValue.f32.positive.e },
-    { bits: kBit.f32.positive.max_ulp, value: kValue.f32.positive.max_ulp },
+    { bits: kBit.f32.max_ulp, value: kValue.f32.max_ulp },
     { bits: kBit.f32.negative.max, value: kValue.f32.negative.max },
     { bits: kBit.f32.negative.min, value: kValue.f32.negative.min },
     { bits: kBit.f32.negative.nearest_min, value: kValue.f32.negative.nearest_min },
@@ -1694,7 +1706,7 @@ g.test('f16LimitsEquivalency')
     { bits: kBit.f16.positive.pi.quarter, value: kValue.f16.positive.pi.quarter },
     { bits: kBit.f16.positive.pi.sixth, value: kValue.f16.positive.pi.sixth },
     { bits: kBit.f16.positive.e, value: kValue.f16.positive.e },
-    { bits: kBit.f16.positive.max_ulp, value: kValue.f16.positive.max_ulp },
+    { bits: kBit.f16.max_ulp, value: kValue.f16.max_ulp },
     { bits: kBit.f16.negative.max, value: kValue.f16.negative.max },
     { bits: kBit.f16.negative.min, value: kValue.f16.negative.min },
     { bits: kBit.f16.negative.nearest_min, value: kValue.f16.negative.nearest_min },

--- a/src/webgpu/util/constants.ts
+++ b/src/webgpu/util/constants.ts
@@ -38,7 +38,6 @@ export const kBit = {
         sixth: BigInt(0x3fe0_c152_382d_7366n),
       },
       e: BigInt(0x4005_bf0a_8b14_5769n),
-      max_ulp: BigInt(0x7ca0_0000_0000_0000n),
     },
     negative: {
       max: BigInt(0x8010_0000_0000_0000n),
@@ -69,6 +68,7 @@ export const kBit = {
       positive: BigInt(0x7ff0_0000_0000_0000n),
       negative: BigInt(0xfff0_0000_0000_0000n),
     },
+    max_ulp: BigInt(0x7ca0_0000_0000_0000n),
   },
 
   // Limits of f32
@@ -88,7 +88,6 @@ export const kBit = {
         sixth: 0x3f06_0a92,
       },
       e: 0x402d_f854,
-      max_ulp: 0x7380_0000,
     },
     negative: {
       max: 0x8080_0000,
@@ -119,6 +118,7 @@ export const kBit = {
       positive: 0x7f80_0000,
       negative: 0xff80_0000,
     },
+    max_ulp: 0x7380_0000,
   },
 
   // Limits of f16
@@ -138,7 +138,6 @@ export const kBit = {
         sixth: 0x3830,
       },
       e: 0x416f,
-      max_ulp: 0x5000,
     },
     negative: {
       max: 0x8400,
@@ -169,6 +168,7 @@ export const kBit = {
       positive: 0x7c00,
       negative: 0xfc00,
     },
+    max_ulp: 0x5000,
   },
 
   // 32-bit representation of power(2, n) n = {-31, ..., 31}
@@ -391,7 +391,6 @@ export const kValue = {
         sixth: reinterpretU64AsF64(kBit.f64.positive.pi.sixth),
       },
       e: reinterpretU64AsF64(kBit.f64.positive.e),
-      max_ulp: reinterpretU64AsF64(kBit.f64.positive.max_ulp),
     },
     negative: {
       max: reinterpretU64AsF64(kBit.f64.negative.max),
@@ -422,6 +421,7 @@ export const kValue = {
       positive: reinterpretU64AsF64(kBit.f64.infinity.positive),
       negative: reinterpretU64AsF64(kBit.f64.infinity.negative),
     },
+    max_ulp: reinterpretU64AsF64(kBit.f64.max_ulp),
   },
 
   // Limits of f32
@@ -441,7 +441,6 @@ export const kValue = {
         sixth: reinterpretU32AsF32(kBit.f32.positive.pi.sixth),
       },
       e: reinterpretU32AsF32(kBit.f32.positive.e),
-      max_ulp: reinterpretU32AsF32(kBit.f32.positive.max_ulp),
       // The positive pipeline-overridable constant with the smallest magnitude
       // which when cast to f32 will produce infinity. This comes from WGSL
       // conversion rules and the rounding rules of WebIDL.
@@ -496,6 +495,8 @@ export const kValue = {
       positive: reinterpretU32AsF32(kBit.f32.infinity.positive),
       negative: reinterpretU32AsF32(kBit.f32.infinity.negative),
     },
+    max_ulp: reinterpretU32AsF32(kBit.f32.max_ulp),
+    emax: 127,
   },
 
   // Limits of i16
@@ -533,7 +534,6 @@ export const kValue = {
         sixth: reinterpretU16AsF16(kBit.f16.positive.pi.sixth),
       },
       e: reinterpretU16AsF16(kBit.f16.positive.e),
-      max_ulp: reinterpretU16AsF16(kBit.f16.positive.max_ulp),
       // The positive pipeline-overridable constant with the smallest magnitude
       // which when cast to f16 will produce infinity. This comes from WGSL
       // conversion rules and the rounding rules of WebIDL.
@@ -588,6 +588,8 @@ export const kValue = {
       positive: reinterpretU16AsF16(kBit.f16.infinity.positive),
       negative: reinterpretU16AsF16(kBit.f16.infinity.negative),
     },
+    max_ulp: reinterpretU16AsF16(kBit.f16.max_ulp),
+    emax: 15,
   },
 
   // Limits of i8

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -341,7 +341,7 @@ export function oneULPF64(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF64(target) : target;
 
-  // For values out of bounds for f64 ulp(x) is defined as the
+  // For values out of bounds for f64.max_ulp(x) is defined as the
   // distance between the two nearest f64 representable numbers to the
   // appropriate edge, which also happens to be the maximum possible ULP.
   if (
@@ -350,7 +350,7 @@ export function oneULPF64(target: number, mode: FlushMode = 'flush'): number {
     target === Number.NEGATIVE_INFINITY ||
     target <= kValue.f64.negative.min
   ) {
-    return kValue.f64.positive.max_ulp;
+    return kValue.f64.max_ulp;
   }
 
   // ulp(x) is min(after - before), where
@@ -382,7 +382,7 @@ export function oneULPF32(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF32(target) : target;
 
-  // For values out of bounds for f32 ulp(x) is defined as the
+  // For values out of bounds for f32.max_ulp(x) is defined as the
   // distance between the two nearest f32 representable numbers to the
   // appropriate edge, which also happens to be the maximum possible ULP.
   if (
@@ -391,7 +391,7 @@ export function oneULPF32(target: number, mode: FlushMode = 'flush'): number {
     target === Number.NEGATIVE_INFINITY ||
     target <= kValue.f32.negative.min
   ) {
-    return kValue.f32.positive.max_ulp;
+    return kValue.f32.max_ulp;
   }
 
   // ulp(x) is min(after - before), where
@@ -428,7 +428,7 @@ export function oneULPF16(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF16(target) : target;
 
-  // For values out of bounds for f16 ulp(x) is defined as the
+  // For values out of bounds for f16.max_ulp(x) is defined as the
   // distance between the two nearest f16 representable numbers to the
   // appropriate edge, which also happens to be the maximum possible ULP.
   if (
@@ -437,7 +437,7 @@ export function oneULPF16(target: number, mode: FlushMode = 'flush'): number {
     target === Number.NEGATIVE_INFINITY ||
     target <= kValue.f16.negative.min
   ) {
-    return kValue.f16.positive.max_ulp;
+    return kValue.f16.max_ulp;
   }
 
   // ulp(x) is min(after - before), where
@@ -496,40 +496,60 @@ export function correctlyRoundedF64(n: number): number[] {
  * This function does not consider flushing mode, so subnormals are maintained.
  * The caller is responsible to flushing before and after as appropriate.
  *
- * Out of range values return the appropriate infinity and edge value.
+ * Out of bounds values need to consider how they interact with the overflow
+ * rules.
+ *  * If a value is OOB but not too far out, an implementation may choose to round
+ * to nearest finite value or the correct infinity. This boundary is at
+ * 2^(f32.emax + 1) and -(2^(f32.emax + 1)) respectively.
+ * Values that are at or beyond these limits must be rounded towards the
+ * appropriate infinity.
  *
  * @param n number to be quantized
  * @returns all of the acceptable roundings for quantizing to 32-bits in
  *          ascending order.
  */
 export function correctlyRoundedF32(n: number): number[] {
-  assert(!Number.isNaN(n), `correctlyRoundedF32 not defined for NaN`);
-  // Above f32 range
-  if (n === Number.POSITIVE_INFINITY || n > kValue.f32.positive.max) {
-    return [kValue.f32.positive.max, Number.POSITIVE_INFINITY];
-  }
-
-  // Below f32 range
-  if (n === Number.NEGATIVE_INFINITY || n < kValue.f32.negative.min) {
-    return [Number.NEGATIVE_INFINITY, kValue.f32.negative.min];
-  }
-
-  const n_32 = new Float32Array([n])[0];
-  const converted: number = n_32;
-  if (n === converted) {
-    // n is precisely expressible as a f32, so should not be rounded
+  if (Number.isNaN(n)) {
     return [n];
   }
 
-  if (converted > n) {
-    // n_32 rounded towards +inf, so is after n
-    const other = nextAfterF32(n_32, 'negative', 'no-flush');
-    return [other, converted];
-  } else {
-    // n_32 rounded towards -inf, so is before n
-    const other = nextAfterF32(n_32, 'positive', 'no-flush');
-    return [converted, other];
+  // Greater than or equal to the upper overflow boundry
+  if (n >= 2 ** (kValue.f32.emax + 1)) {
+    return [Number.POSITIVE_INFINITY];
   }
+
+  // OOB, but less than the upper overflow boundary
+  if (n > kValue.f32.positive.max) {
+    return [kValue.f32.positive.max, Number.POSITIVE_INFINITY];
+  }
+
+  // f32 finite
+  if (n <= kValue.f32.positive.max && n >= kValue.f32.negative.min) {
+    const n_32 = new Float32Array([n])[0];
+    const converted: number = n_32;
+    if (n === converted) {
+      // n is precisely expressible as a f32, so should not be rounded
+      return [n];
+    }
+
+    if (converted > n) {
+      // n_32 rounded towards +inf, so is after n
+      const other = nextAfterF32(n_32, 'negative', 'no-flush');
+      return [other, converted];
+    } else {
+      // n_32 rounded towards -inf, so is before n
+      const other = nextAfterF32(n_32, 'positive', 'no-flush');
+      return [converted, other];
+    }
+  }
+
+  // OOB, but greater the lower overflow boundary
+  if (n > -(2 ** (kValue.f32.emax + 1))) {
+    return [Number.NEGATIVE_INFINITY, kValue.f32.negative.min];
+  }
+
+  // Less than or equal to the lower overflow boundary
+  return [Number.NEGATIVE_INFINITY];
 }
 
 /**
@@ -545,40 +565,60 @@ export function correctlyRoundedF32(n: number): number[] {
  * This function does not consider flushing mode, so subnormals are maintained.
  * The caller is responsible to flushing before and after as appropriate.
  *
- * Out of range values return the appropriate infinity and edge value.
+ * Out of bounds values need to consider how they interact with the overflow
+ * rules.
+ *  * If a value is OOB but not too far out, an implementation may choose to round
+ * to nearest finite value or the correct infinity. This boundary is at
+ * 2^(f16.emax + 1) and -(2^(f16.emax + 1)) respectively.
+ * Values that are at or beyond these limits must be rounded towards the
+ * appropriate infinity.
  *
  * @param n number to be quantized
  * @returns all of the acceptable roundings for quantizing to 16-bits in
  *          ascending order.
  */
 export function correctlyRoundedF16(n: number): number[] {
-  assert(!Number.isNaN(n), `correctlyRoundedF16 not defined for NaN`);
-  // Above f16 range
-  if (n === Number.POSITIVE_INFINITY || n > kValue.f16.positive.max) {
-    return [kValue.f16.positive.max, Number.POSITIVE_INFINITY];
-  }
-
-  // Below f16 range
-  if (n === Number.NEGATIVE_INFINITY || n < kValue.f16.negative.min) {
-    return [Number.NEGATIVE_INFINITY, kValue.f16.negative.min];
-  }
-
-  const n_16 = new Float16Array([n])[0];
-  const converted: number = n_16;
-  if (n === converted) {
-    // n is precisely expressible as a f16, so should not be rounded
+  if (Number.isNaN(n)) {
     return [n];
   }
 
-  if (converted > n) {
-    // n_16 rounded towards +inf, so is after n
-    const other = nextAfterF16(n_16, 'negative', 'no-flush');
-    return [other, converted];
-  } else {
-    // n_16 rounded towards -inf, so is before n
-    const other = nextAfterF16(n_16, 'positive', 'no-flush');
-    return [converted, other];
+  // Greater than or equal to the upper overflow boundry
+  if (n >= 2 ** (kValue.f16.emax + 1)) {
+    return [Number.POSITIVE_INFINITY];
   }
+
+  // OOB, but less than the upper overflow boundary
+  if (n > kValue.f16.positive.max) {
+    return [kValue.f16.positive.max, Number.POSITIVE_INFINITY];
+  }
+
+  // f16 finite
+  if (n <= kValue.f16.positive.max && n >= kValue.f16.negative.min) {
+    const n_16 = new Float16Array([n])[0];
+    const converted: number = n_16;
+    if (n === converted) {
+      // n is precisely expressible as a f16, so should not be rounded
+      return [n];
+    }
+
+    if (converted > n) {
+      // n_16 rounded towards +inf, so is after n
+      const other = nextAfterF16(n_16, 'negative', 'no-flush');
+      return [other, converted];
+    } else {
+      // n_16 rounded towards -inf, so is before n
+      const other = nextAfterF16(n_16, 'positive', 'no-flush');
+      return [converted, other];
+    }
+  }
+
+  // OOB, but greater the lower overflow boundary
+  if (n > -(2 ** (kValue.f16.emax + 1))) {
+    return [Number.NEGATIVE_INFINITY, kValue.f16.negative.min];
+  }
+
+  // Less than or equal to the lower overflow boundary
+  return [Number.NEGATIVE_INFINITY];
 }
 
 /**

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -341,7 +341,7 @@ export function oneULPF64(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF64(target) : target;
 
-  // For values out of bounds for f64.max_ulp(x) is defined as the
+  // For values out of bounds for f64 ulp(x) is defined as the
   // distance between the two nearest f64 representable numbers to the
   // appropriate edge, which also happens to be the maximum possible ULP.
   if (
@@ -382,7 +382,7 @@ export function oneULPF32(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF32(target) : target;
 
-  // For values out of bounds for f32.max_ulp(x) is defined as the
+  // For values out of bounds for f32 ulp(x) is defined as the
   // distance between the two nearest f32 representable numbers to the
   // appropriate edge, which also happens to be the maximum possible ULP.
   if (
@@ -428,7 +428,7 @@ export function oneULPF16(target: number, mode: FlushMode = 'flush'): number {
 
   target = mode === 'flush' ? flushSubnormalNumberF16(target) : target;
 
-  // For values out of bounds for f16.max_ulp(x) is defined as the
+  // For values out of bounds for f16 ulp(x) is defined as the
   // distance between the two nearest f16 representable numbers to the
   // appropriate edge, which also happens to be the maximum possible ULP.
   if (


### PR DESCRIPTION
This adds support for handling different OOB conditions to `correctlyRoundedF32` and `correctlyRoundedF16`

Also moves the max_ulp constants out to the top-level of their sections, since it was odd that I put them in positive in the first place.

Fixes #2776

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
