### PR TITLE
Compat: Skip tests that use different views of same texture

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_pass_encoder.spec.ts
@@ -457,6 +457,17 @@ g.test('subresources_and_binding_types_combination_for_color')
       arrayLayerCount: layerCount1,
     });
 
+    const viewsAreSame =
+      dimension0 === dimension1 &&
+      layerCount0 === layerCount1 &&
+      BASE_LEVEL === baseLevel1 &&
+      levelCount0 === levelCount1 &&
+      BASE_LAYER === baseLayer1 &&
+      layerCount0 === layerCount1;
+    if (!viewsAreSame && t.isCompatibility) {
+      t.skip('different views of same texture are not supported in compatibility mode');
+    }
+
     const encoder = t.device.createCommandEncoder();
     if (type0 === 'render-target') {
       // Note that type1 is 'render-target' too. So we don't need to create bindings.


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
