### PR TITLE
Issue 2832 validate pointer types spelled in WGSL source

### DIFF
--- a/src/webgpu/shader/validation/decl/ptr_spelling.spec.ts
+++ b/src/webgpu/shader/validation/decl/ptr_spelling.spec.ts
@@ -1,0 +1,79 @@
+export const description = `
+Validate spelling of pointer types.
+
+Pointer types may appear.
+
+They are parameterized by:
+- address space, always
+- store type
+- and access mode, as specified by the table in Address Spaces.
+   Concretely, only 'storage' address space allows it, and allows 'read', and 'read_write'.
+
+A pointer type can be spelled only if it corresponds to a variable that could be
+declared in the program.  So we need to test combinations against possible variable
+declarations.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import {
+  AddressSpace,
+  kAccessModeInfo,
+  kAddressSpaceInfo,
+} from '../../types.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import {
+  pointerType,
+  infoExpander,
+  explicitSpaceExpander,
+  accessModeExpander,
+  getVarDeclShader,
+  ShaderStage,
+} from './util.js';
+
+// Address spaces that can hold an i32 variable.
+const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
+  as => as !== 'handle'
+) as AddressSpace[];
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('param_ptr_type')
+  .desc('Validate formal parameter of pointer type on user-declared functions')
+  .unimplemented();
+
+g.test('let_ptr_explicit_type_matches_var')
+  .desc(
+    'Let-declared pointer with explicit type initialized from var with same address space and access mode'
+  )
+  .specURL('https://w3.org/TR#ref-ptr-types')
+  .params(u =>
+    u // Generate non-handle variables in all valid permutations of address space and access mode.
+      .combine('addressSpace', kNonHandleAddressSpaces)
+      .expand('info', infoExpander)
+      .expand('explicitSpace', explicitSpaceExpander)
+      .combine('explicitMode', [false, true])
+      .expand('accessMode', accessModeExpander)
+      // For compute shaders...
+      .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
+      // Vary the store type.
+      .combine('storeType', ['i32', 'u32'])
+  )
+  .fn(t => {
+    // Match the address space and access mode.
+    const prog = getVarDeclShader(t.params, `let p: ${pointerType(t.params)} = &x;`);
+    const ok = t.params.storeType === 'i32'; // The store type matches the variable.
+
+    t.expectCompileResult(ok, prog);
+  });
+
+g.test('let_ptr_reads')
+  .desc('Validate reading via ptr when permitted by access mode')
+  .specURL('https://w3.org/TR#ref-ptr-types')
+  .unimplemented();
+
+g.test('let_ptr_writes')
+  .desc('Validate writing via ptr when permitted by access mode')
+  .specURL('https://w3.org/TR#ref-ptr-types')
+  .unimplemented();

--- a/src/webgpu/shader/validation/decl/ptr_spelling.spec.ts
+++ b/src/webgpu/shader/validation/decl/ptr_spelling.spec.ts
@@ -14,13 +14,14 @@ declared in the program.  So we need to test combinations against possible varia
 declarations.
 `;
 
+// This file tests spelling of the pointer type on let-declared pointers.
+//
+// Spelling of pointer-typed parameters on user-declared functions is tested by
+// webgpu:shader,validation,functions,restrictions:function_parameter_types:"*"
+
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
-import {
-  AddressSpace,
-  kAccessModeInfo,
-  kAddressSpaceInfo,
-} from '../../types.js';
+import { AddressSpace, kAccessModeInfo, kAddressSpaceInfo } from '../../types.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 import {
@@ -29,6 +30,7 @@ import {
   explicitSpaceExpander,
   accessModeExpander,
   getVarDeclShader,
+  supportsWrite,
   ShaderStage,
 } from './util.js';
 
@@ -38,10 +40,6 @@ const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
 ) as AddressSpace[];
 
 export const g = makeTestGroup(ShaderValidationTest);
