### PR TITLE
validate spelling of pointers declared via let

### DIFF
--- a/src/webgpu/shader/validation/decl/ptr_spelling.spec.ts
+++ b/src/webgpu/shader/validation/decl/ptr_spelling.spec.ts
@@ -1,0 +1,75 @@
+export const description = `
+Validate spelling of pointer types.
+
+Pointer types may appear.
+
+They are parameterized by:
+- address space, always
+- store type
+- and access mode, as specified by the table in Address Spaces.
+   Concretely, only 'storage' address space allows it, and allows 'read', and 'read_write'.
+
+A pointer type can be spelled only if it corresponds to a variable that could be
+declared in the program.  So we need to test combinations against possible variable
+declarations.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { AddressSpace, kAddressSpaceInfo } from '../../types.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import {
+  pointerType,
+  infoExpander,
+  explicitSpaceExpander,
+  accessModeExpander,
+  getVarDeclShader,
+  ShaderStage,
+} from './util.js';
+
+// Address spaces that can hold an i32 variable.
+const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
+  as => as !== 'handle'
+) as AddressSpace[];
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('param_ptr_type')
+  .desc('Validate formal parameter of pointer type on user-declared functions')
+  .unimplemented();
+
+g.test('let_ptr_explicit_type_matches_var')
+  .desc(
+    'Let-declared pointer with explicit type initialized from var with same address space and access mode'
+  )
+  .specURL('https://w3.org/TR#ref-ptr-types')
+  .params(u =>
+    u // Generate non-handle variables in all valid permutations of address space and access mode.
+      .combine('addressSpace', kNonHandleAddressSpaces)
+      .expand('info', infoExpander)
+      .expand('explicitSpace', explicitSpaceExpander)
+      .combine('explicitMode', [false, true])
+      .expand('accessMode', accessModeExpander)
+      // For compute shaders...
+      .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
+      // Vary the store type.
+      .combine('storeType', ['i32', 'u32'])
+  )
+  .fn(t => {
+    // Match the address space and access mode.
+    const prog = getVarDeclShader(t.params, `let p: ${pointerType(t.params)} = &x;`);
+    const ok = t.params.storeType === 'i32'; // The store type matches the variable.
+
+    t.expectCompileResult(ok, prog);
+  });
+
+g.test('let_ptr_reads')
+  .desc('Validate reading via ptr when permitted by access mode')
+  .specURL('https://w3.org/TR#ref-ptr-types')
+  .unimplemented();
+
+g.test('let_ptr_writes')
+  .desc('Validate writing via ptr when permitted by access mode')
+  .specURL('https://w3.org/TR#ref-ptr-types')
+  .unimplemented();

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -54,8 +54,8 @@ fn ${arg.name}() {
  * store type i32.
  */
 export function declareVarX(
-  addressSpace: AddressSpace | undefined,
-  accessMode: AccessMode | undefined
+  addressSpace: AddressSpace | '',
+  accessMode: AccessMode | ''
 ): string {
   const parts: string[] = [];
   if (addressSpace && kAddressSpaceInfo[addressSpace].binding) parts.push('@group(0) @binding(0) ');
@@ -100,12 +100,15 @@ export function explicitSpaceExpander(p: { info: AddressSpaceInfo }): readonly b
   return p.info.spell === 'must' ? [true] : [true, false];
 }
 
-/** @returns a list of usable access modes under given experiment conditions.  */
+/**
+ * @returns a list of usable access modes under given experiment conditions, or undefined
+ * if none are allowed.
+ */
 export function accessModeExpander(p: {
   explicitMode: boolean; // Whether the access mode will be emitted.
   info: AddressSpaceInfo;
-}): readonly AccessMode[] {
-  return p.explicitMode && p.info.spellAccessMode !== 'never' ? p.info.accessModes : [];
+}): readonly (AccessMode | '')[] {
+  return p.explicitMode && p.info.spellAccessMode !== 'never' ? p.info.accessModes : [''];
 }
 
 /**
@@ -116,7 +119,7 @@ export function getVarDeclShader(
   p: {
     addressSpace: AddressSpace; // Address space for the variable.
     explicitSpace: boolean; // Should the address space be explicitly spelled?
-    accessMode?: AccessMode; // What access mode to use.
+    accessMode: AccessMode | ''; // What access mode to use.
     explicitMode: boolean; // Should the access mode be explicitly spelled?
     stage: ShaderStage; // What shader stage to use.
   },
@@ -124,8 +127,8 @@ export function getVarDeclShader(
 ): string {
   const as_info = kAddressSpaceInfo[p.addressSpace];
   const decl = declareVarX(
-    p.explicitSpace ? p.addressSpace : undefined,
-    p.explicitMode ? p.accessMode : undefined
+    p.explicitSpace ? p.addressSpace : '',
+    p.explicitMode ? p.accessMode : ''
   );
 
   additionalBody = additionalBody ?? '';
@@ -146,7 +149,7 @@ export function getVarDeclShader(
 export function pointerType(p: {
   addressSpace: AddressSpace; // Address space to use if p.explicitSpace
   explicitSpace: boolean; // If false, use 'function' address space
-  accessMode: AccessMode | undefined; // The access mode to use, if any
+  accessMode: AccessMode | ''; // The access mode to use, if any
   storeType: string; // The store type.
 }): string {
   const space = p.explicitSpace ? p.addressSpace : 'function';
@@ -157,19 +160,19 @@ export function pointerType(p: {
 /** @returns the effective access mode for the given experiment.  */
 export function effectiveAccessMode(p: {
   info: AddressSpaceInfo;
-  accessMode: AccessMode;
+  accessMode: AccessMode | '';
 }): AccessMode {
   return p.accessMode || p.info.accessModes[0]; // default is first.
 }
 
 /** @returns whether the setup allows reads */
-export function supportsRead(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+export function supportsRead(p: { info: AddressSpaceInfo; accessMode: AccessMode | '' }): boolean {
   const mode = effectiveAccessMode(p);
   return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].read;
 }
 
 /** @returns whether the setup allows writes */
-export function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+export function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMode | '' }): boolean {
   const mode = effectiveAccessMode(p);
   return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].write;
 }

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -53,10 +53,7 @@ fn ${arg.name}() {
  * @returns a WGSL var declaration with given parameters for variable 'x' and
  * store type i32.
  */
-export function declareVarX(
-  addressSpace: AddressSpace | '',
-  accessMode: AccessMode | ''
-): string {
+export function declareVarX(addressSpace: AddressSpace | '', accessMode: AccessMode | ''): string {
   const parts: string[] = [];
   if (addressSpace && kAddressSpaceInfo[addressSpace].binding) parts.push('@group(0) @binding(0) ');
   parts.push('var');
@@ -150,11 +147,11 @@ export function pointerType(p: {
   addressSpace: AddressSpace; // Address space to use if p.explicitSpace
   explicitSpace: boolean; // If false, use 'function' address space
   accessMode: AccessMode | ''; // The access mode to use, if any
-  storeType: string; // The store type.
+  ptrStoreType: string; // The store type.
 }): string {
   const space = p.explicitSpace ? p.addressSpace : 'function';
   const modePart = p.accessMode ? ',' + p.accessMode : '';
-  return `ptr<${space},${p.storeType}${modePart}>`;
+  return `ptr<${space},${p.ptrStoreType}${modePart}>`;
 }
 
 /** @returns the effective access mode for the given experiment.  */

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -1,3 +1,11 @@
+import {
+  AccessMode,
+  AddressSpace,
+  AddressSpaceInfo,
+  kAccessModeInfo,
+  kAddressSpaceInfo,
+} from '../../types.js';
+
 /** An enumerator of shader stages */
 export type ShaderStage = 'vertex' | 'fragment' | 'compute';
 
@@ -40,3 +48,100 @@ fn ${arg.name}() {
 }`;
   }
 }
