### PR TITLE
shader/validation: Expand identifier validation tests

### DIFF
--- a/src/webgpu/shader/validation/parse/identifiers.spec.ts
+++ b/src/webgpu/shader/validation/parse/identifiers.spec.ts
@@ -265,14 +265,136 @@ const kInvalidIdentifiers = new Set([
   'writeonly',
   'yield',
 ]);
-g.test('identifiers')
-  .desc(`Test that valid identifiers are accepted, and invalid identifiers are rejected.`)
+
+g.test('module_var_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of module-scope 'var's, and invalid identifiers are rejected.`
+  )
   .params(u =>
     u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
   )
   .fn(t => {
     const type = t.params.ident === 'i32' ? 'u32' : 'i32';
     const code = `var<private> ${t.params.ident} : ${type};`;
+    t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
+  });
+
+g.test('module_const_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of module-scope 'const's, and invalid identifiers are rejected.`
+  )
+  .params(u =>
+    u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
+  )
+  .fn(t => {
+    const type = t.params.ident === 'i32' ? 'u32' : 'i32';
+    const code = `const ${t.params.ident} : ${type} = 0;`;
+    t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
+  });
+
+g.test('override_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of 'override's, and invalid identifiers are rejected.`
+  )
+  .params(u =>
+    u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
+  )
+  .fn(t => {
+    const type = t.params.ident === 'i32' ? 'u32' : 'i32';
+    const code = `override ${t.params.ident} : ${type} = 0;`;
+    t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
+  });
+
+g.test('function_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of functions, and invalid identifiers are rejected.`
+  )
+  .params(u =>
+    u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
+  )
+  .fn(t => {
+    const code = `fn ${t.params.ident}() {}`;
+    t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
+  });
+
+g.test('struct_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of structs, and invalid identifiers are rejected.`
+  )
+  .params(u =>
+    u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
+  )
+  .fn(t => {
+    const type = t.params.ident === 'i32' ? 'u32' : 'i32';
+    const code = `struct ${t.params.ident} { i : ${type} }`;
+    t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
+  });
+
+g.test('alias_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of aliases, and invalid identifiers are rejected.`
+  )
+  .params(u =>
+    u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
+  )
+  .fn(t => {
+    const type = t.params.ident === 'i32' ? 'u32' : 'i32';
+    const code = `alias ${t.params.ident} = ${type};`;
+    t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
+  });
+
+g.test('function_param_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of function parameters, and invalid identifiers are rejected.`
+  )
+  .params(u =>
+    u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
+  )
+  .fn(t => {
+    const type = t.params.ident === 'i32' ? 'u32' : 'i32';
+    const code = `fn F(${t.params.ident} : ${type}) {}`;
+    t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
+  });
+
+g.test('function_const_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of function-scoped 'const's, and invalid identifiers are rejected.`
+  )
+  .params(u =>
+    u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
+  )
+  .fn(t => {
+    const code = `fn F() {
+  const ${t.params.ident} = 1;
+}`;
+    t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
+  });
+
+g.test('function_let_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of function-scoped 'let's, and invalid identifiers are rejected.`
+  )
+  .params(u =>
+    u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
+  )
+  .fn(t => {
+    const code = `fn F() {
+  let ${t.params.ident} = 1;
+}`;
+    t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
+  });
+
+g.test('function_var_name')
+  .desc(
+    `Test that valid identifiers are accepted for names of function-scoped 'var's, and invalid identifiers are rejected.`
+  )
+  .params(u =>
+    u.combine('ident', new Set([...kValidIdentifiers, ...kInvalidIdentifiers])).beginSubcases()
+  )
+  .fn(t => {
+    const code = `fn F() {
+  var ${t.params.ident} = 1;
+}`;
     t.expectCompileResult(kValidIdentifiers.has(t.params.ident), code);
   });
 


### PR DESCRIPTION
Validate identifiers for:
* module-scope var decls
* module-scope const decls
* override decls
* function names
* struct names
* alias names
* function-scope const decls
* function-scope let decls
* function-scope var decls

Fixes: #2317, #2800

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
