### PR TITLE
Validate function declarations

### DIFF
--- a/src/webgpu/shader/validation/functions/restrictions.spec.ts
+++ b/src/webgpu/shader/validation/functions/restrictions.spec.ts
@@ -595,33 +595,24 @@ g.test('param_names_must_differ')
     t.expectCompileResult(t.params.p1 !== t.params.p2, code);
   });
 
+const kParamUseCases: Record<string, string> = {
+  body: `fn foo(param : u32) {
+    let tmp = param;
+  }`,
+  var: `var<private> v : u32 = param;
+  fn foo(param : u32) { }`,
+  const: `const c : u32 = param;
+  fn foo(param : u32) { }`,
+  override: `override o : u32 = param;
+  fn foo(param : u32) { }`,
+  function: `fn bar() { let tmp = param; }
+  fn foo(param : u32) { }`,
+};
+
 g.test('param_scope_is_function_body')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#function-declaration-sec')
   .desc(`Test that function parameters are only in scope in the function body`)
-  .params(u => u.combine('use', ['body', 'var', 'const', 'override', 'function'] as const))
+  .params(u => u.combine('use', keysOf(kParamUseCases)))
   .fn(t => {
-    const body_use = `let tmp = param;`;
-    const var_use = `var<private> v : u32 = param;`;
-    const const_use = `const c : u32 = param;`;
-    const override_use = `override o : u32 = param;`;
-    const function_use = `fn bar() { let tmp = param; }`;
-
-    const body = t.params.use === 'body' ? body_use : '';
-    const var_decl = t.params.use === 'var' ? var_use : '';
-    const const_decl = t.params.use === 'const' ? const_use : '';
-    const override_decl = t.params.use === 'override' ? override_use : '';
-    const other_function = t.params.use === 'function' ? function_use : '';
-
-    const code = `
-${var_decl}
-${const_decl}
-${override_decl}
-
-fn foo(param : u32) {
-  ${body}
-}
-
-${other_function}`;
-
-    t.expectCompileResult(t.params.use === 'body', code);
+    t.expectCompileResult(t.params.use === 'body', kParamUseCases[t.params.use]);
   });

--- a/src/webgpu/shader/validation/functions/restrictions.spec.ts
+++ b/src/webgpu/shader/validation/functions/restrictions.spec.ts
@@ -585,3 +585,43 @@ fn foo() {
 
     t.expectCompileResult(false, code);
   });
+
+g.test('param_names_must_differ')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#function-declaration-sec')
+  .desc(`Test that function parameters must have different names`)
+  .params(u => u.combine('p1', ['a', 'b', 'c'] as const).combine('p2', ['a', 'b', 'c'] as const))
+  .fn(t => {
+    const code = `fn foo(${t.params.p1} : u32, ${t.params.p2} : f32) { }`;
+    t.expectCompileResult(t.params.p1 !== t.params.p2, code);
+  });
+
+g.test('param_scope_is_function_body')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#function-declaration-sec')
+  .desc(`Test that function parameters are only in scope in the function body`)
+  .params(u => u.combine('use', ['body', 'var', 'const', 'override', 'function'] as const))
+  .fn(t => {
+    const body_use = `let tmp = param;`;
+    const var_use = `var<private> v : u32 = param;`;
+    const const_use = `const c : u32 = param;`;
+    const override_use = `override o : u32 = param;`;
+    const function_use = `fn bar() { let tmp = param; }`;
+
+    const body = t.params.use === 'body' ? body_use : '';
+    const var_decl = t.params.use === 'var' ? var_use : '';
+    const const_decl = t.params.use === 'const' ? const_use : '';
+    const override_decl = t.params.use === 'override' ? override_use : '';
+    const other_function = t.params.use === 'function' ? function_use : '';
+
+    const code = `
+${var_decl}
+${const_decl}
+${override_decl}
+
+fn foo(param : u32) {
+  ${body}
+}
+
+${other_function}`;
+
+    t.expectCompileResult(t.params.use === 'body', code);
+  });


### PR DESCRIPTION
Fixes #2830

* Parameters must have different names
* Parameters are only in scope in the function




Issue: #2830

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
