### PR TITLE
Add F16 builtin execution tests: sin, cos

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -2554,22 +2554,22 @@ g.test('cosInterval')
         const constants = trait.constants();
         // prettier-ignore
         return [
-        // This test does not include some common cases. i.e. f(x = π/2) = 0,
-        // because the difference between true x and x as a f32 is sufficiently
-        // large, such that the high slope of f @ x causes the results to be
-        // substantially different, so instead of getting 0 you get a value on the
-        // order of 10^-8 away from 0, thus difficult to express in a
-        // human-readable manner.
-        { input: constants.negative.infinity, expected: kAnyBounds },
-        { input: constants.negative.min, expected: kAnyBounds },
-        { input: constants.negative.pi.whole, expected: [-1, kPlusOneULPFunctions[p.trait](-1)] },
-        { input: 0, expected: [1, 1] },
-        { input: constants.positive.pi.whole, expected: [-1, kPlusOneULPFunctions[p.trait](-1)] },
-        { input: constants.positive.max, expected: kAnyBounds },
-        { input: constants.positive.infinity, expected: kAnyBounds },
+          // This test does not include some common cases. i.e. f(x = π/2) = 0,
+          // because the difference between true x and x as a f32 is sufficiently
+          // large, such that the high slope of f @ x causes the results to be
+          // substantially different, so instead of getting 0 you get a value on the
+          // order of 10^-8 away from 0, thus difficult to express in a
+          // human-readable manner.
+          { input: constants.negative.infinity, expected: kAnyBounds },
+          { input: constants.negative.min, expected: kAnyBounds },
+          { input: constants.negative.pi.whole, expected: [-1, kPlusOneULPFunctions[p.trait](-1)] },
+          { input: 0, expected: [1, 1] },
+          { input: constants.positive.pi.whole, expected: [-1, kPlusOneULPFunctions[p.trait](-1)] },
+          { input: constants.positive.max, expected: kAnyBounds },
+          { input: constants.positive.infinity, expected: kAnyBounds },
 
-        ...(kCosIntervalThirdPiCases[p.trait] as ScalarToIntervalCase[]),
-      ];
+          ...(kCosIntervalThirdPiCases[p.trait] as ScalarToIntervalCase[]),
+        ];
       })
   )
   .fn(t => {
@@ -3169,20 +3169,20 @@ g.test('sinInterval')
         const constants = FP[p.trait].constants();
         // prettier-ignore
         return [
-        // This test does not include some common cases, i.e. f(x = -π|π) = 0,
-        // because the difference between true x and x as a f32 is sufficiently
-        // large, such that the high slope of f @ x causes the results to be
-        // substantially different, so instead of getting 0 you get a value on the
-        // order of 10^-8 away from it, thus difficult to express in a
-        // human-readable manner.
-        { input: constants.negative.infinity, expected: kAnyBounds },
-        { input: constants.negative.min, expected: kAnyBounds },
-        { input: constants.negative.pi.half, expected: [-1, kPlusOneULPFunctions[p.trait](-1)] },
-        { input: 0, expected: 0 },
-        { input: constants.positive.pi.half, expected: [kMinusOneULPFunctions[p.trait](1), 1] },
-        { input: constants.positive.max, expected: kAnyBounds },
-        { input: constants.positive.infinity, expected: kAnyBounds },
-      ];
+          // This test does not include some common cases, i.e. f(x = -π|π) = 0,
+          // because the difference between true x and x as a f32 is sufficiently
+          // large, such that the high slope of f @ x causes the results to be
+          // substantially different, so instead of getting 0 you get a value on the
+          // order of 10^-8 away from it, thus difficult to express in a
+          // human-readable manner.
+          { input: constants.negative.infinity, expected: kAnyBounds },
+          { input: constants.negative.min, expected: kAnyBounds },
+          { input: constants.negative.pi.half, expected: [-1, kPlusOneULPFunctions[p.trait](-1)] },
+          { input: 0, expected: 0 },
+          { input: constants.positive.pi.half, expected: [kMinusOneULPFunctions[p.trait](1), 1] },
+          { input: constants.positive.max, expected: kAnyBounds },
+          { input: constants.positive.infinity, expected: kAnyBounds },
+        ];
       })
   )
   .fn(t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/cos.spec.ts
@@ -5,14 +5,13 @@ S is AbstractFloat, f32, f16
 T is S or vecN<S>
 @const fn cos(e: T ) -> T
 Returns the cosine of e. Component-wise when T is a vector.
-
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { TypeF32 } from '../../../../../util/conversion.js';
+import { TypeF32, TypeF16 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { fullF32Range, fullF16Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, run } from '../../expression.js';
 
@@ -30,6 +29,17 @@ export const d = makeCaseCache('cos', {
       ],
       'unfiltered',
       FP.f32.cosInterval
+    );
+  },
+  f16: () => {
+    return FP.f16.generateScalarToIntervalCases(
+      [
+        // Well-defined accuracy range
+        ...linearRange(-Math.PI, Math.PI, 1000),
+        ...fullF16Range(),
+      ],
+      'unfiltered',
+      FP.f16.cosInterval
     );
   },
 });
