### PR TITLE
Tweak shader_io/id.spec.ts

### DIFF
--- a/src/webgpu/shader/validation/shader_io/id.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/id.spec.ts
@@ -133,7 +133,7 @@ override a = 4;
 
 g.test('id_struct_member')
   .desc(`Test validation of id with struct member`)
-  .params(u => u.combine('id', ['@id(1) override', '']))
+  .params(u => u.combine('id', ['@id(1) override', '@id(1)', '']))
   .fn(t => {
     const code = `
 struct S {


### PR DESCRIPTION
`@id(1) override a: i32` is likely to fail parsing, not because `@id` is not accepted as a struct member attribute, but because there are two identifiers for the member name. Add another case where the `override` is omitted.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
