### PR TITLE
Refactor texture_ok.spec.ts to not use typedarrays as params

### DIFF
--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -313,6 +313,78 @@ export const kTypedArrayBufferViews: {
 export const kTypedArrayBufferViewKeys = keysOf(kTypedArrayBufferViews);
 export const kTypedArrayBufferViewConstructors = Object.values(kTypedArrayBufferViews);
 
+interface TypedArrayMap {
+  Int8Array: Int8Array;
+  Uint8Array: Uint8Array;
+  Int16Array: Int16Array;
+  Uint16Array: Uint16Array;
+  Uint8ClampedArray: Uint8ClampedArray;
+  Int32Array: Int32Array;
+  Uint32Array: Uint32Array;
+  Float32Array: Float32Array;
+  Float64Array: Float64Array;
+  BigInt64Array: BigInt64Array;
+  BigUint64Array: BigUint64Array;
+}
+
+type TypedArrayParam<K extends keyof TypedArrayMap> = {
+  type: K;
+  data: number[];
+};
+
+/**
+ * Creates a case parameter for a typedarray.
+ *
+ * You can't put typedarrays in case parameters directly so instead of
+ *
+ * ```
+ * u.combine('data', [
+ *   new Uint8Array([1, 2, 3]),
+ *   new Float32Array([4, 5, 6]),
+ * ])
+ * ```
+ *
+ * You can use
+ *
+ * ```
+ * u.combine('data', [
+ *   typedArrayParam('Uint8Array' [1, 2, 3]),
+ *   typedArrayParam('Float32Array' [4, 5, 6]),
+ * ])
+ * ```
+ *
+ * and then convert the params to typedarrays eg.
+ *
+ * ```
+ *  .fn(t => {
+ *    const data = t.params.data.map(v => typedArrayFromParam(v));
+ *  })
+ * ```
+ */
+export function typedArrayParam<K extends keyof TypedArrayMap>(
+  type: K,
+  data: number[]
+): TypedArrayParam<K> {
+  return { type, data };
+}
+
+export function createTypedArray<K extends keyof TypedArrayMap>(
+  type: K,
+  data: number[]
+): TypedArrayMap[K] {
+  return new kTypedArrayBufferViews[type](data) as TypedArrayMap[K];
+}
+
+/**
+ * Converts a TypedArrayParam to a typedarray. See typedArrayParam
+ */
+export function typedArrayFromParam<K extends keyof TypedArrayMap>(
+  param: TypedArrayParam<K>
+): TypedArrayMap[K] {
+  const { type, data } = param;
+  return createTypedArray(type, data);
+}
+
 function subarrayAsU8(
   buf: ArrayBuffer | TypedArrayBufferView,
   { start = 0, length }: { start?: number; length?: number }

--- a/src/unittests/texture_ok.spec.ts
+++ b/src/unittests/texture_ok.spec.ts
@@ -3,6 +3,7 @@ Test for texture_ok utils.
 `;
 
 import { makeTestGroup } from '../common/framework/test_group.js';
+import { typedArrayFromParam, typedArrayParam } from '../common/util/util.js';
 import { RegularTextureFormat } from '../webgpu/format_info.js';
 import { TexelView } from '../webgpu/util/texture/texel_view.js';
 import { findFailedPixels } from '../webgpu/util/texture/texture_ok.js';
@@ -30,86 +31,86 @@ g.test('findFailedPixels')
       // Sanity Check
       {
         format: 'rgba8unorm' as RegularTextureFormat,
-        actual: new Uint8Array([0x00, 0x40, 0x80, 0xff]),
-        expected: new Uint8Array([0x00, 0x40, 0x80, 0xff]),
+        actual: typedArrayParam('Uint8Array', [0x00, 0x40, 0x80, 0xff]),
+        expected: typedArrayParam('Uint8Array', [0x00, 0x40, 0x80, 0xff]),
         isSame: true,
       },
       // Slightly different values
       {
         format: 'rgba8unorm' as RegularTextureFormat,
-        actual: new Uint8Array([0x00, 0x40, 0x80, 0xff]),
-        expected: new Uint8Array([0x00, 0x40, 0x81, 0xff]),
+        actual: typedArrayParam('Uint8Array', [0x00, 0x40, 0x80, 0xff]),
+        expected: typedArrayParam('Uint8Array', [0x00, 0x40, 0x81, 0xff]),
         isSame: false,
       },
       // Different representations of the same value
       {
         format: 'rgb9e5ufloat' as RegularTextureFormat,
-        actual: new Uint8Array([0x78, 0x56, 0x34, 0x12]),
-        expected: new Uint8Array([0xf0, 0xac, 0x68, 0x0c]),
+        actual: typedArrayParam('Uint8Array', [0x78, 0x56, 0x34, 0x12]),
+        expected: typedArrayParam('Uint8Array', [0xf0, 0xac, 0x68, 0x0c]),
         isSame: true,
       },
       // Slightly different values
       {
         format: 'rgb9e5ufloat' as RegularTextureFormat,
-        actual: new Uint8Array([0x78, 0x56, 0x34, 0x12]),
-        expected: new Uint8Array([0xf1, 0xac, 0x68, 0x0c]),
+        actual: typedArrayParam('Uint8Array', [0x78, 0x56, 0x34, 0x12]),
+        expected: typedArrayParam('Uint8Array', [0xf1, 0xac, 0x68, 0x0c]),
         isSame: false,
       },
       // Test NaN === NaN
       {
         format: 'r32float' as RegularTextureFormat,
-        actual: new Float32Array([parseFloat('abc')]),
-        expected: new Float32Array([parseFloat('def')]),
+        actual: typedArrayParam('Float32Array', [parseFloat('abc')]),
+        expected: typedArrayParam('Float32Array', [parseFloat('def')]),
         isSame: true,
       },
       // Sanity Check
       {
         format: 'r32float' as RegularTextureFormat,
-        actual: new Float32Array([1.23]),
-        expected: new Float32Array([1.23]),
+        actual: typedArrayParam('Float32Array', [1.23]),
+        expected: typedArrayParam('Float32Array', [1.23]),
         isSame: true,
       },
       // Slightly different values.
       {
         format: 'r32float' as RegularTextureFormat,
-        actual: new Uint32Array([0x3f9d70a4]),
-        expected: new Uint32Array([0x3f9d70a5]),
+        actual: typedArrayParam('Uint32Array', [0x3f9d70a4]),
+        expected: typedArrayParam('Uint32Array', [0x3f9d70a5]),
         isSame: false,
       },
       // Slightly different
       {
         format: 'rg11b10ufloat' as RegularTextureFormat,
-        actual: new Uint32Array([0x3ce]),
-        expected: new Uint32Array([0x3cf]),
+        actual: typedArrayParam('Uint32Array', [0x3ce]),
+        expected: typedArrayParam('Uint32Array', [0x3cf]),
         isSame: false,
       },
       // NaN === NaN (red)
       {
         format: 'rg11b10ufloat' as RegularTextureFormat,
-        actual: new Uint32Array([0b11111000000]),
-        expected: new Uint32Array([0b11111000000]),
+        actual: typedArrayParam('Uint32Array', [0b11111000000]),
+        expected: typedArrayParam('Uint32Array', [0b11111000000]),
         isSame: true,
       },
       // NaN === NaN (green)
       {
         format: 'rg11b10ufloat' as RegularTextureFormat,
-        actual: new Uint32Array([0b11111000000_00000000000]),
-        expected: new Uint32Array([0b11111000000_00000000000]),
+        actual: typedArrayParam('Uint32Array', [0b11111000000_00000000000]),
+        expected: typedArrayParam('Uint32Array', [0b11111000000_00000000000]),
         isSame: true,
       },
       // NaN === NaN (blue)
       {
         format: 'rg11b10ufloat' as RegularTextureFormat,
-        actual: new Uint32Array([0b1111100000_00000000000_00000000000]),
-        expected: new Uint32Array([0b1111100000_00000000000_00000000000]),
+        actual: typedArrayParam('Uint32Array', [0b1111100000_00000000000_00000000000]),
+        expected: typedArrayParam('Uint32Array', [0b1111100000_00000000000_00000000000]),
         isSame: true,
       },
     ])
   )
   .fn(t => {
     const { format, actual, expected, isSame } = t.params;
-    const actualData = new Uint8Array(actual.buffer);
-    const expectedData = new Uint8Array(expected.buffer);
+    const actualData = new Uint8Array(typedArrayFromParam(actual).buffer);
+    const expectedData = new Uint8Array(typedArrayFromParam(expected).buffer);
 
     const actTexelView = TexelView.fromTextureDataByReference(format, actualData, {
       bytesPerRow: actualData.byteLength,


### PR DESCRIPTION


Issue: #2862

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
