### PR TITLE
shader/validation: Fix case parameter types

### DIFF
--- a/src/common/util/data_tables.ts
+++ b/src/common/util/data_tables.ts
@@ -11,6 +11,20 @@ export function numericKeysOf<T>(obj: object): readonly T[] {
 }
 
 /**
+ * @returns a new Record from @p objects, using the string returned by Object.toString() as the keys
+ * and the objects as the values.
+ */
+export function objectsToRecord<T extends Object>(objects: readonly T[]): Record<string, T> {
+  const record = {};
+  return objects.reduce((obj, type) => {
+    return {
+      ...obj,
+      [type.toString()]: type,
+    };
+  }, record);
+}
+
+/**
  * Creates an info lookup object from a more nicely-formatted table. See below for examples.
  *
  * Note: Using `as const` on the arguments to this function is necessary to infer the correct type.

--- a/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   elementType,
@@ -20,6 +21,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatAndIntegerScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -29,12 +32,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatAndIntegerScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
-      .expand('value', u => fullRangeForType(u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
+      .beginSubcases()
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -44,7 +48,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -24,6 +25,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -33,13 +36,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(u.type)))
+      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -49,10 +52,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -60,13 +65,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -25,6 +26,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -34,26 +37,29 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(fullRangeForType(u.type), kMinusTwoToTwo))
+      .expand('value', u => unique(fullRangeForType(kValuesTypes[u.type]), kMinusTwoToTwo))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.acosh(t.params.value), elementType(t.params.type));
+    const type = kValuesTypes[t.params.type];
+    const expectedResult = isRepresentable(Math.acosh(t.params.value), elementType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -61,13 +67,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -24,6 +25,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -33,13 +36,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(u.type)))
+      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -49,10 +52,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -60,13 +65,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -25,6 +26,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -34,26 +37,31 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(fullRangeForType(u.type), linearRange(-2000, 2000, 10)))
+      .expand('value', u =>
+        unique(fullRangeForType(kValuesTypes[u.type]), linearRange(-2000, 2000, 10))
+      )
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.asinh(t.params.value), elementType(t.params.type));
+    const type = kValuesTypes[t.params.type];
+    const expectedResult = isRepresentable(Math.asinh(t.params.value), elementType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -61,13 +69,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -25,6 +26,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -34,27 +37,30 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(u.type)))
+      .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const smallestPositive = fpTraitsFor(elementType(t.params.type)).constants().positive.min;
+    const type = kValuesTypes[t.params.type];
+    const smallestPositive = fpTraitsFor(elementType(type)).constants().positive.min;
     const expectedResult = Math.abs(Math.cos(t.params.value)) > smallestPositive;
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -62,13 +68,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -27,6 +28,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -36,29 +39,33 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('y', u => unique(kMinus3PiTo3Pi, fullRangeForType(u.type, 4)))
-      .expand('x', u => unique(kMinus3PiTo3Pi, fullRangeForType(u.type, 4)))
+      .expand('y', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type], 4)))
+      .expand('x', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type], 4)))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const expectedResult =
-      true ||
-      isRepresentable(Math.abs(Math.atan2(t.params.y, t.params.x)), elementType(t.params.type));
+    const type = kValuesTypes[t.params.type];
+    const expectedResult = isRepresentable(
+      Math.abs(Math.atan2(t.params.y, t.params.x)),
+      elementType(type)
+    );
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.y), t.params.type.create(t.params.x)],
+      [type.create(t.params.y), type.create(t.params.x)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument_y')
   .desc(
@@ -66,14 +73,14 @@ g.test('integer_argument_y')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
-    const yTy = t.params.type;
+    const yTy = kIntegerArgumentTypes[t.params.type];
     const xTy = yTy instanceof Vector ? new VectorType(yTy.size, TypeF32) : TypeF32;
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
+      /* expectedResult */ yTy === TypeF32,
       [yTy.create(1), xTy.create(1)],
       'constant'
     );
@@ -85,14 +92,14 @@ g.test('integer_argument_x')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
-    const xTy = t.params.type;
+    const xTy = kIntegerArgumentTypes[t.params.type];
     const yTy = xTy instanceof Vector ? new VectorType(xTy.size, TypeF32) : TypeF32;
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
+      /* expectedResult */ xTy === TypeF32,
       [yTy.create(1), xTy.create(1)],
       'constant'
     );