+
+/**
+ * @returns a WGSL var declaration with given parameters for variable 'x' and
+ * store type i32.
+ */
+export function declareVarX(
+  addressSpace: AddressSpace | undefined,
+  accessMode: AccessMode | undefined
+): string {
+  const parts: string[] = [];
+  if (addressSpace && kAddressSpaceInfo[addressSpace].binding) parts.push('@group(0) @binding(0) ');
+  parts.push('var');
+
+  const template_parts: string[] = [];
+  if (addressSpace) template_parts.push(addressSpace as string);
+  if (accessMode) template_parts.push(accessMode);
+  if (template_parts.length > 0) parts.push(`<${template_parts.join(',')}>`);
+
+  parts.push(' x: i32;');
+  return parts.join('');
+}
+
+/**
+ * @returns true if an explicit address space is requested on a variable
+ * declaration whenever the address space requires one:
+ *
+ * 	  must implies requested
+ *
+ * Rewrite as:
+ *
+ * 	  !must or requested
+ */
+export function varDeclCompatibleAddressSpace(p: { info: AddressSpaceInfo; explicitSpace: boolean }): boolean {
+  return !(p.info.spell === 'must') || p.explicitSpace;
+}
+
+/** @returns the list of address space info objects for the given address space.  */
+export function infoExpander(p: { addressSpace: AddressSpace }): readonly AddressSpaceInfo[] {
+  return [kAddressSpaceInfo[p.addressSpace]];
+}
+
+/** @returns a list of usable access modes under given experiment conditions.  */
+export function accessModeExpander(p: {
+  explicitMode: boolean; // Whether the access mode will be emitted.
+  info: AddressSpaceInfo;
+}): readonly AccessMode[] {
+  return p.explicitMode && p.info.spellAccessMode !== 'never' ? p.info.accessModes : [];
+}
+
+/**
+ * @returns a WGSL program with a single variable declaration, with the
+ * given parameterization
+ */
+export function getVarDeclShader(
+  p: {
+    addressSpace: AddressSpace; // Address space for the variable.
+    explicitSpace: boolean; // Should the address space be explicitly spelled?
+    accessMode?: AccessMode; // What access mode to use.
+    explicitMode: boolean; // Should the access mode be explicitly spelled?
+    stage: ShaderStage; // What shader stage to use.
+  },
+  additionalBody?: string
+): string {
+  const as_info = kAddressSpaceInfo[p.addressSpace];
+  const decl = declareVarX(
+    p.explicitSpace ? p.addressSpace : undefined,
+    p.explicitMode ? p.accessMode : undefined
+  );
+
+  additionalBody = additionalBody ?? '';
+
+  switch (as_info.scope) {
+    case 'module':
+      return decl + '\n' + declareEntryPoint({ stage: p.stage, body: additionalBody });
+
+    case 'function':
+      return declareEntryPoint({ stage: p.stage, body: decl + '\n' + additionalBody });
+  }
+}
+
+/** @returns the effective access mode for the given experiment.  */
+function effectiveMode(p: { info: AddressSpaceInfo; accessMode: AccessMode }): AccessMode {
+  return p.accessMode || p.info.accessModes[0]; // default is first.
+}
+
+/** @returns whether the setup allows reads */
+export function supportsRead(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+  const mode = effectiveMode(p);
+  return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].read;
+}
+
+/** @returns whether the setup allows writes */
+export function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+  const mode = effectiveMode(p);
+  return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].write;
+}
+

