### PR TITLE
Fix unpackRGB9E5UFloat usage and add tests

### DIFF
--- a/src/unittests/texture_ok.spec.ts
+++ b/src/unittests/texture_ok.spec.ts
@@ -1,0 +1,139 @@
+export const description = `
+Test for texture_ok utils.
+`;
+
+import { makeTestGroup } from '../common/framework/test_group.js';
+import { RegularTextureFormat } from '../webgpu/format_info.js';
+import { TexelView } from '../webgpu/util/texture/texel_view.js';
+import { findFailedPixels } from '../webgpu/util/texture/texture_ok.js';
+
+import { UnitTest } from './unit_test.js';
+
+class F extends UnitTest {
+  test(act: string, exp: string): void {
+    this.expect(act === exp, 'got: ' + act.replace('\n', '⏎'));
+  }
+}
+
+export const g = makeTestGroup(F);
+g.test('findFailedPixels')
+  .desc(
+    `
+    Test findFailedPixels passes what is expected to pass and fails what is expected
+    to fail. For example NaN === NaN should be true in a texture that allows NaN.
+    2 different representations of the same rgb9e5ufloat should compare as equal.
+    etc...
+  `
+  )
+  .params(u =>
+    u.combineWithParams([
+      // Sanity Check
+      {
+        format: 'rgba8unorm' as RegularTextureFormat,
+        actual: new Uint8Array([0x00, 0x40, 0x80, 0xff]),
+        expected: new Uint8Array([0x00, 0x40, 0x80, 0xff]),
+        isSame: true,
+      },
+      // Slightly different values
+      {
+        format: 'rgba8unorm' as RegularTextureFormat,
+        actual: new Uint8Array([0x00, 0x40, 0x80, 0xff]),
+        expected: new Uint8Array([0x00, 0x40, 0x81, 0xff]),
+        isSame: false,
+      },
+      // Different representations of the same value
+      {
+        format: 'rgb9e5ufloat' as RegularTextureFormat,
+        actual: new Uint8Array([0x78, 0x56, 0x34, 0x12]),
+        expected: new Uint8Array([0xf0, 0xac, 0x68, 0x0c]),
+        isSame: true,
+      },
+      // Slightly different values
+      {
+        format: 'rgb9e5ufloat' as RegularTextureFormat,
+        actual: new Uint8Array([0x78, 0x56, 0x34, 0x12]),
+        expected: new Uint8Array([0xf1, 0xac, 0x68, 0x0c]),
+        isSame: false,
+      },
+      // Test NaN === NaN
+      {
+        format: 'r32float' as RegularTextureFormat,
+        actual: new Float32Array([parseFloat('abc')]),
+        expected: new Float32Array([parseFloat('def')]),
+        isSame: true,
+      },
+      // Sanity Check
+      {
+        format: 'r32float' as RegularTextureFormat,
+        actual: new Float32Array([1.23]),
+        expected: new Float32Array([1.23]),
+        isSame: true,
+      },
+      // Slightly different values.
+      {
+        format: 'r32float' as RegularTextureFormat,
+        actual: new Uint32Array([0x3f9d70a4]),
+        expected: new Uint32Array([0x3f9d70a5]),
+        isSame: false,
+      },
+      // Slightly different
+      {
+        format: 'rg11b10ufloat' as RegularTextureFormat,
+        actual: new Uint32Array([0x3ce]),
+        expected: new Uint32Array([0x3cf]),
+        isSame: false,
+      },
+      // NaN === NaN (red)
+      {
+        format: 'rg11b10ufloat' as RegularTextureFormat,
+        actual: new Uint32Array([0b11111000000]),
+        expected: new Uint32Array([0b11111000000]),
+        isSame: true,
+      },
+      // NaN === NaN (green)
+      {
+        format: 'rg11b10ufloat' as RegularTextureFormat,
+        actual: new Uint32Array([0b11111000000_00000000000]),
+        expected: new Uint32Array([0b11111000000_00000000000]),
+        isSame: true,
+      },
+      // NaN === NaN (blue)
+      {
+        format: 'rg11b10ufloat' as RegularTextureFormat,
+        actual: new Uint32Array([0b1111100000_00000000000_00000000000]),
+        expected: new Uint32Array([0b1111100000_00000000000_00000000000]),
+        isSame: true,
+      },
+    ])
+  )
+  .fn(t => {
+    const { format, actual, expected, isSame } = t.params;
+    const actualData = new Uint8Array(actual.buffer);
+    const expectedData = new Uint8Array(expected.buffer);
+
+    const actTexelView = TexelView.fromTextureDataByReference(format, actualData, {
+      bytesPerRow: actualData.byteLength,
+      rowsPerImage: 1,
+      subrectOrigin: [0, 0, 0],
+      subrectSize: [1, 1, 1],
+    });
+    const expTexelView = TexelView.fromTextureDataByReference(format, expectedData, {
+      bytesPerRow: expectedData.byteLength,
+      rowsPerImage: 1,
+      subrectOrigin: [0, 0, 0],
+      subrectSize: [1, 1, 1],
+    });
+
+    const zero = { x: 0, y: 0, z: 0 };
+    const failedPixelsMessage = findFailedPixels(
+      format,
+      zero,
+      { width: 1, height: 1, depthOrArrayLayers: 1 },
+      { actTexelView, expTexelView },
+      {
+        maxFractionalDiff: 0,
+      }
+    );
+
+    t.expect(isSame === !failedPixelsMessage, failedPixelsMessage);
+  });

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -14,10 +14,11 @@ import {
   floatBitsToNormalULPFromZero,
   kFloat32Format,
   kFloat16Format,
+  kUFloat9e5Format,
   numberToFloat32Bits,
   float32BitsToNumber,
   numberToFloatBits,
-  unpackRGB9E5UFloat,
+  ufloatM9E5BitsToNumber,
 } from '../conversion.js';
 import { clamp, signExtend } from '../math.js';
 
