### PR TITLE
Convert remaining unpack intervals to 3 ULP

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -4405,9 +4405,6 @@ g.test('unpack2x16floatInterval')
 // Scope for unpack2x16snormInterval tests so that they can have constants for
 // magic numbers that don't pollute the global namespace or have unwieldy long
 // names.
-//
-// unpack2x16snormInterval has a seperate scope from below, because its accuracy
-// is currently different.
 {
   const kZeroBounds: IntervalBounds = [
     reinterpretU32AsF32(0x81400000),
@@ -4454,16 +4451,21 @@ g.test('unpack2x16floatInterval')
     });
 }
 
-// Scope for remaining unpack* tests so that they can have constants for magic
-// numbers that don't pollute the global namespace or have unwieldy long names.
+// Scope for unpack2x16unormInterval tests so that they can have constants for
+// magic numbers that don't pollute the global namespace or have unwieldy long
+// names.
 {
-  const kZeroBounds: IntervalBounds = [0.0];
-  const kOneBoundsSnorm: IntervalBounds = [1.0];
-  const kOneBoundsUnorm: IntervalBounds = [1.0];
-  const kNegOneBoundsSnorm: IntervalBounds = [-1.0];
-  const kHalfBounds2x16unorm: IntervalBounds = [
-    reinterpretU32AsF32(0x3f000080),
-    reinterpretU32AsF32(0x3f000081),
+  const kZeroBounds: IntervalBounds = [
+    reinterpretU32AsF32(0x8140_0000),
+    reinterpretU32AsF32(0x0140_0000),
+  ]; // ~0
+  const kOneBounds: IntervalBounds = [
+    reinterpretU64AsF64(0x3fef_ffff_a000_0000n),
+    reinterpretU64AsF64(0x3ff0_0000_3000_0000n),
+  ]; // ~1
+  const kHalfBounds: IntervalBounds = [
+    reinterpretU64AsF64(0x3fe0_000f_a000_0000n),
+    reinterpretU64AsF64(0x3fe0_0010_8000_0000n),
   ]; // ~0.5..., due to the lack of accuracy in u16
 
   g.test('unpack2x16unormInterval')
@@ -4471,10 +4473,10 @@ g.test('unpack2x16floatInterval')
       // prettier-ignore
       [
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds] },
-        { input: 0x0000ffff, expected: [kOneBoundsUnorm, kZeroBounds] },
-        { input: 0xffff0000, expected: [kZeroBounds, kOneBoundsUnorm] },
-        { input: 0xffffffff, expected: [kOneBoundsUnorm, kOneBoundsUnorm] },
-        { input: 0x80008000, expected: [kHalfBounds2x16unorm, kHalfBounds2x16unorm] },
+        { input: 0x0000ffff, expected: [kOneBounds, kZeroBounds] },
+        { input: 0xffff0000, expected: [kZeroBounds, kOneBounds] },
+        { input: 0xffffffff, expected: [kOneBounds, kOneBounds] },
+        { input: 0x80008000, expected: [kHalfBounds, kHalfBounds] },
       ]
     )
     .fn(t => {
@@ -4485,14 +4487,31 @@ g.test('unpack2x16floatInterval')
         `unpack2x16unormInterval(${t.params.input})\n\tReturned [${got}]\n\tExpected [${expected}]`
       );
     });
+}
 
