### PR TITLE
Remove excluded formats from image_copy tests

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -31,11 +31,6 @@ export const description = `writeTexture + copyBufferToTexture + copyTextureToBu
     DoCopyTextureToBufferWithDepthAspectTest().
 
 TODO: Expand tests of GPUExtent3D [1]
-
-TODO: Fix this test for the various skipped formats [2]:
-- snorm tests failing due to rounding
-- float tests failing because float values are not byte-preserved
-- compressed formats
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -126,19 +121,7 @@ const kMethodsToTest = [
   { initMethod: 'WriteTexture', checkMethod: 'PartialCopyT2B' },
 ] as const;
 
-// [2]: Fix things so this list can be reduced to zero (see file description)
-const kExcludedFormats: Set<ColorTextureFormat> = new Set([
-  'r8snorm',
-  'rg8snorm',
-  'rgba8snorm',
-  'rg11b10ufloat',
-  'rg16float',
-  'rgba16float',
-  'r32float',
-  'rg32float',
-  'rgba32float',
-]);
-const kWorkingColorTextureFormats = kColorTextureFormats.filter(x => !kExcludedFormats.has(x));
+const kWorkingColorTextureFormats = kColorTextureFormats;
 
 const dataGenerator = new DataArrayGenerator();
 const altDataGenerator = new DataArrayGenerator();

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -121,8 +121,6 @@ const kMethodsToTest = [
   { initMethod: 'WriteTexture', checkMethod: 'PartialCopyT2B' },
 ] as const;
 
-const kWorkingColorTextureFormats = kColorTextureFormats;
-
 const dataGenerator = new DataArrayGenerator();
 const altDataGenerator = new DataArrayGenerator();
 
@@ -1396,7 +1394,7 @@ bytes in copy works for every format.
   .params(u =>
     u
       .combineWithParams(kMethodsToTest)
-      .combine('format', kWorkingColorTextureFormats)
+      .combine('format', kColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', kTextureDimensions)
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
@@ -1497,7 +1495,7 @@ works for every format with 2d and 2d-array textures.
   .params(u =>
     u
       .combineWithParams(kMethodsToTest)
-      .combine('format', kWorkingColorTextureFormats)
+      .combine('format', kColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', kTextureDimensions)
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
@@ -1570,7 +1568,7 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
   .params(u =>
     u
       .combineWithParams(kMethodsToTest)
-      .combine('format', kWorkingColorTextureFormats)
+      .combine('format', kColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', kTextureDimensions)
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
@@ -1735,7 +1733,7 @@ TODO: Make a variant for depth-stencil formats.
   .params(u =>
     u
       .combineWithParams(kMethodsToTest)
-      .combine('format', kWorkingColorTextureFormats)
+      .combine('format', kColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', ['2d', '3d'] as const)
       .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))


### PR DESCRIPTION
I think these formats [pass now](https://dawn-review.googlesource.com/c/dawn/+/142940?tab=checks) with the latest changes.

It's not clear if I should remove `kWorkingColorTextureFormats` and just `s/kWorkingColorTextureFormats/kColorTextureFormats` or if I should leave in `kExcludedFormats` for the future.


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
