### PR TITLE
Validate builtins

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
@@ -1,0 +1,50 @@
+const builtin = 'abs';
+export const description = `
+Validation tests for the ${builtin}() builtin.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import {
+  TypeF16,
+  elementType,
+  kAllFloatAndIntegerScalarsAndVectors,
+} from '../../../../../util/conversion.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import {
+  fullRangeForType,
+  kConstantAndOverrideStages,
+  stageSupportsType,
+  validateConstOrOverrideBuiltinEval,
+} from './const_override_validation.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('values')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() never errors
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatAndIntegerScalarsAndVectors)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .expand('value', u => fullRangeForType(u.type))
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const expectedResult = true; // abs() should never error
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      [t.params.type.create(t.params.value)],
+      t.params.stage
+    );
+  });

--- a/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
@@ -1,0 +1,69 @@
+const builtin = 'ceil';
+export const description = `
+Validation tests for the ${builtin}() builtin.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import {
+  TypeF16,
+  TypeF32,
+  elementType,
+  kAllFloatScalarsAndVectors,
+  kAllIntegerScalarsAndVectors,
+} from '../../../../../util/conversion.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import {
+  fullRangeForType,
+  kConstantAndOverrideStages,
+  stageSupportsType,
+  validateConstOrOverrideBuiltinEval,
+} from './const_override_validation.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('values')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() never errors
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatScalarsAndVectors)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .expand('value', u => fullRangeForType(u.type))
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const expectedResult = true; // ceil() should never error
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      [t.params.type.create(t.params.value)],
+      t.params.stage
+    );
+  });
+
+g.test('integer_argument')
+  .desc(
+    `
+Validates that scalar and vector integer arguments are rejected by ${builtin}()
+`
+  )
+  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .fn(t => {
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      /* expectedResult */ t.params.type === TypeF32,
+      [t.params.type.create(0)],
+      'constant'
+    );
+  });

--- a/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
@@ -1,0 +1,56 @@
+const builtin = 'clamp';
+export const description = `
+Validation tests for the ${builtin}() builtin.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import {
+  TypeF16,
+  elementType,
+  kAllFloatAndIntegerScalarsAndVectors,
+} from '../../../../../util/conversion.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import {
+  fullRangeForType,
+  kConstantAndOverrideStages,
+  stageSupportsType,
+  validateConstOrOverrideBuiltinEval,
+} from './const_override_validation.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('values')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', kAllFloatAndIntegerScalarsAndVectors)
+      .filter(u => stageSupportsType(u.stage, u.type))
+      .expand('e', u => fullRangeForType(u.type, 3))
+      .expand('low', u => fullRangeForType(u.type, 4))
+      .expand('high', u => fullRangeForType(u.type, 4))
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(t.params.type) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const expectedResult = t.params.low <= t.params.high;
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      [
+        t.params.type.create(t.params.e),
+        t.params.type.create(t.params.low),
+        t.params.type.create(t.params.high),
+      ],
+      t.params.stage
+    );
+  });


### PR DESCRIPTION
Fixes: #2676
Fixes: #2677
Fixes: #2678

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
