### PR TITLE
Compat: Test that sample_mask pipelines fail

### DIFF
--- a/src/compat/api/validation/render_pipeline/shader_module.spec.ts
+++ b/src/compat/api/validation/render_pipeline/shader_module.spec.ts
@@ -1,0 +1,74 @@
+export const description = `
+Tests that you can not create a render pipeline with a shader module that uses sample_mask in compat mode.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ValidationTest } from '../../../../webgpu/api/validation/validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('sample_mask')
+  .desc(
+    `
+Tests that you can not create a render pipeline with a shader module that uses sample_mask in compat mode.
+
+- Test that a pipeline with a shader that uses sample_mask fails.
+- Test that a pipeline that references a module that has a shader that uses sample_mask
+  but the pipeline does not reference that shader succeeds.
+    `
+  )
+  .params(u =>
+    u.combine('entryPoint', ['fsWithoutSampleMaskUsage', 'fsWithSampleMaskUsage'] as const)
+  )
+  .fn(t => {
+    const { entryPoint } = t.params;
+
+    const module = t.device.createShaderModule({
+      code: `
+       @vertex fn vs() -> @builtin(position) vec4f {
+            return vec4f(1);
+        }
+        struct Output {
+            @builtin(sample_mask) mask_out: u32,
+            @location(0) color : vec4f,
+        }
+        @fragment fn fsWithoutSampleMaskUsage() -> @location(0) vec4f {
+            return vec4f(1.0, 1.0, 1.0, 1.0);
+        }
+        @fragment fn fsWithSampleMaskUsage() -> Output {
+            var o: Output;
+            // We need to make sure this sample_mask isn't optimized out even its value equals "no op".
+            o.mask_out = 0xFFFFFFFFu;
+            o.color = vec4f(1.0, 1.0, 1.0, 1.0);
+            return o;
+        }
+      `,
+    });
+
+    const pipelineDescriptor: GPURenderPipelineDescriptor = {
+      layout: 'auto',
+      vertex: {
+        module,
+        entryPoint: 'vs',
+      },
+      fragment: {
+        module,
+        entryPoint,
+        targets: [
+          {
+            format: 'rgba8unorm',
+          },
+        ],
+      },
+      multisample: {
+        count: 4,
+      },
+    };
+
+    const isValid = entryPoint === 'fsWithoutSampleMaskUsage';
+    t.expectGPUError(
+      'validation',
+      () => t.device.createRenderPipeline(pipelineDescriptor),
+      !isValid
+    );
+  });

--- a/src/compat/api/validation/render_pipeline/shader_module.spec.ts
+++ b/src/compat/api/validation/render_pipeline/shader_module.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-Tests that you can not create a render pipeline with a shader module that uses sample_mask in compat mode.
+Tests limitations of createRenderPipeline related to shader modules in compat mode.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -37,7 +37,7 @@ Tests that you can not create a render pipeline with a shader module that uses s
         }
         @fragment fn fsWithSampleMaskUsage() -> Output {
             var o: Output;
-            // We need to make sure this sample_mask isn't optimized out even its value equals "no op".
+            // We need to make sure this sample_mask isn't optimized out even if its value equals "no op".
             o.mask_out = 0xFFFFFFFFu;
             o.color = vec4f(1.0, 1.0, 1.0, 1.0);
             return o;


### PR DESCRIPTION
Note: you can run this test with this URL

[http://localhost:8080/standalone/?compatibility=1&runnow=1&q=compat:api,validation,render_pipeline,shader_module:sample_mask:*](http://localhost:8080/standalone/?compatibility=1&runnow=1&q=compat:api,validation,render_pipeline,shader_module:sample_mask:*)

You'll need a browser that supports compat like Chrome Canary with webgpu developer features enabled in flags

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