--- a/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -24,6 +25,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -33,13 +36,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(u.type)))
+      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -49,10 +52,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -60,13 +65,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
@@ -3,28 +3,29 @@ Validation negative tests for bitcast builtins.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../../../common/util/data_tables.js';
 import { kBit } from '../../../../../util/constants.js';
 import { linearRange } from '../../../../../util/math.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
 
-// A VectorCase specfies the number of components a vector type has,
+// A VectorCase specifies the number of components a vector type has,
 // and which component will have a bad value.
 // Use width = 1 to indicate a scalar.
 type VectorCase = { width: number; badIndex: number };
-const vectorCases: VectorCase[] = [
-  { width: 1, badIndex: 0 },
-  { width: 2, badIndex: 0 },
-  { width: 2, badIndex: 1 },
-  { width: 3, badIndex: 0 },
-  { width: 3, badIndex: 1 },
-  { width: 3, badIndex: 2 },
-  { width: 4, badIndex: 0 },
-  { width: 4, badIndex: 1 },
-  { width: 4, badIndex: 2 },
-  { width: 4, badIndex: 3 },
-];
+const kVectorCases: Record<string, VectorCase> = {
+  v1_b0: { width: 1, badIndex: 0 },
+  v2_b0: { width: 2, badIndex: 0 },
+  v2_b1: { width: 2, badIndex: 1 },
+  v3_b0: { width: 3, badIndex: 0 },
+  v3_b1: { width: 3, badIndex: 1 },
+  v3_b2: { width: 3, badIndex: 2 },
+  v4_b0: { width: 4, badIndex: 0 },
+  v4_b1: { width: 4, badIndex: 1 },
+  v4_b2: { width: 4, badIndex: 2 },
+  v4_b3: { width: 4, badIndex: 3 },
+};
 
 const numNaNs = 4;
 const f32InfAndNaNInU32: number[] = [
@@ -51,7 +52,7 @@ It is a shader-creation error if any const-expression of floating-point type eva
   .params(u =>
     u
       .combine('fromScalarType', ['i32', 'u32'] as const)
-      .combine('vectorize', [...vectorCases] as const)
+      .combine('vectorize', keysOf(kVectorCases))
       .beginSubcases()
       .combine('bitBadValue', [...f32InfAndNaNInU32] as const)
   )
@@ -61,8 +62,9 @@ It is a shader-creation error if any const-expression of floating-point type eva
     // For vector cases, generate code where one component is bad. In this case
     // width=4 and badIndex=2
     //  const f = bitcast<vec4f>(vec4<32>(0,0,i32(u32(0x7f800000)),0));
-    const width = t.params.vectorize.width;
-    const badIndex = t.params.vectorize.badIndex;
+    const vectorize = kVectorCases[t.params.vectorize];
+    const width = vectorize.width;
+    const badIndex = vectorize.badIndex;
     const badScalar = `${t.params.fromScalarType}(u32(${t.params.bitBadValue}))`;
     const destType = width === 1 ? 'f32' : `vec${width}f`;
     const srcType =

--- a/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -22,6 +23,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -31,12 +34,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
-      .expand('value', u => fullRangeForType(u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -46,10 +49,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -57,13 +62,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -24,6 +25,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -33,13 +36,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(u.type)))
+      .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -48,10 +51,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       /* expectedResult */ true,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -59,13 +64,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -23,6 +24,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -32,26 +35,29 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.cosh(t.params.value), elementType(t.params.type));
+    const type = kValuesTypes[t.params.type];
+    const expectedResult = isRepresentable(Math.cosh(t.params.value), elementType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -59,13 +65,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -23,6 +24,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -32,29 +35,29 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(
-      (t.params.value * 180) / Math.PI,
-      elementType(t.params.type)
-    );
+    const type = kValuesTypes[t.params.type];
+    const expectedResult = isRepresentable((t.params.value * 180) / Math.PI, elementType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -62,13 +65,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import { kValue } from '../../../../../util/constants.js';
 import {
   TypeF16,
@@ -23,6 +24,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -32,8 +35,8 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
       .combine('value', [
         -1e2,
@@ -62,20 +65,23 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       ])
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.pow(2, t.params.value), elementType(t.params.type));
+    const type = kValuesTypes[t.params.type];
+    const expectedResult = isRepresentable(Math.pow(2, t.params.value), elementType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -83,13 +89,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -25,6 +26,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -34,28 +37,30 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(u.type)))
+      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
+    const type = kValuesTypes[t.params.type];
     const expectedResult =
-      t.params.value > 0 &&
-      isRepresentable(1 / Math.sqrt(t.params.value), elementType(t.params.type));
+      t.params.value > 0 && isRepresentable(1 / Math.sqrt(t.params.value), elementType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -63,13 +68,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   ScalarType,
   TypeF16,
@@ -57,6 +58,8 @@ function calculate(
   };
 }
 
+const kScalarTypes = objectsToRecord(kAllFloatScalars);
+
 g.test('scalar')
   .desc(
     `
@@ -67,13 +70,13 @@ the input scalar value always compiles without error
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalars)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kScalarTypes))
+      .filter(u => stageSupportsType(u.stage, kScalarTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kScalarTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kScalarTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -84,10 +87,12 @@ the input scalar value always compiles without error
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kScalarTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kVec2Types = objectsToRecord(kAllFloatVector2);
 
 g.test('vec2')
   .desc(
@@ -98,16 +103,16 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatVector2)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kVec2Types))
+      .filter(u => stageSupportsType(u.stage, kVec2Types[u.type]))
       .beginSubcases()
-      .expand('x', u => fullRangeForType(u.type, 5))
-      .expand('y', u => fullRangeForType(u.type, 5))
-      .expand('_result', u => [calculate([u.x, u.y], elementType(u.type))])
+      .expand('x', u => fullRangeForType(kVec2Types[u.type], 5))
+      .expand('y', u => fullRangeForType(kVec2Types[u.type], 5))
+      .expand('_result', u => [calculate([u.x, u.y], elementType(kVec2Types[u.type]))])
       .filter(u => u._result.isResultRepresentable === u._result.isIntermediateRepresentable)
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kVec2Types[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -117,10 +122,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
       t,
       builtin,
       expectedResult,
-      [t.params.type.create([t.params.x, t.params.y])],
+      [kVec2Types[t.params.type].create([t.params.x, t.params.y])],
       t.params.stage
     );
   });
+
+const kVec3Types = objectsToRecord(kAllFloatVector3);
 
 g.test('vec3')
   .desc(
@@ -131,17 +138,17 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatVector3)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kVec3Types))
+      .filter(u => stageSupportsType(u.stage, kVec3Types[u.type]))
       .beginSubcases()
-      .expand('x', u => fullRangeForType(u.type, 4))
-      .expand('y', u => fullRangeForType(u.type, 4))
-      .expand('z', u => fullRangeForType(u.type, 4))
-      .expand('_result', u => [calculate([u.x, u.y, u.z], elementType(u.type))])
+      .expand('x', u => fullRangeForType(kVec3Types[u.type], 4))
+      .expand('y', u => fullRangeForType(kVec3Types[u.type], 4))
+      .expand('z', u => fullRangeForType(kVec3Types[u.type], 4))
+      .expand('_result', u => [calculate([u.x, u.y, u.z], elementType(kVec3Types[u.type]))])
       .filter(u => u._result.isResultRepresentable === u._result.isIntermediateRepresentable)
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kVec3Types[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -151,10 +158,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
       t,
       builtin,
       expectedResult,
-      [t.params.type.create([t.params.x, t.params.y, t.params.z])],
+      [kVec3Types[t.params.type].create([t.params.x, t.params.y, t.params.z])],
       t.params.stage
     );
   });
+
+const kVec4Types = objectsToRecord(kAllFloatVector4);
 
 g.test('vec4')
   .desc(
@@ -165,18 +174,18 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatVector4)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kVec4Types))
+      .filter(u => stageSupportsType(u.stage, kVec4Types[u.type]))
       .beginSubcases()
-      .expand('x', u => fullRangeForType(u.type, 3))
-      .expand('y', u => fullRangeForType(u.type, 3))
-      .expand('z', u => fullRangeForType(u.type, 3))
-      .expand('w', u => fullRangeForType(u.type, 3))
-      .expand('_result', u => [calculate([u.x, u.y, u.z, u.w], elementType(u.type))])
+      .expand('x', u => fullRangeForType(kVec4Types[u.type], 3))
+      .expand('y', u => fullRangeForType(kVec4Types[u.type], 3))
+      .expand('z', u => fullRangeForType(kVec4Types[u.type], 3))
+      .expand('w', u => fullRangeForType(kVec4Types[u.type], 3))
+      .expand('_result', u => [calculate([u.x, u.y, u.z, u.w], elementType(kVec4Types[u.type]))])
       .filter(u => u._result.isResultRepresentable === u._result.isIntermediateRepresentable)
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kVec4Types[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -186,10 +195,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
       t,
       builtin,
       expectedResult,
-      [t.params.type.create([t.params.x, t.params.y, t.params.z, t.params.w])],
+      [kVec4Types[t.params.type].create([t.params.x, t.params.y, t.params.z, t.params.w])],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -197,13 +208,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -22,6 +23,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -31,13 +34,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -47,10 +50,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -58,13 +63,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -22,6 +23,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -31,13 +34,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -47,10 +50,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -58,13 +63,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -22,6 +23,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -31,13 +34,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -47,10 +50,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -58,13 +63,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -22,6 +23,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -31,13 +34,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -47,10 +50,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -58,13 +63,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -24,6 +25,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -33,19 +36,19 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
       .expand('value', u => {
-        const constants = fpTraitsFor(elementType(u.type)).constants();
-        return unique(fullRangeForType(u.type), [
+        const constants = fpTraitsFor(elementType(kValuesTypes[u.type])).constants();
+        return unique(fullRangeForType(kValuesTypes[u.type]), [
           constants.negative.min + 0.1,
           constants.positive.max - 0.1,
         ]);
       })
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -55,10 +58,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -66,13 +71,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -22,6 +23,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -31,13 +34,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -47,10 +50,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -58,13 +63,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -22,6 +23,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatAndSignedIntegerScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -31,13 +34,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatAndSignedIntegerScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -47,10 +50,15 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kUnsignedIntegerArgumentTypes = objectsToRecord([
+  TypeF32,
+  ...kAllUnsignedIntegerScalarsAndVectors,
+]);
 
 g.test('unsigned_integer_argument')
   .desc(
@@ -58,13 +66,14 @@ g.test('unsigned_integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllUnsignedIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kUnsignedIntegerArgumentTypes)))
   .fn(t => {
+    const type = kUnsignedIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -24,6 +25,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -33,13 +36,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(u.type)))
+      .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -48,10 +51,12 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t,
       builtin,
       /* expectedResult */ true,
-      [t.params.type.create(t.params.value)],
+      [kValuesTypes[t.params.type].create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -59,13 +64,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -23,6 +24,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -32,26 +35,29 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => fullRangeForType(u.type))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const expectedResult = isRepresentable(Math.sinh(t.params.value), elementType(t.params.type));
+    const type = kValuesTypes[t.params.type];
+    const expectedResult = isRepresentable(Math.sinh(t.params.value), elementType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -59,13 +65,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -25,6 +26,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -34,27 +37,30 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(u.type)))
+      .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
+    const type = kValuesTypes[t.params.type];
     const expectedResult =
-      t.params.value >= 0 && isRepresentable(Math.sqrt(t.params.value), elementType(t.params.type));
+      t.params.value >= 0 && isRepresentable(Math.sqrt(t.params.value), elementType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -62,13 +68,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(1)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(1)],
       'constant'
     );
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
@@ -4,6 +4,7 @@ Validation tests for the ${builtin}() builtin.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
   TypeF32,
@@ -25,6 +26,8 @@ import {
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
 g.test('values')
   .desc(
     `
@@ -34,27 +37,30 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .params(u =>
     u
       .combine('stage', kConstantAndOverrideStages)
-      .combine('type', kAllFloatScalarsAndVectors)
-      .filter(u => stageSupportsType(u.stage, u.type))
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(u.type)))
+      .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(t.params.type) === TypeF16) {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const smallestPositive = fpTraitsFor(elementType(t.params.type)).constants().positive.min;
+    const type = kValuesTypes[t.params.type];
+    const smallestPositive = fpTraitsFor(elementType(type)).constants().positive.min;
     const expectedResult = Math.abs(Math.cos(t.params.value)) > smallestPositive;
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
-      [t.params.type.create(t.params.value)],
+      [type.create(t.params.value)],
       t.params.stage
     );
   });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
   .desc(
@@ -62,13 +68,14 @@ g.test('integer_argument')
 Validates that scalar and vector integer arguments are rejected by ${builtin}()
 `
   )
-  .params(u => u.combine('type', [TypeF32, ...kAllIntegerScalarsAndVectors]))
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
   .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.type === TypeF32,
-      [t.params.type.create(0)],
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
       'constant'
     );
   });


### PR DESCRIPTION
We can't encode types directly into the test cases for the reasons outlined in #2860. Instead use a `Record` to hold the types, and parameterize over the record's keys.

Fixes: #2860

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
