### PR TITLE
Change texture/float comparisons for Inf

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -40,7 +40,7 @@ import { UnitTest } from './unit_test.js';
 
 export const g = makeTestGroup(UnitTest);
 
-const kFloat32BitsToNumberCases = [
+const kFloat16BitsToNumberCases = [
   [0b0_01111_0000000000, 1],
   [0b0_00001_0000000000, 0.00006103515625],
   [0b0_01101_0101010101, 0.33325195],
@@ -59,7 +59,7 @@ const kFloat32BitsToNumberCases = [
 
 g.test('float16BitsToFloat32').fn(t => {
   for (const [bits, number] of [
-    ...kFloat32BitsToNumberCases,
+    ...kFloat16BitsToNumberCases,
     [0b1_00000_0000000000, -0], // (resulting sign is not actually tested)
     [0b0_00000_1111111111, 0.00006104], // subnormal f16 input
     [0b1_00000_1111111111, -0.00006104],
@@ -75,7 +75,7 @@ g.test('float16BitsToFloat32').fn(t => {
 
 g.test('float32ToFloat16Bits').fn(t => {
   for (const [bits, number] of [
-    ...kFloat32BitsToNumberCases,
+    ...kFloat16BitsToNumberCases,
     [0b0_00000_0000000000, 0.00001], // input that becomes subnormal in f16 is rounded to 0
     [0b1_00000_0000000000, -0.00001], // and sign is preserved
   ]) {
@@ -99,7 +99,7 @@ g.test('float32ToFloatBits_floatBitsToNumber')
     const { signed, exponentBits, mantissaBits } = t.params;
     const bias = (1 << (exponentBits - 1)) - 1;
 
-    for (const [, value] of kFloat32BitsToNumberCases) {
+    for (const [, value] of kFloat16BitsToNumberCases) {
       if (value < 0 && signed === 0) continue;
       const bits = float32ToFloatBits(value, signed, exponentBits, mantissaBits, bias);
       const reconstituted = floatBitsToNumber(bits, { signed, exponentBits, mantissaBits, bias });

--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -19,6 +19,7 @@ import {
   kFloat16Format,
   kFloat32Format,
   Matrix,
+  numbersApproximatelyEqual,
   pack2x16float,
   pack2x16snorm,
   pack2x16unorm,
@@ -39,7 +40,7 @@ import { UnitTest } from './unit_test.js';
 
 export const g = makeTestGroup(UnitTest);
 
-const cases = [
+const kFloat32BitsToNumberCases = [
   [0b0_01111_0000000000, 1],
   [0b0_00001_0000000000, 0.00006103515625],
   [0b0_01101_0101010101, 0.33325195],
@@ -51,11 +52,14 @@ const cases = [
   [0b0_10101_1001000000, 100],
   [0b1_01100_1001100110, -0.1999512],
   [0b1_10101_1001000000, -100],
+  [0b0_11111_1111111111, Number.NaN],
+  [0b0_11111_0000000000, Number.POSITIVE_INFINITY],
+  [0b1_11111_0000000000, Number.NEGATIVE_INFINITY],
 ];
 
 g.test('float16BitsToFloat32').fn(t => {
   for (const [bits, number] of [
-    ...cases,
+    ...kFloat32BitsToNumberCases,
     [0b1_00000_0000000000, -0], // (resulting sign is not actually tested)
     [0b0_00000_1111111111, 0.00006104], // subnormal f16 input
     [0b1_00000_1111111111, -0.00006104],
@@ -63,7 +67,7 @@ g.test('float16BitsToFloat32').fn(t => {
     const actual = float16BitsToFloat32(bits);
     t.expect(
       // some loose check
-      Math.abs(actual - number) <= 0.00001,
+      numbersApproximatelyEqual(actual, number, 0.00001),
       `for ${bits.toString(2)}, expected ${number}, got ${actual}`
     );
   }
@@ -71,7 +75,7 @@ g.test('float16BitsToFloat32').fn(t => {
 
 g.test('float32ToFloat16Bits').fn(t => {
   for (const [bits, number] of [
-    ...cases,
+    ...kFloat32BitsToNumberCases,
     [0b0_00000_0000000000, 0.00001], // input that becomes subnormal in f16 is rounded to 0
     [0b1_00000_0000000000, -0.00001], // and sign is preserved
   ]) {
@@ -95,11 +99,14 @@ g.test('float32ToFloatBits_floatBitsToNumber')
     const { signed, exponentBits, mantissaBits } = t.params;
     const bias = (1 << (exponentBits - 1)) - 1;
 
-    for (const [, value] of cases) {
+    for (const [, value] of kFloat32BitsToNumberCases) {
       if (value < 0 && signed === 0) continue;
       const bits = float32ToFloatBits(value, signed, exponentBits, mantissaBits, bias);
       const reconstituted = floatBitsToNumber(bits, { signed, exponentBits, mantissaBits, bias });
-      t.expect(Math.abs(reconstituted - value) <= 0.0000001, `${reconstituted} vs ${value}`);
+      t.expect(
+        numbersApproximatelyEqual(reconstituted, value, 0.0000001),
+        `${reconstituted} vs ${value}`
+      );
     }
   });
 

--- a/src/unittests/texture_ok.spec.ts
+++ b/src/unittests/texture_ok.spec.ts
@@ -84,25 +84,46 @@ g.test('findFailedPixels')
         expected: typedArrayParam('Uint32Array', [0x3cf]),
         isSame: false,
       },
-      // NaN === NaN (red)
+      // Positive.Infinity === Positive.Infinity (red)
       {
         format: 'rg11b10ufloat' as RegularTextureFormat,
         actual: typedArrayParam('Uint32Array', [0b11111000000]),
         expected: typedArrayParam('Uint32Array', [0b11111000000]),
         isSame: true,
       },
-      // NaN === NaN (green)
+      // Positive.Infinity === Positive.Infinity (green)
       {
         format: 'rg11b10ufloat' as RegularTextureFormat,
         actual: typedArrayParam('Uint32Array', [0b11111000000_00000000000]),
         expected: typedArrayParam('Uint32Array', [0b11111000000_00000000000]),
         isSame: true,
       },
-      // NaN === NaN (blue)
+      // Positive.Infinity === Positive.Infinity (blue)
       {
         format: 'rg11b10ufloat' as RegularTextureFormat,
         actual: typedArrayParam('Uint32Array', [0b1111100000_00000000000_00000000000]),
         expected: typedArrayParam('Uint32Array', [0b1111100000_00000000000_00000000000]),
+        isSame: true,
+      },
+      // NaN === NaN (red)
+      {
+        format: 'rg11b10ufloat' as RegularTextureFormat,
+        actual: typedArrayParam('Uint32Array', [0b11111000001]),
+        expected: typedArrayParam('Uint32Array', [0b11111000010]),
+        isSame: true,
+      },
+      // NaN === NaN (green)
+      {
+        format: 'rg11b10ufloat' as RegularTextureFormat,
+        actual: typedArrayParam('Uint32Array', [0b11111000100_00000000000]),
+        expected: typedArrayParam('Uint32Array', [0b11111001000_00000000000]),
+        isSame: true,
+      },
+      // NaN === NaN (blue)
+      {
+        format: 'rg11b10ufloat' as RegularTextureFormat,
+        actual: typedArrayParam('Uint32Array', [0b1111110000_00000000000_00000000000]),
+        expected: typedArrayParam('Uint32Array', [0b1111101000_00000000000_00000000000]),
         isSame: true,
       },
     ])

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -52,6 +52,20 @@ export function normalizedIntegerAsFloat(integer: number, bits: number, signed: 
 }
 
 /**
+ * Compares 2 numbers. Returns true if their absolute value is
+ * less than or equal to maxDiff or if they are both NaN or the
+ * same sign infinity.
+ */
+export function numbersApproximatelyEqual(a: number, b: number, maxDiff: number = 0) {
+  return (
+    (Number.isNaN(a) && Number.isNaN(b)) ||
+    (a === Number.POSITIVE_INFINITY && b === Number.POSITIVE_INFINITY) ||
+    (a === Number.NEGATIVE_INFINITY && b === Number.NEGATIVE_INFINITY) ||
+    Math.abs(a - b) <= maxDiff
+  );
+}
+
+/**
  * Encodes a JS `number` into an IEEE754 floating point number with the specified number of
  * sign, exponent, mantissa bits, and exponent bias.
  * Returns the result as an integer-valued JS `number`.
@@ -70,7 +84,11 @@ export function float32ToFloatBits(
 ): number {
   assert(exponentBits <= 8);
   assert(mantissaBits <= 23);
-  assert(Number.isFinite(n));
+
+  if (Number.isNaN(n)) {
+    // NaN = all exponent bits true, 1 or more mantissia bits true
+    return (((1 << exponentBits) - 1) << mantissaBits) | ((1 << mantissaBits) - 1);
+  }
 
   if (n === 0) {
     return 0;
@@ -78,6 +96,14 @@ export function float32ToFloatBits(
 
   if (signBits === 0) {
     assert(n >= 0);
+  }
+
+  if (!Number.isFinite(n)) {
+    // Infinity = all exponent bits true, no mantissa bits true
+    // plus the sign bit.
+    return (
+      (((1 << exponentBits) - 1) << mantissaBits) | (n < 0 ? 2 ** (exponentBits + mantissaBits) : 0)
+    );
   }
 
   const buf = new DataView(new ArrayBuffer(Float32Array.BYTES_PER_ELEMENT));
@@ -174,8 +200,21 @@ export function floatBitsToNumber(bits: number, fmt: FloatFormat): number {
 
   const kNonSignBits = fmt.exponentBits + fmt.mantissaBits;
   const kNonSignBitsMask = (1 << kNonSignBits) - 1;
-  const expAndMantBits = bits & kNonSignBitsMask;
-  let f32BitsWithWrongBias = expAndMantBits << (kFloat32Format.mantissaBits - fmt.mantissaBits);
+  const exponentAndMantissaBits = bits & kNonSignBitsMask;
+  const exponentMask = ((1 << fmt.exponentBits) - 1) << fmt.mantissaBits;
+  const infinityOrNaN = (bits & exponentMask) === exponentMask;
+  if (infinityOrNaN) {
+    const mantissaMask = (1 << fmt.mantissaBits) - 1;
+    const signBit = 2 ** kNonSignBits;
+    const isNegative = (bits & signBit) !== 0;
+    return bits & mantissaMask
+      ? Number.NaN
+      : isNegative
+      ? Number.NEGATIVE_INFINITY
+      : Number.POSITIVE_INFINITY;
+  }
+  let f32BitsWithWrongBias =
+    exponentAndMantissaBits << (kFloat32Format.mantissaBits - fmt.mantissaBits);
   f32BitsWithWrongBias |= (bits << (31 - kNonSignBits)) & 0x8000_0000;
   const numberWithWrongBias = float32BitsToNumber(f32BitsWithWrongBias);
   return numberWithWrongBias * 2 ** (kFloat32Format.bias - fmt.bias);

--- a/src/webgpu/util/texture/texture_ok.ts
+++ b/src/webgpu/util/texture/texture_ok.ts
@@ -1,6 +1,7 @@
 import { assert, ErrorWithExtra, unreachable } from '../../../common/util/util.js';
 import { kTextureFormatInfo, EncodableTextureFormat } from '../../format_info.js';
 import { GPUTest } from '../../gpu_test.js';
+import { numbersApproximatelyEqual } from '../conversion.js';
 import { generatePrettyTable } from '../pretty_diff_tables.js';
 import { reifyExtent3D, reifyOrigin3D } from '../unions.js';
 
@@ -158,10 +159,7 @@ function comparePerComponent(
     const act = actual[k]!;
     const exp = expected[k];
     if (exp === undefined) return false;
-    if (Number.isNaN(act) && Number.isNaN(exp)) {
-      return true;
-    }
-    return Math.abs(act - exp) <= maxDiff;
+    return numbersApproximatelyEqual(act, exp, maxDiff);
   });
 }
 


### PR DESCRIPTION
The texture comparison code needs to handle
`Positive.Infinity === Positive.Infinity` and
`Negative.Inifitiy === Negative.Infinity` which
needs an explicit check as `a - b`
returns `NaN` when a and b are infinity.

Further, the we need to properly encode/decode
infinity and NaN in order for the comparisons
to round trip.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
