### PR TITLE
Compat: skip copy t2b compressed

### DIFF
--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -3,6 +3,7 @@ import {
   DepthStencilFormat,
   SizedTextureFormat,
   kTextureFormatInfo,
+  isCompressedTextureFormat,
 } from '../../../format_info.js';
 import { align } from '../../../util/math.js';
 import { ImageCopyType } from '../../../util/texture/layout.js';
@@ -61,6 +62,11 @@ export class ImageCopyTest extends ValidationTest {
         break;
       }
       case 'CopyT2B': {
+        if (this.isCompatibility && isCompressedTextureFormat(textureCopyView.texture.format)) {
+          this.skip(
+            'copyTextureToBuffer is not supported for compressed texture formats in compatibility mode.'
+          );
+        }
         const buffer = this.device.createBuffer({
           size: dataSize,
           usage: GPUBufferUsage.COPY_DST,
@@ -159,6 +165,11 @@ export class ImageCopyTest extends ValidationTest {
         break;
       }
       case 'CopyT2B': {
+        if (this.isCompatibility && isCompressedTextureFormat(texture.format)) {
+          this.skip(
+            'copyTextureToBuffer is not supported for compressed texture formats in compatibility mode.'
+          );
+        }
         const { encoder, validateFinish, validateFinishAndSubmit } = this.createEncoder('non-pass');
         encoder.copyTextureToBuffer({ texture }, { buffer, ...textureDataLayout }, size);
 

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1235,4 +1235,8 @@ export function filterFormatsByFeature<T>(
   return formats.filter(f => f === undefined || kTextureFormatInfo[f].feature === feature);
 }
 
+export function isCompressedTextureFormat(format: GPUTextureFormat) {
+  return format in kCompressedTextureFormats;
+}
+
 export const kFeaturesForFormats = getFeaturesForFormats(kTextureFormats);


### PR DESCRIPTION
This is not 100% of the places copyTextureToBuffer is used in the tests on compressed textures. I'll catch the rest in other PRs.


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