-  const kHalfBounds4x8snorm: IntervalBounds = [
-    reinterpretU32AsF32(0x3f010204),
-    reinterpretU32AsF32(0x3f010205),
+// Scope for unpack4x8snormInterval tests so that they can have constants for
+// magic numbers that don't pollute the global namespace or have unwieldy long
+// names.
+{
+  const kZeroBounds: IntervalBounds = [
+    reinterpretU32AsF32(0x8140_0000),
+    reinterpretU32AsF32(0x0140_0000),
+  ]; // ~0
+  const kOneBounds: IntervalBounds = [
+    reinterpretU64AsF64(0x3fef_ffff_a000_0000n),
+    reinterpretU64AsF64(0x3ff0_0000_3000_0000n),
+  ]; // ~1
+  const kNegOneBounds: IntervalBounds = [
+    reinterpretU64AsF64(0xbff0_0000_3000_0000n),
+    reinterpretU64AsF64(0xbfef_ffff_a0000_000n),
+  ]; // ~-1
+  const kHalfBounds: IntervalBounds = [
+    reinterpretU64AsF64(0x3fe0_2040_2000_0000n),
+    reinterpretU64AsF64(0x3fe0_2041_0000_0000n),
   ]; // ~0.50196..., due to lack of precision in i8
-  const kNegHalfBounds4x8snorm: IntervalBounds = [
-    reinterpretU32AsF32(0xbefdfbf8),
-    reinterpretU32AsF32(0xbefdfbf7),
+  const kNegHalfBounds: IntervalBounds = [
+    reinterpretU64AsF64(0xbfdf_bf7f_6000_0000n),
+    reinterpretU64AsF64(0xbfdf_bf7e_8000_0000n),
   ]; // ~-0.49606..., due to lack of precision in i8
 
   g.test('unpack4x8snormInterval')
@@ -4500,26 +4519,26 @@ g.test('unpack2x16floatInterval')
       // prettier-ignore
       [
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
-        { input: 0x0000007f, expected: [kOneBoundsSnorm, kZeroBounds, kZeroBounds, kZeroBounds] },
-        { input: 0x00007f00, expected: [kZeroBounds, kOneBoundsSnorm, kZeroBounds, kZeroBounds] },
-        { input: 0x007f0000, expected: [kZeroBounds, kZeroBounds, kOneBoundsSnorm, kZeroBounds] },
-        { input: 0x7f000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kOneBoundsSnorm] },
-        { input: 0x00007f7f, expected: [kOneBoundsSnorm, kOneBoundsSnorm, kZeroBounds, kZeroBounds] },
-        { input: 0x7f7f0000, expected: [kZeroBounds, kZeroBounds, kOneBoundsSnorm, kOneBoundsSnorm] },
-        { input: 0x7f007f00, expected: [kZeroBounds, kOneBoundsSnorm, kZeroBounds, kOneBoundsSnorm] },
-        { input: 0x007f007f, expected: [kOneBoundsSnorm, kZeroBounds, kOneBoundsSnorm, kZeroBounds] },
-        { input: 0x7f7f7f7f, expected: [kOneBoundsSnorm, kOneBoundsSnorm, kOneBoundsSnorm, kOneBoundsSnorm] },
+        { input: 0x0000007f, expected: [kOneBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x00007f00, expected: [kZeroBounds, kOneBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x007f0000, expected: [kZeroBounds, kZeroBounds, kOneBounds, kZeroBounds] },
+        { input: 0x7f000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kOneBounds] },
+        { input: 0x00007f7f, expected: [kOneBounds, kOneBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x7f7f0000, expected: [kZeroBounds, kZeroBounds, kOneBounds, kOneBounds] },
+        { input: 0x7f007f00, expected: [kZeroBounds, kOneBounds, kZeroBounds, kOneBounds] },
+        { input: 0x007f007f, expected: [kOneBounds, kZeroBounds, kOneBounds, kZeroBounds] },
+        { input: 0x7f7f7f7f, expected: [kOneBounds, kOneBounds, kOneBounds, kOneBounds] },
         {
           input: 0x81818181,
-          expected: [kNegOneBoundsSnorm, kNegOneBoundsSnorm, kNegOneBoundsSnorm, kNegOneBoundsSnorm]
+          expected: [kNegOneBounds, kNegOneBounds, kNegOneBounds, kNegOneBounds]
         },
         {
           input: 0x40404040,
-          expected: [kHalfBounds4x8snorm, kHalfBounds4x8snorm, kHalfBounds4x8snorm, kHalfBounds4x8snorm]
+          expected: [kHalfBounds, kHalfBounds, kHalfBounds, kHalfBounds]
         },
         {
           input: 0xc1c1c1c1,
-          expected: [kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm, kNegHalfBounds4x8snorm]
+          expected: [kNegHalfBounds, kNegHalfBounds, kNegHalfBounds, kNegHalfBounds]
         },
       ]
     )
@@ -4531,10 +4550,23 @@ g.test('unpack2x16floatInterval')
         `unpack4x8snormInterval(${t.params.input})\n\tReturned [${got}]\n\tExpected [${expected}]`
       );
     });
+}
 
