### PR TITLE
[wgsl] Add location validation tests

### DIFF
--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -1,6 +1,7 @@
 export const description = `Validation tests for entry point user-defined IO`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 import { generateShader } from './util.js';
@@ -256,4 +257,122 @@ g.test('duplicates')
     const secondIsRet = t.params.second === 'rb';
     const expectation = firstIsRet !== secondIsRet;
     t.expectCompileResult(expectation, code);
+  });
+
+const kValidationTests = {
+  zero: {
+    src: `@location(0)`,
+    pass: true,
+  },
+  one: {
+    src: `@location(1)`,
+    pass: true,
+  },
+  extra_comma: {
+    src: `@location(1,)`,
+    pass: true,
+  },
+  i32: {
+    src: `@location(1i)`,
+    pass: true,
+  },
+  u32: {
+    src: `@location(1u)`,
+    pass: true,
+  },
+  hex: {
+    src: `@location(0x1)`,
+    pass: true,
+  },
+  const_expr: {
+    src: `@location(a + b)`,
+    pass: true,
+  },
+  max: {
+    src: `@location(2147483647)`,
+    pass: true,
+  },
+  newline: {
+    src: '@\nlocation(1)',
+    pass: true,
+  },
+  comment: {
+    src: `@/* comment */location(1)`,
+    pass: true,
+  },
+
+  misspelling: {
+    src: `@mlocation(1)`,
+    pass: false,
+  },
+  no_parens: {
+    src: `@location`,
+    pass: false,
+  },
+  empty_params: {
+    src: `@location()`,
+    pass: false,
+  },
+  missing_left_paren: {
+    src: `@location 1)`,
+    pass: false,
+  },
+  missing_right_paren: {
+    src: `@location(1`,
+    pass: false,
+  },
+  extra_params: {
+    src: `@location(1, 2)`,
+    pass: false,
+  },
+  f32: {
+    src: `@location(1f)`,
+    pass: false,
+  },
+  f32_literal: {
+    src: `@location(1.0)`,
+    pass: false,
+  },
+  negative: {
+    src: `@location(-1)`,
+    pass: false,
+  },
+  override_expr: {
+    src: `@location(z + y)`,
+    pass: false,
+  },
+};
+g.test('validation')
+  .desc(`Test validation of location`)
+  .params(u => u.combine('attr', keysOf(kValidationTests)))
+  .fn(t => {
+    const code = `
+const a = 5;
+const b = 6;
+override z = 7;
+override y = 8;
+
+@vertex fn main(
+  ${kValidationTests[t.params.attr].src} res: f32
+) -> @builtin(position) vec4f {
+  return vec4f(0);
+}`;
+    t.expectCompileResult(kValidationTests[t.params.attr].pass, code);
+  });
+
+g.test('location_fp16')
+  .desc(`Test validation of location with fp16`)
+  .params(u => u.combine('ext', ['', 'h']))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(t => {
+    const code = `
+
+@vertex fn main(
+  @location(1${t.params.ext}) res: f32
+) -> @builtin(position) vec4f {
+  return vec4f();
+}`;
+    t.expectCompileResult(t.params.ext === '', code);
   });

--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -341,6 +341,10 @@ const kValidationTests = {
     src: `@location(z + y)`,
     pass: false,
   },
+  vec: {
+    src: `@location(vec2(1,1))`,
+    pass: false,
+  },
 };
 g.test('validation')
   .desc(`Test validation of location`)


### PR DESCRIPTION
This CL adds more validation tests for the `location` attribute.

Fixes: #1453

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
