### PR TITLE
shader/validation: Validate length()

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
@@ -48,8 +48,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -66,8 +65,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
@@ -44,13 +44,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.acosh(t.params.value), t.params.type);
+    const expectedResult = isRepresentable(Math.acosh(t.params.value), elementType(t.params.type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -67,8 +66,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
@@ -48,8 +48,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -66,8 +65,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
@@ -44,13 +44,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.asinh(t.params.value), t.params.type);
+    const expectedResult = isRepresentable(Math.asinh(t.params.value), elementType(t.params.type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -67,8 +66,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
@@ -44,14 +44,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     }
   })
   .fn(t => {
-    const smallestPositive = fpTraitsFor(t.params.type).constants().positive.min;
+    const smallestPositive = fpTraitsFor(elementType(t.params.type)).constants().positive.min;
     const expectedResult = Math.abs(Math.cos(t.params.value)) > smallestPositive;
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -68,8 +67,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
@@ -48,8 +48,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -66,8 +65,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
@@ -141,20 +141,32 @@ var<private> v = ${builtin}(${callArgs.join(', ')});`,
 }
 
 /** @returns a sweep of the representable values for element type of @p type */
-export function fullRangeForType(type: Type) {
+export function fullRangeForType(type: Type, count?: number) {
+  if (count === undefined) {
+    count = 25;
+  }
   switch (elementType(type)?.kind) {
     case 'abstract-float':
-      return fullF64Range();
+      return fullF64Range({
+        pos_sub: Math.ceil((count * 1) / 5),
+        pos_norm: Math.ceil((count * 4) / 5),
+      });
     case 'f32':
-      return fullF32Range();
+      return fullF32Range({
+        pos_sub: Math.ceil((count * 1) / 5),
+        pos_norm: Math.ceil((count * 4) / 5),
+      });
     case 'f16':
-      return fullF16Range();
+      return fullF16Range({
+        pos_sub: Math.ceil((count * 1) / 5),
+        pos_norm: Math.ceil((count * 4) / 5),
+      });
     case 'i32':
-      return linearRange(kValue.i32.negative.min, kValue.i32.positive.max, 50).map(f =>
+      return linearRange(kValue.i32.negative.min, kValue.i32.positive.max, count).map(f =>
         Math.floor(f)
       );
     case 'u32':
-      return linearRange(0, kValue.u32.max, 50).map(f => Math.floor(f));
+      return linearRange(0, kValue.u32.max, count).map(f => Math.floor(f));
   }
   unreachable();
 }

--- a/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
@@ -47,8 +47,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       /* expectedResult */ true,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -65,8 +64,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
@@ -42,13 +42,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.cosh(t.params.value), t.params.type);
+    const expectedResult = isRepresentable(Math.cosh(t.params.value), elementType(t.params.type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -65,8 +64,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
@@ -42,13 +42,15 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable((t.params.value * 180) / Math.PI, t.params.type);
+    const expectedResult = isRepresentable(
+      (t.params.value * 180) / Math.PI,
+      elementType(t.params.type)
+    );
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -65,8 +67,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
@@ -66,13 +66,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.exp(t.params.value), t.params.type);
+    const expectedResult = isRepresentable(Math.exp(t.params.value), elementType(t.params.type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -89,8 +88,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
@@ -66,13 +66,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.pow(2, t.params.value), t.params.type);
+    const expectedResult = isRepresentable(Math.pow(2, t.params.value), elementType(t.params.type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -89,8 +88,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
@@ -45,13 +45,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   })
   .fn(t => {
     const expectedResult =
-      t.params.value > 0 && isRepresentable(1 / Math.sqrt(t.params.value), t.params.type);
+      t.params.value > 0 &&
+      isRepresentable(1 / Math.sqrt(t.params.value), elementType(t.params.type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -68,8 +68,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
@@ -1,0 +1,178 @@
+const builtin = 'length';
+export const description = `
+Validation tests for the ${builtin}() builtin.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import {
+  ScalarType,
+  TypeF16,
+  TypeF32,
+  elementType,
+  kAllFloatScalars,
+  kAllFloatVector2,
+  kAllFloatVector3,
+  kAllFloatVector4,
+  kAllIntegerScalarsAndVectors,
+} from '../../../../../util/conversion.js';
+import { isRepresentable } from '../../../../../util/floating_point.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import {
+  fullRangeForType,
+  kConstantAndOverrideStages,
+  stageSupportsType,
+  validateConstOrOverrideBuiltinEval,
+} from './const_override_validation.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+/** @returns true if the sum of the squares of each element in @p vec is representable by @p type */
+function isSquareSumRepresentable(vec: number[], type: ScalarType) {
+  const squareSum = vec.reduce((prev, curr) => prev + curr * curr, 0);
+  return isRepresentable(squareSum, type);
+}
+
+g.test('scalar')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() with
+the input scalar value always compiles without error
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatScalars)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .expand('value', u => fullRangeForType(u.type))
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    // We only validate with numbers known to be representable by the type
+    const expectedResult = true;
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      [t.params.type.create(t.params.value)],
+      t.params.stage
+    );
+  });
+
+g.test('vec2')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() with a vec2 compiles with valid values
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatVector2)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .expand('x', u => fullRangeForType(u.type, 5))
+      .expand('y', u => fullRangeForType(u.type, 5))
+      .filter(u => isSquareSumRepresentable([u.x, u.y], elementType(u.type)))
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const expectedResult = true;
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      [t.params.type.create([t.params.x, t.params.y])],
+      t.params.stage
+    );
+  });
+
+g.test('vec3')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() with a vec3 compiles with valid values
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatVector3)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .expand('x', u => fullRangeForType(u.type, 4))
+      .expand('y', u => fullRangeForType(u.type, 4))
+      .expand('z', u => fullRangeForType(u.type, 4))
+      .filter(u => isSquareSumRepresentable([u.x, u.y, u.z], elementType(u.type)))
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const expectedResult = true;
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      [t.params.type.create([t.params.x, t.params.y, t.params.z])],
+      t.params.stage
+    );
+  });
+
+g.test('vec4')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() with a vec4 compiles with valid values
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatVector4)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .expand('x', u => fullRangeForType(u.type, 3))
+      .expand('y', u => fullRangeForType(u.type, 3))
+      .expand('z', u => fullRangeForType(u.type, 3))
+      .expand('w', u => fullRangeForType(u.type, 3))
+      .filter(u => isSquareSumRepresentable([u.x, u.y, u.z, u.w], elementType(u.type)))
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const expectedResult = true;
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      [t.params.type.create([t.params.x, t.params.y, t.params.z, t.params.w])],
+      t.params.stage
+    );
+  });
+
+g.test('integer_argument')
+  .desc(
+    `
+Validates that scalar and vector integer arguments are rejected by ${builtin}()
+`
+  )
+  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .fn(t => {
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      /* expectedResult */ t.params.type === TypeF32,
+      [t.params.type.create(1)],
+      'constant'
+    );
+  });

