### PR TITLE
[wgsl] Validate no recursion for const/override

### DIFF
--- a/src/webgpu/shader/validation/decl/const.spec.ts
+++ b/src/webgpu/shader/validation/decl/const.spec.ts
@@ -1,0 +1,61 @@
+export const description = `
+Validation tests for const declarations
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('no_direct_recursion')
+  .desc('Test that direct recursion of const declarations is rejected')
+  .params(u => u.combine('target', ['a', 'b']))
+  .fn(t => {
+    const wgsl = `
+const a : i32 = 42;
+const b : i32 = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'a', wgsl);
+  });
+
+g.test('no_indirect_recursion')
+  .desc('Test that indirect recursion of const declarations is rejected')
+  .params(u => u.combine('target', ['a', 'b']))
+  .fn(t => {
+    const wgsl = `
+const a : i32 = 42;
+const b : i32 = c;
+const c : i32 = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'a', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_array_size')
+  .desc('Test that indirect recursion of const declarations via array size expressions is rejected')
+  .params(u => u.combine('target', ['a', 'b']))
+  .fn(t => {
+    const wgsl = `
+const a = 4;
+const b = c[0];
+const c = array<i32, ${t.params.target}>(4, 4, 4, 4);
+`;
+    t.expectCompileResult(t.params.target === 'a', wgsl);
+  });
+
+g.test('no_indirect_recursion_via_struct_attribute')
+  .desc('Test that indirect recursion of const declarations via struct members is rejected')
+  .params(u =>
+    u //
+      .combine('target', ['a', 'b'])
+      .combine('attribute', ['align', 'location', 'size'])
+  )
+  .fn(t => {
+    const wgsl = `
+struct S {
+  @${t.params.attribute}(${t.params.target}) a : i32
+}
+const a = 4;
+const b = S(4).a;
+`;
+    t.expectCompileResult(t.params.target === 'a', wgsl);
+  });

--- a/src/webgpu/shader/validation/decl/override.spec.ts
+++ b/src/webgpu/shader/validation/decl/override.spec.ts
@@ -1,0 +1,31 @@
+export const description = `
+Validation tests for override declarations
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('no_direct_recursion')
+  .desc('Test that direct recursion of override declarations is rejected')
+  .params(u => u.combine('target', ['a', 'b']))
+  .fn(t => {
+    const wgsl = `
+override a : i32 = 42;
+override b : i32 = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'a', wgsl);
+  });
+
+g.test('no_indirect_recursion')
+  .desc('Test that indirect recursion of override declarations is rejected')
+  .params(u => u.combine('target', ['a', 'b']))
+  .fn(t => {
+    const wgsl = `
+override a : i32 = 42;
+override b : i32 = c;
+override c : i32 = ${t.params.target};
+`;
+    t.expectCompileResult(t.params.target === 'a', wgsl);
+  });


### PR DESCRIPTION
Issue: #1467

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
