### PR TITLE
validate access mode on var decl

### DIFF
--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -55,9 +55,14 @@ export const kAccessModeInfo = {
 } as const;
 
 export type AddressSpaceInfo = {
+  // Variables in this address space must be declared in what scope?
   scope: Scope;
+
+  // True if a variable in this address space requires a binding.
   binding: boolean;
-  spell: Requirement; // Spell the address space in var declarations?
+
+  // Spell the address space in var declarations?
+  spell: Requirement;
 
   // Access modes for ordinary accesses (loads, stores).
   // The first one is the default.
@@ -72,7 +77,7 @@ export type AddressSpaceInfo = {
   spellAccessMode: Requirement;
 };
 
-export const kAddressSpaceInfo = {
+export const kAddressSpaceInfo: Record<string, AddressSpaceInfo> = {
   storage: {
     scope: 'module',
     binding: true,

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -4,6 +4,7 @@ import { align } from '../util/math.js';
 
 const kArrayLength = 3;
 
+export type Requirement = 'never' | 'may' | 'must'; // never is the same as "must not"
 export type ContainerType = 'scalar' | 'vector' | 'matrix' | 'atomic' | 'array';
 export type ScalarType = 'i32' | 'u32' | 'f32' | 'bool';
 
@@ -43,7 +44,78 @@ export const kMatrixContainerTypeInfo = /* prettier-ignore */ {
 /** List of all matNxN<> container types. */
 export const kMatrixContainerTypes = keysOf(kMatrixContainerTypeInfo);
 
-export type AddressSpace = 'storage' | 'uniform' | 'private' | 'function' | 'workgroup';
+export type AddressSpace = 'storage' | 'uniform' | 'private' | 'function' | 'workgroup' | 'handle';
+export type AccessMode = 'read' | 'write' | 'read_write';
+export type Scope = 'module' | 'function';
+
+export const kAccessModeInfo = {
+  read: { read: true, write: false },
+  write: { read: false, write: true },
+  read_write: { read: true, write: true },
+} as const;
+
+export type AddressSpaceInfo = {
+  scope: Scope;
+  binding: boolean;
+  spell: Requirement; // Spell the address space in var declarations?
+
+  // Access modes for ordinary accesses (loads, stores).
+  // The first one is the default.
+  // This is empty for the 'handle' address space where access is opaque.
+  accessModes: readonly AccessMode[];
+
+  // Spell the access mode in var declarations?
+  //   7.3 var Declarations
+  //   The access mode always has a default value, and except for variables
+  //   in the storage address space, must not be specified in the WGSL source.
+  //   See §13.3 Address Spaces.
+  spellAccessMode: Requirement;
+};
+
+export const kAddressSpaceInfo = {
+  storage: {
+    scope: 'module',
+    binding: true,
+    spell: 'must',
+    accessModes: ['read', 'read_write'],
+    spellAccessMode: 'may',
+  },
+  uniform: {
+    scope: 'module',
+    binding: true,
+    spell: 'must',
+    accessModes: ['read'],
+    spellAccessMode: 'never',
+  },
+  private: {
+    scope: 'module',
+    binding: false,
+    spell: 'must',
+    accessModes: ['read_write'],
+    spellAccessMode: 'never',
+  },
+  workgroup: {
+    scope: 'module',
+    binding: false,
+    spell: 'must',
+    accessModes: ['read_write'],
+    spellAccessMode: 'never',
+  },
+  function: {
+    scope: 'function',
+    binding: false,
+    spell: 'may',
+    accessModes: ['read_write'],
+    spellAccessMode: 'never',
+  },
+  handle: {
+    scope: 'module',
+    binding: true,
+    spell: 'never',
+    accessModes: [],
+    spellAccessMode: 'never',
+  },
+} as const;
 
 /** List of texel formats and their shader representation */
 export const TexelFormats = [
@@ -181,7 +253,7 @@ export function* generateTypes({
 /** Atomic access requires scalar/array container type and storage/workgroup memory. */
 export function supportsAtomics(p: {
   addressSpace: string;
-  storageMode: string | undefined;
+  storageMode: AccessMode | undefined;
   access: string;
   containerType: ContainerType;
 }) {

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -1,0 +1,42 @@
+/** An enumerator of shader stages */
+export type ShaderStage = 'vertex' | 'fragment' | 'compute';
+
+/** The list of all shader stages */
+export const kShaderStages = ['vertex', 'fragment', 'compute'] as const;
+
+/**
+ * declareEntrypoint emits the WGSL to declare an entry point with the name, stage and body.
+ * The generated function will have an appropriate return type and return statement, so that @p body
+ * does not have to change between stage.
+ * @param {{name?:String; stage: ShaderStage; body:string}} - arg specifies the
+ * optional entry point function name, the shader stage, and the body of the
+ * function, excluding any automatically generated return statements.
+ * @returns the WGSL string for the entry point
+ */
+export function declareEntryPoint(arg: {
+  name?: string;
+  stage: ShaderStage;
+  body: string;
+}): string {
+  if (arg.name === undefined) {
+    arg.name = 'main';
+  }
+  switch (arg.stage) {
+    case 'vertex':
+      return `@vertex
+fn ${arg.name}() -> @builtin(position) vec4f {
+  ${arg.body}
+  return vec4f();
+}`;
+    case 'fragment':
+      return `@fragment
+fn ${arg.name}() {
+  ${arg.body}
+}`;
+    case 'compute':
+      return `@compute @workgroup_size(1)
+fn ${arg.name}() {
+  ${arg.body}
+}`;
+  }
+}

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -8,7 +8,7 @@ export const kShaderStages = ['vertex', 'fragment', 'compute'] as const;
  * declareEntrypoint emits the WGSL to declare an entry point with the name, stage and body.
  * The generated function will have an appropriate return type and return statement, so that @p body
  * does not have to change between stage.
- * @param {{name?:String; stage: ShaderStage; body:string}} - arg specifies the
+ * @param arg - arg specifies the
  * optional entry point function name, the shader stage, and the body of the
  * function, excluding any automatically generated return statements.
  * @returns the WGSL string for the entry point

--- a/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
+++ b/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
@@ -1,0 +1,226 @@
+export const description = `
+7.3 var Declarations
+
+The access mode always has a default value, and except for variables in the
+storage address space, must not be specified in the WGSL source. See §13.3 Address Spaces.
+`;
+
+// TODO(4128): Validate the similar rules on pointer types.
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import {
+  AccessMode,
+  AddressSpace,
+  AddressSpaceInfo,
+  kAccessModeInfo,
+  kAddressSpaceInfo,
+} from '../../types.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { declareEntryPoint, ShaderStage } from './util.js';
+
+// Test address spaces that we can hold an i32 variable.
+const kOrdinaryAddressSpaces = keysOf(kAddressSpaceInfo).filter(as => as !== 'handle');
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+/**
+ * @returns a WGSL declaration for an 'x' variable with the given parameters.
+ */
+function declareVarX(
+  addressSpace: AddressSpace | undefined,
+  accessMode: AccessMode | undefined
+): string {
+  const bindingPart =
+    addressSpace && kAddressSpaceInfo[addressSpace].binding ? '@group(0) @binding(0) ' : '';
+  const spacePart = addressSpace ? (addressSpace as string) : '';
+  const modePart = accessMode ? (accessMode as string) : '';
+  const comma = spacePart && modePart ? ',' : '';
+  const templatePart = spacePart || modePart ? `<${spacePart}${comma}${modePart}>` : '';
+
+  return `${bindingPart}var${templatePart} x: i32;`;
+}
+
+/**
+ * @returns a WGSL program for the test parameterization.
+ */
+function getShader(
+  p: {
+    addressSpace: AddressSpace; // What address space for the variable.
+    explicitSpace: boolean; // Should the address space be explicitly spelled?
+    accessMode?: AccessMode; // What access mode to use.
+    explicitMode: boolean; // Should the access mode be explicitly spelled?
+    stage: ShaderStage; // What shader stage to use.
+  },
+  additionalBody?: string
+): string {
+  const as_info = kAddressSpaceInfo[p.addressSpace];
+  const decl = declareVarX(
+    p.explicitSpace ? p.addressSpace : undefined,
+    p.explicitMode ? p.accessMode : undefined
+  );
+  const beforeShader = as_info.scope === 'module' ? decl : '';
+  const insideShader = as_info.scope === 'function' ? decl : '';
+  const body = `${insideShader}\n${additionalBody ? additionalBody : ''}`;
+  const entryPoint = declareEntryPoint({ stage: p.stage, body });
+  const prog = `${beforeShader}\n${entryPoint}`;
+  return prog;
+}
+
+/** @returns the list of address space info objects for the given address space.  */
+function infoExpander(p: { addressSpace: AddressSpace }): readonly AddressSpaceInfo[] {
+  return [kAddressSpaceInfo[p.addressSpace]];
+}
+
+/** @returns a list of booleans indicating valid cases of specifying the address
+ * space.
+ */
+function explicitSpaceExpander(p: { info: AddressSpaceInfo }): readonly boolean[] {
+  return p.info.spell === 'must' ? [true] : [true, false];
+}
+/** @returns a list of usable access modes under given experiment conditions. */
+function accessModeExpander(p: {
+  explicitMode: boolean; // Whether the access mode will be emitted.
+  info: AddressSpaceInfo;
+}): readonly AccessMode[] {
+  return p.explicitMode && p.info.spellAccessMode !== 'never' ? p.info.accessModes : [];
+}
+
+/** @returns false if the test does not spell the address space in the var
+ * declaration but the address space requires it.
+ * Use this filter when trying to test something other than access mode
+ * functionality.
+ */
+function compatibleAS(p: { info: AddressSpaceInfo; explicitSpace: boolean }): boolean {
+  return !p.explicitSpace && p.info.spell === 'must';
+}
+
+/** @returns the effective access mode for the given experiment.  */
+function effectiveMode(p: { info: AddressSpaceInfo; accessMode: AccessMode }): AccessMode {
+  return p.accessMode || p.info.accessModes[0]; // default is first.
+}
+/** @returns whether the setup allows reads */
+function supportsRead(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+  const mode = effectiveMode(p);
+  return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].read;
+}
+/** @returns whether the setup allows writes */
+function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+  const mode = effectiveMode(p);
+  return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].write;
+}
+
+g.test('explicit_access_mode')
+  .desc('Validate uses of an explicit access mode on a variable declaration')
+  .params(
+    u =>
+      u
+        .combine('addressSpace', kOrdinaryAddressSpaces)
+        .expand('info', infoExpander)
+        .combine('explicitSpace', [true, false])
+        .filter(t => compatibleAS(t))
+        .combine('explicitMode', [true])
+        .combine('accessMode', keysOf(kAccessModeInfo))
+        .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
+  )
+  .fn(t => {
+    const prog = getShader(t.params);
+
+    const ok =
+      // The address space must be explicitly specified.
+      t.params.explicitSpace &&
+      // The address space must allow an access mode to be spelled, and the
+      // access mode must be in the list of modes for the address space.
+      t.params.info.spellAccessMode !== 'never' &&
+      (t.params.info.accessModes as readonly string[]).includes(t.params.accessMode);
+
+    t.expectCompileResult(ok, prog);
+  });
+
+g.test('implicit_access_mode')
+  .desc('Validate an implicit access mode on a variable declaration')
+  .params(
+    u =>
+      u
+        .combine('addressSpace', kOrdinaryAddressSpaces)
+        .expand('info', infoExpander)
+        .expand('explicitSpace', explicitSpaceExpander)
+        .combine('explicitMode', [false])
+        .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
+  )
+  .fn(t => {
+    const prog = getShader(t.params);
+
+    // 7.3 var Declarations
+    // "The access mode always has a default value,.."
+    const ok = true;
+
+    t.expectCompileResult(ok, prog);
+  });
+
+g.test('read_access')
+  .desc('A variable can be read from when the access mode permits')
+  .params(
+    u =>
+      u
+        .combine('addressSpace', kOrdinaryAddressSpaces)
+        .expand('info', infoExpander)
+        .expand('explicitSpace', explicitSpaceExpander)
+        .combine('explicitMode', [false, true])
+        .expand('accessMode', accessModeExpander)
+        .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
+  )
+  .fn(t => {
+    const prog = getShader(t.params, 'let copy = x;');
+    const ok = supportsRead(t.params);
+    t.expectCompileResult(ok, prog);
+  });
+
+g.test('write_access')
+  .desc('A variable can be written to when the access mode permits')
+  .params(
+    u =>
+      u
+        .combine('addressSpace', kOrdinaryAddressSpaces)
+        .expand('info', infoExpander)
+        .expand('explicitSpace', explicitSpaceExpander)
+        .combine('explicitMode', [false, true])
+        .expand('accessMode', accessModeExpander)
+        .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
+  )
+  .fn(t => {
+    const prog = getShader(t.params, 'x = 0;');
+    const ok = supportsWrite(t.params);
+    t.expectCompileResult(ok, prog);
+  });
+
+g.test('bad_template_contents')
+  .desc('A variable declaration has explicit access mode with varying other template list contents')
+  .params(u =>
+    u
+      .combine('accessMode', ['read', 'read_write'])
+      .combine('prefix', ['storage,', '', ','])
+      .combine('suffix', [',storage', ',read', ',', ''])
+  )
+  .fn(t => {
+    const prog = `@group(0) @binding(0)
+                  var<${t.params.prefix}${t.params.accessMode}${t.params.suffix}> x: i32;`;
+    const ok = t.params.prefix === 'storage,' && t.params.suffix === '';
+    t.expectCompileResult(ok, prog);
+  });
+
+g.test('bad_template_delim')
+  .desc('A variable declaration has explicit access mode with varying template list delimiters')
+  .params(u =>
+    u
+      .combine('accessMode', ['read', 'read_write'])
+      .combine('prefix', ['', '<', '>', ','])
+      .combine('suffix', ['', '<', '>', ','])
+  )
+  .fn(t => {
+    const prog = `@group(0) @binding(0)
+                  var ${t.params.prefix}storage,${t.params.accessMode}${t.params.suffix} x: i32;`;
+    const ok = t.params.prefix === '<' && t.params.suffix === '>';
+    t.expectCompileResult(ok, prog);
+  });

--- a/src/webgpu/shader/validation/parse/var_and_let.spec.ts
+++ b/src/webgpu/shader/validation/parse/var_and_let.spec.ts
@@ -70,3 +70,37 @@ g.test('initializer_type')
     const expectation = lhsType === rhsType;
     t.expectCompileResult(expectation, code);
   });
+
+g.test('var_access_mode_bad_other_template_contents')
+  .desc(
+    'A variable declaration with explicit access mode with varying other template list contents'
+  )
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#var-decls')
+  .params(u =>
+    u
+      .combine('accessMode', ['read', 'read_write'])
+      .combine('prefix', ['storage,', '', ','])
+      .combine('suffix', [',storage', ',read', ',', ''])
+  )
+  .fn(t => {
+    const prog = `@group(0) @binding(0)
+                  var<${t.params.prefix}${t.params.accessMode}${t.params.suffix}> x: i32;`;
+    const ok = t.params.prefix === 'storage,' && t.params.suffix === '';
+    t.expectCompileResult(ok, prog);
+  });
+
+g.test('var_access_mode_bad_template_delim')
+  .desc('A variable declaration has explicit access mode with varying template list delimiters')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#var-decls')
+  .params(u =>
+    u
+      .combine('accessMode', ['read', 'read_write'])
+      .combine('prefix', ['', '<', '>', ','])
+      .combine('suffix', ['', '<', '>', ','])
+  )
+  .fn(t => {
+    const prog = `@group(0) @binding(0)
+                  var ${t.params.prefix}storage,${t.params.accessMode}${t.params.suffix} x: i32;`;
+    const ok = t.params.prefix === '<' && t.params.suffix === '>';
+    t.expectCompileResult(ok, prog);
+  });


### PR DESCRIPTION
Contributes to #1538




Issue: #1538
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
