### PR TITLE
Fix case generation for validation of variable declaration access modes

### DIFF
--- a/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
+++ b/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
@@ -97,13 +97,20 @@ function accessModeExpander(p: {
 }
 
 /**
- * @returns false if the test does not spell the address space in the var
- * declaration but the address space requires it.
- * Use this filter when trying to test something other than access mode
- * functionality.
+ * @returns true if an explicit address space is requested on a variable
+ * declaration whenever the address space requires one:
+ *
+ *       must implies requested
+ *
+ * Rewrite as:
+ *
+ *       !must or requested
  */
-function compatibleAS(p: { info: AddressSpaceInfo; explicitSpace: boolean }): boolean {
-  return !p.explicitSpace && p.info.spell === 'must';
+export function varDeclCompatibleAddressSpace(p: {
+  info: AddressSpaceInfo;
+  explicitSpace: boolean;
+}): boolean {
+  return !(p.info.spell === 'must') || p.explicitSpace;
 }
 
 /** @returns the effective access mode for the given experiment.  */
@@ -130,7 +137,7 @@ g.test('explicit_access_mode')
         .combine('addressSpace', kNonHandleAddressSpaces)
         .expand('info', infoExpander)
         .combine('explicitSpace', [true, false])
-        .filter(t => compatibleAS(t))
+        .filter(t => varDeclCompatibleAddressSpace(t))
         .combine('explicitMode', [true])
         .combine('accessMode', keysOf(kAccessModeInfo))
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders


### PR DESCRIPTION
I had the logic backwards, so it wasn't testing the interesting cases for explicit_access_mode.

Affects:
webgpu:shader,validation,decl,var_access_mode:explicit_access_mode:*




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
