### PR TITLE
[wgsl] Validate no recursion in structure types

### DIFF
--- a/src/webgpu/shader/validation/types/struct.spec.ts
+++ b/src/webgpu/shader/validation/types/struct.spec.ts
@@ -34,7 +34,7 @@ struct T {
 
 g.test('no_indirect_recursion_via_array_element')
   .desc('Test that indirect recursion of structures via array element types is rejected')
-  .params(u => u.combine('target', ['i32', 'A']))
+  .params(u => u.combine('target', ['i32', 'S']))
   .fn(t => {
     const wgsl = `
 struct S {
@@ -77,4 +77,23 @@ struct S2 {
 }
 `;
     t.expectCompileResult(t.params.target === 'S1', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_struct_member_nested_in_alias')
+  .desc(
+    `Test that indirect recursion of structures via struct members is rejected when the member type
+    is an alias that contains the structure`
+  )
+  .params(u => u.combine('target', ['i32', 'A']))
+  .fn(t => {
+    const wgsl = `
+alias A = array<S2, 4>;
+struct S1 {
+  a : ${t.params.target}
+}
+struct S2 {
+  a : S1
+}
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
   });

--- a/src/webgpu/shader/validation/types/struct.spec.ts
+++ b/src/webgpu/shader/validation/types/struct.spec.ts
@@ -1,0 +1,80 @@
+export const description = `
+Validation tests for struct types
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('no_direct_recursion')
+  .desc('Test that direct recursion of structures is rejected')
+  .params(u => u.combine('target', ['i32', 'S']))
+  .fn(t => {
+    const wgsl = `
+struct S {
+  a : ${t.params.target}
+}`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion')
+  .desc('Test that indirect recursion of structures is rejected')
+  .params(u => u.combine('target', ['i32', 'S']))
+  .fn(t => {
+    const wgsl = `
+struct S {
+  a : T
+}
+struct T {
+  a : ${t.params.target}
+}`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_array_element')
+  .desc('Test that indirect recursion of structures via array element types is rejected')
+  .params(u => u.combine('target', ['i32', 'A']))
+  .fn(t => {
+    const wgsl = `
+struct S {
+  a : array<${t.params.target}, 4>
+}
+`;
+    t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_array_size')
+  .desc('Test that indirect recursion of structures via array size expressions is rejected')
+  .params(u => u.combine('target', ['S1', 'S2']))
+  .fn(t => {
+    const wgsl = `
+struct S1 {
+  a : i32,
+}
+struct S2 {
+  a : i32,
+  b : array<i32, ${t.params.target}().a + 1>,
+}
+`;
+    t.expectCompileResult(t.params.target === 'S1', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_struct_attribute')
+  .desc('Test that indirect recursion of structures via struct members is rejected')
+  .params(u =>
+    u //
+      .combine('target', ['S1', 'S2'])
+      .combine('attribute', ['align', 'location', 'size'])
+  )
+  .fn(t => {
+    const wgsl = `
+struct S1 {
+  a : i32
+}
+struct S2 {
+  @${t.params.attribute}(${t.params.target}(4).a) a : i32
+}
+`;
+    t.expectCompileResult(t.params.target === 'S1', wgsl);
+  });


### PR DESCRIPTION
Issue: #1467

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
