### PR TITLE
Tests for atomic builtins: atomicLoad, atomicStore, atomicExchange, a…

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicAdd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicAdd.spec.ts
@@ -35,7 +35,7 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     u
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
@@ -44,7 +44,7 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
     const initValue = 0;
     const op = `atomicAdd(&output[0], 1)`;
-    const expected = new (typedArrayCtor(t.params.scalarKind))(bufferNumElements);
+    const expected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements);
     expected[0] = numInvocations;
 
     runStorageVariableTest({
@@ -72,7 +72,7 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     u
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
@@ -81,7 +81,7 @@ fn atomicAdd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const initValue = 0;
     const op = `atomicAdd(&wg[0], 1)`;
 
-    const expected = new (typedArrayCtor(t.params.scalarKind))(
+    const expected = new (typedArrayCtor(t.params.scalarType))(
       wgNumElements * t.params.dispatchSize
     );
     for (let d = 0; d < t.params.dispatchSize; ++d) {

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicAnd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicAnd.spec.ts
@@ -38,7 +38,7 @@ fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
@@ -50,15 +50,15 @@ fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0xffffffff;
 
-    const scalarKind = t.params.scalarKind;
+    const scalarType = t.params.scalarType;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
       let i = map_id(u32(id));
-      atomicAnd(&output[i / 32], ~(${scalarKind}(1) << i))
+      atomicAnd(&output[i / 32], ~(${scalarType}(1) << i))
     `;
 
-    const expected = new (typedArrayCtor(scalarKind))(bufferNumElements).fill(initValue);
+    const expected = new (typedArrayCtor(scalarType))(bufferNumElements).fill(initValue);
     for (let id = 0; id < numInvocations; ++id) {
       const i = mapId.f(id, numInvocations);
       expected[Math.floor(i / 32)] &= ~(1 << i);
@@ -91,7 +91,7 @@ fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize;
@@ -103,15 +103,15 @@ fn atomicAnd(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0xffffffff;
 
-    const scalarKind = t.params.scalarKind;
+    const scalarType = t.params.scalarType;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
       let i = map_id(u32(id));
-      atomicAnd(&wg[i / 32], ~(${scalarKind}(1) << i))
+      atomicAnd(&wg[i / 32], ~(${scalarType}(1) << i))
     `;
 
-    const expected = new (typedArrayCtor(scalarKind))(wgNumElements * t.params.dispatchSize).fill(
+    const expected = new (typedArrayCtor(scalarType))(wgNumElements * t.params.dispatchSize).fill(
       initValue
     );
     for (let d = 0; d < t.params.dispatchSize; ++d) {

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicCompareExchangeWeak.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicCompareExchangeWeak.spec.ts
@@ -14,11 +14,21 @@ component of the result vector equals cmp.
 `;
 
 import { makeTestGroup } from '../../../../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../../../../common/util/data_tables.js';
+import { assert } from '../../../../../../../common/util/util.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
+
+import {
+  dispatchSizes,
+  workgroupSizes,
+  typedArrayCtor,
+  kMapId,
+  onlyWorkgroupSizes,
+} from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('exchange')
+g.test('compare_exchange_weak_storage_basic')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
@@ -34,6 +44,699 @@ struct __atomic_compare_exchange_result<T> {
 `
   )
   .params(u =>
-    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
   )
-  .unimplemented();
+  .fn(async t => {
+    const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
+    const bufferNumElements = numInvocations;
+    const scalarType = t.params.scalarType;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const wgsl =
+      `
+      @group(0) @binding(0)
+      var<storage, read_write> input : array<atomic<${scalarType}>>;
+
+      @group(0) @binding(1)
+      var<storage, read_write> output : array<${scalarType}>;
+
+      @group(0) @binding(2)
+      var<storage, read_write> exchanged : array<${scalarType}>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+          ) {
+        let id = ${scalarType}(global_invocation_id[0]);
+
+        // Exchange every third value
+        var comp = id + 1;
+        if (id % 3 == 0) {
+          comp = id;
+        }
+        let r = atomicCompareExchangeWeak(&input[id], comp, map_id(id * 2));
+
+        // Store results
+            output[id] = r.old_value;
+        if (r.exchanged) {
+          exchanged[id] = 1;
+        } else {
+          exchanged[id] = 0;
+        }
+      }
+    ` + extra;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    // Create input buffer with values [0..n]
+    const inputBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+    });
+    t.trackForCleanup(inputBuffer);
+    const data = new arrayType(inputBuffer.getMappedRange());
+    data.forEach((_, i) => (data[i] = i));
+    inputBuffer.unmap();
+
+    const outputBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const exchangedBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(exchangedBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: inputBuffer } },
+        { binding: 1, resource: { buffer: outputBuffer } },
+        { binding: 2, resource: { buffer: exchangedBuffer } },
+      ],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(t.params.dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Output buffer should be the same as the initial input buffer as it contains
+    // values returned from atomicCompareExchangeWeak
+    const outputExpected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements);
+    outputExpected.forEach((_, i) => (outputExpected[i] = i));
+    t.expectGPUBufferValuesEqual(outputBuffer, outputExpected);
+
+    // Read back exchanged buffer
+    const exchangedBufferResult = await t.readGPUBufferRangeTyped(exchangedBuffer, {
+      type: arrayType,
+      typedLength: exchangedBuffer.size / arrayType.BYTES_PER_ELEMENT,
+    });
+
+    // The input buffer should have been modified to a computed value for every third value,
+    // unless the comparison spuriously failed.
+    const inputExpected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements);
+    inputExpected.forEach((_, i) => {
+      if (i % 3 === 0 && exchangedBufferResult.data[i]) {
+        inputExpected[i] = mapId.f(i * 2, numInvocations);
+      } else {
+        inputExpected[i] = i; // No change
+      }
+    });
+    t.expectGPUBufferValuesEqual(inputBuffer, inputExpected);
+  });
+
+g.test('compare_exchange_weak_workgroup_basic')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+
+struct __atomic_compare_exchange_result<T> {
+  old_value : T,    // old value stored in the atomic
+  exchanged : bool, // true if the exchange was done
+}
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(async t => {
+    const numInvocations = t.params.workgroupSize;
+    const wgNumElements = numInvocations;
+    const scalarType = t.params.scalarType;
+    const dispatchSize = t.params.dispatchSize;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const wgsl =
+      `
+      var<workgroup> wg: array<atomic<${scalarType}>, ${wgNumElements}>;
+
+      @group(0) @binding(0)
+      var<storage, read_write> output: array<${scalarType}, ${wgNumElements * dispatchSize}>;
+
+      @group(0) @binding(1)
+      var<storage, read_write> exchanged: array<${scalarType}, ${wgNumElements * dispatchSize}>;
+
+      // Result of each workgroup is written to output[workgroup_id.x]
+      @group(0) @binding(2)
+      var<storage, read_write> wg_copy: array<${scalarType}, ${wgNumElements * dispatchSize}>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(local_invocation_index) local_invocation_index: u32,
+          @builtin(workgroup_id) workgroup_id : vec3<u32>
+          ) {
+        let id = ${scalarType}(local_invocation_index);
+        let global_id = ${scalarType}(workgroup_id.x * ${wgNumElements} + local_invocation_index);
+
+        // Initialize wg[id] with this invocations global id
+        atomicStore(&wg[id], global_id);
+
+        // Exchange every third value
+        var comp = global_id + 1;
+        if (global_id % 3 == 0) {
+          comp = global_id;
+        }
+        let r = atomicCompareExchangeWeak(&wg[id], comp, map_id(global_id * 2));
+
+        // Store results
+        output[global_id] = r.old_value;
+        if (r.exchanged) {
+          exchanged[global_id] = 1;
+        } else {
+          exchanged[global_id] = 0;
+        }
+
+        // Copy new value into wg_copy
+        wg_copy[global_id] = atomicLoad(&wg[id]);
+      }
+      ` + extra;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    const outputBuffer = t.device.createBuffer({
+      size: wgNumElements * dispatchSize * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const wgCopyBuffer = t.device.createBuffer({
+      size: wgNumElements * dispatchSize * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const exchangedBuffer = t.device.createBuffer({
+      size: wgNumElements * dispatchSize * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(exchangedBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: outputBuffer } },
+        { binding: 1, resource: { buffer: exchangedBuffer } },
+        { binding: 2, resource: { buffer: wgCopyBuffer } },
+      ],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Output buffer should be the same as the initial wg buffer as it contains
+    // values returned from atomicCompareExchangeWeak
+    const outputExpected = new (typedArrayCtor(t.params.scalarType))(wgNumElements * dispatchSize);
+    outputExpected.forEach((_, i) => (outputExpected[i] = i));
+    t.expectGPUBufferValuesEqual(outputBuffer, outputExpected);
+
+    // Read back exchanged buffer
+    const exchangedBufferResult = await t.readGPUBufferRangeTyped(exchangedBuffer, {
+      type: arrayType,
+      typedLength: exchangedBuffer.size / arrayType.BYTES_PER_ELEMENT,
+    });
+
+    // And the wg copy buffer should have been modified to a computed value for every third value,
+    // unless the comparison spuriously failed.
+    const wgCopyBufferExpected = new (typedArrayCtor(t.params.scalarType))(
+      wgNumElements * dispatchSize
+    );
+    wgCopyBufferExpected.forEach((_, i) => {
+      if (i % 3 === 0 && exchangedBufferResult.data[i]) {
+        wgCopyBufferExpected[i] = mapId.f(i * 2, numInvocations);
+      } else {
+        wgCopyBufferExpected[i] = i; // No change
+      }
+    });
+    t.expectGPUBufferValuesEqual(wgCopyBuffer, wgCopyBufferExpected);
+  });
+
+g.test('compare_exchange_weak_storage_advanced')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+
+struct __atomic_compare_exchange_result<T> {
+  old_value : T,    // old value stored in the atomic
+  exchanged : bool, // true if the exchange was done
+}
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', onlyWorkgroupSizes) //
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(async t => {
+    const numInvocations = t.params.workgroupSize;
+    const scalarType = t.params.scalarType;
+
+    // Number of times each workgroup attempts to exchange the same value to the same memory address
+    const numWrites = 4;
+
+    const bufferNumElements = numInvocations * numWrites;
+    const pingPongValues = [24, 68];
+
+    const wgsl = `
+      @group(0) @binding(0)
+      var<storage, read_write> data : atomic<${scalarType}>;
+
+      @group(0) @binding(1)
+      var<storage, read_write> old_values : array<${scalarType}>;
+
+      @group(0) @binding(2)
+      var<storage, read_write> exchanged : array<${scalarType}>;
+
+      fn ping_pong_value(i: u32) -> ${scalarType} {
+        if (i % 2 == 0) {
+          return ${pingPongValues[0]};
+        } else {
+          return ${pingPongValues[1]};
+        }
+      }
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+          ) {
+        let id = ${scalarType}(global_invocation_id[0]);
+
+        // Each invocation attempts to write an alternating (ping-pong) value, once per loop.
+        // The data value is initialized with the first of the two ping-pong values.
+        // Only one invocation per loop iteration should succeed. Note the workgroupBarrier() used
+        // to synchronize each invocation in the loop.
+        // The reason we alternate is in case atomicCompareExchangeWeak spurioulsy fails:
+        // If all invocations of one iteration spuriously fail, the very next iteration will also
+        // fail since the value will not have been exchanged; however, the subsequent one will succeed
+        // (assuming not all iterations spuriously fail yet again).
+
+        for (var i = 0u; i < ${numWrites}u; i++) {
+          let compare = ping_pong_value(i);
+          let next = ping_pong_value(i + 1);
+
+          let r = atomicCompareExchangeWeak(&data, compare, next);
+
+          let slot = i * ${numInvocations}u + u32(id);
+          old_values[slot] = r.old_value;
+          if (r.exchanged) {
+            exchanged[slot] = 1;
+          } else {
+            exchanged[slot] = 0;
+          }
+
+          workgroupBarrier();
+        }
+      }
+    `;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+    const defaultValue = 99999999;
+
+    // Create single-value data buffer initialized to the first ping-pong value
+    const dataBuffer = t.device.createBuffer({
+      size: 1 * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+    });
+    {
+      const data = new arrayType(dataBuffer.getMappedRange());
+      data[0] = pingPongValues[0];
+      dataBuffer.unmap();
+    }
+    t.trackForCleanup(dataBuffer);
+
+    const oldValuesBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+    });
+    t.trackForCleanup(oldValuesBuffer);
+    {
+      const data = new arrayType(oldValuesBuffer.getMappedRange());
+      data.fill(defaultValue);
+      oldValuesBuffer.unmap();
+    }
+
+    const exchangedBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+    });
+    t.trackForCleanup(exchangedBuffer);
+    {
+      const data = new arrayType(exchangedBuffer.getMappedRange());
+      data.fill(defaultValue);
+      exchangedBuffer.unmap();
+    }
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: dataBuffer } },
+        { binding: 1, resource: { buffer: oldValuesBuffer } },
+        { binding: 2, resource: { buffer: exchangedBuffer } },
+      ],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(1);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Read back buffers
+    const oldValuesBufferResult = (
+      await t.readGPUBufferRangeTyped(oldValuesBuffer, {
+        type: arrayType,
+        typedLength: oldValuesBuffer.size / arrayType.BYTES_PER_ELEMENT,
+      })
+    ).data;
+    const exchangedBufferResult = (
+      await t.readGPUBufferRangeTyped(exchangedBuffer, {
+        type: arrayType,
+        typedLength: exchangedBuffer.size / arrayType.BYTES_PER_ELEMENT,
+      })
+    ).data;
+
+    for (let w = 0; w < numWrites; ++w) {
+      const offset = w * numInvocations;
+      const exchanged = exchangedBufferResult.subarray(offset, offset + numInvocations);
+      const oldValues = oldValuesBufferResult.subarray(offset, offset + numInvocations);
+
+      const dumpValues = () => {
+        return `
+        For write: ${w}
+        exchanged: ${exchanged}
+        oldValues: ${oldValues}`;
+      };
+
+      // Only one of the invocations should have succeeded to exchange - or none if spurious failures occured
+      const noExchanges = exchanged.every(v => v === 0);
+      if (noExchanges) {
+        // Spurious failure, all values in oldValues should be the default value
+        if (!oldValues.every(v => v === defaultValue)) {
+          t.fail(
+            `Spurious failure detected, expected only default value of ${defaultValue} in oldValues buffer.${dumpValues()}`
+          );
+          return;
+        }
+      } else {
+        // Only one invocation should have exchanged its value
+        if (exchanged.filter(v => v === 1).length !== 1) {
+          t.fail(`More than one invocation exchanged its value.${dumpValues()}`);
+          return;
+        }
+
+        // Get its index
+        const idx = exchanged.findIndex(v => v === 1);
+        assert(idx !== -1);
+
+        // Its output should contain the old value after exchange
+        const oldValue = pingPongValues[w % 2];
+        if (oldValues[idx] !== oldValue) {
+          t.fail(
+            `oldValues[${idx}] expected to contain old value from exchange: ${oldValue}.${dumpValues()}'`
+          );
+          return;
+        }
+
+        // The rest of oldValues should either contain the old value or the newly exchanged value,
+        // depending on whether they executed atomicCompareExchangWeak before or after invocation 'idx'.
+        const oldValuesRest = oldValues.filter((_, i) => i !== idx);
+        if (!oldValuesRest.every(v => pingPongValues.includes(v))) {
+          t.fail(
+            `Values in oldValues buffer should be one of '${pingPongValues}', except at index '${idx} where it is '${oldValue}'.${dumpValues()}`
+          );
+          return;
+        }
+      }
+    }
+  });
+
+g.test('compare_exchange_weak_workgroup_advanced')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicCompareExchangeWeak(atomic_ptr: ptr<AS, atomic<T>, read_write>, cmp: T, v: T) -> __atomic_compare_exchange_result<T>
+
+struct __atomic_compare_exchange_result<T> {
+  old_value : T,    // old value stored in the atomic
+  exchanged : bool, // true if the exchange was done
+}
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', onlyWorkgroupSizes) //
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(async t => {
+    const numInvocations = t.params.workgroupSize;
+    const scalarType = t.params.scalarType;
+
+    // Number of times each workgroup attempts to exchange the same value to the same memory address
+    const numWrites = 4;
+
+    const bufferNumElements = numInvocations * numWrites;
+    const pingPongValues = [24, 68];
+
+    const wgsl = `
+      var<workgroup> wg: atomic<${scalarType}>;
+
+      @group(0) @binding(0)
+      var<storage, read_write> old_values : array<${scalarType}>;
+
+      @group(0) @binding(1)
+      var<storage, read_write> exchanged : array<${scalarType}>;
+
+      fn ping_pong_value(i: u32) -> ${scalarType} {
+        if (i % 2 == 0) {
+          return ${pingPongValues[0]};
+        } else {
+          return ${pingPongValues[1]};
+        }
+      }
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+        @builtin(local_invocation_index) local_invocation_index: u32,
+        @builtin(workgroup_id) workgroup_id : vec3<u32>
+        ) {
+          let id = ${scalarType}(local_invocation_index);
+
+        // Each invocation attempts to write an alternating (ping-pong) value, once per loop.
+        // The input value is initialized with the first of the two ping-pong values.
+        // Only one invocation per loop iteration should succeed. Note the workgroupBarrier() used
+        // to synchronize each invocation in the loop.
+        // The reason we alternate is in case atomicCompareExchangeWeak spurioulsy fails:
+        // If all invocations of one iteration spuriously fail, the very next iteration will also
+        // fail since the value will not have been exchanged; however, the subsequent one will succeed
+        // (assuming not all iterations spuriously fail yet again).
+
+        // Initialize wg
+        if (local_invocation_index == 0) {
+          atomicStore(&wg, ${pingPongValues[0]});
+        }
+        workgroupBarrier();
+
+        for (var i = 0u; i < ${numWrites}u; i++) {
+          let compare = ping_pong_value(i);
+          let next = ping_pong_value(i + 1);
+
+          let r = atomicCompareExchangeWeak(&wg, compare, next);
+
+          let slot = i * ${numInvocations}u + u32(id);
+          old_values[slot] = r.old_value;
+          if (r.exchanged) {
+            exchanged[slot] = 1;
+          } else {
+            exchanged[slot] = 0;
+          }
+
+          workgroupBarrier();
+        }
+      }
+    `;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+    const defaultValue = 99999999;
+
+    const oldValuesBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+    });
+    t.trackForCleanup(oldValuesBuffer);
+    {
+      const data = new arrayType(oldValuesBuffer.getMappedRange());
+      data.fill(defaultValue);
+      oldValuesBuffer.unmap();
+    }
+
+    const exchangedBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+    });
+    t.trackForCleanup(exchangedBuffer);
+    {
+      const data = new arrayType(exchangedBuffer.getMappedRange());
+      data.fill(defaultValue);
+      exchangedBuffer.unmap();
+    }
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: oldValuesBuffer } },
+        { binding: 1, resource: { buffer: exchangedBuffer } },
+      ],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(1);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Read back buffers
+    const oldValuesBufferResult = (
+      await t.readGPUBufferRangeTyped(oldValuesBuffer, {
+        type: arrayType,
+        typedLength: oldValuesBuffer.size / arrayType.BYTES_PER_ELEMENT,
+      })
+    ).data;
+    const exchangedBufferResult = (
+      await t.readGPUBufferRangeTyped(exchangedBuffer, {
+        type: arrayType,
+        typedLength: exchangedBuffer.size / arrayType.BYTES_PER_ELEMENT,
+      })
+    ).data;
+
+    for (let w = 0; w < numWrites; ++w) {
+      const offset = w * numInvocations;
+      const exchanged = exchangedBufferResult.subarray(offset, offset + numInvocations);
+      const oldValues = oldValuesBufferResult.subarray(offset, offset + numInvocations);
+
+      const dumpValues = () => {
+        return `
+        For write: ${w}
+        exchanged: ${exchanged}
+        oldValues: ${oldValues}`;
+      };
+
+      // Only one of the invocations should have succeeded to exchange - or none if spurious failures occured
+      const noExchanges = exchanged.every(v => v === 0);
+      if (noExchanges) {
+        // Spurious failure, all values in oldValues should be the default value
+        if (!oldValues.every(v => v === defaultValue)) {
+          t.fail(
+            `Spurious failure detected, expected only default value of ${defaultValue} in oldValues buffer.${dumpValues()}`
+          );
+          return;
+        }
+      } else {
+        // Only one invocation should have exchanged its value
+        if (exchanged.filter(v => v === 1).length !== 1) {
+          t.fail(`More than one invocation exchanged its value.${dumpValues()}`);
+          return;
+        }
+
+        // Get its index
+        const idx = exchanged.findIndex(v => v === 1);
+        assert(idx !== -1);
+
+        // Its output should contain the old value after exchange
+        const oldValue = pingPongValues[w % 2];
+        if (oldValues[idx] !== oldValue) {
+          t.fail(
+            `oldValues[${idx}] expected to contain old value from exchange: ${oldValue}.${dumpValues()}'`
+          );
+          return;
+        }
+
+        // The rest of oldValues should either contain the old value or the newly exchanged value,
+        // depending on whether they executed atomicCompareExchangWeak before or after invocation 'idx'.
+        const oldValuesRest = oldValues.filter((_, i) => i !== idx);
+        if (!oldValuesRest.every(v => pingPongValues.includes(v))) {
+          t.fail(
+            `Values in oldValues buffer should be one of '${pingPongValues}', except at index '${idx} where it is '${oldValue}'.${dumpValues()}`
+          );
+          return;
+        }
+      }
+    }
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicExchange.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicExchange.spec.ts
@@ -3,11 +3,15 @@ Atomically stores the value v in the atomic object pointed to atomic_ptr and ret
 `;
 
 import { makeTestGroup } from '../../../../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../../../../common/util/data_tables.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
+import { checkElementsEqual } from '../../../../../../util/check_contents.js';
+
+import { dispatchSizes, workgroupSizes, typedArrayCtor, kMapId } from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('exchange')
+g.test('exchange_storage_basic')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
   .desc(
     `
