### PR TITLE
Compat: Test you can't use bgra8unorm-srgb

### DIFF
--- a/src/compat/api/validation/texture/createTexture.spec.ts
+++ b/src/compat/api/validation/texture/createTexture.spec.ts
@@ -1,0 +1,41 @@
+export const description = `
+Tests that you can not use bgra8unorm-srgb in compat mode.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ValidationTest } from '../../../../webgpu/api/validation/validation_test.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('unsupportedTextureFormats')
+  .desc(`Tests that you can not create a bgra8unorm-srgb texture in compat mode.`)
+  .fn(t => {
+    t.expectGPUError(
+      'validation',
+      () =>
+        t.device.createTexture({
+          size: [1, 1, 1],
+          format: 'bgra8unorm-srgb',
+          usage: GPUTextureUsage.TEXTURE_BINDING,
+        }),
+      true
+    );
+  });
+
+g.test('unsupportedTextureViewFormats')
+  .desc(
+    `Tests that you can not create a bgra8unorm texture with a bgra8unorm-srgb viewFormat in compat mode.`
+  )
+  .fn(t => {
+    t.expectGPUError(
+      'validation',
+      () =>
+        t.device.createTexture({
+          size: [1, 1, 1],
+          format: 'bgra8unorm',
+          viewFormats: ['bgra8unorm-srgb'],
+          usage: GPUTextureUsage.TEXTURE_BINDING,
+        }),
+      true
+    );
+  });


### PR DESCRIPTION
Tests both that you can't create a bgra8unorm-srgb texture nor can you create a bgra8unorm texture with a bgra8unorm-srgb viewFormat.

Note: You can run these tests with this url: [http://localhost:8080/standalone/?compatibility=1&runnow=1&q=compat:api,validation,texture,createTexture:*](http://localhost:8080/standalone/?compatibility=1&runnow=1&q=compat:api,validation,texture,createTexture:*) 

You'll need a browser that supports compat like Chrome Canary with webgpu developer features enabled in flags

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
