### PR TITLE
[wgsl] More workgroup_size tests.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/workgroup_size.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/workgroup_size.spec.ts
@@ -19,6 +19,18 @@ const kWorkgroupSizeTests = {
     src: `@workgroup_size(8, 8, 8f)`,
     pass: false,
   },
+  x_only_float_literal: {
+    src: `@workgroup_size(8.0)`,
+    pass: false,
+  },
+  xy_only_float_literal: {
+    src: `@workgroup_size(8, 8.0)`,
+    pass: false,
+  },
+  xyz_float_literal: {
+    src: `@workgroup_size(8, 8, 8.0)`,
+    pass: false,
+  },
   empty: {
     src: `@workgroup_size()`,
     pass: false,
@@ -70,6 +82,18 @@ const kWorkgroupSizeTests = {
   },
   xyz_signed: {
     src: `@workgroup_size(8i, 8i, 8i)`,
+    pass: true,
+  },
+  x_only_hex: {
+    src: `@workgroup_size(0x1)`,
+    pass: true,
+  },
+  xy_only_hex: {
+    src: `@workgroup_size(0x1, 0x1)`,
+    pass: true,
+  },
+  xyz_hex: {
+    src: `@workgroup_size(0x1, 0x1, 0x1)`,
     pass: true,
   },
 
@@ -155,6 +179,50 @@ const kWorkgroupSizeTests = {
     src: `@workgroup_size(256, 256, 64)`,
     pass: true,
   },
+
+  missing_left_paren: {
+    src: `@workgroup_size 1, 2, 3)`,
+    pass: false,
+  },
+  missing_right_paren: {
+    src: `@workgroup_size(1, 2, 3`,
+    pass: false,
+  },
+  misspelling: {
+    src: `@aworkgroup_size(1)`,
+    pass: false,
+  },
+  no_params: {
+    src: `@workgroup_size`,
+    pass: false,
+  },
+  multi_line: {
+    src: '@\nworkgroup_size(1)',
+    pass: true,
+  },
+  comment: {
+    src: `@/* comment */workgroup_size(1)`,
+    pass: true,
+  },
+
+  mix_ux: {
+    src: `@workgroup_size(1u, 1i, 1i)`,
+    pass: false,
+  },
+  mix_uy: {
+    src: `@workgroup_size(1i, 1u, 1i)`,
+    pass: false,
+  },
+  mix_uz: {
+    src: `@workgroup_size(1i, 1i, 1u)`,
+    pass: false,
+  },
+
+  duplicate: {
+    src: `@workgroup_size(1)
+@workgroup_size(2, 2, 2)`,
+    pass: false,
+  },
 };
 g.test('workgroup_size')
   .desc(`Test validation of workgroup_size`)
@@ -164,4 +232,69 @@ g.test('workgroup_size')
 ${kWorkgroupSizeTests[t.params.attr].src}
 @compute fn main() {}`;
     t.expectCompileResult(kWorkgroupSizeTests[t.params.attr].pass, code);
+  });
+
+g.test('workgroup_size_fragment_shader')
+  .desc(`Test validation of workgroup_size on fragment shader`)
+  .fn(t => {
+    const code = `
+@workgroup_size(1)
+@fragment fn main(@builtin(position) pos: vec4<f32>) {}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('workgroup_size_vertex_shader')
+  .desc(`Test validation of workgroup_size on fragment shader`)
+  .fn(t => {
+    const code = `
+@workgroup_size(1)
+@vertex fn main() -> @builtin(position) vec4<f32> {}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('workgroup_size_function')
+  .desc(`Test validation of workgroup_size on user function`)
+  .fn(t => {
+    const code = `
+@workgroup_size(1)
+fn my_func() {}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('workgroup_size_const')
+  .desc(`Test validation of workgroup_size on user function`)
+  .fn(t => {
+    const code = `
+@workgroup_size(1)
+const a : i32 = 4;
+
+fn my_func() {}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('workgroup_size_var')
+  .desc(`Test validation of workgroup_size on user function`)
+  .fn(t => {
+    const code = `
+@workgroup_size(1)
+@group(1) @binding(1)
+var<storage> a: i32;
+
+fn my_func() {
+  _ = a;
+}`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('workgroup_size_fp16')
+  .desc(`Test validation of workgroup_size with fp16`)
+  .params(u => u.combine('ext', ['', 'h']))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(t => {
+    const code = `
+@workgroup_size(1${t.params.ext})
+@compute fn main() {}`;
+    t.expectCompileResult(t.params.ext === '', code);
   });

--- a/src/webgpu/shader/validation/shader_io/workgroup_size.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/workgroup_size.spec.ts
@@ -235,7 +235,7 @@ ${kWorkgroupSizeTests[t.params.attr].src}
   });
 
 g.test('workgroup_size_fragment_shader')
-  .desc(`Test validation of workgroup_size on fragment shader`)
+  .desc(`Test validation of workgroup_size on a fragment shader`)
   .fn(t => {
     const code = `
 @workgroup_size(1)
@@ -244,7 +244,7 @@ g.test('workgroup_size_fragment_shader')
   });
 
 g.test('workgroup_size_vertex_shader')
-  .desc(`Test validation of workgroup_size on fragment shader`)
+  .desc(`Test validation of workgroup_size on a vertex shader`)
   .fn(t => {
     const code = `
 @workgroup_size(1)
@@ -262,7 +262,7 @@ fn my_func() {}`;
   });
 
 g.test('workgroup_size_const')
-  .desc(`Test validation of workgroup_size on user function`)
+  .desc(`Test validation of workgroup_size on a const`)
   .fn(t => {
     const code = `
 @workgroup_size(1)
@@ -273,7 +273,7 @@ fn my_func() {}`;
   });
 
 g.test('workgroup_size_var')
-  .desc(`Test validation of workgroup_size on user function`)
+  .desc(`Test validation of workgroup_size on a var`)
   .fn(t => {
     const code = `
 @workgroup_size(1)


### PR DESCRIPTION
Add more validation tests for `workgroup_size`.

Fixes: #1462

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
