### PR TITLE
Compat: Pass in cts options to workers

### DIFF
--- a/src/common/runtime/helper/options.ts
+++ b/src/common/runtime/helper/options.ts
@@ -32,6 +32,14 @@ export interface CTSOptions {
   powerPreference?: GPUPowerPreference | '';
 }
 
+export const kDefaultCTSOptions: CTSOptions = {
+  worker: false,
+  debug: true,
+  compatibility: false,
+  unrollConstEvalLoops: false,
+  powerPreference: '',
+};
+
 /**
  * Extra per option info.
  */

--- a/src/common/runtime/helper/test_worker-worker.ts
+++ b/src/common/runtime/helper/test_worker-worker.ts
@@ -1,10 +1,13 @@
 import { setBaseResourcePath } from '../../framework/resources.js';
+import { globalTestConfig } from '../../framework/test_config.js';
 import { DefaultTestFileLoader } from '../../internal/file_loader.js';
 import { Logger } from '../../internal/logging/logger.js';
 import { parseQuery } from '../../internal/query/parseQuery.js';
 import { TestQueryWithExpectation } from '../../internal/query/query.js';
 import { setDefaultRequestAdapterOptions } from '../../util/navigator_gpu.js';
 import { assert } from '../../util/util.js';
+
+import { CTSOptions } from './options.js';
 
 // Should be DedicatedWorkerGlobalScope, but importing lib "webworker" conflicts with lib "dom".
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -17,14 +20,22 @@ setBaseResourcePath('../../../resources');
 self.onmessage = async (ev: MessageEvent) => {
   const query: string = ev.data.query;
   const expectations: TestQueryWithExpectation[] = ev.data.expectations;
-  const defaultRequestAdapterOptions: GPURequestAdapterOptions =
-    ev.data.defaultRequestAdapterOptions;
-  const debug: boolean = ev.data.debug;
+  const ctsOptions: CTSOptions = ev.data.ctsOptions;
 
-  setDefaultRequestAdapterOptions(defaultRequestAdapterOptions);
+  const { debug, unrollConstEvalLoops, powerPreference, compatibility } = ctsOptions;
+  globalTestConfig.unrollConstEvalLoops = unrollConstEvalLoops;
+  globalTestConfig.compatibility = compatibility;
 
   Logger.globalDebugMode = debug;
   const log = new Logger();
+
+  if (powerPreference || compatibility) {
+    setDefaultRequestAdapterOptions({
+      ...(powerPreference && { powerPreference }),
+      // MAINTENANCE_TODO: Change this to whatever the option ends up being
+      ...(compatibility && { compatibilityMode: true }),
+    });
+  }
 
   const testcases = Array.from(await loader.loadCases(parseQuery(query)));
   assert(testcases.length === 1, 'worker query resulted in != 1 cases');

--- a/src/common/runtime/helper/test_worker.ts
+++ b/src/common/runtime/helper/test_worker.ts
@@ -2,16 +2,16 @@ import { LogMessageWithStack } from '../../internal/logging/log_message.js';
 import { TransferredTestCaseResult, LiveTestCaseResult } from '../../internal/logging/result.js';
 import { TestCaseRecorder } from '../../internal/logging/test_case_recorder.js';
 import { TestQueryWithExpectation } from '../../internal/query/query.js';
-import { getDefaultRequestAdapterOptions } from '../../util/navigator_gpu.js';
+
+import { CTSOptions, kDefaultCTSOptions } from './options.js';
 
 export class TestWorker {
-  private readonly debug: boolean;
+  private readonly ctsOptions: CTSOptions;
   private readonly worker: Worker;
   private readonly resolvers = new Map<string, (result: LiveTestCaseResult) => void>();
 
-  constructor(debug: boolean) {
-    this.debug = debug;
-
+  constructor(ctsOptions?: CTSOptions) {
+    this.ctsOptions = { ...(ctsOptions || kDefaultCTSOptions), ...{ worker: true } };
     const selfPath = import.meta.url;
     const selfPathDir = selfPath.substring(0, selfPath.lastIndexOf('/'));
     const workerPath = selfPathDir + '/test_worker-worker.js';
@@ -39,8 +39,7 @@ export class TestWorker {
     this.worker.postMessage({
       query,
       expectations,
-      debug: this.debug,
-      defaultRequestAdapterOptions: getDefaultRequestAdapterOptions(),
+      ctsOptions: this.ctsOptions,
     });
     const workerResult = await new Promise<LiveTestCaseResult>(resolve => {
       this.resolvers.set(query, resolve);

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -56,7 +56,7 @@ const logger = new Logger();
 
 setBaseResourcePath('../out/resources');
 
-const worker = options.worker ? new TestWorker(debug) : undefined;
+const worker = options.worker ? new TestWorker(options) : undefined;
 
 const autoCloseOnPass = document.getElementById('autoCloseOnPass') as HTMLInputElement;
 const resultsVis = document.getElementById('resultsVis')!;

--- a/src/common/runtime/wpt.ts
+++ b/src/common/runtime/wpt.ts
@@ -32,7 +32,7 @@ setup({
 
 void (async () => {
   const workerEnabled = optionEnabled('worker');
-  const worker = workerEnabled ? new TestWorker(false) : undefined;
+  const worker = workerEnabled ? new TestWorker() : undefined;
 
   globalTestConfig.unrollConstEvalLoops = optionEnabled('unroll_const_eval_loops');
 

--- a/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
@@ -269,7 +269,6 @@ class F extends TextureTestMixin(GPUTest) {
     await super.init();
     if (this.isCompatibility) {
       this.skip('WGSL sample_mask is not supported in compatibility mode');
-      return;
     }
     // Create a 2x2 color texture to sample from
     // texel 0 - Red


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
