### PR TITLE
Reimplement `packRGB9E5UFloat()`, add `unpackRGB9E5UFloat()`

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -1,6 +1,8 @@
 export const description = `Unit tests for conversion`;
 
+import { mergeParams } from '../common/internal/params_utils.js';
 import { makeTestGroup } from '../common/internal/test_group.js';
+import { keysOf } from '../common/util/data_tables.js';
 import { assert, objectEquals } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
 import {
@@ -22,9 +24,11 @@ import {
   pack2x16unorm,
   pack4x8snorm,
   pack4x8unorm,
+  packRGB9E5UFloat,
   Scalar,
   toMatrix,
   u32,
+  unpackRGB9E5UFloat,
   vec2,
   vec3,
   vec4,
@@ -560,4 +564,63 @@ g.test('pack4x8unorm')
     const expect = test.params.result;
 
     test.expect(got === expect, `pack4x8unorm(${inputs}) returned ${got}. Expected ${expect}`);
+  });
+
+const kRGB9E5UFloatCommonData = {
+  zero: /*        */ { encoded: 0b00000_000000000_000000000_000000000, rgb: [0, 0, 0] },
+  max: /*         */ { encoded: 0b11111_111111111_111111111_111111111, rgb: [65408, 65408, 65408] },
+  r1: /*          */ { encoded: 0b10000_000000000_000000000_100000000, rgb: [1, 0, 0] },
+  r2: /*          */ { encoded: 0b10001_000000000_000000000_100000000, rgb: [2, 0, 0] },
+  g1: /*          */ { encoded: 0b10000_000000000_100000000_000000000, rgb: [0, 1, 0] },
+  g2: /*          */ { encoded: 0b10001_000000000_100000000_000000000, rgb: [0, 2, 0] },
+  b1: /*          */ { encoded: 0b10000_100000000_000000000_000000000, rgb: [0, 0, 1] },
+  b2: /*          */ { encoded: 0b10001_100000000_000000000_000000000, rgb: [0, 0, 2] },
+  r1_g1_b1: /*    */ { encoded: 0b10000_100000000_100000000_100000000, rgb: [1, 1, 1] },
+  r1_g2_b1: /*    */ { encoded: 0b10001_010000000_100000000_010000000, rgb: [1, 2, 1] },
+  r4_g8_b2: /*    */ { encoded: 0b10011_001000000_100000000_010000000, rgb: [4, 8, 2] },
+  r1_g2_b3: /*    */ { encoded: 0b10001_110000000_100000000_010000000, rgb: [1, 2, 3] },
+  r128_g3968_b65408: { encoded: 0b11111_111111111_000011111_000000001, rgb: [128, 3968, 65408] },
+  r128_g1984_b30016: { encoded: 0b11110_111010101_000011111_000000010, rgb: [128, 1984, 30016] },
+  r_5_g_25_b_8: /**/ { encoded: 0b10011_100000000_000001000_000010000, rgb: [0.5, 0.25, 8] },
+};
+
+const kPackRGB9E5UFloatData = mergeParams(kRGB9E5UFloatCommonData, {
+  clamp_max: /*   */ { encoded: 0b11111_111111111_111111111_111111111, rgb: [1e7, 1e10, 1e50] },
+  subnormals: /*  */ { encoded: 0b00000_000000000_000000000_000000000, rgb: [1e-10, 1e-20, 1e-30] },
+  r57423_g54_b3478: { encoded: 0b11111_000011011_000000000_111000001, rgb: [57423, 54, 3478] },
+  r6852_g3571_b2356: { encoded: 0b11100_010010011_011011111_110101100, rgb: [6852, 3571, 2356] },
+  r68312_g12_b8123: { encoded: 0b11111_000111111_000000000_111111111, rgb: [68312, 12, 8123] },
+  r7321_g846_b32: { encoded: 0b11100_000000010_000110101_111001010, rgb: [7321, 846, 32] },
+});
+
+function bits5_9_9_9(x: number) {
+  const s = (x >>> 0).toString(2).padStart(32, '0');
+  return `${s.slice(0, 5)}_${s.slice(5, 14)}_${s.slice(14, 23)}_${s.slice(23, 32)}`;
+}
+
+g.test('packRGB9E5UFloat')
+  .params(u => u.combine('case', keysOf(kPackRGB9E5UFloatData)))
+  .fn(test => {
+    const c = kPackRGB9E5UFloatData[test.params.case];
+    const got = packRGB9E5UFloat(c.rgb[0], c.rgb[1], c.rgb[2]);
+    const expect = c.encoded;
+
+    test.expect(
+      got === expect,
+      `packRGB9E5UFloat(${c.rgb}) returned ${bits5_9_9_9(got)}. Expected ${bits5_9_9_9(expect)}`
+    );
+  });
+
+g.test('unpackRGB9E5UFloat')
+  .params(u => u.combine('case', keysOf(kRGB9E5UFloatCommonData)))
+  .fn(test => {
+    const c = kRGB9E5UFloatCommonData[test.params.case];
+    const got = unpackRGB9E5UFloat(c.encoded);
+    const expect = c.rgb;
+
+    test.expect(
+      got.R === expect[0] && got.G === expect[1] && got.B === expect[2],
+      `unpackRGB9E5UFloat(${bits5_9_9_9(c.encoded)} ` +
+        `returned ${got.R},${got.G},${got.B}. Expected ${expect}`
+    );
   });

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -225,47 +225,49 @@ export function floatBitsToNormalULPFromZero(bits: number, fmt: FloatFormat): nu
  * There is no sign bit, and there is a shared 5-bit biased (15) exponent and a 9-bit
  * mantissa for each channel. The mantissa does NOT have an implicit leading "1.",
  * and instead has an implicit leading "0.".