-
-g.test('param_ptr_type')
-  .desc('Validate formal parameter of pointer type on user-declared functions')
-  .unimplemented();
 
 g.test('let_ptr_explicit_type_matches_var')
   .desc(
@@ -55,25 +53,105 @@ g.test('let_ptr_explicit_type_matches_var')
       .expand('explicitSpace', explicitSpaceExpander)
       .combine('explicitMode', [false, true])
       .expand('accessMode', accessModeExpander)
-      // For compute shaders...
       .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
       // Vary the store type.
-      .combine('storeType', ['i32', 'u32'])
+      .combine('ptrStoreType', ['i32', 'u32'])
   )
   .fn(t => {
     // Match the address space and access mode.
     const prog = getVarDeclShader(t.params, `let p: ${pointerType(t.params)} = &x;`);
-    const ok = t.params.storeType === 'i32'; // The store type matches the variable.
+    const ok = t.params.ptrStoreType === 'i32'; // The store type matches the variable's store type.
 
     t.expectCompileResult(ok, prog);
   });
 
 g.test('let_ptr_reads')
   .desc('Validate reading via ptr when permitted by access mode')
-  .specURL('https://w3.org/TR#ref-ptr-types')
-  .unimplemented();
+  .params(u =>
+    u // Generate non-handle variables in all valid permutations of address space and access mode.
+      .combine('addressSpace', kNonHandleAddressSpaces)
+      .expand('info', infoExpander)
+      .expand('explicitSpace', explicitSpaceExpander)
+      .combine('explicitMode', [false, true])
+      .expand('accessMode', accessModeExpander)
+      .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
+      .combine('inferPtrType', [false, true])
+      .combine('ptrStoreType', ['i32'])
+  )
+  .fn(t => {
+    // Try reading through the pointer.
+    const typePart = t.params.inferPtrType ? `: ${pointerType(t.params)}` : '';
+    const prog = getVarDeclShader(t.params, `let p${typePart} = &x; let read = *p;`);
+    const ok = true; // We can always read.
+
+    t.expectCompileResult(ok, prog);
+  });
 
 g.test('let_ptr_writes')
   .desc('Validate writing via ptr when permitted by access mode')
   .specURL('https://w3.org/TR#ref-ptr-types')
-  .unimplemented();
+  .params(u =>
+    u // Generate non-handle variables in all valid permutations of address space and access mode.
+      .combine('addressSpace', kNonHandleAddressSpaces)
+      .expand('info', infoExpander)
+      .expand('explicitSpace', explicitSpaceExpander)
+      .combine('explicitMode', [false, true])
+      .expand('accessMode', accessModeExpander)
+      .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
+      .combine('inferPtrType', [false, true])
+      .combine('ptrStoreType', ['i32'])
+  )
+  .fn(t => {
+    // Try writing through the pointer.
+    const typePart = t.params.inferPtrType ? `: ${pointerType(t.params)}` : '';
+    const prog = getVarDeclShader(t.params, `let p${typePart} = &x; *p = 42;`);
+    const ok = supportsWrite(t.params);
+
+    t.expectCompileResult(ok, prog);
+  });
+
+g.test('ptr_handle_space_invalid').fn(t => {
+  t.expectCompileResult(false, 'alias p = ptr<handle,u32>;');
+});
+
+g.test('ptr_bad_store_type')
+  .params(u => u.combine('storeType', ['undeclared', 'clamp', '1']))
+  .fn(t => {
+    t.expectCompileResult(false, `alias p = ptr<private,${t.params.storeType}>;`);
+  });
+
+g.test('ptr_address_space_never_uses_access_mode')
+  .params(u =>
+    u
+      .combine(
+        'addressSpace',
+        keysOf(kAddressSpaceInfo).filter(i => kAddressSpaceInfo[i].spellAccessMode === 'never')
+      )
+      .combine('accessMode', keysOf(kAccessModeInfo))
+  )
+  .fn(t => {
+    const prog = `alias pty = ptr<${t.params.addressSpace},u32,;${t.params.accessMode}>;`;
+    t.expectCompileResult(false, prog);
+  });
+
+const kStoreTypeNotInstantiable: Record<string, string> = {
+  ptr: 'alias p = ptr<storage,ptr<private,i32>>;',
+  privateAtomic: 'alias p = ptr<private,atomic<u32>>;',
+  functionAtomic: 'alias p = ptr<function,atomic<u32>>;',
+  uniformAtomic: 'alias p = ptr<uniform,atomic<u32>>;',
+  workgroupRTArray: 'alias p = ptr<workgroup,array<i32>>;',
+  uniformRTArray: 'alias p = ptr<uniform,array<i32>>;',
+  privateRTArray: 'alias p = ptr<private,array<i32>>;',
+  functionRTArray: 'alias p = ptr<function,array<i32>>;',
+  RTArrayNotLast: 'struct S { a: array<i32>, b: i32 } alias p = ptr<storage,S>;',
+  nestedRTArray: 'struct S { a: array<i32>, b: i32 } struct { s: S } alias p = ptr<storage,T>;',
+} as const;
+
+g.test('ptr_not_instantiable')
+  .desc(
+    'Validate that ptr type must correspond to a variable that could be declared somewhere; test bad cases'
+  )
+  .params(u => u.combine('case', keysOf(kStoreTypeNotInstantiable)))
+  .fn(t => {
+    t.expectCompileResult(false, kStoreTypeNotInstantiable[t.params.case]);
+  });

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -89,6 +89,14 @@ export function infoExpander(p: { addressSpace: AddressSpace }): readonly Addres
   return [kAddressSpaceInfo[p.addressSpace]];
 }
 
