### PR TITLE
Prevent server from exiting on bad suite name

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -589,7 +589,14 @@ void (async () => {
   loader.addEventListener('finish', () => {
     $('#info')[0].textContent = '';
   });
-  const tree = await loader.loadTree(rootQuery);
+
+  let tree;
+  try {
+    tree = await loader.loadTree(rootQuery);
+  } catch (err) {
+    $('#info')[0].textContent = (err as Error).toString();
+    return;
+  }
 
   tree.dissolveSingleChildTrees();
 

--- a/src/common/tools/crawl.ts
+++ b/src/common/tools/crawl.ts
@@ -45,8 +45,7 @@ async function crawlFilesRecursively(dir: string): Promise<string[]> {
 
 export async function crawl(suiteDir: string, validate: boolean): Promise<TestSuiteListingEntry[]> {
   if (!fs.existsSync(suiteDir)) {
-    console.error(`Could not find ${suiteDir}`);
-    process.exit(1);
+    throw new Error(`Could not find suite: ${suiteDir}`);
   }
 
   // Crawl files and convert paths to be POSIX-style, relative to suiteDir.


### PR DESCRIPTION
I type the wrong suite name often and then I have to go manually restart the server so I thought I'd try to make it so it doesn't just exit.

It seems like throwing should be enough?

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