-  const kHalfBounds4x8unorm: IntervalBounds = [
-    reinterpretU32AsF32(0x3f008080),
-    reinterpretU32AsF32(0x3f008081),
+// Scope for unpack4x8unormInterval tests so that they can have constants for
+// magic numbers that don't pollute the global namespace or have unwieldy long
+// names.
+{
+  const kZeroBounds: IntervalBounds = [
+    reinterpretU32AsF32(0x8140_0000),
+    reinterpretU32AsF32(0x0140_0000),
+  ]; // ~0
+  const kOneBounds: IntervalBounds = [
+    reinterpretU64AsF64(0x3fef_ffff_a000_0000n),
+    reinterpretU64AsF64(0x3ff0_0000_3000_0000n),
+  ]; // ~1
+  const kHalfBounds: IntervalBounds = [
+    reinterpretU64AsF64(0x3fe0_100f_a000_0000n),
+    reinterpretU64AsF64(0x3fe0_1010_8000_0000n),
   ]; // ~0.50196..., due to lack of precision in u8
 
   g.test('unpack4x8unormInterval')
@@ -4542,18 +4574,18 @@ g.test('unpack2x16floatInterval')
       // prettier-ignore
       [
         { input: 0x00000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
-        { input: 0x000000ff, expected: [kOneBoundsUnorm, kZeroBounds, kZeroBounds, kZeroBounds] },
-        { input: 0x0000ff00, expected: [kZeroBounds, kOneBoundsUnorm, kZeroBounds, kZeroBounds] },
-        { input: 0x00ff0000, expected: [kZeroBounds, kZeroBounds, kOneBoundsUnorm, kZeroBounds] },
-        { input: 0xff000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kOneBoundsUnorm] },
-        { input: 0x0000ffff, expected: [kOneBoundsUnorm, kOneBoundsUnorm, kZeroBounds, kZeroBounds] },
-        { input: 0xffff0000, expected: [kZeroBounds, kZeroBounds, kOneBoundsUnorm, kOneBoundsUnorm] },
-        { input: 0xff00ff00, expected: [kZeroBounds, kOneBoundsUnorm, kZeroBounds, kOneBoundsUnorm] },
-        { input: 0x00ff00ff, expected: [kOneBoundsUnorm, kZeroBounds, kOneBoundsUnorm, kZeroBounds] },
-        { input: 0xffffffff, expected: [kOneBoundsUnorm, kOneBoundsUnorm, kOneBoundsUnorm, kOneBoundsUnorm] },
+        { input: 0x000000ff, expected: [kOneBounds, kZeroBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x0000ff00, expected: [kZeroBounds, kOneBounds, kZeroBounds, kZeroBounds] },
+        { input: 0x00ff0000, expected: [kZeroBounds, kZeroBounds, kOneBounds, kZeroBounds] },
+        { input: 0xff000000, expected: [kZeroBounds, kZeroBounds, kZeroBounds, kOneBounds] },
+        { input: 0x0000ffff, expected: [kOneBounds, kOneBounds, kZeroBounds, kZeroBounds] },
+        { input: 0xffff0000, expected: [kZeroBounds, kZeroBounds, kOneBounds, kOneBounds] },
+        { input: 0xff00ff00, expected: [kZeroBounds, kOneBounds, kZeroBounds, kOneBounds] },
+        { input: 0x00ff00ff, expected: [kOneBounds, kZeroBounds, kOneBounds, kZeroBounds] },
+        { input: 0xffffffff, expected: [kOneBounds, kOneBounds, kOneBounds, kOneBounds] },
         {
           input: 0x80808080,
-          expected: [kHalfBounds4x8unorm, kHalfBounds4x8unorm, kHalfBounds4x8unorm, kHalfBounds4x8unorm]
+          expected: [kHalfBounds, kHalfBounds, kHalfBounds, kHalfBounds]
         },
       ]
     )

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -4413,7 +4413,7 @@ class F32Traits extends FPTraits {
       'unpack2x16unormInterval only accepts values on the bounds of u32'
     );
     const op = (n: number): FPInterval => {
-      return this.correctlyRoundedInterval(n / 65535);
+      return this.ulpInterval(n / 65535, 3);
     };
 
     this.unpackDataU32[0] = n;
@@ -4429,7 +4429,7 @@ class F32Traits extends FPTraits {
       'unpack4x8snormInterval only accepts values on the bounds of u32'
     );
     const op = (n: number): FPInterval => {
-      return this.correctlyRoundedInterval(Math.max(n / 127, -1));
+      return this.ulpInterval(Math.max(n / 127, -1), 3);
     };
     this.unpackDataU32[0] = n;
     return [
@@ -4449,7 +4449,7 @@ class F32Traits extends FPTraits {
       'unpack4x8unormInterval only accepts values on the bounds of u32'
     );
     const op = (n: number): FPInterval => {
-      return this.correctlyRoundedInterval(n / 255);
+      return this.ulpInterval(n / 255, 3);
     };
 
     this.unpackDataU32[0] = n;


### PR DESCRIPTION
Fixes #2777

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
