### PR TITLE
Compat: Skip Cube-Array

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -313,6 +313,11 @@ g.test('texture_must_have_correct_dimension')
       dimension: getTextureDimensionFromView(dimension),
     });
 
+    if (t.isCompatibility && viewDimension === 'cube-array') {
+      t.skip('cube-array texture view is not supported in compatibility mode');
+      return;
+    }
+
     const shouldError = viewDimension !== dimension;
     const textureView = texture.createView({ dimension });
 

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -212,6 +212,10 @@ g.test('array_layers')
       arrayLayerCount,
     } = t.params;
 
+    if (t.isCompatibility && viewDimension === 'cube-array') {
+      t.skip('cube-array is not supported in compatibility mode');
+    }
+
     const kWidth = 1 << (kLevels - 1); // 32
     const textureDescriptor: GPUTextureDescriptor = {
       format: 'rgba8unorm',
@@ -271,6 +275,10 @@ g.test('mip_levels')
       mipLevelCount,
     } = t.params;
 
+    if (t.isCompatibility && viewDimension === 'cube-array') {
+      t.skip('cube-array is not supported in compatibility mode');
+    }
+
     const textureDescriptor: GPUTextureDescriptor = {
       format: 'rgba8unorm',
       dimension: textureDimension,
@@ -308,6 +316,10 @@ g.test('cube_faces_square')
   )
   .fn(t => {
     const { dimension, size } = t.params;
+
+    if (t.isCompatibility && dimension === 'cube-array') {
+      t.skip('cube-array is not supported in compatibility mode');
+    }
 
     const texture = t.device.createTexture({
       format: 'rgba8unorm',


### PR DESCRIPTION
Skip testing cube-array texture views in compat mode. Note: creating a bindGroupLayout that specifies it requires a cube-array is okay in compat mode. It's just impossible to create a matching texture view.



<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