+ *
+ * @see https://registry.khronos.org/OpenGL/extensions/EXT/EXT_texture_shared_exponent.txt
  */
 export function packRGB9E5UFloat(r: number, g: number, b: number): number {
-  for (const v of [r, g, b]) {
-    assert(v >= 0 && v < Math.pow(2, 16));
-  }
+  const N = 9; // number of mantissa bits
+  const Emax = 31; // max exponent
+  const B = 15; // exponent bias
+  const sharedexp_max = (((1 << N) - 1) / (1 << N)) * Math.pow(2, Emax - B);
+  const red_c = clamp(r, { min: 0, max: sharedexp_max });
+  const green_c = clamp(g, { min: 0, max: sharedexp_max });
+  const blue_c = clamp(b, { min: 0, max: sharedexp_max });
+  const max_c = Math.max(red_c, green_c, blue_c);
+  const exp_shared_p = Math.max(-B - 1, Math.floor(Math.log2(max_c))) + 1 + B;
+  const max_s = Math.floor(max_c / Math.pow(2, exp_shared_p - B - N) + 0.5);
+  const exp_shared = max_s === 1 << N ? exp_shared_p + 1 : exp_shared_p;
+  const scalar = 1 / Math.pow(2, exp_shared - B - N);
+  const red_s = Math.floor(red_c * scalar + 0.5);
+  const green_s = Math.floor(green_c * scalar + 0.5);
+  const blue_s = Math.floor(blue_c * scalar + 0.5);
+  assert(red_s >= 0 && red_s <= 0b111111111);
+  assert(green_s >= 0 && green_s <= 0b111111111);
+  assert(blue_s >= 0 && blue_s <= 0b111111111);
+  assert(exp_shared >= 0 && exp_shared <= 0b11111);
+  return ((exp_shared << 27) | (blue_s << 18) | (green_s << 9) | red_s) >>> 0;
+}
 
