### PR TITLE
[wgsl] Validate @group and @binding parsing

### DIFF
--- a/src/webgpu/shader/validation/shader_io/binding.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/binding.spec.ts
@@ -1,0 +1,140 @@
+export const description = `Validation tests for binding`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kTests = {
+  const_expr: {
+    src: `const z = 5;
+    const y = 2;
+    @binding(z + y)`,
+    pass: true,
+  },
+  override_expr: {
+    src: `override z = 5;
+    @binding(z)`,
+    pass: false,
+  },
+
+  zero: {
+    src: `@binding(0)`,
+    pass: true,
+  },
+  one: {
+    src: `@binding(1)`,
+    pass: true,
+  },
+  comment: {
+    src: `@/* comment */binding(1)`,
+    pass: true,
+  },
+  split_line: {
+    src: '@ \n binding(1)',
+    pass: true,
+  },
+  trailing_comma: {
+    src: `@binding(1,)`,
+    pass: true,
+  },
+  int_literal: {
+    src: `@binding(1i)`,
+    pass: true,
+  },
+  uint_literal: {
+    src: `@binding(1u)`,
+    pass: true,
+  },
+  hex_literal: {
+    src: `@binding(0x1)`,
+    pass: true,
+  },
+
+  negative: {
+    src: `@binding(-1)`,
+    pass: false,
+  },
+  missing_value: {
+    src: `@binding()`,
+    pass: false,
+  },
+  missing_left_paren: {
+    src: `@binding 1)`,
+    pass: false,
+  },
+  missing_right_paren: {
+    src: `@binding(1`,
+    pass: false,
+  },
+  multiple_values: {
+    src: `@binding(1,2)`,
+    pass: false,
+  },
+  f32_val_literal: {
+    src: `@binding(1.0)`,
+    pass: false,
+  },
+  f32_val: {
+    src: `@binding(1f)`,
+    pass: false,
+  },
+  no_params: {
+    src: `@binding`,
+    pass: false,
+  },
+  misspelling: {
+    src: `@abinding(1)`,
+    pass: false,
+  },
+  multi_binding: {
+    src: `@binding(1) @binding(1)`,
+    pass: false,
+  },
+};
+g.test('binding')
+  .desc(`Test validation of binding`)
+  .params(u => u.combine('attr', keysOf(kTests)))
+  .fn(t => {
+    const code = `
+${kTests[t.params.attr].src} @group(1)
+var<storage> a: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(kTests[t.params.attr].pass, code);
+  });
+
+g.test('binding_f16')
+  .desc(`Test validation of binding with f16`)
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(t => {
+    const code = `
+@group(1) @binding(1h)
+var<storage> a: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('binding_without_group')
+  .desc(`Test validation of binding without group`)
+  .fn(t => {
+    const code = `
+@binding(1)
+var<storage> a: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(false, code);
+  });

--- a/src/webgpu/shader/validation/shader_io/group.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/group.spec.ts
@@ -1,0 +1,140 @@
+export const description = `Validation tests for group`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kTests = {
+  const_expr: {
+    src: `const z = 5;
+    const y = 2;
+    @group(z + y)`,
+    pass: true,
+  },
+  override_expr: {
+    src: `override z = 5;
+    @group(z)`,
+    pass: false,
+  },
+
+  zero: {
+    src: `@group(0)`,
+    pass: true,
+  },
+  one: {
+    src: `@group(1)`,
+    pass: true,
+  },
+  comment: {
+    src: `@/* comment */group(1)`,
+    pass: true,
+  },
+  split_line: {
+    src: '@ \n group(1)',
+    pass: true,
+  },
+  trailing_comma: {
+    src: `@group(1,)`,
+    pass: true,
+  },
+  int_literal: {
+    src: `@group(1i)`,
+    pass: true,
+  },
+  uint_literal: {
+    src: `@group(1u)`,
+    pass: true,
+  },
+  hex_literal: {
+    src: `@group(0x1)`,
+    pass: true,
+  },
+
+  negative: {
+    src: `@group(-1)`,
+    pass: false,
+  },
+  missing_value: {
+    src: `@group()`,
+    pass: false,
+  },
+  missing_left_paren: {
+    src: `@group 1)`,
+    pass: false,
+  },
+  missing_right_paren: {
+    src: `@group(1`,
+    pass: false,
+  },
+  multiple_values: {
+    src: `@group(1,2)`,
+    pass: false,
+  },
+  f32_val_literal: {
+    src: `@group(1.0)`,
+    pass: false,
+  },
+  f32_val: {
+    src: `@group(1f)`,
+    pass: false,
+  },
+  no_params: {
+    src: `@group`,
+    pass: false,
+  },
+  misspelling: {
+    src: `@agroup(1)`,
+    pass: false,
+  },
+  multi_group: {
+    src: `@group(1) @group(1)`,
+    pass: false,
+  },
+};
+g.test('group')
+  .desc(`Test validation of group`)
+  .params(u => u.combine('attr', keysOf(kTests)))
+  .fn(t => {
+    const code = `
+${kTests[t.params.attr].src} @binding(1)
+var<storage> a: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(kTests[t.params.attr].pass, code);
+  });
+
+g.test('group_f16')
+  .desc(`Test validation of group with f16`)
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(t => {
+    const code = `
+@group(1h) @binding(1)
+var<storage> a: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('group_without_binding')
+  .desc(`Test validation of group without binding`)
+  .fn(t => {
+    const code = `
+@group(1)
+var<storage> a: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(false, code);
+  });

--- a/src/webgpu/shader/validation/shader_io/group_and_binding.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/group_and_binding.spec.ts
@@ -1,0 +1,116 @@
+export const description = `Validation tests for group and binding`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('storage')
+  .desc(`Test validation of group and binding on storage resources`)
+  .fn(t => {
+    const code = `
+@group(1) @binding(1)
+var<storage> a: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(true, code);
+  });
+
+g.test('uniform')
+  .desc(`Test validation of group and binding on uniform resources`)
+  .fn(t => {
+    const code = `
+@group(1) @binding(1)
+var<uniform> a: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(true, code);
+  });
+
+g.test('texture')
+  .desc(`Test validation of group and binding on texture resources`)
+  .fn(t => {
+    const code = `
+@group(1) @binding(1)
+var a: texture_2d<f32>;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(true, code);
+  });
+
+g.test('sampler')
+  .desc(`Test validation of group and binding on sampler resources`)
+  .fn(t => {
+    const code = `
+@group(1) @binding(1)
+var a: sampler;
+
+@group(0) @binding(2)
+var b: sampler_comparison;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+  _ = b;
+}`;
+    t.expectCompileResult(true, code);
+  });
+
+g.test('private_module_scope')
+  .desc(`Test validation of group and binding on private resources`)
+  .fn(t => {
+    const code = `
+@group(1) @binding(1)
+var<private> a: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('private_function_scope')
+  .desc(`Test validation of group and binding on function-scope private resources`)
+  .fn(t => {
+    const code = `
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  @group(1) @binding(1)
+  var<private> a: i32;
+}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('function_scope')
+  .desc(`Test validation of group and binding on function-scope private resources`)
+  .fn(t => {
+    const code = `
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  @group(1) @binding(1)
+  var a: i32;
+}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('function_scope_texture')
+  .desc(`Test validation of group and binding on function-scope private resources`)
+  .fn(t => {
+    const code = `
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  @group(1) @binding(1)
+  var a: texture_2d<f32>;
+}`;
+    t.expectCompileResult(false, code);
+  });

--- a/src/webgpu/shader/validation/shader_io/group_and_binding.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/group_and_binding.spec.ts
@@ -1,6 +1,7 @@
 export const description = `Validation tests for group and binding`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
@@ -65,6 +66,50 @@ var b: sampler_comparison;
     t.expectCompileResult(true, code);
   });
 
+const kRequiredSettingTests = {
+  storage: {
+    space: '<storage>',
+    kind: 'i32',
+    pass: false,
+  },
+  uniform: {
+    space: '<uniform>',
+    kind: 'i32',
+    pass: false,
+  },
+  handle_tex: {
+    space: '',
+    kind: 'texture_2d<f32>',
+    pass: false,
+  },
+  handle_sampler: {
+    space: '',
+    kind: 'sampler',
+    pass: false,
+  },
+  none: {
+    space: '<private>',
+    kind: 'i32',
+    pass: true,
+  },
+};
+
+g.test('required_group_and_binding')
+  .desc(`Test validation of group and binding missing on required address spaces`)
+  .params(u => u.combine('attr', keysOf(kRequiredSettingTests)))
+  .fn(t => {
+    const data = kRequiredSettingTests[t.params.attr];
+
+    const code = `
+var${data.space} a: ${data.kind};
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+}`;
+    t.expectCompileResult(data.pass, code);
+  });
+
 g.test('private_module_scope')
   .desc(`Test validation of group and binding on private resources`)
   .fn(t => {
@@ -113,4 +158,43 @@ g.test('function_scope_texture')
   var a: texture_2d<f32>;
 }`;
     t.expectCompileResult(false, code);
+  });
+
+g.test('duplicate_group_binding_same_entry_point')
+  .desc(
+    `Test validation of group and binding when same values set on a var used in the same entry point`
+  )
+  .params(u => u.combine('group', [1, 2]))
+  .fn(t => {
+    const code = `
+@group(${t.params.group}) @binding(1) var a: texture_2d<f32>;
+@group(1) @binding(1) var<storage> b: i32;
+
+@workgroup_size(1, 1, 1)
+@compute fn main() {
+  _ = a;
+  _ = b;
+}`;
+    t.expectCompileResult(`${t.params.group}` === '2', code);
+  });
+
+g.test('duplicate_group_binding_different_entry_point')
+  .desc(
+    `Test validation of group and binding when same values set on a var used in different entry points`
+  )
+  .fn(t => {
+    const code = `
+@group(1) @binding(1) var a: texture_2d<f32>;
+@group(1) @binding(1) var b: sampler;
+
+@workgroup_size(1, 1, 1)
+@compute fn main_a() {
+  _ = a;
+}
+
+@workgroup_size(1, 1, 1)
+@compute fn main_b() {
+  _ = b;
+}`;
+    t.expectCompileResult(true, code);
   });


### PR DESCRIPTION
Add validation for various parsing rules for `@group` and `@binding`.

Fixes: #1439, #1434

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
