### PR TITLE
[wgsl] Add more interpolation tests

### DIFF
--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -1,6 +1,7 @@
 export const description = `Validation tests for the interpolate attribute`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 import { generateShader } from './util.js';
@@ -141,4 +142,76 @@ g.test('duplicate')
       use_struct: false,
     });
     t.expectCompileResult(t.params.attr === '', code);
+  });
+
+const kValidationTests = {
+  valid: {
+    src: `@interpolate(flat)`,
+    pass: true,
+  },
+  no_space: {
+    src: `@interpolate(perspective,center)`,
+    pass: true,
+  },
+  trailing_comma_one_arg: {
+    src: `@interpolate(flat,)`,
+    pass: true,
+  },
+  trailing_comma_two_arg: {
+    src: `@interpolate(perspective, center,)`,
+    pass: true,
+  },
+  newline: {
+    src: '@\ninterpolate(flat)',
+    pass: true,
+  },
+  comment: {
+    src: `@/* comment */interpolate(flat)`,
+    pass: true,
+  },
+
+  no_params: {
+    src: `@interpolate()`,
+    pass: false,
+  },
+  missing_left_paren: {
+    src: `@interpolate flat)`,
+    pass: false,
+  },
+  missing_value_and_left_paren: {
+    src: `@interpolate)`,
+    pass: false,
+  },
+  missing_right_paren: {
+    src: `@interpolate(flat`,
+    pass: false,
+  },
+  missing_parens: {
+    src: `@interpolate`,
+    pass: false,
+  },
+  missing_comma: {
+    src: `@interpolate(perspective center)`,
+    pass: false,
+  },
+  numeric: {
+    src: `@interpolate(1)`,
+    pass: false,
+  },
+  numeric_second_param: {
+    src: `@interpolate(perspective, 1)`,
+    pass: false,
+  },
+};
+
+g.test('interpolation_validation')
+  .desc(`Test validation of interpolation`)
+  .params(u => u.combine('attr', keysOf(kValidationTests)))
+  .fn(t => {
+    const code = `
+@vertex fn main(${kValidationTests[t.params.attr].src} @location(0) b: f32) ->
+    @builtin(position) vec4<f32> {
+  return vec4f(0);
+}`;
+    t.expectCompileResult(kValidationTests[t.params.attr].pass, code);
   });


### PR DESCRIPTION
Add tests for various invalid shaders involving interpolation.

Fixes: #1449

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