-  const buf = new DataView(new ArrayBuffer(Float32Array.BYTES_PER_ELEMENT));
-  const extractMantissaAndExponent = (n: number) => {
-    const mantissaBits = 9;
-    buf.setFloat32(0, n, true);
-    const bits = buf.getUint32(0, true);
-    // >> to remove mantissa, & to remove sign
-    let biasedExponent = (bits >> 23) & 0xff;
-    const mantissaBitsToDiscard = 23 - mantissaBits;
-    let mantissa = (bits & 0x7fffff) >> mantissaBitsToDiscard;
-
-    // RGB9E5UFloat has an implicit leading 0. instead of a leading 1.,
-    // so we need to move the 1. into the mantissa and bump the exponent.
-    // For float32 encoding, the leading 1 is only present if the biased
-    // exponent is non-zero.
-    if (biasedExponent !== 0) {
-      mantissa = (mantissa >> 1) | 0b100000000;
-      biasedExponent += 1;
-    }
-    return { biasedExponent, mantissa };
+/**
+ * Decodes a RGB9E5 encoded color.
+ * @see packRGB9E5UFloat
+ */
+export function unpackRGB9E5UFloat(encoded: number): { R: number; G: number; B: number } {
+  const N = 9; // number of mantissa bits
+  const B = 15; // exponent bias
+  const red_s = (encoded >>> 0) & 0b111111111;
+  const green_s = (encoded >>> 9) & 0b111111111;
+  const blue_s = (encoded >>> 18) & 0b111111111;
+  const exp_shared = (encoded >>> 27) & 0b11111;
+  const exp = Math.pow(2, exp_shared - B - N);
+  return {
+    R: exp * red_s,
+    G: exp * green_s,
+    B: exp * blue_s,
   };
-
-  const { biasedExponent: rExp, mantissa: rOrigMantissa } = extractMantissaAndExponent(r);
-  const { biasedExponent: gExp, mantissa: gOrigMantissa } = extractMantissaAndExponent(g);
-  const { biasedExponent: bExp, mantissa: bOrigMantissa } = extractMantissaAndExponent(b);
-
-  // Use the largest exponent, and shift the mantissa accordingly
-  const exp = Math.max(rExp, gExp, bExp);
-  const rMantissa = rOrigMantissa >> (exp - rExp);
-  const gMantissa = gOrigMantissa >> (exp - gExp);
-  const bMantissa = bOrigMantissa >> (exp - bExp);
-
-  const bias = 15;
-  const biasedExp = exp === 0 ? 0 : exp - 127 + bias;
-  assert(biasedExp >= 0 && biasedExp <= 31);
-  return rMantissa | (gMantissa << 9) | (bMantissa << 18) | (biasedExp << 27);
 }
 
 /**

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -17,6 +17,7 @@ import {
   numberToFloat32Bits,
   float32BitsToNumber,
   numberToFloatBits,
+  unpackRGB9E5UFloat,
 } from '../conversion.js';
 import { clamp, signExtend } from '../math.js';
 
@@ -769,13 +770,7 @@ export const kTexelRepresentationInfo: {
         ]).buffer,
       // For the purpose of unpacking, expand into three "ufloat14" values.
       unpackBits: (data: Uint8Array) => {
-        // Pretend the exponent part is A so we can use unpackComponentsBits.
-        const parts = unpackComponentsBits(kRGBA, data, { R: 9, G: 9, B: 9, A: 5 });
-        return {
-          R: (parts.A! << 9) | parts.R!,
-          G: (parts.A! << 9) | parts.G!,
-          B: (parts.A! << 9) | parts.B!,
-        };
+        return unpackRGB9E5UFloat((data[3] << 24) | (data[2] << 16) | (data[1] << 8) | data[0]);
       },
       numberToBits: components => ({
         R: float32ToFloatBits(components.R ?? unreachable(), 0, 5, 9, 15),


### PR DESCRIPTION
Implement `packRGB9E5UFloat()` following the algorithm specified by `EXT_texture_shared_exponent`. This has slightly different quantization behaviours to the previous implementation.

Add tests.




Issue: #2268

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