--- a/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
@@ -46,8 +46,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -64,8 +63,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
@@ -46,8 +46,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -64,8 +63,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
@@ -46,8 +46,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -64,8 +63,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
@@ -46,8 +46,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -64,8 +63,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
@@ -36,7 +36,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .combine('type', kAllFloatScalarsAndVectors)
       .filter(u => stageSupportsType(u.stage, u.type))
       .expand('value', u => {
-        const constants = fpTraitsFor(u.type).constants();
+        const constants = fpTraitsFor(elementType(u.type)).constants();
         return unique(fullRangeForType(u.type), [
           constants.negative.min + 0.1,
           constants.positive.max - 0.1,
@@ -54,8 +54,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -72,8 +71,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
@@ -46,8 +46,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -64,8 +63,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
@@ -46,8 +46,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -64,8 +63,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
@@ -47,8 +47,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       /* expectedResult */ true,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -65,8 +64,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
@@ -42,13 +42,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.sinh(t.params.value), t.params.type);
+    const expectedResult = isRepresentable(Math.sinh(t.params.value), elementType(t.params.type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -65,8 +64,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
@@ -45,13 +45,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   })
   .fn(t => {
     const expectedResult =
-      t.params.value >= 0 && isRepresentable(Math.sqrt(t.params.value), t.params.type);
+      t.params.value >= 0 && isRepresentable(Math.sqrt(t.params.value), elementType(t.params.type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -68,8 +67,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 1,
-      t.params.type,
+      [t.params.type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
@@ -44,14 +44,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     }
   })
   .fn(t => {
-    const smallestPositive = fpTraitsFor(t.params.type).constants().positive.min;
+    const smallestPositive = fpTraitsFor(elementType(t.params.type)).constants().positive.min;
     const expectedResult = Math.abs(Math.cos(t.params.value)) > smallestPositive;
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      t.params.value,
-      t.params.type,
+      [t.params.type.create(t.params.value)],
       t.params.stage
     );
   });
@@ -68,8 +67,7 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       t,
       builtin,
       /* expectedResult */ t.params.type === TypeF32,
-      /* value */ 0,
-      t.params.type,
+      [t.params.type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -616,9 +616,14 @@ export class VectorType {
     return this.elementType.size * this.width;
   }
 
-  /** Constructs a Vector of this type with @p value in each element */
-  public create(value: number): Vector {
-    return new Vector(Array(this.width).fill(this.elementType.create(value)));
+  /** Constructs a Vector of this type with the given values */
+  public create(value: number | number[]): Vector {
+    if (value instanceof Array) {
+      assert(value.length === this.width);
+    } else {
+      value = Array(this.width).fill(value);
+    }
+    return new Vector(value.map(v => this.elementType.create(v)));
   }
 }
 
@@ -1415,21 +1420,39 @@ export function isFloatType(ty: Type): boolean {
   return false;
 }
 
-/// All floating-point scalar and vector types
-export const kAllFloatScalarsAndVectors = [
-  TypeAbstractFloat,
+/// All floating-point scalar types
+export const kAllFloatScalars = [TypeAbstractFloat, TypeF32, TypeF16] as const;
+
+/// All floating-point vec2 types
+export const kAllFloatVector2 = [
   TypeVec(2, TypeAbstractFloat),
-  TypeVec(3, TypeAbstractFloat),
-  TypeVec(4, TypeAbstractFloat),
-  TypeF32,
   TypeVec(2, TypeF32),
-  TypeVec(3, TypeF32),
-  TypeVec(4, TypeF32),
-  TypeF16,
   TypeVec(2, TypeF16),
+] as const;
+
+/// All floating-point vec3 types
+export const kAllFloatVector3 = [
+  TypeVec(3, TypeAbstractFloat),
+  TypeVec(3, TypeF32),
   TypeVec(3, TypeF16),
+] as const;
+
+/// All floating-point vec4 types
+export const kAllFloatVector4 = [
+  TypeVec(4, TypeAbstractFloat),
+  TypeVec(4, TypeF32),
   TypeVec(4, TypeF16),
 ] as const;
+
+/// All floating-point vector types
+export const kAllFloatVectors = [
+  ...kAllFloatVector2,
+  ...kAllFloatVector3,
+  ...kAllFloatVector4,
+] as const;
+
+/// All floating-point scalar and vector types
+export const kAllFloatScalarsAndVectors = [...kAllFloatScalars, ...kAllFloatVectors] as const;
 
 /// All integer scalar and vector types
 export const kAllIntegerScalarsAndVectors = [

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -5,7 +5,6 @@ import { Case, IntervalFilter } from '../shader/execution/expression/expression.
 import { anyOf } from './compare.js';
 import { kValue } from './constants.js';
 import {
-  elementType,
   f16,
   f32,
   f64,
@@ -17,9 +16,9 @@ import {
   reinterpretU32AsF32,
   reinterpretU32sAsF64,
   Scalar,
+  ScalarType,
   toMatrix,
   toVector,
-  Type,
   u32,
 } from './conversion.js';
 import {
@@ -4967,10 +4966,9 @@ export const FP = {
   abstract: new FPAbstractTraits(),
 };
 
-/** @returns the floating-point traits for the element type of @p type */
-export function fpTraitsFor(type: Type): FPTraits {
-  const elTy = elementType(type);
-  switch (elTy?.kind) {
+/** @returns the floating-point traits for @p type */
+export function fpTraitsFor(type: ScalarType): FPTraits {
+  switch (type.kind) {
     case 'abstract-float':
       return FP.abstract;
     case 'f32':
@@ -4978,23 +4976,18 @@ export function fpTraitsFor(type: Type): FPTraits {
     case 'f16':
       return FP.f16;
     default:
-      unreachable(`unsupported type: ${elTy}`);
+      unreachable(`unsupported type: ${type}`);
   }
 }
 
-/**
- * @returns true if the value @p value is representable with the element type of @p type
- */
-export function isRepresentable(value: number, type: Type) {
+/** @returns true if the value @p value is representable with @p type */
+export function isRepresentable(value: number, type: ScalarType) {
   if (!Number.isFinite(value)) {
     return false;
   }
-  const elTy = elementType(type);
-  if (elTy !== null) {
-    if (isFloatType(elTy)) {
-      const constants = fpTraitsFor(type).constants();
-      return value >= constants.negative.min && value <= constants.positive.max;
-    }
+  if (isFloatType(type)) {
+    const constants = fpTraitsFor(type).constants();
+    return value >= constants.negative.min && value <= constants.positive.max;
   }
-  assert(false, `isRepresentable() is not yet implemented for type ${elTy}`);
+  assert(false, `isRepresentable() is not yet implemented for type ${type}`);
 }


### PR DESCRIPTION
I'll followup with a non-splatted version.

Fixed: #2715
Fixed: #2716
Fixed: #2717

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