@@ -18,6 +22,449 @@ fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 `
   )
   .params(u =>
-    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
   )
-  .unimplemented();
+  .fn(t => {
+    const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
+    const bufferNumElements = numInvocations;
+    const scalarType = t.params.scalarType;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const wgsl =
+      `
+      @group(0) @binding(0)
+      var<storage, read_write> input : array<atomic<${scalarType}>>;
+
+      @group(0) @binding(1)
+      var<storage, read_write> output : array<${scalarType}>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+          ) {
+        let id = ${scalarType}(global_invocation_id[0]);
+
+        output[id] = atomicExchange(&input[id], map_id(id * 2));
+      }
+    ` + extra;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    // Create input buffer with values [0..n]
+    const inputBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+    });
+    t.trackForCleanup(inputBuffer);
+    const data = new arrayType(inputBuffer.getMappedRange());
+    data.forEach((_, i) => (data[i] = i));
+    inputBuffer.unmap();
+
+    const outputBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: inputBuffer } },
+        { binding: 1, resource: { buffer: outputBuffer } },
+      ],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(t.params.dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Output buffer should be the same as the initial input buffer as it contains
+    // values returned from atomicExchange
+    const outputExpected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements);
+    outputExpected.forEach((_, i) => (outputExpected[i] = i));
+    t.expectGPUBufferValuesEqual(outputBuffer, outputExpected);
+
+    // And the input buffer should have been modified to a computed value
+    const inputExpected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements);
+    inputExpected.forEach((_, i) => (inputExpected[i] = mapId.f(i * 2, numInvocations)));
+    t.expectGPUBufferValuesEqual(inputBuffer, inputExpected);
+  });
+
+g.test('exchange_workgroup_basic')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-load')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
+
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(t => {
+    const numInvocations = t.params.workgroupSize;
+    const wgNumElements = numInvocations;
+    const scalarType = t.params.scalarType;
+    const dispatchSize = t.params.dispatchSize;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const wgsl =
+      `
+      var<workgroup> wg: array<atomic<${scalarType}>, ${wgNumElements}>;
+
+      // Result of each workgroup is written to output[workgroup_id.x]
+      @group(0) @binding(0)
+      var<storage, read_write> output: array<${scalarType}, ${wgNumElements * dispatchSize}>;
+
+      @group(0) @binding(1)
+      var<storage, read_write> wg_copy: array<${scalarType}, ${wgNumElements * dispatchSize}>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(local_invocation_index) local_invocation_index: u32,
+          @builtin(workgroup_id) workgroup_id : vec3<u32>
+          ) {
+        let id = ${scalarType}(local_invocation_index);
+        let global_id = ${scalarType}(workgroup_id.x * ${wgNumElements} + local_invocation_index);
+
+        // Initialize wg[id] with this invocations global id
+        atomicStore(&wg[id], global_id);
+        workgroupBarrier();
+
+        // Test atomicExchange, storing old value into output
+        output[global_id] = atomicExchange(&wg[id], map_id(global_id * 2));
+
+        // Copy new value into wg_copy
+        wg_copy[global_id] = atomicLoad(&wg[id]);
+      }
+      ` + extra;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    const outputBuffer = t.device.createBuffer({
+      size: wgNumElements * dispatchSize * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const wgCopyBuffer = t.device.createBuffer({
+      size: wgNumElements * dispatchSize * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: outputBuffer } },
+        { binding: 1, resource: { buffer: wgCopyBuffer } },
+      ],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Output buffer should be the same as the initial wg buffer as it contains
+    // values returned from atomicExchange
+    const outputExpected = new (typedArrayCtor(t.params.scalarType))(wgNumElements * dispatchSize);
+    outputExpected.forEach((_, i) => (outputExpected[i] = i));
+    t.expectGPUBufferValuesEqual(outputBuffer, outputExpected);
+
+    // And the wg copy buffer should have been modified to a computed value
+    const wgCopyBufferExpected = new (typedArrayCtor(t.params.scalarType))(
+      wgNumElements * dispatchSize
+    );
+    wgCopyBufferExpected.forEach(
+      (_, i) => (wgCopyBufferExpected[i] = mapId.f(i * 2, numInvocations))
+    );
+    t.expectGPUBufferValuesEqual(wgCopyBuffer, wgCopyBufferExpected);
+  });
+
+g.test('exchange_storage_advanced')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-rmw')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicExchange(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(async t => {
+    const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
+    const bufferNumElements = numInvocations;
+    const scalarType = t.params.scalarType;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const wgsl =
+      `
+      @group(0) @binding(0)
+      var<storage, read_write> input : atomic<${scalarType}>;
+
+      @group(0) @binding(1)
+      var<storage, read_write> output : array<${scalarType}>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+          ) {
+        let id = ${scalarType}(global_invocation_id[0]);
+
+        // All invocations exchange with same single memory address, and we store
+        // the old value at the current invocation's location in the output buffer.
+        output[id] = atomicExchange(&input, map_id(id));
+      }
+    ` + extra;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    // Create input buffer of size 1 with initial value 0
+    const inputBuffer = t.device.createBuffer({
+      size: 1 * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(inputBuffer);
+
+    const outputBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: inputBuffer } },
+        { binding: 1, resource: { buffer: outputBuffer } },
+      ],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(t.params.dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Read back buffers
+    const inputBufferResult = await t.readGPUBufferRangeTyped(inputBuffer, {
+      type: arrayType,
+      typedLength: inputBuffer.size / arrayType.BYTES_PER_ELEMENT,
+    });
+    const outputBufferResult = await t.readGPUBufferRangeTyped(outputBuffer, {
+      type: arrayType,
+      typedLength: outputBuffer.size / arrayType.BYTES_PER_ELEMENT,
+    });
+
+    // The one value in the input buffer plus all values in the output buffer
+    // should contain initial value 0 plus map_id(0..n), unsorted.
+    const values = new arrayType([...inputBufferResult.data, ...outputBufferResult.data]);
+
+    const expected = new arrayType(values.length);
+    expected.forEach((_, i) => {
+      if (i === 0) {
+        expected[0] = 0;
+      } else {
+        expected[i] = mapId.f(i - 1, numInvocations);
+      }
+    });
+
+    // Sort both arrays and compare
+    values.sort();
+    expected.sort(); // Sort because we store hashed results when mapId == 'remap'
+    t.expectOK(checkElementsEqual(values, expected));
+  });
+
+g.test('exchange_workgroup_advanced')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-load')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
+
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(async t => {
+    const numInvocations = t.params.workgroupSize;
+    const scalarType = t.params.scalarType;
+    const dispatchSize = t.params.dispatchSize;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const wgsl =
+      `
+      var<workgroup> wg: atomic<${scalarType}>;
+
+      // Will contain the atomicExchange result for each invocation at global index
+      @group(0) @binding(0)
+      var<storage, read_write> output: array<${scalarType}, ${numInvocations * dispatchSize}>;
+
+      // Will contain the final value in wg in wg_copy for this dispatch
+      @group(0) @binding(1)
+      var<storage, read_write> wg_copy: array<${scalarType}, ${dispatchSize}>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(local_invocation_index) local_invocation_index: u32,
+          @builtin(workgroup_id) workgroup_id : vec3<u32>
+          ) {
+        let id = ${scalarType}(local_invocation_index);
+        let global_id = ${scalarType}(workgroup_id.x * ${numInvocations} + local_invocation_index);
+
+        // All invocations exchange with same single memory address, and we store
+        // the old value at the current invocation's location in the output buffer.
+        output[global_id] = atomicExchange(&wg, map_id(id));
+
+        // Once all invocations have completed, the first one copies the final exchanged value
+        // to wg_copy for this dispatch (workgroup_id.x)
+        workgroupBarrier();
+        if (local_invocation_index == 0u) {
+          wg_copy[workgroup_id.x] = atomicLoad(&wg);
+        }
+      }
+      ` + extra;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    const outputBuffer = t.device.createBuffer({
+      size: numInvocations * dispatchSize * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const wgCopyBuffer = t.device.createBuffer({
+      size: dispatchSize * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: outputBuffer } },
+        { binding: 1, resource: { buffer: wgCopyBuffer } },
+      ],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Read back buffers
+    const outputBufferResult = await t.readGPUBufferRangeTyped(outputBuffer, {
+      type: arrayType,
+      typedLength: outputBuffer.size / arrayType.BYTES_PER_ELEMENT,
+    });
+    const wgCopyBufferResult = await t.readGPUBufferRangeTyped(wgCopyBuffer, {
+      type: arrayType,
+      typedLength: wgCopyBuffer.size / arrayType.BYTES_PER_ELEMENT,
+    });
+
+    // For each dispatch, the one value in wgCopyBuffer plus all values in the output buffer
+    // should contain initial value 0 plus map_id(0..n), unsorted.
+
+    // Expected values for each dispatch
+    const expected = new arrayType(numInvocations + 1);
+    expected.forEach((_, i) => {
+      if (i === 0) {
+        expected[0] = 0;
+      } else {
+        expected[i] = mapId.f(i - 1, numInvocations);
+      }
+    });
+    expected.sort(); // Sort because we store hashed results when mapId == 'remap'
+
+    // Test values for each dispatch
+    for (let d = 0; d < dispatchSize; ++d) {
+      // Get values for this dispatch
+      const dispatchOffset = d * numInvocations;
+      const values = new arrayType([
+        wgCopyBufferResult.data[d], // Last 'wg' value for this dispatch
+        ...outputBufferResult.data.subarray(dispatchOffset, dispatchOffset + numInvocations), // Rest of the returned values
+      ]);
+
+      values.sort();
+      t.expectOK(checkElementsEqual(values, expected));
+    }
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicLoad.spec.ts
@@ -3,11 +3,14 @@ Returns the atomically loaded the value pointed to by atomic_ptr. It does not mo
 `;
 
 import { makeTestGroup } from '../../../../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../../../../common/util/data_tables.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
