### PR TITLE
[wgsl] More invariant parsing tests.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/invariant.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/invariant.spec.ts
@@ -1,12 +1,64 @@
 export const description = `Validation tests for the invariant attribute`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 import { kBuiltins } from './builtins.spec.js';
 import { generateShader } from './util.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
+
+const kTests = {
+  invariant: {
+    src: `@invariant`,
+    pass: true,
+  },
+  comment: {
+    src: `@/* comment */invariant`,
+    pass: true,
+  },
+  split_line: {
+    src: '@\ninvariant',
+    pass: true,
+  },
+  empty_parens: {
+    src: `@invariant()`,
+    pass: false,
+  },
+  value: {
+    src: `@invariant(0)`,
+    pass: false,
+  },
+  missing_right_paren: {
+    src: `@invariant(`,
+    pass: false,
+  },
+  missing_left_paren: {
+    src: `@invariant)`,
+    pass: false,
+  },
+  duplicate: {
+    src: `@invariant @invariant`,
+    pass: false,
+  },
+};
+
+g.test('parsing')
+  .desc(`Test parsing of the invariant attribute`)
+  .params(u => u.combine('attr', keysOf(kTests)))
+  .fn(t => {
+    const code = `
+    struct VertexOut {
+      @builtin(position) ${kTests[t.params.attr].src} position : vec4<f32>
+    };
+    @vertex
+    fn main() -> VertexOut {
+      return VertexOut();
+    }
+    `;
+    t.expectCompileResult(kTests[t.params.attr].pass, code);
+  });
 
 g.test('valid_only_with_vertex_position_builtin')
   .desc(`Test that the invariant attribute is only accepted with the vertex position builtin`)
@@ -44,45 +96,4 @@ g.test('not_valid_on_user_defined_io')
     }
     `;
     t.expectCompileResult(!t.params.use_invariant, code);
-  });
-
-g.test('invalid_use_of_parameters')
-  .desc(`Test that no parameters are accepted for the invariant attribute`)
-  .params(u => u.combine('suffix', ['', '()', '(0)'] as const).beginSubcases())
-  .fn(t => {
-    const code = `
-    struct VertexOut {
-      @builtin(position) @invariant${t.params.suffix} position : vec4<f32>
-    };
-    @vertex
-    fn main() -> VertexOut {
-      return VertexOut();
-    }
-    `;
-    t.expectCompileResult(t.params.suffix === '', code);
-  });
-
-g.test('duplicate')
-  .desc(`Test that the invariant attribute can only be applied once.`)
-  .params(u =>
-    u
-      .combineWithParams(kBuiltins)
-      .combine('use_struct', [true, false] as const)
-      .combine('attr', ['', '@invariant'] as const)
-      .beginSubcases()
-  )
-  .fn(t => {
-    if (t.params.name !== 'position') {
-      t.skip('only valid with position');
-    }
-
-    const code = generateShader({
-      attribute: `@builtin(${t.params.name}) @invariant ${t.params.attr}`,
-      type: t.params.type,
-      stage: t.params.stage,
-      io: t.params.io,
-      use_struct: t.params.use_struct,
-    });
-
-    t.expectCompileResult(t.params.attr === '', code);
   });


### PR DESCRIPTION
This CL extends the invariant parsing to more invalid cases. The number of skipped tests is also reduced.

Fixes: #1447

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
