### PR TITLE
Compat: verify compressed format copies by rendering

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -16,8 +16,10 @@ import {
   depthStencilFormatAspectSize,
   DepthStencilFormat,
   ColorTextureFormat,
+  isCompressedTextureFormat,
+  viewCompatible,
 } from '../../../format_info.js';
-import { GPUTest } from '../../../gpu_test.js';
+import { GPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { makeBufferWithContents } from '../../../util/buffer.js';
 import { checkElementsEqual, checkElementsEqualEither } from '../../../util/check_contents.js';
 import { align } from '../../../util/math.js';
@@ -27,7 +29,7 @@ import { kBytesPerRowAlignment, dataBytesForCopyOrFail } from '../../../util/tex
 
 const dataGenerator = new DataArrayGenerator();
 
-class F extends GPUTest {
+class F extends TextureTestMixin(GPUTest) {
   GetInitialDataPerMipLevel(
     dimension: GPUTextureDimension,
     textureSize: Required<GPUExtent3DDict>,
@@ -77,6 +79,12 @@ class F extends GPUTest {
   ): void {
     this.skipIfTextureFormatNotSupported(srcFormat, dstFormat);
 
+    // If we're in compatibility mode and it's a compressed texture
+    // then we need to render the texture to test the results of the copy.
+    const extraTextureUsageFlags =
+      isCompressedTextureFormat(dstFormat) && this.isCompatibility
+        ? GPUTextureUsage.TEXTURE_BINDING
+        : 0;
     const mipLevelCount = dimension === '1d' ? 1 : 4;
 
     // Create srcTexture and dstTexture
@@ -93,7 +101,7 @@ class F extends GPUTest {
       dimension,
       size: dstTextureSize,
       format: dstFormat,
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
+      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST | extraTextureUsageFlags,
       mipLevelCount,
     };
     const dstTexture = this.device.createTexture(dstTextureDesc);
@@ -174,14 +182,22 @@ class F extends GPUTest {
     );
     assert(appliedCopyDepth >= 0);
 
-    const encoder = this.device.createCommandEncoder();
-    encoder.copyTextureToTexture(
-      { texture: srcTexture, mipLevel: srcCopyLevel, origin: appliedSrcOffset },
-      { texture: dstTexture, mipLevel: dstCopyLevel, origin: appliedDstOffset },
-      { width: appliedCopyWidth, height: appliedCopyHeight, depthOrArrayLayers: appliedCopyDepth }
-    );
+    const appliedSize = {
+      width: appliedCopyWidth,
+      height: appliedCopyHeight,
+      depthOrArrayLayers: appliedCopyDepth,
+    };
 
-    // Copy the whole content of dstTexture at dstCopyLevel to dstBuffer.
+    {
+      const encoder = this.device.createCommandEncoder();
+      encoder.copyTextureToTexture(
+        { texture: srcTexture, mipLevel: srcCopyLevel, origin: appliedSrcOffset },
+        { texture: dstTexture, mipLevel: dstCopyLevel, origin: appliedDstOffset },
+        appliedSize
+      );
+      this.device.queue.submit([encoder.finish()]);
+    }
+
     const dstBlocksPerRow = dstTextureSizeAtLevel.width / blockWidth;
     const dstBlockRowsPerImage = dstTextureSizeAtLevel.height / blockHeight;
     const bytesPerDstAlignedBlockRow = align(dstBlocksPerRow * bytesPerBlock, 256);
@@ -189,6 +205,66 @@ class F extends GPUTest {
       (dstBlockRowsPerImage * dstTextureSizeAtLevel.depthOrArrayLayers - 1) *
         bytesPerDstAlignedBlockRow +
       align(dstBlocksPerRow * bytesPerBlock, 4);
+
+    if (isCompressedTextureFormat(dstTexture.format) && this.isCompatibility) {
+      assert(viewCompatible(srcFormat, dstFormat));
+      // compare by rendering. We need the expected texture to match
+      // the dstTexture so we'll create a texture where we supply
+      // all of the data in JavaScript.
+      const expectedTexture = this.device.createTexture({
+        size: [dstTexture.width, dstTexture.height, dstTexture.depthOrArrayLayers],
+        mipLevelCount: dstTexture.mipLevelCount,
+        format: dstTexture.format,
+        usage: dstTexture.usage,
+      });
+      const expectedData = new Uint8Array(dstBufferSize);
+
+      // Execute the equivalent of `copyTextureToTexture`, copying
+      // from `initialSrcData` to `expectedData`.
+      this.updateLinearTextureDataSubBox(dstFormat, appliedSize, {
+        src: {
+          dataLayout: {
+            bytesPerRow: srcBlocksPerRow * bytesPerBlock,
+            rowsPerImage: srcBlockRowsPerImage,
+            offset: 0,
+          },
+          origin: appliedSrcOffset,
+          data: initialSrcData,
+        },
+        dest: {
+          dataLayout: {
+            bytesPerRow: dstBlocksPerRow * bytesPerBlock,
+            rowsPerImage: dstBlockRowsPerImage,
+            offset: 0,
+          },
+          origin: appliedDstOffset,
+          data: expectedData,
+        },
+      });
+
+      // Upload `expectedData` to `expectedTexture`. If `copyTextureToTexture`
+      // worked then the contents of `dstTexture` should match `expectedTexture`
+      this.queue.writeTexture(
+        { texture: expectedTexture, mipLevel: dstCopyLevel },
+        expectedData,
+        {
+          bytesPerRow: dstBlocksPerRow * bytesPerBlock,
+          rowsPerImage: dstBlockRowsPerImage,
+        },
+        dstTextureSizeAtLevel
+      );
+
+      this.expectTexturesToMatchByRendering(
+        dstTexture,
+        expectedTexture,
+        dstCopyLevel,
+        appliedDstOffset,
+        appliedSize
+      );
+      return;
+    }
+
+    // Copy the whole content of dstTexture at dstCopyLevel to dstBuffer.
     const dstBufferDesc: GPUBufferDescriptor = {
       size: dstBufferSize,
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
@@ -196,16 +272,19 @@ class F extends GPUTest {
     const dstBuffer = this.device.createBuffer(dstBufferDesc);
     this.trackForCleanup(dstBuffer);
 
-    encoder.copyTextureToBuffer(
-      { texture: dstTexture, mipLevel: dstCopyLevel },
-      {
-        buffer: dstBuffer,
-        bytesPerRow: bytesPerDstAlignedBlockRow,
-        rowsPerImage: dstBlockRowsPerImage,
-      },
-      dstTextureSizeAtLevel
-    );
-    this.device.queue.submit([encoder.finish()]);
+    {
+      const encoder = this.device.createCommandEncoder();
+      encoder.copyTextureToBuffer(
+        { texture: dstTexture, mipLevel: dstCopyLevel },
+        {
+          buffer: dstBuffer,
+          bytesPerRow: bytesPerDstAlignedBlockRow,
+          rowsPerImage: dstBlockRowsPerImage,
+        },
+        dstTextureSizeAtLevel
+      );
+      this.device.queue.submit([encoder.finish()]);
+    }
 
     // Fill expectedUint8DataWithPadding with the expected data of dstTexture. The other values in
     // expectedUint8DataWithPadding are kept 0 to check if the texels untouched by the copy are 0

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -63,10 +63,11 @@ import {
   RegularTextureFormat,
   isCompressedTextureFormat,
 } from '../../../format_info.js';
-import { GPUTest } from '../../../gpu_test.js';
+import { GPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { makeBufferWithContents } from '../../../util/buffer.js';
 import { checkElementsEqual } from '../../../util/check_contents.js';
 import { align } from '../../../util/math.js';
+import { physicalMipSizeFromTexture } from '../../../util/texture/base.js';
 import { DataArrayGenerator } from '../../../util/texture/data_generation.js';
 import {
   bytesInACompleteRow,
@@ -84,12 +85,6 @@ interface TextureCopyViewWithRequiredOrigin {
   origin: Required<GPUOrigin3DDict>;
 }
 
-type LinearCopyParameters = {
-  dataLayout: Required<GPUImageDataLayout>;
-  origin: Required<GPUOrigin3DDict>;
-  data: Uint8Array;
-};
-
 /** Describes the function used to copy the initial data into the texture. */
 type InitMethod = 'WriteTexture' | 'CopyB2T';
 /**
@@ -99,6 +94,10 @@ type InitMethod = 'WriteTexture' | 'CopyB2T';
  * - FullCopyT2B: do CopyT2B on the whole texture and check wether the part we copied to matches
  *   the data we were copying and that the nothing else was modified - that's primarily for testing
  *   WriteTexture and CopyB2T.
+ *
+ *   Note: in compatibility mode, copyTextureToBuffer is not supported for compressed textures.
+ *   In this case, we render the texture as well as a texture with the contents we except in the
+ *   copy and then expect the rendered results to match.
  */
 type CheckMethod = 'PartialCopyT2B' | 'FullCopyT2B';
 
@@ -144,54 +143,7 @@ const kWorkingColorTextureFormats = kColorTextureFormats.filter(x => !kExcludedF
 const dataGenerator = new DataArrayGenerator();
 const altDataGenerator = new DataArrayGenerator();
 
-class ImageCopyTest extends GPUTest {
-  /** Offset for a particular texel in the linear texture data */
-  getTexelOffsetInBytes(
-    textureDataLayout: Required<GPUImageDataLayout>,
-    format: ColorTextureFormat,
-    texel: Required<GPUOrigin3DDict>,
-    origin: Required<GPUOrigin3DDict> = { x: 0, y: 0, z: 0 }
-  ): number {
-    const { offset, bytesPerRow, rowsPerImage } = textureDataLayout;
-    const info = kTextureFormatInfo[format];
-
-    assert(texel.x % info.blockWidth === 0);
-    assert(texel.y % info.blockHeight === 0);
-    assert(origin.x % info.blockWidth === 0);
-    assert(origin.y % info.blockHeight === 0);
-
-    const bytesPerImage = rowsPerImage * bytesPerRow;
-
-    return (
-      offset +
-      (texel.z + origin.z) * bytesPerImage +
-      ((texel.y + origin.y) / info.blockHeight) * bytesPerRow +
-      ((texel.x + origin.x) / info.blockWidth) * info.color.bytes
-    );
-  }
-
-  *iterateBlockRows(
-    size: Required<GPUExtent3DDict>,
-    format: ColorTextureFormat
-  ): Generator<Required<GPUOrigin3DDict>> {
-    if (size.width === 0 || size.height === 0 || size.depthOrArrayLayers === 0) {
-      // do not iterate anything for an empty region
-      return;
-    }
-    const info = kTextureFormatInfo[format];
-    assert(size.height % info.blockHeight === 0);
-    // Note: it's important that the order is in increasing memory address order.
-    for (let z = 0; z < size.depthOrArrayLayers; ++z) {
-      for (let y = 0; y < size.height; y += info.blockHeight) {
-        yield {
-          x: 0,
-          y,
-          z,
-        };
-      }
-    }
-  }
-
+class ImageCopyTest extends TextureTestMixin(GPUTest) {
   /**
    * This is used for testing passing undefined members of `GPUImageDataLayout` instead of actual
    * values where possible. Passing arguments as values and not as objects so that they are passed
@@ -490,6 +442,80 @@ class ImageCopyTest extends GPUTest {
     }
   }
 
+  generateMatchingTextureInJSRenderAndCompareContents(
+    {
+      texture: actualTexture,
+      mipLevel: mipLevelOrUndefined,
+      origin,
+    }: TextureCopyViewWithRequiredOrigin,
+    copySize: Required<GPUExtent3DDict>,
+    format: ColorTextureFormat,
+    expected: Uint8Array,
+    expectedDataLayout: Required<GPUImageDataLayout>
+  ): void {
+    const size = [
+      actualTexture.width,
+      actualTexture.height,
+      actualTexture.depthOrArrayLayers,
+    ] as const;
+    const expectedTexture = this.device.createTexture({
+      label: 'expectedTexture',
+      size,
+      dimension: actualTexture.dimension,
+      format,
+      mipLevelCount: actualTexture.mipLevelCount,
+      usage: actualTexture.usage,
+    });
+    this.trackForCleanup(expectedTexture);
+
+    const mipLevel = mipLevelOrUndefined || 0;
+    const fullMipLevelTextureCopyLayout = getTextureCopyLayout(
+      format,
+      actualTexture.dimension,
+      size,
+      {
+        mipLevel,
+      }
+    );
+
+    // allocate data for entire mip level.
+    const expectedTextureMipLevelData = new Uint8Array(
+      align(fullMipLevelTextureCopyLayout.byteLength, 4)
+    );
+    const mipSize = physicalMipSizeFromTexture(expectedTexture, mipLevel);
+
+    // update the data for the entire mip level with the data
+    // that would be copied to the "actual" texture
+    this.updateLinearTextureDataSubBox(format, copySize, {
+      src: {
+        dataLayout: expectedDataLayout,
+        origin: { x: 0, y: 0, z: 0 },
+        data: expected,
+      },
+      dest: {
+        dataLayout: { offset: 0, ...fullMipLevelTextureCopyLayout },
+        origin,
+        data: expectedTextureMipLevelData,
+      },
+    });
+
+    // MAINTENANCE_TODO: If we're testing writeTexture should this use copyBufferToTexture instead?
+    this.queue.writeTexture(
+      { texture: expectedTexture, mipLevel },
+      expectedTextureMipLevelData,
+      { ...fullMipLevelTextureCopyLayout, offset: 0 },
+      mipSize
+    );
+
+    this.expectTexturesToMatchByRendering(
+      actualTexture,
+      expectedTexture,
+      mipLevel,
+      origin,
+      copySize
+    );
+  }
+
   /**
    * We check an appropriate part of the texture against the given data.
    * Used directly with PartialCopyT2B check method (for a subpart of the texture)
@@ -529,6 +555,9 @@ class ImageCopyTest extends GPUTest {
       changeBeforePass
     );
 
+    // We originally copied expected to texture using expectedDataLayout.
+    // We're copying back out of texture above.
+
     // bufferData has ...... in it.
     // Update bufferData to have the same contents as buffer.
     // When done, bufferData now has t.t.t. because the rows are padded.
@@ -552,67 +581,6 @@ class ImageCopyTest extends GPUTest {
       checkSize,
       expectedDataLayout
     );
-  }
-
-  /**
-   * Copies the whole texture into linear data stored in a buffer for further checks.
-   *
-   * Used for `copyWholeTextureToBufferAndCheckContentsWithUpdatedData`.
-   */
-  copyWholeTextureToNewBuffer(
-    { texture, mipLevel }: { texture: GPUTexture; mipLevel: number | undefined },
-    resultDataLayout: TextureCopyLayout
-  ): GPUBuffer {
-    const { mipSize, byteLength, bytesPerRow, rowsPerImage } = resultDataLayout;
-    const buffer = this.device.createBuffer({
-      size: align(byteLength, 4), // this is necessary because we need to copy and map data from this buffer
-      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
-    });
-    this.trackForCleanup(buffer);
-
-    const encoder = this.device.createCommandEncoder();
-    encoder.copyTextureToBuffer(
-      { texture, mipLevel },
-      { buffer, bytesPerRow, rowsPerImage },
-      mipSize
-    );
-    this.device.queue.submit([encoder.finish()]);
-
-    return buffer;
-  }
-
-  /**
-   * Takes the data returned by `copyWholeTextureToNewBuffer` and updates it after a copy operation
-   * on the texture by emulating the copy behaviour here directly.
-   */
-  updateLinearTextureDataSubBox(
-    format: ColorTextureFormat,
-    copySize: Required<GPUExtent3DDict>,
-    copyParams: {
-      dest: LinearCopyParameters;
-      src: LinearCopyParameters;
-    }
-  ): void {
-    const { src, dest } = copyParams;
-    const rowLength = bytesInACompleteRow(copySize.width, format);
-    for (const texel of this.iterateBlockRows(copySize, format)) {
-      const srcOffsetElements = this.getTexelOffsetInBytes(
-        src.dataLayout,
-        format,
-        texel,
-        src.origin
-      );
-      const dstOffsetElements = this.getTexelOffsetInBytes(
-        dest.dataLayout,
-        format,
-        texel,
-        dest.origin
-      );
-      memcpy(
-        { src: src.data, start: srcOffsetElements, length: rowLength },
-        { dst: dest.data, start: dstOffsetElements }
-      );
-    }
   }
 
   /**
@@ -718,14 +686,24 @@ class ImageCopyTest extends GPUTest {
           changeBeforePass
         );
 
-        this.copyPartialTextureToBufferAndCheckContents(
-          { texture, mipLevel, origin },
-          copySize,
-          format,
-          data,
-          textureDataLayout,
-          changeBeforePass
-        );
+        if (this.canCallCopyTextureToBufferWithTextureFormat(texture.format)) {
+          this.copyPartialTextureToBufferAndCheckContents(
+            { texture, mipLevel, origin },
+            copySize,
+            format,
+            data,
+            textureDataLayout,
+            changeBeforePass
+          );
+        } else {
+          this.generateMatchingTextureInJSRenderAndCompareContents(
+            { texture, mipLevel, origin },
+            copySize,
+            format,
+            data,
+            textureDataLayout
+          );
+        }
         break;
       }
       case 'FullCopyT2B': {
@@ -738,25 +716,36 @@ class ImageCopyTest extends GPUTest {
           changeBeforePass
         );
 
-        const fullTextureCopyLayout = getTextureCopyLayout(format, dimension, textureSize, {
-          mipLevel,
-        });
+        if (this.canCallCopyTextureToBufferWithTextureFormat(texture.format)) {
+          const fullTextureCopyLayout = getTextureCopyLayout(format, dimension, textureSize, {
+            mipLevel,
+          });
 
-        const fullData = this.copyWholeTextureToNewBuffer(
-          { texture, mipLevel },
-          fullTextureCopyLayout
-        );
+          const fullData = this.copyWholeTextureToNewBuffer(
+            { texture, mipLevel },
+            fullTextureCopyLayout
+          );
 
-        this.copyWholeTextureToBufferAndCheckContentsWithUpdatedData(
-          { texture, mipLevel, origin },
-          fullTextureCopyLayout,
-          textureDataLayout,
-          copySize,
-          format,
-          fullData,
-          data
-        );
-
+          this.copyWholeTextureToBufferAndCheckContentsWithUpdatedData(
+            { texture, mipLevel, origin },
+            fullTextureCopyLayout,
+            textureDataLayout,
+            copySize,
+            format,
+            fullData,
+            data
+          );
+        } else {
+          this.generateMatchingTextureInJSRenderAndCompareContents(
+            { texture, mipLevel, origin },
+            copySize,
+            format,
+            data,
+            textureDataLayout
+            //fullTextureCopyLayout,
+            //fullData,
+          );
+        }
         break;
       }
       default:

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1111,9 +1111,25 @@ export interface TextureTestMixinType {
 
   /**
    * Renders the 2 given textures to an rgba8unorm texture at the size of the
-   * specified mipLevel. Expects contents of both textures to match.
-   * Also expects contents described by origin and size to not be a constant value
-   * so as to make sure something interesting was actually compared.
+   * specified mipLevel, each time reading the contents of the result.
+   * Expects contents of both renders to match. Also expects contents described
+   * by origin and size to not be a constant value so as to make sure something
+   * interesting was actually compared.
+   *
+   * The point of this function is to compare compressed texture contents in
+   * compatibility mode. `copyTextureToBuffer` does not work for compressed
+   * textures in compatibility mode so instead, we pass 2 compressed texture
+   * to this function. Each one will be rendered to an `rgba8unorm` texture,
+   * the results of that `rgba8unorm` texture read via `copyTextureToBuffer`,
+   * and then results compared. This indirectly lets us compare the contents
+   * of the 2 compressed textures.
+   *
+   * Code calling this function would generate the textures where the
+   * `actualTexture` is generated calling `writeTexture`, `copyBufferToTexture`
+   * or `copyTextureToTexture` and `expectedTexture`'s data is generated entirely
+   * on the CPU in such a way that its content should match whatever process
+   * was used to generate `actualTexture`. Often this involves calling
+   * `updateLinearTextureDataSubBox`
    */
   expectTexturesToMatchByRendering(
     actualTexture: GPUTexture,

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -11,6 +11,7 @@ import {
 import { globalTestConfig } from '../common/framework/test_config.js';
 import {
   assert,
+  memcpy,
   range,
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
@@ -24,6 +25,8 @@ import {
   resolvePerAspectFormat,
   SizedTextureFormat,
   EncodableTextureFormat,
+  isCompressedTextureFormat,
+  ColorTextureFormat,
 } from './format_info.js';
 import { makeBufferWithContents } from './util/buffer.js';
 import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';
@@ -32,7 +35,9 @@ import { ScalarType } from './util/conversion.js';
 import { DevicePool, DeviceProvider, UncanonicalizedDeviceDescriptor } from './util/device_pool.js';
 import { align, roundDown } from './util/math.js';
 import { createTextureFromTexelView, createTextureFromTexelViews } from './util/texture.js';
+import { physicalMipSizeFromTexture, virtualMipSize } from './util/texture/base.js';
 import {
+  bytesInACompleteRow,
   getTextureCopyLayout,
   getTextureSubCopyLayout,
   LayoutOptions as TextureLayoutOptions,
@@ -246,6 +251,10 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
 
   get isCompatibility() {
     return globalTestConfig.compatibility;
+  }
+
+  canCallCopyTextureToBufferWithTextureFormat(format: GPUTextureFormat) {
+    return !this.isCompatibility || !isCompressedTextureFormat(format);
   }
 
   /** Snapshot a GPUBuffer's contents, returning a new GPUBuffer with the `MAP_READ` usage. */
@@ -1099,7 +1108,143 @@ export interface TextureTestMixinType {
     exp: PerPixelComparison<E>[],
     comparisonOptions?: TexelCompareOptions
   ): void;
+
+  /**
+   * Renders the 2 given textures to an rgba8unorm texture at the size of the
+   * specified mipLevel. Expects contents of both textures to match.
+   * Also expects contents described by origin and size to not be a constant value
+   * so as to make sure something interesting was actually compared.
+   */
+  expectTexturesToMatchByRendering(
+    actualTexture: GPUTexture,
+    expectedTexture: GPUTexture,
+    mipLevel: number,
+    origin: Required<GPUOrigin3DDict>,
+    size: Required<GPUExtent3DDict>
+  ): void;
+
+  /**
+   * Copies an entire texture's mipLevel to a buffer
+   */
+  copyWholeTextureToNewBufferSimple(texture: GPUTexture, mipLevel: number): GPUBuffer;
+
+  /**
+   * Copies an texture's mipLevel to a buffer
+   * The size of the buffer is specified by `byteLength`
+   */
+  copyWholeTextureToNewBuffer(
+    { texture, mipLevel }: { texture: GPUTexture; mipLevel: number | undefined },
+    resultDataLayout: {
+      bytesPerBlock: number;
+      byteLength: number;
+      bytesPerRow: number;
+      rowsPerImage: number;
+      mipSize: [number, number, number];
+    }
+  ): GPUBuffer;
+
+  /**
+   * Updates a Uint8Array with a cubic portion of data from another Uint8Array.
+   * Effectively it's a Uint8Array to Uint8Array copy that
+   * does the same thing as `writeTexture` but because the
+   * destination is a buffer you have to provide the parameters
+   * of the destination buffer similarly to how you'd provide them
+   * to `copyTextureToBuffer`
+   */
+  updateLinearTextureDataSubBox(
+    format: ColorTextureFormat,
+    copySize: Required<GPUExtent3DDict>,
+    copyParams: {
+      dest: LinearCopyParameters;
+      src: LinearCopyParameters;
+    }
+  ): void;
+
+  /**
+   * Gets a byte offset to a texel
+   */
+  getTexelOffsetInBytes(
+    textureDataLayout: Required<GPUImageDataLayout>,
+    format: ColorTextureFormat,
+    texel: Required<GPUOrigin3DDict>,
+    origin?: Required<GPUOrigin3DDict>
+  ): number;
+
+  iterateBlockRows(
+    size: Required<GPUExtent3DDict>,
+    format: ColorTextureFormat
+  ): Generator<Required<GPUOrigin3DDict>>;
 }
+
+type ImageCopyTestResources = {
+  pipeline: GPURenderPipeline;
+};
+
+const s_deviceToResourcesMap = new WeakMap<GPUDevice, ImageCopyTestResources>();
+
+/**
+ * Gets a (cached) pipeline to render a texture to an rgba8unorm texture
+ */
+function getPipelineToRenderTextureToRGB8UnormTexture(device: GPUDevice) {
+  if (!s_deviceToResourcesMap.has(device)) {
+    const module = device.createShaderModule({
+      code: `
+        struct VSOutput {
+          @builtin(position) position: vec4f,
+          @location(0) texcoord: vec2f,
+        };
+
+        @vertex fn vs(
+          @builtin(vertex_index) vertexIndex : u32
+        ) -> VSOutput {
+            let pos = array(
+               vec2f(-1, -1),
+               vec2f(-1,  3),
+               vec2f( 3, -1),
+            );
+
+            var vsOutput: VSOutput;
+
+            let xy = pos[vertexIndex];
+
+            vsOutput.position = vec4f(xy, 0.0, 1.0);
+            vsOutput.texcoord = xy * vec2f(0.5, -0.5) + vec2f(0.5);
+
+            return vsOutput;
+         }
+
+         @group(0) @binding(0) var ourSampler: sampler;
+         @group(0) @binding(1) var ourTexture: texture_2d<f32>;
+
+         @fragment fn fs(fsInput: VSOutput) -> @location(0) vec4f {
+            return textureSample(ourTexture, ourSampler, fsInput.texcoord);
+         }
+      `,
+    });
+    const pipeline = device.createRenderPipeline({
+      layout: 'auto',
+      vertex: {
+        module,
+        entryPoint: 'vs',
+      },
+      fragment: {
+        module,
+        entryPoint: 'fs',
+        targets: [{ format: 'rgba8unorm' }],
+      },
+    });
+    s_deviceToResourcesMap.set(device, { pipeline });
+  }
+  const { pipeline } = s_deviceToResourcesMap.get(device)!;
+  return pipeline;
+}
+
+type LinearCopyParameters = {
+  dataLayout: Required<GPUImageDataLayout>;
+  origin: Required<GPUOrigin3DDict>;
+  data: Uint8Array;
+};
+
 export function TextureTestMixin<F extends FixtureClass<GPUTest>>(
   Base: F
 ): FixtureClassWithMixin<F, TextureTestMixinType> {
@@ -1223,6 +1368,252 @@ export function TextureTestMixin<F extends FixtureClass<GPUTest>>(
         )
       );
     }
+
+    expectTexturesToMatchByRendering(
+      actualTexture: GPUTexture,
+      expectedTexture: GPUTexture,
+      mipLevel: number,
+      origin: Required<GPUOrigin3DDict>,
+      size: Required<GPUExtent3DDict>
+    ): void {
+      // Render every layer of both textures at mipLevel to an rgba8unorm texture
+      // that matches the size of the mipLevel. After each render, copy the
+      // result to a buffer and expect the results from both textures to match.
+      const pipeline = getPipelineToRenderTextureToRGB8UnormTexture(this.device);
+      const readbackPromisesPerTexturePerLayer = [actualTexture, expectedTexture].map(
+        (texture, ndx) => {
+          const attachmentSize = virtualMipSize('2d', [texture.width, texture.height, 1], mipLevel);
+          const attachment = this.device.createTexture({
+            label: `readback${ndx}`,
+            size: attachmentSize,
+            format: 'rgba8unorm',
+            usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+          });
+          this.trackForCleanup(attachment);
+
+          const sampler = this.device.createSampler();
+
+          const numLayers = texture.depthOrArrayLayers;
+          const readbackPromisesPerLayer = [];
+          for (let layer = 0; layer < numLayers; ++layer) {
+            const bindGroup = this.device.createBindGroup({
+              layout: pipeline.getBindGroupLayout(0),
+              entries: [
+                { binding: 0, resource: sampler },
+                {
+                  binding: 1,
+                  resource: texture.createView({
+                    baseMipLevel: mipLevel,
+                    mipLevelCount: 1,
+                    baseArrayLayer: layer,
+                    arrayLayerCount: 1,
+                    dimension: '2d',
+                  }),
+                },
+              ],
+            });
+
+            const encoder = this.device.createCommandEncoder();
+            const pass = encoder.beginRenderPass({
+              colorAttachments: [
+                {
+                  view: attachment.createView(),
+                  clearValue: [0.5, 0.5, 0.5, 0.5],
+                  loadOp: 'clear',
+                  storeOp: 'store',
+                },
+              ],
+            });
+            pass.setPipeline(pipeline);
+            pass.setBindGroup(0, bindGroup);
+            pass.draw(3);
+            pass.end();
+            this.queue.submit([encoder.finish()]);
+
+            const buffer = this.copyWholeTextureToNewBufferSimple(attachment, 0);
+
+            readbackPromisesPerLayer.push(
+              this.readGPUBufferRangeTyped(buffer, {
+                type: Uint8Array,
+                typedLength: buffer.size,
+              })
+            );
+          }
+          return readbackPromisesPerLayer;
+        }
+      );
+
+      this.eventualAsyncExpectation(async niceStack => {
+        const readbacksPerTexturePerLayer = [];
+
+        // Wait for all buffers to be ready
+        for (const readbackPromises of readbackPromisesPerTexturePerLayer) {
+          readbacksPerTexturePerLayer.push(await Promise.all(readbackPromises));
+        }
+
+        function arrayNotAllTheSameValue(arr: TypedArrayBufferView | number[], msg?: string) {
+          const first = arr[0];
+          return arr.length <= 1 || arr.findIndex(v => v !== first) >= 0
+            ? undefined
+            : Error(`array is entirely ${first} so likely nothing was tested: ${msg || ''}`);
+        }
+
+        // Compare each layer of each texture as read from buffer.
+        const [actualReadbacksPerLayer, expectedReadbacksPerLayer] = readbacksPerTexturePerLayer;
+        for (let layer = 0; layer < actualReadbacksPerLayer.length; ++layer) {
+          const actualReadback = actualReadbacksPerLayer[layer];
+          const expectedReadback = expectedReadbacksPerLayer[layer];
+          const sameOk =
+            size.width === 0 ||
+            size.height === 0 ||
+            layer < origin.z ||
+            layer >= origin.z + size.depthOrArrayLayers;
+          this.expectOK(
+            sameOk ? undefined : arrayNotAllTheSameValue(actualReadback.data, 'actualTexture')
+          );
+          this.expectOK(
+            sameOk ? undefined : arrayNotAllTheSameValue(expectedReadback.data, 'expectedTexture')
+          );
+          this.expectOK(checkElementsEqual(actualReadback.data, expectedReadback.data), {
+            mode: 'fail',
+            niceStack,
+          });
+          actualReadback.cleanup();
+          expectedReadback.cleanup();
+        }
+      });
+    }
+
+    copyWholeTextureToNewBufferSimple(texture: GPUTexture, mipLevel: number) {
+      const { blockWidth, blockHeight, bytesPerBlock } = kTextureFormatInfo[texture.format];
+      const mipSize = physicalMipSizeFromTexture(texture, mipLevel);
+      assert(bytesPerBlock !== undefined);
+
+      const blocksPerRow = mipSize[0] / blockWidth;
+      const blocksPerColumn = mipSize[1] / blockHeight;
+
+      assert(blocksPerRow % 1 === 0);
+      assert(blocksPerColumn % 1 === 0);
+
+      const bytesPerRow = align(blocksPerRow * bytesPerBlock, 256);
+      const byteLength = bytesPerRow * blocksPerColumn * mipSize[2];
+
+      return this.copyWholeTextureToNewBuffer(
+        { texture, mipLevel },
+        {
+          bytesPerBlock,
+          bytesPerRow,
+          rowsPerImage: blocksPerColumn,
+          byteLength,
+        }
+      );
+    }
+
+    copyWholeTextureToNewBuffer(
+      { texture, mipLevel }: { texture: GPUTexture; mipLevel: number | undefined },
+      resultDataLayout: {
+        bytesPerBlock: number;
+        byteLength: number;
+        bytesPerRow: number;
+        rowsPerImage: number;
+      }
+    ): GPUBuffer {
+      const { byteLength, bytesPerRow, rowsPerImage } = resultDataLayout;
+      const buffer = this.device.createBuffer({
+        size: align(byteLength, 4), // this is necessary because we need to copy and map data from this buffer
+        usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+      });
+      this.trackForCleanup(buffer);
+
+      const mipSize = physicalMipSizeFromTexture(texture, mipLevel || 0);
+      const encoder = this.device.createCommandEncoder();
+      encoder.copyTextureToBuffer(
+        { texture, mipLevel },
+        { buffer, bytesPerRow, rowsPerImage },
+        mipSize
+      );
+      this.device.queue.submit([encoder.finish()]);
+
+      return buffer;
+    }
+
+    updateLinearTextureDataSubBox(
+      format: ColorTextureFormat,
+      copySize: Required<GPUExtent3DDict>,
+      copyParams: {
+        dest: LinearCopyParameters;
+        src: LinearCopyParameters;
+      }
+    ): void {
+      const { src, dest } = copyParams;
+      const rowLength = bytesInACompleteRow(copySize.width, format);
+      for (const texel of this.iterateBlockRows(copySize, format)) {
+        const srcOffsetElements = this.getTexelOffsetInBytes(
+          src.dataLayout,
+          format,
+          texel,
+          src.origin
+        );
+        const dstOffsetElements = this.getTexelOffsetInBytes(
+          dest.dataLayout,
+          format,
+          texel,
+          dest.origin
+        );
+        memcpy(
+          { src: src.data, start: srcOffsetElements, length: rowLength },
+          { dst: dest.data, start: dstOffsetElements }
+        );
+      }
+    }
+
+    /** Offset for a particular texel in the linear texture data */
+    getTexelOffsetInBytes(
+      textureDataLayout: Required<GPUImageDataLayout>,
+      format: ColorTextureFormat,
+      texel: Required<GPUOrigin3DDict>,
+      origin: Required<GPUOrigin3DDict> = { x: 0, y: 0, z: 0 }
+    ): number {
+      const { offset, bytesPerRow, rowsPerImage } = textureDataLayout;
+      const info = kTextureFormatInfo[format];
+
+      assert(texel.x % info.blockWidth === 0);
+      assert(texel.y % info.blockHeight === 0);
+      assert(origin.x % info.blockWidth === 0);
+      assert(origin.y % info.blockHeight === 0);
+
+      const bytesPerImage = rowsPerImage * bytesPerRow;
+
+      return (
+        offset +
+        (texel.z + origin.z) * bytesPerImage +
+        ((texel.y + origin.y) / info.blockHeight) * bytesPerRow +
+        ((texel.x + origin.x) / info.blockWidth) * info.color.bytes
+      );
+    }
+
+    *iterateBlockRows(
+      size: Required<GPUExtent3DDict>,
+      format: ColorTextureFormat
+    ): Generator<Required<GPUOrigin3DDict>> {
+      if (size.width === 0 || size.height === 0 || size.depthOrArrayLayers === 0) {
+        // do not iterate anything for an empty region
+        return;
+      }
+      const info = kTextureFormatInfo[format];
+      assert(size.height % info.blockHeight === 0);
+      // Note: it's important that the order is in increasing memory address order.
+      for (let z = 0; z < size.depthOrArrayLayers; ++z) {
+        for (let y = 0; y < size.height; y += info.blockHeight) {
+          yield {
+            x: 0,
+            y,
+            z,
+          };
+        }
+      }
+    }
   }
+
   return (TextureExpectations as unknown) as FixtureClassWithMixin<F, TextureTestMixinType>;
 }

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -90,6 +90,18 @@ export function physicalMipSize(
 }
 
 /**
+ * Compute the "physical size" of a mip level: the size of the level, rounded up to a
+ * multiple of the texel block size.
+ */
+export function physicalMipSizeFromTexture(
+  texture: GPUTexture,
+  mipLevel: number
+): [number, number, number] {
+  const size = physicalMipSize(texture, texture.format, texture.dimension, mipLevel);
+  return [size.width, size.height, size.depthOrArrayLayers];
+}
+
+/**
  * Compute the "virtual size" of a mip level of a texture (not accounting for texel block rounding).
  *
  * MAINTENANCE_TODO: Change input/output to Required<GPUExtent3DDict> for consistency.


### PR DESCRIPTION
Compat: verify compressed format copies by rendering

The image_copy tests and copyTextureToTexture tests were using
`copyTextureToBuffer` to validate `writeTexture`,
`copyBufferToTexture`, and `copyTextureToTexture` but
`copyTextureToBuffer` does not work in compat for compressed
texture formats.

So instead, for those formats, create one texture and update
a portion of its content with `writeTexture`, `copyBufferToTexture`,
or `copyTextureToTexture`

Create another texture, this texture is the same size and format but
has its content generated on the CPU. In other words, the equivalent
of `writeTexture` / `copyBufferToTexture` / `copyTextureToTexture`
is executed on a Uint8Array that represents the entire content of the
texture.

The 2 textures are then rendered, layer by layer, to an rgba8unorm
texture and each render is read to a buffer. The buffers from
each texture's layers are expected to match.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
