### PR TITLE
Compat: Skip sample_mask test

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/multisample_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/multisample_state.spec.ts
@@ -60,6 +60,10 @@ g.test('alpha_to_coverage,sample_mask')
   .fn(t => {
     const { isAsync, alphaToCoverageEnabled, hasSampleMaskOutput } = t.params;
 
+    if (t.isCompatibility && hasSampleMaskOutput) {
+      t.skip('WGSL sample_mask is not supported in compatibility mode');
+    }
+
     const descriptor = t.getDescriptor({
       multisample: { alphaToCoverageEnabled, count: 4 },
       fragmentShaderCode: hasSampleMaskOutput


### PR DESCRIPTION
`sample_mask` is not supported in compat mode

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
