### PR TITLE
Fix size_fp16 test

### DIFF
--- a/src/webgpu/shader/validation/shader_io/size.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/size.spec.ts
@@ -132,7 +132,7 @@ g.test('size_fp16')
   .fn(t => {
     const code = `
 struct S {
-  @size(1${t.params.ext}) a: f32,
+  @size(4${t.params.ext}) a: f32,
 }
 @group(0) @binding(0)
 var<storage> a: S;


### PR DESCRIPTION
* Size attribute was too small




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