+/**
+ * @returns a list of booleans indicating valid cases of specifying the address
+ * space.
+ */
+export function explicitSpaceExpander(p: { info: AddressSpaceInfo }): readonly boolean[] {
+  return p.info.spell === 'must' ? [true] : [true, false];
+}
+
 /** @returns a list of usable access modes under given experiment conditions.  */
 export function accessModeExpander(p: {
   explicitMode: boolean; // Whether the access mode will be emitted.
@@ -128,20 +136,36 @@ export function getVarDeclShader(
   }
 }
 
+/**
+ * @returns the WGSL spelling of a pointer type corresponding to a variable
+ * declared with the given parameters.
+ */
+export function pointerType( p: {
+  addressSpace: AddressSpace, // Address space to use if p.explicitSpace
+  explicitSpace: boolean, // If false, use 'function' address space
+  accessMode: AccessMode | undefined, // The access mode to use, if any
+  storeType: string // The store type.
+}
+): string {
+  const space = p.explicitSpace ? p.addressSpace : 'function';
+  const modePart = p.accessMode ? ',' + p.accessMode : '';
+  return `ptr<${space},${p.storeType}${modePart}>`;
+}
+
 /** @returns the effective access mode for the given experiment.  */
-function effectiveMode(p: { info: AddressSpaceInfo; accessMode: AccessMode }): AccessMode {
+export function effectiveAccessMode(p: { info: AddressSpaceInfo; accessMode: AccessMode }): AccessMode {
   return p.accessMode || p.info.accessModes[0]; // default is first.
 }
 
 /** @returns whether the setup allows reads */
 export function supportsRead(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
-  const mode = effectiveMode(p);
+  const mode = effectiveAccessMode(p);
   return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].read;
 }
 
 /** @returns whether the setup allows writes */
 export function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
-  const mode = effectiveMode(p);
+  const mode = effectiveAccessMode(p);
   return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].write;
 }
 

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -70,6 +70,20 @@ export function declareVarX(
   return parts.join('');
 }
 