--- a/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
+++ b/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
@@ -97,13 +97,20 @@ function accessModeExpander(p: {
 }
 
 /**
- * @returns false if the test does not spell the address space in the var
- * declaration but the address space requires it.
- * Use this filter when trying to test something other than access mode
- * functionality.
+ * @returns true if an explicit address space is requested on a variable
+ * declaration whenever the address space requires one:
+ *
+ *       must implies requested
+ *
+ * Rewrite as:
+ *
+ *       !must or requested
  */
-function compatibleAS(p: { info: AddressSpaceInfo; explicitSpace: boolean }): boolean {
-  return !p.explicitSpace && p.info.spell === 'must';
+export function varDeclCompatibleAddressSpace(p: {
+  info: AddressSpaceInfo;
+  explicitSpace: boolean;
+}): boolean {
+  return !(p.info.spell === 'must') || p.explicitSpace;
 }
 
 /** @returns the effective access mode for the given experiment.  */
@@ -130,7 +137,7 @@ g.test('explicit_access_mode')
         .combine('addressSpace', kNonHandleAddressSpaces)
         .expand('info', infoExpander)
         .combine('explicitSpace', [true, false])
-        .filter(t => compatibleAS(t))
+        .filter(t => varDeclCompatibleAddressSpace(t))
         .combine('explicitMode', [true])
         .combine('accessMode', keysOf(kAccessModeInfo))
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders

--- a/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
+++ b/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
@@ -7,7 +7,7 @@ storage address space, must not be specified in the WGSL source. See §13.3 Addr
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
-import { AddressSpace, AddressSpaceInfo, kAccessModeInfo, kAddressSpaceInfo } from '../../types.js';
+import { AddressSpace, kAccessModeInfo, kAddressSpaceInfo } from '../../types.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 import {
@@ -66,6 +66,7 @@ g.test('implicit_access_mode')
         .expand('info', infoExpander)
         .expand('explicitSpace', explicitSpaceExpander)
         .combine('explicitMode', [false])
+        .combine('accessMode', [''] as const)
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {

--- a/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
+++ b/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
@@ -7,16 +7,19 @@ storage address space, must not be specified in the WGSL source. See §13.3 Addr
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
-import {
-  AccessMode,
-  AddressSpace,
-  AddressSpaceInfo,
-  kAccessModeInfo,
-  kAddressSpaceInfo,
-} from '../../types.js';
+import { AddressSpace, AddressSpaceInfo, kAccessModeInfo, kAddressSpaceInfo } from '../../types.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
-import { declareEntryPoint, getVarDeclShader, accessModeExpander, infoExpander, supportsRead, supportsWrite, ShaderStage } from './util.js';
+import {
+  explicitSpaceExpander,
+  varDeclCompatibleAddressSpace,
+  getVarDeclShader,
+  accessModeExpander,
+  infoExpander,
+  supportsRead,
+  supportsWrite,
+  ShaderStage,
+} from './util.js';
 
 // Address spaces that can hold an i32 variable.
 const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
@@ -24,31 +27,6 @@ const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
 ) as AddressSpace[];
 
 export const g = makeTestGroup(ShaderValidationTest);
-
-/**
- * @returns a list of booleans indicating valid cases of specifying the address
- * space.
- */
-function explicitSpaceExpander(p: { info: AddressSpaceInfo }): readonly boolean[] {
-  return p.info.spell === 'must' ? [true] : [true, false];
-}
-
-/**
- * @returns true if an explicit address space is requested on a variable
- * declaration whenever the address space requires one:
- *
- *       must implies requested
- *
- * Rewrite as:
- *
- *       !must or requested
- */
-export function varDeclCompatibleAddressSpace(p: {
-  info: AddressSpaceInfo;
-  explicitSpace: boolean;
-}): boolean {
-  return !(p.info.spell === 'must') || p.explicitSpace;
-}
 
 g.test('explicit_access_mode')
   .desc('Validate uses of an explicit access mode on a var declaration')


### PR DESCRIPTION


Issue: #2832

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
