### PR TITLE
Compat: Test copyTextureToBuffer fails on compressed textures

### DIFF
--- a/src/compat/api/validation/encoding/cmds/copyTextureToBuffer.spec.ts
+++ b/src/compat/api/validation/encoding/cmds/copyTextureToBuffer.spec.ts
@@ -1,0 +1,47 @@
+export const description = `
+Tests that you can not call copyTextureToBuffer with compressed textures in compat mode.
+`;
+
+import { makeTestGroup } from '../../../../../common/internal/test_group.js';
+import { ValidationTest } from '../../../../../webgpu/api/validation/validation_test.js';
+import {
+  kCompressedTextureFormats,
+  kTextureFormatInfo,
+} from '../../../../../webgpu/format_info.js';
+import { align } from '../../../../../webgpu/util/math.js';
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('compressed')
+  .desc(`Tests that you can not call copyTextureToBuffer with compressed textures in compat mode.`)
+  .params(u => u.combine('format', kCompressedTextureFormats))
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    t.selectDeviceOrSkipTestCase([kTextureFormatInfo[format].feature]);
+  })
+  .fn(t => {
+    const { format } = t.params;
+
+    const { blockWidth, blockHeight, bytesPerBlock } = kTextureFormatInfo[format];
+
+    const texture = t.device.createTexture({
+      size: [blockWidth, blockHeight, 1],
+      format,
+      usage: GPUTextureUsage.COPY_SRC,
+    });
+    t.trackForCleanup(texture);
+
+    const bytesPerRow = align(bytesPerBlock, 256);
+
+    const buffer = t.device.createBuffer({
+      size: bytesPerRow,
+      usage: GPUBufferUsage.COPY_DST,
+    });
+    t.trackForCleanup(buffer);
+
+    const encoder = t.device.createCommandEncoder();
+    encoder.copyTextureToBuffer({ texture }, { buffer, bytesPerRow }, [blockWidth, blockHeight, 1]);
+    t.expectGPUError('validation', () => {
+      encoder.finish();
+    });
+  });

--- a/src/compat/api/validation/encoding/cmds/copyTextureToBuffer.spec.ts
+++ b/src/compat/api/validation/encoding/cmds/copyTextureToBuffer.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-Tests that you can not call copyTextureToBuffer with compressed textures in compat mode.
+Tests limitations of copyTextureToBuffer in compat mode.
 `;
 
 import { makeTestGroup } from '../../../../../common/internal/test_group.js';


### PR DESCRIPTION
Note: You can run these tests with this URL: [http://localhost:8080/standalone/?compatibility=1&runnow=1&q=compat:api,validation,encoding,cmds,copyTextureToBuffer:*](http://localhost:8080/standalone/?compatibility=1&runnow=1&q=compat:api,validation,encoding,cmds,copyTextureToBuffer:*)

You'll need a browser that supports compat like Chrome Canary with webgpu developer features enabled in flags

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