@@ -590,7 +591,6 @@ const identity = (n: number) => n;
 
 const kFloat11Format = { signed: 0, exponentBits: 5, mantissaBits: 6, bias: 15 } as const;
 const kFloat10Format = { signed: 0, exponentBits: 5, mantissaBits: 5, bias: 15 } as const;
-const kFloat9e5Format = { signed: 0, exponentBits: 5, mantissaBits: 9, bias: 15 } as const;
 
 export type TexelRepresentationInfo = {
   /** Order of components in the packed representation. */
@@ -775,9 +775,17 @@ export const kTexelRepresentationInfo: {
             components.B ?? unreachable()
           ),
         ]).buffer,
-      // For the purpose of unpacking, expand into three "ufloat14" values.
       unpackBits: (data: Uint8Array) => {
-        return unpackRGB9E5UFloat((data[3] << 24) | (data[2] << 16) | (data[1] << 8) | data[0]);
+        const encoded = (data[3] << 24) | (data[2] << 16) | (data[1] << 8) | data[0];
+        const redMantissa = (encoded >>> 0) & 0b111111111;
+        const greenMantissa = (encoded >>> 9) & 0b111111111;
+        const blueMantissa = (encoded >>> 18) & 0b111111111;
+        const exponentSharedBits = ((encoded >>> 27) & 0b11111) << 9;
+        return {
+          R: exponentSharedBits | redMantissa,
+          G: exponentSharedBits | greenMantissa,
+          B: exponentSharedBits | blueMantissa,
+        };
       },
       numberToBits: components => ({
         R: float32ToFloatBits(components.R ?? unreachable(), 0, 5, 9, 15),
@@ -785,14 +793,14 @@ export const kTexelRepresentationInfo: {
         B: float32ToFloatBits(components.B ?? unreachable(), 0, 5, 9, 15),
       }),
       bitsToNumber: components => ({
-        R: floatBitsToNumber(components.R!, kFloat9e5Format),
-        G: floatBitsToNumber(components.G!, kFloat9e5Format),
-        B: floatBitsToNumber(components.B!, kFloat9e5Format),
+        R: ufloatM9E5BitsToNumber(components.R!, kUFloat9e5Format),
+        G: ufloatM9E5BitsToNumber(components.G!, kUFloat9e5Format),
+        B: ufloatM9E5BitsToNumber(components.B!, kUFloat9e5Format),
       }),
       bitsToULPFromZero: components => ({
-        R: floatBitsToNormalULPFromZero(components.R!, kFloat9e5Format),
-        G: floatBitsToNormalULPFromZero(components.G!, kFloat9e5Format),
-        B: floatBitsToNormalULPFromZero(components.B!, kFloat9e5Format),
+        R: floatBitsToNormalULPFromZero(components.R!, kUFloat9e5Format),
+        G: floatBitsToNormalULPFromZero(components.G!, kUFloat9e5Format),
+        B: floatBitsToNormalULPFromZero(components.B!, kUFloat9e5Format),
       }),
       numericRange: { min: 0, max: Number.POSITIVE_INFINITY },
     },

--- a/src/webgpu/util/texture/texture_ok.ts
+++ b/src/webgpu/util/texture/texture_ok.ts
@@ -158,6 +158,9 @@ function comparePerComponent(
     const act = actual[k]!;
     const exp = expected[k];
     if (exp === undefined) return false;
+    if (Number.isNaN(act) && Number.isNaN(exp)) {
+      return true;
+    }
     return Math.abs(act - exp) <= maxDiff;
   });
 }


### PR DESCRIPTION
Fix TexelView for rgb9e5uflroat

The issue was `unpackRGB9e5ufloat` was being called in `unpackBits`
but `unpackRGB9e5ufloat` doesn't return bits, it returns "number".
The code in `TexelView`

https://github.com/gpuweb/cts/blob/7f06106f08266ecd6178f66c14eb54f6dd94dbc8/src/webgpu/util/texture/texel_view.ts#L103

calls `bitsToNumber` with the results of `unpackBits` and `bitsToNumber` expects bits

Added a few tests. And made NaN match NaN. The tests often
put in pseudo random binary data which might be NaN and expect
NaN to come back out but the tests fail if comparing NaN to NaN
returns false.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
