### PR TITLE
Disallow % in queries

### DIFF
--- a/src/common/internal/params_utils.ts
+++ b/src/common/internal/params_utils.ts
@@ -33,8 +33,11 @@ export function extractPublicParams(params: TestParams): TestParams {
   return publicParams;
 }
 
+/** Used to escape reserved characters in URIs */
+const kPercent = '%';
+
 export const badParamValueChars = new RegExp(
-  '[' + kParamKVSeparator + kParamSeparator + kWildcard + ']'
+  '[' + kParamKVSeparator + kParamSeparator + kWildcard + kPercent + ']'
 );
 
 export function publicParamsEquals(x: TestParams, y: TestParams): boolean {

--- a/src/webgpu/shader/validation/parse/literal.spec.ts
+++ b/src/webgpu/shader/validation/parse/literal.spec.ts
@@ -193,7 +193,7 @@ const kAbstractFloat = new Set([
   ]);
   const kInvalidF16s = new Set([
     '1.1eh', // Missing exponent value
-    '1.1e%2h', // Invalid exponent sign
+    '1.1e!2h', // Invalid exponent sign
     '1.1e+h', // Missing exponent with sign
     '1.0e+999999h', // Too large
     '0x1.0p+999999h', // Too large hex
@@ -277,7 +277,7 @@ const kAbstractFloat = new Set([
     '1u', // unsigned int
     '1f', // no conversion from f32 to f16
     '1.1eh', // Missing exponent value
-    '1.1e%2h', // Invalid exponent sign
+    '1.1e!2h', // Invalid exponent sign
     '1.1e+h', // Missing exponent with sign
     '1.0e+999999h', // Too large
     '0x1.0p+999999h', // Too large hex


### PR DESCRIPTION
`%` is an escape character in URLs and it would be difficult to encode/decode in all the proper places to make sure % is correctly passed through all the various tools

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
