### PR TITLE
Validate `atan()`, `exp2()` and `exp()`

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
@@ -1,0 +1,73 @@
+const builtin = 'atan';
+export const description = `
+Validation tests for the ${builtin}() builtin.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import {
+  TypeF16,
+  TypeF32,
+  elementType,
+  kAllFloatScalarsAndVectors,
+  kAllIntegerScalarsAndVectors,
+} from '../../../../../util/conversion.js';
+import { fpTraitsFor } from '../../../../../util/floating_point.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import {
+  kConstantAndOverrideStages,
+  kMinus3PiTo3Pi,
+  stageSupportsType,
+  validateConstOrOverrideBuiltinEval,
+} from './const_override_validation.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('values')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatScalarsAndVectors)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('value', kMinus3PiTo3Pi)
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const smallestPositive = fpTraitsFor(t.params.type).constants().positive.min;
+    const expectedResult = Math.abs(Math.cos(t.params.value)) > smallestPositive;
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      t.params.value,
+      t.params.type,
+      t.params.stage
+    );
+  });
+
+g.test('integer_argument')
+  .desc(
+    `
+Validates that scalar and vector integer arguments are rejected by ${builtin}()
+`
+  )
+  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .fn(t => {
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      /* expectedResult */ t.params.type === TypeF32,
+      /* value */ 0,
+      t.params.type,
+      'constant'
+    );
+  });

--- a/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
@@ -1,5 +1,4 @@
-import { assert, unreachable } from '../../../../../../common/util/util.js';
-import { kValue } from '../../../../../util/constants.js';
+import { assert } from '../../../../../../common/util/util.js';
 import {
   Type,
   TypeF16,

--- a/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
@@ -1,4 +1,5 @@
-import { assert } from '../../../../../../common/util/util.js';
+import { assert, unreachable } from '../../../../../../common/util/util.js';
+import { kValue } from '../../../../../util/constants.js';
 import {
   Type,
   TypeF16,
@@ -22,6 +23,35 @@ export const kMinusOneToTwo = [
   1.5,
   1.9,
   2.0,
+] as const;
+
+/// An array of values ranging from -3π to 3π.
+export const kMinus3PiTo3Pi = [
+  -3 * Math.PI,
+  -2.999 * Math.PI,
+  -2.5 * Math.PI,
+  -2.001 * Math.PI,
+  -2.0 * Math.PI,
+  -1.999 * Math.PI,
+  -1.5 * Math.PI,
+  -1.001 * Math.PI,
+  -1.0 * Math.PI,
+  -0.999 * Math.PI,
+  -0.5 * Math.PI,
+  -0.001,
+  0,
+  0.001,
+  0.5 * Math.PI,
+  0.999 * Math.PI,
+  1.0 * Math.PI,
+  1.001 * Math.PI,
+  1.5 * Math.PI,
+  1.999 * Math.PI,
+  2.0 * Math.PI,
+  2.5 * Math.PI,
+  2.001 * Math.PI,
+  2.999 * Math.PI,
+  3 * Math.PI,
 ] as const;
 
 /// The evaluation stages to test

--- a/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
@@ -1,0 +1,96 @@
+const builtin = 'exp';
+export const description = `
+Validation tests for the ${builtin}() builtin.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { kValue } from '../../../../../util/constants.js';
+import {
+  TypeF16,
+  TypeF32,
+  elementType,
+  kAllFloatScalarsAndVectors,
+  kAllIntegerScalarsAndVectors,
+} from '../../../../../util/conversion.js';
+import { isRepresentable } from '../../../../../util/floating_point.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import {
+  kConstantAndOverrideStages,
+  stageSupportsType,
+  validateConstOrOverrideBuiltinEval,
+} from './const_override_validation.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('values')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatScalarsAndVectors)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('value', [
+        -1e2,
+        -1e3,
+        -4,
+        -3,
+        -2,
+        -1,
+        -1e-1,
+        -1e-2,
+        -1e-3,
+        0,
+        1e-3,
+        1e-2,
+        1e-1,
+        1,
+        2,
+        3,
+        4,
+        1e2,
+        1e3,
+        Math.log2(kValue.f16.positive.max) - 0.1,
+        Math.log2(kValue.f16.positive.max) + 0.1,
+        Math.log2(kValue.f32.positive.max) - 0.1,
+        Math.log2(kValue.f32.positive.max) + 0.1,
+      ])
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const expectedResult = isRepresentable(Math.exp(t.params.value), t.params.type);
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      t.params.value,
+      t.params.type,
+      t.params.stage
+    );
+  });
+
+g.test('integer_argument')
+  .desc(
+    `
+Validates that scalar and vector integer arguments are rejected by ${builtin}()
+`
+  )
+  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .fn(t => {
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      /* expectedResult */ t.params.type === TypeF32,
+      /* value */ 0,
+      t.params.type,
+      'constant'
+    );
+  });

--- a/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
@@ -1,0 +1,96 @@
+const builtin = 'exp2';
+export const description = `
+Validation tests for the ${builtin}() builtin.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { kValue } from '../../../../../util/constants.js';
+import {
+  TypeF16,
+  TypeF32,
+  elementType,
+  kAllFloatScalarsAndVectors,
+  kAllIntegerScalarsAndVectors,
+} from '../../../../../util/conversion.js';
+import { isRepresentable } from '../../../../../util/floating_point.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import {
+  kConstantAndOverrideStages,
+  stageSupportsType,
+  validateConstOrOverrideBuiltinEval,
+} from './const_override_validation.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('values')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatScalarsAndVectors)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('value', [
+        -1e2,
+        -1e3,
+        -4,
+        -3,
+        -2,
+        -1,
+        -1e-1,
+        -1e-2,
+        -1e-3,
+        0,
+        1e-3,
+        1e-2,
+        1e-1,
+        1,
+        2,
+        3,
+        4,
+        1e2,
+        1e3,
+        Math.log2(kValue.f16.positive.max) - 0.1,
+        Math.log2(kValue.f16.positive.max) + 0.1,
+        Math.log2(kValue.f32.positive.max) - 0.1,
+        Math.log2(kValue.f32.positive.max) + 0.1,
+      ])
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const expectedResult = isRepresentable(Math.pow(2, t.params.value), t.params.type);
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      t.params.value,
+      t.params.type,
+      t.params.stage
+    );
+  });
+
+g.test('integer_argument')
+  .desc(
+    `
+Validates that scalar and vector integer arguments are rejected by ${builtin}()
+`
+  )
+  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .fn(t => {
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      /* expectedResult */ t.params.type === TypeF32,
+      /* value */ 0,
+      t.params.type,
+      'constant'
+    );
+  });


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
