### PR TITLE
Implement f16-based bitcast validation tests

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
@@ -141,4 +141,43 @@ Can't cast numeric type to vec3<f16> because it is 48 bits wide
 and no other type is that size.
 `
   )
-  .unimplemented();
+  .params(u =>
+    u
+      .combine('other_type', [
+        'bool',
+        'u32',
+        'i32',
+        'f32',
+        'vec2<bool>',
+        'vec3<bool>',
+        'vec4<bool>',
+        'vec2u',
+        'vec3u',
+        'vec4u',
+        'vec2i',
+        'vec3i',
+        'vec4i',
+        'vec2f',
+        'vec3f',
+        'vec4f',
+        'vec2h',
+        'vec4h',
+      ] as const)
+      .combine('direction', ['to', 'from'] as const)
+      .combine('type', ['vec3<f16>', 'vec3h'])
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(t => {
+    const src_type = t.params.direction === 'to' ? t.params.type : t.params.other_type;
+    const dst_type = t.params.direction === 'from' ? t.params.type : t.params.other_type;
+    const code = `
+enable f16;
+@fragment
+fn main() {
+  var src : ${src_type};
+  let dst = bitcast<${dst_type}>(src);
+}`;
+    t.expectCompileResult(false, code);
+  });

--- a/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
@@ -181,3 +181,52 @@ fn main() {
 }`;
     t.expectCompileResult(false, code);
   });
+
+g.test('bad_to_f16')
+  .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
+  .desc(
+    `
+Can't cast non-16-bit types to f16 because it is 16 bits wide
+and no other type is that size.
+`
+  )
+  .params(u =>
+    u
+      .combine('other_type', [
+        'bool',
+        'u32',
+        'i32',
+        'f32',
+        'vec2<bool>',
+        'vec3<bool>',
+        'vec4<bool>',
+        'vec2u',
+        'vec3u',
+        'vec4u',
+        'vec2i',
+        'vec3i',
+        'vec4i',
+        'vec2f',
+        'vec3f',
+        'vec4f',
+        'vec2h',
+        'vec3h',
+        'vec4h',
+      ] as const)
+      .combine('direction', ['to', 'from'] as const)
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(t => {
+    const src_type = t.params.direction === 'to' ? 'f16' : t.params.other_type;
+    const dst_type = t.params.direction === 'from' ? 'f16' : t.params.other_type;
+    const code = `
+enable f16;
+@fragment
+fn main() {
+  var src : ${src_type};
+  let dst = bitcast<${dst_type}>(src);
+}`;
+    t.expectCompileResult(false, code);
+  });

--- a/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
@@ -230,3 +230,60 @@ fn main() {
 }`;
     t.expectCompileResult(false, code);
   });
+
+g.test('valid_vec2h')
+  .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
+  .desc(`Check valid vec2<f16> bitcasts`)
+  .params(u =>
+    u
+      .combine('other_type', ['u32', 'i32', 'f32'] as const)
+      .combine('type', ['vec2<f16>', 'vec2h'] as const)
+      .combine('direction', ['to', 'from'] as const)
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(t => {
+    const src_type = t.params.direction === 'to' ? t.params.type : t.params.other_type;
+    const dst_type = t.params.direction === 'from' ? t.params.type : t.params.other_type;
+    const code = `
+enable f16;
+@fragment
+fn main() {
+  var src : ${src_type};
+  let dst = bitcast<${dst_type}>(src);
+}`;
+    t.expectCompileResult(true, code);
+  });
+
+g.test('valid_vec4h')
+  .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
+  .desc(`Check valid vec2<f16> bitcasts`)
+  .params(u =>
+    u
+      .combine('other_type', [
+        'vec2<u32>',
+        'vec2u',
+        'vec2<i32>',
+        'vec2i',
+        'vec2<f32>',
+        'vec2f',
+      ] as const)
+      .combine('type', ['vec4<f16>', 'vec4h'] as const)
+      .combine('direction', ['to', 'from'] as const)
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(t => {
+    const src_type = t.params.direction === 'to' ? t.params.type : t.params.other_type;
+    const dst_type = t.params.direction === 'from' ? t.params.type : t.params.other_type;
+    const code = `
+enable f16;
+@fragment
+fn main() {
+  var src : ${src_type};
+  let dst = bitcast<${dst_type}>(src);
+}`;
+    t.expectCompileResult(true, code);
+  });


### PR DESCRIPTION
See https://crbug.com/tint/1977

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