@@ -65,4 +75,10 @@ g.test('f16')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16');
+    await run(t, builtin('cos'), [TypeF16], TypeF16, t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sin.spec.ts
@@ -9,9 +9,9 @@ Returns the sine of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { TypeF32 } from '../../../../../util/conversion.js';
+import { TypeF32, TypeF16 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { fullF32Range, linearRange } from '../../../../../util/math.js';
+import { fullF32Range, fullF16Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, run } from '../../expression.js';
 
@@ -29,6 +29,17 @@ export const d = makeCaseCache('sin', {
       ],
       'unfiltered',
       FP.f32.sinInterval
+    );
+  },
+  f16: () => {
+    return FP.f16.generateScalarToIntervalCases(
+      [
+        // Well-defined accuracy range
+        ...linearRange(-Math.PI, Math.PI, 1000),
+        ...fullF16Range(),
+      ],
+      'unfiltered',
+      FP.f16.sinInterval
     );
   },
 });
@@ -64,4 +75,10 @@ g.test('f16')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16');
+    await run(t, builtin('sin'), [TypeF16], TypeF16, t.params, cases);
+  });

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -2788,7 +2788,9 @@ export abstract class FPTraits {
     impl: this.limitScalarToIntervalDomain(
       this.constants().negPiToPiInterval,
       (n: number): FPInterval => {
-        return this.absoluteErrorInterval(Math.cos(n), 2 ** -11);
+        assert(this.kind === 'f32' || this.kind === 'f16');
+        const abs_error = this.kind === 'f32' ? 2 ** -11 : 2 ** -7;
+        return this.absoluteErrorInterval(Math.cos(n), abs_error);
       }
     ),
   };
@@ -3868,7 +3870,9 @@ export abstract class FPTraits {
     impl: this.limitScalarToIntervalDomain(
       this.constants().negPiToPiInterval,
       (n: number): FPInterval => {
-        return this.absoluteErrorInterval(Math.sin(n), 2 ** -11);
+        assert(this.kind === 'f32' || this.kind === 'f16');
+        const abs_error = this.kind === 'f32' ? 2 ** -11 : 2 ** -7;
+        return this.absoluteErrorInterval(Math.sin(n), abs_error);
       }
     ),
   };
@@ -4889,7 +4893,7 @@ class F16Traits extends FPTraits {
   public readonly clampMedianInterval = this.unimplementedScalarTripleToInterval.bind(this);
   public readonly clampMinMaxInterval = this.unimplementedScalarTripleToInterval.bind(this);
   public readonly clampIntervals = [this.clampMedianInterval, this.clampMinMaxInterval];
-  public readonly cosInterval = this.unimplementedScalarToInterval.bind(this);
+  public readonly cosInterval = this.cosIntervalImpl.bind(this);
   public readonly coshInterval = this.unimplementedScalarToInterval.bind(this);
   public readonly crossInterval = this.unimplementedVectorPairToVector.bind(this);
   public readonly degreesInterval = this.unimplementedScalarToInterval.bind(this);
@@ -4941,7 +4945,7 @@ class F16Traits extends FPTraits {
   public readonly roundInterval = this.roundIntervalImpl.bind(this);
   public readonly saturateInterval = this.unimplementedScalarToInterval.bind(this);
   public readonly signInterval = this.unimplementedScalarToInterval.bind(this);
-  public readonly sinInterval = this.unimplementedScalarToInterval.bind(this);
+  public readonly sinInterval = this.sinIntervalImpl.bind(this);
   public readonly sinhInterval = this.unimplementedScalarToInterval.bind(this);
   public readonly smoothStepInterval = this.unimplementedScalarTripleToInterval.bind(this);
   public readonly sqrtInterval = this.unimplementedScalarToInterval.bind(this);


### PR DESCRIPTION
This PR add shader execution test for f16 builtin sin and cos.

Issue: #1248

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
