### PR TITLE
[wgsl] Validate no recursion in type aliases

### DIFF
--- a/src/webgpu/shader/validation/types/alias.spec.ts
+++ b/src/webgpu/shader/validation/types/alias.spec.ts
@@ -1,0 +1,123 @@
+export const description = `
+Validation tests for type aliases
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('no_direct_recursion')
+  .desc('Test that direct recursion of type aliases is rejected')
+  .params(u => u.combine('target', ['i32', 'T']))
+  .fn(t => {
+    const wgsl = `alias T = ${t.params.target};`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion')
+  .desc('Test that indirect recursion of type aliases is rejected')
+  .params(u => u.combine('target', ['i32', 'S']))
+  .fn(t => {
+    const wgsl = `
+alias S = T;
+alias T = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_vector_element')
+  .desc('Test that indirect recursion of type aliases via vector element types is rejected')
+  .params(u => u.combine('target', ['i32', 'V']))
+  .fn(t => {
+    const wgsl = `
+alias V = vec4<T>;
+alias T = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_matrix_element')
+  .desc('Test that indirect recursion of type aliases via matrix element types is rejected')
+  .params(u => u.combine('target', ['f32', 'M']))
+  .fn(t => {
+    const wgsl = `
+alias M = mat4x4<T>;
+alias T = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'f32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_array_element')
+  .desc('Test that indirect recursion of type aliases via array element types is rejected')
+  .params(u => u.combine('target', ['i32', 'A']))
+  .fn(t => {
+    const wgsl = `
+alias A = array<T, 4>;
+alias T = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_array_size')
+  .desc('Test that indirect recursion of type aliases via array size expressions is rejected')
+  .params(u => u.combine('target', ['i32', 'A']))
+  .fn(t => {
+    const wgsl = `
+alias A = array<i32, T(1)>;
+alias T = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_atomic')
+  .desc('Test that indirect recursion of type aliases via atomic types is rejected')
+  .params(u => u.combine('target', ['i32', 'A']))
+  .fn(t => {
+    const wgsl = `
+alias A = atomic<T>;
+alias T = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_ptr_store_type')
+  .desc('Test that indirect recursion of type aliases via pointer store types is rejected')
+  .params(u => u.combine('target', ['i32', 'P']))
+  .fn(t => {
+    const wgsl = `
+alias P = ptr<function, T>;
+alias T = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_struct_member')
+  .desc('Test that indirect recursion of type aliases via struct members is rejected')
+  .params(u => u.combine('target', ['i32', 'S']))
+  .fn(t => {
+    const wgsl = `
+struct S {
+  a : T
+}
+alias T = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_struct_attribute')
+  .desc('Test that indirect recursion of type aliases via struct members is rejected')
+  .params(u =>
+    u //
+      .combine('target', ['i32', 'S'])
+      .combine('attribute', ['align', 'location', 'size'])
+  )
+  .fn(t => {
+    const wgsl = `
+struct S {
+  @${t.params.attribute}(T(4)) a : f32
+}
+alias T = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });


### PR DESCRIPTION
Issue #1467

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