+/**
+ * @returns true if an explicit address space is requested on a variable
+ * declaration whenever the address space requires one:
+ *
+ * 	  must implies requested
+ *
+ * Rewrite as:
+ *
+ * 	  !must or requested
+ */
+export function varDeclCompatibleAddressSpace(p: { info: AddressSpaceInfo; explicitSpace: boolean }): boolean {
+  return !(p.info.spell === 'must') || p.explicitSpace;
+}
+
 /** @returns the list of address space info objects for the given address space.  */
 export function infoExpander(p: { addressSpace: AddressSpace }): readonly AddressSpaceInfo[] {
   return [kAddressSpaceInfo[p.addressSpace]];

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -1,3 +1,11 @@
+import {
+  AccessMode,
+  AddressSpace,
+  AddressSpaceInfo,
+  kAccessModeInfo,
+  kAddressSpaceInfo,
+} from '../../types.js';
+
 /** An enumerator of shader stages */
 export type ShaderStage = 'vertex' | 'fragment' | 'compute';
 
@@ -40,3 +48,86 @@ fn ${arg.name}() {
 }`;
   }
 }
+
+/**
+ * @returns a WGSL var declaration with given parameters for variable 'x' and
+ * store type i32.
+ */
+export function declareVarX(
+  addressSpace: AddressSpace | undefined,
+  accessMode: AccessMode | undefined
+): string {
+  const parts: string[] = [];
+  if (addressSpace && kAddressSpaceInfo[addressSpace].binding) parts.push('@group(0) @binding(0) ');
+  parts.push('var');
+
+  const template_parts: string[] = [];
+  if (addressSpace) template_parts.push(addressSpace as string);
+  if (accessMode) template_parts.push(accessMode);
+  if (template_parts.length > 0) parts.push(`<${template_parts.join(',')}>`);
+
+  parts.push(' x: i32;');
+  return parts.join('');
+}
+
+/** @returns the list of address space info objects for the given address space.  */
+export function infoExpander(p: { addressSpace: AddressSpace }): readonly AddressSpaceInfo[] {
+  return [kAddressSpaceInfo[p.addressSpace]];
+}
+
+/** @returns a list of usable access modes under given experiment conditions.  */
+export function accessModeExpander(p: {
+  explicitMode: boolean; // Whether the access mode will be emitted.
+  info: AddressSpaceInfo;
+}): readonly AccessMode[] {
+  return p.explicitMode && p.info.spellAccessMode !== 'never' ? p.info.accessModes : [];
+}
+
+/**
+ * @returns a WGSL program with a single variable declaration, with the
+ * given parameterization
+ */
+export function getVarDeclShader(
+  p: {
+    addressSpace: AddressSpace; // Address space for the variable.
+    explicitSpace: boolean; // Should the address space be explicitly spelled?
+    accessMode?: AccessMode; // What access mode to use.
+    explicitMode: boolean; // Should the access mode be explicitly spelled?
+    stage: ShaderStage; // What shader stage to use.
+  },
+  additionalBody?: string
+): string {
+  const as_info = kAddressSpaceInfo[p.addressSpace];
+  const decl = declareVarX(
+    p.explicitSpace ? p.addressSpace : undefined,
+    p.explicitMode ? p.accessMode : undefined
+  );
+
+  additionalBody = additionalBody ?? '';
+
+  switch (as_info.scope) {
+    case 'module':
+      return decl + '\n' + declareEntryPoint({ stage: p.stage, body: additionalBody });
+
+    case 'function':
+      return declareEntryPoint({ stage: p.stage, body: decl + '\n' + additionalBody });
+  }
+}
+
+/** @returns the effective access mode for the given experiment.  */
+function effectiveMode(p: { info: AddressSpaceInfo; accessMode: AccessMode }): AccessMode {
+  return p.accessMode || p.info.accessModes[0]; // default is first.
+}
+
+/** @returns whether the setup allows reads */
+export function supportsRead(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+  const mode = effectiveMode(p);
+  return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].read;
+}
+
+/** @returns whether the setup allows writes */
+export function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+  const mode = effectiveMode(p);
+  return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].write;
+}
+

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -53,10 +53,7 @@ fn ${arg.name}() {
  * @returns a WGSL var declaration with given parameters for variable 'x' and
  * store type i32.
  */
-export function declareVarX(
-  addressSpace: AddressSpace | '',
-  accessMode: AccessMode | ''
-): string {
+export function declareVarX(addressSpace: AddressSpace | '', accessMode: AccessMode | ''): string {
   const parts: string[] = [];
   if (addressSpace && kAddressSpaceInfo[addressSpace].binding) parts.push('@group(0) @binding(0) ');
   parts.push('var');
@@ -74,13 +71,16 @@ export function declareVarX(
  * @returns true if an explicit address space is requested on a variable
  * declaration whenever the address space requires one:
  *
- * 	  must implies requested
+ *    must implies requested
  *
  * Rewrite as:
  *
- * 	  !must or requested
+ *    !must or requested
  */
-export function varDeclCompatibleAddressSpace(p: { info: AddressSpaceInfo; explicitSpace: boolean }): boolean {
+export function varDeclCompatibleAddressSpace(p: {
+  info: AddressSpaceInfo;
+  explicitSpace: boolean;
+}): boolean {
   return !(p.info.spell === 'must') || p.explicitSpace;
 }
 
@@ -147,11 +147,11 @@ export function pointerType(p: {
   addressSpace: AddressSpace; // Address space to use if p.explicitSpace
   explicitSpace: boolean; // If false, use 'function' address space
   accessMode: AccessMode | ''; // The access mode to use, if any
-  storeType: string; // The store type.
+  ptrStoreType: string; // The store type.
 }): string {
   const space = p.explicitSpace ? p.addressSpace : 'function';
   const modePart = p.accessMode ? ',' + p.accessMode : '';
-  return `ptr<${space},${p.storeType}${modePart}>`;
+  return `ptr<${space},${p.ptrStoreType}${modePart}>`;
 }
 
 /** @returns the effective access mode for the given experiment.  */
@@ -173,4 +173,3 @@ export function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMod
   const mode = effectiveAccessMode(p);
   return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].write;
 }
-

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -54,8 +54,8 @@ fn ${arg.name}() {
  * store type i32.
  */
 export function declareVarX(
-  addressSpace: AddressSpace | undefined,
-  accessMode: AccessMode | undefined
+  addressSpace: AddressSpace | '',
+  accessMode: AccessMode | ''
 ): string {
   const parts: string[] = [];
   if (addressSpace && kAddressSpaceInfo[addressSpace].binding) parts.push('@group(0) @binding(0) ');
@@ -97,12 +97,15 @@ export function explicitSpaceExpander(p: { info: AddressSpaceInfo }): readonly b
   return p.info.spell === 'must' ? [true] : [true, false];
 }
 
-/** @returns a list of usable access modes under given experiment conditions.  */
+/**
+ * @returns a list of usable access modes under given experiment conditions, or undefined
+ * if none are allowed.
+ */
 export function accessModeExpander(p: {
   explicitMode: boolean; // Whether the access mode will be emitted.
   info: AddressSpaceInfo;
-}): readonly AccessMode[] {
-  return p.explicitMode && p.info.spellAccessMode !== 'never' ? p.info.accessModes : [];
+}): readonly (AccessMode | '')[] {
+  return p.explicitMode && p.info.spellAccessMode !== 'never' ? p.info.accessModes : [''];
 }
 
 /**
@@ -113,7 +116,7 @@ export function getVarDeclShader(
   p: {
     addressSpace: AddressSpace; // Address space for the variable.
     explicitSpace: boolean; // Should the address space be explicitly spelled?
-    accessMode?: AccessMode; // What access mode to use.
+    accessMode: AccessMode | ''; // What access mode to use.
     explicitMode: boolean; // Should the access mode be explicitly spelled?
     stage: ShaderStage; // What shader stage to use.
   },
@@ -121,8 +124,8 @@ export function getVarDeclShader(
 ): string {
   const as_info = kAddressSpaceInfo[p.addressSpace];
   const decl = declareVarX(
-    p.explicitSpace ? p.addressSpace : undefined,
-    p.explicitMode ? p.accessMode : undefined
+    p.explicitSpace ? p.addressSpace : '',
+    p.explicitMode ? p.accessMode : ''
   );
 
   additionalBody = additionalBody ?? '';
@@ -140,31 +143,33 @@ export function getVarDeclShader(
  * @returns the WGSL spelling of a pointer type corresponding to a variable
  * declared with the given parameters.
  */
-export function pointerType( p: {
-  addressSpace: AddressSpace, // Address space to use if p.explicitSpace
-  explicitSpace: boolean, // If false, use 'function' address space
-  accessMode: AccessMode | undefined, // The access mode to use, if any
-  storeType: string // The store type.
-}
-): string {
+export function pointerType(p: {
+  addressSpace: AddressSpace; // Address space to use if p.explicitSpace
+  explicitSpace: boolean; // If false, use 'function' address space
+  accessMode: AccessMode | ''; // The access mode to use, if any
+  storeType: string; // The store type.
+}): string {
   const space = p.explicitSpace ? p.addressSpace : 'function';
   const modePart = p.accessMode ? ',' + p.accessMode : '';
   return `ptr<${space},${p.storeType}${modePart}>`;
 }
 
 /** @returns the effective access mode for the given experiment.  */
-export function effectiveAccessMode(p: { info: AddressSpaceInfo; accessMode: AccessMode }): AccessMode {
+export function effectiveAccessMode(p: {
+  info: AddressSpaceInfo;
+  accessMode: AccessMode | '';
+}): AccessMode {
   return p.accessMode || p.info.accessModes[0]; // default is first.
 }
 
 /** @returns whether the setup allows reads */
-export function supportsRead(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+export function supportsRead(p: { info: AddressSpaceInfo; accessMode: AccessMode | '' }): boolean {
   const mode = effectiveAccessMode(p);
   return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].read;
 }
 
 /** @returns whether the setup allows writes */
-export function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
+export function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMode | '' }): boolean {
   const mode = effectiveAccessMode(p);
   return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].write;
 }

--- a/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
+++ b/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
@@ -13,7 +13,6 @@ import { ShaderValidationTest } from '../shader_validation_test.js';
 import {
   explicitSpaceExpander,
   varDeclCompatibleAddressSpace,
-  declareEntryPoint,
   getVarDeclShader,
   accessModeExpander,
   infoExpander,

--- a/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
+++ b/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
@@ -16,9 +16,9 @@ import {
 } from '../../types.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
-import { declareEntryPoint, ShaderStage } from './util.js';
+import { declareEntryPoint, getVarDeclShader, accessModeExpander, infoExpander, supportsRead, supportsWrite, ShaderStage } from './util.js';
 
-// Test address spaces that we can hold an i32 variable.
+// Address spaces that can hold an i32 variable.
 const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
   as => as !== 'handle'
 ) as AddressSpace[];
@@ -26,74 +26,11 @@ const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
 export const g = makeTestGroup(ShaderValidationTest);
 
 /**
- * @returns a WGSL var declaration with given parameters for variable 'x' and
- * store type i32.
- */
-function declareVarX(
-  addressSpace: AddressSpace | undefined,
-  accessMode: AccessMode | undefined
-): string {
-  const parts: string[] = [];
-  if (addressSpace && kAddressSpaceInfo[addressSpace].binding) parts.push('@group(0) @binding(0) ');
-  parts.push('var');
-
-  const template_parts: string[] = [];
-  if (addressSpace) template_parts.push(addressSpace as string);
-  if (accessMode) template_parts.push(accessMode);
-  if (template_parts.length > 0) parts.push(`<${template_parts.join(',')}>`);
-
-  parts.push(' x: i32;');
-  return parts.join('');
-}
-
-/**
- * @returns a WGSL program for the test parameterization.
- */
-function getShader(
-  p: {
-    addressSpace: AddressSpace; // What address space for the variable.
-    explicitSpace: boolean; // Should the address space be explicitly spelled?
-    accessMode?: AccessMode; // What access mode to use.
-    explicitMode: boolean; // Should the access mode be explicitly spelled?
-    stage: ShaderStage; // What shader stage to use.
-  },
-  additionalBody?: string
-): string {
-  const as_info = kAddressSpaceInfo[p.addressSpace];
-  const decl = declareVarX(
-    p.explicitSpace ? p.addressSpace : undefined,
-    p.explicitMode ? p.accessMode : undefined
-  );
-
-  additionalBody = additionalBody ?? '';
-
-  switch (as_info.scope) {
-    case 'module':
-      return decl + '\n' + declareEntryPoint({ stage: p.stage, body: additionalBody });
-
-    case 'function':
-      return declareEntryPoint({ stage: p.stage, body: decl + '\n' + additionalBody });
-  }
-}
-
-/** @returns the list of address space info objects for the given address space.  */
-function infoExpander(p: { addressSpace: AddressSpace }): readonly AddressSpaceInfo[] {
-  return [kAddressSpaceInfo[p.addressSpace]];
-}
-
-/**
  * @returns a list of booleans indicating valid cases of specifying the address
  * space.
  */
 function explicitSpaceExpander(p: { info: AddressSpaceInfo }): readonly boolean[] {
   return p.info.spell === 'must' ? [true] : [true, false];
-}
-/** @returns a list of usable access modes under given experiment conditions.  */
-function accessModeExpander(p: {
-  explicitMode: boolean; // Whether the access mode will be emitted.
-  info: AddressSpaceInfo;
-}): readonly AccessMode[] {
-  return p.explicitMode && p.info.spellAccessMode !== 'never' ? p.info.accessModes : [];
 }
 
 /**
@@ -104,21 +41,6 @@ function accessModeExpander(p: {
  */
 function compatibleAS(p: { info: AddressSpaceInfo; explicitSpace: boolean }): boolean {
   return !p.explicitSpace && p.info.spell === 'must';
-}
-
-/** @returns the effective access mode for the given experiment.  */
-function effectiveMode(p: { info: AddressSpaceInfo; accessMode: AccessMode }): AccessMode {
-  return p.accessMode || p.info.accessModes[0]; // default is first.
-}
-/** @returns whether the setup allows reads */
-function supportsRead(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
-  const mode = effectiveMode(p);
-  return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].read;
-}
-/** @returns whether the setup allows writes */
-function supportsWrite(p: { info: AddressSpaceInfo; accessMode: AccessMode }): boolean {
-  const mode = effectiveMode(p);
-  return p.info.accessModes.includes(mode) && kAccessModeInfo[mode].write;
 }
 
 g.test('explicit_access_mode')
@@ -136,7 +58,7 @@ g.test('explicit_access_mode')
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {
-    const prog = getShader(t.params);
+    const prog = getVarDeclShader(t.params);
 
     const ok =
       // The address space must be explicitly specified.
@@ -162,7 +84,7 @@ g.test('implicit_access_mode')
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {
-    const prog = getShader(t.params);
+    const prog = getVarDeclShader(t.params);
 
     // 7.3 var Declarations
     // "The access mode always has a default value,.."
@@ -185,7 +107,7 @@ g.test('read_access')
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {
-    const prog = getShader(t.params, 'let copy = x;');
+    const prog = getVarDeclShader(t.params, 'let copy = x;');
     const ok = supportsRead(t.params);
     t.expectCompileResult(ok, prog);
   });
@@ -204,7 +126,7 @@ g.test('write_access')
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {
-    const prog = getShader(t.params, 'x = 0;');
+    const prog = getVarDeclShader(t.params, 'x = 0;');
     const ok = supportsWrite(t.params);
     t.expectCompileResult(ok, prog);
   });

--- a/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
+++ b/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
@@ -16,7 +16,17 @@ import {
 } from '../../types.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
-import { declareEntryPoint, getVarDeclShader, accessModeExpander, infoExpander, supportsRead, supportsWrite, ShaderStage } from './util.js';
+import {
+  explicitSpaceExpander,
+  varDeclCompatibleAddressSpace,
+  declareEntryPoint,
+  getVarDeclShader,
+  accessModeExpander,
+  infoExpander,
+  supportsRead,
+  supportsWrite,
+  ShaderStage,
+} from './util.js';
 
 // Address spaces that can hold an i32 variable.
 const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
@@ -24,24 +34,6 @@ const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
 ) as AddressSpace[];
 
 export const g = makeTestGroup(ShaderValidationTest);
-
-/**
- * @returns a list of booleans indicating valid cases of specifying the address
- * space.
- */
-function explicitSpaceExpander(p: { info: AddressSpaceInfo }): readonly boolean[] {
-  return p.info.spell === 'must' ? [true] : [true, false];
-}
-
-/**
- * @returns false if the test does not spell the address space in the var
- * declaration but the address space requires it.
- * Use this filter when trying to test something other than access mode
- * functionality.
- */
-function compatibleAS(p: { info: AddressSpaceInfo; explicitSpace: boolean }): boolean {
-  return !p.explicitSpace && p.info.spell === 'must';
-}
 
 g.test('explicit_access_mode')
   .desc('Validate uses of an explicit access mode on a var declaration')
@@ -52,7 +44,7 @@ g.test('explicit_access_mode')
         .combine('addressSpace', kNonHandleAddressSpaces)
         .expand('info', infoExpander)
         .combine('explicitSpace', [true, false])
-        .filter(t => compatibleAS(t))
+        .filter(t => varDeclCompatibleAddressSpace(t))
         .combine('explicitMode', [true])
         .combine('accessMode', keysOf(kAccessModeInfo))
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders

--- a/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
+++ b/src/webgpu/shader/validation/decl/var_access_mode.spec.ts
@@ -7,13 +7,7 @@ storage address space, must not be specified in the WGSL source. See §13.3 Addr
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
-import {
-  AccessMode,
-  AddressSpace,
-  AddressSpaceInfo,
-  kAccessModeInfo,
-  kAddressSpaceInfo,
-} from '../../types.js';
+import { AddressSpace, kAccessModeInfo, kAddressSpaceInfo } from '../../types.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 import {
@@ -73,6 +67,7 @@ g.test('implicit_access_mode')
         .expand('info', infoExpander)
         .expand('explicitSpace', explicitSpaceExpander)
         .combine('explicitMode', [false])
+        .combine('accessMode', [''] as const)
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {

--- a/src/webgpu/shader/validation/functions/restrictions.spec.ts
+++ b/src/webgpu/shader/validation/functions/restrictions.spec.ts
@@ -248,14 +248,24 @@ const kFunctionParamTypeCases: Record<string, ParamTypeCase> = {
 
   // Invalid pointers.
   ptr5: { name: `ptr<storage, u32>`, valid: false },
-  ptr6: { name: `ptr<storage, u32, read_write>`, valid: false },
-  ptr7: { name: `ptr<uniform, u32>`, valid: false },
-  ptr8: { name: `ptr<workgroup, u32>`, valid: false },
+  ptr6: { name: `ptr<storage, u32, read>`, valid: false },
+  ptr7: { name: `ptr<storage, u32, read_write>`, valid: false },
+  ptr8: { name: `ptr<uniform, u32>`, valid: false },
+  ptr9: { name: `ptr<workgroup, u32>`, valid: false },
+  ptr10: { name: `ptr<handle, u32>`, valid: false }, // Can't spell handle address space
+  ptr12: { name: `ptr<not_an_address_space, u32>`, valid: false },
+  ptr13: { name: `ptr<storage>`, valid: false }, // No store type
+  ptr14: { name: `ptr<private,clamp>`, valid: false }, // Invalid store type
+  ptr15: { name: `ptr<private,u32,read>`, valid: false }, // Can't specify access mode
+  ptr16: { name: `ptr<private,u32,write>`, valid: false }, // Can't specify access mode
+  ptr17: { name: `ptr<private,u32,read_write>`, valid: false }, // Can't specify access mode
+  ptrWorkgroupAtomic: { name: `ptr<workgroup, atomic<u32>>`, valid: false },
+  ptrWorkgroupNestedAtomic: { name: `ptr<workgroup, array<atomic<u32>,1>>`, valid: false },
 };
 
 g.test('function_parameter_types')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#function-restriction')
-  .desc(`Test that function return types must be constructible`)
+  .desc(`Test validation of user-declared function parameter types`)
   .params(u => u.combine('case', keysOf(kFunctionParamTypeCases)))
   .beforeAllSubcases(t => {
     if (kFunctionParamTypeCases[t.params.case].name === 'f16') {
@@ -438,7 +448,9 @@ function parameterMatches(decl: string, matches: string[]): boolean {
 
 g.test('function_parameter_matching')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#function-restriction')
-  .desc(`Test that function return types must be constructible`)
+  .desc(
+    `Test that function parameter types match function parameter type on user-declared functions`
+  )
   .params(u =>
     u
       .combine('decl', keysOf(kFunctionParamTypeCases))


### PR DESCRIPTION


Issue: #2832 #1427 #1589

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
