### PR TITLE
Massively speed up zero_init workgroup memory tests on Android

### DIFF
--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -423,8 +423,21 @@ g.test('compute,zero_init')
       }
       `;
 
+      const fillLayout = t.device.createBindGroupLayout({
+        entries: [{
+          binding: 0,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type: 'read-only-storage' },
+        }, {
+          binding: 1,
+          visibility: GPUShaderStage.COMPUTE,
+          buffer: { type: 'storage' },
+        }]
+      });
+
       const fillPipeline = t.device.createComputePipeline({
-        layout: 'auto',
+        layout: t.device.createPipelineLayout({ bindGroupLayouts: [fillLayout] }),
+        label: 'Workgroup Fill Pipeline',
         compute: {
           module: t.device.createShaderModule({
             code: wgsl,

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -424,15 +424,18 @@ g.test('compute,zero_init')
       `;
 
       const fillLayout = t.device.createBindGroupLayout({
-        entries: [{
-          binding: 0,
-          visibility: GPUShaderStage.COMPUTE,
-          buffer: { type: 'read-only-storage' },
-        }, {
-          binding: 1,
-          visibility: GPUShaderStage.COMPUTE,
-          buffer: { type: 'storage' },
-        }]
+        entries: [
+          {
+            binding: 0,
+            visibility: GPUShaderStage.COMPUTE,
+            buffer: { type: 'read-only-storage' },
+          },
+          {
+            binding: 1,
+            visibility: GPUShaderStage.COMPUTE,
+            buffer: { type: 'storage' },
+          },
+        ],
       });
 
       const fillPipeline = t.device.createComputePipeline({


### PR DESCRIPTION
These tests are currently so slow that the Chrome bots time out when running them. It's about 30-40s on a Pixel 6 for each batch of 15.

Profiling with Chrome's about:tracing on one batch to see where the time was going, I got back a trace with fifteen (the test batch size) ~2s long pipeline creation blocks. Worth noting that the Tint translation portion of each block was only about 0.3ms.
<img width="1076" alt="test_profile_01" src="https://github.com/gpuweb/cts/assets/805273/dfc12781-7206-4612-8d11-654847ea9315">

Each test creates a custom pipeline to check the memory zero init state, so at first glance it felt like there wasn't much that could be done here. But by zooming in closer you could see another pipeline creation immediately following the massive one. This one only took ~2ms each time.
<img width="748" alt="test_profile_02" src="https://github.com/gpuweb/cts/assets/805273/a288bb93-5cbb-457b-8ad4-4756a0ade04a">

Turns out the smaller of the two pipeline builds is the custom shader for each test. The larger one is from a pipeline that preps for the test by stomping on the entirely of workgroup memory with a known pattern so we can ensure the zeroing behavior is legit. This shader has a loop in it the size of which is determined by the workgroup memory size, and it's not too hard to imagine a Vulkan driver trying to unroll it internally.

Fortunately, this pipeline is the same for every single run, so we can cache it! Doing so cuts the test time down by a couple orders of magnitude! (~2s for the first test batch, then ~300ms for every other batch.)

There's a few more things that could be cached here (like the buffer used to copy the fill value from) but those are already performing well and I'd prefer to add as few "globally" cached values as possible.

Issue: https://bugs.chromium.org/p/dawn/issues/detail?id=1901

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
