### PR TITLE
Add bool cases to vector type validation

### DIFF
--- a/src/webgpu/shader/validation/types/vector.spec.ts
+++ b/src/webgpu/shader/validation/types/vector.spec.ts
@@ -10,6 +10,9 @@ export const g = makeTestGroup(ShaderValidationTest);
 
 const kCases = {
   // Valid vector types
+  vec2_bool: { wgsl: 'alias T = vec2<bool>;', ok: true },
+  vec3_bool: { wgsl: 'alias T = vec3<bool>;', ok: true },
+  vec4_bool: { wgsl: 'alias T = vec4<bool>;', ok: true },
   vec2_i32: { wgsl: 'alias T = vec2<i32>;', ok: true },
   vec3_i32: { wgsl: 'alias T = vec3<i32>;', ok: true },
   vec4_i32: { wgsl: 'alias T = vec4<i32>;', ok: true },
@@ -55,6 +58,7 @@ const kCases = {
   vec_of_atomic: { wgsl: 'alias T = vec3<atomic<i32>>;', ok: false },
   vec_of_matrix: { wgsl: 'alias T = vec3<mat2x2f>;', ok: false },
   vec_of_vec: { wgsl: 'alias T = vec3<vec2f>;', ok: false },
+  no_bool_shortform: { wgsl: 'const c : vec2b = vec2<bool>();', ok: false },
 };
 
 g.test('vector')


### PR DESCRIPTION


Issue: #1495
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