+
+import { dispatchSizes, workgroupSizes, typedArrayCtor, kMapId } from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('load')
+g.test('load_storage')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-load')
   .desc(
     `
@@ -19,6 +22,171 @@ fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
 `
   )
   .params(u =>
-    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
   )
-  .unimplemented();
+  .fn(t => {
+    const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
+    const bufferNumElements = numInvocations;
+    const scalarType = t.params.scalarType;
+    const mapId = kMapId[t.params.mapId];
+
+    const wgsl = `
+      @group(0) @binding(0)
+      var<storage, read_write> input : array<atomic<${scalarType}>>;
+
+      @group(0) @binding(1)
+      var<storage, read_write> output : array<${scalarType}>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+          ) {
+        let id = ${scalarType}(global_invocation_id[0]);
+        output[id] = atomicLoad(&input[id]);
+      }
+    `;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    // Create input buffer with values [map_id(0)..map_id(n)]
+    const inputBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+    });
+    t.trackForCleanup(inputBuffer);
+    const data = new arrayType(inputBuffer.getMappedRange());
+    data.forEach((_, i) => (data[i] = mapId.f(i, numInvocations)));
+    inputBuffer.unmap();
+
+    const outputBuffer = t.device.createBuffer({
+      size: bufferNumElements * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: inputBuffer } },
+        { binding: 1, resource: { buffer: outputBuffer } },
+      ],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(t.params.dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Both input and output buffer should be the same now
+    const expected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements);
+    expected.forEach((_, i) => (expected[i] = mapId.f(i, numInvocations)));
+    t.expectGPUBufferValuesEqual(inputBuffer, expected);
+    t.expectGPUBufferValuesEqual(outputBuffer, expected);
+  });
+
+g.test('load_workgroup')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-load')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicLoad(atomic_ptr: ptr<AS, atomic<T>, read_write>) -> T
+
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(t => {
+    const numInvocations = t.params.workgroupSize;
+    const wgNumElements = numInvocations;
+    const scalarType = t.params.scalarType;
+    const dispatchSize = t.params.dispatchSize;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const wgsl =
+      `
+      var<workgroup> wg: array<atomic<${scalarType}>, ${wgNumElements}>;
+
+      // Result of each workgroup is written to output[workgroup_id.x]
+      @group(0) @binding(0)
+      var<storage, read_write> output: array<${scalarType}, ${wgNumElements * dispatchSize}>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(local_invocation_index) local_invocation_index: u32,
+          @builtin(workgroup_id) workgroup_id : vec3<u32>
+          ) {
+        let id = ${scalarType}(local_invocation_index);
+        let global_id = ${scalarType}(workgroup_id.x * ${wgNumElements} + local_invocation_index);
+
+        // Initialize wg[id] with this invocations global id (mapped)
+        atomicStore(&wg[id], map_id(global_id));
+        workgroupBarrier();
+
+        // Test atomic loading of value at wg[id] and store result in output[global_id]
+        output[global_id] = atomicLoad(&wg[id]);
+      }
+      ` + extra;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    const outputBuffer = t.device.createBuffer({
+      size: wgNumElements * dispatchSize * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer: outputBuffer } }],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Expected values should be map_id(0..n)
+    const expected = new (typedArrayCtor(t.params.scalarType))(
+      wgNumElements * t.params.dispatchSize
+    );
+    expected.forEach((_, i) => (expected[i] = mapId.f(i, numInvocations)));
+
+    t.expectGPUBufferValuesEqual(outputBuffer, expected);
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMax.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMax.spec.ts
@@ -35,7 +35,7 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     u
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
@@ -44,7 +44,7 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
     const initValue = 0;
     const op = `atomicMax(&output[0], id)`;
-    const expected = new (typedArrayCtor(t.params.scalarKind))(bufferNumElements);
+    const expected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements);
     expected[0] = numInvocations - 1;
 
     runStorageVariableTest({
@@ -72,7 +72,7 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     u
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
@@ -81,7 +81,7 @@ fn atomicMax(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const initValue = 0;
     const op = `atomicMax(&wg[0], id)`;
 
-    const expected = new (typedArrayCtor(t.params.scalarKind))(
+    const expected = new (typedArrayCtor(t.params.scalarType))(
       wgNumElements * t.params.dispatchSize
     ).fill(initValue);
     for (let d = 0; d < t.params.dispatchSize; ++d) {

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicMin.spec.ts
@@ -35,15 +35,15 @@ fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     u
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
     const bufferNumElements = 2;
 
-    const initValue = t.params.scalarKind === 'u32' ? 0xffffffff : 0x7fffffff;
+    const initValue = t.params.scalarType === 'u32' ? 0xffffffff : 0x7fffffff;
     const op = `atomicMin(&output[0], id)`;
-    const expected = new (typedArrayCtor(t.params.scalarKind))(bufferNumElements).fill(initValue);
+    const expected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements).fill(initValue);
     expected[0] = 0;
 
     runStorageVariableTest({
@@ -71,16 +71,16 @@ fn atomicMin(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     u
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
     const wgNumElements = 2;
 
-    const initValue = t.params.scalarKind === 'u32' ? 0xffffffff : 0x7fffffff;
+    const initValue = t.params.scalarType === 'u32' ? 0xffffffff : 0x7fffffff;
     const op = `atomicMin(&wg[0], id)`;
 
-    const expected = new (typedArrayCtor(t.params.scalarKind))(
+    const expected = new (typedArrayCtor(t.params.scalarType))(
       wgNumElements * t.params.dispatchSize
     ).fill(initValue);
     for (let d = 0; d < t.params.dispatchSize; ++d) {

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicOr.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicOr.spec.ts
@@ -38,7 +38,7 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
@@ -50,14 +50,14 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0;
 
-    const scalarKind = t.params.scalarKind;
+    const scalarType = t.params.scalarType;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
     let i = map_id(u32(id));
-      atomicOr(&output[i / 32], ${scalarKind}(1) << i)
+      atomicOr(&output[i / 32], ${scalarType}(1) << i)
     `;
-    const expected = new (typedArrayCtor(scalarKind))(bufferNumElements);
+    const expected = new (typedArrayCtor(scalarType))(bufferNumElements);
     for (let id = 0; id < numInvocations; ++id) {
       const i = mapId.f(id, numInvocations);
       expected[Math.floor(i / 32)] |= 1 << i;
@@ -90,7 +90,7 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize;
@@ -102,14 +102,14 @@ fn atomicOr(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0;
 
-    const scalarKind = t.params.scalarKind;
+    const scalarType = t.params.scalarType;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
     let i = map_id(u32(id));
-      atomicOr(&wg[i / 32], ${scalarKind}(1) << i)
+      atomicOr(&wg[i / 32], ${scalarType}(1) << i)
     `;
-    const expected = new (typedArrayCtor(scalarKind))(wgNumElements * t.params.dispatchSize);
+    const expected = new (typedArrayCtor(scalarType))(wgNumElements * t.params.dispatchSize);
     for (let d = 0; d < t.params.dispatchSize; ++d) {
       for (let id = 0; id < numInvocations; ++id) {
         const wg = expected.subarray(d * wgNumElements);

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicStore.spec.ts
@@ -3,11 +3,21 @@ Atomically stores the value v in the atomic object pointed to by atomic_ptr.
 `;
 
 import { makeTestGroup } from '../../../../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../../../../common/util/data_tables.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
+
+import {
+  dispatchSizes,
+  workgroupSizes,
+  runStorageVariableTest,
+  runWorkgroupVariableTest,
+  typedArrayCtor,
+  kMapId,
+} from './harness.js';
 
 export const g = makeTestGroup(GPUTest);
 
-g.test('store')
+g.test('store_storage_basic')
   .specURL('https://www.w3.org/TR/WGSL/#atomic-store')
   .desc(
     `
@@ -18,6 +28,274 @@ fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
 `
   )
   .params(u =>
-    u.combine('SC', ['storage', 'uniform'] as const).combine('T', ['i32', 'u32'] as const)
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
   )
-  .unimplemented();
+  .fn(t => {
+    const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
+    const bufferNumElements = numInvocations;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const initValue = 0;
+    const op = `atomicStore(&output[id], map_id(id))`;
+    const expected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements);
+    expected.forEach((_, i) => (expected[i] = mapId.f(i, numInvocations)));
+
+    runStorageVariableTest({
+      t,
+      workgroupSize: t.params.workgroupSize,
+      dispatchSize: t.params.dispatchSize,
+      bufferNumElements,
+      initValue,
+      op,
+      expected,
+      extra,
+    });
+  });
+
+g.test('store_workgroup_basic')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-store')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(t => {
+    const numInvocations = t.params.workgroupSize;
+    const wgNumElements = numInvocations;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const initValue = 0;
+    const op = `atomicStore(&wg[id], map_id(global_id))`;
+    const expected = new (typedArrayCtor(t.params.scalarType))(
+      wgNumElements * t.params.dispatchSize
+    );
+    expected.forEach((_, i) => (expected[i] = mapId.f(i, numInvocations)));
+
+    runWorkgroupVariableTest({
+      t,
+      workgroupSize: t.params.workgroupSize,
+      dispatchSize: t.params.dispatchSize,
+      wgNumElements,
+      initValue,
+      op,
+      expected,
+      extra,
+    });
+  });
+
+g.test('store_storage_advanced')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-store')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
+
+Tests that multiple invocations of atomicStore to the same location returns
+one of the values written.
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(async t => {
+    const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
+    const scalarType = t.params.scalarType;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const wgsl =
+      `
+      @group(0) @binding(0)
+      var<storage, read_write> output : array<atomic<${scalarType}>>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(global_invocation_id) global_invocation_id : vec3<u32>,
+          ) {
+        let id = ${scalarType}(global_invocation_id[0]);
+
+        // All invocations store to the same location
+        atomicStore(&output[0], map_id(id));
+      }
+    ` + extra;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    // Output buffer has only 1 element
+    const outputBuffer = t.device.createBuffer({
+      size: 1 * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer: outputBuffer } }],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(t.params.dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Read back the buffer
+    const outputBufferResult = (
+      await t.readGPUBufferRangeTyped(outputBuffer, {
+        type: arrayType,
+        typedLength: outputBuffer.size / arrayType.BYTES_PER_ELEMENT,
+      })
+    ).data;
+
+    // All invocations wrote to the output[0], so validate that it contains one
+    // of the possible computed values.
+    const expected_one_of = new arrayType(numInvocations);
+    expected_one_of.forEach((_, i) => (expected_one_of[i] = mapId.f(i, numInvocations)));
+
+    if (!expected_one_of.includes(outputBufferResult[0])) {
+      t.fail(
+        `Unexpected value in output[0]: '${outputBufferResult[0]}, expected value to be one of: ${expected_one_of}`
+      );
+    }
+  });
+
+g.test('store_workgroup_advanced')
+  .specURL('https://www.w3.org/TR/WGSL/#atomic-store')
+  .desc(
+    `
+AS is storage or workgroup
+T is i32 or u32
+
+fn atomicStore(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T)
+
+Tests that multiple invocations of atomicStore to the same location returns
+one of the values written.
+`
+  )
+  .params(u =>
+    u
+      .combine('workgroupSize', workgroupSizes)
+      .combine('dispatchSize', dispatchSizes)
+      .combine('mapId', keysOf(kMapId))
+      .combine('scalarType', ['u32', 'i32'])
+  )
+  .fn(async t => {
+    const numInvocations = t.params.workgroupSize;
+    const scalarType = t.params.scalarType;
+    const dispatchSize = t.params.dispatchSize;
+    const mapId = kMapId[t.params.mapId];
+    const extra = mapId.wgsl(numInvocations, t.params.scalarType); // Defines map_id()
+
+    const wgsl =
+      `
+      var<workgroup> wg: atomic<${scalarType}>;
+
+      // Result of each workgroup is written to output[workgroup_id.x]
+      @group(0) @binding(0)
+      var<storage, read_write> output: array<${scalarType}, ${dispatchSize}>;
+
+      @compute @workgroup_size(${t.params.workgroupSize})
+      fn main(
+          @builtin(local_invocation_index) local_invocation_index: u32,
+          @builtin(workgroup_id) workgroup_id : vec3<u32>
+          ) {
+        let id = ${scalarType}(local_invocation_index);
+
+        // All invocations of a given dispatch store to the same location.
+        // In the end, the final value should be randomly equal to one of the ids.
+        atomicStore(&wg, map_id(id));
+
+        // Once all invocations have completed, the first one copies the result
+        // to output for this dispatch (workgroup_id.x)
+        workgroupBarrier();
+        if (local_invocation_index == 0u) {
+          output[workgroup_id.x] = atomicLoad(&wg);
+        }
+      }
+      ` + extra;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({ code: wgsl }),
+        entryPoint: 'main',
+      },
+    });
+
+    const arrayType = typedArrayCtor(scalarType);
+
+    const outputBuffer = t.device.createBuffer({
+      size: dispatchSize * arrayType.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(outputBuffer);
+
+    const bindGroup = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer: outputBuffer } }],
+    });
+
+    // Run the shader.
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(dispatchSize);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    // Read back the buffer
+    const outputBufferResult = (
+      await t.readGPUBufferRangeTyped(outputBuffer, {
+        type: arrayType,
+        typedLength: outputBuffer.size / arrayType.BYTES_PER_ELEMENT,
+      })
+    ).data;
+
+    // Each dispatch wrote to a single atomic workgroup var that was copied
+    // to outputBuffer[dispatch]. Validate that each value in the output buffer
+    // is one of the possible computed values.
+    const expected_one_of = new arrayType(numInvocations);
+    expected_one_of.forEach((_, i) => (expected_one_of[i] = mapId.f(i, numInvocations)));
+
+    for (let d = 0; d < dispatchSize; d++) {
+      if (!expected_one_of.includes(outputBufferResult[d])) {
+        t.fail(
+          `Unexpected value in output[d] for dispatch d '${d}': '${outputBufferResult[d]}', expected value to be one of: ${expected_one_of}`
+        );
+      }
+    }
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
@@ -35,7 +35,7 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     u
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
@@ -44,7 +44,7 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
 
     const initValue = 0;
     const op = `atomicSub(&output[0], 1)`;
-    const expected = new (typedArrayCtor(t.params.scalarKind))(bufferNumElements);
+    const expected = new (typedArrayCtor(t.params.scalarType))(bufferNumElements);
     expected[0] = -1 * numInvocations;
 
     runStorageVariableTest({
@@ -72,7 +72,7 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     u
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     // Allocate one extra element to ensure it doesn't get modified
@@ -81,7 +81,7 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     const initValue = 0;
     const op = `atomicSub(&wg[0], 1)`;
 
-    const expected = new (typedArrayCtor(t.params.scalarKind))(
+    const expected = new (typedArrayCtor(t.params.scalarType))(
       wgNumElements * t.params.dispatchSize
     );
     for (let d = 0; d < t.params.dispatchSize; ++d) {

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicXor.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicXor.spec.ts
@@ -38,7 +38,7 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize * t.params.dispatchSize;
@@ -50,15 +50,15 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0b11000011010110100000111100111100;
 
-    const scalarKind = t.params.scalarKind;
+    const scalarType = t.params.scalarType;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
     let i = map_id(u32(id));
-      atomicXor(&output[i / 32], ${scalarKind}(1) << i)
+      atomicXor(&output[i / 32], ${scalarType}(1) << i)
     `;
 
-    const expected = new (typedArrayCtor(scalarKind))(bufferNumElements).fill(initValue);
+    const expected = new (typedArrayCtor(scalarType))(bufferNumElements).fill(initValue);
     for (let id = 0; id < numInvocations; ++id) {
       const i = mapId.f(id, numInvocations);
       expected[Math.floor(i / 32)] ^= 1 << i;
@@ -91,7 +91,7 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       .combine('workgroupSize', workgroupSizes)
       .combine('dispatchSize', dispatchSizes)
       .combine('mapId', keysOf(kMapId))
-      .combine('scalarKind', ['u32', 'i32'])
+      .combine('scalarType', ['u32', 'i32'])
   )
   .fn(t => {
     const numInvocations = t.params.workgroupSize;
@@ -103,15 +103,15 @@ fn atomicXor(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
     // Note: Both WGSL and JS will shift left 1 by id modulo 32.
     const initValue = 0b11000011010110100000111100111100;
 
-    const scalarKind = t.params.scalarKind;
+    const scalarType = t.params.scalarType;
     const mapId = kMapId[t.params.mapId];
     const extra = mapId.wgsl(numInvocations); // Defines map_id()
     const op = `
       let i = map_id(u32(id));
-      atomicXor(&wg[i / 32], ${scalarKind}(1) << i)
+      atomicXor(&wg[i / 32], ${scalarType}(1) << i)
     `;
 
-    const expected = new (typedArrayCtor(scalarKind))(wgNumElements * t.params.dispatchSize).fill(
+    const expected = new (typedArrayCtor(scalarType))(wgNumElements * t.params.dispatchSize).fill(
       initValue
     );
     for (let d = 0; d < t.params.dispatchSize; ++d) {

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/harness.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/harness.ts
@@ -5,17 +5,23 @@ import {
 } from '../../../../../../../common/util/util.js';
 import { GPUTest } from '../../../../../../gpu_test.js';
 
+// Use these in combination.
 export const workgroupSizes = [1, 2, 32, 64];
 export const dispatchSizes = [1, 4, 8, 16];
+
+// Use this alone - dispatch size should be 1.
+export const onlyWorkgroupSizes = [1, 2, 4, 8, 16, 32, 64, 128, 256];
+
 export const kMapId = {
   passthrough: {
     f: (id: number, max: number) => id,
-    wgsl: (max: number) => 'fn map_id(id: u32) -> u32 { return id; }',
+    wgsl: (max: number, scalarType = 'u32') =>
+      `fn map_id(id: ${scalarType}) -> ${scalarType} { return id; }`,
   },
   remap: {
     f: (id: number, max: number) => (((id >>> 0) * 14957) ^ (((id >>> 0) * 26561) >> 2)) % max,
-    wgsl: (max: number) =>
-      `fn map_id(id: u32) -> u32 { return ((id * 14957) ^ ((id * 26561) >> 2)) % ${max}; }`,
+    wgsl: (max: number, scalarType = 'u32') =>
+      `fn map_id(id: ${scalarType}) -> ${scalarType} { return ((id * 14957) ^ ((id * 26561) >> 2)) % ${max}; }`,
   },
 };
 
@@ -37,7 +43,9 @@ export function runStorageVariableTest({
   dispatchSize, // Dispatch X-size
   bufferNumElements, // Number of 32-bit elements in output buffer
   initValue, // 32-bit initial value used to fill output buffer
-  op, // Atomic op source executed by the compute shader, NOTE: 'id' is global_invocation_id.x
+  // Atomic op source executed by the compute shader, NOTE: 'id' is global_invocation_id.x,
+  // and `output` is a storage array of atomics.
+  op,
   expected, // Expected values array to compare against output buffer
   extra, // Optional extra WGSL source
 }: {
@@ -57,7 +65,7 @@ export function runStorageVariableTest({
 
   const wgsl = `
     @group(0) @binding(0)
-    var<storage, read_write> output: array<atomic<${scalarType}>>;
+    var<storage, read_write> output : array<atomic<${scalarType}>>;
 
     @compute @workgroup_size(${workgroupSize})
     fn main(
@@ -111,7 +119,11 @@ export function runWorkgroupVariableTest({
   dispatchSize, // Dispatch X-size
   wgNumElements, // Number of 32-bit elements in 'wg' array. Output buffer is sized to wgNumElements * dispatchSize.
   initValue, // 32-bit initial value used to fill 'wg' array
-  op, // Atomic op source executed by the compute shader, NOTE: 'id' is local_invocation_index
+  // Atomic op source executed by the compute shader, NOTE: 'id' is local_invocation_index,
+  // `wg` is a workgroup array of atomics of size `workgroupSize`, `output` is a storage array of non-atomics of size
+  // `workgroupSize * dispatcSize` to which each dispatch of `wg` gets copied to (dispatch 0 to first workgroupSize elements,
+  // dispatch 1 to second workgroupSize elements, etc.).
+  op,
   expected, // Expected values array to compare against output buffer
   extra, // Optional extra WGSL source
 }: {
@@ -142,6 +154,7 @@ export function runWorkgroupVariableTest({
         @builtin(workgroup_id) workgroup_id : vec3<u32>
         ) {
       let id = ${scalarType}(local_invocation_index);
+      let global_id = ${scalarType}(workgroup_id.x * ${wgNumElements} + local_invocation_index);
 
       // Initialize workgroup array
       if (local_invocation_index == 0) {


### PR DESCRIPTION
…tomicCompareExchangeWeak

Issue: #1273
Issue: #1274
Issue: #1282
Issue: #1283

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
